### PR TITLE
[UT] Add debug block operator tests for pipeline execution

### DIFF
--- a/test/sql/test_pipeline/R/test_debug_block_queries
+++ b/test/sql/test_pipeline/R/test_debug_block_queries
@@ -1,0 +1,455 @@
+-- name: test_debug_block_source_groupby
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series % 5, generate_series FROM TABLE(generate_series(1,  10000));
+-- result:
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c1, count(*) from t0 group by c1 order by c1;
+-- result:
+0	2000
+1	2000
+2	2000
+3	2000
+4	2000
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c1, count(*) from t0 group by c1 order by c1;
+-- result:
+0	2000
+1	2000
+2	2000
+3	2000
+4	2000
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c1, count(*) from t0 group by c1 order by c1;
+-- result:
+0	2000
+1	2000
+2	2000
+3	2000
+4	2000
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c1, count(*) from t0 group by c1 order by c1;
+-- result:
+0	2000
+1	2000
+2	2000
+3	2000
+4	2000
+-- !result
+-- name: test_debug_block_sink_groupby
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series % 5, generate_series FROM TABLE(generate_series(1,  10000));
+-- result:
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c1, count(*) from t0 group by c1 order by c1;
+-- result:
+0	2000
+1	2000
+2	2000
+3	2000
+4	2000
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c1, count(*) from t0 group by c1 order by c1;
+-- result:
+0	2000
+1	2000
+2	2000
+3	2000
+4	2000
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c1, count(*) from t0 group by c1 order by c1;
+-- result:
+0	2000
+1	2000
+2	2000
+3	2000
+4	2000
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c1, count(*) from t0 group by c1 order by c1;
+-- result:
+0	2000
+1	2000
+2	2000
+3	2000
+4	2000
+-- !result
+-- name: test_debug_block_source_join
+CREATE TABLE `t1` (
+  `k` int DEFAULT NULL,
+  `v` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `k` int DEFAULT NULL,
+  `v` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 SELECT generate_series, generate_series FROM TABLE(generate_series(1, 1000));
+-- result:
+-- !result
+insert into t2 SELECT generate_series * 2, generate_series FROM TABLE(generate_series(1, 500));
+-- result:
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+-- result:
+500
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+-- result:
+500
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+-- result:
+500
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+-- result:
+500
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":4, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+-- result:
+500
+-- !result
+-- name: test_debug_block_sink_join
+CREATE TABLE `t1` (
+  `k` int DEFAULT NULL,
+  `v` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `k` int DEFAULT NULL,
+  `v` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 SELECT generate_series, generate_series FROM TABLE(generate_series(1, 1000));
+-- result:
+-- !result
+insert into t2 SELECT generate_series * 2, generate_series FROM TABLE(generate_series(1, 500));
+-- result:
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+-- result:
+500
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+-- result:
+500
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+-- result:
+500
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+-- result:
+500
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":4, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+-- result:
+500
+-- !result
+-- name: test_debug_block_topn
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 10000 - generate_series, generate_series FROM TABLE(generate_series(1, 10000));
+-- result:
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c0 from t0 order by c0 desc limit 5;
+-- result:
+10000
+9999
+9998
+9997
+9996
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c0 from t0 order by c0 desc limit 5;
+-- result:
+10000
+9999
+9998
+9997
+9996
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c0 from t0 order by c0 asc limit 5;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select c0 from t0 order by c0 asc limit 5;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+-- name: test_debug_block_union
+CREATE TABLE `t1` (
+  `k` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `k` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 SELECT generate_series FROM TABLE(generate_series(1, 100));
+-- result:
+-- !result
+insert into t2 SELECT generate_series FROM TABLE(generate_series(1, 200));
+-- result:
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from (select k from t1 union all select k from t2) u;
+-- result:
+300
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from (select k from t1 union all select k from t2) u;
+-- result:
+300
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from (select k from t1 union all select k from t2) u;
+-- result:
+300
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from (select k from t1 union all select k from t2) u;
+-- result:
+300
+-- !result
+-- name: test_debug_block_multiple_actions
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1, 10000));
+-- result:
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}, {"plan_node_id":2, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+10000
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}, {"plan_node_id":1, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}, {"plan_node_id":2, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}, {"plan_node_id":3, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+10000
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}, {"plan_node_id":0, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+10000
+-- !result
+-- name: test_debug_block_reset
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1, 1000));
+-- result:
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+1000
+-- !result
+set query_debug_options = '';
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+1000
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+1000
+-- !result
+set query_debug_options = '';
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+1000
+-- !result

--- a/test/sql/test_pipeline/T/test_debug_block_queries
+++ b/test/sql/test_pipeline/T/test_debug_block_queries
@@ -1,0 +1,224 @@
+-- name: test_debug_block_source_groupby
+
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, generate_series % 5, generate_series FROM TABLE(generate_series(1,  10000));
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select c1, count(*) from t0 group by c1 order by c1;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select c1, count(*) from t0 group by c1 order by c1;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select c1, count(*) from t0 group by c1 order by c1;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select c1, count(*) from t0 group by c1 order by c1;
+
+-- name: test_debug_block_sink_groupby
+
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, generate_series % 5, generate_series FROM TABLE(generate_series(1,  10000));
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select c1, count(*) from t0 group by c1 order by c1;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select c1, count(*) from t0 group by c1 order by c1;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select c1, count(*) from t0 group by c1 order by c1;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select c1, count(*) from t0 group by c1 order by c1;
+
+-- name: test_debug_block_source_join
+
+CREATE TABLE `t1` (
+  `k` int DEFAULT NULL,
+  `v` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `t2` (
+  `k` int DEFAULT NULL,
+  `v` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t1 SELECT generate_series, generate_series FROM TABLE(generate_series(1, 1000));
+insert into t2 SELECT generate_series * 2, generate_series FROM TABLE(generate_series(1, 500));
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":4, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+
+-- name: test_debug_block_sink_join
+
+CREATE TABLE `t1` (
+  `k` int DEFAULT NULL,
+  `v` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `t2` (
+  `k` int DEFAULT NULL,
+  `v` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t1 SELECT generate_series, generate_series FROM TABLE(generate_series(1, 1000));
+insert into t2 SELECT generate_series * 2, generate_series FROM TABLE(generate_series(1, 500));
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":4, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from t1 inner join t2 on t1.k = t2.k;
+
+-- name: test_debug_block_topn
+
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, 10000 - generate_series, generate_series FROM TABLE(generate_series(1, 10000));
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select c0 from t0 order by c0 desc limit 5;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select c0 from t0 order by c0 desc limit 5;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select c0 from t0 order by c0 asc limit 5;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select c0 from t0 order by c0 asc limit 5;
+
+-- name: test_debug_block_union
+
+CREATE TABLE `t1` (
+  `k` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `t2` (
+  `k` int DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t1 SELECT generate_series FROM TABLE(generate_series(1, 100));
+insert into t2 SELECT generate_series FROM TABLE(generate_series(1, 200));
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select count(*) from (select k from t1 union all select k from t2) u;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":1, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from (select k from t1 union all select k from t2) u;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select count(*) from (select k from t1 union all select k from t2) u;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from (select k from t1 union all select k from t2) u;
+
+-- name: test_debug_block_multiple_actions
+
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1, 10000));
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}, {"plan_node_id":2, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from t0;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}, {"plan_node_id":1, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}, {"plan_node_id":2, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}, {"plan_node_id":3, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from t0;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}, {"plan_node_id":0, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from t0;
+
+-- name: test_debug_block_reset
+
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1, 1000));
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SOURCE_OPERATOR", "value":100}]}';
+select count(*) from t0;
+set query_debug_options = '';
+select count(*) from t0;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"BLOCK_SINK_OPERATOR", "value":100}]}';
+select count(*) from t0;
+set query_debug_options = '';
+select count(*) from t0;


### PR DESCRIPTION
## Why I'm doing:

To ensure the query debug options for blocking source and sink operators work correctly across different query patterns and execution scenarios in the pipeline execution engine.

## What I'm doing:

Added comprehensive test cases for the `BLOCK_SOURCE_OPERATOR` and `BLOCK_SINK_OPERATOR` debug actions in the pipeline execution framework. The tests cover:

- **Group by queries**: Testing blocking at different plan node IDs in aggregation operations
- **Join queries**: Testing blocking at different plan node IDs in join operations
- **Top-N queries**: Testing blocking in sorting and limit operations
- **Union queries**: Testing blocking in union all operations
- **Multiple debug actions**: Testing simultaneous blocking of multiple plan nodes
- **Debug option reset**: Testing that debug options can be cleared and reapplied

These tests verify that queries produce correct results even when source or sink operators are blocked, ensuring the debug infrastructure doesn't interfere with query correctness.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

https://claude.ai/code/session_01P3robzCDKPLMpoizwHkAas