### PR TITLE
[BugFix] Fix EOF errors for SQL comments

### DIFF
--- a/docs/en/release_notes/release-4.1.md
+++ b/docs/en/release_notes/release-4.1.md
@@ -155,6 +155,7 @@ Release Date: April 13, 2026
   - Supports multiple compression formats (GZIP/SNAPPY/ZSTD/LZ4/DEFLATE/ZLIB/BZIP2) for CSV file exports. [#68054](https://github.com/StarRocks/starrocks/pull/68054)
   - Supports `STRUCT_CAST_BY_NAME` SQL mode for name-based struct field matching. [#69845](https://github.com/StarRocks/starrocks/pull/69845)
   - Supports `last_query_id()` in `ANALYZE PROFILE` for easy query profile analysis. [#64557](https://github.com/StarRocks/starrocks/pull/64557)
+  - Supports `--` comments without EOF parse errors, including comment-only input and end-of-line comments in SQL statements.
 
 ### Management & Observability
 

--- a/docs/zh/release_notes/release-4.1.md
+++ b/docs/zh/release_notes/release-4.1.md
@@ -155,6 +155,7 @@ displayed_sidebar: docs
   - 支持 CSV 文件导出多种压缩格式（GZIP/SNAPPY/ZSTD/LZ4/DEFLATE/ZLIB/BZIP2）。[#68054](https://github.com/StarRocks/starrocks/pull/68054)
   - 支持 `STRUCT_CAST_BY_NAME` SQL 模式用于基于名称的结构体字段匹配。[#69845](https://github.com/StarRocks/starrocks/pull/69845)
   - 支持 `ANALYZE PROFILE` 中的 `last_query_id()`，以便轻松进行查询配置文件分析。[#64557](https://github.com/StarRocks/starrocks/pull/64557)
+  - 支持 `--` 注释不再触发 EOF 解析错误，包括仅注释输入以及 SQL 语句末尾的行尾注释。
 
 ### 管理与可观测性
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -23,6 +23,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.EmptyStmt;
 import com.starrocks.sql.ast.ImportColumnsStmt;
 import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.PrepareStmt;
@@ -35,6 +36,7 @@ import io.trino.sql.parser.StatementSplitter;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.atn.LexerATNSimulator;
 import org.antlr.v4.runtime.atn.ParserATNSimulator;
 import org.antlr.v4.runtime.atn.PredictionContextCache;
@@ -152,6 +154,12 @@ public class SqlParser {
 
     private static List<StatementBase> parseWithStarRocksDialect(String sql, SessionVariable sessionVariable) {
         List<StatementBase> statements = Lists.newArrayList();
+        if (hasNoVisibleTokens(sql, sessionVariable)) {
+            StatementBase statement = new EmptyStmt();
+            statement.setOrigStmt(new OriginStatement(sql, 0));
+            statements.add(statement);
+            return statements;
+        }
         Pair<ParserRuleContext, com.starrocks.sql.parser.StarRocksParser> pair =
                 invokeParser(sql, sessionVariable, com.starrocks.sql.parser.StarRocksParser::sqlStatements);
         com.starrocks.sql.parser.StarRocksParser.SqlStatementsContext sqlStatementsContext =
@@ -244,6 +252,15 @@ public class SqlParser {
         return expressionListContext.expression().stream()
                 .map(e -> (Expr) astBuilder.visit(e))
                 .collect(Collectors.toList());
+    }
+
+    private static boolean hasNoVisibleTokens(String sql, SessionVariable sessionVariable) {
+        StarRocksLexer lexer = new StarRocksLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
+        lexer.setSqlMode(sessionVariable.getSqlMode());
+        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+        tokenStream.fill();
+        return tokenStream.getTokens().stream().allMatch(token ->
+                token.getChannel() != Token.DEFAULT_CHANNEL || token.getType() == Token.EOF);
     }
 
     public static ImportColumnsStmt parseImportColumns(String expressionSql, long sqlMode) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -28,6 +28,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterDatabaseSetStmt;
 import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.EmptyStmt;
 import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.MergeTabletClause;
@@ -100,6 +101,29 @@ class ParserTest {
             assertContains(e.getMessage(), "Getting syntax error at line 1, column 14. " +
                     "Detail message: Unexpected input 'tbl', the most similar input is {<EOF>, ';'}.");
         }
+    }
+
+    @Test
+    void commentOnlySqlParsesAsEmptyStatement() {
+        SessionVariable sessionVariable = new SessionVariable();
+
+        List<StatementBase> singleLineComment = SqlParser.parse("-- SELECT 1;", sessionVariable);
+        Assertions.assertEquals(1, singleLineComment.size());
+        Assertions.assertInstanceOf(EmptyStmt.class, singleLineComment.get(0));
+
+        List<StatementBase> bracketedComment = SqlParser.parse("/* comment */", sessionVariable);
+        Assertions.assertEquals(1, bracketedComment.size());
+        Assertions.assertInstanceOf(EmptyStmt.class, bracketedComment.get(0));
+    }
+
+    @Test
+    void inlineSingleLineCommentPreservesStatementParsing() {
+        SessionVariable sessionVariable = new SessionVariable();
+        String sql = "SELECT 1 -- or whatever\n, 2 + 2; -- trailing comment";
+
+        List<StatementBase> statements = SqlParser.parse(sql, sessionVariable);
+        Assertions.assertEquals(1, statements.size());
+        Assertions.assertInstanceOf(QueryStatement.class, statements.get(0));
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

Comment-only SQL such as `-- SELECT 1;` or `/* comment */` can fail with an EOF syntax error even though StarRocks already lexes these as comments. This is especially annoying in MySQL client sessions, and it also makes `--` end-of-line comments feel inconsistent.

## What I'm doing:

- treat comment-only SQL as an empty statement in the StarRocks parser
- add focused FE parser coverage for:
  - `-- SELECT 1;`
  - `/* comment */`
  - inline end-of-line comments such as:
    `SELECT 1 -- or whatever`
    `, 2 + 2; -- trailing comment`
- add a short release note documenting that `--` comments no longer trigger EOF parse errors

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Validation:

- `mvn -pl fe-core -am -DskipITs -Dcheckstyle.skip -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.clean.skip=true -Dtest=ParserTest test`