### PR TITLE
[Enhancement] Add snapshot-aware partition API for Iceberg pinned mode (backport #71662)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -224,6 +224,12 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public List<PartitionInfo> getPartitions(Table table, List<String> partitionNames,
+                                             ConnectorMetadatRequestContext requestContext) {
+        return normal.getPartitions(table, partitionNames, requestContext);
+    }
+
+    @Override
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit,
                                          TvrVersionRange version) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -211,6 +211,15 @@ public interface ConnectorMetadata {
     }
 
     /**
+     * Get partition info at a specific snapshot identified by the request context.
+     * Default implementation ignores the context and falls back to the live-snapshot variant.
+     */
+    default List<PartitionInfo> getPartitions(Table table, List<String> partitionNames,
+                                              ConnectorMetadatRequestContext requestContext) {
+        return getPartitions(table, partitionNames);
+    }
+
+    /**
      * Get statistics for the table.
      *
      * @param session           optimizer context

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.partitiontraits.CachedPartitionTraits;
 import com.starrocks.connector.partitiontraits.DeltaLakePartitionTraits;
 import com.starrocks.connector.partitiontraits.HivePartitionTraits;
@@ -131,10 +132,35 @@ public abstract class ConnectorPartitionTraits {
         return buildWithCache(ctx, null, table);
     }
 
+    /**
+     * Build traits with a pinned version range. Subclasses that support snapshot-aware partition
+     * operations (currently Iceberg) will use the pinned snapshot instead of the live one.
+     * Other connectors store the range but ignore it in their partition methods.
+     */
+    public static ConnectorPartitionTraits build(Table table, TvrVersionRange pinnedVersionRange) {
+        ConnectorPartitionTraits traits = build(table);
+        if (pinnedVersionRange != null) {
+            traits.setPinnedVersionRange(pinnedVersionRange);
+        }
+        return traits;
+    }
+
     private static ConnectorPartitionTraits buildWithoutCache(Table table) {
         ConnectorPartitionTraits res = build(table.getType());
         res.table = table;
         return res;
+    }
+
+    // When set, subclasses that support snapshot-aware partition operations (e.g. Iceberg)
+    // use this version range instead of the live snapshot. Other connectors ignore it.
+    protected TvrVersionRange pinnedVersionRange;
+
+    public void setPinnedVersionRange(TvrVersionRange range) {
+        this.pinnedVersionRange = range;
+    }
+
+    public TvrVersionRange getPinnedVersionRange() {
+        return pinnedVersionRange;
     }
 
     public Table getTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -33,6 +33,7 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -251,6 +252,15 @@ public class PartitionUtil {
         return ConnectorPartitionTraits.build(table).getPartitionNames();
     }
 
+    /**
+     * Get partition names at a specific pinned snapshot. For Iceberg tables, partition enumeration
+     * uses the pinned snapshot ID instead of currentSnapshot(). For non-Iceberg tables, falls back
+     * to the live variant.
+     */
+    public static List<String> getPartitionNames(Table table, TvrVersionRange pinnedVersionRange) {
+        return ConnectorPartitionTraits.build(table, pinnedVersionRange).getPartitionNames();
+    }
+
     // use partitionValues to filter partitionNames
     // eg. partitionNames: [p1=1/p2=2, p1=1/p2=3, p1=2/p2=2, p1=2/p2=3]
     //     partitionValues: [empty, 2]
@@ -318,10 +328,28 @@ public class PartitionUtil {
      *
      * @param table           : the ref base table of materialized view
      * @param partitionColumn : the ref base table's partition column which mv's partition derives
+     * @param pinnedVersionRange if non-null, uses this snapshot for Iceberg; if null, uses live snapshot.
      */
+    public static PCellSortedSet getPartitionKeyRange(Table table, Column partitionColumn, Expr partitionExpr,
+                                                      TvrVersionRange pinnedVersionRange)
+            throws StarRocksException {
+        return ConnectorPartitionTraits.build(table, pinnedVersionRange)
+                .getPartitionKeyRange(partitionColumn, partitionExpr);
+    }
+
     public static PCellSortedSet getPartitionKeyRange(Table table, Column partitionColumn, Expr partitionExpr)
             throws StarRocksException {
-        return ConnectorPartitionTraits.build(table).getPartitionKeyRange(partitionColumn, partitionExpr);
+        return getPartitionKeyRange(table, partitionColumn, partitionExpr, null);
+    }
+
+    /**
+     * Get partition cells, optionally at a pinned snapshot.
+     * @param pinnedVersionRange if non-null, uses this snapshot for Iceberg; if null, uses live snapshot.
+     */
+    public static PCellSortedSet getPartitionCells(Table table, List<Column> partitionColumns,
+                                                   TvrVersionRange pinnedVersionRange)
+            throws StarRocksException {
+        return ConnectorPartitionTraits.build(table, pinnedVersionRange).getPartitionCells(partitionColumns);
     }
 
     /**
@@ -329,7 +357,7 @@ public class PartitionUtil {
      */
     public static PCellSortedSet getPartitionCells(Table table, List<Column> partitionColumns)
             throws StarRocksException {
-        return ConnectorPartitionTraits.build(table).getPartitionCells(partitionColumns);
+        return getPartitionCells(table, partitionColumns, null);
     }
 
     // check the partitionColumn exist in the partitionColumns

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -545,6 +545,9 @@ public interface IcebergCatalog extends MemoryTrackable {
         }
     }
 
+    /**
+     * Get partition info by names using the current (live) snapshot.
+     */
     default List<Partition> getPartitionsByNames(IcebergTable icebergTable,
                                                  ExecutorService executorService,
                                                  List<String> partitionNames) {
@@ -553,7 +556,18 @@ public interface IcebergCatalog extends MemoryTrackable {
         if (nativeTable.currentSnapshot() != null) {
             snapshotId = nativeTable.currentSnapshot().snapshotId();
         }
+        return getPartitionsByNames(icebergTable, snapshotId, executorService, partitionNames);
+    }
 
+    /**
+     * Get partition info by names at a specific snapshot.
+     * @param snapshotId the Iceberg snapshot ID to read partitions from, or -1 for current snapshot
+     */
+    default List<Partition> getPartitionsByNames(IcebergTable icebergTable,
+                                                 long snapshotId,
+                                                 ExecutorService executorService,
+                                                 List<String> partitionNames) {
+        Table nativeTable = icebergTable.getNativeTable();
         // Call public method so subclasses can override and optimize this method.
         Map<String, Partition> partitionMap = getPartitions(icebergTable, snapshotId, executorService);
         if (nativeTable.spec().isUnpartitioned()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -882,6 +882,15 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public List<PartitionInfo> getPartitions(Table table, List<String> partitionNames,
+                                             ConnectorMetadatRequestContext requestContext) {
+        long snapshotId = requestContext.getSnapshotId();
+        List<Partition> ans =
+                icebergCatalog.getPartitionsByNames((IcebergTable) table, snapshotId, null, partitionNames);
+        return new ArrayList<>(ans);
+    }
+
+    @Override
     public boolean prepareMetadata(MetaPreparationItem item, Tracers tracers, ConnectContext connectContext) {
         IcebergTable icebergTable;
         icebergTable = (IcebergTable) item.getTable();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ThrowingSupplier;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.sql.ast.expression.Expr;
@@ -104,6 +105,12 @@ public class CachedPartitionTraits extends DefaultTraits {
         });
         stats.incr(cacheKey);
         return Optional.ofNullable(result).map(x -> (T) x).orElse(defaultSupplier.get());
+    }
+
+    @Override
+    public void setPinnedVersionRange(TvrVersionRange range) {
+        super.setPinnedVersionRange(range);
+        delegate.setPinnedVersionRange(range);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
@@ -58,6 +58,12 @@ public class IcebergPartitionTraits extends DefaultTraits {
     @Override
     public List<PartitionInfo> getPartitions(List<String> partitionNames) {
         IcebergTable icebergTable = (IcebergTable) table;
+        if (pinnedVersionRange != null) {
+            ConnectorMetadatRequestContext ctx = new ConnectorMetadatRequestContext();
+            ctx.setTableVersionRange(pinnedVersionRange);
+            return GlobalStateMgr.getCurrentState().getMetadataMgr().
+                    getPartitions(icebergTable.getCatalogName(), table, partitionNames, ctx);
+        }
         return GlobalStateMgr.getCurrentState().getMetadataMgr().
                 getPartitions(icebergTable.getCatalogName(), table, partitionNames);
     }
@@ -75,11 +81,15 @@ public class IcebergPartitionTraits extends DefaultTraits {
         }
 
         IcebergTable icebergTable = (IcebergTable) table;
-        Optional<Long> snapshotId = Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot())
-                .map(Snapshot::snapshotId);
         ConnectorMetadatRequestContext requestContext = new ConnectorMetadatRequestContext();
         requestContext.setQueryMVRewrite(isQueryMVRewrite());
-        requestContext.setTableVersionRange(TvrTableSnapshot.of(snapshotId));
+        if (pinnedVersionRange != null) {
+            requestContext.setTableVersionRange(pinnedVersionRange);
+        } else {
+            Optional<Long> snapshotId = Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot())
+                    .map(Snapshot::snapshotId);
+            requestContext.setTableVersionRange(TvrTableSnapshot.of(snapshotId));
+        }
         return GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
                 table.getCatalogName(), getCatalogDBName(), getTableName(), requestContext);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -871,6 +871,23 @@ public class MetadataMgr {
         return new ArrayList<>();
     }
 
+    /**
+     * Get partition info at a specific snapshot identified by the request context.
+     */
+    public List<PartitionInfo> getPartitions(String catalogName, Table table, List<String> partitionNames,
+                                             ConnectorMetadatRequestContext requestContext) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        if (connectorMetadata.isPresent()) {
+            try {
+                return connectorMetadata.get().getPartitions(table, partitionNames, requestContext);
+            } catch (Exception e) {
+                LOG.error("Failed to get partitions on catalog [{}], table [{}]", catalogName, table, e);
+                throw e;
+            }
+        }
+        return new ArrayList<>();
+    }
+
     public SerializedMetaSpec getSerializedMetaSpec(String catalogName, String dbName, String tableName, long snapshotId,
                                                     String serializedPredicate, MetadataTableType type) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);


### PR DESCRIPTION
Manual backport of PR #71662 to branch-4.1. Adapts the changes to the 4.1 codebase where MVPartitionCellBuilder does not exist — the equivalent overloads are added to PartitionUtil instead.

Changes:
- IcebergCatalog: getPartitionsByNames(table, snapshotId, executor, names)
- ConnectorMetadata/CatalogConnectorMetadata/IcebergMetadata: getPartitions with ConnectorMetadatRequestContext
- MetadataMgr: getPartitions(catalog, table, names, requestContext)
- ConnectorPartitionTraits: pinnedVersionRange field + setPinnedVersionRange + build(Table, TvrVersionRange) factory overload
- IcebergPartitionTraits: respect pinnedVersionRange in getPartitionNames and getPartitions
- CachedPartitionTraits: propagate setPinnedVersionRange to delegate
- PartitionUtil: getPartitionNames/getPartitionKeyRange/getPartitionCells overloads with TvrVersionRange (equivalent to MVPartitionCellBuilder on main)

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

