### PR TITLE
[Enhancement] Add sort-key sampling to lake segments for accurate tablet split

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -318,6 +318,13 @@ CONF_mInt32(disk_stat_monitor_interval, "5");
 CONF_mInt32(profile_report_interval, "30");
 CONF_mInt32(unused_rowset_monitor_interval, "30");
 CONF_String(storage_root_path, "${STARROCKS_HOME}/storage");
+// Row interval between consecutive sort-key samples recorded by the segment
+// writer. Samples are consumed by tablet split and range-split parallel
+// compaction to accurately estimate row distribution for overlapping segments.
+// Setting to 0 disables sampling. The per-segment value is persisted in
+// SegmentMetadataPB.sort_key_sample_row_interval so that a runtime change
+// does not break cross-version readers.
+CONF_mInt64(segment_sort_key_sample_row_interval, "65536");
 CONF_Bool(enable_transparent_data_encryption, "false");
 // BE process will exit if the percentage of error disk reach this value.
 CONF_mInt32(max_percentage_of_error_disk, "0");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -768,6 +768,7 @@
     {
       "path": "be/src/common/config_rowset_fwd.h",
       "configs": [
+        "segment_sort_key_sample_row_interval",
         "enable_transparent_data_encryption",
         "default_num_rows_per_column_file_block",
         "data_page_size",

--- a/be/src/common/config_rowset_fwd.h
+++ b/be/src/common/config_rowset_fwd.h
@@ -20,6 +20,14 @@
 #include "common/configbase.h"
 
 namespace starrocks::config {
+// Row interval between consecutive sort-key samples recorded by the segment
+// writer. Samples are consumed by tablet split and range-split parallel
+// compaction to accurately estimate row distribution for overlapping segments.
+// Setting to 0 disables sampling. The per-segment value is persisted in
+// SegmentMetadataPB.sort_key_sample_row_interval so that a runtime change
+// does not break cross-version readers.
+CONF_mInt64(segment_sort_key_sample_row_interval, "65536");
+
 CONF_Bool(enable_transparent_data_encryption, "false");
 
 // CONF_Int32(default_num_rows_per_data_block, "1024");

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -102,6 +102,7 @@ set(STORAGE_FILES
     rowset/data_sample.cpp
     rowset/dict_page.cpp
     rowset/segment.cpp
+    rowset/segment_file_info.cpp
     rowset/segment_writer.cpp
     rowset/segment_rewriter.cpp
     rowset/segment_group.cpp

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -85,8 +85,7 @@ Status CompactionTask::fill_compaction_segment_info(TxnLogPB_OpCompaction* op_co
             op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
             op_compaction->mutable_output_rowset()->add_segment_encryption_metas(file.encryption_meta);
             auto* segment_meta = op_compaction->mutable_output_rowset()->add_segment_metas();
-            file.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
-            file.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
+            file.write_sort_key_fields_to(segment_meta);
             segment_meta->set_num_rows(file.num_rows);
             segment_meta->set_segment_idx(segment_idx);
         }

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -804,8 +804,7 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
             op_write->mutable_rowset()->add_bundle_file_offsets(f.bundle_file_offset.value());
         }
         auto* segment_meta = op_write->mutable_rowset()->add_segment_metas();
-        f.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
-        f.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
+        f.write_sort_key_fields_to(segment_meta);
         segment_meta->set_num_rows(f.num_rows);
         segment_meta->set_segment_idx(segment_idx);
     }

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -241,8 +241,7 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
             // This is a bundle data file.
             segment_file_info.bundle_file_offset = _seg_writer->bundle_file_offset();
         }
-        segment_file_info.sort_key_min = _seg_writer->get_sort_key_min();
-        segment_file_info.sort_key_max = _seg_writer->get_sort_key_max();
+        _seg_writer->write_sort_key_fields_to(segment_file_info);
         segment_file_info.num_rows = _seg_writer->num_rows();
         // Record the vector index IDs configured for this segment. For non-empty segments
         // VectorIndexWriter::finish() always produces a .vi file (real index or empty-mark)
@@ -391,8 +390,7 @@ Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
         segment_file_info.path = std::string(basename(segment_path));
         segment_file_info.size = segment_size;
         segment_file_info.encryption_meta = segment_writer->encryption_meta();
-        segment_file_info.sort_key_min = segment_writer->get_sort_key_min();
-        segment_file_info.sort_key_max = segment_writer->get_sort_key_max();
+        segment_writer->write_sort_key_fields_to(segment_file_info);
         segment_file_info.num_rows = segment_writer->num_rows();
         // Record the vector index IDs configured for this segment. See the matching
         // comment in HorizontalGeneralTabletWriter: a zero-row segment writes no .vi

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -126,8 +126,7 @@ Status HorizontalPkTabletWriter::flush_segment_writer(SegmentPB* segment) {
             // This is a shared data file.
             segment_file_info.bundle_file_offset = _seg_writer->bundle_file_offset();
         }
-        segment_file_info.sort_key_min = _seg_writer->get_sort_key_min();
-        segment_file_info.sort_key_max = _seg_writer->get_sort_key_max();
+        _seg_writer->write_sort_key_fields_to(segment_file_info);
         segment_file_info.num_rows = _seg_writer->num_rows();
         _data_size += segment_size;
         collect_writer_stats(_stats, _seg_writer.get());

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -218,8 +218,7 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
         }
         if (metadata().segment_metas_size() > 0) {
             auto* segment_meta = op_compaction->mutable_output_rowset()->add_segment_metas();
-            file.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
-            file.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
+            file.write_sort_key_fields_to(segment_meta);
             segment_meta->set_num_rows(file.num_rows);
             segment_meta->set_segment_idx(next_segment_id++);
         }

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -248,8 +248,7 @@ Status DirectSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
         new_rowset_metadata->add_segment_size(f.size.value());
         new_rowset_metadata->add_segment_encryption_metas(f.encryption_meta);
         auto* segment_meta = new_rowset_metadata->add_segment_metas();
-        f.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
-        f.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
+        f.write_sort_key_fields_to(segment_meta);
         segment_meta->set_num_rows(f.num_rows);
         segment_meta->set_segment_idx(segment_idx);
     }
@@ -340,8 +339,7 @@ Status SortedSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
         new_rowset_metadata->add_segment_size(f.size.value());
         new_rowset_metadata->add_segment_encryption_metas(f.encryption_meta);
         auto* segment_meta = new_rowset_metadata->add_segment_metas();
-        f.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
-        f.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
+        f.write_sort_key_fields_to(segment_meta);
         segment_meta->set_num_rows(f.num_rows);
         segment_meta->set_segment_idx(segment_idx);
     }

--- a/be/src/storage/lake/spark_load.cpp
+++ b/be/src/storage/lake/spark_load.cpp
@@ -122,8 +122,7 @@ Status SparkLoadHandler::_load_convert(VersionedTablet& cur_tablet) {
         op_write->mutable_rowset()->add_segment_size(f.size.value());
         op_write->mutable_rowset()->add_segment_encryption_metas(f.encryption_meta);
         auto* segment_meta = op_write->mutable_rowset()->add_segment_metas();
-        f.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
-        f.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
+        f.write_sort_key_fields_to(segment_meta);
         segment_meta->set_num_rows(f.num_rows);
         segment_meta->set_segment_idx(segment_idx);
     }

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -2378,15 +2378,15 @@ bool TabletParallelCompactionManager::_can_use_range_split(const std::vector<Row
         return false;
     }
     for (const auto& rowset : rowsets) {
-        const auto& meta = rowset->metadata();
-        if (meta.segment_metas_size() == 0) {
+        const auto& rowset_meta = rowset->metadata();
+        if (rowset_meta.segment_metas_size() == 0) {
             return false;
         }
-        for (const auto& seg_meta : meta.segment_metas()) {
-            if (!seg_meta.has_sort_key_min() || !seg_meta.has_sort_key_max()) {
+        for (const auto& segment_meta : rowset_meta.segment_metas()) {
+            if (!segment_meta.has_sort_key_min() || !segment_meta.has_sort_key_max()) {
                 return false;
             }
-            if (seg_meta.sort_key_min().values_size() == 0 || seg_meta.sort_key_max().values_size() == 0) {
+            if (segment_meta.sort_key_min().values_size() == 0 || segment_meta.sort_key_max().values_size() == 0) {
                 return false;
             }
         }
@@ -2396,29 +2396,30 @@ bool TabletParallelCompactionManager::_can_use_range_split(const std::vector<Row
 
 StatusOr<std::vector<SegmentSplitInfo>> TabletParallelCompactionManager::_collect_segment_key_bounds(
         const std::vector<RowsetPtr>& rowsets) {
-    std::vector<SegmentSplitInfo> seg_bounds;
+    std::vector<SegmentSplitInfo> segments;
 
     for (const auto& rowset : rowsets) {
-        const auto& meta = rowset->metadata();
-        int32_t num_segments = meta.segment_metas_size();
+        const auto& rowset_meta = rowset->metadata();
+        int32_t num_segments = rowset_meta.segment_metas_size();
         int64_t rowset_data_size = rowset->data_size();
         int64_t rowset_num_rows = rowset->num_rows();
 
-        for (const auto& seg_meta : meta.segment_metas()) {
-            SegmentSplitInfo bound;
-            RETURN_IF_ERROR(bound.min_key.from_proto(seg_meta.sort_key_min()));
-            RETURN_IF_ERROR(bound.max_key.from_proto(seg_meta.sort_key_max()));
-            bound.num_rows = seg_meta.has_num_rows() ? seg_meta.num_rows() : 0;
-            if (bound.num_rows > 0 && rowset_num_rows > 0) {
-                bound.data_size = rowset_data_size * bound.num_rows / rowset_num_rows;
+        for (const auto& segment_meta : rowset_meta.segment_metas()) {
+            SegmentSplitInfo segment;
+            RETURN_IF_ERROR(segment.min_key.from_proto(segment_meta.sort_key_min()));
+            RETURN_IF_ERROR(segment.max_key.from_proto(segment_meta.sort_key_max()));
+            segment.num_rows = segment_meta.has_num_rows() ? segment_meta.num_rows() : 0;
+            if (segment.num_rows > 0 && rowset_num_rows > 0) {
+                segment.data_size = rowset_data_size * segment.num_rows / rowset_num_rows;
             } else if (num_segments > 0) {
-                bound.data_size = rowset_data_size / num_segments;
+                segment.data_size = rowset_data_size / num_segments;
             }
-            seg_bounds.push_back(std::move(bound));
+            RETURN_IF_ERROR(segment.load_sort_key_samples(segment_meta));
+            segments.push_back(std::move(segment));
         }
     }
 
-    return seg_bounds;
+    return segments;
 }
 
 OlapTuple TabletParallelCompactionManager::_variant_tuple_to_olap_tuple(const VariantTuple& vt) {
@@ -2438,17 +2439,17 @@ OlapTuple TabletParallelCompactionManager::_variant_tuple_to_olap_tuple(const Va
 std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_range_split_groups(
         int64_t tablet_id, const std::vector<RowsetPtr>& rowsets, int32_t max_parallel, int64_t max_bytes_per_subtask) {
     // Collect segment key bounds
-    auto seg_bounds_or = _collect_segment_key_bounds(rowsets);
-    if (!seg_bounds_or.ok() || seg_bounds_or.value().empty()) {
+    auto segments_or = _collect_segment_key_bounds(rowsets);
+    if (!segments_or.ok() || segments_or.value().empty()) {
         VLOG(1) << "Range split: tablet=" << tablet_id << " failed to collect segment key bounds, fallback";
         return {};
     }
-    auto& seg_bounds = seg_bounds_or.value();
+    auto& segments = segments_or.value();
 
     // Calculate total data
     int64_t total_bytes = 0;
-    for (const auto& bound : seg_bounds) {
-        total_bytes += bound.data_size;
+    for (const auto& segment : segments) {
+        total_bytes += segment.data_size;
     }
 
     int32_t target_subtasks = std::min(
@@ -2456,7 +2457,7 @@ std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_range_split_g
     target_subtasks = std::max(2, target_subtasks);
 
     // Use calculate_range_split_boundaries from tablet_splitter to compute boundaries
-    auto split_result_or = calculate_range_split_boundaries(seg_bounds, target_subtasks, max_bytes_per_subtask,
+    auto split_result_or = calculate_range_split_boundaries(segments, target_subtasks, max_bytes_per_subtask,
                                                             /*use_num_rows=*/false);
     if (!split_result_or.ok() || split_result_or.value().boundaries.empty()) {
         VLOG(1) << "Range split: tablet=" << tablet_id << " failed to calculate boundaries, fallback";
@@ -2500,7 +2501,7 @@ std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_range_split_g
     }
 
     VLOG(1) << "Range split: tablet=" << tablet_id << " created " << groups.size() << " range split subtasks"
-            << " from " << rowsets.size() << " rowsets, " << seg_bounds.size() << " segments"
+            << " from " << rowsets.size() << " rowsets, " << segments.size() << " segments"
             << ", boundaries=" << boundaries.size() << ", total_bytes=" << total_bytes;
 
     return groups;

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -15,6 +15,7 @@
 #include "storage/lake/tablet_splitter.h"
 
 #include <bvar/bvar.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <set>
@@ -32,6 +33,149 @@ extern bvar::Adder<int64_t> g_tablet_reshard_split_fallback_total;
 
 namespace starrocks::lake {
 
+Status SegmentSplitInfo::load_sort_key_samples(const SegmentMetadataPB& segment_meta) {
+    if (segment_meta.sort_key_samples_size() == 0 || !segment_meta.has_sort_key_sample_row_interval()) {
+        return Status::OK();
+    }
+    const int64_t row_interval = segment_meta.sort_key_sample_row_interval();
+    const int64_t num_samples = segment_meta.sort_key_samples_size();
+    // Overflow-safe validity: sort_key_samples.size() * row_interval < num_rows.
+    if (!(row_interval > 0 && num_rows > 0 && num_samples <= (num_rows - 1) / row_interval)) {
+        return Status::OK(); // Invalid metadata -- fall through with empty samples.
+    }
+    sort_key_sample_row_interval = row_interval;
+    sort_key_samples.reserve(num_samples);
+    for (const auto& sample_pb : segment_meta.sort_key_samples()) {
+        VariantTuple sample;
+        RETURN_IF_ERROR(sample.from_proto(sample_pb));
+        DCHECK(sort_key_samples.empty() || sort_key_samples.back().compare(sample) <= 0);
+        sort_key_samples.push_back(std::move(sample));
+    }
+    return Status::OK();
+}
+
+// ================================================================================
+// Internal data structures and helpers for range splitting
+// ================================================================================
+
+namespace {
+
+struct RangeInfo {
+    VariantTuple min;
+    VariantTuple max;
+    int64_t num_rows = 0;
+    int64_t data_size = 0;
+    SourceStats source_stats;
+};
+
+// Find ordered_ranges overlapping [sub_min, sub_max].
+// For zero-width sub-segments (sub_min == sub_max), uses [lower, upper) point
+// ownership: non-last range owns x iff r.min <= x < r.max; last range owns x
+// iff r.min <= x <= r.max. For non-zero-width sub-segments, uses the standard
+// two-comparator binary-search overlap rule.
+void find_overlapping_ranges(const VariantTuple& sub_min, const VariantTuple& sub_max,
+                             std::vector<RangeInfo>& ordered_ranges, std::vector<RangeInfo*>& result) {
+    result.clear();
+    const size_t last_range_index = ordered_ranges.size() - 1;
+
+    if (sub_min.compare(sub_max) == 0) {
+        // Zero-width: point ownership matching split output [lower, upper).
+        for (size_t i = 0; i < ordered_ranges.size(); ++i) {
+            auto& r = ordered_ranges[i];
+            bool owns = (i != last_range_index) ? (r.min.compare(sub_min) <= 0 && sub_min.compare(r.max) < 0)
+                                                : (r.min.compare(sub_min) <= 0 && sub_min.compare(r.max) <= 0);
+            if (owns) {
+                result.push_back(&r);
+                return;
+            }
+        }
+        return;
+    }
+
+    // Non-zero-width: binary search for the first overlapping range.
+    size_t lo = 0, hi = ordered_ranges.size();
+    while (lo < hi) {
+        size_t mid = lo + (hi - lo) / 2;
+        int cmp = ordered_ranges[mid].max.compare(sub_min);
+        if ((mid == last_range_index) ? (cmp < 0) : (cmp <= 0)) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    for (size_t i = lo; i < ordered_ranges.size(); i++) {
+        auto& r = ordered_ranges[i];
+        if (r.min.compare(sub_max) > 0) break;
+        if (i != last_range_index && r.min.compare(sub_max) >= 0) break;
+        result.push_back(&r);
+    }
+}
+
+// Distribute num_rows/data_size evenly across overlapping ranges with remainder
+// correction, optionally tracking per-source statistics.
+void distribute_to_ranges(const std::vector<RangeInfo*>& overlapping, int64_t num_rows, int64_t data_size,
+                          uint32_t source_id, bool track_sources) {
+    if (overlapping.empty()) return;
+    const auto count = static_cast<int64_t>(overlapping.size());
+    for (int64_t i = 0; i < count; i++) {
+        int64_t delta_rows = num_rows / count + (i < num_rows % count ? 1 : 0);
+        int64_t delta_size = data_size / count + (i < data_size % count ? 1 : 0);
+        overlapping[i]->num_rows += delta_rows;
+        overlapping[i]->data_size += delta_size;
+        if (track_sources) {
+            auto& stats = overlapping[i]->source_stats[source_id];
+            stats.first += delta_rows;
+            stats.second += delta_size;
+        }
+    }
+}
+
+// Distribute one segment's data across ordered_ranges. When the segment has
+// sort-key samples, it is split into N+1 sub-segments with known row counts;
+// otherwise, the entire segment is treated as a single [min_key, max_key] range.
+void distribute_segment_to_ranges(const SegmentSplitInfo& segment, std::vector<RangeInfo>& ordered_ranges,
+                                  bool track_sources) {
+    if (segment.num_rows == 0 && segment.data_size == 0) return;
+
+    std::vector<RangeInfo*> overlapping;
+    const int64_t num_samples = static_cast<int64_t>(segment.sort_key_samples.size());
+
+    if (num_samples == 0) {
+        find_overlapping_ranges(segment.min_key, segment.max_key, ordered_ranges, overlapping);
+        distribute_to_ranges(overlapping, segment.num_rows, segment.data_size, segment.source_id, track_sources);
+        return;
+    }
+
+    // Sampled path: N+1 sub-segments with known row counts.
+    const int64_t row_interval = segment.sort_key_sample_row_interval;
+    const int64_t tail_rows = segment.num_rows - num_samples * row_interval;
+    DCHECK_GT(tail_rows, 0);
+
+    // bound(k) returns the k-th sub-segment boundary; k in [0, num_samples+1].
+    auto bound = [&](int64_t k) -> const VariantTuple& {
+        if (k == 0) return segment.min_key;
+        if (k == num_samples + 1) return segment.max_key;
+        return segment.sort_key_samples[k - 1];
+    };
+    // Per-sub-segment byte share; 128-bit intermediate avoids signed overflow.
+    auto bytes_for = [&](int64_t rows) -> int64_t {
+        return static_cast<int64_t>((static_cast<__int128>(rows) * segment.data_size) / segment.num_rows);
+    };
+
+    int64_t bytes_assigned = 0;
+    for (int64_t k = 0; k <= num_samples; ++k) {
+        const int64_t sub_rows = (k < num_samples) ? row_interval : tail_rows;
+        DCHECK_GT(sub_rows, 0);
+        const int64_t sub_bytes = (k == num_samples) ? (segment.data_size - bytes_assigned) : bytes_for(sub_rows);
+        bytes_assigned += sub_bytes;
+        find_overlapping_ranges(bound(k), bound(k + 1), ordered_ranges, overlapping);
+        distribute_to_ranges(overlapping, sub_rows, sub_bytes, segment.source_id, track_sources);
+    }
+    DCHECK_EQ(bytes_assigned, segment.data_size);
+}
+
+} // anonymous namespace
+
 // ================================================================================
 // Core range split algorithm (public API)
 // ================================================================================
@@ -46,12 +190,15 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
         return result;
     }
 
-    // Step 1: Collect all unique boundary points and sort them.
+    // Step 1: Collect all unique boundary points (including sort-key samples) and sort them.
     auto comparator = [](const VariantTuple* a, const VariantTuple* b) { return a->compare(*b) < 0; };
     std::set<const VariantTuple*, decltype(comparator)> ordered_boundaries(comparator);
-    for (const auto& seg : segments) {
-        ordered_boundaries.insert(&seg.min_key);
-        ordered_boundaries.insert(&seg.max_key);
+    for (const auto& segment : segments) {
+        ordered_boundaries.insert(&segment.min_key);
+        ordered_boundaries.insert(&segment.max_key);
+        for (const auto& sample : segment.sort_key_samples) {
+            ordered_boundaries.insert(&sample);
+        }
     }
 
     if (ordered_boundaries.size() < 2) {
@@ -59,14 +206,6 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
     }
 
     // Step 2: Build ordered ranges between adjacent boundary points.
-    struct RangeInfo {
-        VariantTuple min;
-        VariantTuple max;
-        int64_t num_rows = 0;
-        int64_t data_size = 0;
-        SourceStats source_stats;
-    };
-
     std::vector<RangeInfo> ordered_ranges;
     ordered_ranges.reserve(ordered_boundaries.size());
     const VariantTuple* last_boundary = nullptr;
@@ -83,60 +222,9 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
         return result;
     }
 
-    // Step 3: Distribute segment data proportionally across overlapping ranges.
-    // Use binary search to find the first overlapping range for each segment.
-    size_t last_range_idx = ordered_ranges.size() - 1;
-    for (const auto& seg : segments) {
-        // Binary search for the first range whose max_key could overlap with seg.min_key.
-        size_t lo = 0, hi = ordered_ranges.size();
-        while (lo < hi) {
-            size_t mid = lo + (hi - lo) / 2;
-            bool mid_is_last = (mid == last_range_idx);
-            int cmp = ordered_ranges[mid].max.compare(seg.min_key);
-            if (mid_is_last ? (cmp < 0) : (cmp <= 0)) {
-                lo = mid + 1;
-            } else {
-                hi = mid;
-            }
-        }
-
-        // Scan forward from 'lo' to collect all overlapping ranges.
-        std::vector<RangeInfo*> overlapping;
-        for (size_t ri = lo; ri < ordered_ranges.size(); ri++) {
-            auto& range = ordered_ranges[ri];
-            if (range.min.compare(seg.max_key) > 0) {
-                break;
-            }
-            if (ri != last_range_idx && range.min.compare(seg.max_key) >= 0) {
-                break;
-            }
-            overlapping.push_back(&range);
-        }
-
-        if (overlapping.empty()) {
-            continue;
-        }
-
-        auto count = static_cast<int64_t>(overlapping.size());
-
-        int64_t rows_per_range = seg.num_rows / count;
-        int64_t rows_remainder = seg.num_rows % count;
-        int64_t size_per_range = seg.data_size / count;
-        int64_t size_remainder = seg.data_size % count;
-
-        for (int64_t i = 0; i < count; i++) {
-            int64_t delta_rows = rows_per_range + (i < rows_remainder ? 1 : 0);
-            int64_t delta_size = size_per_range + (i < size_remainder ? 1 : 0);
-
-            overlapping[i]->num_rows += delta_rows;
-            overlapping[i]->data_size += delta_size;
-
-            if (track_sources) {
-                auto& stats = overlapping[i]->source_stats[seg.source_id];
-                stats.first += delta_rows;
-                stats.second += delta_size;
-            }
-        }
+    // Step 3: Distribute segment data across overlapping ranges.
+    for (const auto& segment : segments) {
+        distribute_segment_to_ranges(segment, ordered_ranges, track_sources);
     }
 
     // Step 4: Calculate split boundaries using a greedy algorithm.
@@ -240,18 +328,19 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
     }
 
     {
-        size_t boundary_idx = 0;
+        size_t boundary_index = 0;
         for (const auto* range : candidate_ranges) {
-            while (boundary_idx < result.boundaries.size() && range->max.compare(result.boundaries[boundary_idx]) > 0) {
-                boundary_idx++;
+            while (boundary_index < result.boundaries.size() &&
+                   range->max.compare(result.boundaries[boundary_index]) > 0) {
+                boundary_index++;
             }
-            int32_t group_idx = std::min(static_cast<int32_t>(boundary_idx), num_splits - 1);
-            result.range_data_sizes[group_idx] += range->data_size;
-            result.range_num_rows[group_idx] += range->num_rows;
+            int32_t group_index = std::min(static_cast<int32_t>(boundary_index), num_splits - 1);
+            result.range_data_sizes[group_index] += range->data_size;
+            result.range_num_rows[group_index] += range->num_rows;
 
             if (track_sources) {
                 for (const auto& [source_id, stats_pair] : range->source_stats) {
-                    auto& dest = result.range_source_stats[group_idx][source_id];
+                    auto& dest = result.range_source_stats[group_index][source_id];
                     dest.first += stats_pair.first;
                     dest.second += stats_pair.second;
                 }
@@ -338,6 +427,15 @@ void allocate_rowset_num_dels_across_splits(uint32_t source_id, int64_t total_nu
     }
 }
 
+// Compute split_count tablet ranges covering the tablet's key space.
+//
+// Postcondition on Status::OK: split_ranges->size() == split_count.
+// When the algorithm cannot produce exactly that many ranges (insufficient
+// boundary points given the segment key distribution), returns
+// Status::InvalidArgument with split_ranges cleared. The caller (split_tablet)
+// is expected to fall back to identical-tablet publish; only new_tablet_ids(0)
+// is consumed in that case, and FE is responsible for reclaiming the remaining
+// preallocated tablet ids.
 Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
                                int32_t split_count, std::vector<TabletRangeInfo>* split_ranges) {
     if (split_count < 2) {
@@ -352,14 +450,15 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
             return Status::InvalidArgument("Segment metadata is inconsistent with segment list");
         }
         for (int32_t i = 0; i < rowset.segments_size(); ++i) {
-            SegmentSplitInfo seg;
-            seg.source_id = rowset.id();
+            SegmentSplitInfo segment;
+            segment.source_id = rowset.id();
             const auto& segment_meta = rowset.segment_metas(i);
-            RETURN_IF_ERROR(seg.min_key.from_proto(segment_meta.sort_key_min()));
-            RETURN_IF_ERROR(seg.max_key.from_proto(segment_meta.sort_key_max()));
-            seg.num_rows = segment_meta.num_rows();
-            seg.data_size = rowset.segment_size(i);
-            segments.push_back(std::move(seg));
+            RETURN_IF_ERROR(segment.min_key.from_proto(segment_meta.sort_key_min()));
+            RETURN_IF_ERROR(segment.max_key.from_proto(segment_meta.sort_key_max()));
+            segment.num_rows = segment_meta.num_rows();
+            segment.data_size = rowset.segment_size(i);
+            RETURN_IF_ERROR(segment.load_sort_key_samples(segment_meta));
+            segments.push_back(std::move(segment));
         }
     }
 
@@ -372,8 +471,8 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
     RETURN_IF_ERROR(tablet_range.from_proto(tablet_metadata->range()));
 
     int64_t total_num_rows = 0;
-    for (const auto& seg : segments) {
-        total_num_rows += seg.num_rows;
+    for (const auto& segment : segments) {
+        total_num_rows += segment.num_rows;
     }
     int64_t avg_num_rows = std::max<int64_t>(1, total_num_rows / split_count);
 
@@ -422,9 +521,14 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
         }
     }
 
-    if (split_ranges->size() < 2) {
+    if (split_ranges->size() != static_cast<size_t>(split_count)) {
+        LOG(WARNING) << "Insufficient split boundaries: tablet_id=" << tablet_metadata->id()
+                     << " version=" << tablet_metadata->version() << " requested=" << split_count
+                     << " produced=" << split_ranges->size();
+        auto produced = split_ranges->size();
         split_ranges->clear();
-        return Status::InvalidArgument("Not enough split ranges available");
+        return Status::InvalidArgument(
+                fmt::format("Insufficient split boundaries: requested {}, produced {}", split_count, produced));
     }
 
     // Only PK tablets maintain delete vectors; duplicate/aggregate keys never populate
@@ -481,7 +585,14 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
         return new_metadatas;
     }
 
-    DCHECK(split_ranges.size() == splitting_tablet.new_tablet_ids_size());
+    // Defense-in-depth: get_tablet_split_ranges guarantees
+    // split_ranges.size() == new_tablet_ids_size() on OK, but a runtime check
+    // here prevents OOB reads into split_ranges[i] if the contract is ever
+    // broken by a future refactor (Release builds strip DCHECK).
+    if (split_ranges.size() != static_cast<size_t>(splitting_tablet.new_tablet_ids_size())) {
+        return Status::InternalError(fmt::format("split_ranges size mismatch: expected={}, actual={}",
+                                                 splitting_tablet.new_tablet_ids_size(), split_ranges.size()));
+    }
     for (int32_t i = 0; i < splitting_tablet.new_tablet_ids_size(); ++i) {
         auto new_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_metadata);
         new_tablet_new_metadata->set_id(splitting_tablet.new_tablet_ids(i));

--- a/be/src/storage/lake/tablet_splitter.h
+++ b/be/src/storage/lake/tablet_splitter.h
@@ -37,6 +37,24 @@ struct SegmentSplitInfo {
     int64_t num_rows = 0;
     int64_t data_size = 0;
     uint32_t source_id = 0; // Optional: for per-source statistics tracking (e.g., rowset_id)
+
+    // Equal-row-interval samples of the sort key (NON-DECREASING) and the row
+    // interval used to produce them. Populated from SegmentMetadataPB when
+    // available. Empty sort_key_samples <=> sort_key_sample_row_interval == 0.
+    // When non-empty, the producer guarantees
+    //   sort_key_samples.size() * sort_key_sample_row_interval < num_rows.
+    // Consumed by calculate_range_split_boundaries() to treat each segment as
+    // N+1 sub-segments with known row counts, instead of a single [min, max]
+    // range with a single divide-by-overlap-count estimate.
+    std::vector<VariantTuple> sort_key_samples;
+    int64_t sort_key_sample_row_interval = 0;
+
+    // Load sort-key samples from a SegmentMetadataPB. Validates that
+    // sort_key_samples.size() * sort_key_sample_row_interval < num_rows
+    // (overflow-safe); on failure, leaves sort_key_samples and
+    // sort_key_sample_row_interval at their defaults (empty/zero).
+    // Requires num_rows to be set before calling.
+    Status load_sort_key_samples(const SegmentMetadataPB& segment_meta);
 };
 
 // Per-range estimated statistics keyed by source_id.

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -712,8 +712,7 @@ Status UpdateManager::_handle_column_upsert_mode(const TxnLogPB_OpWrite& op_writ
         }
         uint32_t segment_idx = new_rows_op.rowset().segments_size() - 1;
         auto* segment_meta = new_rows_op.mutable_rowset()->add_segment_metas();
-        writer.get_sort_key_min().to_proto(segment_meta->mutable_sort_key_min());
-        writer.get_sort_key_max().to_proto(segment_meta->mutable_sort_key_max());
+        writer.write_sort_key_fields_to(segment_meta);
         segment_meta->set_num_rows(writer.num_rows());
         segment_meta->set_segment_idx(segment_idx);
 

--- a/be/src/storage/rowset/segment_file_info.cpp
+++ b/be/src/storage/rowset/segment_file_info.cpp
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/segment_file_info.h"
+
+#include "gen_cpp/lake_types.pb.h"
+
+namespace starrocks {
+
+void SegmentFileInfo::write_sort_key_fields_to(SegmentMetadataPB* segment_meta) const {
+    sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
+    sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
+    for (const auto& sample : sort_key_samples) {
+        sample.to_proto(segment_meta->add_sort_key_samples());
+    }
+    if (!sort_key_samples.empty() && sort_key_sample_row_interval > 0) {
+        segment_meta->set_sort_key_sample_row_interval(sort_key_sample_row_interval);
+    }
+}
+
+} // namespace starrocks

--- a/be/src/storage/rowset/segment_file_info.h
+++ b/be/src/storage/rowset/segment_file_info.h
@@ -21,12 +21,25 @@
 
 namespace starrocks {
 
+class SegmentMetadataPB;
+
 struct SegmentFileInfo : public FileInfo {
     VariantTuple sort_key_min;
     VariantTuple sort_key_max;
+    // Equal-row-interval samples of the sort key (NON-DECREASING) collected by
+    // SegmentWriter. May be empty for small segments (num_rows <= interval) or
+    // segments where sampling was not armed. Always paired with
+    // sort_key_sample_row_interval: samples.empty() <=> sort_key_sample_row_interval == 0.
+    std::vector<VariantTuple> sort_key_samples;
+    int64_t sort_key_sample_row_interval = 0;
     int64_t num_rows = 0;
     // IDs of vector indexes configured for this segment (one .vi file per id).
     std::vector<int64_t> vector_index_ids;
+
+    // Copy sort_key_min, sort_key_max, sort_key_samples, and
+    // sort_key_sample_row_interval into a SegmentMetadataPB. Does NOT
+    // set num_rows or segment_idx (callers handle those separately).
+    void write_sort_key_fields_to(SegmentMetadataPB* segment_meta) const;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -49,6 +49,7 @@
 #include "common/config_rowset_fwd.h"
 #include "common/logging.h" // LOG
 #include "fs/fs.h"          // FileSystem
+#include "gen_cpp/lake_types.pb.h"
 #include "gen_cpp/segment.pb.h"
 #include "storage/chunk_variant_helper.h"
 #include "storage/index/index_descriptor.h"
@@ -56,6 +57,7 @@
 #include "storage/rowset/column_writer.h" // ColumnWriter
 #include "storage/rowset/json_column_writer.h"
 #include "storage/rowset/page_io.h"
+#include "storage/rowset/segment_file_info.h"
 #include "storage/seek_tuple.h"
 #include "storage/short_key_index.h"
 #include "types/json_value.h"
@@ -276,6 +278,27 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
     if (_has_key) {
         _index_builder = std::make_unique<ShortKeyIndexBuilder>(_segment_id, _opts.num_rows_per_block);
     }
+
+    // Sort-key sampler one-shot init: arm only on the first key-columns pass.
+    // The vertical writer (general_tablet_writer.cpp) re-enters this init() for
+    // each non-key column group on the same SegmentWriter; we must preserve the
+    // previously armed state and the already-collected samples. Use the
+    // `has_key` parameter rather than the `_has_key` member so the check is
+    // independent of assignment ordering above.
+    //
+    // The vertical writer's invariant (general_tablet_writer.cpp:247) requires
+    // the first write_columns() call to have is_key=true, so _num_rows_written
+    // must be 0 here when has_key first becomes true. The DCHECK makes this
+    // contract crash-loud in debug/test builds; in release we fall back to
+    // leaving the sampler disabled instead of sampling mid-stream.
+    if (has_key && !_sort_column_indexes.empty() && _sort_key_sample_row_interval == 0) {
+        DCHECK_EQ(_num_rows_written, 0) << "sampler arm requires fresh writer";
+        const int64_t row_interval = config::segment_sort_key_sample_row_interval;
+        if (_num_rows_written == 0 && row_interval > 0) {
+            _sort_key_sample_row_interval = row_interval;
+            _next_sort_key_sample_row_index = row_interval;
+        }
+    }
     const auto& column = _tablet_schema->columns().back();
     if (column.name() == Schema::FULL_ROW_COLUMN) {
         std::vector<ColumnId> cids(_tablet_schema->num_columns() - 1);
@@ -288,6 +311,24 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
     _verify_footer();
 
     return Status::OK();
+}
+
+void SegmentWriter::write_sort_key_fields_to(SegmentFileInfo& file_info) {
+    file_info.sort_key_min = _sort_key_min;
+    file_info.sort_key_max = _sort_key_max;
+    file_info.sort_key_samples = std::move(_sort_key_samples);
+    file_info.sort_key_sample_row_interval = file_info.sort_key_samples.empty() ? 0 : _sort_key_sample_row_interval;
+}
+
+void SegmentWriter::write_sort_key_fields_to(SegmentMetadataPB* segment_meta) const {
+    _sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
+    _sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
+    for (const auto& sample : _sort_key_samples) {
+        sample.to_proto(segment_meta->add_sort_key_samples());
+    }
+    if (!_sort_key_samples.empty() && _sort_key_sample_row_interval > 0) {
+        segment_meta->set_sort_key_sample_row_interval(_sort_key_sample_row_interval);
+    }
 }
 
 // TODO(lingbin): Currently this function does not include the size of various indexes,
@@ -466,6 +507,15 @@ Status SegmentWriter::append_chunk(const Chunk& chunk) {
                 std::string encoded_key;
                 encoded_key = tuple.short_key_encode(keys, _sort_column_indexes, 0);
                 RETURN_IF_ERROR(_index_builder->add_item(encoded_key));
+            }
+            // Sort-key sample: take one tuple every _sort_key_sample_row_interval
+            // rows. Samples are at 0-indexed rows interval, 2*interval, 3*interval,
+            // ... so samples[k] is the key at row (k+1) * interval. The producer
+            // invariant samples.size() * interval < num_rows holds strictly
+            // because the last sample lands at row N*interval (< num_rows).
+            if (_sort_key_sample_row_interval > 0 && _num_rows_written == _next_sort_key_sample_row_index) {
+                _sort_key_samples.emplace_back(build_variant_tuple_from_chunk_row(chunk, i, _sort_column_indexes));
+                _next_sort_key_sample_row_index += _sort_key_sample_row_interval;
             }
             ++_num_rows_written;
         }

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -63,6 +63,8 @@ class WritableFile;
 class Chunk;
 class ColumnWriter;
 class Schema;
+struct SegmentFileInfo;
+class SegmentMetadataPB;
 
 extern const char* const k_segment_magic;
 extern const uint32_t k_segment_magic_length;
@@ -166,8 +168,21 @@ public:
     bool has_key() { return _has_key; }
 
     const VariantTuple& get_sort_key_min() { return _sort_key_min; }
-
     const VariantTuple& get_sort_key_max() { return _sort_key_max; }
+
+    // Transfer sort-key min, max, samples, and interval into a SegmentFileInfo.
+    // Moves _sort_key_samples out; preserves the carrier invariant
+    // (samples.empty() <=> interval == 0).
+    void write_sort_key_fields_to(SegmentFileInfo& file_info);
+
+    // Copy sort-key min, max, samples, and interval into a proto.
+    // Used by update_manager.cpp which reads from SegmentWriter directly
+    // instead of going through a SegmentFileInfo carrier.
+    void write_sort_key_fields_to(SegmentMetadataPB* segment_meta) const;
+
+    // Accessors for sort-key samples (used in unit tests).
+    int64_t get_sort_key_sample_row_interval() const { return _sort_key_sample_row_interval; }
+    const std::vector<VariantTuple>& get_sort_key_samples() const { return _sort_key_samples; }
 
     const std::map<int64_t, std::string>& vector_index_file_paths() const { return _opts.vector_index_file_paths; }
 
@@ -195,6 +210,13 @@ private:
     std::vector<uint32_t> _sort_column_indexes;
     VariantTuple _sort_key_min;
     VariantTuple _sort_key_max;
+
+    // Sort-key sampler state. Armed at most once, on the first init() call
+    // with has_key=true and non-empty _sort_column_indexes. Preserved across
+    // vertical-writer non-key column-group re-init calls.
+    std::vector<VariantTuple> _sort_key_samples;
+    int64_t _next_sort_key_sample_row_index = 0;
+    int64_t _sort_key_sample_row_interval = 0; // 0 = disabled / not yet armed
     std::unique_ptr<Schema> _schema_without_full_row_column;
 
     // num rows written when appending [partial] columns

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -449,6 +449,7 @@ SET(DW_TEST_FILES
     ./storage/lake/primary_key_publish_test.cpp
     ./storage/lake/tablet_reshard_helper_test.cpp
     ./storage/lake/tablet_reshard_test.cpp
+    ./storage/lake/tablet_splitter_test.cpp
     ./storage/lake/replication_txn_manager_test.cpp
     ./storage/lake/rowset_test.cpp
     ./storage/lake/segment_metadata_filter_test.cpp
@@ -533,6 +534,7 @@ SET(DW_TEST_FILES
     ./storage/rowset/segment_iterator_test.cpp
     ./storage/rowset/segment_rewriter_test.cpp
     ./storage/rowset/segment_test.cpp
+    ./storage/rowset/segment_writer_sort_key_sampling_test.cpp
     ./storage/rowset/series_column_iterator_test.cpp
     ./storage/rowset/struct_column_rw_test.cpp
     ./storage/rowset/unique_rowset_id_generator_test.cpp

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -313,6 +313,65 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting) {
     EXPECT_EQ(0, tablet_ranges.size());
 }
 
+// Regression for the crash discovered during SSB SF100 testing: FE requests
+// N new tablet ids, but the sampled algorithm can only produce M < N ranges.
+// Before the fix, get_tablet_split_ranges silently returned M ranges and
+// split_tablet read OOB on split_ranges[M..N-1]. Now get_tablet_split_ranges
+// returns InvalidArgument and split_tablet falls back to identical-tablet
+// publish (only new_tablet_ids(0) consumed).
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_fewer_ranges_than_requested_falls_back) {
+    starrocks::TabletMetadata metadata;
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+
+    // Single segment with 2 sort-key samples -> 4 boundary points -> 3
+    // candidate ranges. Requesting 8 splits cannot be satisfied.
+    auto* rowset_meta_pb = metadata.add_rowsets();
+    rowset_meta_pb->set_id(2);
+    rowset_meta_pb->add_segments("seg_0.dat");
+    rowset_meta_pb->add_segment_size(1024);
+    auto* segment_meta = rowset_meta_pb->add_segment_metas();
+    segment_meta->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    segment_meta->mutable_sort_key_max()->CopyFrom(generate_sort_key(300));
+    segment_meta->set_num_rows(300);
+    segment_meta->set_sort_key_sample_row_interval(100);
+    segment_meta->add_sort_key_samples()->CopyFrom(generate_sort_key(100));
+    segment_meta->add_sort_key_samples()->CopyFrom(generate_sort_key(200));
+    rowset_meta_pb->set_num_rows(300);
+    rowset_meta_pb->set_data_size(1024);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting_tablet = *resharding.mutable_splitting_tablet_info();
+    splitting_tablet.set_old_tablet_id(tablet_id);
+    for (int i = 0; i < 8; ++i) {
+        splitting_tablet.add_new_tablet_ids(next_id());
+    }
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto res =
+            lake::publish_resharding_tablet(_tablet_manager.get(), resharding, metadata.version(),
+                                            metadata.version() + 1, txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_OK(res);
+    // Fallback produces: old_tablet_id (committed under new_version) +
+    // new_tablet_ids(0) carrying all data. The remaining 7 new tablet ids
+    // are abandoned by BE; FE is responsible for reclaiming them.
+    EXPECT_EQ(2U, tablet_metadatas.size());
+    EXPECT_EQ(1U, tablet_ranges.size());
+    EXPECT_TRUE(tablet_metadatas.count(tablet_id));
+    EXPECT_TRUE(tablet_metadatas.count(splitting_tablet.new_tablet_ids(0)));
+    for (int i = 1; i < splitting_tablet.new_tablet_ids_size(); ++i) {
+        EXPECT_FALSE(tablet_metadatas.count(splitting_tablet.new_tablet_ids(i)));
+    }
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_splitting_with_gap_boundary) {
     starrocks::TabletMetadata metadata;
     auto tablet_id = next_id();

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -1,0 +1,419 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_splitter.h"
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "storage/tablet_range.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks::lake {
+
+namespace {
+
+static VariantTuple make_int_tuple(int64_t value) {
+    VariantTuple tuple;
+    tuple.append(DatumVariant(get_type_info(LogicalType::TYPE_BIGINT), Datum(value)));
+    return tuple;
+}
+
+// Build a SegmentSplitInfo without samples.
+static SegmentSplitInfo make_seg(int64_t min_v, int64_t max_v, int64_t num_rows, int64_t data_size,
+                                 uint32_t source_id = 0) {
+    SegmentSplitInfo s;
+    s.min_key = make_int_tuple(min_v);
+    s.max_key = make_int_tuple(max_v);
+    s.num_rows = num_rows;
+    s.data_size = data_size;
+    s.source_id = source_id;
+    return s;
+}
+
+// Build a SegmentSplitInfo with sort-key samples at row interval `row_interval`
+// and row count covering exactly N samples + tail, where N = sample_values.size().
+// Producer invariant: sort_key_samples.size() * row_interval < num_rows.
+static SegmentSplitInfo make_sampled_seg(int64_t min_v, int64_t max_v, int64_t num_rows, int64_t data_size,
+                                         int64_t row_interval, const std::vector<int64_t>& sample_values,
+                                         uint32_t source_id = 0) {
+    SegmentSplitInfo s = make_seg(min_v, max_v, num_rows, data_size, source_id);
+    s.sort_key_sample_row_interval = row_interval;
+    s.sort_key_samples.reserve(sample_values.size());
+    for (int64_t v : sample_values) {
+        s.sort_key_samples.push_back(make_int_tuple(v));
+    }
+    return s;
+}
+
+// Sum of per-source row/byte stats across all split groups for a given source.
+static std::pair<int64_t, int64_t> sum_source_stats(const RangeSplitResult& result, uint32_t source_id) {
+    int64_t rows = 0;
+    int64_t bytes = 0;
+    for (const auto& group : result.range_source_stats) {
+        auto it = group.find(source_id);
+        if (it != group.end()) {
+            rows += it->second.first;
+            bytes += it->second.second;
+        }
+    }
+    return {rows, bytes};
+}
+
+} // namespace
+
+// -----------------------------------------------------------------------------
+// Baseline: N == 0 (no samples) matches pre-sampling behavior on non-degenerate
+// segments. A single segment produces exactly 1 ordered range (two boundary
+// points: its min and its max). The algorithm needs at least `split_count`
+// non-empty ranges to produce a boundary, so a single segment alone cannot
+// be split into 2 — this mirrors the pre-sampling algorithm's behavior and
+// is the reason the real RCA required >1 overlapping segment.
+// Two non-overlapping segments produce 2 ordered ranges and can therefore
+// be split.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterTest, two_disjoint_segments_no_samples_split_in_half) {
+    std::vector<SegmentSplitInfo> segs = {make_seg(0, 50, 100, 1000, /*source_id=*/1),
+                                          make_seg(100, 200, 100, 1000, /*source_id=*/2)};
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/100,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true));
+    ASSERT_EQ(1, result.boundaries.size());
+    ASSERT_EQ(2, result.range_num_rows.size());
+    EXPECT_EQ(200, result.range_num_rows[0] + result.range_num_rows[1]);
+    EXPECT_EQ(2000, result.range_data_sizes[0] + result.range_data_sizes[1]);
+    auto [s1_rows, s1_bytes] = sum_source_stats(result, 1);
+    auto [s2_rows, s2_bytes] = sum_source_stats(result, 2);
+    EXPECT_EQ(100, s1_rows);
+    EXPECT_EQ(1000, s1_bytes);
+    EXPECT_EQ(100, s2_rows);
+    EXPECT_EQ(1000, s2_bytes);
+}
+
+// A single segment (only 1 ordered range exists) cannot be 2-way split; the
+// algorithm returns empty boundaries rather than fabricating one. Matches
+// pre-sampling behavior exactly.
+TEST(TabletSplitterTest, single_segment_cannot_split_without_samples) {
+    std::vector<SegmentSplitInfo> segs = {make_seg(0, 100, 100, 1000, /*source_id=*/1)};
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/50,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true));
+    EXPECT_TRUE(result.boundaries.empty()) << "1 segment yields 1 range; cannot produce N>=2 splits without samples";
+}
+
+// -----------------------------------------------------------------------------
+// With samples, the algorithm can split overlapping segments accurately.
+// Two overlapping segments each [0, 100] with 10 samples each (11 sub-segments
+// of 9 or 10 rows). A 2-way split should land near the median, and row total
+// should be exactly preserved.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterTest, overlapping_segments_with_samples_balanced_split) {
+    // 2 segments, each 100 rows, 10 samples at rows 10, 20, ..., 90.
+    std::vector<int64_t> samples;
+    for (int64_t v = 10; v < 100; v += 10) samples.push_back(v);
+
+    std::vector<SegmentSplitInfo> segs;
+    segs.push_back(make_sampled_seg(0, 100, 100, 1000, /*iv=*/10, samples, /*source_id=*/1));
+    segs.push_back(make_sampled_seg(0, 100, 100, 1000, /*iv=*/10, samples, /*source_id=*/2));
+
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/100,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true));
+    ASSERT_EQ(1, result.boundaries.size());
+
+    int64_t total_rows = 0;
+    int64_t total_bytes = 0;
+    for (int i = 0; i < 2; ++i) {
+        total_rows += result.range_num_rows[i];
+        total_bytes += result.range_data_sizes[i];
+    }
+    EXPECT_EQ(200, total_rows);
+    EXPECT_EQ(2000, total_bytes);
+
+    // Each side should be roughly balanced (±20 rows acceptable due to sample
+    // granularity); if sampling is doing its job this should be much tighter
+    // than a by-overlap-count baseline.
+    EXPECT_LT(std::abs(result.range_num_rows[0] - result.range_num_rows[1]), 30);
+}
+
+// -----------------------------------------------------------------------------
+// Off-by-one: a sample equals max_key (producer's off-by-one when
+// num_rows == N * interval + 1). The tail sub-segment is [max, max], a
+// zero-width point. The point-ownership fallback must credit the rightmost
+// range whose r.max == global_max (via the last-range closed comparator).
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterTest, zero_width_tail_sample_equals_max) {
+    // Segment with num_rows = interval + 1 = 11, one sample at row 10 which
+    // coincidentally equals max_key.
+    auto seg = make_sampled_seg(/*min=*/0, /*max=*/50, /*num_rows=*/11, /*data_size=*/110,
+                                /*iv=*/10, /*samples=*/{50}, /*source_id=*/1);
+    // Include a second non-overlapping segment so ordered_ranges.size() >= 2.
+    auto seg2 = make_seg(/*min=*/100, /*max=*/200, /*num_rows=*/50, /*data_size=*/500, /*source_id=*/2);
+
+    std::vector<SegmentSplitInfo> segs = {seg, seg2};
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/30,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true));
+
+    // Conservation: all 61 rows and 610 bytes must be credited somewhere.
+    auto [s1_rows, s1_bytes] = sum_source_stats(result, 1);
+    auto [s2_rows, s2_bytes] = sum_source_stats(result, 2);
+    EXPECT_EQ(11, s1_rows);
+    EXPECT_EQ(110, s1_bytes);
+    EXPECT_EQ(50, s2_rows);
+    EXPECT_EQ(500, s2_bytes);
+}
+
+// -----------------------------------------------------------------------------
+// Leading-min duplicate: first sample equals min_key (producer's case when the
+// first `interval + 1` rows share the min value). The leading sub-segment is
+// [min, min] (zero-width); point-ownership fallback should credit the leftmost
+// range (whose r.min == min) — and all rows must be conserved.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterTest, zero_width_head_sample_equals_min) {
+    // Segment with 21 rows, 2 samples at rows 10 and 20.
+    // If rows 0..10 are all `0`, sample[0] == 0 == min_key.
+    auto seg = make_sampled_seg(/*min=*/0, /*max=*/50, /*num_rows=*/21, /*data_size=*/210,
+                                /*iv=*/10, /*samples=*/{0, 25}, /*source_id=*/1);
+    auto seg2 = make_seg(/*min=*/100, /*max=*/200, /*num_rows=*/50, /*data_size=*/500, /*source_id=*/2);
+
+    std::vector<SegmentSplitInfo> segs = {seg, seg2};
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/40,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true));
+
+    auto [s1_rows, s1_bytes] = sum_source_stats(result, 1);
+    auto [s2_rows, s2_bytes] = sum_source_stats(result, 2);
+    EXPECT_EQ(21, s1_rows);
+    EXPECT_EQ(210, s1_bytes);
+    EXPECT_EQ(50, s2_rows);
+    EXPECT_EQ(500, s2_bytes);
+}
+
+// -----------------------------------------------------------------------------
+// Interior duplicate samples: sample[i] == sample[i+1] (heavy clustering on
+// one specific key). The sub-segment [x, x] is zero-width and must be
+// attributed to the range whose `[r.min, r.max)` owns the point (right range
+// at an internal shared boundary), preserving row conservation.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterTest, zero_width_interior_duplicate_samples) {
+    // samples[1] == samples[2] == 30. Produces sub-segments
+    //   [0, 10], [10, 30], [30, 30], [30, 40], [40, 50]
+    // where [30, 30] is zero-width.
+    auto seg = make_sampled_seg(/*min=*/0, /*max=*/50, /*num_rows=*/41, /*data_size=*/410,
+                                /*iv=*/10, /*samples=*/{10, 30, 30, 40}, /*source_id=*/1);
+    auto seg2 = make_seg(/*min=*/100, /*max=*/200, /*num_rows=*/50, /*data_size=*/500, /*source_id=*/2);
+    std::vector<SegmentSplitInfo> segs = {seg, seg2};
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/40,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true));
+
+    auto [s1_rows, s1_bytes] = sum_source_stats(result, 1);
+    EXPECT_EQ(41, s1_rows);
+    EXPECT_EQ(410, s1_bytes);
+}
+
+// -----------------------------------------------------------------------------
+// Loader validity check formula: producers guarantee
+//   sort_key_samples.size() * sort_key_sample_row_interval < num_rows
+// strictly. The loaders (get_tablet_split_ranges and _collect_segment_key_bounds)
+// encode this with the overflow-safe form
+//   num_samples <= (num_rows - 1) / row_interval
+// This test directly exercises the formula at the boundary, ensuring that:
+//   (a) a maximally-valid layout (ns * iv == num_rows - 1) is accepted; and
+//   (b) the smallest-invalid layout (ns * iv == num_rows) is rejected.
+// If the formula ever drifts (e.g. someone changes <= to <), this test fires.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterTest, loader_validity_formula_boundary) {
+    auto check = [](int64_t ns, int64_t iv, int64_t num_rows) {
+        return iv > 0 && num_rows > 0 && ns <= (num_rows - 1) / iv;
+    };
+
+    // Boundary-valid: num_rows = N*iv + 1, accepted.
+    EXPECT_TRUE(check(/*ns=*/2, /*iv=*/10, /*num_rows=*/21));
+    // Boundary-invalid: num_rows = N*iv, rejected (would imply tail_rows == 0
+    // which the producer never creates).
+    EXPECT_FALSE(check(/*ns=*/2, /*iv=*/10, /*num_rows=*/20));
+    // Way under: small segment with no samples.
+    EXPECT_TRUE(check(/*ns=*/0, /*iv=*/10, /*num_rows=*/5));
+    // Pathological iv == 0 (would crash on division), rejected by `iv > 0`.
+    EXPECT_FALSE(check(/*ns=*/1, /*iv=*/0, /*num_rows=*/100));
+    // Pathological num_rows == 0, rejected.
+    EXPECT_FALSE(check(/*ns=*/1, /*iv=*/10, /*num_rows=*/0));
+
+    // Overflow-safety: large N and iv that would overflow (ns*iv) in int64
+    // but for which (num_rows - 1) / iv is well-defined. Confirms the
+    // overflow-safe form.
+    constexpr int64_t kBigIv = 1LL << 32;
+    constexpr int64_t kBigN = 1LL << 32; // ns * iv = 2^64 in math, overflows int64
+    constexpr int64_t kSmallNum = 100;
+    EXPECT_FALSE(check(kBigN, kBigIv, kSmallNum)); // (100-1)/2^32 = 0; ns(2^32) > 0 -> rejected.
+}
+
+// -----------------------------------------------------------------------------
+// Defense-in-depth: even if a corrupt SegmentSplitInfo somehow slips past the
+// loader (e.g. test setup, future helper that bypasses the validity check),
+// `calculate_range_split_boundaries` itself must not crash in DEBUG builds.
+// In release builds the DCHECK is a no-op; the function may produce garbled
+// per-range stats but must still return without UB.
+//
+// We construct an invalid segment with ns * iv == num_rows (tail_rows == 0)
+// and surround it with a valid second segment so ordered_ranges has >= 2
+// boundaries (otherwise the function returns early at step 2). We expect:
+//  - In release: the call returns Status::OK (or empty boundaries) without UB.
+//  - In debug: DCHECK_GT(tail_rows, 0) fires; we don't run this branch when
+//    NDEBUG is unset.
+// -----------------------------------------------------------------------------
+#ifdef NDEBUG
+TEST(TabletSplitterTest, calculate_range_split_handles_invalid_input_without_ub) {
+    // num_rows=20, samples.size()=2, iv=10  ->  ns*iv=20=num_rows  ->  tail=0.
+    auto bad = make_sampled_seg(0, 50, 20, 200, 10, {10, 20}, /*source_id=*/1);
+    auto good = make_seg(100, 200, 50, 500, /*source_id=*/2);
+
+    auto result_or = calculate_range_split_boundaries({bad, good}, /*target_split_count=*/2,
+                                                      /*target_value_per_split=*/40,
+                                                      /*use_num_rows=*/true, /*track_sources=*/true);
+    EXPECT_TRUE(result_or.ok());
+    // The good segment's 50 rows must still be credited; the bad segment's
+    // 20 rows may be partially mis-attributed but must not blow up.
+    if (result_or.ok()) {
+        auto [good_rows, good_bytes] = sum_source_stats(result_or.value(), 2);
+        EXPECT_EQ(50, good_rows);
+        EXPECT_EQ(500, good_bytes);
+    }
+}
+#endif
+
+// -----------------------------------------------------------------------------
+// Overflow safety: very large total_bytes and total_rows should not overflow
+// the 128-bit intermediate in bytes_for. With num_rows = 1e9 and
+// data_size = 1e11, the raw product rows * total_bytes overflows int64 at
+// ~1e20, so the __int128 cast is required.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterTest, bytes_for_does_not_overflow_at_extreme_scale) {
+    constexpr int64_t kRows = 1'000'000'000LL;    // 1e9
+    constexpr int64_t kBytes = 100'000'000'000LL; // 1e11
+    constexpr int64_t kInterval = 65536LL;
+    constexpr int64_t kN = (kRows - 1) / kInterval; // ~15258, fits invariant
+
+    std::vector<int64_t> sample_values;
+    sample_values.reserve(kN);
+    for (int64_t k = 1; k <= kN; ++k) {
+        sample_values.push_back(k); // monotonic; values distinct
+    }
+    auto seg = make_sampled_seg(0, kN + 1, kRows, kBytes, kInterval, sample_values, /*source_id=*/1);
+
+    ASSIGN_OR_ABORT(auto result, calculate_range_split_boundaries({seg}, /*target_split_count=*/2,
+                                                                  /*target_value_per_split=*/kBytes / 2,
+                                                                  /*use_num_rows=*/false, /*track_sources=*/true));
+
+    // Must not crash; byte conservation must hold exactly.
+    int64_t total_bytes = 0;
+    int64_t total_rows = 0;
+    for (size_t i = 0; i < result.range_data_sizes.size(); ++i) {
+        total_bytes += result.range_data_sizes[i];
+        total_rows += result.range_num_rows[i];
+    }
+    EXPECT_EQ(kBytes, total_bytes);
+    EXPECT_EQ(kRows, total_rows);
+}
+
+// -----------------------------------------------------------------------------
+// Parallel-compaction-style invocation: use_num_rows=false (byte-weighted) and
+// track_sources=false. Verifies the sampled path is usable in that mode too.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterTest, byte_weighted_mode_and_no_track_sources) {
+    std::vector<SegmentSplitInfo> segs;
+    for (int i = 0; i < 4; ++i) {
+        std::vector<int64_t> samples = {10 + i, 20 + i, 30 + i, 40 + i};
+        segs.push_back(make_sampled_seg(/*min=*/i, /*max=*/50, /*num_rows=*/50, /*data_size=*/500,
+                                        /*iv=*/10, samples, /*source_id=*/static_cast<uint32_t>(i)));
+    }
+    ASSIGN_OR_ABORT(auto result, calculate_range_split_boundaries(segs, /*target_split_count=*/2,
+                                                                  /*target_value_per_split=*/1000,
+                                                                  /*use_num_rows=*/false, /*track_sources=*/false));
+    // No source stats when track_sources=false.
+    EXPECT_TRUE(result.range_source_stats.empty());
+    ASSERT_EQ(1, result.boundaries.size());
+
+    int64_t total_rows = 0;
+    int64_t total_bytes = 0;
+    for (size_t i = 0; i < result.range_num_rows.size(); ++i) {
+        total_rows += result.range_num_rows[i];
+        total_bytes += result.range_data_sizes[i];
+    }
+    EXPECT_EQ(4 * 50, total_rows);
+    EXPECT_EQ(4 * 500, total_bytes);
+}
+
+// -----------------------------------------------------------------------------
+// Whole tablet has a single distinct key: every segment's min == max == k.
+// ordered_boundaries has one unique value, ordered_ranges is empty; the
+// algorithm must return an empty RangeSplitResult (no boundaries), not crash
+// and not silently attribute rows to a non-existent range.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterTest, all_segments_single_identical_key_no_split) {
+    std::vector<SegmentSplitInfo> segs;
+    for (int i = 0; i < 3; ++i) {
+        segs.push_back(make_seg(/*min=*/42, /*max=*/42, /*num_rows=*/10, /*data_size=*/100,
+                                /*source_id=*/static_cast<uint32_t>(i)));
+    }
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/15,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true));
+    EXPECT_TRUE(result.boundaries.empty());
+    EXPECT_TRUE(result.range_num_rows.empty());
+    EXPECT_TRUE(result.range_data_sizes.empty());
+}
+
+// -----------------------------------------------------------------------------
+// Large-scale reproducer of the RCA scenario (scaled down): overlapping
+// segments, each carrying samples that densify the middle key interval. With
+// samples, the split point should land near the median, not at a cluster edge.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterTest, rca_reproducer_scaled_down) {
+    // 40 segments, each with min ~100-300, max ~5700-5900. Each has 100 rows
+    // and 10 uniform samples spanning ~300..5800. Total 4000 rows; without
+    // samples the algorithm would treat each segment as one [min, max] range
+    // and pick a pathological split point; with samples it should find the
+    // median near 3000.
+    std::vector<SegmentSplitInfo> segs;
+    for (int i = 0; i < 40; ++i) {
+        int64_t min_v = 100 + i * 5;
+        int64_t max_v = 5800 + i * 3;
+        std::vector<int64_t> samples;
+        // 9 samples evenly spaced between min and max
+        // (sort_key_sample_row_interval = 10, num_rows = 100, so 9 samples +
+        // tail = 10 rows per sub-segment).
+        for (int s = 1; s <= 9; ++s) {
+            int64_t v = min_v + (max_v - min_v) * s / 10;
+            samples.push_back(v);
+        }
+        segs.push_back(make_sampled_seg(min_v, max_v, /*num_rows=*/100, /*data_size=*/1000, /*iv=*/10, samples,
+                                        /*source_id=*/static_cast<uint32_t>(i)));
+    }
+
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/2000,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true));
+    ASSERT_EQ(1, result.boundaries.size());
+
+    // Balanced split: |left - right| should be small compared to total 4000.
+    int64_t left = result.range_num_rows[0];
+    int64_t right = result.range_num_rows[1];
+    EXPECT_EQ(4000, left + right);
+    EXPECT_LT(std::abs(left - right) * 4, 4000) << "sampled-path split should be within 25% imbalance";
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/rowset/segment_writer_sort_key_sampling_test.cpp
+++ b/be/test/storage/rowset/segment_writer_sort_key_sampling_test.cpp
@@ -1,0 +1,275 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "fs/fs_memory.h"
+#include "gutil/strings/substitute.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/segment_file_info.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/tablet_schema.h"
+#include "storage/tablet_schema_helper.h"
+
+namespace starrocks {
+
+// Matches the default of config::segment_sort_key_sample_row_interval
+// (declared in be/src/common/config.h). Kept in sync manually; if the config
+// default changes, update this test constant too.
+static constexpr int64_t kInterval = 65536;
+
+// Build a DUP_KEYS-style tablet schema with a single INT sort-key column and
+// one INT value column. INT (4 bytes) is sufficient to exercise the sampler;
+// the sampler behavior is independent of sort-key data type.
+static std::shared_ptr<TabletSchema> make_int_key_schema() {
+    std::vector<ColumnPB> cols;
+    cols.push_back(create_int_key_pb(/*id=*/1));
+    cols.push_back(create_int_value_pb(/*id=*/2));
+    auto unique = TabletSchemaHelper::create_tablet_schema(cols);
+    return std::shared_ptr<TabletSchema>(std::move(unique));
+}
+
+// Fixture that spins up an in-memory writable file and builds SegmentWriters.
+class SegmentWriterSortKeySamplingTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _fs = std::make_shared<MemoryFileSystem>();
+        ASSERT_OK(_fs->create_dir(kDir));
+        _schema = make_int_key_schema();
+    }
+
+    std::unique_ptr<SegmentWriter> new_writer(uint32_t seg_id, const SegmentWriterOptions& opts = {}) {
+        std::string filename = strings::Substitute("$0/seg_$1.dat", kDir, seg_id);
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(filename));
+        return std::make_unique<SegmentWriter>(std::move(wfile), seg_id, _schema, opts);
+    }
+
+    // Create a chunk with `n` rows where column 0 (key) is a monotonic int32
+    // starting at `start_key`, and column 1 (value) is a constant 0.
+    ChunkUniquePtr make_increasing_chunk(int64_t n, int32_t start_key) {
+        auto s = ChunkHelper::convert_schema(_schema);
+        auto chunk = ChunkHelper::new_chunk(s, n);
+        auto cols = chunk->mutable_columns();
+        for (int64_t i = 0; i < n; ++i) {
+            cols[0]->append_datum(Datum(static_cast<int32_t>(start_key + i)));
+            cols[1]->append_datum(Datum(static_cast<int32_t>(0)));
+        }
+        return chunk;
+    }
+
+    std::shared_ptr<MemoryFileSystem> _fs;
+    std::shared_ptr<TabletSchema> _schema;
+    const std::string kDir = "/sampling_test";
+};
+
+// ---------------------------------------------------------------------------
+// Row count sweep: for each N, verify sample count matches (N-1)/interval and
+// the invariant samples.size() * interval < num_rows (strict) holds.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, row_count_sweep_produces_expected_sample_counts) {
+    const int64_t row_interval = kInterval;
+    // Mix of edge cases: below interval, at interval, just over, 2*interval
+    // boundaries. Use small row counts relative to kInterval for test speed --
+    // the sampler's behavior is identical at any scale.
+    std::vector<int64_t> row_counts = {1,
+                                       row_interval - 1,
+                                       row_interval,
+                                       row_interval + 1,
+                                       2 * row_interval - 1,
+                                       2 * row_interval,
+                                       2 * row_interval + 1};
+    for (int64_t num_rows : row_counts) {
+        auto w = new_writer(/*seg_id=*/static_cast<uint32_t>(num_rows));
+        ASSERT_OK(w->init(true));
+        auto chunk = make_increasing_chunk(num_rows, /*start_key=*/0);
+        ASSERT_OK(w->append_chunk(*chunk));
+
+        const auto& samples = w->get_sort_key_samples();
+        // Expected: samples fire whenever _num_rows_written (pre-increment)
+        // equals k*row_interval, so the largest k with
+        // k*row_interval <= num_rows - 1 wins.
+        const int64_t expected = (num_rows >= 1) ? ((num_rows - 1) / row_interval) : 0;
+        EXPECT_EQ(static_cast<size_t>(expected), samples.size())
+                << "num_rows=" << num_rows << " row_interval=" << row_interval;
+        if (!samples.empty()) {
+            EXPECT_LT(static_cast<int64_t>(samples.size()) * row_interval, num_rows);
+        }
+        EXPECT_EQ(row_interval, w->get_sort_key_sample_row_interval());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Samples are non-decreasing on ordered input.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, samples_are_non_decreasing_on_ordered_input) {
+    const int64_t num_rows = 3 * kInterval + 123;
+    auto w = new_writer(0);
+    ASSERT_OK(w->init(true));
+    auto chunk = make_increasing_chunk(num_rows, 0);
+    ASSERT_OK(w->append_chunk(*chunk));
+
+    const auto& samples = w->get_sort_key_samples();
+    ASSERT_FALSE(samples.empty());
+    for (size_t i = 1; i < samples.size(); ++i) {
+        EXPECT_LE(samples[i - 1].compare(samples[i]), 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Off-by-one: feed interval+1 rows where last row's key equals max_key.
+// Expected: samples.size() == 1 and samples[0] == max_key.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, off_by_one_trailing_max_sample) {
+    const int64_t num_rows = kInterval + 1;
+    auto w = new_writer(0);
+    ASSERT_OK(w->init(true));
+    auto chunk = make_increasing_chunk(num_rows, 0);
+    ASSERT_OK(w->append_chunk(*chunk));
+
+    const auto& samples = w->get_sort_key_samples();
+    ASSERT_EQ(1U, samples.size());
+    EXPECT_EQ(0, samples[0].compare(w->get_sort_key_max()));
+}
+
+// ---------------------------------------------------------------------------
+// Leading-min duplicates: feed `interval + 1` rows of key 0 followed by
+// further monotonic rows. samples[0] should equal min (0).
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, leading_min_duplicate_samples) {
+    const int64_t leading = kInterval + 1;
+    const int64_t trailing = kInterval + 5;
+    const int64_t num_rows = leading + trailing;
+
+    auto w = new_writer(0);
+    ASSERT_OK(w->init(true));
+
+    auto s = ChunkHelper::convert_schema(_schema);
+    auto chunk = ChunkHelper::new_chunk(s, num_rows);
+    auto cols = chunk->mutable_columns();
+    for (int64_t i = 0; i < leading; ++i) {
+        cols[0]->append_datum(Datum(static_cast<int32_t>(0)));
+        cols[1]->append_datum(Datum(static_cast<int32_t>(0)));
+    }
+    for (int64_t i = 0; i < trailing; ++i) {
+        cols[0]->append_datum(Datum(static_cast<int32_t>(1 + i)));
+        cols[1]->append_datum(Datum(static_cast<int32_t>(0)));
+    }
+    ASSERT_OK(w->append_chunk(*chunk));
+
+    const auto& samples = w->get_sort_key_samples();
+    ASSERT_FALSE(samples.empty());
+    EXPECT_EQ(0, samples[0].compare(w->get_sort_key_min()));
+}
+
+// ---------------------------------------------------------------------------
+// All-identical-key segment: samples all equal the single key; min == max ==
+// every sample.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, all_identical_key) {
+    const int64_t num_rows = 2 * kInterval + 7;
+    auto w = new_writer(0);
+    ASSERT_OK(w->init(true));
+
+    auto s = ChunkHelper::convert_schema(_schema);
+    auto chunk = ChunkHelper::new_chunk(s, num_rows);
+    auto cols = chunk->mutable_columns();
+    for (int64_t i = 0; i < num_rows; ++i) {
+        cols[0]->append_datum(Datum(static_cast<int32_t>(42)));
+        cols[1]->append_datum(Datum(static_cast<int32_t>(0)));
+    }
+    ASSERT_OK(w->append_chunk(*chunk));
+
+    const auto& samples = w->get_sort_key_samples();
+    ASSERT_FALSE(samples.empty());
+    for (const auto& sample : samples) {
+        EXPECT_EQ(0, sample.compare(w->get_sort_key_min()));
+        EXPECT_EQ(0, sample.compare(w->get_sort_key_max()));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vertical writer re-entry: init() with is_key=true produces samples, then a
+// subsequent init({non_key_cols}, is_key=false) MUST NOT wipe the sampler
+// state. This is the vertical-compaction-compat contract.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, vertical_writer_reinit_preserves_sampler_state) {
+    const int64_t num_rows = kInterval + 5;
+    auto w = new_writer(0);
+
+    // First init: column 0 only (the key column). is_key=true arms the sampler.
+    std::vector<uint32_t> key_cols{0};
+    ASSERT_OK(w->init(key_cols, true));
+
+    // Append key-column-only chunks.
+    auto key_schema_view = ChunkHelper::convert_schema(_schema, key_cols);
+    auto key_chunk = ChunkHelper::new_chunk(key_schema_view, num_rows);
+    auto* key_col = key_chunk->mutable_columns()[0].get();
+    for (int64_t i = 0; i < num_rows; ++i) {
+        key_col->append_datum(Datum(static_cast<int32_t>(i)));
+    }
+    ASSERT_OK(w->append_chunk(*key_chunk));
+
+    const auto samples_after_key = w->get_sort_key_samples();
+    const int64_t row_interval_after_key = w->get_sort_key_sample_row_interval();
+    ASSERT_EQ(1U, samples_after_key.size());
+    ASSERT_EQ(kInterval, row_interval_after_key);
+
+    // Vertical writer calls finalize_columns between column-group passes; this
+    // clears _column_writers/_column_indexes so the next init() does not
+    // assert. We mirror that sequence here.
+    uint64_t index_size = 0;
+    ASSERT_OK(w->finalize_columns(&index_size));
+
+    // Second init: column 1 only (value column), is_key=false.
+    std::vector<uint32_t> non_key_cols{1};
+    ASSERT_OK(w->init(non_key_cols, false));
+
+    // Sampler state must survive re-init.
+    EXPECT_EQ(row_interval_after_key, w->get_sort_key_sample_row_interval());
+    ASSERT_EQ(samples_after_key.size(), w->get_sort_key_samples().size());
+    for (size_t i = 0; i < samples_after_key.size(); ++i) {
+        EXPECT_EQ(0, samples_after_key[i].compare(w->get_sort_key_samples()[i]));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// write_sort_key_fields_to(SegmentFileInfo&) transfers min, max, samples, and
+// interval into a SegmentFileInfo. Preserves the carrier invariant
+// (samples.empty() <=> 0).
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, write_sort_key_fields_to_transfers_ownership) {
+    const int64_t num_rows = 2 * kInterval + 3;
+    auto w = new_writer(0);
+    ASSERT_OK(w->init(true));
+    auto chunk = make_increasing_chunk(num_rows, 0);
+    ASSERT_OK(w->append_chunk(*chunk));
+
+    SegmentFileInfo file_info;
+    w->write_sort_key_fields_to(file_info);
+    EXPECT_EQ(2U, file_info.sort_key_samples.size());
+    EXPECT_EQ(kInterval, file_info.sort_key_sample_row_interval);
+    EXPECT_FALSE(file_info.sort_key_min.empty());
+    EXPECT_FALSE(file_info.sort_key_max.empty());
+    // After fill, writer's samples should be moved out.
+    EXPECT_TRUE(w->get_sort_key_samples().empty());
+}
+
+} // namespace starrocks

--- a/format-sdk/src/main/cpp/format/starrocks_format_writer.cpp
+++ b/format-sdk/src/main/cpp/format/starrocks_format_writer.cpp
@@ -129,8 +129,7 @@ private:
             op_write->mutable_rowset()->add_segments(f.path);
             op_write->mutable_rowset()->add_segment_size(f.size.value());
             auto* segment_meta = op_write->mutable_rowset()->add_segment_metas();
-            f.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
-            f.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
+            f.write_sort_key_fields_to(segment_meta);
             segment_meta->set_num_rows(f.num_rows);
         }
         for (const auto& f : _tablet_writer->dels()) {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -142,6 +142,22 @@ message SegmentMetadataPB {
     // IDs of vector indexes that need .vi files for this segment.
     // Only populated when the segment meets the build threshold.
     repeated int64 vector_index_ids = 5;
+    // Equal-row-interval samples of the sort key, NON-DECREASING.
+    // sort_key_samples[i] is the sort key at 0-indexed row (i+1) * interval,
+    // where interval == sort_key_sample_row_interval. Always paired with
+    // a positive sort_key_sample_row_interval. May be empty when num_rows
+    // is not greater than interval (small segments produce no samples
+    // because the first sample row is at index `interval`, which only
+    // exists for num_rows > interval). Consumed by tablet split and
+    // range-split parallel compaction to accurately estimate row
+    // distribution for overlapping segments.
+    repeated TuplePB sort_key_samples = 6;
+    // Row interval used to produce sort_key_samples. Set if and only if
+    // sort_key_samples_size() > 0; in that case the value is > 0 and
+    // sort_key_samples.size() * sort_key_sample_row_interval < num_rows.
+    // Persisted per-segment so a future change to the producer's interval
+    // constant cannot break cross-version readers.
+    optional int64 sort_key_sample_row_interval = 7;
 }
 
 message RowsetMetadataPB {


### PR DESCRIPTION
## Why I'm doing:                                                                                                                                                                                                                                                             
                                                                                                                      
  When segments are overlapping (typical for stream-load / broker-load without sorting), the tablet split algorithm in calculate_range_split_boundaries distributes each segment's rows equally by the count of overlapping ranges. This implicitly assumes uniform data distribution within each segment. When segment min/max keys cluster at both extremes of the key space, the middle key interval is counted as just one range, and its actual row count is underestimated by 10x-100x. This causes severely skewed split points (e.g. 87.5% vs 12.5% in a lineorder benchmark).                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                             
## What I'm doing:                                                                                                                                                                                                                                                            
                                                    
  Add equal-row-interval sort-key sampling to SegmentWriter. Each sample is persisted in SegmentMetadataPB (new proto fields 6, 7) and consumed by calculate_range_split_boundaries to treat each segment as N+1 sub-segments with exactly known row counts, instead of a single [min, max] range with a single divide-by-count estimate. Both tablet split and range-split parallel compaction benefit automatically through the shared SegmentSplitInfo struct.                                                                                    
                                                                                                                                                                                                                                                                             
  Key design decisions:
  - Config segment_sort_key_sample_row_interval (default 65536, mutable at runtime); per-segment interval persisted in proto for cross-version compatibility
  - Sampling is unconditional when _has_key is true, matching the existing _sort_key_min/max pattern (no lake/classic gating flag)
  - No sample trim; zero-width sub-segments (sample == min/max/adjacent) handled by [lower, upper) point-ownership fallback
  - 8 SegmentMetadataPB producers updated (including format-sdk); code deduplicated via SegmentFileInfo::serialize_sort_key_fields() and SegmentWriter::serialize_sort_key_fields()
  - 2 SegmentSplitInfo loaders updated via SegmentSplitInfo::load_samples()
  - Step 3 of calculate_range_split_boundaries extracted into distribute_segment_to_ranges() with helpers find_overlapping_ranges() and distribute_to_ranges()

 Test results (SSB SF100 scale, 3-CN shared-data cluster):                                                           
                                                                                                                                                                                                                                                                             
  600M rows loaded in 6 batches (creating 6 overlapping segments with lo_orderkey ~ Uniform[1, 6×10⁹]), then split into 2 tablets:

<img width="599" height="211" alt="image" src="https://github.com/user-attachments/assets/b22e23d1-77ad-4152-be2b-5ef599b0a8a3" />


Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
