### PR TITLE
[BugFix] Fix the bug of reverse(DecimalV3)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -574,11 +574,21 @@ public class DecimalV3FunctionAnalyzer {
             case FunctionSet.ARRAY_DISTINCT:
             case FunctionSet.ARRAY_SORT:
             case FunctionSet.ARRAY_SORT_LAMBDA:
-            case FunctionSet.REVERSE:
             case FunctionSet.ARRAY_INTERSECT:
             case FunctionSet.ARRAY_CONCAT: {
                 newFn.setArgsType(new Type[] {argumentTypes[0]});
                 newFn.setRetType(argumentTypes[0]);
+                return newFn;
+            }
+            case FunctionSet.REVERSE: {
+                // reverse() supports both VARCHAR and array arguments.
+                // Only apply array-decimal type fixup when the argument is actually an array;
+                // for scalar decimal arguments the matched reverse(VARCHAR) is kept as-is so
+                // that ImplicitCastRule inserts the required cast(decimal -> VARCHAR).
+                if (argumentTypes[0].isArrayType()) {
+                    newFn.setArgsType(new Type[] {argumentTypes[0]});
+                    newFn.setRetType(argumentTypes[0]);
+                }
                 return newFn;
             }
             case FunctionSet.ARRAY_MAX:

--- a/test/sql/test_string_functions/R/test_reverse
+++ b/test/sql/test_string_functions/R/test_reverse
@@ -1,0 +1,198 @@
+-- name: test_reverse
+select reverse('hello');
+-- result:
+olleh
+-- !result
+select reverse('abcde');
+-- result:
+edcba
+-- !result
+select reverse('');
+-- result:
+
+-- !result
+select reverse(NULL);
+-- result:
+None
+-- !result
+select reverse('a');
+-- result:
+a
+-- !result
+select reverse('中文字符');
+-- result:
+符字文中
+-- !result
+select reverse('hello世界');
+-- result:
+界世olleh
+-- !result
+select reverse('!@#$%');
+-- result:
+%$#@!
+-- !result
+create table t_reverse(id int, s varchar(65533), ns varchar(65533))
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id)
+        BUCKETS 1
+        PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t_reverse values
+    (1, 'hello', NULL),
+    (2, 'abcde', 'edcba'),
+    (3, '',      ''),
+    (4, '中文字符', NULL),
+    (5, 'hello世界', NULL);
+-- result:
+-- !result
+select reverse(s) from t_reverse order by id;
+-- result:
+olleh
+edcba
+
+符字文中
+界世olleh
+-- !result
+select reverse(ns) from t_reverse order by id;
+-- result:
+None
+abcde
+
+None
+None
+-- !result
+select s = reverse(reverse(s)) from t_reverse order by id;
+-- result:
+1
+1
+1
+1
+1
+-- !result
+drop table t_reverse;
+-- result:
+-- !result
+-- implicit cast: numeric types
+select reverse(123);
+-- result:
+321
+-- !result
+select reverse(1234567890);
+-- result:
+0987654321
+-- !result
+select reverse(cast(3.14 as float));
+-- result:
+41.3
+-- !result
+select reverse(cast(3.14 as double));
+-- result:
+41.3
+-- !result
+select reverse(cast(12345678901234 as bigint));
+-- result:
+43210987654321
+-- !result
+-- implicit cast: decimal
+select reverse(cast(123.456 as decimal(10,3)));
+-- result:
+654.321
+-- !result
+select reverse(cast(-99.99 as decimal(10,2)));
+-- result:
+99.99-
+-- !result
+select reverse(cast(0.00 as decimal(10,2)));
+-- result:
+00.0
+-- !result
+select reverse(cast(1234567890.12 as decimal(20,2)));
+-- result:
+21.0987654321
+-- !result
+-- implicit cast: boolean
+select reverse(true);
+-- result:
+1
+-- !result
+select reverse(false);
+-- result:
+0
+-- !result
+-- implicit cast: date / datetime
+select reverse(cast('2024-01-15' as date));
+-- result:
+51-10-4202
+-- !result
+select reverse(cast('2024-01-15 12:34:56' as datetime));
+-- result:
+65:43:21 51-10-4202
+-- !result
+-- implicit cast via table columns
+create table t_reverse_types(
+    id int,
+    c_int int,
+    c_bigint bigint,
+    c_boolean boolean,
+    c_date date,
+    c_datetime datetime,
+    c_double double,
+    c_decimal decimal(20,3)
+) DUPLICATE KEY(id)
+  DISTRIBUTED BY HASH(id)
+  BUCKETS 1
+  PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t_reverse_types values
+    (1, 123,  1234567890123, true,  '2024-01-15', '2024-01-15 12:34:56', 3.14,  123.456),
+    (2, -456, -9876543210,   false, '1999-12-31', '1999-12-31 23:59:59', -2.71, -99.990),
+    (3, 0,    0,             NULL,  NULL,          NULL,                  NULL,  NULL);
+-- result:
+-- !result
+select reverse(c_int)      from t_reverse_types order by id;
+-- result:
+321
+654-
+0
+-- !result
+select reverse(c_bigint)   from t_reverse_types order by id;
+-- result:
+3210987654321
+0123456789-
+0
+-- !result
+select reverse(c_boolean)  from t_reverse_types order by id;
+-- result:
+1
+0
+None
+-- !result
+select reverse(c_date)     from t_reverse_types order by id;
+-- result:
+51-10-4202
+13-21-9991
+None
+-- !result
+select reverse(c_datetime) from t_reverse_types order by id;
+-- result:
+65:43:21 51-10-4202
+95:95:32 13-21-9991
+None
+-- !result
+select reverse(c_double)   from t_reverse_types order by id;
+-- result:
+41.3
+17.2-
+None
+-- !result
+select reverse(c_decimal)  from t_reverse_types order by id;
+-- result:
+654.321
+099.99-
+None
+-- !result
+drop table t_reverse_types;
+-- result:
+-- !result

--- a/test/sql/test_string_functions/T/test_reverse
+++ b/test/sql/test_string_functions/T/test_reverse
@@ -1,0 +1,79 @@
+-- name: test_reverse
+select reverse('hello');
+select reverse('abcde');
+select reverse('');
+select reverse(NULL);
+select reverse('a');
+select reverse('中文字符');
+select reverse('hello世界');
+select reverse('!@#$%');
+
+create table t_reverse(id int, s varchar(65533), ns varchar(65533))
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id)
+        BUCKETS 1
+        PROPERTIES('replication_num'='1');
+
+insert into t_reverse values
+    (1, 'hello', NULL),
+    (2, 'abcde', 'edcba'),
+    (3, '',      ''),
+    (4, '中文字符', NULL),
+    (5, 'hello世界', NULL);
+
+select reverse(s) from t_reverse order by id;
+select reverse(ns) from t_reverse order by id;
+select s = reverse(reverse(s)) from t_reverse order by id;
+
+drop table t_reverse;
+
+-- implicit cast: numeric types
+select reverse(123);
+select reverse(1234567890);
+select reverse(cast(3.14 as float));
+select reverse(cast(3.14 as double));
+select reverse(cast(12345678901234 as bigint));
+
+-- implicit cast: decimal
+select reverse(cast(123.456 as decimal(10,3)));
+select reverse(cast(-99.99 as decimal(10,2)));
+select reverse(cast(0.00 as decimal(10,2)));
+select reverse(cast(1234567890.12 as decimal(20,2)));
+
+-- implicit cast: boolean
+select reverse(true);
+select reverse(false);
+
+-- implicit cast: date / datetime
+select reverse(cast('2024-01-15' as date));
+select reverse(cast('2024-01-15 12:34:56' as datetime));
+
+-- implicit cast via table columns
+create table t_reverse_types(
+    id int,
+    c_int int,
+    c_bigint bigint,
+    c_boolean boolean,
+    c_date date,
+    c_datetime datetime,
+    c_double double,
+    c_decimal decimal(20,3)
+) DUPLICATE KEY(id)
+  DISTRIBUTED BY HASH(id)
+  BUCKETS 1
+  PROPERTIES('replication_num'='1');
+
+insert into t_reverse_types values
+    (1, 123,  1234567890123, true,  '2024-01-15', '2024-01-15 12:34:56', 3.14,  123.456),
+    (2, -456, -9876543210,   false, '1999-12-31', '1999-12-31 23:59:59', -2.71, -99.990),
+    (3, 0,    0,             NULL,  NULL,          NULL,                  NULL,  NULL);
+
+select reverse(c_int)      from t_reverse_types order by id;
+select reverse(c_bigint)   from t_reverse_types order by id;
+select reverse(c_boolean)  from t_reverse_types order by id;
+select reverse(c_date)     from t_reverse_types order by id;
+select reverse(c_datetime) from t_reverse_types order by id;
+select reverse(c_double)   from t_reverse_types order by id;
+select reverse(c_decimal)  from t_reverse_types order by id;
+
+drop table t_reverse_types;


### PR DESCRIPTION
## Why I'm doing:

```
@          0x7d2b0c0 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
@     0x2b9537bc8630 (/usr/lib64/libpthread-2.17.so+0xf62f)
@     0x2b9538733387 __GI_raise
@     0x2b9538734a78 __GI_abort
@          0xc40a282 __gnu_cxx::__verbose_terminate_handler()
@          0xc408c86 __cxxabiv1::__terminate(void (*)())
@          0xc408cf1 std::terminate()
@          0xc408e44 __cxa_throw
@          0x36faf61 __wrap___cxa_throw
@          0x330e007 std::__throw_length_error(char const*)
@          0x70bee39 void std::vector<unsigned int, std::allocator<unsigned int> >::_M_assign_aux<__gnu_cxx::__normal_iterator<unsigned int*, std::vector<unsigned int, std::allocator<unsigned int> > > >(__gnu_cxx::__normal_iterator<unsigned int*, std::vector<unsigned int, std:����
@          0x70fa7fb std::shared_ptr<starrocks::Column> starrocks::ReverseFunction::evaluate<(starrocks::LogicalType)17, (starrocks::LogicalType)17>(std::shared_ptr<starrocks::Column> const&)
@          0x70faefd std::shared_ptr<starrocks::Column> starrocks::DealNullableColumnUnaryFunction<starrocks::UnpackConstColumnUnaryFunction<starrocks::ReverseFunction> >::evaluate<(starrocks::LogicalType)17, (starrocks::LogicalType)17>(std::shared_ptr<starrocks::Column> const����
@          0x70e5519 starrocks::StringFunctions::reverse(starrocks::FunctionContext*, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > > const&)
@          0x5ee7a1b starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
@          0x5e55467 starrocks::VectorizedCastToStringExpr<(starrocks::LogicalType)48, false>::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
@          0x538abeb starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
@          0x5ee7814 starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
@          0x5e61376 starrocks::VectorizedCastExpr<(starrocks::LogicalType)17, (starrocks::LogicalType)5, false>::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
@          0x5570be4 starrocks::VectorizedBinaryPredicate<(starrocks::LogicalType)5, starrocks::BinaryPredFunc<std::greater<int> > >::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
@          0x538abeb starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
@          0x538b06f starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
@          0x6b073b4 starrocks::ColumnExprPredicate::evaluate(starrocks::Column const*, unsigned char*, unsigned short, unsigned short) const
@          0x6b07a79 starrocks::ColumnExprPredicate::evaluate_and(starrocks::Column const*, unsigned char*, unsigned short, unsigned short) const
@          0x62d0e57 starrocks::ConjunctivePredicates::evaluate(starrocks::Chunk const*, unsigned char*, unsigned short, unsigned short) const
@          0x47740dc starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage(starrocks::RuntimeState*, starrocks::Chunk*)
@          0x47746c1 starrocks::pipeline::OlapChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
@          0x476a888 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
@          0x443e45d auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const [clone .constprop.0]
@          0x4539a6b starrocks::workgroup::ScanExecutor::worker_thread()
@          0x3966ca3 starrocks::ThreadPool::dispatch_thread()
```

reverse() supports both VARCHAR and array arguments, Only apply array-decimal type fixup when the argument is actually an array; for scalar decimal arguments the matched reverse(VARCHAR) is kept as-is so that ImplicitCastRule inserts the required cast(decimal -> VARCHAR).   

Reproduce:

```
mysql> create table t2(c1 int, c2 decimal(20,2)) properties("replication_num"="1");
Query OK, 0 rows affected (0.01 sec)

mysql> insert into t2 values (1, 11.1);
Query OK, 1 row affected (0.42 sec)
{'label':'insert_019d9a4f-98da-75d1-b786-1c7403b5281c', 'status':'VISIBLE', 'txnId':'3139'}

mysql> select reverse(c2) from t2;
```

## What I'm doing:

Fix the bug of reverse(DecimalV3)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
