### PR TITLE
[Enhancement] Add spill metrics for monitoring

### DIFF
--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include "base/metrics.h"
 #include "base/string/slice.h"
 #include "common/runtime_profile.h"
 #include "common/status.h"
@@ -76,6 +77,12 @@ struct BlockReaderOptions {
     RuntimeProfile::Counter* read_io_timer = nullptr;
     RuntimeProfile::Counter* read_io_count = nullptr;
     RuntimeProfile::Counter* read_io_bytes = nullptr;
+
+    // Global per-(operator_type, storage_type) counters mirrored for
+    // server-level observability. May be null if the caller has no
+    // global metrics registered.
+    IntCounter* global_read_io_duration_ns = nullptr;
+    IntCounter* global_read_bytes = nullptr;
 };
 
 class BlockReader {

--- a/be/src/exec/spill/block_reader.cpp
+++ b/be/src/exec/spill/block_reader.cpp
@@ -84,28 +84,61 @@ Status BlockReader::read_fully(void* data, int64_t count) {
             int64_t length_need_read = count - length_in_buffer;
             if (length_need_read >= _options.max_buffer_bytes) {
                 // if res length is larger than max_buffer_bytes, read from file directly
-                SCOPED_TIMER(_options.read_io_timer);
+                int64_t io_ns = 0;
+                int64_t read_len = 0;
+                {
+                    SCOPED_RAW_TIMER(&io_ns);
+                    ASSIGN_OR_RETURN(read_len, try_to_read_from_file(_readable.get(), offset, length_need_read));
+                }
+                COUNTER_UPDATE(_options.read_io_timer, io_ns);
                 COUNTER_UPDATE(_options.read_io_count, 1);
-                ASSIGN_OR_RETURN(auto read_len, try_to_read_from_file(_readable.get(), offset, length_need_read));
-                _slice.clear();
                 COUNTER_UPDATE(_options.read_io_bytes, read_len);
+                if (_options.global_read_io_duration_ns != nullptr) {
+                    _options.global_read_io_duration_ns->increment(io_ns);
+                }
+                if (_options.global_read_bytes != nullptr) {
+                    _options.global_read_bytes->increment(read_len);
+                }
+                _slice.clear();
             } else {
                 // refill buffer, then read res data from buffer
-                SCOPED_TIMER(_options.read_io_timer);
+                int64_t io_ns = 0;
+                int64_t read_len = 0;
+                {
+                    SCOPED_RAW_TIMER(&io_ns);
+                    ASSIGN_OR_RETURN(read_len, try_to_read_from_file(_readable.get(), _buffer.get(),
+                                                                     _options.max_buffer_bytes, length_need_read));
+                }
+                COUNTER_UPDATE(_options.read_io_timer, io_ns);
                 COUNTER_UPDATE(_options.read_io_count, 1);
-                ASSIGN_OR_RETURN(auto read_len, try_to_read_from_file(_readable.get(), _buffer.get(),
-                                                                      _options.max_buffer_bytes, length_need_read));
+                COUNTER_UPDATE(_options.read_io_bytes, read_len);
+                if (_options.global_read_io_duration_ns != nullptr) {
+                    _options.global_read_io_duration_ns->increment(io_ns);
+                }
+                if (_options.global_read_bytes != nullptr) {
+                    _options.global_read_bytes->increment(read_len);
+                }
                 _slice = Slice(_buffer.get(), read_len);
                 std::memcpy(offset, _slice.data, length_need_read);
                 _slice.remove_prefix(length_need_read);
-                COUNTER_UPDATE(_options.read_io_bytes, read_len);
             }
         }
     } else {
-        SCOPED_TIMER(_options.read_io_timer);
+        int64_t io_ns = 0;
+        int64_t read_len = 0;
+        {
+            SCOPED_RAW_TIMER(&io_ns);
+            ASSIGN_OR_RETURN(read_len, try_to_read_from_file(_readable.get(), data, count));
+        }
+        COUNTER_UPDATE(_options.read_io_timer, io_ns);
         COUNTER_UPDATE(_options.read_io_count, 1);
-        ASSIGN_OR_RETURN(auto read_len, try_to_read_from_file(_readable.get(), data, count));
         COUNTER_UPDATE(_options.read_io_bytes, read_len);
+        if (_options.global_read_io_duration_ns != nullptr) {
+            _options.global_read_io_duration_ns->increment(io_ns);
+        }
+        if (_options.global_read_bytes != nullptr) {
+            _options.global_read_bytes->increment(read_len);
+        }
     }
     _offset += count;
     return Status::OK();

--- a/be/src/exec/spill/data_stream.cpp
+++ b/be/src/exec/spill/data_stream.cpp
@@ -71,7 +71,7 @@ Status BlockSpillOutputDataStream::_prepare_block(RuntimeState* state, size_t wr
         COUNTER_UPDATE(block_count, 1);
         if (auto* g = _spiller->metrics().global(is_remote); g != nullptr) {
             g->blocks_write_total->increment(1);
-            if (!_spiller->metrics().global_spill_triggered.exchange(true)) {
+            if (!_spiller->global_spill_triggered().exchange(true)) {
                 g->trigger_total->increment(1);
             }
         }

--- a/be/src/exec/spill/data_stream.cpp
+++ b/be/src/exec/spill/data_stream.cpp
@@ -21,8 +21,6 @@
 #include "exec/spill/serde.h"
 #include "exec/spill/spiller.h"
 #include "runtime/runtime_state.h"
-#include "util/global_metrics_registry.h"
-#include "util/metrics/spill_metrics.h"
 
 namespace starrocks::spill {
 // spill output stream. output serialized chunk data to BlockManager and add handle to block group.
@@ -71,13 +69,10 @@ Status BlockSpillOutputDataStream::_prepare_block(RuntimeState* state, size_t wr
         bool is_remote = block->is_remote();
         auto block_count = GET_METRICS(is_remote, _spiller->metrics(), block_count);
         COUNTER_UPDATE(block_count, 1);
-        if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
-            const std::string& op = _spiller->options().name;
-            const char* storage = is_remote ? SpillMetrics::kStorageTypeRemote : SpillMetrics::kStorageTypeLocal;
-            auto* bucket = spill_metrics->get(op, storage);
-            bucket->blocks_write_total->increment(1);
-            if (_spiller->mark_spill_triggered()) {
-                bucket->trigger_total->increment(1);
+        if (auto* g = _spiller->metrics().global(is_remote); g != nullptr) {
+            g->blocks_write_total->increment(1);
+            if (!_spiller->metrics().global_spill_triggered.exchange(true)) {
+                g->trigger_total->increment(1);
             }
         }
         TRACE_SPILL_LOG << fmt::format("allocate block [{}], affinity group[{}]", block->debug_string(),
@@ -102,22 +97,16 @@ Status BlockSpillOutputDataStream::append(RuntimeState* state, const std::vector
         TRACE_SPILL_LOG << fmt::format("append block[{}], size[{}]", _cur_block->debug_string(), total_write_size);
         append_st = _cur_block->append(data);
     }
-    auto write_io_timer = GET_METRICS(is_remote, _spiller->metrics(), write_io_timer);
-    COUNTER_UPDATE(write_io_timer, io_ns);
-    if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
-        const std::string& op = _spiller->options().name;
-        const char* storage = is_remote ? SpillMetrics::kStorageTypeRemote : SpillMetrics::kStorageTypeLocal;
-        spill_metrics->write_io_duration_ns_total(op, storage)->increment(io_ns);
+    COUNTER_UPDATE(GET_METRICS(is_remote, _spiller->metrics(), write_io_timer), io_ns);
+    if (auto* g = _spiller->metrics().global(is_remote); g != nullptr) {
+        g->write_io_duration_ns_total->increment(io_ns);
     }
     RETURN_IF_ERROR(append_st);
     _cur_block->inc_num_rows(write_num_rows);
-    auto flush_bytes = GET_METRICS(is_remote, _spiller->metrics(), flush_bytes);
-    COUNTER_UPDATE(flush_bytes, total_write_size);
+    COUNTER_UPDATE(GET_METRICS(is_remote, _spiller->metrics(), flush_bytes), total_write_size);
     (*_spiller->metrics().total_spill_bytes) += total_write_size;
-    if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
-        const std::string& op = _spiller->options().name;
-        const char* storage = is_remote ? SpillMetrics::kStorageTypeRemote : SpillMetrics::kStorageTypeLocal;
-        spill_metrics->bytes_write_total(op, storage)->increment(total_write_size);
+    if (auto* g = _spiller->metrics().global(is_remote); g != nullptr) {
+        g->bytes_write_total->increment(total_write_size);
     }
     return Status::OK();
 }
@@ -134,12 +123,9 @@ Status BlockSpillOutputDataStream::flush() {
         flush_st = _cur_block->flush();
         TRACE_SPILL_LOG << fmt::format("flush block[{}]", _cur_block->debug_string());
     }
-    auto write_io_timer = GET_METRICS(is_remote, _spiller->metrics(), write_io_timer);
-    COUNTER_UPDATE(write_io_timer, io_ns);
-    if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
-        const std::string& op = _spiller->options().name;
-        const char* storage = is_remote ? SpillMetrics::kStorageTypeRemote : SpillMetrics::kStorageTypeLocal;
-        spill_metrics->write_io_duration_ns_total(op, storage)->increment(io_ns);
+    COUNTER_UPDATE(GET_METRICS(is_remote, _spiller->metrics(), write_io_timer), io_ns);
+    if (auto* g = _spiller->metrics().global(is_remote); g != nullptr) {
+        g->write_io_duration_ns_total->increment(io_ns);
     }
     RETURN_IF_ERROR(flush_st);
 

--- a/be/src/exec/spill/data_stream.cpp
+++ b/be/src/exec/spill/data_stream.cpp
@@ -21,6 +21,8 @@
 #include "exec/spill/serde.h"
 #include "exec/spill/spiller.h"
 #include "runtime/runtime_state.h"
+#include "util/global_metrics_registry.h"
+#include "util/metrics/spill_metrics.h"
 
 namespace starrocks::spill {
 // spill output stream. output serialized chunk data to BlockManager and add handle to block group.
@@ -66,8 +68,18 @@ Status BlockSpillOutputDataStream::_prepare_block(RuntimeState* state, size_t wr
         opts.affinity_group = _block_group->get_affinity_group();
         ASSIGN_OR_RETURN(auto block, _block_manager->acquire_block(opts));
         // update metrics
-        auto block_count = GET_METRICS(block->is_remote(), _spiller->metrics(), block_count);
+        bool is_remote = block->is_remote();
+        auto block_count = GET_METRICS(is_remote, _spiller->metrics(), block_count);
         COUNTER_UPDATE(block_count, 1);
+        if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
+            const std::string& op = _spiller->options().name;
+            const char* storage = is_remote ? SpillMetrics::kStorageTypeRemote : SpillMetrics::kStorageTypeLocal;
+            auto* bucket = spill_metrics->get(op, storage);
+            bucket->blocks_write_total->increment(1);
+            if (_spiller->mark_spill_triggered()) {
+                bucket->trigger_total->increment(1);
+            }
+        }
         TRACE_SPILL_LOG << fmt::format("allocate block [{}], affinity group[{}]", block->debug_string(),
                                        opts.affinity_group);
         _cur_block = std::move(block);
@@ -82,15 +94,30 @@ Status BlockSpillOutputDataStream::append(RuntimeState* state, const std::vector
     // acquire block if current block is nullptr or full
     RETURN_IF_ERROR(_prepare_block(state, total_write_size));
     _append_rows += write_num_rows;
+    bool is_remote = _cur_block->is_remote();
+    int64_t io_ns = 0;
+    Status append_st;
     {
-        auto write_io_timer = GET_METRICS(_cur_block->is_remote(), _spiller->metrics(), write_io_timer);
-        SCOPED_TIMER(write_io_timer);
+        SCOPED_RAW_TIMER(&io_ns);
         TRACE_SPILL_LOG << fmt::format("append block[{}], size[{}]", _cur_block->debug_string(), total_write_size);
-        RETURN_IF_ERROR(_cur_block->append(data));
-        _cur_block->inc_num_rows(write_num_rows);
-        auto flush_bytes = GET_METRICS(_cur_block->is_remote(), _spiller->metrics(), flush_bytes);
-        COUNTER_UPDATE(flush_bytes, total_write_size);
-        (*_spiller->metrics().total_spill_bytes) += total_write_size;
+        append_st = _cur_block->append(data);
+    }
+    auto write_io_timer = GET_METRICS(is_remote, _spiller->metrics(), write_io_timer);
+    COUNTER_UPDATE(write_io_timer, io_ns);
+    if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
+        const std::string& op = _spiller->options().name;
+        const char* storage = is_remote ? SpillMetrics::kStorageTypeRemote : SpillMetrics::kStorageTypeLocal;
+        spill_metrics->write_io_duration_ns_total(op, storage)->increment(io_ns);
+    }
+    RETURN_IF_ERROR(append_st);
+    _cur_block->inc_num_rows(write_num_rows);
+    auto flush_bytes = GET_METRICS(is_remote, _spiller->metrics(), flush_bytes);
+    COUNTER_UPDATE(flush_bytes, total_write_size);
+    (*_spiller->metrics().total_spill_bytes) += total_write_size;
+    if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
+        const std::string& op = _spiller->options().name;
+        const char* storage = is_remote ? SpillMetrics::kStorageTypeRemote : SpillMetrics::kStorageTypeLocal;
+        spill_metrics->bytes_write_total(op, storage)->increment(total_write_size);
     }
     return Status::OK();
 }
@@ -99,12 +126,22 @@ Status BlockSpillOutputDataStream::flush() {
     if (_cur_block == nullptr) {
         return Status::OK();
     }
+    bool is_remote = _cur_block->is_remote();
+    int64_t io_ns = 0;
+    Status flush_st;
     {
-        auto write_io_timer = GET_METRICS(_cur_block->is_remote(), _spiller->metrics(), write_io_timer);
-        SCOPED_TIMER(write_io_timer);
-        RETURN_IF_ERROR(_cur_block->flush());
+        SCOPED_RAW_TIMER(&io_ns);
+        flush_st = _cur_block->flush();
         TRACE_SPILL_LOG << fmt::format("flush block[{}]", _cur_block->debug_string());
     }
+    auto write_io_timer = GET_METRICS(is_remote, _spiller->metrics(), write_io_timer);
+    COUNTER_UPDATE(write_io_timer, io_ns);
+    if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
+        const std::string& op = _spiller->options().name;
+        const char* storage = is_remote ? SpillMetrics::kStorageTypeRemote : SpillMetrics::kStorageTypeLocal;
+        spill_metrics->write_io_duration_ns_total(op, storage)->increment(io_ns);
+    }
+    RETURN_IF_ERROR(flush_st);
 
     RETURN_IF_ERROR(_block_manager->release_block(std::move(_cur_block)));
     DCHECK(_cur_block == nullptr);

--- a/be/src/exec/spill/dir_manager.h
+++ b/be/src/exec/spill/dir_manager.h
@@ -100,6 +100,10 @@ public:
 
     StatusOr<DirPtr> acquire_writable_dir(const AcquireDirOptions& opts);
 
+    // Read-only snapshot of the managed directories; used by metrics hooks
+    // to aggregate spill disk usage.
+    std::vector<DirPtr> dirs() const { return _dirs; }
+
 private:
     bool is_same_disk(const std::string& path1, const std::string& path2) {
         struct statfs stat1, stat2;

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -33,6 +33,8 @@
 #include "exec/workgroup/work_group.h"
 #include "runtime/runtime_state.h"
 #include "runtime/sorted_chunks_merger.h"
+#include "util/global_metrics_registry.h"
+#include "util/metrics/spill_metrics.h"
 
 namespace starrocks::spill {
 
@@ -291,6 +293,16 @@ StatusOr<ChunkUniquePtr> SequenceInputStream::get_next(workgroup::YieldContext& 
             _options.read_io_bytes = GET_METRICS(is_remote, _serde->parent()->metrics(), restore_bytes);
             _options.read_io_timer = GET_METRICS(is_remote, _serde->parent()->metrics(), read_io_timer);
             _options.read_io_count = GET_METRICS(is_remote, _serde->parent()->metrics(), read_io_count);
+            _options.global_read_bytes = nullptr;
+            _options.global_read_io_duration_ns = nullptr;
+            if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
+                const std::string& op = _serde->parent()->options().name;
+                const char* storage =
+                        is_remote ? SpillMetrics::kStorageTypeRemote : SpillMetrics::kStorageTypeLocal;
+                _options.global_read_bytes = spill_metrics->bytes_read_total(op, storage);
+                _options.global_read_io_duration_ns = spill_metrics->read_io_duration_ns_total(op, storage);
+                spill_metrics->blocks_read_total(op, storage)->increment(1);
+            }
             _current_reader = _input_blocks[_current_idx]->get_reader(_options);
         }
         auto& block = _input_blocks[_current_idx];

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -33,8 +33,6 @@
 #include "exec/workgroup/work_group.h"
 #include "runtime/runtime_state.h"
 #include "runtime/sorted_chunks_merger.h"
-#include "util/global_metrics_registry.h"
-#include "util/metrics/spill_metrics.h"
 
 namespace starrocks::spill {
 
@@ -290,18 +288,16 @@ StatusOr<ChunkUniquePtr> SequenceInputStream::get_next(workgroup::YieldContext& 
     while (true) {
         if (_current_reader == nullptr) {
             bool is_remote = _input_blocks[_current_idx]->is_remote();
-            _options.read_io_bytes = GET_METRICS(is_remote, _serde->parent()->metrics(), restore_bytes);
-            _options.read_io_timer = GET_METRICS(is_remote, _serde->parent()->metrics(), read_io_timer);
-            _options.read_io_count = GET_METRICS(is_remote, _serde->parent()->metrics(), read_io_count);
+            const auto& metrics = _serde->parent()->metrics();
+            _options.read_io_bytes = GET_METRICS(is_remote, metrics, restore_bytes);
+            _options.read_io_timer = GET_METRICS(is_remote, metrics, read_io_timer);
+            _options.read_io_count = GET_METRICS(is_remote, metrics, read_io_count);
             _options.global_read_bytes = nullptr;
             _options.global_read_io_duration_ns = nullptr;
-            if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
-                const std::string& op = _serde->parent()->options().name;
-                const char* storage =
-                        is_remote ? SpillMetrics::kStorageTypeRemote : SpillMetrics::kStorageTypeLocal;
-                _options.global_read_bytes = spill_metrics->bytes_read_total(op, storage);
-                _options.global_read_io_duration_ns = spill_metrics->read_io_duration_ns_total(op, storage);
-                spill_metrics->blocks_read_total(op, storage)->increment(1);
+            if (auto* g = metrics.global(is_remote); g != nullptr) {
+                _options.global_read_bytes = g->bytes_read_total.get();
+                _options.global_read_io_duration_ns = g->read_io_duration_ns_total.get();
+                g->blocks_read_total->increment(1);
             }
             _current_reader = _input_blocks[_current_idx]->get_reader(_options);
         }

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -38,6 +38,8 @@
 #include "gutil/port.h"
 #include "runtime/runtime_state.h"
 #include "serde/column_array_serde.h"
+#include "util/global_metrics_registry.h"
+#include "util/metrics/spill_metrics.h"
 
 namespace starrocks::spill {
 DEFINE_FAIL_POINT(spill_restore_sleep);
@@ -131,6 +133,14 @@ Status Spiller::prepare(RuntimeState* state) {
 #ifndef BE_TEST
     DCHECK(_opts.wg != nullptr) << "workgroup must be set";
 #endif
+
+    // Resolve the server-level spill counter buckets for this operator
+    // once up-front so hot paths can update them without going through
+    // the global registry or the label map on every IO event.
+    if (auto* sm = GlobalMetricsRegistry::instance()->spill_metrics(); sm != nullptr) {
+        _metrics.global_local = sm->get(_opts.name, SpillMetrics::kStorageTypeLocal);
+        _metrics.global_remote = sm->get(_opts.name, SpillMetrics::kStorageTypeRemote);
+    }
 
     ASSIGN_OR_RETURN(_serde, Serde::create_serde(this));
 

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -134,13 +134,12 @@ Status Spiller::prepare(RuntimeState* state) {
     DCHECK(_opts.wg != nullptr) << "workgroup must be set";
 #endif
 
-    // Resolve the server-level spill counter buckets for this operator
-    // once up-front so hot paths can update them without going through
-    // the global registry or the label map on every IO event.
+    // Resolve the server-level spill counter buckets once up-front so
+    // hot paths can update them without going through the global
+    // registry on every IO event.
     if (auto* sm = GlobalMetricsRegistry::instance()->spill_metrics(); sm != nullptr) {
-        auto op = SpillMetrics::parse_operator_type(_opts.name);
-        _metrics.global_local = sm->get(op, /*is_remote=*/false);
-        _metrics.global_remote = sm->get(op, /*is_remote=*/true);
+        _metrics.global_local = sm->get(/*is_remote=*/false);
+        _metrics.global_remote = sm->get(/*is_remote=*/true);
     }
 
     ASSIGN_OR_RETURN(_serde, Serde::create_serde(this));

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -138,8 +138,9 @@ Status Spiller::prepare(RuntimeState* state) {
     // once up-front so hot paths can update them without going through
     // the global registry or the label map on every IO event.
     if (auto* sm = GlobalMetricsRegistry::instance()->spill_metrics(); sm != nullptr) {
-        _metrics.global_local = sm->get(_opts.name, SpillMetrics::kStorageTypeLocal);
-        _metrics.global_remote = sm->get(_opts.name, SpillMetrics::kStorageTypeRemote);
+        auto op = SpillMetrics::parse_operator_type(_opts.name);
+        _metrics.global_local = sm->get(op, /*is_remote=*/false);
+        _metrics.global_remote = sm->get(op, /*is_remote=*/true);
     }
 
     ASSIGN_OR_RETURN(_serde, Serde::create_serde(this));

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -126,6 +126,16 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_in
     skew_mem_table_output_bytes = ADD_CHILD_COUNTER(profile, "SkewMemTableOutputBytes", TUnit::BYTES, parent);
     skew_mem_table_input_rows = ADD_CHILD_COUNTER(profile, "SkewMemTableInputRows", TUnit::UNIT, parent);
     skew_mem_table_output_rows = ADD_CHILD_COUNTER(profile, "SkewMemTableOutputRows", TUnit::UNIT, parent);
+
+    // Resolve the server-level spill counter buckets here (rather than in
+    // Spiller::prepare()) so the pointers travel with the SpillProcessMetrics
+    // value. Several operators (e.g. SpillableAggregateBlockingSinkOperator)
+    // call Spiller::prepare() before set_metrics(), and a later set_metrics()
+    // assignment would otherwise clobber pointers cached on the Spiller.
+    if (auto* sm = GlobalMetricsRegistry::instance()->spill_metrics(); sm != nullptr) {
+        global_local = sm->get(/*is_remote=*/false);
+        global_remote = sm->get(/*is_remote=*/true);
+    }
 }
 
 Status Spiller::prepare(RuntimeState* state) {
@@ -133,14 +143,6 @@ Status Spiller::prepare(RuntimeState* state) {
 #ifndef BE_TEST
     DCHECK(_opts.wg != nullptr) << "workgroup must be set";
 #endif
-
-    // Resolve the server-level spill counter buckets once up-front so
-    // hot paths can update them without going through the global
-    // registry on every IO event.
-    if (auto* sm = GlobalMetricsRegistry::instance()->spill_metrics(); sm != nullptr) {
-        _metrics.global_local = sm->get(/*is_remote=*/false);
-        _metrics.global_remote = sm->get(/*is_remote=*/true);
-    }
 
     ASSIGN_OR_RETURN(_serde, Serde::create_serde(this));
 

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -143,13 +143,12 @@ public:
     RuntimeProfile::Counter* skew_mem_table_input_bytes = nullptr;
     RuntimeProfile::Counter* skew_mem_table_output_bytes = nullptr;
 
-    // Server-level counters pre-resolved by Spiller::prepare() based on the
-    // Spiller's operator name. The bucket pointers stay stable for the
-    // lifetime of the GlobalMetricsRegistry, so hot-path callers just use
-    // `global(is_remote)` instead of looking up by label on every IO.
+    // Server-level counters pre-resolved by Spiller::prepare(). The
+    // bucket pointers stay stable for the lifetime of the
+    // GlobalMetricsRegistry, so hot-path callers use `global(is_remote)`
+    // instead of looking up by label on every IO event.
     SpillMetrics::LabeledCounters* global_local = nullptr;
     SpillMetrics::LabeledCounters* global_remote = nullptr;
-    std::atomic_bool global_spill_triggered = false;
 
     SpillMetrics::LabeledCounters* global(bool is_remote) const { return is_remote ? global_remote : global_local; }
 };
@@ -258,6 +257,12 @@ public:
     BlockManager* block_manager() { return _block_manager; }
     const ChunkBuilder& chunk_builder() { return _chunk_builder; }
 
+    // Shared flag used to bump the global query_spill_trigger_total
+    // counter at most once per Spiller instance. Lives on Spiller itself
+    // (not SpillProcessMetrics) because std::atomic_bool would break
+    // SpillProcessMetrics copy-assignment in set_metrics().
+    std::atomic_bool& global_spill_triggered() { return _global_spill_triggered; }
+
     Status reset_state(RuntimeState* state);
 
     size_t max_sorted_block_cnt() const { return _max_sorted_block_cnt; }
@@ -295,6 +300,7 @@ private:
     spill::BlockManager* _block_manager = nullptr;
     size_t _max_sorted_block_cnt = 0;
     std::atomic_bool _is_cancel = false;
+    std::atomic_bool _global_spill_triggered{false};
 };
 
 } // namespace starrocks::spill

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -247,6 +247,14 @@ public:
     BlockManager* block_manager() { return _block_manager; }
     const ChunkBuilder& chunk_builder() { return _chunk_builder; }
 
+    // Returns true on the first call, false afterwards. Used to drive the
+    // global "spill triggered" counter so each operator instance is counted
+    // at most once.
+    bool mark_spill_triggered() {
+        bool expected = false;
+        return _spill_triggered.compare_exchange_strong(expected, true);
+    }
+
     Status reset_state(RuntimeState* state);
 
     size_t max_sorted_block_cnt() const { return _max_sorted_block_cnt; }
@@ -284,6 +292,7 @@ private:
     spill::BlockManager* _block_manager = nullptr;
     size_t _max_sorted_block_cnt = 0;
     std::atomic_bool _is_cancel = false;
+    std::atomic_bool _spill_triggered = false;
 };
 
 } // namespace starrocks::spill

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -40,6 +40,7 @@
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_state_fwd.h"
 #include "util/compression/block_compression.h"
+#include "util/metrics/spill_metrics.h"
 
 #define GET_METRICS(remote, metrics, key) (remote ? metrics.remote_##key : metrics.local_##key)
 
@@ -141,6 +142,16 @@ public:
     RuntimeProfile::Counter* skew_mem_table_output_rows = nullptr;
     RuntimeProfile::Counter* skew_mem_table_input_bytes = nullptr;
     RuntimeProfile::Counter* skew_mem_table_output_bytes = nullptr;
+
+    // Server-level counters pre-resolved by Spiller::prepare() based on the
+    // Spiller's operator name. The bucket pointers stay stable for the
+    // lifetime of the GlobalMetricsRegistry, so hot-path callers just use
+    // `global(is_remote)` instead of looking up by label on every IO.
+    SpillMetrics::LabeledCounters* global_local = nullptr;
+    SpillMetrics::LabeledCounters* global_remote = nullptr;
+    std::atomic_bool global_spill_triggered = false;
+
+    SpillMetrics::LabeledCounters* global(bool is_remote) const { return is_remote ? global_remote : global_local; }
 };
 
 // major spill interfaces
@@ -247,14 +258,6 @@ public:
     BlockManager* block_manager() { return _block_manager; }
     const ChunkBuilder& chunk_builder() { return _chunk_builder; }
 
-    // Returns true on the first call, false afterwards. Used to drive the
-    // global "spill triggered" counter so each operator instance is counted
-    // at most once.
-    bool mark_spill_triggered() {
-        bool expected = false;
-        return _spill_triggered.compare_exchange_strong(expected, true);
-    }
-
     Status reset_state(RuntimeState* state);
 
     size_t max_sorted_block_cnt() const { return _max_sorted_block_cnt; }
@@ -292,7 +295,6 @@ private:
     spill::BlockManager* _block_manager = nullptr;
     size_t _max_sorted_block_cnt = 0;
     std::atomic_bool _is_cancel = false;
-    std::atomic_bool _spill_triggered = false;
 };
 
 } // namespace starrocks::spill

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -143,10 +143,12 @@ public:
     RuntimeProfile::Counter* skew_mem_table_input_bytes = nullptr;
     RuntimeProfile::Counter* skew_mem_table_output_bytes = nullptr;
 
-    // Server-level counters pre-resolved by Spiller::prepare(). The
-    // bucket pointers stay stable for the lifetime of the
-    // GlobalMetricsRegistry, so hot-path callers use `global(is_remote)`
-    // instead of looking up by label on every IO event.
+    // Server-level counters pre-resolved in the SpillProcessMetrics
+    // constructor so the pointers travel with the value (operators may
+    // reassign SpillProcessMetrics via Spiller::set_metrics after prepare,
+    // which would lose pointers cached on Spiller itself). Stable for the
+    // lifetime of the GlobalMetricsRegistry; callers use `global(is_remote)`
+    // and skip updates when null (e.g. in unit tests without a registry).
     SpillMetrics::LabeledCounters* global_local = nullptr;
     SpillMetrics::LabeledCounters* global_remote = nullptr;
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -777,8 +777,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     // DirManager lives for the lifetime of ExecEnv.
     if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
         GlobalMetricsRegistry::instance()->metrics()->register_hook(
-                "spill_disk_bytes_used",
-                [dir_mgr = _spill_dir_mgr.get(), spill_metrics]() {
+                "spill_disk_bytes_used", [dir_mgr = _spill_dir_mgr.get(), spill_metrics]() {
                     int64_t local_bytes = 0;
                     for (auto& dir : dir_mgr->dirs()) {
                         local_bytes += dir->get_current_size();

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -112,6 +112,7 @@
 #include "udf/python/env.h"
 #include "util/brpc_stub_cache.h"
 #include "util/global_metrics_registry.h"
+#include "util/metrics/spill_metrics.h"
 #include "util/priority_thread_pool.hpp"
 
 #ifdef STARROCKS_JIT_ENABLE
@@ -770,7 +771,21 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
 
     _spill_dir_mgr = std::make_shared<spill::DirManager>();
     RETURN_IF_ERROR(_spill_dir_mgr->init(config::spill_local_storage_dir));
-    GlobalMetricsRegistry::instance()->set_spill_local_dir_manager(_spill_dir_mgr.get());
+    // Bridge the local spill DirManager into the spill_disk_bytes_used gauge
+    // via a collect-time hook so the metrics registry stays decoupled from
+    // spill internals. The callback captures a raw pointer because the
+    // DirManager lives for the lifetime of ExecEnv.
+    if (auto* spill_metrics = GlobalMetricsRegistry::instance()->spill_metrics(); spill_metrics != nullptr) {
+        GlobalMetricsRegistry::instance()->metrics()->register_hook(
+                "spill_disk_bytes_used",
+                [dir_mgr = _spill_dir_mgr.get(), spill_metrics]() {
+                    int64_t local_bytes = 0;
+                    for (auto& dir : dir_mgr->dirs()) {
+                        local_bytes += dir->get_current_size();
+                    }
+                    spill_metrics->disk_bytes_used(SpillMetrics::kStorageTypeLocal)->set_value(local_bytes);
+                });
+    }
 
     _global_spill_manager = std::make_shared<spill::GlobalSpillManager>();
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -770,6 +770,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
 
     _spill_dir_mgr = std::make_shared<spill::DirManager>();
     RETURN_IF_ERROR(_spill_dir_mgr->init(config::spill_local_storage_dir));
+    GlobalMetricsRegistry::instance()->set_spill_local_dir_manager(_spill_dir_mgr.get());
 
     _global_spill_manager = std::make_shared<spill::GlobalSpillManager>();
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -783,7 +783,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                     for (auto& dir : dir_mgr->dirs()) {
                         local_bytes += dir->get_current_size();
                     }
-                    spill_metrics->disk_bytes_used(SpillMetrics::kStorageTypeLocal)->set_value(local_bytes);
+                    spill_metrics->local_disk_bytes_used()->set_value(local_bytes);
                 });
     }
 

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -33,6 +33,7 @@ set(UTIL_FILES
   global_metrics_registry.cpp
   metrics/file_scan_metrics.cpp
   metrics/catalog_scan_metrics.cpp
+  metrics/spill_metrics.cpp
 # TODO: not supported on RHEL 5
 # perf-counters.cpp
   static_asserts.cpp

--- a/be/src/util/global_metrics_registry.cpp
+++ b/be/src/util/global_metrics_registry.cpp
@@ -17,7 +17,6 @@
 #include <unistd.h>
 
 #include "exec/pipeline/pipeline_metrics.h"
-#include "exec/spill/dir_manager.h"
 #include "fs/fs.h"
 #include "runtime/starrocks_metrics.h"
 #include "util/system_metrics.h"
@@ -318,23 +317,6 @@ void GlobalMetricsRegistry::initialize(const std::vector<std::string>& paths, bo
 void GlobalMetricsRegistry::_update() {
     _update_process_thread_num();
     _update_process_fd_num();
-    _update_spill_disk_bytes_used();
-}
-
-void GlobalMetricsRegistry::_update_spill_disk_bytes_used() {
-    if (_spill_metrics == nullptr) {
-        return;
-    }
-    int64_t local_bytes = 0;
-    if (_spill_local_dir_mgr != nullptr) {
-        for (auto& dir : _spill_local_dir_mgr->dirs()) {
-            local_bytes += dir->get_current_size();
-        }
-    }
-    _spill_metrics->disk_bytes_used(SpillMetrics::kStorageTypeLocal)->set_value(local_bytes);
-    // Remote spill storage is managed per-query, so there is no single
-    // global counter to report. Leave the remote gauge at zero until a
-    // global remote directory tracker exists.
 }
 
 // get num of thread of starrocks_be process

--- a/be/src/util/global_metrics_registry.cpp
+++ b/be/src/util/global_metrics_registry.cpp
@@ -17,6 +17,7 @@
 #include <unistd.h>
 
 #include "exec/pipeline/pipeline_metrics.h"
+#include "exec/spill/dir_manager.h"
 #include "fs/fs.h"
 #include "runtime/starrocks_metrics.h"
 #include "util/system_metrics.h"
@@ -300,6 +301,7 @@ void GlobalMetricsRegistry::initialize(const std::vector<std::string>& paths, bo
 
     _file_scan_metrics = std::make_unique<FileScanMetrics>(&_metrics);
     _catalog_scan_metrics = std::make_unique<CatalogScanMetrics>(&_metrics);
+    _spill_metrics = std::make_unique<SpillMetrics>(&_metrics);
 
 #ifndef __APPLE__
     if (init_jvm_metrics) {
@@ -316,6 +318,23 @@ void GlobalMetricsRegistry::initialize(const std::vector<std::string>& paths, bo
 void GlobalMetricsRegistry::_update() {
     _update_process_thread_num();
     _update_process_fd_num();
+    _update_spill_disk_bytes_used();
+}
+
+void GlobalMetricsRegistry::_update_spill_disk_bytes_used() {
+    if (_spill_metrics == nullptr) {
+        return;
+    }
+    int64_t local_bytes = 0;
+    if (_spill_local_dir_mgr != nullptr) {
+        for (auto& dir : _spill_local_dir_mgr->dirs()) {
+            local_bytes += dir->get_current_size();
+        }
+    }
+    _spill_metrics->disk_bytes_used(SpillMetrics::kStorageTypeLocal)->set_value(local_bytes);
+    // Remote spill storage is managed per-query, so there is no single
+    // global counter to report. Leave the remote gauge at zero until a
+    // global remote directory tracker exists.
 }
 
 // get num of thread of starrocks_be process

--- a/be/src/util/global_metrics_registry.h
+++ b/be/src/util/global_metrics_registry.h
@@ -28,11 +28,16 @@
 #include "common/util/table_metrics.h"
 #include "util/metrics/catalog_scan_metrics.h"
 #include "util/metrics/file_scan_metrics.h"
+#include "util/metrics/spill_metrics.h"
 #include "util/system_metrics.h"
 
 namespace starrocks {
 
 class StarRocksMetrics;
+
+namespace spill {
+class DirManager;
+}
 
 class GlobalMetricsRegistry {
 public:
@@ -50,6 +55,11 @@ public:
     TableMetricsPtr table_metrics(uint64_t table_id) { return _table_metrics_mgr.get_table_metrics(table_id); }
     FileScanMetrics* file_scan_metrics() { return _file_scan_metrics.get(); }
     CatalogScanMetrics* catalog_scan_metrics() { return _catalog_scan_metrics.get(); }
+    SpillMetrics* spill_metrics() { return _spill_metrics.get(); }
+    // Register the DirManager whose disk usage should be reported via the
+    // spill_disk_bytes_used gauge. The caller retains ownership; the pointer
+    // must outlive the GlobalMetricsRegistry (typically the process).
+    void set_spill_local_dir_manager(spill::DirManager* mgr) { _spill_local_dir_mgr = mgr; }
     pipeline::PipelineExecutorMetrics* pipeline_executor_metrics() { return &_pipeline_executor_metrics; }
 
 private:
@@ -58,6 +68,7 @@ private:
     void _update();
     void _update_process_thread_num();
     void _update_process_fd_num();
+    void _update_spill_disk_bytes_used();
 
 private:
     static const std::string _s_registry_name;
@@ -72,6 +83,8 @@ private:
     TableMetricsManager _table_metrics_mgr;
     std::unique_ptr<FileScanMetrics> _file_scan_metrics;
     std::unique_ptr<CatalogScanMetrics> _catalog_scan_metrics;
+    std::unique_ptr<SpillMetrics> _spill_metrics;
+    spill::DirManager* _spill_local_dir_mgr = nullptr;
     pipeline::PipelineExecutorMetrics _pipeline_executor_metrics;
 };
 

--- a/be/src/util/global_metrics_registry.h
+++ b/be/src/util/global_metrics_registry.h
@@ -35,10 +35,6 @@ namespace starrocks {
 
 class StarRocksMetrics;
 
-namespace spill {
-class DirManager;
-}
-
 class GlobalMetricsRegistry {
 public:
     static GlobalMetricsRegistry* instance();
@@ -56,10 +52,6 @@ public:
     FileScanMetrics* file_scan_metrics() { return _file_scan_metrics.get(); }
     CatalogScanMetrics* catalog_scan_metrics() { return _catalog_scan_metrics.get(); }
     SpillMetrics* spill_metrics() { return _spill_metrics.get(); }
-    // Register the DirManager whose disk usage should be reported via the
-    // spill_disk_bytes_used gauge. The caller retains ownership; the pointer
-    // must outlive the GlobalMetricsRegistry (typically the process).
-    void set_spill_local_dir_manager(spill::DirManager* mgr) { _spill_local_dir_mgr = mgr; }
     pipeline::PipelineExecutorMetrics* pipeline_executor_metrics() { return &_pipeline_executor_metrics; }
 
 private:
@@ -68,7 +60,6 @@ private:
     void _update();
     void _update_process_thread_num();
     void _update_process_fd_num();
-    void _update_spill_disk_bytes_used();
 
 private:
     static const std::string _s_registry_name;
@@ -84,7 +75,6 @@ private:
     std::unique_ptr<FileScanMetrics> _file_scan_metrics;
     std::unique_ptr<CatalogScanMetrics> _catalog_scan_metrics;
     std::unique_ptr<SpillMetrics> _spill_metrics;
-    spill::DirManager* _spill_local_dir_mgr = nullptr;
     pipeline::PipelineExecutorMetrics _pipeline_executor_metrics;
 };
 

--- a/be/src/util/metrics/spill_metrics.cpp
+++ b/be/src/util/metrics/spill_metrics.cpp
@@ -14,104 +14,95 @@
 
 #include "util/metrics/spill_metrics.h"
 
+#include <unordered_map>
+
 namespace starrocks {
 
-SpillMetrics::SpillMetrics(MetricRegistry* registry) : _registry(registry) {
+const char* SpillMetrics::operator_type_label(SpillOperatorType op) {
+    switch (op) {
+    case SpillOperatorType::kHashJoinBuild:
+        return "hash-join-build";
+    case SpillOperatorType::kHashJoinProbe:
+        return "hash-join-probe";
+    case SpillOperatorType::kNestloopJoinBuild:
+        return "nestloop-join-build";
+    case SpillOperatorType::kAggBlocking:
+        return "agg-blocking";
+    case SpillOperatorType::kAggDistinctBlocking:
+        return "agg-distinct-blocking";
+    case SpillOperatorType::kDistinctBlocking:
+        return "distinct-blocking";
+    case SpillOperatorType::kLocalSort:
+        return "local-sort";
+    case SpillOperatorType::kMcastLocalExchange:
+        return "mcast-local-exchange";
+    case SpillOperatorType::kUnknown:
+    case SpillOperatorType::kCount:
+        break;
+    }
+    return "unknown";
+}
+
+SpillOperatorType SpillMetrics::parse_operator_type(std::string_view name) {
+    // Keyed by the string literals assigned to SpilledOptions::name in each
+    // spillable operator. Kept alongside operator_type_label so it is easy
+    // to spot when a new operator is added.
+    static const std::unordered_map<std::string_view, SpillOperatorType> kMap = {
+            {"hash-join-build", SpillOperatorType::kHashJoinBuild},
+            {"hash-join-probe", SpillOperatorType::kHashJoinProbe},
+            {"spillable-nestloop-join-build", SpillOperatorType::kNestloopJoinBuild},
+            {"agg-blocking-spill", SpillOperatorType::kAggBlocking},
+            {"agg-distinct-blocking-spill", SpillOperatorType::kAggDistinctBlocking},
+            {"distinct-blocking-spill", SpillOperatorType::kDistinctBlocking},
+            {"local-sort-spill", SpillOperatorType::kLocalSort},
+            {"mcast_local_exchange", SpillOperatorType::kMcastLocalExchange},
+    };
+    auto it = kMap.find(name);
+    return it != kMap.end() ? it->second : SpillOperatorType::kUnknown;
+}
+
+SpillMetrics::SpillMetrics(MetricRegistry* registry) {
     _local_disk_bytes_used = std::make_unique<IntGauge>(MetricUnit::BYTES);
-    _registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", kStorageTypeLocal),
-                               _local_disk_bytes_used.get());
+    registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", storage_type_label(false)),
+                              _local_disk_bytes_used.get());
 
     _remote_disk_bytes_used = std::make_unique<IntGauge>(MetricUnit::BYTES);
-    _registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", kStorageTypeRemote),
-                               _remote_disk_bytes_used.get());
-}
+    registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", storage_type_label(true)),
+                              _remote_disk_bytes_used.get());
 
-SpillMetrics::LabeledCounters* SpillMetrics::_get_or_register(const std::string& operator_type,
-                                                              const std::string& storage_type) {
-    std::string key;
-    key.reserve(operator_type.size() + 1 + storage_type.size());
-    key.append(operator_type).push_back('\0');
-    key.append(storage_type);
+    for (size_t op_idx = 0; op_idx < kOperatorCount; ++op_idx) {
+        auto op = static_cast<SpillOperatorType>(op_idx);
+        for (size_t storage_idx = 0; storage_idx < kStorageCount; ++storage_idx) {
+            bool is_remote = storage_idx == 1;
+            auto& bucket = _buckets[op_idx][storage_idx];
+            MetricLabels labels;
+            labels.add("operator_type", operator_type_label(op));
+            labels.add("storage_type", storage_type_label(is_remote));
 
-    std::lock_guard<std::mutex> l(_mutex);
-    auto it = _counters.find(key);
-    if (it != _counters.end()) {
-        return it->second.get();
+            bucket.trigger_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
+            registry->register_metric("query_spill_trigger_total", labels, bucket.trigger_total.get());
+
+            bucket.bytes_write_total = std::make_unique<IntCounter>(MetricUnit::BYTES);
+            registry->register_metric("query_spill_bytes_write_total", labels, bucket.bytes_write_total.get());
+
+            bucket.bytes_read_total = std::make_unique<IntCounter>(MetricUnit::BYTES);
+            registry->register_metric("query_spill_bytes_read_total", labels, bucket.bytes_read_total.get());
+
+            bucket.blocks_write_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
+            registry->register_metric("query_spill_blocks_write_total", labels, bucket.blocks_write_total.get());
+
+            bucket.blocks_read_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
+            registry->register_metric("query_spill_blocks_read_total", labels, bucket.blocks_read_total.get());
+
+            bucket.write_io_duration_ns_total = std::make_unique<IntCounter>(MetricUnit::NANOSECONDS);
+            registry->register_metric("query_spill_write_io_duration_ns_total", labels,
+                                      bucket.write_io_duration_ns_total.get());
+
+            bucket.read_io_duration_ns_total = std::make_unique<IntCounter>(MetricUnit::NANOSECONDS);
+            registry->register_metric("query_spill_read_io_duration_ns_total", labels,
+                                      bucket.read_io_duration_ns_total.get());
+        }
     }
-
-    auto bucket = std::make_unique<LabeledCounters>();
-    MetricLabels labels;
-    labels.add("operator_type", operator_type);
-    labels.add("storage_type", storage_type);
-
-    bucket->trigger_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
-    _registry->register_metric("query_spill_trigger_total", labels, bucket->trigger_total.get());
-
-    bucket->bytes_write_total = std::make_unique<IntCounter>(MetricUnit::BYTES);
-    _registry->register_metric("query_spill_bytes_write_total", labels, bucket->bytes_write_total.get());
-
-    bucket->bytes_read_total = std::make_unique<IntCounter>(MetricUnit::BYTES);
-    _registry->register_metric("query_spill_bytes_read_total", labels, bucket->bytes_read_total.get());
-
-    bucket->blocks_write_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
-    _registry->register_metric("query_spill_blocks_write_total", labels, bucket->blocks_write_total.get());
-
-    bucket->blocks_read_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
-    _registry->register_metric("query_spill_blocks_read_total", labels, bucket->blocks_read_total.get());
-
-    bucket->write_io_duration_ns_total = std::make_unique<IntCounter>(MetricUnit::NANOSECONDS);
-    _registry->register_metric("query_spill_write_io_duration_ns_total", labels,
-                               bucket->write_io_duration_ns_total.get());
-
-    bucket->read_io_duration_ns_total = std::make_unique<IntCounter>(MetricUnit::NANOSECONDS);
-    _registry->register_metric("query_spill_read_io_duration_ns_total", labels,
-                               bucket->read_io_duration_ns_total.get());
-
-    auto* raw = bucket.get();
-    _counters.emplace(std::move(key), std::move(bucket));
-    return raw;
-}
-
-SpillMetrics::LabeledCounters* SpillMetrics::get(const std::string& operator_type,
-                                                 const std::string& storage_type) {
-    return _get_or_register(operator_type, storage_type);
-}
-
-IntCounter* SpillMetrics::trigger_total(const std::string& operator_type, const std::string& storage_type) {
-    return _get_or_register(operator_type, storage_type)->trigger_total.get();
-}
-
-IntCounter* SpillMetrics::bytes_write_total(const std::string& operator_type, const std::string& storage_type) {
-    return _get_or_register(operator_type, storage_type)->bytes_write_total.get();
-}
-
-IntCounter* SpillMetrics::bytes_read_total(const std::string& operator_type, const std::string& storage_type) {
-    return _get_or_register(operator_type, storage_type)->bytes_read_total.get();
-}
-
-IntCounter* SpillMetrics::blocks_write_total(const std::string& operator_type, const std::string& storage_type) {
-    return _get_or_register(operator_type, storage_type)->blocks_write_total.get();
-}
-
-IntCounter* SpillMetrics::blocks_read_total(const std::string& operator_type, const std::string& storage_type) {
-    return _get_or_register(operator_type, storage_type)->blocks_read_total.get();
-}
-
-IntCounter* SpillMetrics::write_io_duration_ns_total(const std::string& operator_type,
-                                                     const std::string& storage_type) {
-    return _get_or_register(operator_type, storage_type)->write_io_duration_ns_total.get();
-}
-
-IntCounter* SpillMetrics::read_io_duration_ns_total(const std::string& operator_type,
-                                                    const std::string& storage_type) {
-    return _get_or_register(operator_type, storage_type)->read_io_duration_ns_total.get();
-}
-
-IntGauge* SpillMetrics::disk_bytes_used(const std::string& storage_type) {
-    if (storage_type == kStorageTypeRemote) {
-        return _remote_disk_bytes_used.get();
-    }
-    return _local_disk_bytes_used.get();
 }
 
 } // namespace starrocks

--- a/be/src/util/metrics/spill_metrics.cpp
+++ b/be/src/util/metrics/spill_metrics.cpp
@@ -14,39 +14,37 @@
 
 #include "util/metrics/spill_metrics.h"
 
+#include <array>
 #include <unordered_map>
 
 namespace starrocks {
 
-const char* SpillMetrics::operator_type_label(SpillOperatorType op) {
-    switch (op) {
-    case SpillOperatorType::kHashJoinBuild:
-        return "hash-join-build";
-    case SpillOperatorType::kHashJoinProbe:
-        return "hash-join-probe";
-    case SpillOperatorType::kNestloopJoinBuild:
-        return "nestloop-join-build";
-    case SpillOperatorType::kAggBlocking:
-        return "agg-blocking";
-    case SpillOperatorType::kAggDistinctBlocking:
-        return "agg-distinct-blocking";
-    case SpillOperatorType::kDistinctBlocking:
-        return "distinct-blocking";
-    case SpillOperatorType::kLocalSort:
-        return "local-sort";
-    case SpillOperatorType::kMcastLocalExchange:
-        return "mcast-local-exchange";
-    case SpillOperatorType::kUnknown:
-    case SpillOperatorType::kCount:
-        break;
-    }
-    return "unknown";
-}
+namespace {
+
+// Keep aligned with enum SpillOperatorType; index = enum value.
+constexpr std::array<const char*, SpillMetrics::kOperatorCount> kOperatorTypeLabels = {
+        "unknown",                // kUnknown
+        "hash-join-build",        // kHashJoinBuild
+        "hash-join-probe",        // kHashJoinProbe
+        "nestloop-join-build",    // kNestloopJoinBuild
+        "agg-blocking",           // kAggBlocking
+        "agg-distinct-blocking",  // kAggDistinctBlocking
+        "distinct-blocking",      // kDistinctBlocking
+        "local-sort",             // kLocalSort
+        "mcast-local-exchange",   // kMcastLocalExchange
+};
+
+constexpr const char* kStorageTypeLabels[SpillMetrics::kStorageCount] = {
+        "local",  // is_remote == false
+        "remote", // is_remote == true
+};
+
+} // namespace
 
 SpillOperatorType SpillMetrics::parse_operator_type(std::string_view name) {
     // Keyed by the string literals assigned to SpilledOptions::name in each
-    // spillable operator. Kept alongside operator_type_label so it is easy
-    // to spot when a new operator is added.
+    // spillable operator. Update this table (and kOperatorTypeLabels above)
+    // when a new spillable operator is introduced.
     static const std::unordered_map<std::string_view, SpillOperatorType> kMap = {
             {"hash-join-build", SpillOperatorType::kHashJoinBuild},
             {"hash-join-probe", SpillOperatorType::kHashJoinProbe},
@@ -63,21 +61,19 @@ SpillOperatorType SpillMetrics::parse_operator_type(std::string_view name) {
 
 SpillMetrics::SpillMetrics(MetricRegistry* registry) {
     _local_disk_bytes_used = std::make_unique<IntGauge>(MetricUnit::BYTES);
-    registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", storage_type_label(false)),
+    registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", kStorageTypeLabels[0]),
                               _local_disk_bytes_used.get());
 
     _remote_disk_bytes_used = std::make_unique<IntGauge>(MetricUnit::BYTES);
-    registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", storage_type_label(true)),
+    registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", kStorageTypeLabels[1]),
                               _remote_disk_bytes_used.get());
 
     for (size_t op_idx = 0; op_idx < kOperatorCount; ++op_idx) {
-        auto op = static_cast<SpillOperatorType>(op_idx);
         for (size_t storage_idx = 0; storage_idx < kStorageCount; ++storage_idx) {
-            bool is_remote = storage_idx == 1;
             auto& bucket = _buckets[op_idx][storage_idx];
             MetricLabels labels;
-            labels.add("operator_type", operator_type_label(op));
-            labels.add("storage_type", storage_type_label(is_remote));
+            labels.add("operator_type", kOperatorTypeLabels[op_idx]);
+            labels.add("storage_type", kStorageTypeLabels[storage_idx]);
 
             bucket.trigger_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
             registry->register_metric("query_spill_trigger_total", labels, bucket.trigger_total.get());

--- a/be/src/util/metrics/spill_metrics.cpp
+++ b/be/src/util/metrics/spill_metrics.cpp
@@ -14,91 +14,50 @@
 
 #include "util/metrics/spill_metrics.h"
 
-#include <array>
-#include <unordered_map>
-
 namespace starrocks {
 
 namespace {
 
-// Keep aligned with enum SpillOperatorType; index = enum value.
-constexpr std::array<const char*, SpillMetrics::kOperatorCount> kOperatorTypeLabels = {
-        "unknown",                // kUnknown
-        "hash-join-build",        // kHashJoinBuild
-        "hash-join-probe",        // kHashJoinProbe
-        "nestloop-join-build",    // kNestloopJoinBuild
-        "agg-blocking",           // kAggBlocking
-        "agg-distinct-blocking",  // kAggDistinctBlocking
-        "distinct-blocking",      // kDistinctBlocking
-        "local-sort",             // kLocalSort
-        "mcast-local-exchange",   // kMcastLocalExchange
-};
+void register_labeled(MetricRegistry* registry, const char* storage_type, SpillMetrics::LabeledCounters* bucket) {
+    MetricLabels labels;
+    labels.add("storage_type", storage_type);
 
-constexpr const char* kStorageTypeLabels[SpillMetrics::kStorageCount] = {
-        "local",  // is_remote == false
-        "remote", // is_remote == true
-};
+    bucket->trigger_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
+    registry->register_metric("query_spill_trigger_total", labels, bucket->trigger_total.get());
+
+    bucket->bytes_write_total = std::make_unique<IntCounter>(MetricUnit::BYTES);
+    registry->register_metric("query_spill_bytes_write_total", labels, bucket->bytes_write_total.get());
+
+    bucket->bytes_read_total = std::make_unique<IntCounter>(MetricUnit::BYTES);
+    registry->register_metric("query_spill_bytes_read_total", labels, bucket->bytes_read_total.get());
+
+    bucket->blocks_write_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
+    registry->register_metric("query_spill_blocks_write_total", labels, bucket->blocks_write_total.get());
+
+    bucket->blocks_read_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
+    registry->register_metric("query_spill_blocks_read_total", labels, bucket->blocks_read_total.get());
+
+    bucket->write_io_duration_ns_total = std::make_unique<IntCounter>(MetricUnit::NANOSECONDS);
+    registry->register_metric("query_spill_write_io_duration_ns_total", labels,
+                              bucket->write_io_duration_ns_total.get());
+
+    bucket->read_io_duration_ns_total = std::make_unique<IntCounter>(MetricUnit::NANOSECONDS);
+    registry->register_metric("query_spill_read_io_duration_ns_total", labels, bucket->read_io_duration_ns_total.get());
+}
 
 } // namespace
 
-SpillOperatorType SpillMetrics::parse_operator_type(std::string_view name) {
-    // Keyed by the string literals assigned to SpilledOptions::name in each
-    // spillable operator. Update this table (and kOperatorTypeLabels above)
-    // when a new spillable operator is introduced.
-    static const std::unordered_map<std::string_view, SpillOperatorType> kMap = {
-            {"hash-join-build", SpillOperatorType::kHashJoinBuild},
-            {"hash-join-probe", SpillOperatorType::kHashJoinProbe},
-            {"spillable-nestloop-join-build", SpillOperatorType::kNestloopJoinBuild},
-            {"agg-blocking-spill", SpillOperatorType::kAggBlocking},
-            {"agg-distinct-blocking-spill", SpillOperatorType::kAggDistinctBlocking},
-            {"distinct-blocking-spill", SpillOperatorType::kDistinctBlocking},
-            {"local-sort-spill", SpillOperatorType::kLocalSort},
-            {"mcast_local_exchange", SpillOperatorType::kMcastLocalExchange},
-    };
-    auto it = kMap.find(name);
-    return it != kMap.end() ? it->second : SpillOperatorType::kUnknown;
-}
-
 SpillMetrics::SpillMetrics(MetricRegistry* registry) {
     _local_disk_bytes_used = std::make_unique<IntGauge>(MetricUnit::BYTES);
-    registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", kStorageTypeLabels[0]),
+    registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", "local"),
                               _local_disk_bytes_used.get());
 
     _remote_disk_bytes_used = std::make_unique<IntGauge>(MetricUnit::BYTES);
-    registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", kStorageTypeLabels[1]),
+    registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", "remote"),
                               _remote_disk_bytes_used.get());
 
-    for (size_t op_idx = 0; op_idx < kOperatorCount; ++op_idx) {
-        for (size_t storage_idx = 0; storage_idx < kStorageCount; ++storage_idx) {
-            auto& bucket = _buckets[op_idx][storage_idx];
-            MetricLabels labels;
-            labels.add("operator_type", kOperatorTypeLabels[op_idx]);
-            labels.add("storage_type", kStorageTypeLabels[storage_idx]);
-
-            bucket.trigger_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
-            registry->register_metric("query_spill_trigger_total", labels, bucket.trigger_total.get());
-
-            bucket.bytes_write_total = std::make_unique<IntCounter>(MetricUnit::BYTES);
-            registry->register_metric("query_spill_bytes_write_total", labels, bucket.bytes_write_total.get());
-
-            bucket.bytes_read_total = std::make_unique<IntCounter>(MetricUnit::BYTES);
-            registry->register_metric("query_spill_bytes_read_total", labels, bucket.bytes_read_total.get());
-
-            bucket.blocks_write_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
-            registry->register_metric("query_spill_blocks_write_total", labels, bucket.blocks_write_total.get());
-
-            bucket.blocks_read_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
-            registry->register_metric("query_spill_blocks_read_total", labels, bucket.blocks_read_total.get());
-
-            bucket.write_io_duration_ns_total = std::make_unique<IntCounter>(MetricUnit::NANOSECONDS);
-            registry->register_metric("query_spill_write_io_duration_ns_total", labels,
-                                      bucket.write_io_duration_ns_total.get());
-
-            bucket.read_io_duration_ns_total = std::make_unique<IntCounter>(MetricUnit::NANOSECONDS);
-            registry->register_metric("query_spill_read_io_duration_ns_total", labels,
-                                      bucket.read_io_duration_ns_total.get());
-        }
-    }
+    register_labeled(registry, "local", &_local);
+    register_labeled(registry, "remote", &_remote);
 }
 
 } // namespace starrocks

--- a/be/src/util/metrics/spill_metrics.cpp
+++ b/be/src/util/metrics/spill_metrics.cpp
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/metrics/spill_metrics.h"
+
+namespace starrocks {
+
+SpillMetrics::SpillMetrics(MetricRegistry* registry) : _registry(registry) {
+    _local_disk_bytes_used = std::make_unique<IntGauge>(MetricUnit::BYTES);
+    _registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", kStorageTypeLocal),
+                               _local_disk_bytes_used.get());
+
+    _remote_disk_bytes_used = std::make_unique<IntGauge>(MetricUnit::BYTES);
+    _registry->register_metric("spill_disk_bytes_used", MetricLabels().add("storage_type", kStorageTypeRemote),
+                               _remote_disk_bytes_used.get());
+}
+
+SpillMetrics::LabeledCounters* SpillMetrics::_get_or_register(const std::string& operator_type,
+                                                              const std::string& storage_type) {
+    std::string key;
+    key.reserve(operator_type.size() + 1 + storage_type.size());
+    key.append(operator_type).push_back('\0');
+    key.append(storage_type);
+
+    std::lock_guard<std::mutex> l(_mutex);
+    auto it = _counters.find(key);
+    if (it != _counters.end()) {
+        return it->second.get();
+    }
+
+    auto bucket = std::make_unique<LabeledCounters>();
+    MetricLabels labels;
+    labels.add("operator_type", operator_type);
+    labels.add("storage_type", storage_type);
+
+    bucket->trigger_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
+    _registry->register_metric("query_spill_trigger_total", labels, bucket->trigger_total.get());
+
+    bucket->bytes_write_total = std::make_unique<IntCounter>(MetricUnit::BYTES);
+    _registry->register_metric("query_spill_bytes_write_total", labels, bucket->bytes_write_total.get());
+
+    bucket->bytes_read_total = std::make_unique<IntCounter>(MetricUnit::BYTES);
+    _registry->register_metric("query_spill_bytes_read_total", labels, bucket->bytes_read_total.get());
+
+    bucket->blocks_write_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
+    _registry->register_metric("query_spill_blocks_write_total", labels, bucket->blocks_write_total.get());
+
+    bucket->blocks_read_total = std::make_unique<IntCounter>(MetricUnit::OPERATIONS);
+    _registry->register_metric("query_spill_blocks_read_total", labels, bucket->blocks_read_total.get());
+
+    bucket->write_io_duration_ns_total = std::make_unique<IntCounter>(MetricUnit::NANOSECONDS);
+    _registry->register_metric("query_spill_write_io_duration_ns_total", labels,
+                               bucket->write_io_duration_ns_total.get());
+
+    bucket->read_io_duration_ns_total = std::make_unique<IntCounter>(MetricUnit::NANOSECONDS);
+    _registry->register_metric("query_spill_read_io_duration_ns_total", labels,
+                               bucket->read_io_duration_ns_total.get());
+
+    auto* raw = bucket.get();
+    _counters.emplace(std::move(key), std::move(bucket));
+    return raw;
+}
+
+SpillMetrics::LabeledCounters* SpillMetrics::get(const std::string& operator_type,
+                                                 const std::string& storage_type) {
+    return _get_or_register(operator_type, storage_type);
+}
+
+IntCounter* SpillMetrics::trigger_total(const std::string& operator_type, const std::string& storage_type) {
+    return _get_or_register(operator_type, storage_type)->trigger_total.get();
+}
+
+IntCounter* SpillMetrics::bytes_write_total(const std::string& operator_type, const std::string& storage_type) {
+    return _get_or_register(operator_type, storage_type)->bytes_write_total.get();
+}
+
+IntCounter* SpillMetrics::bytes_read_total(const std::string& operator_type, const std::string& storage_type) {
+    return _get_or_register(operator_type, storage_type)->bytes_read_total.get();
+}
+
+IntCounter* SpillMetrics::blocks_write_total(const std::string& operator_type, const std::string& storage_type) {
+    return _get_or_register(operator_type, storage_type)->blocks_write_total.get();
+}
+
+IntCounter* SpillMetrics::blocks_read_total(const std::string& operator_type, const std::string& storage_type) {
+    return _get_or_register(operator_type, storage_type)->blocks_read_total.get();
+}
+
+IntCounter* SpillMetrics::write_io_duration_ns_total(const std::string& operator_type,
+                                                     const std::string& storage_type) {
+    return _get_or_register(operator_type, storage_type)->write_io_duration_ns_total.get();
+}
+
+IntCounter* SpillMetrics::read_io_duration_ns_total(const std::string& operator_type,
+                                                    const std::string& storage_type) {
+    return _get_or_register(operator_type, storage_type)->read_io_duration_ns_total.get();
+}
+
+IntGauge* SpillMetrics::disk_bytes_used(const std::string& storage_type) {
+    if (storage_type == kStorageTypeRemote) {
+        return _remote_disk_bytes_used.get();
+    }
+    return _local_disk_bytes_used.get();
+}
+
+} // namespace starrocks

--- a/be/src/util/metrics/spill_metrics.h
+++ b/be/src/util/metrics/spill_metrics.h
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "base/metrics.h"
+
+namespace starrocks {
+
+// Per-query spill metrics labeled by operator_type and storage_type.
+// Labels are registered lazily on first access to keep the label set
+// restricted to operator/storage pairs that actually spill.
+class SpillMetrics {
+public:
+    static constexpr const char* kStorageTypeLocal = "local";
+    static constexpr const char* kStorageTypeRemote = "remote";
+
+    struct LabeledCounters {
+        std::unique_ptr<IntCounter> trigger_total;
+        std::unique_ptr<IntCounter> bytes_write_total;
+        std::unique_ptr<IntCounter> bytes_read_total;
+        std::unique_ptr<IntCounter> blocks_write_total;
+        std::unique_ptr<IntCounter> blocks_read_total;
+        std::unique_ptr<IntCounter> write_io_duration_ns_total;
+        std::unique_ptr<IntCounter> read_io_duration_ns_total;
+    };
+
+    SpillMetrics(MetricRegistry* registry);
+    ~SpillMetrics() = default;
+
+    // Fetch (and lazily register) the counter bucket for a given
+    // (operator_type, storage_type) pair. Prefer this when multiple
+    // counters from the same bucket are updated together - it avoids
+    // re-taking the registration mutex for each accessor.
+    LabeledCounters* get(const std::string& operator_type, const std::string& storage_type);
+
+    // Convenience single-counter accessors.
+    IntCounter* trigger_total(const std::string& operator_type, const std::string& storage_type);
+    IntCounter* bytes_write_total(const std::string& operator_type, const std::string& storage_type);
+    IntCounter* bytes_read_total(const std::string& operator_type, const std::string& storage_type);
+    IntCounter* blocks_write_total(const std::string& operator_type, const std::string& storage_type);
+    IntCounter* blocks_read_total(const std::string& operator_type, const std::string& storage_type);
+    IntCounter* write_io_duration_ns_total(const std::string& operator_type, const std::string& storage_type);
+    IntCounter* read_io_duration_ns_total(const std::string& operator_type, const std::string& storage_type);
+
+    // spill_disk_bytes_used gauge, labeled by storage_type only. The
+    // GlobalMetricsRegistry update hook refreshes these from the spill
+    // DirManagers.
+    IntGauge* disk_bytes_used(const std::string& storage_type);
+
+private:
+    LabeledCounters* _get_or_register(const std::string& operator_type, const std::string& storage_type);
+
+    MetricRegistry* _registry;
+
+    std::mutex _mutex;
+    // key = operator_type + "\0" + storage_type
+    std::map<std::string, std::unique_ptr<LabeledCounters>> _counters;
+
+    std::unique_ptr<IntGauge> _local_disk_bytes_used;
+    std::unique_ptr<IntGauge> _remote_disk_bytes_used;
+};
+
+} // namespace starrocks

--- a/be/src/util/metrics/spill_metrics.h
+++ b/be/src/util/metrics/spill_metrics.h
@@ -14,22 +14,35 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
-#include <mutex>
 #include <string>
+#include <string_view>
 
 #include "base/metrics.h"
 
 namespace starrocks {
 
-// Per-query spill metrics labeled by operator_type and storage_type.
-// Labels are registered lazily on first access to keep the label set
-// restricted to operator/storage pairs that actually spill.
+// Closed set of spillable operator types. The enum exists so hot paths
+// can index into the metric bucket array in O(1), avoiding any string
+// comparison or label map lookup.
+enum class SpillOperatorType : uint8_t {
+    kUnknown = 0,
+    kHashJoinBuild,
+    kHashJoinProbe,
+    kNestloopJoinBuild,
+    kAggBlocking,
+    kAggDistinctBlocking,
+    kDistinctBlocking,
+    kLocalSort,
+    kMcastLocalExchange,
+    // keep last
+    kCount,
+};
+
 class SpillMetrics {
 public:
-    static constexpr const char* kStorageTypeLocal = "local";
-    static constexpr const char* kStorageTypeRemote = "remote";
+    static constexpr size_t kOperatorCount = static_cast<size_t>(SpillOperatorType::kCount);
+    static constexpr size_t kStorageCount = 2; // local, remote
 
     struct LabeledCounters {
         std::unique_ptr<IntCounter> trigger_total;
@@ -44,35 +57,25 @@ public:
     SpillMetrics(MetricRegistry* registry);
     ~SpillMetrics() = default;
 
-    // Fetch (and lazily register) the counter bucket for a given
-    // (operator_type, storage_type) pair. Prefer this when multiple
-    // counters from the same bucket are updated together - it avoids
-    // re-taking the registration mutex for each accessor.
-    LabeledCounters* get(const std::string& operator_type, const std::string& storage_type);
+    // O(1) array indexing, no allocation, no locking. Safe on hot paths.
+    LabeledCounters* get(SpillOperatorType op, bool is_remote) {
+        return &_buckets[static_cast<size_t>(op)][is_remote ? 1 : 0];
+    }
 
-    // Convenience single-counter accessors.
-    IntCounter* trigger_total(const std::string& operator_type, const std::string& storage_type);
-    IntCounter* bytes_write_total(const std::string& operator_type, const std::string& storage_type);
-    IntCounter* bytes_read_total(const std::string& operator_type, const std::string& storage_type);
-    IntCounter* blocks_write_total(const std::string& operator_type, const std::string& storage_type);
-    IntCounter* blocks_read_total(const std::string& operator_type, const std::string& storage_type);
-    IntCounter* write_io_duration_ns_total(const std::string& operator_type, const std::string& storage_type);
-    IntCounter* read_io_duration_ns_total(const std::string& operator_type, const std::string& storage_type);
+    IntGauge* local_disk_bytes_used() { return _local_disk_bytes_used.get(); }
+    IntGauge* remote_disk_bytes_used() { return _remote_disk_bytes_used.get(); }
 
-    // spill_disk_bytes_used gauge, labeled by storage_type only. The
-    // GlobalMetricsRegistry update hook refreshes these from the spill
-    // DirManagers.
-    IntGauge* disk_bytes_used(const std::string& storage_type);
+    // Map SpilledOptions::name to a SpillOperatorType. Returns kUnknown
+    // for unrecognized names. Callers should invoke this once at Spiller
+    // setup time and cache the result.
+    static SpillOperatorType parse_operator_type(std::string_view name);
+
+    // Exposed for tests and label construction.
+    static const char* operator_type_label(SpillOperatorType op);
+    static const char* storage_type_label(bool is_remote) { return is_remote ? "remote" : "local"; }
 
 private:
-    LabeledCounters* _get_or_register(const std::string& operator_type, const std::string& storage_type);
-
-    MetricRegistry* _registry;
-
-    std::mutex _mutex;
-    // key = operator_type + "\0" + storage_type
-    std::map<std::string, std::unique_ptr<LabeledCounters>> _counters;
-
+    LabeledCounters _buckets[kOperatorCount][kStorageCount];
     std::unique_ptr<IntGauge> _local_disk_bytes_used;
     std::unique_ptr<IntGauge> _remote_disk_bytes_used;
 };

--- a/be/src/util/metrics/spill_metrics.h
+++ b/be/src/util/metrics/spill_metrics.h
@@ -15,35 +15,16 @@
 #pragma once
 
 #include <memory>
-#include <string>
-#include <string_view>
 
 #include "base/metrics.h"
 
 namespace starrocks {
 
-// Closed set of spillable operator types. The enum exists so hot paths
-// can index into the metric bucket array in O(1), avoiding any string
-// comparison or label map lookup.
-enum class SpillOperatorType : uint8_t {
-    kUnknown = 0,
-    kHashJoinBuild,
-    kHashJoinProbe,
-    kNestloopJoinBuild,
-    kAggBlocking,
-    kAggDistinctBlocking,
-    kDistinctBlocking,
-    kLocalSort,
-    kMcastLocalExchange,
-    // keep last
-    kCount,
-};
-
+// Server-level spill counters aggregated across all spillable operators.
+// Only split by storage_type (local vs. remote); per-operator breakdown
+// already lives in each operator's RuntimeProfile.
 class SpillMetrics {
 public:
-    static constexpr size_t kOperatorCount = static_cast<size_t>(SpillOperatorType::kCount);
-    static constexpr size_t kStorageCount = 2; // local, remote
-
     struct LabeledCounters {
         std::unique_ptr<IntCounter> trigger_total;
         std::unique_ptr<IntCounter> bytes_write_total;
@@ -57,21 +38,14 @@ public:
     SpillMetrics(MetricRegistry* registry);
     ~SpillMetrics() = default;
 
-    // O(1) array indexing, no allocation, no locking. Safe on hot paths.
-    LabeledCounters* get(SpillOperatorType op, bool is_remote) {
-        return &_buckets[static_cast<size_t>(op)][is_remote ? 1 : 0];
-    }
+    LabeledCounters* get(bool is_remote) { return is_remote ? &_remote : &_local; }
 
     IntGauge* local_disk_bytes_used() { return _local_disk_bytes_used.get(); }
     IntGauge* remote_disk_bytes_used() { return _remote_disk_bytes_used.get(); }
 
-    // Map SpilledOptions::name to a SpillOperatorType. Returns kUnknown
-    // for unrecognized names. Callers should invoke this once at Spiller
-    // setup time and cache the result.
-    static SpillOperatorType parse_operator_type(std::string_view name);
-
 private:
-    LabeledCounters _buckets[kOperatorCount][kStorageCount];
+    LabeledCounters _local;
+    LabeledCounters _remote;
     std::unique_ptr<IntGauge> _local_disk_bytes_used;
     std::unique_ptr<IntGauge> _remote_disk_bytes_used;
 };

--- a/be/src/util/metrics/spill_metrics.h
+++ b/be/src/util/metrics/spill_metrics.h
@@ -70,10 +70,6 @@ public:
     // setup time and cache the result.
     static SpillOperatorType parse_operator_type(std::string_view name);
 
-    // Exposed for tests and label construction.
-    static const char* operator_type_label(SpillOperatorType op);
-    static const char* storage_type_label(bool is_remote) { return is_remote ? "remote" : "local"; }
-
 private:
     LabeledCounters _buckets[kOperatorCount][kStorageCount];
     std::unique_ptr<IntGauge> _local_disk_bytes_used;

--- a/docs/en/administration/management/monitoring/metric_details/q-z.md
+++ b/docs/en/administration/management/monitoring/metric_details/q-z.md
@@ -70,7 +70,7 @@ For more information on how to build a monitoring service for your StarRocks clu
 
 - Unit: Count
 - Labels: `operator_type`, `storage_type`
-- Description: Number of spillable operator instances that triggered at least one spill, broken down by operator type (for example `hash-join-build`, `agg-blocking-spill`) and storage backend (`local`, `remote`). Incremented once per operator instance at the first flush callback.
+- Description: Number of spillable operator instances that triggered at least one spill, broken down by operator type (for example `hash-join-build`, `agg-blocking`, `local-sort`) and storage backend (`local`, `remote`). Incremented once per operator instance at the first flush callback.
 
 ## `query_spill_bytes_write_total`
 

--- a/docs/en/administration/management/monitoring/metric_details/q-z.md
+++ b/docs/en/administration/management/monitoring/metric_details/q-z.md
@@ -69,44 +69,44 @@ For more information on how to build a monitoring service for your StarRocks clu
 ## `query_spill_trigger_total`
 
 - Unit: Count
-- Labels: `operator_type`, `storage_type`
-- Description: Number of spillable operator instances that triggered at least one spill, broken down by operator type (for example `hash-join-build`, `agg-blocking`, `local-sort`) and storage backend (`local`, `remote`). Incremented once per operator instance at the first flush callback.
+- Labels: `storage_type`
+- Description: Number of spillable operator instances that triggered at least one spill, broken down by storage backend (`local`, `remote`). Incremented once per operator instance at the first flush callback.
 
 ## `query_spill_bytes_write_total`
 
 - Unit: Bytes
-- Labels: `operator_type`, `storage_type`
-- Description: Cumulative payload bytes written by spillable operators to spill storage, broken down by operator type and storage backend (`local`, `remote`).
+- Labels: `storage_type`
+- Description: Cumulative payload bytes written by spillable operators to spill storage, broken down by storage backend (`local`, `remote`).
 
 ## `query_spill_bytes_read_total`
 
 - Unit: Bytes
-- Labels: `operator_type`, `storage_type`
-- Description: Cumulative payload bytes read back from spill storage during restore, broken down by operator type and storage backend.
+- Labels: `storage_type`
+- Description: Cumulative payload bytes read back from spill storage during restore, broken down by storage backend.
 
 ## `query_spill_blocks_write_total`
 
 - Unit: Count
-- Labels: `operator_type`, `storage_type`
-- Description: Number of spill blocks allocated for writing, broken down by operator type and storage backend. Useful for estimating IO count scale on the write path.
+- Labels: `storage_type`
+- Description: Number of spill blocks allocated for writing, broken down by storage backend. Useful for estimating IO count scale on the write path.
 
 ## `query_spill_blocks_read_total`
 
 - Unit: Count
-- Labels: `operator_type`, `storage_type`
-- Description: Number of spill blocks opened for reading, broken down by operator type and storage backend. Useful for estimating IO count scale on the read path.
+- Labels: `storage_type`
+- Description: Number of spill blocks opened for reading, broken down by storage backend. Useful for estimating IO count scale on the read path.
 
 ## `query_spill_write_io_duration_ns_total`
 
 - Unit: Nanoseconds
-- Labels: `operator_type`, `storage_type`
-- Description: Cumulative wall-clock time spent in write-side spill IO (block append and flush), broken down by operator type and storage backend. Useful for tracking write-side spill performance.
+- Labels: `storage_type`
+- Description: Cumulative wall-clock time spent in write-side spill IO (block append and flush), broken down by storage backend. Useful for tracking write-side spill performance.
 
 ## `query_spill_read_io_duration_ns_total`
 
 - Unit: Nanoseconds
-- Labels: `operator_type`, `storage_type`
-- Description: Cumulative wall-clock time spent in read-side spill IO (block reads during restore), broken down by operator type and storage backend. Useful for tracking read-side spill performance.
+- Labels: `storage_type`
+- Description: Cumulative wall-clock time spent in read-side spill IO (block reads during restore), broken down by storage backend. Useful for tracking read-side spill performance.
 
 ## `readable_blocks_total (Deprecated)`
 

--- a/docs/en/administration/management/monitoring/metric_details/q-z.md
+++ b/docs/en/administration/management/monitoring/metric_details/q-z.md
@@ -66,6 +66,48 @@ For more information on how to build a monitoring service for your StarRocks clu
 - Unit: Count
 - Description: Total number of scanned rows.
 
+## `query_spill_trigger_total`
+
+- Unit: Count
+- Labels: `operator_type`, `storage_type`
+- Description: Number of spillable operator instances that triggered at least one spill, broken down by operator type (for example `hash-join-build`, `agg-blocking-spill`) and storage backend (`local`, `remote`). Incremented once per operator instance at the first flush callback.
+
+## `query_spill_bytes_write_total`
+
+- Unit: Bytes
+- Labels: `operator_type`, `storage_type`
+- Description: Cumulative payload bytes written by spillable operators to spill storage, broken down by operator type and storage backend (`local`, `remote`).
+
+## `query_spill_bytes_read_total`
+
+- Unit: Bytes
+- Labels: `operator_type`, `storage_type`
+- Description: Cumulative payload bytes read back from spill storage during restore, broken down by operator type and storage backend.
+
+## `query_spill_blocks_write_total`
+
+- Unit: Count
+- Labels: `operator_type`, `storage_type`
+- Description: Number of spill blocks allocated for writing, broken down by operator type and storage backend. Useful for estimating IO count scale on the write path.
+
+## `query_spill_blocks_read_total`
+
+- Unit: Count
+- Labels: `operator_type`, `storage_type`
+- Description: Number of spill blocks opened for reading, broken down by operator type and storage backend. Useful for estimating IO count scale on the read path.
+
+## `query_spill_write_io_duration_ns_total`
+
+- Unit: Nanoseconds
+- Labels: `operator_type`, `storage_type`
+- Description: Cumulative wall-clock time spent in write-side spill IO (block append and flush), broken down by operator type and storage backend. Useful for tracking write-side spill performance.
+
+## `query_spill_read_io_duration_ns_total`
+
+- Unit: Nanoseconds
+- Labels: `operator_type`, `storage_type`
+- Description: Cumulative wall-clock time spent in read-side spill IO (block reads during restore), broken down by operator type and storage backend. Useful for tracking read-side spill performance.
+
 ## `readable_blocks_total (Deprecated)`
 
 ## `resource_group_bigquery_count`
@@ -202,6 +244,12 @@ For more information on how to build a monitoring service for your StarRocks clu
 
 - Unit: Count
 - Description: Number of small file caches.
+
+## `spill_disk_bytes_used`
+
+- Unit: Bytes
+- Labels: `storage_type`
+- Description: Current disk bytes reserved across all spill storage directories. The `storage_type=local` variant aggregates the live reserved bytes across every directory managed by the BE's spill `DirManager`. The `storage_type=remote` variant is reported for completeness and is currently always 0 because remote spill storage is tracked per-query rather than globally.
 
 ## `snmp`
 

--- a/docs/zh/administration/management/monitoring/metric_details/q-z.md
+++ b/docs/zh/administration/management/monitoring/metric_details/q-z.md
@@ -69,44 +69,44 @@ description: "Alphabetical q - z"
 ## `query_spill_trigger_total`
 
 - 单位：计数
-- 标签：`operator_type`、`storage_type`
-- 描述：按算子类型（例如 `hash-join-build`、`agg-blocking`、`local-sort`）和存储后端（`local`、`remote`）细分的、触发过至少一次落盘的 spillable 算子实例数量。每个算子实例首次执行 flush 回调时累加一次。
+- 标签：`storage_type`
+- 描述：按存储后端（`local`、`remote`）细分的、触发过至少一次落盘的 spillable 算子实例数量。每个算子实例首次执行 flush 回调时累加一次。
 
 ## `query_spill_bytes_write_total`
 
 - 单位：字节
-- 标签：`operator_type`、`storage_type`
-- 描述：按算子类型和存储后端细分的、spillable 算子累计写入溢出存储的有效负载字节数。
+- 标签：`storage_type`
+- 描述：按存储后端细分的、spillable 算子累计写入溢出存储的有效负载字节数。
 
 ## `query_spill_bytes_read_total`
 
 - 单位：字节
-- 标签：`operator_type`、`storage_type`
-- 描述：按算子类型和存储后端细分的、恢复阶段从溢出存储累计读回的有效负载字节数。
+- 标签：`storage_type`
+- 描述：按存储后端细分的、恢复阶段从溢出存储累计读回的有效负载字节数。
 
 ## `query_spill_blocks_write_total`
 
 - 单位：计数
-- 标签：`operator_type`、`storage_type`
-- 描述：按算子类型和存储后端细分的、为写入分配的溢出 block 数量。用于估算写路径的 IO 次数规模。
+- 标签：`storage_type`
+- 描述：按存储后端细分的、为写入分配的溢出 block 数量。用于估算写路径的 IO 次数规模。
 
 ## `query_spill_blocks_read_total`
 
 - 单位：计数
-- 标签：`operator_type`、`storage_type`
-- 描述：按算子类型和存储后端细分的、打开用于读取的溢出 block 数量。用于估算读路径的 IO 次数规模。
+- 标签：`storage_type`
+- 描述：按存储后端细分的、打开用于读取的溢出 block 数量。用于估算读路径的 IO 次数规模。
 
 ## `query_spill_write_io_duration_ns_total`
 
 - 单位：纳秒
-- 标签：`operator_type`、`storage_type`
-- 描述：按算子类型和存储后端细分的、写侧溢出 IO（block append 与 flush）累计耗时。用于跟踪写盘性能。
+- 标签：`storage_type`
+- 描述：按存储后端细分的、写侧溢出 IO（block append 与 flush）累计耗时。用于跟踪写盘性能。
 
 ## `query_spill_read_io_duration_ns_total`
 
 - 单位：纳秒
-- 标签：`operator_type`、`storage_type`
-- 描述：按算子类型和存储后端细分的、恢复阶段读侧溢出 IO（block 读取）累计耗时。用于跟踪读盘性能。
+- 标签：`storage_type`
+- 描述：按存储后端细分的、恢复阶段读侧溢出 IO（block 读取）累计耗时。用于跟踪读盘性能。
 
 ## `readable_blocks_total (Deprecated)`
 

--- a/docs/zh/administration/management/monitoring/metric_details/q-z.md
+++ b/docs/zh/administration/management/monitoring/metric_details/q-z.md
@@ -70,7 +70,7 @@ description: "Alphabetical q - z"
 
 - 单位：计数
 - 标签：`operator_type`、`storage_type`
-- 描述：按算子类型（例如 `hash-join-build`、`agg-blocking-spill`）和存储后端（`local`、`remote`）细分的、触发过至少一次落盘的 spillable 算子实例数量。每个算子实例首次执行 flush 回调时累加一次。
+- 描述：按算子类型（例如 `hash-join-build`、`agg-blocking`、`local-sort`）和存储后端（`local`、`remote`）细分的、触发过至少一次落盘的 spillable 算子实例数量。每个算子实例首次执行 flush 回调时累加一次。
 
 ## `query_spill_bytes_write_total`
 

--- a/docs/zh/administration/management/monitoring/metric_details/q-z.md
+++ b/docs/zh/administration/management/monitoring/metric_details/q-z.md
@@ -66,6 +66,48 @@ description: "Alphabetical q - z"
 - 单位：计数
 - 描述：扫描的总行数。
 
+## `query_spill_trigger_total`
+
+- 单位：计数
+- 标签：`operator_type`、`storage_type`
+- 描述：按算子类型（例如 `hash-join-build`、`agg-blocking-spill`）和存储后端（`local`、`remote`）细分的、触发过至少一次落盘的 spillable 算子实例数量。每个算子实例首次执行 flush 回调时累加一次。
+
+## `query_spill_bytes_write_total`
+
+- 单位：字节
+- 标签：`operator_type`、`storage_type`
+- 描述：按算子类型和存储后端细分的、spillable 算子累计写入溢出存储的有效负载字节数。
+
+## `query_spill_bytes_read_total`
+
+- 单位：字节
+- 标签：`operator_type`、`storage_type`
+- 描述：按算子类型和存储后端细分的、恢复阶段从溢出存储累计读回的有效负载字节数。
+
+## `query_spill_blocks_write_total`
+
+- 单位：计数
+- 标签：`operator_type`、`storage_type`
+- 描述：按算子类型和存储后端细分的、为写入分配的溢出 block 数量。用于估算写路径的 IO 次数规模。
+
+## `query_spill_blocks_read_total`
+
+- 单位：计数
+- 标签：`operator_type`、`storage_type`
+- 描述：按算子类型和存储后端细分的、打开用于读取的溢出 block 数量。用于估算读路径的 IO 次数规模。
+
+## `query_spill_write_io_duration_ns_total`
+
+- 单位：纳秒
+- 标签：`operator_type`、`storage_type`
+- 描述：按算子类型和存储后端细分的、写侧溢出 IO（block append 与 flush）累计耗时。用于跟踪写盘性能。
+
+## `query_spill_read_io_duration_ns_total`
+
+- 单位：纳秒
+- 标签：`operator_type`、`storage_type`
+- 描述：按算子类型和存储后端细分的、恢复阶段读侧溢出 IO（block 读取）累计耗时。用于跟踪读盘性能。
+
 ## `readable_blocks_total (Deprecated)`
 
 ## `resource_group_bigquery_count`
@@ -202,6 +244,12 @@ description: "Alphabetical q - z"
 
 - 单位: 计数
 - 描述: 小文件缓存的数量。
+
+## `spill_disk_bytes_used`
+
+- 单位: 字节
+- 标签: `storage_type`
+- 描述: 所有溢出存储目录当前已占用的磁盘字节数。`storage_type=local` 汇总 BE 溢出 `DirManager` 管理的每个目录中正在使用的字节数。`storage_type=remote` 为对称保留，当前始终为 0，因为远端溢出存储由单独的查询实例各自管理，没有全局的聚合数据。
 
 ## `snmp`
 


### PR DESCRIPTION
## Why I'm doing:

Spill operations are critical for query performance and resource management. Currently, spill metrics are only tracked at the operator level in RuntimeProfile. We need server-level aggregated metrics to monitor spill behavior across all queries and operators for better observability and performance tracking.

## What I'm doing:

This PR introduces comprehensive server-level spill metrics that aggregate spill activity across all spillable operators, broken down by storage backend (local vs. remote):

### New Metrics Added:
- `query_spill_trigger_total`: Count of spillable operator instances that triggered spilling
- `query_spill_bytes_write_total`: Cumulative bytes written to spill storage
- `query_spill_bytes_read_total`: Cumulative bytes read from spill storage during restore
- `query_spill_blocks_write_total`: Number of spill blocks allocated for writing
- `query_spill_blocks_read_total`: Number of spill blocks opened for reading
- `query_spill_write_io_duration_ns_total`: Wall-clock time spent in write-side spill IO
- `query_spill_read_io_duration_ns_total`: Wall-clock time spent in read-side spill IO
- `spill_disk_bytes_used`: Current disk bytes reserved across all spill storage directories

### Implementation Details:
1. Created new `SpillMetrics` class to manage server-level spill counters with labeled buckets for local/remote storage
2. Integrated metrics collection into spill IO paths:
   - `BlockSpillOutputDataStream`: Tracks write operations and IO duration
   - `BlockReader`: Tracks read operations and IO duration
   - `SequenceInputStream`: Registers read metrics for restore operations
3. Added metrics hook in `ExecEnv` to aggregate local spill directory usage
4. Pre-resolved global metric pointers in `SpillProcessMetrics` for efficient hot-path updates
5. Updated documentation with metric descriptions in both English and Chinese

### Key Design Decisions:
- Metrics are split by storage type (local/remote) for better observability
- Global counters are pre-resolved during spiller preparation to avoid registry lookups on every IO
- Used atomic flag to track spill trigger events (incremented only once per operator instance)
- Integrated with existing `SCOPED_RAW_TIMER` mechanism to measure IO duration separately from other operations

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

https://claude.ai/code/session_01183ashjeTaTJFq6W51sfhq