### PR TITLE
[BugFix]  Align LDAP Group Cache Refresh Interval Documentation with Implementation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
@@ -392,7 +392,7 @@ public class LDAPGroupProvider extends GroupProvider {
     }
 
     public Long getLdapCacheRefreshInterval() {
-        return Long.parseLong(properties.getOrDefault(LDAP_CACHE_REFRESH_INTERVAL, "300"));
+        return Long.parseLong(properties.getOrDefault(LDAP_CACHE_REFRESH_INTERVAL, "900"));
     }
 
     private void validateIntegerProp(Map<String, String> propertyMap, String key, int min, int max)


### PR DESCRIPTION
This PR resolves a mismatch between the documented and actual default value of `ldap_cache_refresh_interval` for LDAP group providers.

## Why I'm doing:
There is a mismatch between the documented and actual default value of ldap_cache_refresh_interval. The current implementation uses 300 seconds (5 minutes), while the documentation states 15 minutes. Additionally, a 5-minute refresh interval can introduce unnecessary load on the LDAP server, especially in large environments.

## What I'm doing:
Updating the default value of `ldap_cache_refresh_interval` in the code from 300 seconds (5 minutes) to 900 seconds (15 minutes) to align with the documentation and reduce the frequency of LDAP group cache refreshes.

Fixes #71830

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
