### PR TITLE
[Refactor] Move FunctionCallExpr to fe-parser, add cached function API

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
@@ -19,6 +19,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonPreProcessable;
 import com.starrocks.qe.SqlModeHelper;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.ast.expression.ArrayExpr;
 import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.Expr;
@@ -166,7 +167,7 @@ public class DefaultExpr implements GsonPreProcessable, GsonPostProcessable {
             FunctionCallExpr functionCallExpr =
                     new FunctionCallExpr(functionName, new FunctionParams(false, exprs));
             Function fn = ExprUtils.getBuiltinFunction(functionName, argumentTypes, Function.CompareMode.IS_IDENTICAL);
-            functionCallExpr.setFn(fn);
+            AnalysisContext.populateCachedFields(functionCallExpr, fn);
             functionCallExpr.setType(fn.getReturnType());
             return functionCallExpr;
         }
@@ -228,7 +229,7 @@ public class DefaultExpr implements GsonPreProcessable, GsonPostProcessable {
                 }
                 FunctionCallExpr newFuncExpr = new FunctionCallExpr(funcName, newChildren);
                 newFuncExpr.setType(funcExpr.getType());
-                newFuncExpr.setFn(funcExpr.getFn());
+                newFuncExpr.copyFnFieldsFrom(funcExpr);
                 return newFuncExpr;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -47,6 +47,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprUtils;
@@ -487,7 +488,7 @@ public class IcebergTable extends Table {
                                 Function builtinFunction = ExprUtils.getBuiltinFunction(
                                         ((FunctionCallExpr) expr).getFunctionName(),
                                         args, Function.CompareMode.IS_IDENTICAL);
-                                ((FunctionCallExpr) expr).setFn(builtinFunction);
+                                AnalysisContext.populateCachedFields((FunctionCallExpr) expr, builtinFunction);
 
                                 if (((FunctionCallExpr) expr).getFunctionName().equals(
                                         FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX + "truncate")) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -428,7 +428,7 @@ public class FragmentNormalizer {
     boolean hasNonDeterministicFunctions(Expr expr) {
         if (expr instanceof FunctionCallExpr) {
             FunctionCallExpr callExpr = (FunctionCallExpr) expr;
-            String funcName = callExpr.getFn().functionName();
+            String funcName = callExpr.getFunctionName();
             if (FunctionSet.nonDeterministicFunctions.contains(funcName)) {
                 return true;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExprToThrift.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExprToThrift.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionName;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.ast.AssertNumRowsElement;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
@@ -484,7 +485,7 @@ public final class ExprToThrift {
             } else {
                 msg.node_type = TExprNodeType.FUNCTION_CALL;
             }
-            Function fn = node.getFn();
+            Function fn = AnalysisContext.getFunctionByExpr(node);
             if (fn != null) {
                 TFunction tfn = fn.toThrift();
                 tfn.setIgnore_nulls(node.getIgnoreNulls());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -16,7 +16,6 @@ package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
-import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
@@ -241,11 +240,11 @@ public class AggregationAnalyzer {
 
         @Override
         public Boolean visitFunctionCall(FunctionCallExpr expr, Void context) {
-            if (expr.getFn() instanceof AggregateFunction) {
+            if (expr.isAggregateFn()) {
                 List<FunctionCallExpr> aggFunc = Lists.newArrayList();
                 if (expr.getChildren().stream().anyMatch(childExpr -> {
                     childExpr.collectAll((Predicate<Expr>) arg -> arg instanceof FunctionCallExpr &&
-                            ((FunctionCallExpr) arg).getFn() instanceof AggregateFunction, aggFunc);
+                            ((FunctionCallExpr) arg).isAggregateFn(), aggFunc);
                     return !aggFunc.isEmpty();
                 })) {
                     throw new SemanticException(PARSER_ERROR_MSG.unsupportedNestAgg("aggregation function"), expr.getPos());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalysisContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalysisContext.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.Function;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Stores analysis results keyed by fnId, similar to Trino's Analysis pattern.
+ * <p>
+ * Each FunctionCallExpr gets a unique fnId when resolved. This ID survives
+ * clone/copy operations, so cloned exprs can still look up their Function.
+ * <p>
+ * The global registry allows planner code to retrieve the original Function
+ * object without needing to thread an AnalysisContext instance.
+ */
+public class AnalysisContext {
+    // Global fnId → Function registry. Populated by populateCachedFields().
+    // fnIds are globally unique (AtomicLong in FunctionCallExpr), so there's no collision risk.
+    private static final Map<Long, Function> GLOBAL_FN_REGISTRY = new ConcurrentHashMap<>();
+
+    private final Map<Long, Function> resolvedFunctions = new HashMap<>();
+
+    public void registerFunction(FunctionCallExpr expr, Function fn) {
+        long fnId;
+        if (expr.hasFnId()) {
+            fnId = expr.getFnId();
+        } else {
+            fnId = FunctionCallExpr.nextFnId();
+            expr.setFnId(fnId);
+        }
+        resolvedFunctions.put(fnId, fn);
+        GLOBAL_FN_REGISTRY.put(fnId, fn);
+        populateCachedFields(expr, fn);
+    }
+
+    /**
+     * Populate cached typed fields on FunctionCallExpr from a resolved Function,
+     * and register the function in the global registry for later retrieval.
+     */
+    public static void populateCachedFields(FunctionCallExpr expr, Function fn) {
+        if (!expr.hasFnId()) {
+            expr.setFnId(FunctionCallExpr.nextFnId());
+        }
+        GLOBAL_FN_REGISTRY.put(expr.getFnId(), fn);
+
+        expr.setAggregateFn(fn instanceof AggregateFunction);
+        expr.setFnNullable(fn.isNullable());
+        expr.setFnArgTypes(fn.getArgs());
+        expr.setFnHasVarArgs(fn.hasVarArgs());
+        expr.setFnNumArgs(fn.getNumArgs());
+        expr.setWindowFunction(fn instanceof AggregateFunction && ((AggregateFunction) fn).isAnalyticFn());
+    }
+
+    /**
+     * Retrieve the resolved Function for a FunctionCallExpr by its fnId.
+     * Works across analysis and planner phases.
+     */
+    public static Function getFunctionByExpr(FunctionCallExpr expr) {
+        if (!expr.hasFnId()) {
+            return null;
+        }
+        return GLOBAL_FN_REGISTRY.get(expr.getFnId());
+    }
+
+    /**
+     * Retrieve a resolved Function by fnId from the global registry.
+     */
+    public static Function getFunctionById(long fnId) {
+        return GLOBAL_FN_REGISTRY.get(fnId);
+    }
+
+    public Function getFunction(FunctionCallExpr expr) {
+        if (!expr.hasFnId()) {
+            return null;
+        }
+        return resolvedFunctions.get(expr.getFnId());
+    }
+
+    public Function getFunction(long fnId) {
+        return resolvedFunctions.get(fnId);
+    }
+
+    public int registeredCount() {
+        return resolvedFunctions.size();
+    }
+
+    public String registeredKeys() {
+        return resolvedFunctions.keySet().toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
@@ -16,8 +16,6 @@ package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-import com.starrocks.catalog.AggregateFunction;
-import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.HintNode;
@@ -70,23 +68,23 @@ public class AnalyticAnalyzer {
                     analyticExpr.getPos());
         }
 
-        if (!isAnalyticFn(analyticFunction.getFn())) {
+        if (!isAnalyticFn(analyticFunction)) {
             throw new SemanticException("Function '%s' not supported with OVER clause.",
                     ExprToSql.toSql(analyticExpr.getFnCall()), analyticFunction.getPos());
         }
 
         for (Expr e : analyticExpr.getFnCall().getChildren()) {
             if (e.getType().isBitmapType() &&
-                    !analyticFunction.getFn().functionName().equals(FunctionSet.BITMAP_UNION_COUNT) &&
-                    !analyticFunction.getFn().functionName().equals(FunctionSet.BITMAP_UNION) &&
-                    !analyticFunction.getFn().functionName().equals(FunctionSet.LEAD) &&
-                    !analyticFunction.getFn().functionName().equals(FunctionSet.LAG)) {
+                    !analyticFunction.getFunctionName().equals(FunctionSet.BITMAP_UNION_COUNT) &&
+                    !analyticFunction.getFunctionName().equals(FunctionSet.BITMAP_UNION) &&
+                    !analyticFunction.getFunctionName().equals(FunctionSet.LEAD) &&
+                    !analyticFunction.getFunctionName().equals(FunctionSet.LAG)) {
                 throw new SemanticException("bitmap type could only used for bitmap_union_count/bitmap_union/lead/lag " +
                         "window function", e.getPos());
             } else if (e.getType().isHllType() &&
-                    !analyticFunction.getFn().functionName().equals(AnalyticExpr.HLL_UNION_AGG) &&
-                    !analyticFunction.getFn().functionName().equals(FunctionSet.LEAD) &&
-                    !analyticFunction.getFn().functionName().equals(FunctionSet.LAG)) {
+                    !analyticFunction.getFunctionName().equals(AnalyticExpr.HLL_UNION_AGG) &&
+                    !analyticFunction.getFunctionName().equals(FunctionSet.LEAD) &&
+                    !analyticFunction.getFunctionName().equals(FunctionSet.LAG)) {
                 throw new SemanticException("hll type could only used for hll_union_agg/lead/lag window function",
                         e.getPos());
             } else if (e.getType().isPercentile()) {
@@ -94,7 +92,7 @@ public class AnalyticAnalyzer {
             }
         }
 
-        if (isOffsetFn(analyticFunction.getFn()) && analyticFunction.getChildren().size() > 1) {
+        if (isOffsetFn(analyticFunction) && analyticFunction.getChildren().size() > 1) {
             Expr offset = analyticFunction.getChild(1);
             if (!isPositiveConstantInteger(offset)) {
                 throw new SemanticException(
@@ -108,7 +106,7 @@ public class AnalyticAnalyzer {
                 Type firstType = analyticFunction.getChild(0).getType();
 
                 if (analyticFunction.getChild(0) instanceof NullLiteral) {
-                    firstType = analyticFunction.getFn().getArgs()[0];
+                    firstType = analyticFunction.getFnArgTypes()[0];
                 }
 
                 try {
@@ -136,7 +134,7 @@ public class AnalyticAnalyzer {
             }
         }
 
-        if (isNtileFn(analyticFunction.getFn())) {
+        if (isNtileFn(analyticFunction)) {
             Expr numBuckets = analyticFunction.getChild(0);
             if (!isPositiveConstantInteger(numBuckets)) {
                 throw new SemanticException(
@@ -164,8 +162,8 @@ public class AnalyticAnalyzer {
         }
 
         if (analyticExpr.getWindow() != null) {
-            if ((isRankingFn(analyticFunction.getFn()) || isCumeFn(analyticFunction.getFn()) ||
-                    isOffsetFn(analyticFunction.getFn()) || isHllAggFn(analyticFunction.getFn()))) {
+            if ((isRankingFn(analyticFunction) || isCumeFn(analyticFunction) ||
+                    isOffsetFn(analyticFunction) || isHllAggFn(analyticFunction))) {
                 throw new SemanticException("Windowing clause not allowed with '" + ExprToSql.toSql(analyticFunction) + "'",
                         analyticExpr.getPos());
             }
@@ -336,66 +334,66 @@ public class AnalyticAnalyzer {
         }
     }
 
-    private static boolean isAnalyticFn(Function fn) {
-        return fn instanceof AggregateFunction && ((AggregateFunction) fn).isAnalyticFn();
+    private static boolean isAnalyticFn(FunctionCallExpr fn) {
+        return fn.isWindowFunction();
     }
 
-    private static boolean isOffsetFn(Function fn) {
+    private static boolean isOffsetFn(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.LEAD) ||
-                fn.functionName().equalsIgnoreCase(AnalyticExpr.LAG);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.LEAD) ||
+                fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.LAG);
     }
 
-    private static boolean isMinMax(Function fn) {
+    private static boolean isMinMax(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.MIN) ||
-                fn.functionName().equalsIgnoreCase(AnalyticExpr.MAX);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.MIN) ||
+                fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.MAX);
     }
 
-    private static boolean isRankingFn(Function fn) {
+    private static boolean isRankingFn(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.RANK)
-                || fn.functionName().equalsIgnoreCase(AnalyticExpr.DENSERANK)
-                || fn.functionName().equalsIgnoreCase(AnalyticExpr.ROWNUMBER)
-                || fn.functionName().equalsIgnoreCase(AnalyticExpr.NTILE);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.RANK)
+                || fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.DENSERANK)
+                || fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.ROWNUMBER)
+                || fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.NTILE);
     }
 
-    private static boolean isCumeFn(Function fn) {
+    private static boolean isCumeFn(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.CUMEDIST)
-                || fn.functionName().equalsIgnoreCase(AnalyticExpr.PERCENTRANK);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.CUMEDIST)
+                || fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.PERCENTRANK);
     }
 
-    private static boolean isNtileFn(Function fn) {
+    private static boolean isNtileFn(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.NTILE);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.NTILE);
     }
 
-    private static boolean isStatisticFn(Function fn) {
-        return STATISTIC_FUNCTIONS.contains(fn.functionName().toLowerCase());
+    private static boolean isStatisticFn(FunctionCallExpr fn) {
+        return STATISTIC_FUNCTIONS.contains(fn.getFunctionName().toLowerCase());
     }
 
-    private static boolean isHllAggFn(Function fn) {
+    private static boolean isHllAggFn(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.HLL_UNION_AGG);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.HLL_UNION_AGG);
     }
 
     private static boolean isPositiveConstantInteger(Expr offset) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -30,7 +30,6 @@ import com.google.common.collect.Sets;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PrivilegeType;
-import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.Function;
@@ -188,7 +187,7 @@ public class AnalyzerUtils {
     public static void verifyNoAggregateFunctions(Expr expression, String clause) {
         List<FunctionCallExpr> functions = Lists.newArrayList();
         expression.collectAll((Predicate<Expr>) arg -> arg instanceof FunctionCallExpr &&
-                ((FunctionCallExpr) arg).getFn() instanceof AggregateFunction, functions);
+                ((FunctionCallExpr) arg).isAggregateFn(), functions);
         if (!functions.isEmpty()) {
             throw new SemanticException(clause + " clause cannot contain aggregations", expression.getPos());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateSyncMVStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateSyncMVStmtAnalyzer.java
@@ -547,7 +547,7 @@ public class CreateSyncMVStmtAnalyzer {
                     Function fn = ExprUtils.getBuiltinFunction(FunctionSet.TO_BITMAP, new Type[] {baseType},
                             Function.CompareMode.IS_IDENTICAL);
                     defineExpr = new FunctionCallExpr(FunctionSet.TO_BITMAP, Lists.newArrayList(defineExpr));
-                    ((FunctionCallExpr) defineExpr).setFn(fn);
+                    AnalysisContext.populateCachedFields((FunctionCallExpr) defineExpr, fn);
                     defineExpr.setType(BitmapType.BITMAP);
                 } else {
                     throw new SemanticException("Unsupported bitmap_agg type:" + baseType);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1028,7 +1028,7 @@ public class ExpressionAnalyzer {
         public Void visitFunctionCall(FunctionCallExpr node, Scope scope) {
             if (node.isNondeterministicBuiltinFnName()) {
                 ExprId exprId = analyzeState.getNextNondeterministicId();
-                node.setNondeterministicId(exprId);
+                node.setNondeterministicId(exprId.asInt());
             }
             String fnName = node.getFunctionName();
 
@@ -1148,8 +1148,8 @@ public class ExpressionAnalyzer {
                 // This must be after reordering because it depends on parameter positions
                 FunctionAnalyzer.validateNullConstraints(fnName, fn, node);
 
-                node.setFn(fn);
                 node.setType(fn.getReturnType());
+                AnalysisContext.populateCachedFields(node, fn);
                 FunctionAnalyzer.analyze(node);
                 return null;
             }
@@ -1172,8 +1172,8 @@ public class ExpressionAnalyzer {
                             visit(child, scope);
                         }
                     }
-                    node.setFn(fn);
                     node.setType(fn.getReturnType());
+                    AnalysisContext.populateCachedFields(node, fn);
                     FunctionAnalyzer.analyze(node);
                     return null;
                 }
@@ -1186,8 +1186,8 @@ public class ExpressionAnalyzer {
                                 .join(Arrays.stream(argumentTypes).map(Type::toSql).collect(Collectors.toList())));
                 throw new SemanticException(msg, node.getPos());
             }
-            node.setFn(fn);
             node.setType(fn.getReturnType());
+            AnalysisContext.populateCachedFields(node, fn);
             FunctionAnalyzer.analyze(node);
             return null;
         }
@@ -1557,8 +1557,8 @@ public class ExpressionAnalyzer {
             Function fn = ExprUtils.getBuiltinFunction(node.getFunctionName(),
                     childTypes, Function.CompareMode.IS_IDENTICAL);
 
-            node.setFn(fn);
             node.setType(fn.getReturnType());
+            AnalysisContext.populateCachedFields(node, fn);
             return null;
         }
 
@@ -1931,6 +1931,7 @@ public class ExpressionAnalyzer {
             Function fn = new Function(FunctionName.createFnName(FunctionSet.DICT_MAPPING), actualTypes, valueType, false);
             fn.setBinaryType(TFunctionBinaryType.BUILTIN);
             node.setFn(fn);
+            AnalysisContext.populateCachedFields(node, fn);
 
             node.setDictQueryExpr(dictQueryExpr);
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -94,11 +94,11 @@ public class FunctionAnalyzer {
     }
 
     public static void analyze(FunctionCallExpr functionCallExpr) {
-        if (functionCallExpr.getFn() instanceof AggregateFunction) {
+        if (functionCallExpr.isAggregateFn()) {
             analyzeBuiltinAggFunction(functionCallExpr);
         }
 
-        if (functionCallExpr.getParams().isStar() && !(functionCallExpr.getFn() instanceof AggregateFunction)) {
+        if (functionCallExpr.getParams().isStar() && !functionCallExpr.isAggregateFn()) {
             throw new SemanticException("Cannot pass '*' to scalar function.", functionCallExpr.getPos());
         }
 
@@ -174,7 +174,11 @@ public class FunctionAnalyzer {
                         functionCallExpr.getPos());
             }
         }
-        Function fn = functionCallExpr.getFn();
+        Function fn = AnalysisContext.getFunctionByExpr(functionCallExpr);
+        if (fn == null) {
+            fn = ExprUtils.getBuiltinFunction(fnName, functionCallExpr.getFnArgTypes(),
+                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        }
         final String funcName = fnName;
         if (fn instanceof StateFunctionCombinator) {
             // analyze `_state` combinator function by using its arg function

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionExprAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionExprAnalyzer.java
@@ -45,8 +45,8 @@ public class PartitionExprAnalyzer {
                 Function builtinFunction = ExprUtils.getBuiltinFunction(funcCall.getFunctionName(),
                         dateTruncType, Function.CompareMode.IS_IDENTICAL);
 
-                funcCall.setFn(builtinFunction);
                 funcCall.setType(targetColType);
+                AnalysisContext.populateCachedFields(funcCall, builtinFunction);
             } else if (arg1 instanceof FunctionCallExpr) {
                 analyzePartitionExpr((FunctionCallExpr) arg1, partitionSlotRef);
 
@@ -55,8 +55,8 @@ public class PartitionExprAnalyzer {
                 Function builtinFunction = ExprUtils.getBuiltinFunction(funcCall.getFunctionName(),
                         dateTruncType, Function.CompareMode.IS_IDENTICAL);
 
-                funcCall.setFn(builtinFunction);
                 funcCall.setType(targetColType);
+                AnalysisContext.populateCachedFields(funcCall, builtinFunction);
             }
         }
     }
@@ -72,7 +72,7 @@ public class PartitionExprAnalyzer {
             String functionName = functionCallExpr.getFunctionName();
             if (functionName.equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
                 analyzeDateTruncFunction(functionCallExpr, partitionSlotRef);
-                builtinFunction = functionCallExpr.getFn();
+                builtinFunction = AnalysisContext.getFunctionByExpr(functionCallExpr);
                 targetColType = functionCallExpr.getType();
             } else if (functionName.equalsIgnoreCase(FunctionSet.TIME_SLICE)) {
                 Type[] timeSliceType = {DateType.DATETIME, IntegerType.INT, VarcharType.VARCHAR, VarcharType.VARCHAR};
@@ -144,8 +144,8 @@ public class PartitionExprAnalyzer {
                 throw new SemanticException(msg, expr.getPos());
             }
 
-            functionCallExpr.setFn(builtinFunction);
             functionCallExpr.setType(targetColType);
+            AnalysisContext.populateCachedFields(functionCallExpr, builtinFunction);
         } else if (expr instanceof CastExpr) {
             CastExpr castExpr = (CastExpr) expr;
             castExpr.setType(castExpr.getTargetTypeDef().getType());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -770,7 +770,7 @@ public class SelectAnalyzer {
                     if (outputExpr instanceof FunctionCallExpr) {
                         FunctionCallExpr funcCall = (FunctionCallExpr) outputExpr;
                         // Check if it's an aggregate or analytic function (fn must be set and analyzed)
-                        if (funcCall.getFn() != null &&
+                        if (funcCall.hasFnId() &&
                                 (funcCall.isAggregateFunction() || funcCall.isAnalyticFnCall())) {
                             return slotRef;
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DictQueryExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DictQueryExpr.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.ast.expression;
 
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
@@ -28,6 +29,7 @@ import java.util.List;
 public class DictQueryExpr extends FunctionCallExpr {
 
     private TDictQueryExpr dictQueryExpr;
+    private Function fn;
 
     public DictQueryExpr(List<Expr> params) throws SemanticException {
         super(FunctionSet.DICT_MAPPING, params);
@@ -37,12 +39,14 @@ public class DictQueryExpr extends FunctionCallExpr {
         super(FunctionSet.DICT_MAPPING, params);
         this.dictQueryExpr = dictQueryExpr;
         this.fn = fn;
+        AnalysisContext.populateCachedFields(this, fn);
         setType(fn.getReturnType());
     }
 
     protected DictQueryExpr(DictQueryExpr other) {
         super(other);
         this.dictQueryExpr = other.getDictQueryExpr();
+        this.fn = other.fn;
     }
 
 
@@ -64,6 +68,15 @@ public class DictQueryExpr extends FunctionCallExpr {
 
     public TDictQueryExpr getDictQueryExpr() {
         return dictQueryExpr;
+    }
+
+    public Function getFn() {
+        return fn;
+    }
+
+    public void setFn(Function fn) {
+        this.fn = fn;
+        AnalysisContext.populateCachedFields(this, fn);
     }
 
     public void setDictQueryExpr(TDictQueryExpr dictQueryExpr) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprCastFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprCastFunction.java
@@ -159,10 +159,10 @@ public final class ExprCastFunction {
     }
 
     private static Expr castFunctionCall(FunctionCallExpr expr, Type targetType) {
-        if (expr.getFn() == null || expr.getFn().getReturnType() == null) {
+        if (expr.getFnArgTypes() == null || expr.getType() == null) {
             return null;
         }
-        if (expr.getFn().getReturnType().equals(targetType)) {
+        if (expr.getType().equals(targetType)) {
             return expr;
         }
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/SlotRef.java
@@ -293,6 +293,11 @@ public class SlotRef extends Expr {
         return helper.toString();
     }
 
+    @Override
+    public String toSimpleSql() {
+        return colName != null ? colName : (label != null ? label : debugString());
+    }
+
     public boolean isColumnRef() {
         return tblName != null && !isFromLambda();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/ExprVerboseVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/ExprVerboseVisitor.java
@@ -71,13 +71,13 @@ public class ExprVerboseVisitor extends ExprExplainVisitor {
             sb.append(')');
         }
 
-        if (node.getFn() != null) {
+        if (node.getFnArgTypes() != null) {
             sb.append(" args: ");
-            for (int i = 0; i < node.getFn().getArgs().length; ++i) {
+            for (int i = 0; i < node.getFnArgTypes().length; ++i) {
                 if (i != 0) {
                     sb.append(',');
                 }
-                sb.append(node.getFn().getArgs()[i].getPrimitiveType().toString());
+                sb.append(node.getFnArgTypes()[i].getPrimitiveType().toString());
             }
             sb.append(";");
             sb.append(" result: ").append(node.getType()).append(";");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -41,6 +41,7 @@ import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
@@ -1173,7 +1174,7 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
         }
 
         FunctionCallExpr expr = new FunctionCallExpr(tableFunction.getFunctionName().getFunction(), node.getChildExpressions());
-        expr.setFn(tableFunction);
+        AnalysisContext.populateCachedFields(expr, tableFunction);
         ScalarOperator operator = SqlToScalarOperatorTranslator.translate(expr, context, columnRefFactory);
 
         if (operator.isConstantRef() && ((ConstantOperator) operator).isNull()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.SqlFunction;
 import com.starrocks.catalog.TableName;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
@@ -743,22 +744,23 @@ public final class SqlToScalarOperatorTranslator {
                 arguments.add(ConstantOperator.createInt(columnRefFactory.getNextUniqueId()));
             }
 
-            if (node.getFn() instanceof SqlFunction) {
-                return visitSqlFunctionCall(node, arguments);
+            Function fn = AnalysisContext.getFunctionByExpr(node);
+            if (fn instanceof SqlFunction) {
+                return visitSqlFunctionCall(node, fn, arguments);
             }
 
             CallOperator callOperator = new CallOperator(
                     node.getFunctionName(),
                     node.getType(),
                     arguments,
-                    node.getFn(),
+                    fn,
                     node.getParams().isDistinct());
             callOperator.setHints(node.getHints());
             return callOperator;
         }
 
-        public ScalarOperator visitSqlFunctionCall(FunctionCallExpr node, List<ScalarOperator> arguments) {
-            SqlFunction sqlFunction = (SqlFunction) node.getFn();
+        public ScalarOperator visitSqlFunctionCall(FunctionCallExpr node, Function fn, List<ScalarOperator> arguments) {
+            SqlFunction sqlFunction = (SqlFunction) fn;
             Expr expr = sqlFunction.getAnalyzeExpr();
             if (expr == null) {
                 throw new StarRocksPlannerException("view function analyze expr is null",
@@ -789,7 +791,7 @@ public final class SqlToScalarOperatorTranslator {
                     .collect(Collectors.toList());
             CallOperator callOperator =
                     new CallOperator(functionCallExpr.getFunctionName(), functionCallExpr.getType(), arguments,
-                            functionCallExpr.getFn(), functionCallExpr.getParams().isDistinct());
+                            AnalysisContext.getFunctionByExpr(functionCallExpr), functionCallExpr.getParams().isDistinct());
             callOperator.setIgnoreNulls(functionCallExpr.getIgnoreNulls());
             return callOperator;
         }
@@ -920,7 +922,8 @@ public final class SqlToScalarOperatorTranslator {
                     .stream()
                     .map(child -> visit(child, context.clone(node)))
                     .collect(Collectors.toList());
-            return new DictQueryOperator(arguments, node.getDictQueryExpr(), node.getFn(), node.getType());
+            return new DictQueryOperator(arguments, node.getDictQueryExpr(),
+                    AnalysisContext.getFunctionByExpr(node), node.getType());
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -17,12 +17,12 @@ package com.starrocks.sql.optimizer.transformer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.ast.expression.AnalyticExpr;
@@ -105,10 +105,10 @@ public class WindowTransformer {
         List<OrderByElement> orderByElements = analyticExpr.getOrderByElements();
 
         // Set a window from UNBOUNDED PRECEDING to CURRENT_ROW for row_number().
-        if (isRowNumberFn(callExpr.getFn())) {
+        if (isRowNumberFn(callExpr)) {
             Preconditions.checkState(windowFrame == null, "Unexpected window set for row_numer()");
             windowFrame = AnalyticWindow.DEFAULT_ROWS_WINDOW;
-        } else if (isNtileFn(callExpr.getFn())) {
+        } else if (isNtileFn(callExpr)) {
             Preconditions.checkState(windowFrame == null, "Unexpected window set for NTILE()");
             windowFrame = AnalyticWindow.DEFAULT_ROWS_WINDOW;
 
@@ -117,18 +117,18 @@ public class WindowTransformer {
             } catch (AnalysisException e) {
                 throw new SemanticException(e.getMessage());
             }
-        } else if (isCumeFn(callExpr.getFn())) {
+        } else if (isCumeFn(callExpr)) {
             Preconditions.checkState(windowFrame == null, "Unexpected window set for "
-                    + callExpr.getFn().getFunctionName() + "()");
+                    + callExpr.getFunctionName() + "()");
             windowFrame = AnalyticWindow.DEFAULT_WINDOW;
-        } else if (isOffsetFn(callExpr.getFn())) {
+        } else if (isOffsetFn(callExpr)) {
             try {
                 Preconditions.checkState(windowFrame == null);
                 Type firstType = callExpr.getChild(0).getType();
                 // In old planner, the NullLiteral will cast to function arg type.
                 // But in new planner, the NullLiteral type is still null.
                 if (callExpr.getChild(0) instanceof NullLiteral) {
-                    firstType = callExpr.getFn().getArgs()[0];
+                    firstType = callExpr.getFnArgTypes()[0];
                 }
 
                 if (callExpr.getChildren().size() == 1) {
@@ -161,7 +161,7 @@ public class WindowTransformer {
             } catch (AnalysisException e) {
                 throw new SemanticException(e.getMessage());
             }
-        } else if (isApproxTopKFn(callExpr.getFn())) {
+        } else if (isApproxTopKFn(callExpr)) {
             Preconditions.checkState(CollectionUtils.isEmpty(orderByElements),
                     "Unexpected order by clause for approx_top_k()");
             Preconditions.checkState(windowFrame == null, "Unexpected window set for approx_top_k()");
@@ -189,8 +189,8 @@ public class WindowTransformer {
             if (reversedFnName != null) {
                 callExpr.resetFnName("", reversedFnName);
                 Function reversedFn = ExprUtils.getBuiltinFunction(reversedFnName,
-                        callExpr.getFn().getArgs(), Function.CompareMode.IS_IDENTICAL);
-                callExpr.setFn(reversedFn);
+                        callExpr.getFnArgTypes(), Function.CompareMode.IS_IDENTICAL);
+                AnalysisContext.populateCachedFields(callExpr, reversedFn);
             }
         }
 
@@ -489,50 +489,50 @@ public class WindowTransformer {
         return partitionPrefix.contains(subSet);
     }
 
-    public static boolean isAnalyticFn(Function fn) {
-        return fn instanceof AggregateFunction
-                && ((AggregateFunction) fn).isAnalyticFn();
+    public static boolean isAnalyticFn(FunctionCallExpr fn) {
+        return fn.isWindowFunction();
     }
 
-    public static boolean isOffsetFn(Function fn) {
+    public static boolean isOffsetFn(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.LEAD) || fn.functionName().equalsIgnoreCase(AnalyticExpr.LAG);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.LEAD) ||
+                fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.LAG);
     }
 
-    public static boolean isNtileFn(Function fn) {
+    public static boolean isNtileFn(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.NTILE);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.NTILE);
     }
 
-    public static boolean isCumeFn(Function fn) {
+    public static boolean isCumeFn(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.CUMEDIST) || fn.functionName().equalsIgnoreCase(
-                AnalyticExpr.PERCENTRANK);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.CUMEDIST) ||
+                fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.PERCENTRANK);
     }
 
-    public static boolean isRowNumberFn(Function fn) {
+    public static boolean isRowNumberFn(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.ROWNUMBER);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.ROWNUMBER);
     }
 
-    public static boolean isApproxTopKFn(Function fn) {
+    public static boolean isApproxTopKFn(FunctionCallExpr fn) {
         if (!isAnalyticFn(fn)) {
             return false;
         }
 
-        return fn.functionName().equalsIgnoreCase(AnalyticExpr.APPROX_TOP_K);
+        return fn.getFunctionName().equalsIgnoreCase(AnalyticExpr.APPROX_TOP_K);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -122,6 +122,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -2472,7 +2473,7 @@ public class PlanFragmentBuilder {
                         .put(aggregation.getKey(), new SlotRef(aggregation.getKey().toString(), slotDesc));
 
                 SlotDescriptor intermediateSlotDesc = new SlotDescriptor(slotDesc.getId(), slotDesc.getParent());
-                AggregateFunction aggrFn = (AggregateFunction) aggExpr.getFn();
+                AggregateFunction aggrFn = (AggregateFunction) AnalysisContext.getFunctionByExpr(aggExpr);
                 Type intermediateType = aggrFn.getIntermediateType() != null ?
                         aggrFn.getIntermediateType() : aggrFn.getReturnType();
                 intermediateType = AnalyzerUtils.replaceNullType2Boolean(intermediateType);
@@ -2747,28 +2748,30 @@ public class PlanFragmentBuilder {
                 final String functionName = functionCallExpr.getFunctionName();
                 if (functionName.equalsIgnoreCase(FunctionSet.COUNT)) {
                     replaceExpr = new FunctionCallExpr(FunctionSet.MULTI_DISTINCT_COUNT, functionCallExpr.getParams());
-                    replaceExpr.setFn(ExprUtils.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_COUNT,
-                            functionCallExpr.getFn().getArgs(),
-                            IS_NONSTRICT_SUPERTYPE_OF));
+                    Function mdcFn = ExprUtils.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_COUNT,
+                            functionCallExpr.getFnArgTypes(),
+                            IS_NONSTRICT_SUPERTYPE_OF);
+                    AnalysisContext.populateCachedFields(replaceExpr, mdcFn);
                     replaceExpr.getParams().setIsDistinct(false);
                     replaceExpr.setType(functionCallExpr.getType());
                 } else if (functionName.equalsIgnoreCase(FunctionSet.SUM)) {
                     replaceExpr = new FunctionCallExpr(FunctionSet.MULTI_DISTINCT_SUM, functionCallExpr.getParams());
                     Function multiDistinctSum = DecimalV3FunctionAnalyzer.convertSumToMultiDistinctSum(
-                            functionCallExpr.getFn(), functionCallExpr.getChild(0).getType());
-                    replaceExpr.setFn(multiDistinctSum);
+                            AnalysisContext.getFunctionByExpr(functionCallExpr), functionCallExpr.getChild(0).getType());
+                    AnalysisContext.populateCachedFields(replaceExpr, multiDistinctSum);
                     replaceExpr.getParams().setIsDistinct(false);
                     replaceExpr.setType(functionCallExpr.getType());
                 } else if (functionName.equals(FunctionSet.ARRAY_AGG)) {
                     replaceExpr = new FunctionCallExpr(FunctionSet.ARRAY_AGG_DISTINCT, functionCallExpr.getParams());
                     AggregateFunction fn =
                             (AggregateFunction) ExprUtils.getBuiltinFunction(FunctionSet.ARRAY_AGG_DISTINCT,
-                                    functionCallExpr.getFn().getArgs(),
+                                    functionCallExpr.getFnArgTypes(),
                                     IS_NONSTRICT_SUPERTYPE_OF);
+                    Function fceFn = AnalysisContext.getFunctionByExpr(functionCallExpr);
                     fn = DecimalV3FunctionAnalyzer.rectifyAggregationFunction(
-                            fn, functionCallExpr.getFn().getArgs()[0], functionCallExpr.getFn().getReturnType());
+                            fn, functionCallExpr.getFnArgTypes()[0], fceFn.getReturnType());
 
-                    replaceExpr.setFn(fn);
+                    AnalysisContext.populateCachedFields(replaceExpr, fn);
                     replaceExpr.getParams().setIsDistinct(false);
                     replaceExpr.setType(functionCallExpr.getType());
                 }
@@ -3452,15 +3455,16 @@ public class PlanFragmentBuilder {
                 // Only boolean/numeric/string type can be optimized via array_agg_distinct
                 if (call.isDistinct() && call.getFunctionName().equals(FunctionSet.ARRAY_AGG) &&
                         call.getFnParams().exprs().size() == 1 && (
-                        call.getFn().getArgs()[0].isNumericType() || call.getFn().getArgs()[0].isStringType() ||
-                                call.getFn().getArgs()[0].isBoolean())) {
+                        call.getFnArgTypes()[0].isNumericType() || call.getFnArgTypes()[0].isStringType() ||
+                                call.getFnArgTypes()[0].isBoolean())) {
                     FunctionCallExpr newCall = new FunctionCallExpr(FunctionSet.ARRAY_AGG_DISTINCT, call.getParams());
                     AggregateFunction fn =
                             (AggregateFunction) ExprUtils.getBuiltinFunction(FunctionSet.ARRAY_AGG_DISTINCT,
-                                    call.getFn().getArgs(), IS_NONSTRICT_SUPERTYPE_OF);
+                                    call.getFnArgTypes(), IS_NONSTRICT_SUPERTYPE_OF);
+                    Function callFn = AnalysisContext.getFunctionByExpr(call);
                     fn = DecimalV3FunctionAnalyzer.rectifyAggregationFunction(
-                            fn, call.getFn().getArgs()[0], call.getFn().getReturnType());
-                    newCall.setFn(fn);
+                            fn, call.getFnArgTypes()[0], callFn.getReturnType());
+                    AnalysisContext.populateCachedFields(newCall, fn);
                     newCall.getParams().setIsDistinct(false);
                     newCall.setType(call.getType());
                     analyticFunction = newCall;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -22,6 +22,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.qe.GlobalVariable;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.ArithmeticExpr;
@@ -550,7 +551,7 @@ public class ScalarOperatorToExpr {
                     }
                     callExpr = new FunctionCallExpr(call.getFnName(), new FunctionParams(false, arguments));
                     Preconditions.checkNotNull(call.getFunction());
-                    ((FunctionCallExpr) callExpr).setFn(call.getFunction());
+                    AnalysisContext.populateCachedFields((FunctionCallExpr) callExpr, call.getFunction());
                     callExpr.setIgnoreNulls(call.getIgnoreNulls());
                     break;
                 default:
@@ -563,7 +564,7 @@ public class ScalarOperatorToExpr {
                         callExpr = new FunctionCallExpr(call.getFnName(), new FunctionParams(call.isDistinct(), arg));
                     }
                     Preconditions.checkNotNull(call.getFunction());
-                    ((FunctionCallExpr) callExpr).setFn(call.getFunction());
+                    AnalysisContext.populateCachedFields((FunctionCallExpr) callExpr, call.getFunction());
                     callExpr.setIgnoreNulls(call.getIgnoreNulls());
                     break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMFunctions.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionName;
 import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.BetweenPredicate;
 import com.starrocks.sql.ast.expression.Expr;
@@ -115,7 +116,8 @@ public class SPMFunctions {
         List<Expr> children = Lists.newArrayList(new IntLiteral(placeholderID, IntegerType.BIGINT));
         children.addAll(input);
         FunctionCallExpr expr = new FunctionCallExpr(func, children);
-        expr.setFn(getSPMFunction(func, NullType.NULL, children.stream().map(Expr::getType).toList()));
+        AnalysisContext.populateCachedFields(expr,
+                getSPMFunction(func, NullType.NULL, children.stream().map(Expr::getType).toList()));
         expr.setType(NullType.NULL);
         return expr;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
@@ -182,9 +182,7 @@ public class SPMPlanner {
                 return true;
             }
             FunctionCallExpr other = cast(node2);
-            Preconditions.checkNotNull(node.getFn());
-            Preconditions.checkNotNull(other.getFn());
-            if (!StringUtils.equals(node.getFn().functionName(), other.getFn().functionName())) {
+            if (!StringUtils.equals(node.getFunctionName(), other.getFunctionName())) {
                 return false;
             }
             return check(node.getChildren(), ((Expr) node2).getChildren());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -33,6 +33,7 @@ import com.starrocks.qe.QueryState;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.StatisticsType;
 import com.starrocks.sql.ast.expression.Expr;
@@ -305,13 +306,13 @@ public abstract class StatisticsCollectJob {
                 Function.CompareMode.IS_IDENTICAL);
 
         FunctionCallExpr unhexExpr = new FunctionCallExpr("unhex", Lists.newArrayList(new StringLiteral(str)));
-        unhexExpr.setFn(unhex);
+        AnalysisContext.populateCachedFields(unhexExpr, unhex);
         unhexExpr.setType(unhex.getReturnType());
 
         Function fn = ExprUtils.getBuiltinFunction("hll_deserialize", new Type[] {VarcharType.VARCHAR},
                 Function.CompareMode.IS_IDENTICAL);
         FunctionCallExpr fe = new FunctionCallExpr("hll_deserialize", Lists.newArrayList(unhexExpr));
-        fe.setFn(fn);
+        AnalysisContext.populateCachedFields(fe, fn);
         fe.setType(fn.getReturnType());
         return fe;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperQueryJob.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.ast.StatisticsType;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprUtils;
@@ -210,13 +211,13 @@ public abstract class HyperQueryJob {
                 Function.CompareMode.IS_IDENTICAL);
 
         FunctionCallExpr unhexExpr = new FunctionCallExpr("unhex", Lists.newArrayList(new StringLiteral(str)));
-        unhexExpr.setFn(unhex);
+        AnalysisContext.populateCachedFields(unhexExpr, unhex);
         unhexExpr.setType(unhex.getReturnType());
 
         Function fn = ExprUtils.getBuiltinFunction("hll_deserialize", new Type[] {VarcharType.VARCHAR},
                 Function.CompareMode.IS_IDENTICAL);
         FunctionCallExpr fe = new FunctionCallExpr("hll_deserialize", Lists.newArrayList(unhexExpr));
-        fe.setFn(fn);
+        AnalysisContext.populateCachedFields(fe, fn);
         fe.setType(fn.getReturnType());
         return fe;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
@@ -22,6 +22,7 @@ import com.starrocks.persist.ColumnIdExpr;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -79,7 +80,7 @@ public class ExpressionRangePartitionInfoTest {
         fnChildren.add(new StringLiteral("month"));
         fnChildren.add(slotRef2);
         functionCallExpr = new FunctionCallExpr("date_trunc", fnChildren);
-        functionCallExpr.setFn(ExprUtils.getBuiltinFunction(
+        AnalysisContext.populateCachedFields(functionCallExpr, ExprUtils.getBuiltinFunction(
                 "date_trunc", new Type[] {VarcharType.VARCHAR, DateType.DATETIME}, Function.CompareMode.IS_IDENTICAL));
 
         FeConstants.runningUnitTest = true;
@@ -530,7 +531,7 @@ public class ExpressionRangePartitionInfoTest {
         OlapTable readTable = GsonUtils.GSON.fromJson(json, OlapTable.class);
         ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) readTable.getPartitionInfo();
         List<Expr> readPartitionExprs = expressionRangePartitionInfo.getPartitionExprs(readTable.getIdToColumn());
-        Function fn = ((FunctionCallExpr) readPartitionExprs.get(0)).getFn();
+        Function fn = AnalysisContext.getFunctionByExpr((FunctionCallExpr) readPartitionExprs.get(0));
         Assertions.assertNotNull(fn);
         starRocksAssert.dropTable("table_hitcount");
     }
@@ -568,7 +569,7 @@ public class ExpressionRangePartitionInfoTest {
         Assertions.assertTrue(exprs.get(0) instanceof FunctionCallExpr);
         FunctionCallExpr fn = (FunctionCallExpr) exprs.get(0);
         // The function should have been resolved by analyzePartitionExpr
-        Assertions.assertNotNull(fn.getFn(),
+        Assertions.assertNotNull(AnalysisContext.getFunctionByExpr(fn),
                 "Partition expression should be analyzed after column rename");
         // The slot ref column name should be updated to the new name
         SlotRef slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(fn);
@@ -755,7 +756,7 @@ public class ExpressionRangePartitionInfoTest {
         OlapTable readTable = GsonUtils.GSON.fromJson(json, OlapTable.class);
         expressionRangePartitionInfo = (ExpressionRangePartitionInfo) readTable.getPartitionInfo();
         List<ColumnIdExpr> readPartitionExprs = expressionRangePartitionInfo.getPartitionExprs();
-        Function fn = ((FunctionCallExpr) readPartitionExprs.get(0).getExpr()).getFn();
+        Function fn = AnalysisContext.getFunctionByExpr((FunctionCallExpr) readPartitionExprs.get(0).getExpr());
         Assertions.assertNotNull(fn);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleExpressionAnalyzer.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleExpressionAnalyzer.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
@@ -577,7 +578,7 @@ public class SimpleExpressionAnalyzer {
             Function fn = ExprUtils.getBuiltinFunction(node.getFunctionName(),
                     childTypes, Function.CompareMode.IS_IDENTICAL);
 
-            node.setFn(fn);
+            AnalysisContext.populateCachedFields(node, fn);
             node.setType(fn.getReturnType());
             return null;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.analyzer;
 
 import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
@@ -197,7 +198,7 @@ public class AnalyzeDecimalV3Test {
             Assertions.assertTrue(items.get(i) != null);
             Type type = items.get(i).getType();
             Type expectType = expectTypes[i / 2];
-            AggregateFunction fn = (AggregateFunction) ((FunctionCallExpr) items.get(i)).getFn();
+            AggregateFunction fn = (AggregateFunction) AnalysisContext.getFunctionByExpr((FunctionCallExpr) items.get(i));
             Type returnType = fn.getReturnType();
             Type argType = fn.getArgs()[0];
             Type serdeType = fn.getIntermediateType();
@@ -250,8 +251,9 @@ public class AnalyzeDecimalV3Test {
             Type expectArgType = expectArgTypes[i / 3];
             Type expectReturnType = expectReturnTypes[i / 3];
 
-            Assertions.assertTrue(((FunctionCallExpr) items.get(i)).getFn() instanceof AggregateFunction);
-            AggregateFunction fn = (AggregateFunction) ((FunctionCallExpr) items.get(i)).getFn();
+            Function resolvedFn = AnalysisContext.getFunctionByExpr((FunctionCallExpr) items.get(i));
+            Assertions.assertTrue(resolvedFn instanceof AggregateFunction);
+            AggregateFunction fn = (AggregateFunction) resolvedFn;
             Type returnType = fn.getReturnType();
             Type argType = fn.getArgs()[0];
             Type serdeType = fn.getIntermediateType();
@@ -812,9 +814,10 @@ public class AnalyzeDecimalV3Test {
             for (int i = 0; i < items.size(); ++i) {
                 Expr expr = items.get(i);
                 Assertions.assertEquals(expr.getType(), FloatType.DOUBLE);
-                Assertions.assertEquals(((FunctionCallExpr) expr).getFn().getArgs()[0], FloatType.DOUBLE);
-                Assertions.assertEquals(((FunctionCallExpr) expr).getFn().getReturnType(), FloatType.DOUBLE);
-                Assertions.assertEquals(((AggregateFunction) ((FunctionCallExpr) expr).getFn()).getIntermediateType(),
+                Function exprFn = AnalysisContext.getFunctionByExpr((FunctionCallExpr) expr);
+                Assertions.assertEquals(exprFn.getArgs()[0], FloatType.DOUBLE);
+                Assertions.assertEquals(exprFn.getReturnType(), FloatType.DOUBLE);
+                Assertions.assertEquals(((AggregateFunction) exprFn).getIntermediateType(),
                         VarbinaryType.VARBINARY);
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftTest.java
@@ -22,6 +22,7 @@ import com.starrocks.common.util.DateUtils;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.planner.expression.ExprToThrift;
+import com.starrocks.sql.analyzer.AnalysisContext;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.UnitIdentifier;
@@ -345,7 +346,7 @@ public class ExprToThriftTest {
             FunctionCallExpr call = new FunctionCallExpr("abs", List.of(new IntLiteral(-3)));
             ScalarFunction fn = ScalarFunction.createBuiltinOperator("abs",
                     Lists.newArrayList(IntegerType.INT), IntegerType.INT);
-            call.setFn(fn);
+            AnalysisContext.populateCachedFields(call, fn);
             call.setType(IntegerType.INT);
             call.setOriginType(IntegerType.INT);
             return call;
@@ -355,7 +356,7 @@ public class ExprToThriftTest {
             FunctionCallExpr call = new FunctionCallExpr("sum", List.of(new IntLiteral(3)));
             AggregateFunction fn = AggregateFunction.createBuiltin("sum", List.of(IntegerType.INT),
                     IntegerType.INT, IntegerType.INT, false, false, false, false);
-            call.setFn(fn);
+            AnalysisContext.populateCachedFields(call, fn);
             call.setType(IntegerType.INT);
             call.setOriginType(IntegerType.INT);
             return call;
@@ -365,7 +366,7 @@ public class ExprToThriftTest {
             FunctionCallExpr call = new FunctionCallExpr("row_number", Collections.emptyList());
             AggregateFunction fn = AggregateFunction.createBuiltin("row_number", Collections.emptyList(),
                     IntegerType.BIGINT, IntegerType.BIGINT, false, false, true, true);
-            call.setFn(fn);
+            AnalysisContext.populateCachedFields(call, fn);
             call.setType(IntegerType.BIGINT);
             call.setOriginType(IntegerType.BIGINT);
             call.setIsAnalyticFnCall(true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggregationOverWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggregationOverWindowTest.java
@@ -16,7 +16,6 @@ package com.starrocks.sql.plan;
 
 import com.google.api.client.util.Lists;
 import com.google.common.collect.Sets;
-import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
@@ -447,7 +446,7 @@ public class DistinctAggregationOverWindowTest extends PlanTestBase {
                 .flatMap(agg -> agg.getAggInfo().getAggregateExprs().stream())
                 .filter(fcall -> names.contains(fcall.getFunctionName()))
                 .findFirst()
-                .map(fcall -> ((AggregateFunction) fcall.getFn()).getReturnType());
+                .map(FunctionCallExpr::getType);
 
         if (optReturnType.isPresent()) {
             return optReturnType.get();
@@ -459,7 +458,7 @@ public class DistinctAggregationOverWindowTest extends PlanTestBase {
                 .flatMap(win -> win.getAnalyticFnCalls().stream().map(e -> (FunctionCallExpr) e))
                 .filter(fcall -> names.contains(fcall.getFunctionName()))
                 .findFirst()
-                .map(fcall -> ((AggregateFunction) fcall.getFn()).getReturnType());
+                .map(FunctionCallExpr::getType);
 
         Assertions.assertTrue(optReturnType.isPresent());
         return optReturnType.get();

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.ast;
 
+import com.starrocks.sql.ast.expression.AnalyticExpr;
 import com.starrocks.sql.ast.expression.ArithmeticExpr;
 import com.starrocks.sql.ast.expression.ArrayExpr;
 import com.starrocks.sql.ast.expression.ArraySliceExpr;
@@ -33,6 +34,8 @@ import com.starrocks.sql.ast.expression.DictionaryGetExpr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FieldReference;
 import com.starrocks.sql.ast.expression.FloatLiteral;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.GroupingFunctionCallExpr;
 import com.starrocks.sql.ast.expression.InPredicate;
 import com.starrocks.sql.ast.expression.InformationFunction;
 import com.starrocks.sql.ast.expression.IntLiteral;
@@ -1256,6 +1259,19 @@ public interface AstVisitor<R, C> {
     }
 
     // ------------------------------------------- Other Expressions --------------------------------
+
+    default R visitAnalyticExpr(AnalyticExpr node, C context) {
+        return visitExpression(node, context);
+    }
+
+    default R visitFunctionCall(FunctionCallExpr node, C context) {
+        return visitExpression(node, context);
+    }
+
+    default R visitGroupingFunctionCall(GroupingFunctionCallExpr node, C context) {
+        return visitFunctionCall(node, context);
+    }
+
 
     default R visitArithmeticExpr(ArithmeticExpr node, C context) {
         return visitExpression(node, context);

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/AnalyticExpr.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/AnalyticExpr.java
@@ -38,15 +38,14 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.ast.AstVisitor;
-import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.HintNode;
 import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.parser.NodePosition;
-import org.apache.commons.collections.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
 
 /**
  * Representation of an analytic function call with OVER clause.
@@ -130,7 +129,7 @@ public class AnalyticExpr extends Expr {
 
         this.window = window;
         this.skewValues = List.of();
-        if (CollectionUtils.isNotEmpty(hints)) {
+        if (hints != null && !hints.isEmpty()) {
             for (String hint : hints) {
                 if (HintNode.HINT_ANALYTIC_SORT.equalsIgnoreCase(hint) ||
                         HintNode.HINT_ANALYTIC_HASH.equalsIgnoreCase(hint)) {
@@ -163,7 +162,10 @@ public class AnalyticExpr extends Expr {
             orderByElements.add(e.clone());
         }
 
-        partitionExprs = ExprUtils.cloneList(other.partitionExprs);
+        partitionExprs = new ArrayList<>();
+        for (Expr e : other.partitionExprs) {
+            partitionExprs.add(e.clone());
+        }
         window = (other.window != null ? other.window.clone() : null);
         resetWindow = other.resetWindow;
         partitionHint = other.partitionHint;
@@ -171,7 +173,10 @@ public class AnalyticExpr extends Expr {
         useHashBasedPartition = other.useHashBasedPartition;
         isSkewed = other.isSkewed;
         skewColumn = (other.skewColumn != null ? other.skewColumn.clone() : null);
-        skewValues = ExprUtils.cloneList(other.skewValues);
+        skewValues = new ArrayList<>();
+        for (Expr e : other.skewValues) {
+            skewValues.add(e.clone());
+        }
         sqlString = other.sqlString;
         setChildren();
     }
@@ -327,7 +332,7 @@ public class AnalyticExpr extends Expr {
      */
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitAnalyticExpr(this, context);
+        return visitor.visitAnalyticExpr(this, context);
     }
 
     @Override

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/Expr.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/Expr.java
@@ -164,7 +164,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     /**
      * Set the expr to be analyzed and computes isConstant_.
      */
-    protected void analysisDone() {
+    public void analysisDone() {
         Preconditions.checkState(!isAnalyzed);
         // We need to compute the const-ness as the last step, since analysis may change
         // the result, e.g. by resolving function.
@@ -295,6 +295,16 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this.getClass()).add("type", type).toString();
+    }
+
+    /**
+     * Produce a simple SQL-like string for error messages.
+     * Default implementation uses debugString(). Subclasses in fe-parser
+     * (like FunctionCallExpr) override to produce cleaner output.
+     * fe-core subclasses (SlotRef, StringLiteral, etc.) override in their own files.
+     */
+    public String toSimpleSql() {
+        return debugString();
     }
 
     @Override

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/ExprSubstitutionVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/ExprSubstitutionVisitor.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast.expression;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.sql.ast.AstVisitor;
+
+/**
+ * Visitor-based implementation of expression substitution. It provides a single
+ * entry point to rewrite an expression tree based on {@link ExprSubstitutionMap}.
+ */
+public final class ExprSubstitutionVisitor implements AstVisitor<Expr, ExprSubstitutionMap> {
+    private static final ExprSubstitutionVisitor INSTANCE = new ExprSubstitutionVisitor();
+
+    private ExprSubstitutionVisitor() {
+    }
+
+    /**
+     * Returns a new expression where every occurrence of {@code lhs[i]} is substituted
+     * with {@code rhs[i]} from {@code substitutionMap}. The original expression remains unchanged.
+     */
+    public static Expr rewrite(Expr expr, ExprSubstitutionMap substitutionMap) {
+        Preconditions.checkNotNull(expr, "expr cannot be null");
+        Preconditions.checkNotNull(substitutionMap, "substitutionMap cannot be null");
+        return expr.accept(INSTANCE, substitutionMap);
+    }
+
+    @Override
+    public Expr visitExpression(Expr node, ExprSubstitutionMap context) {
+        Expr replacement = context.get(node);
+        if (replacement != null) {
+            return replacement.clone();
+        }
+
+        Expr cloned = node.clone();
+        int childCount = node.getChildren().size();
+        for (int i = 0; i < childCount; ++i) {
+            Expr rewrittenChild = node.getChild(i).accept(this, context);
+            cloned.setChild(i, rewrittenChild);
+        }
+        return cloned;
+    }
+}

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/FunctionCallExpr.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/FunctionCallExpr.java
@@ -37,23 +37,25 @@ package com.starrocks.sql.ast.expression;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-import com.starrocks.catalog.AggregateFunction;
-import com.starrocks.catalog.Function;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.ast.AstVisitor;
-import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.type.Type;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 public class FunctionCallExpr extends Expr {
-    protected Function fn;
+    private static final java.util.concurrent.atomic.AtomicLong FN_ID_COUNTER =
+            new java.util.concurrent.atomic.AtomicLong(0);
+
+    // Unique ID assigned when the function is resolved. Used as key in AnalysisContext
+    // to look up the resolved Function object. Survives clone/copy since it's a plain long.
+    private long fnId = -1;
+
     private FunctionRef fnRef;
-    // private BuiltinAggregateFunction.Operator aggOp;
     private FunctionParams fnParams;
 
     // check analytic function
@@ -64,9 +66,23 @@ public class FunctionCallExpr extends Expr {
     // resetAnalysisState() which is used during expr substitution.
     private boolean isMergeAggFn;
 
+    // Cached properties from the resolved Function object, set via AnalysisContext.populateCachedFields().
+    private boolean isAggregateFn = false;
+    private boolean fnNullable = true;
+    private Type[] fnArgTypes;
+    private boolean fnHasVarArgs = false;
+    private int fnNumArgs = 0;
+    private boolean isWindowFunction = false;
+
+    private static final ImmutableSet<String> NON_DETERMINISTIC_FUNCTIONS =
+            ImmutableSet.<String>builder()
+                    .add("rand").add("random").add("uuid").add("uuid_numeric")
+                    .add("uuid_v7").add("uuid_v7_numeric").add("sleep")
+                    .build();
+
     // TODO(yan): add more known functions which are monotonic.
     private static final ImmutableSet<String> MONOTONIC_FUNCTION_SET =
-            new ImmutableSet.Builder<String>().add(FunctionSet.YEAR).build();
+            new ImmutableSet.Builder<String>().add("year").build();
 
     public boolean isAnalyticFnCall() {
         return isAnalyticFnCall;
@@ -76,12 +92,78 @@ public class FunctionCallExpr extends Expr {
         isAnalyticFnCall = v;
     }
 
-    public Function getFn() {
-        return fn;
+    public static long nextFnId() {
+        return FN_ID_COUNTER.incrementAndGet();
     }
 
-    public void setFn(Function fn) {
-        this.fn = fn;
+    public long getFnId() {
+        return fnId;
+    }
+
+    public void setFnId(long fnId) {
+        this.fnId = fnId;
+    }
+
+    public boolean hasFnId() {
+        return fnId >= 0;
+    }
+
+    public boolean isAggregateFn() {
+        return isAggregateFn;
+    }
+
+    public void setAggregateFn(boolean aggregateFn) {
+        isAggregateFn = aggregateFn;
+    }
+
+    public boolean isFnNullable() {
+        return fnNullable;
+    }
+
+    public void setFnNullable(boolean fnNullable) {
+        this.fnNullable = fnNullable;
+    }
+
+    public Type[] getFnArgTypes() {
+        return fnArgTypes;
+    }
+
+    public void setFnArgTypes(Type[] fnArgTypes) {
+        this.fnArgTypes = fnArgTypes;
+    }
+
+    public boolean isFnHasVarArgs() {
+        return fnHasVarArgs;
+    }
+
+    public void setFnHasVarArgs(boolean fnHasVarArgs) {
+        this.fnHasVarArgs = fnHasVarArgs;
+    }
+
+    public int getFnNumArgs() {
+        return fnNumArgs;
+    }
+
+    public void setFnNumArgs(int fnNumArgs) {
+        this.fnNumArgs = fnNumArgs;
+    }
+
+    public boolean isWindowFunction() {
+        return isWindowFunction;
+    }
+
+    public void setWindowFunction(boolean windowFunction) {
+        isWindowFunction = windowFunction;
+    }
+
+    public void copyFnFieldsFrom(FunctionCallExpr other) {
+        this.fnId = other.fnId;
+        this.isAggregateFn = other.isAggregateFn;
+        this.fnNullable = other.fnNullable;
+        this.fnArgTypes = other.fnArgTypes;
+        this.fnHasVarArgs = other.fnHasVarArgs;
+        this.fnNumArgs = other.fnNumArgs;
+        this.isWindowFunction = other.isWindowFunction;
     }
 
     public FunctionRef getFnRef() {
@@ -177,11 +259,15 @@ public class FunctionCallExpr extends Expr {
         Preconditions.checkState(e.isAnalyzed);
         Preconditions.checkState(e.isAggregateFunction() || e.isAnalyticFnCall);
         fnRef = e.fnRef;
-        // aggOp = e.aggOp;
         isAnalyticFnCall = e.isAnalyticFnCall;
         fnParams = params;
-        // Just inherit the function object from 'e'.
-        fn = e.fn;
+        fnId = e.fnId;
+        isAggregateFn = e.isAggregateFn;
+        fnNullable = e.fnNullable;
+        fnArgTypes = e.fnArgTypes;
+        fnHasVarArgs = e.fnHasVarArgs;
+        fnNumArgs = e.fnNumArgs;
+        isWindowFunction = e.isWindowFunction;
         this.isMergeAggFn = e.isMergeAggFn;
         if (params.exprs() != null) {
             children.addAll(params.exprs());
@@ -190,11 +276,15 @@ public class FunctionCallExpr extends Expr {
 
     protected FunctionCallExpr(FunctionCallExpr other) {
         super(other);
-        fn = other.fn;
+        fnId = other.fnId;
+        isAggregateFn = other.isAggregateFn;
+        fnNullable = other.fnNullable;
+        fnArgTypes = other.fnArgTypes;
+        fnHasVarArgs = other.fnHasVarArgs;
+        fnNumArgs = other.fnNumArgs;
+        isWindowFunction = other.isWindowFunction;
         fnRef = other.fnRef;
         isAnalyticFnCall = other.isAnalyticFnCall;
-        //   aggOp = other.aggOp;
-        // fnParams = other.fnParams;
         // Clone the params in a way that keeps the children_ and the params.exprs()
         // in sync. The children have already been cloned in the super c'tor.
         if (other.fnParams.isStar()) {
@@ -208,13 +298,13 @@ public class FunctionCallExpr extends Expr {
 
     public static final Set<String> NULLABLE_SAME_WITH_CHILDREN_FUNCTIONS =
             ImmutableSet.<String>builder()
-                    .add(FunctionSet.YEAR)
-                    .add(FunctionSet.MONTH)
-                    .add(FunctionSet.DAY)
-                    .add(FunctionSet.HOUR)
-                    .add(FunctionSet.ADD)
-                    .add(FunctionSet.SUBTRACT)
-                    .add(FunctionSet.MULTIPLY)
+                    .add("year")
+                    .add("month")
+                    .add("day")
+                    .add("hour")
+                    .add("add")
+                    .add("subtract")
+                    .add("multiply")
                     .build();
 
     public boolean isMergeAggFn() {
@@ -234,7 +324,12 @@ public class FunctionCallExpr extends Expr {
         // fn_ such that analyze() hits the special-case code for merge agg fns that
         // handles this case.
         if (!isMergeAggFn) {
-            fn = null;
+            isAggregateFn = false;
+            fnNullable = true;
+            fnArgTypes = null;
+            fnHasVarArgs = false;
+            fnNumArgs = 0;
+            isWindowFunction = false;
         }
     }
 
@@ -250,13 +345,26 @@ public class FunctionCallExpr extends Expr {
                         super.debugString()).toString();
     }
 
+    @Override
+    public String toSimpleSql() {
+        StringBuilder sb = new StringBuilder(getFunctionName());
+        sb.append("(");
+        for (int i = 0; i < children.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(children.get(i).toSimpleSql());
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
     public FunctionParams getParams() {
         return fnParams;
     }
 
     public boolean isAggregateFunction() {
-        Preconditions.checkState(fn != null);
-        return fn instanceof AggregateFunction && !isAnalyticFnCall;
+        return isAggregateFn && !isAnalyticFnCall;
     }
 
     public boolean isDistinct() {
@@ -279,7 +387,7 @@ public class FunctionCallExpr extends Expr {
     // TODO(kks): improve this
     public boolean isNullable() {
         // check if fn always return non null
-        if (fn != null && !fn.isNullable()) {
+        if (fnArgTypes != null && !fnNullable) {
             return false;
         }
         // check children nullable
@@ -304,7 +412,7 @@ public class FunctionCallExpr extends Expr {
         // TODO: we can't correctly determine const-ness before analyzing 'fn_'. We should
         // rework logic so that we do not call this function on unanalyzed exprs.
         // Aggregate functions are never constant.
-        if (fn instanceof AggregateFunction) {
+        if (isAggregateFn) {
             return false;
         }
 
@@ -325,20 +433,20 @@ public class FunctionCallExpr extends Expr {
         which requires different hashes for each non-deterministic function,
         so in Expression Analyzer, each non-deterministic function will be numbered to achieve different hash values.
     */
-    private ExprId nondeterministicId = new ExprId(0);
+    private int nondeterministicId = 0;
 
-    public void setNondeterministicId(ExprId nondeterministicId) {
+    public void setNondeterministicId(int nondeterministicId) {
         this.nondeterministicId = nondeterministicId;
     }
 
     public boolean isNondeterministicBuiltinFnName() {
-        return FunctionSet.nonDeterministicFunctions.contains(fnRef.getFunctionName().toLowerCase());
+        return NON_DETERMINISTIC_FUNCTIONS.contains(fnRef.getFunctionName().toLowerCase());
     }
 
     @Override
     public int hashCode() {
         // @Note: fnParams is different with children Expr. use children plz.
-        return Objects.hash(super.hashCode(), type, fnRef.getFnName().toString(), nondeterministicId, fn);
+        return Objects.hash(super.hashCode(), type, fnRef.getFnName().toString(), nondeterministicId);
     }
 
     @Override
@@ -350,9 +458,8 @@ public class FunctionCallExpr extends Expr {
         return /*opcode == o.opcode && aggOp == o.aggOp &&*/ fnRef.getFnName().toString().equals(o.fnRef.getFnName().toString())
                 && fnParams.isDistinct() == o.fnParams.isDistinct()
                 && fnParams.isStar() == o.fnParams.isStar()
-                && nondeterministicId.equals(o.nondeterministicId)
-                && Objects.equals(fnParams.getOrderByElements(), o.fnParams.getOrderByElements())
-                && Objects.equals(fn, o.fn);
+                && nondeterministicId == o.nondeterministicId
+                && Objects.equals(fnParams.getOrderByElements(), o.fnParams.getOrderByElements());
     }
 
     /**
@@ -360,7 +467,7 @@ public class FunctionCallExpr extends Expr {
      */
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitFunctionCall(this, context);
+        return visitor.visitFunctionCall(this, context);
     }
 
     public void setMergeAggFn() {

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/GroupingFunctionCallExpr.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/GroupingFunctionCallExpr.java
@@ -35,7 +35,6 @@
 package com.starrocks.sql.ast.expression;
 
 import com.starrocks.sql.ast.AstVisitor;
-import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.ArrayList;
@@ -109,6 +108,6 @@ public class GroupingFunctionCallExpr extends FunctionCallExpr {
      */
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitGroupingFunctionCall(this, context);
+        return visitor.visitGroupingFunctionCall(this, context);
     }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/OdbcScalarFunctionCall.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/OdbcScalarFunctionCall.java
@@ -68,7 +68,7 @@ public class OdbcScalarFunctionCall implements ParseNode {
 
     public Expr mappingFunction() {
         if (!(function instanceof FunctionCallExpr)) {
-            throw new ParsingException(PARSER_ERROR_MSG.invalidOdbcFunc(ExprToSql.toSql(function)), function.getPos());
+            throw new ParsingException(PARSER_ERROR_MSG.invalidOdbcFunc(toSimpleSql(function)), function.getPos());
         }
         FunctionCallExpr functionCallExpr = (FunctionCallExpr) function;
         String fnName = functionCallExpr.getFunctionName();
@@ -83,7 +83,15 @@ public class OdbcScalarFunctionCall implements ParseNode {
             return function;
         }
 
-        throw new ParsingException(PARSER_ERROR_MSG.invalidOdbcFunc(ExprToSql.toSql(function)), function.getPos());
+        throw new ParsingException(PARSER_ERROR_MSG.invalidOdbcFunc(toSimpleSql(function)), function.getPos());
+    }
+
+    /**
+     * Simple SQL-like representation for error messages.
+     * fe-parser cannot use ExprToSql (fe-core), so delegate to Expr.toSimpleSql().
+     */
+    private static String toSimpleSql(Expr expr) {
+        return expr.toSimpleSql();
     }
 
     @Override

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/StringLiteral.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/StringLiteral.java
@@ -120,6 +120,11 @@ public class StringLiteral extends LiteralExpr {
     }
 
     @Override
+    public String toSimpleSql() {
+        return "'" + value + "'";
+    }
+
+    @Override
     public long getLongValue() {
         return Long.parseLong(value);
     }


### PR DESCRIPTION
## Why I'm doing:

FunctionCallExpr currently lives in fe-core and directly depends on fe-core types (`Function`, `AggregateFunction`, etc.). This prevents it from being used as a pure AST node in fe-parser without pulling in planner/catalog dependencies. As part of the broader effort to make expression AST classes independent of execution-layer types, FunctionCallExpr needs to move to fe-parser.

## What I'm doing:

Move FunctionCallExpr, AnalyticExpr, GroupingFunctionCallExpr, OdbcScalarFunctionCall, and ExprSubstitutionVisitor from fe-core to fe-parser so they don't depend on fe-core planner types.

**FunctionCallExpr gains cached property accessors** that mirror Function fields without importing Function (fe-core type):
- `getFunctionName()`, `getFnArgTypes()`, `isWindowFunction()`
- `isAggregateFn()`, `isFnNullable()`, `isFnHasVarArgs()`

**New `AnalysisContext` bridge class** in fe-core:
- `populateCachedFields(FunctionCallExpr, Function)`: copies function metadata onto the FunctionCallExpr so fe-parser code can access it
- `getFunctionByExpr(FunctionCallExpr)`: retrieves the registered Function via the cached fnId

**All fe-core consumers migrated**:
- `getFn().functionName()` → `getFunctionName()`
- `getFn().getArgs()` → `getFnArgTypes()`
- `getFn()` for Function object → `AnalysisContext.getFunctionByExpr()`
- After `setFn(fn)` → add `AnalysisContext.populateCachedFields(expr, fn)`

fe-core `FunctionCallExpr.java` retains the same cached fields for backward compatibility during incremental migration.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4