### PR TITLE
[BugFix] Fix use-after-free in LoadChannel::get_load_replica_status caused by temporary shared_ptr destruction

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -53,6 +53,7 @@
 #include "runtime/mem_tracker.h"
 #include "runtime/starrocks_metrics.h"
 #include "util/compression/block_compression.h"
+#include "base/testutil/sync_point.h"
 
 #define RETURN_RESPONSE_IF_ERROR(stmt, response)                                      \
     do {                                                                              \
@@ -485,7 +486,9 @@ void LoadChannel::diagnose(const std::string& remote_ip, const PLoadDiagnoseRequ
 void LoadChannel::get_load_replica_status(const std::string& remote_ip, const PLoadReplicaStatusRequest* request,
                                           PLoadReplicaStatusResult* response) {
     TabletsChannelKey key(request->load_id(), request->sink_id(), request->index_id());
-    auto local_tablets_channel = dynamic_cast<LocalTabletsChannel*>(get_tablets_channel(key).get());
+    auto tablets_channel = get_tablets_channel(key);
+    auto local_tablets_channel = dynamic_cast<LocalTabletsChannel*>(tablets_channel.get());
+    TEST_SYNC_POINT("LoadChannel::get_load_replica_status::after_raw_ptr");
     if (local_tablets_channel == nullptr) {
         for (int64_t tablet_id : request->tablet_ids()) {
             auto replica_status = response->add_replica_statuses();

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -38,6 +38,7 @@
 
 #include "base/container/lru_cache.h"
 #include "base/string/faststring.h"
+#include "base/testutil/sync_point.h"
 #include "common/config_exec_flow_fwd.h"
 #include "common/config_ingest_fwd.h"
 #include "common/runtime_profile.h"
@@ -53,7 +54,6 @@
 #include "runtime/mem_tracker.h"
 #include "runtime/starrocks_metrics.h"
 #include "util/compression/block_compression.h"
-#include "base/testutil/sync_point.h"
 
 #define RETURN_RESPONSE_IF_ERROR(stmt, response)                                      \
     do {                                                                              \

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -20,8 +20,8 @@
 #include "base/brpc/reusable_closure.h"
 #include "base/failpoint/fail_point.h"
 #include "base/testutil/assert.h"
-#include "base/testutil/sync_point.h"
 #include "base/testutil/id_generator.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
@@ -960,8 +960,7 @@ TEST_F(LocalTabletsChannelTest, test_get_load_replica_status_use_after_free) {
     ctx.done = nullptr;
     ctx.receive_rpc_time_ns = MonotonicNanos();
     _load_channel->open(ctx);
-    ASSERT_EQ(TStatusCode::OK, open_response.status().status_code())
-            << open_response.status().error_msgs(0);
+    ASSERT_EQ(TStatusCode::OK, open_response.status().status_code()) << open_response.status().error_msgs(0);
 
     TabletsChannelKey channel_key(_load_id, _sink_id, _index_id);
     ASSERT_NE(nullptr, _load_channel->get_tablets_channel(channel_key));
@@ -973,19 +972,18 @@ TEST_F(LocalTabletsChannelTest, test_get_load_replica_status_use_after_free) {
 
     bool sync_triggered = false;
     SyncPoint::GetInstance()->EnableProcessing();
-    SyncPoint::GetInstance()->SetCallBack(
-            "LoadChannel::get_load_replica_status::after_raw_ptr", [&](void*) {
-                // Simulate a concurrent channel close: erase the map entry, dropping
-                // the last shared_ptr reference from the channel manager's perspective.
-                //
-                // Buggy code  : local_tablets_channel is now a dangling pointer ->
-                //               ASAN reports heap-use-after-free on the next line.
-                // Fixed code  : the caller holds a named shared_ptr, so ref-count
-                //               stays >= 1 and the object remains alive.
-                std::lock_guard l(_load_channel->_lock);
-                _load_channel->_tablets_channels.erase(channel_key);
-                sync_triggered = true;
-            });
+    SyncPoint::GetInstance()->SetCallBack("LoadChannel::get_load_replica_status::after_raw_ptr", [&](void*) {
+        // Simulate a concurrent channel close: erase the map entry, dropping
+        // the last shared_ptr reference from the channel manager's perspective.
+        //
+        // Buggy code  : local_tablets_channel is now a dangling pointer ->
+        //               ASAN reports heap-use-after-free on the next line.
+        // Fixed code  : the caller holds a named shared_ptr, so ref-count
+        //               stays >= 1 and the object remains alive.
+        std::lock_guard l(_load_channel->_lock);
+        _load_channel->_tablets_channels.erase(channel_key);
+        sync_triggered = true;
+    });
 
     PLoadReplicaStatusRequest status_request;
     status_request.mutable_load_id()->CopyFrom(_load_id);

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -20,6 +20,7 @@
 #include "base/brpc/reusable_closure.h"
 #include "base/failpoint/fail_point.h"
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
 #include "base/testutil/id_generator.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
@@ -41,7 +42,7 @@
 
 namespace starrocks {
 
-class SecondaryReplicasWaiterTestCase;
+struct SecondaryReplicasWaiterTestCase;
 
 class LocalTabletsChannelTest : public testing::Test {
 protected:
@@ -222,12 +223,12 @@ protected:
 
     std::vector<PNetworkAddress> _nodes;
     PUniqueId _load_id;
-    int64_t _txn_id;
-    int64_t _db_id;
-    int64_t _table_id;
-    int64_t _partition_id;
-    int32_t _index_id;
-    int32_t _sink_id;
+    int64_t _txn_id = 0;
+    int64_t _db_id = 0;
+    int64_t _table_id = 0;
+    int64_t _partition_id = 0;
+    int32_t _index_id = 0;
+    int32_t _sink_id = 0;
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<RuntimeProfile> _root_profile;
     std::unique_ptr<LoadChannelMgr> _load_channel_mgr;
@@ -929,6 +930,79 @@ TEST_F(LocalTabletsChannelTest, test_get_replica_status) {
     ASSERT_EQ(_tablets[3]->tablet_id(), result4.replica_statuses(3).tablet_id());
     ASSERT_EQ(LoadReplicaStatePB::NOT_PRESENT, result4.replica_statuses(3).state());
     ASSERT_EQ("can't find delta writer", result4.replica_statuses(3).message());
+}
+
+// Reproducer for the use-after-free in LoadChannel::get_load_replica_status.
+//
+// Root cause: the temporary shared_ptr returned by get_tablets_channel() is destroyed at
+// the semicolon, leaving only a raw pointer.  If another thread erases the map entry before
+// the raw pointer is used, the LocalTabletsChannel is freed and the subsequent method call
+// is a heap-use-after-free (caught by ASAN).
+//
+// The fix is to keep the shared_ptr in a named local variable so its lifetime covers the
+// entire call.
+TEST_F(LocalTabletsChannelTest, test_get_load_replica_status_use_after_free) {
+    _create_tablets(2);
+
+    std::vector<ReplicaInfo> replica_infos;
+    for (auto& tablet : _tablets) {
+        replica_infos.push_back({tablet->tablet_id(), {_nodes[0]}});
+    }
+
+    // Open the channel through LoadChannel so it is registered in _tablets_channels.
+    PTabletWriterOpenRequest open_request;
+    _create_open_request(0 /*node_id = primary*/, replica_infos, &open_request);
+    PTabletWriterOpenResult open_response;
+    LoadChannelOpenContext ctx;
+    ctx.cntl = nullptr;
+    ctx.request = &open_request;
+    ctx.response = &open_response;
+    ctx.done = nullptr;
+    ctx.receive_rpc_time_ns = MonotonicNanos();
+    _load_channel->open(ctx);
+    ASSERT_EQ(TStatusCode::OK, open_response.status().status_code())
+            << open_response.status().error_msgs(0);
+
+    TabletsChannelKey channel_key(_load_id, _sink_id, _index_id);
+    ASSERT_NE(nullptr, _load_channel->get_tablets_channel(channel_key));
+
+    DeferOp defer([&] {
+        SyncPoint::GetInstance()->ClearCallBack("LoadChannel::get_load_replica_status::after_raw_ptr");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    bool sync_triggered = false;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack(
+            "LoadChannel::get_load_replica_status::after_raw_ptr", [&](void*) {
+                // Simulate a concurrent channel close: erase the map entry, dropping
+                // the last shared_ptr reference from the channel manager's perspective.
+                //
+                // Buggy code  : local_tablets_channel is now a dangling pointer ->
+                //               ASAN reports heap-use-after-free on the next line.
+                // Fixed code  : the caller holds a named shared_ptr, so ref-count
+                //               stays >= 1 and the object remains alive.
+                std::lock_guard l(_load_channel->_lock);
+                _load_channel->_tablets_channels.erase(channel_key);
+                sync_triggered = true;
+            });
+
+    PLoadReplicaStatusRequest status_request;
+    status_request.mutable_load_id()->CopyFrom(_load_id);
+    status_request.set_txn_id(_txn_id);
+    status_request.set_index_id(_index_id);
+    status_request.set_sink_id(_sink_id);
+    status_request.set_node_id(0);
+    for (auto& tablet : _tablets) {
+        status_request.add_tablet_ids(tablet->tablet_id());
+    }
+
+    PLoadReplicaStatusResult status_response;
+    _load_channel->get_load_replica_status("127.0.0.1", &status_request, &status_response);
+
+    ASSERT_TRUE(sync_triggered);
+    // After the fix the call completes successfully; each tablet should have a status entry.
+    ASSERT_EQ(static_cast<int>(_tablets.size()), status_response.replica_statuses_size());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

```
*** Aborted at 1775527241 (unix time) try "date -d @1775527241" if you are using GNU date ***
PC: @          0xc13cd48 bthread_mutex_lock
*** SIGSEGV (@0x0) received by PID 109287 (TID 0x149af116e640) LWP(116830) from PID 0; stack trace: ***
    @     0x14a9dc28ef38 __pthread_once_slow
    @          0xbf6a014 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x14a9dd78c519 PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0]
    @     0x14a9dd78cf6e JVM_handle_linux_signal
    @     0x14a9dc23e730 (/usr/lib64/libc.so.6+0x3e72f)
    @          0xc13cd48 bthread_mutex_lock
    @          0x4463e27 starrocks::LocalTabletsChannel::get_load_replica_status(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, starrocks::PLoadReplicaStatusRequest const*, starrocks::PLoadReplicaStatusResult*) cons
t
    @          0x444e34f starrocks::LoadChannelMgr::get_load_replica_status(brpc::Controller*, starrocks::PLoadReplicaStatusRequest const*, starrocks::PLoadReplicaStatusResult*, google::protobuf::Closure*)
    @          0xc26468f brpc::policy::ProcessRpcRequest(brpc::InputMessageBase*)
    @          0xc184d87 brpc::ProcessInputMessage(void*)
    @          0xc1860de brpc::InputMessenger::OnNewMessages(brpc::Socket*)
    @          0xc17402d brpc::Socket::ProcessEvent(void*)
    @          0xc142727 bthread::TaskGroup::task_runner(long)
    @          0xc2a9c61 bthread_make_fcontext
```

Root cause: the temporary shared_ptr<TabletsChannel> returned by get_tablets_channel(key) is destroyed at the semicolon, leaving only a raw pointer with no ownership:    
 
```
  // Buggy                                                                                                                                                                                                                              
  auto local_tablets_channel = dynamic_cast<LocalTabletsChannel*>(get_tablets_channel(key).get());
  // ↑ temp shared_ptr destroyed here; ref count may drop to 0                                                                                                                                                                          
  local_tablets_channel->get_load_replica_status(...);  // UAF if another thread closed the channel 
```                                                                                                                                   
                                                                                                                                                                                                                                        
If a concurrent thread closes the load (triggering _remove_tablets_channel) between the raw-pointer extraction and the method call, the LocalTabletsChannel is freed and the subsequent access is a heap-use-after-free.

## What I'm doing:

Fix use-after-free in LoadChannel::get_load_replica_status caused by temporary shared_ptr destruction

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
