### PR TITLE
[BugFix] Fix warehouse mismatch in explicit transactions with SET_VAR hints

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -51,6 +51,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.FeNameFormat;
@@ -71,6 +72,8 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.task.LoadEtlTask;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TLoadJobType;
+import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -183,9 +186,21 @@ public class TransactionStmtExecutor {
         try {
             if (transactionState.getDbId() == 0) {
                 transactionState.setDbId(database.getId());
+                // BEGIN binds the transaction's compute resource from the session at BEGIN time.
+                // When the session warehouse at BEGIN was the default warehouse (i.e. the user
+                // did not explicitly choose a warehouse before BEGIN), allow the first DML's
+                // SET_VAR(warehouse=...) hint to take over so the publish version RPC is routed
+                // correctly. Otherwise, require the session warehouse (possibly modified by hint)
+                // to match the already-bound warehouse; any mismatch is rejected explicitly to
+                // avoid silently overriding the user's explicit choice.
+                resolveTxnComputeResource(context.getCurrentComputeResource(), transactionState);
                 DatabaseTransactionMgr databaseTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                         .getDatabaseTransactionMgr(database.getId());
                 databaseTransactionMgr.upsertTransactionState(transactionState);
+            } else {
+                // Subsequent DMLs in the same transaction must stick to the warehouse
+                // already bound to the transaction.
+                checkTxnWarehouseConsistent(context.getCurrentComputeResource(), transactionState);
             }
 
             if (database.getId() != transactionState.getDbId()) {
@@ -237,9 +252,12 @@ public class TransactionStmtExecutor {
 
         if (transactionState.getDbId() == 0) {
             transactionState.setDbId(dbId);
+            resolveTxnComputeResource(context.getCurrentComputeResource(), transactionState);
             DatabaseTransactionMgr databaseTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                     .getDatabaseTransactionMgr(dbId);
             databaseTransactionMgr.upsertTransactionState(transactionState);
+        } else {
+            checkTxnWarehouseConsistent(context.getCurrentComputeResource(), transactionState);
         }
 
         transactionState.addTableIdList(tableId);
@@ -676,5 +694,56 @@ public class TransactionStmtExecutor {
             }
         }
         return ConnectContext.get().getSessionVariable().getInsertMaxFilterRatio();
+    }
+
+    /**
+     * Resolve the transaction's compute resource when the first DML binds the transaction to a db.
+     *
+     * <p>BEGIN binds the transaction's compute resource to whatever the session had at BEGIN time
+     * (often the default warehouse if the user did not SET warehouse beforehand). For a SET_VAR
+     * warehouse hint on the first DML to route publish correctly, we upgrade the binding here:
+     * <ul>
+     *   <li>If the transaction is still bound to the default warehouse, adopt the session's current
+     *       (possibly hint-modified) compute resource.</li>
+     *   <li>If the transaction is already bound to a non-default warehouse and the current session
+     *       warehouse differs, reject the conflict explicitly instead of silently overriding the
+     *       user's explicit pre-BEGIN choice.</li>
+     * </ul>
+     */
+    static void resolveTxnComputeResource(ComputeResource sessionCr, TransactionState transactionState) {
+        long sessionWhId = sessionCr.getWarehouseId();
+        long txnWhId = transactionState.getWarehouseId();
+        if (txnWhId == sessionWhId) {
+            return;
+        }
+        if (txnWhId == WarehouseManager.DEFAULT_WAREHOUSE_ID) {
+            transactionState.setComputeResource(sessionCr);
+            return;
+        }
+        throw ErrorReportException.report(ErrorCode.ERR_EXPLICIT_TXN_WAREHOUSE_MISMATCH,
+                warehouseName(txnWhId), warehouseName(sessionWhId));
+    }
+
+    /**
+     * Ensure a subsequent DML within the same explicit transaction uses the already-bound warehouse.
+     * The transaction's publish version can only be executed on a single warehouse, so any
+     * divergence introduced by a later SET_VAR(warehouse=...) hint must be rejected.
+     */
+    static void checkTxnWarehouseConsistent(ComputeResource sessionCr, TransactionState transactionState) {
+        long sessionWhId = sessionCr.getWarehouseId();
+        long txnWhId = transactionState.getWarehouseId();
+        if (txnWhId != sessionWhId) {
+            throw ErrorReportException.report(ErrorCode.ERR_EXPLICIT_TXN_WAREHOUSE_MISMATCH,
+                    warehouseName(txnWhId), warehouseName(sessionWhId));
+        }
+    }
+
+    private static String warehouseName(long warehouseId) {
+        WarehouseManager mgr = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        if (mgr == null) {
+            return String.valueOf(warehouseId);
+        }
+        Warehouse wh = mgr.getWarehouseAllowNull(warehouseId);
+        return wh == null ? String.valueOf(warehouseId) : wh.getName();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -185,7 +185,6 @@ public class TransactionStmtExecutor {
 
         try {
             if (transactionState.getDbId() == 0) {
-                transactionState.setDbId(database.getId());
                 // BEGIN binds the transaction's compute resource from the session at BEGIN time.
                 // When the session warehouse at BEGIN was the default warehouse (i.e. the user
                 // did not explicitly choose a warehouse before BEGIN), allow the first DML's
@@ -193,7 +192,11 @@ public class TransactionStmtExecutor {
                 // correctly. Otherwise, require the session warehouse (possibly modified by hint)
                 // to match the already-bound warehouse; any mismatch is rejected explicitly to
                 // avoid silently overriding the user's explicit choice.
+                //
+                // Resolve before mutating dbId so a mismatch error leaves the transaction state
+                // untouched and a subsequent retry behaves identically to the first attempt.
                 resolveTxnComputeResource(context.getCurrentComputeResource(), transactionState);
+                transactionState.setDbId(database.getId());
                 DatabaseTransactionMgr databaseTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                         .getDatabaseTransactionMgr(database.getId());
                 databaseTransactionMgr.upsertTransactionState(transactionState);
@@ -251,8 +254,10 @@ public class TransactionStmtExecutor {
         TransactionState transactionState = explicitTxnState.getTransactionState();
 
         if (transactionState.getDbId() == 0) {
-            transactionState.setDbId(dbId);
+            // Resolve before mutating dbId so a mismatch error leaves the transaction state
+            // untouched and a subsequent retry behaves identically to the first attempt.
             resolveTxnComputeResource(context.getCurrentComputeResource(), transactionState);
+            transactionState.setDbId(dbId);
             DatabaseTransactionMgr databaseTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                     .getDatabaseTransactionMgr(dbId);
             databaseTransactionMgr.upsertTransactionState(transactionState);

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -48,6 +48,8 @@ import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.task.LoadEtlTask;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -699,5 +701,102 @@ public class ExplicitTxnTest {
         // Cleanup
         globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
         context.setTxnId(0);
+    }
+
+    /**
+     * Bug scenario: user did not SET warehouse before BEGIN, so the transaction is bound to the
+     * default warehouse at BEGIN time. A subsequent DML carries SET_VAR(warehouse=...) hint which
+     * changes the session's compute resource. The first-DML resolve step must adopt the session's
+     * compute resource so the publish version RPC is routed to the hinted warehouse, not the
+     * default one (which was the original bug causing wrong-warehouse publish).
+     */
+    @Test
+    public void testResolveTxnComputeResourceAdoptsHintWhenBoundToDefault() {
+        TransactionState transactionState = newTxnState(1000L, "test-adopt-label");
+        // Mimic beginStmt: initial binding is default warehouse (warehouseId = 0)
+        transactionState.setComputeResource(WarehouseComputeResource.DEFAULT);
+        Assertions.assertEquals(0L, transactionState.getWarehouseId());
+
+        // Session warehouse has been changed by SET_VAR hint to a non-default warehouse.
+        ComputeResource hinted = WarehouseComputeResource.of(114176L);
+
+        TransactionStmtExecutor.resolveTxnComputeResource(hinted, transactionState);
+
+        Assertions.assertEquals(114176L, transactionState.getWarehouseId());
+        Assertions.assertSame(hinted, transactionState.getComputeResource());
+    }
+
+    /**
+     * If the transaction was explicitly bound to a non-default warehouse (i.e. user did
+     * SET warehouse before BEGIN), a conflicting SET_VAR(warehouse=...) hint on the first DML
+     * must be rejected instead of silently overriding the user's explicit choice.
+     */
+    @Test
+    public void testResolveTxnComputeResourceRejectsMismatchOnFirstDml() {
+        TransactionState transactionState = newTxnState(1001L, "test-reject-first");
+        transactionState.setComputeResource(WarehouseComputeResource.of(111L));
+
+        // Session warehouse diverges from the already-bound warehouse.
+        ComputeResource sessionCr = WarehouseComputeResource.of(222L);
+
+        ErrorReportException e = Assertions.assertThrows(ErrorReportException.class, () ->
+                TransactionStmtExecutor.resolveTxnComputeResource(sessionCr, transactionState));
+        Assertions.assertEquals(ErrorCode.ERR_EXPLICIT_TXN_WAREHOUSE_MISMATCH, e.getErrorCode());
+        // Transaction binding must not be mutated on reject.
+        Assertions.assertEquals(111L, transactionState.getWarehouseId());
+    }
+
+    /**
+     * When the session warehouse already matches the transaction's bound warehouse, resolve
+     * must be a no-op and must not touch the transaction's compute resource reference.
+     */
+    @Test
+    public void testResolveTxnComputeResourceNoOpOnMatch() {
+        TransactionState transactionState = newTxnState(1002L, "test-match-label");
+        ComputeResource bound = WarehouseComputeResource.of(333L);
+        transactionState.setComputeResource(bound);
+
+        TransactionStmtExecutor.resolveTxnComputeResource(WarehouseComputeResource.of(333L), transactionState);
+
+        Assertions.assertEquals(333L, transactionState.getWarehouseId());
+        Assertions.assertSame(bound, transactionState.getComputeResource());
+    }
+
+    /**
+     * A subsequent DML within the same explicit transaction must not change the bound warehouse.
+     * The publish version can only run on a single warehouse, so any divergence is rejected.
+     */
+    @Test
+    public void testCheckTxnWarehouseConsistentRejectsSubsequentMismatch() {
+        TransactionState transactionState = newTxnState(1003L, "test-sub-reject");
+        transactionState.setComputeResource(WarehouseComputeResource.of(444L));
+
+        ComputeResource sessionCr = WarehouseComputeResource.of(555L);
+
+        ErrorReportException e = Assertions.assertThrows(ErrorReportException.class, () ->
+                TransactionStmtExecutor.checkTxnWarehouseConsistent(sessionCr, transactionState));
+        Assertions.assertEquals(ErrorCode.ERR_EXPLICIT_TXN_WAREHOUSE_MISMATCH, e.getErrorCode());
+    }
+
+    /**
+     * A subsequent DML whose session warehouse still matches the transaction's bound warehouse
+     * is accepted without error.
+     */
+    @Test
+    public void testCheckTxnWarehouseConsistentAllowsMatch() {
+        TransactionState transactionState = newTxnState(1004L, "test-sub-match");
+        transactionState.setComputeResource(WarehouseComputeResource.of(666L));
+
+        Assertions.assertDoesNotThrow(() ->
+                TransactionStmtExecutor.checkTxnWarehouseConsistent(
+                        WarehouseComputeResource.of(666L), transactionState));
+    }
+
+    private static TransactionState newTxnState(long txnId, String label) {
+        return new TransactionState(txnId, label, null,
+                TransactionState.LoadJobSourceType.INSERT_STREAMING,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
+                        FrontendOptions.getLocalHostAddress()),
+                60_000L);
     }
 }

--- a/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
@@ -283,6 +283,10 @@ public enum ErrorCode {
             "Explicit transaction only support single update/delete before insert statement"),
     ERR_EXPLICIT_TXN_SELECT_ON_MODIFIED_TABLE(5307, new byte[] {'2', '5', 'P', '0', '1'},
             "SELECT cannot read table '%s' modified earlier in the same transaction"),
+    ERR_EXPLICIT_TXN_WAREHOUSE_MISMATCH(5308, new byte[] {'2', '5', 'P', '0', '1'},
+            "Explicit transaction is already bound to warehouse '%s'; "
+                    + "SET_VAR(warehouse='%s') hint cannot change the transaction warehouse. "
+                    + "Use SET warehouse = ... before BEGIN instead"),
 
     /**
      * 5400 - 5499: Internal error


### PR DESCRIPTION
## Why I'm doing:

When a user begins an explicit transaction without explicitly setting a warehouse, the transaction is bound to the default warehouse. If a subsequent DML statement includes a `SET_VAR(warehouse=...)` hint, the publish version RPC was being routed to the hinted warehouse instead of the originally bound warehouse, causing incorrect behavior. Additionally, if a user explicitly set a warehouse before BEGIN and then a DML includes a conflicting warehouse hint, the system was silently overriding the user's explicit choice instead of rejecting the conflict.

## What I'm doing:

Implements warehouse consistency validation for explicit transactions:

1. **First DML resolution** (`resolveTxnComputeResource`): When the first DML binds the transaction to a database:
   - If the transaction is bound to the default warehouse, adopt the session's current (possibly hint-modified) compute resource
   - If the transaction is already bound to a non-default warehouse and the session warehouse differs, reject the conflict explicitly

2. **Subsequent DML validation** (`checkTxnWarehouseConsistent`): For any subsequent DML in the same transaction:
   - Ensure the session warehouse matches the already-bound warehouse
   - Reject any divergence to prevent silent override of the user's explicit choice

3. **Error handling**: Added new error code `ERR_EXPLICIT_TXN_WAREHOUSE_MISMATCH` (5308) with clear messaging directing users to set the warehouse before BEGIN if they want to use a non-default warehouse.

4. **Comprehensive test coverage**: Added 6 new unit tests covering:
   - Adopting hint when bound to default warehouse
   - Rejecting mismatches on first DML
   - No-op behavior on matching warehouses
   - Rejecting subsequent DML mismatches
   - Allowing subsequent DML matches

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr