### PR TITLE
[BugFix] Fix mixed information function projection handling

### DIFF
--- a/be/src/exprs/info_func.cpp
+++ b/be/src/exprs/info_func.cpp
@@ -21,6 +21,9 @@
 namespace starrocks {
 
 VectorizedInfoFunc::VectorizedInfoFunc(const TExprNode& node) : Expr(node) {
+    if (node.info_func.__isset.func_name) {
+        _func_name = node.info_func.func_name;
+    }
     switch (_type.type) {
     case TYPE_BIGINT: {
         _value = ColumnHelper::create_const_column<TYPE_BIGINT>(node.info_func.int_value, 1);
@@ -50,7 +53,11 @@ StatusOr<ColumnPtr> VectorizedInfoFunc::evaluate_checked(ExprContext* context, C
 std::string VectorizedInfoFunc::debug_string() const {
     std::stringstream out;
     out << "VectorizedInfoFunc("
-        << "type=" << this->type().debug_string() << " )";
+        << "type=" << this->type().debug_string();
+    if (!_func_name.empty()) {
+        out << ", func_name=" << _func_name;
+    }
+    out << " )";
     return out.str();
 }
 

--- a/be/src/exprs/info_func.h
+++ b/be/src/exprs/info_func.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "common/object_pool.h"
 #include "exprs/expr.h"
 
@@ -34,5 +36,6 @@ public:
 private:
     // @IMPORTANT: BinaryColumnPtr's build_slice will cause multi-thread(OLAP_SCANNER) crash
     ColumnPtr _value;
+    std::string _func_name;
 };
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecInformationFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecInformationFunction.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.planner.expression;
 
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TInfoFunc;
@@ -74,9 +73,7 @@ public class ExecInformationFunction extends ExecExpr {
     @Override
     public void toThrift(TExprNode node) {
         node.info_func = new TInfoFunc(intValue, strValue);
-        if (FunctionSet.CURRENT_WAREHOUSE.equalsIgnoreCase(funcName) && strValue != null) {
-            node.info_func.setStr_value(strValue);
-        }
+        node.info_func.setFunc_name(funcName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExprToThrift.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExprToThrift.java
@@ -404,10 +404,7 @@ public final class ExprToThrift {
         public Void visitInformationFunction(InformationFunction node, TExprNode msg) {
             msg.node_type = TExprNodeType.INFO_FUNC;
             msg.info_func = new TInfoFunc(node.getIntValue(), node.getStrValue());
-            if (FunctionSet.CURRENT_WAREHOUSE.equalsIgnoreCase(node.getFuncType())
-                    && node.getStrValue() != null) {
-                msg.info_func.setStr_value(node.getStrValue());
-            }
+            msg.info_func.setFunc_name(node.getFuncType());
             return null;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
@@ -2766,6 +2766,7 @@ public class ExecExprTest {
         assertNotNull(node.info_func);
         assertEquals("testdb", node.info_func.getStr_value());
         assertEquals(0L, node.info_func.getInt_value());
+        assertEquals("database", node.info_func.getFunc_name());
     }
 
     @Test
@@ -2778,6 +2779,7 @@ public class ExecExprTest {
 
         assertNotNull(node.info_func);
         assertEquals("wh1", node.info_func.getStr_value());
+        assertEquals("current_warehouse", node.info_func.getFunc_name());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftTest.java
@@ -32,7 +32,6 @@ import com.starrocks.thrift.TExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TInPredicate;
-import com.starrocks.thrift.TInfoFunc;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
@@ -144,8 +143,11 @@ public class ExprToThriftTest {
                 Assertions.assertFalse(node.isSetNode_type());
             }));
             cases.add(nodeCase("InformationFunction", ExprCaseFactory::buildInformationFunction,
-                    TExprNodeType.INFO_FUNC, node -> Assertions.assertEquals(new TInfoFunc(11, "cluster"),
-                            node.getInfo_func())));
+                    TExprNodeType.INFO_FUNC, node -> {
+                        Assertions.assertEquals(11, node.getInfo_func().getInt_value());
+                        Assertions.assertEquals("cluster", node.getInfo_func().getStr_value());
+                        Assertions.assertEquals("CURRENT_CATALOG", node.getInfo_func().getFunc_name());
+                    }));
             cases.add(nodeCase("TimestampArithmeticExpr", ExprCaseFactory::buildTimestampArithmeticExpr,
                     TExprNodeType.COMPUTE_FUNCTION_CALL));
             cases.add(nodeCase("LambdaFunctionExpr", ExprCaseFactory::buildLambdaFunctionExpr,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -103,6 +103,39 @@ public class SelectConstTest extends PlanTestBase {
         assertPlanContains("select database(), catalog()",
                 "<slot 2> : 'test'",
                 "<slot 3> : 'default_catalog'");
+        assertPlanContains("select database(), current_user()",
+                "<slot 2> : 'test'",
+                "<slot 3> : '\\'root\\'@\\'%\\''");
+        assertPlanContains("select schema(), current_warehouse()",
+                "<slot 2> : 'test'",
+                "<slot 3> : 'default_warehouse'");
+        assertPlanContains("select current_user(), current_warehouse()",
+                "<slot 2> : '\\'root\\'@\\'%\\''",
+                "<slot 3> : 'default_warehouse'");
+        assertPlanContains("select current_warehouse(), current_user()",
+                "<slot 2> : 'default_warehouse'",
+                "<slot 3> : '\\'root\\'@\\'%\\''");
+    }
+
+    @Test
+    public void testExecuteInFeMultipleInformationFunctions() throws Exception {
+        assertFeExecuteRow("select database(), current_user()", "test", "'root'@'%'");
+        assertFeExecuteRow("select schema(), current_warehouse()", "test", "default_warehouse");
+        assertFeExecuteRow("select current_user(), current_warehouse()", "'root'@'%'", "default_warehouse");
+        assertFeExecuteRow("select current_warehouse(), current_user()", "default_warehouse", "'root'@'%'");
+    }
+
+    @Test
+    public void testExecuteInFeInformationFunctionsWithoutSelectedDb() throws Exception {
+        String originalDb = connectContext.getDatabase();
+        try {
+            connectContext.setDatabase("");
+            assertFeExecuteRow("select database(), schema()", "", "");
+            assertFeExecuteRow("select database(), current_user()", "", "'root'@'%'");
+            assertFeExecuteRow("select schema(), current_warehouse()", "", "default_warehouse");
+        } finally {
+            connectContext.setDatabase(originalDb);
+        }
     }
 
     @Test
@@ -278,6 +311,43 @@ public class SelectConstTest extends PlanTestBase {
             }
             System.out.println(value);
             Assertions.assertEquals(expected, value);
+        }
+    }
+
+    private void assertFeExecuteRow(String sql, String... expected) throws Exception {
+        ExecPlan execPlan = getExecPlan(sql);
+        FeExecuteCoordinator coordinator = new FeExecuteCoordinator(connectContext, execPlan);
+        RowBatch rowBatch = coordinator.getNext();
+        TResultBatch tResultBatch = rowBatch.getBatch();
+        Assertions.assertEquals(1, tResultBatch.rows.size());
+        byte[] bytes = tResultBatch.getRows().get(0).array();
+        int offset = 0;
+        for (String expectedValue : expected) {
+            int header = bytes[offset] & 0xff;
+            String actualValue;
+            if (header == 251) {
+                actualValue = "NULL";
+                offset += 1;
+            } else {
+                int length;
+                if (header < 251) {
+                    length = header;
+                    offset += 1;
+                } else if (header == 252) {
+                    length = (bytes[offset + 1] & 0xff) | ((bytes[offset + 2] & 0xff) << 8);
+                    offset += 3;
+                } else if (header == 253) {
+                    length = (bytes[offset + 1] & 0xff)
+                            | ((bytes[offset + 2] & 0xff) << 8)
+                            | ((bytes[offset + 3] & 0xff) << 16);
+                    offset += 4;
+                } else {
+                    throw new IllegalStateException("Unsupported length-encoded row value in test: " + header);
+                }
+                actualValue = new String(bytes, offset, length, StandardCharsets.UTF_8);
+                offset += length;
+            }
+            Assertions.assertEquals(expectedValue, actualValue);
         }
     }
 

--- a/gensrc/thrift/Exprs.thrift
+++ b/gensrc/thrift/Exprs.thrift
@@ -168,6 +168,7 @@ struct TStringLiteral {
 struct TInfoFunc {
   1: required i64 int_value;
   2: required string str_value;
+  3: optional string func_name;
 }
 
 struct TFunctionCallExpr {


### PR DESCRIPTION
## Why I'm doing:

Mixed `INFO_FUNC` projections can lose earlier values because the FE/BE path does not preserve the information-function identity when multiple different info functions appear in the same row. In the buggy case, the last projected information function can overwrite the earlier one during FE execution.

## What I'm doing:

- add `func_name` to `TInfoFunc`
- serialize the information-function name from both planner expression thrift paths
- preserve the function name in BE `VectorizedInfoFunc`
- add focused FE tests for mixed information-function projections and FE execution results

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Reproduction script:

```sql
-- Before the fix, the last information function in the projection can wipe out
-- an earlier one when FE execution materializes the row.

select database(), current_user();
select schema(), current_warehouse();
select current_warehouse(), current_user();
```

Expected results in a default test session are along these lines:

```text
+------------+-------------+
| test       | 'root'@'%'  |
+------------+-------------+

+------------+-------------------+
| test       | default_warehouse |
+------------+-------------------+

+-------------------+-------------+
| default_warehouse | 'root'@'%'  |
+-------------------+-------------+
```

## Validation:

- `mvn -pl fe-core -am -DskipITs -Dcheckstyle.skip -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.clean.skip=true -Dtest=ExecExprTest,ExprToThriftTest,SelectConstTest test`
