### PR TITLE
[BugFix] Register loaded indexes for compaction/replication/bypass-write transactions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/BypassWriteTransactionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/BypassWriteTransactionHandler.java
@@ -14,9 +14,12 @@
 
 package com.starrocks.http.rest.transaction;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -37,8 +40,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.FunctionSet.HOST_NAME;
 import static com.starrocks.transaction.TransactionState.LoadJobSourceType.BYPASS_WRITE;
@@ -135,6 +143,7 @@ public class BypassWriteTransactionHandler implements TransactionOperationHandle
         TransactionResult result = new TransactionResult();
         switch (txnStatus) {
             case PREPARE:
+                registerLoadedIndexes(txnState, committedTablets);
                 GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().prepareTransaction(
                         dbId, txnId, preparedTimeoutMs, committedTablets, failedTablets,
                         new MiniLoadTxnCommitAttachment(), timeoutMillis);
@@ -225,6 +234,38 @@ public class BypassWriteTransactionHandler implements TransactionOperationHandle
 
         throw new StarRocksException(String.format(
                 "Transaction found by label %s isn't created in %s scenario.", label, BYPASS_WRITE.name()));
+    }
+
+    @VisibleForTesting
+    static void registerLoadedIndexes(TransactionState txnState, List<TabletCommitInfo> committedTablets) {
+        if (committedTablets == null || committedTablets.isEmpty()) {
+            return;
+        }
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        List<Long> tabletIds = committedTablets.stream()
+                .map(TabletCommitInfo::getTabletId).collect(Collectors.toList());
+        List<TabletMeta> tabletMetaList = invertedIndex.getTabletMetaList(tabletIds);
+
+        // Group tablet index IDs by (tableId, partitionId)
+        Map<Long, Map<Long, Set<Long>>> tablePartitionIndexIds = new HashMap<>();
+        for (TabletMeta meta : tabletMetaList) {
+            if (meta == TabletInvertedIndex.NOT_EXIST_TABLET_META) {
+                continue;
+            }
+            tablePartitionIndexIds
+                    .computeIfAbsent(meta.getTableId(), k -> new HashMap<>())
+                    .computeIfAbsent(meta.getPhysicalPartitionId(), k -> new HashSet<>())
+                    .add(meta.getIndexId());
+        }
+
+        for (Map.Entry<Long, Map<Long, Set<Long>>> tableEntry : tablePartitionIndexIds.entrySet()) {
+            long tableId = tableEntry.getKey();
+            for (Map.Entry<Long, Set<Long>> partEntry : tableEntry.getValue().entrySet()) {
+                long partitionId = partEntry.getKey();
+                List<Long> indexIds = new ArrayList<>(partEntry.getValue());
+                txnState.addPartitionLoadedIndexes(tableId, partitionId, indexIds);
+            }
+        }
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -337,7 +337,7 @@ public class CompactionScheduler extends Daemon {
 
             // Note: call `beginTransaction()` in the scope of database reader lock to make sure no shadow index will
             // be added to this table(i.e., no schema change) before calling `beginTransaction()`.
-            txnId = beginTransaction(partitionIdentifier, info.computeResource);
+            txnId = beginTransaction(partitionIdentifier, partition, info.computeResource);
 
             partition.setMinRetainVersion(currentVersion);
 
@@ -516,8 +516,9 @@ public class CompactionScheduler extends Daemon {
         return beToTablets;
     }
 
-    // REQUIRE: has acquired the exclusive lock of Database.
-    protected long beginTransaction(PartitionIdentifier partition, ComputeResource computeResource)
+    // REQUIRE: has acquired the read lock of Database.
+    protected long beginTransaction(PartitionIdentifier partition, PhysicalPartition physicalPartition,
+            ComputeResource computeResource)
             throws RunningTxnExceedException, AnalysisException, LabelAlreadyUsedException, DuplicatedRequestException {
         long dbId = partition.getDbId();
         long tableId = partition.getTableId();
@@ -528,8 +529,21 @@ public class CompactionScheduler extends Daemon {
         TransactionState.TxnCoordinator coordinator = new TransactionState.TxnCoordinator(txnSourceType, HOST_NAME);
         String label = String.format("COMPACTION_%d-%d-%d-%d", dbId, tableId, partitionId, currentTs);
 
-        return transactionMgr.beginTransaction(dbId, Lists.newArrayList(tableId), label, coordinator,
+        long txnId = transactionMgr.beginTransaction(dbId, Lists.newArrayList(tableId), label, coordinator,
                 loadJobSourceType, Config.lake_compaction_default_timeout_second, computeResource);
+
+        // Register loaded indexes so preCommit() validates the same indexes that were collected,
+        // not the latest (which may change due to tablet split).
+        TransactionState txnState = transactionMgr.getTransactionState(dbId, txnId);
+        if (txnState != null) {
+            List<Long> indexIds = physicalPartition.getLatestMaterializedIndices(
+                    MaterializedIndex.IndexExtState.VISIBLE)
+                    .stream().map(MaterializedIndex::getId)
+                    .collect(Collectors.toList());
+            txnState.addPartitionLoadedIndexes(tableId, physicalPartition.getId(), indexIds);
+        }
+
+        return txnId;
     }
 
     private void commitCompaction(PartitionIdentifier partition, CompactionJob job, boolean forceCommit)

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -934,6 +934,19 @@ public class ReplicationJob implements GsonPostProcessable {
         transactionId = GlobalStateMgr.getServingState().getGlobalTransactionMgr().beginTransaction(databaseId,
                 Lists.newArrayList(tableId), label, coordinator, loadJobSourceType,
                 Config.replication_transaction_timeout_sec);
+
+        // Register loaded indexes so preCommit() validates the same indexes that were collected,
+        // not the latest (which may change due to tablet split).
+        TransactionState txnState = GlobalStateMgr.getServingState().getGlobalTransactionMgr()
+                .getTransactionState(databaseId, transactionId);
+        if (txnState != null) {
+            for (PartitionInfo partitionInfo : partitionInfos.values()) {
+                List<Long> indexIds = partitionInfo.getIndexInfos().values().stream()
+                        .map(IndexInfo::getIndexId)
+                        .collect(Collectors.toList());
+                txnState.addPartitionLoadedIndexes(tableId, partitionInfo.getPartitionId(), indexIds);
+            }
+        }
     }
 
     protected void commitTransaction() throws StarRocksException {

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/transaction/BypassWriteTransactionHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/transaction/BypassWriteTransactionHandlerTest.java
@@ -1,0 +1,110 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.transaction;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionState.LoadJobSourceType;
+import com.starrocks.transaction.TransactionState.TxnCoordinator;
+import com.starrocks.transaction.TransactionState.TxnSourceType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BypassWriteTransactionHandlerTest {
+
+    @Test
+    public void testRegisterLoadedIndexes() {
+        long dbId = 1000L;
+        long tableId = 2000L;
+        long partitionId1 = 3000L;
+        long partitionId2 = 3001L;
+        long indexId1 = 4000L;
+        long indexId2 = 4001L;
+        long tabletId1 = 5000L;
+        long tabletId2 = 5001L;
+        long tabletId3 = 5002L;
+
+        // Set up tablet inverted index with real tablet metadata
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        invertedIndex.addTablet(tabletId1,
+                new TabletMeta(dbId, tableId, partitionId1, indexId1, TStorageMedium.HDD, true));
+        invertedIndex.addTablet(tabletId2,
+                new TabletMeta(dbId, tableId, partitionId1, indexId2, TStorageMedium.HDD, true));
+        invertedIndex.addTablet(tabletId3,
+                new TabletMeta(dbId, tableId, partitionId2, indexId1, TStorageMedium.HDD, true));
+
+        // Create transaction state
+        TransactionState txnState = new TransactionState(dbId, Lists.newArrayList(tableId),
+                9000L, "label_bypass", null,
+                LoadJobSourceType.BYPASS_WRITE,
+                new TxnCoordinator(TxnSourceType.FE, "127.0.0.1"), 0, 60_000);
+
+        // Build committed tablets
+        List<TabletCommitInfo> committedTablets = new ArrayList<>();
+        committedTablets.add(new TabletCommitInfo(tabletId1, 1));
+        committedTablets.add(new TabletCommitInfo(tabletId2, 1));
+        committedTablets.add(new TabletCommitInfo(tabletId3, 1));
+
+        // Call registerLoadedIndexes
+        BypassWriteTransactionHandler.registerLoadedIndexes(txnState, committedTablets);
+
+        // Verify: partition1 should have both indexId1 and indexId2 registered
+        MaterializedIndex idx1ForP1 = new MaterializedIndex(indexId1);
+        MaterializedIndex idx2ForP1 = new MaterializedIndex(indexId2);
+        PhysicalPartition pp1 = new PhysicalPartition(partitionId1, partitionId1, idx1ForP1);
+        pp1.createRollupIndex(idx2ForP1);
+
+        List<MaterializedIndex> loaded1 = txnState.getPartitionLoadedIndexes(tableId, pp1);
+        Assertions.assertEquals(2, loaded1.size());
+        List<Long> loadedIds1 = new ArrayList<>();
+        for (MaterializedIndex idx : loaded1) {
+            loadedIds1.add(idx.getId());
+        }
+        Assertions.assertTrue(loadedIds1.contains(indexId1));
+        Assertions.assertTrue(loadedIds1.contains(indexId2));
+
+        // Verify: partition2 should have indexId1 registered
+        MaterializedIndex idx1ForP2 = new MaterializedIndex(indexId1);
+        PhysicalPartition pp2 = new PhysicalPartition(partitionId2, partitionId2, idx1ForP2);
+
+        List<MaterializedIndex> loaded2 = txnState.getPartitionLoadedIndexes(tableId, pp2);
+        Assertions.assertEquals(1, loaded2.size());
+        Assertions.assertEquals(indexId1, loaded2.get(0).getId());
+    }
+
+    @Test
+    public void testRegisterLoadedIndexesWithNullTablets() {
+        TransactionState txnState = new TransactionState(1L, Lists.newArrayList(2L),
+                100L, "label", null,
+                LoadJobSourceType.BYPASS_WRITE,
+                new TxnCoordinator(TxnSourceType.FE, "127.0.0.1"), 0, 60_000);
+
+        // Should not throw with null
+        BypassWriteTransactionHandler.registerLoadedIndexes(txnState, null);
+
+        // Should not throw with empty list
+        BypassWriteTransactionHandler.registerLoadedIndexes(txnState, new ArrayList<>());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -28,6 +28,7 @@ import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.lake.LakeAggregator;
 import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.proto.AggregateCompactRequest;
 import com.starrocks.proto.CompactRequest;
 import com.starrocks.proto.ComputeNodePB;
@@ -43,6 +44,7 @@ import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.transaction.DatabaseTransactionMgr;
 import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.MockedWarehouseManager;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -180,7 +182,8 @@ public class CompactionSchedulerTest {
 
         new MockUp<CompactionScheduler>() {
             @Mock
-            protected long beginTransaction(PartitionIdentifier partition, ComputeResource computeResource) {
+            protected long beginTransaction(PartitionIdentifier partition, PhysicalPartition physicalPartition,
+                    ComputeResource computeResource) {
                 return 100L;
             }
 
@@ -763,5 +766,53 @@ public class CompactionSchedulerTest {
             // maxBytesPerSubtask is 0 (let BE use its own config)
             Assertions.assertEquals(0L, (long) req.parallelConfig.maxBytesPerSubtask);
         }
+    }
+
+    @Test
+    public void testBeginTransactionRegistersLoadedIndexes() throws Exception {
+        long dbId = 100L;
+        long tableId = 200L;
+        long partitionId = 300L;
+        long indexId = 400L;
+        long txnId = 500L;
+
+        // Create a PhysicalPartition with a visible index
+        MaterializedIndex baseIndex = new MaterializedIndex(indexId);
+        baseIndex.addTablet(new LakeTablet(1001L), null, false);
+        PhysicalPartition physicalPartition = new PhysicalPartition(partitionId, partitionId, baseIndex);
+
+        // Create a real TransactionState that will capture the loaded indexes
+        TransactionState txnState = new TransactionState(dbId, Lists.newArrayList(tableId),
+                txnId, "COMPACTION_test", null,
+                TransactionState.LoadJobSourceType.LAKE_COMPACTION,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "127.0.0.1"),
+                0, 60_000);
+
+        new Expectations() {
+            {
+                globalTransactionMgr.beginTransaction(dbId, (List<Long>) any, anyString,
+                        (TransactionState.TxnCoordinator) any,
+                        (TransactionState.LoadJobSourceType) any,
+                        anyLong, (ComputeResource) any);
+                result = txnId;
+
+                globalTransactionMgr.getTransactionState(dbId, txnId);
+                result = txnState;
+            }
+        };
+
+        CompactionScheduler scheduler = new CompactionScheduler(new CompactionMgr(), null,
+                globalTransactionMgr, globalStateMgr, "");
+
+        PartitionIdentifier partitionIdentifier = new PartitionIdentifier(dbId, tableId, partitionId);
+        long resultTxnId = scheduler.beginTransaction(partitionIdentifier, physicalPartition,
+                WarehouseManager.DEFAULT_RESOURCE);
+
+        Assertions.assertEquals(txnId, resultTxnId);
+
+        // Verify loaded indexes were registered
+        List<MaterializedIndex> loadedIndexes = txnState.getPartitionLoadedIndexes(tableId, physicalPartition);
+        Assertions.assertEquals(1, loadedIndexes.size());
+        Assertions.assertEquals(indexId, loadedIndexes.get(0).getId());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTestHelper.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTestHelper.java
@@ -57,6 +57,16 @@ public class LakeTableTestHelper {
         return table;
     }
 
+    LakeTable buildLakeTableWithIndex(MaterializedIndex index) {
+        Partition partition = new Partition(partitionId, physicalPartitionId, "p0", index, null);
+        LakeTable table = new LakeTable(
+                tableId, "t0",
+                Lists.newArrayList(new Column("c0", IntegerType.BIGINT)),
+                KeysType.DUP_KEYS, null, null);
+        table.addPartition(partition);
+        return table;
+    }
+
     DatabaseTransactionMgr addDatabaseTransactionMgr() {
         GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().addDatabaseTransactionMgr(dbId);
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnStateListenerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnStateListenerTest.java
@@ -15,14 +15,20 @@
 package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.lake.compaction.PartitionIdentifier;
 import com.starrocks.lake.compaction.Quantiles;
 import com.starrocks.proto.AbortTxnRequest;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TStorageMedium;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -31,8 +37,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -113,6 +121,100 @@ public class LakeTableTxnStateListenerTest extends LakeTableTestHelper {
             finishedTablets = Collections.singletonList(new TabletCommitInfo(tableId, 10001));
         }
         listener.postAbort(txnState, finishedTablets, Collections.emptyList());
+    }
+
+    /**
+     * Verifies that compaction preCommit succeeds after tablet split when loaded indexes are registered.
+     * Simulates: compaction collects I_old tablets → tablet split adds I_new → preCommit validates I_old.
+     */
+    @Test
+    public void testCompactionPreCommitWithTabletSplitAndRegisteredIndexes() throws TransactionException {
+        // Build table with I_old (1 tablet)
+        long oldIndexId = 20001;
+        long oldTabletId = 20002;
+        long newIndexId = 20003;
+        long[] newTabletIds = {20004, 20005, 20006};
+
+        MaterializedIndex oldIndex = new MaterializedIndex(oldIndexId);
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, 0, TStorageMedium.HDD, true);
+        invertedIndex.addTablet(oldTabletId, tabletMeta);
+        oldIndex.addTablet(new LakeTablet(oldTabletId), tabletMeta);
+
+        LakeTable table = buildLakeTableWithIndex(oldIndex);
+        PhysicalPartition partition = table.getPhysicalPartition(physicalPartitionId);
+
+        // Create compaction transaction and register loaded indexes (the fix)
+        TransactionState txnState = newCompactionTransactionState();
+        List<Long> loadedIndexIds = partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
+                .stream().map(MaterializedIndex::getId).collect(Collectors.toList());
+        txnState.addPartitionLoadedIndexes(tableId, partition.getId(), loadedIndexIds);
+
+        // Simulate tablet split: add I_new with 3 new tablets (same metaId as I_old)
+        MaterializedIndex newIndex = new MaterializedIndex(newIndexId, oldIndexId,
+                MaterializedIndex.IndexState.NORMAL, 0L);
+        for (long tid : newTabletIds) {
+            TabletMeta meta = new TabletMeta(dbId, tableId, physicalPartitionId, 0, TStorageMedium.HDD, true);
+            invertedIndex.addTablet(tid, meta);
+            newIndex.addTablet(new LakeTablet(tid), meta);
+        }
+        partition.addMaterializedIndex(newIndex, true);
+
+        // Build finishedTablets from I_old's tablet only
+        List<TabletCommitInfo> finishedTablets = new ArrayList<>();
+        finishedTablets.add(new TabletCommitInfo(oldTabletId, 1));
+
+        // preCommit should succeed because it validates I_old (registered), not I_new (latest)
+        DatabaseTransactionMgr databaseTransactionMgr = addDatabaseTransactionMgr();
+        LakeTableTxnStateListener listener = new LakeTableTxnStateListener(databaseTransactionMgr, table);
+        listener.preCommit(txnState, finishedTablets, Collections.emptyList());
+    }
+
+    /**
+     * Confirms the bug: without registering loaded indexes, compaction preCommit fails after tablet split
+     * because it falls back to the latest index (I_new) whose tablets are not in finishedTablets.
+     */
+    @Test
+    public void testCompactionPreCommitWithTabletSplitWithoutRegisteredIndexes() {
+        // Build table with I_old (1 tablet)
+        long oldIndexId = 30001;
+        long oldTabletId = 30002;
+        long newIndexId = 30003;
+        long[] newTabletIds = {30004, 30005, 30006};
+
+        MaterializedIndex oldIndex = new MaterializedIndex(oldIndexId);
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, 0, TStorageMedium.HDD, true);
+        invertedIndex.addTablet(oldTabletId, tabletMeta);
+        oldIndex.addTablet(new LakeTablet(oldTabletId), tabletMeta);
+
+        LakeTable table = buildLakeTableWithIndex(oldIndex);
+        PhysicalPartition partition = table.getPhysicalPartition(physicalPartitionId);
+
+        // Create compaction transaction WITHOUT registering loaded indexes
+        TransactionState txnState = newCompactionTransactionState();
+
+        // Simulate tablet split: add I_new with 3 new tablets
+        MaterializedIndex newIndex = new MaterializedIndex(newIndexId, oldIndexId,
+                MaterializedIndex.IndexState.NORMAL, 0L);
+        for (long tid : newTabletIds) {
+            TabletMeta meta = new TabletMeta(dbId, tableId, physicalPartitionId, 0, TStorageMedium.HDD, true);
+            invertedIndex.addTablet(tid, meta);
+            newIndex.addTablet(new LakeTablet(tid), meta);
+        }
+        partition.addMaterializedIndex(newIndex, true);
+
+        // Build finishedTablets from I_old's tablet only
+        List<TabletCommitInfo> finishedTablets = new ArrayList<>();
+        finishedTablets.add(new TabletCommitInfo(oldTabletId, 1));
+
+        // preCommit should FAIL because it falls back to I_new (latest), whose tablets are not finished
+        DatabaseTransactionMgr databaseTransactionMgr = addDatabaseTransactionMgr();
+        LakeTableTxnStateListener listener = new LakeTableTxnStateListener(databaseTransactionMgr, table);
+        TransactionCommitFailedException exception = Assertions.assertThrows(
+                TransactionCommitFailedException.class,
+                () -> listener.preCommit(txnState, finishedTablets, Collections.emptyList()));
+        Assertions.assertTrue(exception.getMessage().contains("has unfinished tablets"));
     }
 
     private void makeCompactionScoreExceedSlowdownThreshold() {


### PR DESCRIPTION
## Why I'm doing:                                                                                                                                                                                                                                                          
                            
  During tablet split on a shared-data table, compaction transactions fail to commit with
  `"table 'xxx' has unfinished tablets: [yyy]"`.
                                                                 
  `LakeTableTxnStateListener.preCommit()` calls `getPartitionLoadedIndexesWithoutLock()` to
  determine which MaterializedIndex to validate. When no loaded indexes are registered, it
  falls back to `getLatestMaterializedIndices(ALL)`, which after tablet split returns I_new
  (with new tablet IDs) instead of I_old that the transaction actually wrote to.

  Full audit of all 12 `LoadJobSourceType` values found 3 types that never call
  `addPartitionLoadedIndexes()`: `LAKE_COMPACTION`, `REPLICATION`, `BYPASS_WRITE`.

## What I'm doing:

  Add `addPartitionLoadedIndexes()` calls for the three affected transaction source types:

  - **CompactionScheduler**: Add `PhysicalPartition` parameter to `beginTransaction()` and
    register current visible indexes inside it, under the same DB read lock scope as
    `collectPartitionTablets()`.
  - **ReplicationJob**: Register indexes from `partitionInfos` at the end of
    `beginTransaction()`.
  - **BypassWriteTransactionHandler**: Resolve committed tablets to their partition/index
    via `TabletInvertedIndex` and register before calling `prepareTransaction()`.

  Add two tests in `LakeTableTxnStateListenerTest`:
  - Positive: register loaded indexes before tablet split, verify `preCommit()` passes.
  - Negative: skip registration, verify `preCommit()` fails with "unfinished tablets".

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
