### PR TITLE
[BugFix] Fix CN segfault on startup from hash_util static init order

### DIFF
--- a/be/src/util/hash_util.cpp
+++ b/be/src/util/hash_util.cpp
@@ -18,7 +18,9 @@
 #include <nmmintrin.h>
 #endif
 
-#include "util/cpu_info.h"
+#include <mutex>
+
+#include "gutil/cpu.h"
 #include "util/murmur_hash3.h"
 #include "util/xxh3.h"
 
@@ -34,40 +36,69 @@ static uint64_t crc_hash64_sse42(const void* data, int32_t bytes, uint64_t hash)
 using Hash32Func = uint32_t (*)(const void*, int32_t, uint32_t);
 using Hash64Func = uint64_t (*)(const void*, int32_t, uint64_t);
 
-// Function pointers that will be initialized at program startup based on CPU capabilities
-static Hash32Func g_hash32_func = nullptr;
-static Hash64Func g_hash64_func = nullptr;
-static Hash32Func g_crc32_func = nullptr;
-static Hash64Func g_crc64_func = nullptr;
+// Forward declarations for stub functions.
+static uint32_t hash32_init_stub(const void* data, int32_t bytes, uint32_t hash);
+static uint64_t hash64_init_stub(const void* data, int32_t bytes, uint64_t hash);
+static uint32_t crc32_init_stub(const void* data, int32_t bytes, uint32_t hash);
+static uint64_t crc64_init_stub(const void* data, int32_t bytes, uint64_t hash);
 
-// Initialize function pointers at program startup based on CPU capabilities.
-// This avoids runtime CPU checks in the hot path (hash(), hash64(), crc_hash(), crc_hash64() functions).
-// The constructor attribute ensures this runs before main(), but after CpuInfo::init()
-// is called in Daemon::init(). If CpuInfo hasn't been initialized yet, we initialize it here.
-__attribute__((constructor)) void select_hash_functions() {
-    // Ensure CpuInfo is initialized
-    CpuInfo::init();
+// Function pointers. Start at init stubs; the first call lazily picks the real
+// implementation. Lazy init (instead of __attribute__((constructor))) avoids a
+// static-init-order fiasco where dispatch ran before glog/gflags globals were
+// constructed and crashed inside LogMessage::Init. See issue #71731.
+static Hash32Func g_hash32_func = hash32_init_stub;
+static Hash64Func g_hash64_func = hash64_init_stub;
+static Hash32Func g_crc32_func = crc32_init_stub;
+static Hash64Func g_crc64_func = crc64_init_stub;
 
+static std::once_flag g_hash_init_once;
+
+static uint64_t crc_hash64_fallback(const void* data, int32_t bytes, uint64_t hash) {
+    // For 64-bit fallback, use zlib_crc_hash on both halves.
+    uint32_t h1 = hash >> 32;
+    uint32_t h2 = (hash << 32) >> 32;
+    h1 = HashUtil::zlib_crc_hash(data, bytes, h1);
+    h2 = HashUtil::zlib_crc_hash(data, bytes, h2);
+    return (static_cast<uint64_t>(h1) << 32) | h2;
+}
+
+static void init_hash_functions() {
     g_hash32_func = HashUtil::fnv_hash;
     g_hash64_func = HashUtil::hash64_fallback;
     g_crc32_func = HashUtil::zlib_crc_hash;
-    g_crc64_func = [](const void* data, int32_t bytes, uint64_t hash) -> uint64_t {
-        // For 64-bit fallback, use zlib_crc_hash on both halves
-        uint32_t h1 = hash >> 32;
-        uint32_t h2 = (hash << 32) >> 32;
-        h1 = HashUtil::zlib_crc_hash(data, bytes, h1);
-        h2 = HashUtil::zlib_crc_hash(data, bytes, h2);
-        return ((uint64_t)h1 << 32) | h2;
-    };
+    g_crc64_func = crc_hash64_fallback;
 
 #ifdef __SSE4_2__
-    if (CpuInfo::is_supported(CpuInfo::SSE4_2)) {
+    // base::CPU reads cpuid directly and does not depend on glog/gflags, so it
+    // is safe to use even if this ever fires early.
+    base::CPU cpu;
+    if (cpu.has_sse42()) {
         g_hash32_func = crc_hash_sse42;
         g_hash64_func = crc_hash64_sse42;
         g_crc32_func = crc_hash_sse42;
         g_crc64_func = crc_hash64_sse42;
     }
 #endif
+}
+
+static uint32_t hash32_init_stub(const void* data, int32_t bytes, uint32_t hash) {
+    std::call_once(g_hash_init_once, init_hash_functions);
+    return g_hash32_func(data, bytes, hash);
+}
+
+static uint64_t hash64_init_stub(const void* data, int32_t bytes, uint64_t hash) {
+    std::call_once(g_hash_init_once, init_hash_functions);
+    return g_hash64_func(data, bytes, hash);
+}
+
+static uint32_t crc32_init_stub(const void* data, int32_t bytes, uint32_t hash) {
+    std::call_once(g_hash_init_once, init_hash_functions);
+    return g_crc32_func(data, bytes, hash);
+}
+
+static uint64_t crc64_init_stub(const void* data, int32_t bytes, uint64_t hash) {
+    std::call_once(g_hash_init_once, init_hash_functions);
+    return g_crc64_func(data, bytes, hash);
 }
 
 uint64_t HashUtil::xx_hash3_64(const void* key, int32_t len, uint64_t seed) {


### PR DESCRIPTION
Drop __attribute__((constructor)) select_hash_functions and switch to lazy std::call_once dispatch via stub function pointers. The prior constructor called CpuInfo::init(), which emits LOG(...) and reads gflags during static initialization; when its TU initialized before the gflags string globals, LogMessage::Init dereferenced an unconstructed std::string and crashed before main().

Also replace CpuInfo::is_supported(SSE4_2) with base::CPU::has_sse42() so SSE4.2 detection no longer depends on glog/gflags.

minimal backport of #68912.

## Why I'm doing:

## What I'm doing:

Fixes #71731

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

