### PR TITLE
[BugFix] Fix ANALYZE HISTOGRAM clause order regression

### DIFF
--- a/docs/en/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
@@ -111,6 +111,14 @@ PROPERTIES(
    "histogram_mcv_size" = "32",
    "histogram_sample_ratio" = "0.5"
 );
+
+-- Manually collect histograms on v3 in asynchronous mode, with 32 buckets and 50% sampling ratio.
+ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v3
+WITH ASYNC MODE
+WITH 32 BUCKETS
+PROPERTIES(
+   "histogram_sample_ratio" = "0.5"
+);
 ```
 
 ## References

--- a/docs/en/using_starrocks/Cost_based_optimizer.md
+++ b/docs/en/using_starrocks/Cost_based_optimizer.md
@@ -350,6 +350,14 @@ PROPERTIES(
    "histogram_sample_ratio" = "0.5"
 );
 
+-- Manually collect histograms on v3 in asynchronous mode, with 32 buckets and 50% sampling ratio.
+ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v3
+WITH ASYNC MODE
+WITH 32 BUCKETS
+PROPERTIES(
+   "histogram_sample_ratio" = "0.5"
+);
+
 -- Collect histograms on v3 using the 'hll' mode for accurate distinct count estimation per bucket.
 ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v3
 PROPERTIES(

--- a/docs/zh/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
@@ -110,6 +110,14 @@ PROPERTIES(
    "histogram_mcv_size" = "32",
    "histogram_sample_ratio" = "0.5"
 );
+
+-- 手动异步采集 v3 列的直方图信息，指定 32 个分桶，采样比例为 50%。
+ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v3
+WITH ASYNC MODE
+WITH 32 BUCKETS
+PROPERTIES(
+   "histogram_sample_ratio" = "0.5"
+);
 ```
 
 ## 相关文档

--- a/docs/zh/using_starrocks/Cost_based_optimizer.md
+++ b/docs/zh/using_starrocks/Cost_based_optimizer.md
@@ -345,6 +345,14 @@ PROPERTIES(
    "histogram_sample_ratio" = "0.5"
 );
 
+-- 手动异步采集 v3 列的直方图信息，指定 32 个分桶，采样比例为 50%。
+ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v3
+WITH ASYNC MODE
+WITH 32 BUCKETS
+PROPERTIES(
+   "histogram_sample_ratio" = "0.5"
+);
+
 -- 采集 v3 列的直方图，对每个桶使用 'hll' 模式进行精准去重估算。
 ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v3
 PROPERTIES(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -3281,6 +3281,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             bucket = Config.histogram_buckets_size;
         }
 
+        return buildHistogramAnalyzeStmt(tableRef, analyzeColumn, properties, bucket, context);
+    }
+
+    private AnalyzeStmt buildHistogramAnalyzeStmt(TableRef tableRef, Pair<Boolean, List<Expr>> analyzeColumn,
+                                                  Map<String, String> properties, long bucket,
+                                                  ParserRuleContext context) {
         return new AnalyzeStmt(tableRef, analyzeColumn.second, null, properties, true,
                 false, analyzeColumn.first, new AnalyzeHistogramDesc(bucket), createPos(context));
     }
@@ -3288,7 +3294,15 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitAnalyzeHistogramStatement(
             com.starrocks.sql.parser.StarRocksParser.AnalyzeHistogramStatementContext context) {
-        AnalyzeStmt analyzeStmt = histogramStatement(context.histogramStatement());
+        QualifiedName qualifiedName = getQualifiedName(context.tableName().qualifiedName());
+        TableRef tableRef = new TableRef(normalizeName(qualifiedName), null, createPos(context));
+        Pair<Boolean, List<Expr>> analyzeColumn = visitAnalyzeColumnClause(context.analyzeColumnClause());
+        Map<String, String> properties = getCaseSensitiveProperties(context.properties());
+        long bucket = context.bucket != null
+                ? Long.parseLong(context.bucket.getText())
+                : Config.histogram_buckets_size;
+
+        AnalyzeStmt analyzeStmt = buildHistogramAnalyzeStmt(tableRef, analyzeColumn, properties, bucket, context);
         analyzeStmt.setIsAsync(context.ASYNC() != null);
         return analyzeStmt;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AnalyzeHistogramDesc;
 import com.starrocks.sql.ast.CreateAnalyzeJobStmt;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -36,12 +37,41 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.getConnectContext;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.getStarRocksAssert;
 
 public class AnalyzeCreateAnalyzeJobTest {
     private static StarRocksAssert starRocksAssert;
+
+    private static CreateAnalyzeJobStmt assertCreateAnalyzeStmt(String sql, StatsConstants.AnalyzeType expectedAnalyzeType,
+                                                                String expectedSampleCollectRows) {
+        CreateAnalyzeJobStmt analyzeStmt = (CreateAnalyzeJobStmt) analyzeSuccess(sql);
+        Assertions.assertEquals(expectedAnalyzeType, analyzeStmt.getAnalyzeType(), sql);
+        if (expectedSampleCollectRows == null) {
+            Assertions.assertTrue(
+                    !analyzeStmt.getProperties().containsKey(StatsConstants.STATISTIC_SAMPLE_COLLECT_ROWS), sql);
+        } else {
+            Assertions.assertEquals(expectedSampleCollectRows,
+                    analyzeStmt.getProperties().get(StatsConstants.STATISTIC_SAMPLE_COLLECT_ROWS), sql);
+        }
+        return analyzeStmt;
+    }
+
+    private static CreateAnalyzeJobStmt assertCreateHistogramAnalyzeStmt(String sql, long expectedBuckets,
+                                                                         Boolean expectSampleRatioProperty) {
+        CreateAnalyzeJobStmt analyzeStmt = (CreateAnalyzeJobStmt) analyzeSuccess(sql);
+        Assertions.assertEquals(StatsConstants.AnalyzeType.HISTOGRAM, analyzeStmt.getAnalyzeType(), sql);
+        Assertions.assertTrue(analyzeStmt.getAnalyzeTypeDesc() instanceof AnalyzeHistogramDesc, sql);
+        Assertions.assertEquals(expectedBuckets,
+                ((AnalyzeHistogramDesc) analyzeStmt.getAnalyzeTypeDesc()).getBuckets(), sql);
+        if (expectSampleRatioProperty != null) {
+            Assertions.assertEquals(expectSampleRatioProperty,
+                    analyzeStmt.getProperties().containsKey(StatsConstants.HISTOGRAM_SAMPLE_RATIO), sql);
+        }
+        return analyzeStmt;
+    }
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -113,6 +143,47 @@ public class AnalyzeCreateAnalyzeJobTest {
         DDLStmtExecutor.execute(analyzeStmt, starRocksAssert.getCtx());
         Assertions.assertEquals(2,
                 starRocksAssert.getCtx().getGlobalStateMgr().getAnalyzeMgr().getAllAnalyzeJobList().size());
+    }
+
+    @Test
+    public void testCreateAnalyzeSyntaxMatrix() {
+        assertCreateAnalyzeStmt("create analyze table db.tbl",
+                StatsConstants.AnalyzeType.FULL, null);
+        assertCreateAnalyzeStmt("create analyze full table db.tbl",
+                StatsConstants.AnalyzeType.FULL, null);
+        assertCreateAnalyzeStmt("create analyze sample table db.tbl",
+                StatsConstants.AnalyzeType.SAMPLE, null);
+        assertCreateAnalyzeStmt("create analyze full table db.tbl " +
+                        "properties(\"statistic_sample_collect_rows\"=\"100000\")",
+                StatsConstants.AnalyzeType.FULL, "100000");
+        assertCreateAnalyzeStmt("create analyze sample table db.tbl " +
+                        "properties(\"statistic_sample_collect_rows\"=\"100000\")",
+                StatsConstants.AnalyzeType.SAMPLE, "100000");
+    }
+
+    @Test
+    public void testCreateAnalyzeHistogramSyntaxMatrix() {
+        assertCreateHistogramAnalyzeStmt("create analyze table db.tbl1 update histogram on c1,c2",
+                Config.histogram_buckets_size, null);
+        assertCreateHistogramAnalyzeStmt("create analyze table db.tbl1 update histogram on c1,c2 with 128 buckets",
+                128, null);
+        assertCreateHistogramAnalyzeStmt(
+                "create analyze table db.tbl1 update histogram on c1,c2 " +
+                        "properties(\"histogram_sample_ratio\"=\"0.1\")",
+                Config.histogram_buckets_size, true);
+        assertCreateHistogramAnalyzeStmt(
+                "create analyze table db.tbl1 update histogram on c1,c2 with 128 buckets " +
+                        "properties(\"histogram_sample_ratio\"=\"0.1\")",
+                128, true);
+
+        analyzeFail("create analyze table db.tbl1 update histogram on c1,c2 with async mode",
+                "Unexpected input 'async'");
+        analyzeFail("create analyze table db.tbl1 update histogram on c1,c2 with async mode " +
+                        "properties(\"histogram_sample_ratio\"=\"0.1\")",
+                "Unexpected input 'async'");
+        analyzeFail("create analyze table db.tbl1 update histogram on c1,c2 with sync mode with 128 buckets " +
+                        "properties(\"histogram_sample_ratio\"=\"0.1\")",
+                "Unexpected input 'sync'");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.AlreadyExistsException;
+import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
@@ -94,6 +95,34 @@ import static com.starrocks.statistic.AnalyzeMgr.IS_MULTI_COLUMN_STATS;
 
 public class AnalyzeStmtTest {
     private static StarRocksAssert starRocksAssert;
+
+    private static AnalyzeStmt assertBasicAnalyzeStmt(String sql, boolean expectedAsync, boolean expectedSample,
+                                                      String expectedSampleCollectRows) {
+        AnalyzeStmt analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
+        Assertions.assertEquals(expectedAsync, analyzeStmt.isAsync(), sql);
+        Assertions.assertEquals(expectedSample, analyzeStmt.isSample(), sql);
+        if (expectedSampleCollectRows == null) {
+            Assertions.assertTrue(analyzeStmt.getProperties().isEmpty(), sql);
+        } else {
+            Assertions.assertEquals(expectedSampleCollectRows,
+                    analyzeStmt.getProperties().get(StatsConstants.STATISTIC_SAMPLE_COLLECT_ROWS), sql);
+        }
+        return analyzeStmt;
+    }
+
+    private static AnalyzeStmt assertHistogramAnalyzeStmt(String sql, boolean expectedAsync, long expectedBuckets,
+                                                          Boolean expectSampleRatioProperty) {
+        AnalyzeStmt analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
+        Assertions.assertEquals(expectedAsync, analyzeStmt.isAsync(), sql);
+        Assertions.assertTrue(analyzeStmt.getAnalyzeTypeDesc() instanceof AnalyzeHistogramDesc, sql);
+        Assertions.assertEquals(expectedBuckets,
+                ((AnalyzeHistogramDesc) analyzeStmt.getAnalyzeTypeDesc()).getBuckets(), sql);
+        if (expectSampleRatioProperty != null) {
+            Assertions.assertEquals(expectSampleRatioProperty,
+                    analyzeStmt.getProperties().containsKey(StatsConstants.HISTOGRAM_SAMPLE_RATIO), sql);
+        }
+        return analyzeStmt;
+    }
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -555,11 +584,57 @@ public class AnalyzeStmtTest {
         Assertions.assertTrue(analyzeStmt.getAnalyzeTypeDesc() instanceof AnalyzeHistogramDesc);
         Assertions.assertEquals(((AnalyzeHistogramDesc) (analyzeStmt.getAnalyzeTypeDesc())).getBuckets(), 256);
 
+        sql = "analyze table t0 update histogram on v1,v2 with async mode with 256 buckets " +
+                "properties(\"histogram_sample_ratio\"=\"0.1\")";
+        analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
+        Assertions.assertTrue(analyzeStmt.isAsync());
+        Assertions.assertTrue(analyzeStmt.getAnalyzeTypeDesc() instanceof AnalyzeHistogramDesc);
+        Assertions.assertEquals(((AnalyzeHistogramDesc) (analyzeStmt.getAnalyzeTypeDesc())).getBuckets(), 256);
+        Assertions.assertEquals("0.1", analyzeStmt.getProperties().get(StatsConstants.HISTOGRAM_SAMPLE_RATIO));
+
         sql = "analyze table t0 drop histogram on v1";
         DropHistogramStmt dropHistogramStmt = (DropHistogramStmt) analyzeSuccess(sql);
         Assertions.assertEquals("test", dropHistogramStmt.getDbName());
         Assertions.assertEquals("t0", dropHistogramStmt.getTableName());
         Assertions.assertEquals(dropHistogramStmt.getColumnNames().toString(), "[v1]");
+    }
+
+    @Test
+    public void testAnalyzeBasicSyntaxMatrix() {
+        assertBasicAnalyzeStmt("analyze table db.tbl", false, false, null);
+        assertBasicAnalyzeStmt("analyze sample table db.tbl with async mode", true, true, null);
+        assertBasicAnalyzeStmt("analyze sample table db.tbl properties(\"statistic_sample_collect_rows\"=\"100000\")",
+                false, true, "100000");
+        assertBasicAnalyzeStmt(
+                "analyze sample table db.tbl with async mode properties(\"statistic_sample_collect_rows\"=\"100000\")",
+                true, true, "100000");
+    }
+
+    @Test
+    public void testAnalyzeHistogramSyntaxMatrix() {
+        assertHistogramAnalyzeStmt("analyze table t0 update histogram on v1,v2",
+                false, Config.histogram_buckets_size, null);
+        assertHistogramAnalyzeStmt("analyze table t0 update histogram on v1,v2 with async mode",
+                true, Config.histogram_buckets_size, null);
+        assertHistogramAnalyzeStmt("analyze table t0 update histogram on v1,v2 with 256 buckets",
+                false, 256, null);
+        assertHistogramAnalyzeStmt(
+                "analyze table t0 update histogram on v1,v2 properties(\"histogram_sample_ratio\"=\"0.1\")",
+                false, Config.histogram_buckets_size, true);
+        assertHistogramAnalyzeStmt("analyze table t0 update histogram on v1,v2 with async mode with 256 buckets",
+                true, 256, null);
+        assertHistogramAnalyzeStmt(
+                "analyze table t0 update histogram on v1,v2 with async mode " +
+                        "properties(\"histogram_sample_ratio\"=\"0.1\")",
+                true, Config.histogram_buckets_size, true);
+        assertHistogramAnalyzeStmt(
+                "analyze table t0 update histogram on v1,v2 with 256 buckets " +
+                        "properties(\"histogram_sample_ratio\"=\"0.1\")",
+                false, 256, true);
+        assertHistogramAnalyzeStmt(
+                "analyze table t0 update histogram on v1,v2 with async mode with 256 buckets " +
+                        "properties(\"histogram_sample_ratio\"=\"0.1\")",
+                true, 256, true);
     }
 
     @Test

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -1461,8 +1461,10 @@ histogramStatement:
     ;
 
 analyzeHistogramStatement
-    : histogramStatement
+    : ANALYZE TABLE tableName UPDATE HISTOGRAM ON analyzeColumnClause
         (WITH (SYNC | ASYNC) MODE)?
+        (WITH bucket=INTEGER_VALUE BUCKETS)?
+        properties?
     ;
 
 dropHistogramStatement

--- a/test/sql/test_analyze_statistics/R/test_histogram
+++ b/test/sql/test_analyze_statistics/R/test_histogram
@@ -326,9 +326,9 @@ insert into test_escaped_string select "aaaaa's";
 insert into test_escaped_string select "bbbbbbb";
 -- result:
 -- !result
-[UC] analyze table test_escaped_string update histogram on k1;
+analyze table test_escaped_string update histogram on k1;
 -- result:
-analyze_test_2e4abb11b7ab470b9ba904f3afeb9ed4.test_escaped_string	histogram	status	OK
+[REGEX]analyze_test_.*\.test_escaped_string	histogram	status	OK
 -- !result
 function: assert_explain_costs_contains('select k1 from test_escaped_string', 'MCV')
 -- result:

--- a/test/sql/test_analyze_statistics/T/test_histogram
+++ b/test/sql/test_analyze_statistics/T/test_histogram
@@ -159,7 +159,7 @@ function: assert_explain_costs_contains('SELECT COUNT(*) FROM (t1 n1 JOIN t2 n2 
 create table test_escaped_string (k1 string) properties("replication_num"="1");
 insert into test_escaped_string select "aaaaa's";
 insert into test_escaped_string select "bbbbbbb";
-[UC] analyze table test_escaped_string update histogram on k1;
+analyze table test_escaped_string update histogram on k1;
 function: assert_explain_costs_contains('select k1 from test_escaped_string', 'MCV')
 
 
@@ -310,4 +310,3 @@ INSERT INTO t_histogram_all_columns VALUES
 
 [UC] ANALYZE TABLE t_histogram_all_columns UPDATE HISTOGRAM ON ALL COLUMNS;
 function: assert_explain_costs_contains('select * from t_histogram_all_columns', 'MCV: [[1:10][2:10][3:10]]', 'MCV: [[b:20][a:10]] ESTIMATE', 'MCV: [[2020-01-01:10][2020-01-02:10][2020-01-03:10]]')
-


### PR DESCRIPTION
## Why I'm doing:

`ANALYZE TABLE ... UPDATE HISTOGRAM` regressed clause ordering support and failed to parse valid forms that place `WITH ASYNC MODE`, `WITH <n> BUCKETS`, and `PROPERTIES(...)` after the histogram clause.

## What I'm doing:

- update the histogram analyze grammar to accept async mode, bucket count, and properties in the supported order
- reuse the histogram analyze statement builder in `AstBuilder`
- add focused analyzer syntax-matrix coverage for `ANALYZE` and `CREATE ANALYZE`
- refresh histogram SQL golden tests
- update matching English and Chinese docs examples

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Validation:

- `mvn -pl fe-core -am -DskipITs -Dcheckstyle.skip -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.clean.skip=true -Dtest=AnalyzeStmtTest,AnalyzeCreateAnalyzeJobTest test`