### PR TITLE
[Tool] Allow relaxing required fields to optional in schema compatibility checks

### DIFF
--- a/build-support/check_gensrc_schema_compatibility.py
+++ b/build-support/check_gensrc_schema_compatibility.py
@@ -361,7 +361,7 @@ def compare_schemas(repo_path: str, base_schema: ParsedSchema | None, head_schem
                     )
                 )
                 continue
-            if before.cardinality != after.cardinality:
+            if before.cardinality != after.cardinality and not _is_allowed_cardinality_relaxation(before, after):
                 issues.append(
                     Violation(
                         path=repo_path,
@@ -823,6 +823,12 @@ def _parse_proto_field_line(path: str, container: str, syntax: str | None, raw_l
         line=line_number,
         syntax=syntax,
     )
+
+
+def _is_allowed_cardinality_relaxation(before: FieldDecl, after: FieldDecl) -> bool:
+    # Relaxing an existing field from required to optional is wire-compatible and
+    # brings the schema in line with the repo-wide "no required" rule.
+    return before.cardinality == "required" and after.cardinality == "optional"
 
 
 def _new_field_rule(field: FieldDecl, container: ContainerDecl) -> str | None:

--- a/build-support/test_check_gensrc_schema_compatibility.py
+++ b/build-support/test_check_gensrc_schema_compatibility.py
@@ -1079,6 +1079,108 @@ class CheckGensrcSchemaCompatibilityTest(unittest.TestCase):
             self.assertEqual("SampleService.ping(throws)", issues[0].container)
             self.assertEqual(1, issues[0].field_number)
 
+    def test_changed_mode_allows_thrift_required_to_optional(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            self._init_repo(repo)
+            thrift_path = repo / "gensrc" / "thrift" / "sample.thrift"
+            thrift_path.write_text(
+                textwrap.dedent(
+                    """\
+                    struct TSample {
+                      1: required string name
+                    }
+                    """
+                )
+            )
+            self._commit_all(repo, "base")
+
+            thrift_path.write_text(
+                textwrap.dedent(
+                    """\
+                    struct TSample {
+                      1: optional string name
+                    }
+                    """
+                )
+            )
+            self._commit_all(repo, "head")
+
+            issues = module.check_repo(repo, mode="changed", base="HEAD~1")
+
+            self.assertEqual([], issues)
+
+    def test_changed_mode_rejects_thrift_optional_to_required(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            self._init_repo(repo)
+            thrift_path = repo / "gensrc" / "thrift" / "sample.thrift"
+            thrift_path.write_text(
+                textwrap.dedent(
+                    """\
+                    struct TSample {
+                      1: optional string name
+                    }
+                    """
+                )
+            )
+            self._commit_all(repo, "base")
+
+            thrift_path.write_text(
+                textwrap.dedent(
+                    """\
+                    struct TSample {
+                      1: required string name
+                    }
+                    """
+                )
+            )
+            self._commit_all(repo, "head")
+
+            issues = module.check_repo(repo, mode="changed", base="HEAD~1")
+
+            self.assertEqual(["field_cardinality_changed"], [issue.rule for issue in issues])
+            self.assertEqual("TSample", issues[0].container)
+            self.assertEqual(1, issues[0].field_number)
+
+    def test_changed_mode_allows_proto_required_to_optional(self) -> None:
+        module = _load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            self._init_repo(repo)
+            proto_path = repo / "gensrc" / "proto" / "sample.proto"
+            proto_path.write_text(
+                textwrap.dedent(
+                    """\
+                    syntax = "proto2";
+
+                    message SamplePB {
+                      required string name = 1;
+                    }
+                    """
+                )
+            )
+            self._commit_all(repo, "base")
+
+            proto_path.write_text(
+                textwrap.dedent(
+                    """\
+                    syntax = "proto2";
+
+                    message SamplePB {
+                      optional string name = 1;
+                    }
+                    """
+                )
+            )
+            self._commit_all(repo, "head")
+
+            issues = module.check_repo(repo, mode="changed", base="HEAD~1")
+
+            self.assertEqual([], issues)
+
     def test_changed_mode_parses_thrift_field_annotations(self) -> None:
         module = _load_module()
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Why I'm doing:

Schema compatibility checks currently reject any change in field cardinality, including relaxing required fields to optional. However, relaxing a field from required to optional is wire-compatible and aligns with best practices (the repo-wide "no required" rule). This unnecessarily blocks legitimate schema evolution.

## What I'm doing:

Modified the schema compatibility checker to allow relaxing fields from required to optional, as this change is backward compatible and doesn't break existing clients.

**Changes:**
- Added `_is_allowed_cardinality_relaxation()` function to identify wire-compatible cardinality changes (required → optional)
- Updated the cardinality comparison logic to skip violations for allowed relaxations
- Added comprehensive test coverage for both Thrift and Proto schemas:
  - `test_changed_mode_allows_thrift_required_to_optional`: Verifies required→optional is allowed for Thrift
  - `test_changed_mode_rejects_thrift_optional_to_required`: Verifies optional→required is still rejected for Thrift
  - `test_changed_mode_allows_proto_required_to_optional`: Verifies required→optional is allowed for Proto2

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4


https://claude.ai/code/session_01BmYyVepLw66Lbz9h6MRZvX