### PR TITLE
[BugFix] Fix tablet stats after shared-data range split

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1164,23 +1164,26 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                     for (const auto& rowset : (*tablet_metadata)->rowsets()) {
                         int64_t num_deletes = 0;
                         if (is_pk_tablet) {
-                            if (accurate_mode) {
+                            if (rowset.has_range()) {
+                                // Rowset went through a reshard (split or merge-back). Shared delvec
+                                // cardinality reflects the parent's full delete set, not this child's
+                                // share, so reading delvec would over-subtract. Use the pre-scaled
+                                // num_dels written by tablet_splitter / tablet_merger / tablet_reshard_helper.
+                                num_deletes = rowset.has_num_dels() ? rowset.num_dels() : 0;
+                            } else if (accurate_mode) {
                                 // Accurate mode (default): fetch delete vectors from object storage.
                                 // Reuses the already-loaded tablet metadata to avoid repeated loads per segment.
                                 num_deletes = static_cast<int64_t>(
                                         _tablet_mgr->update_mgr()->get_rowset_num_deletes(**tablet_metadata, rowset));
-                            } else {
+                            } else if (rowset.has_num_dels()) {
                                 // Approximate mode: prefer the pre-stored num_dels field in rowset
                                 // metadata. This avoids additional I/O while still providing a reasonable estimate.
                                 // Rows deleted but not yet compacted may be slightly overcounted.
-                                if (rowset.has_num_dels()) {
-                                    num_deletes = rowset.num_dels();
-                                } else {
-                                    // Fallback for old metadata without num_dels.
-                                    num_deletes =
-                                            static_cast<int64_t>(_tablet_mgr->update_mgr()->get_rowset_num_deletes(
-                                                    **tablet_metadata, rowset));
-                                }
+                                num_deletes = rowset.num_dels();
+                            } else {
+                                // Fallback for old metadata without num_dels.
+                                num_deletes = static_cast<int64_t>(
+                                        _tablet_mgr->update_mgr()->get_rowset_num_deletes(**tablet_metadata, rowset));
                             }
                         }
                         // For non-PK tablets, num_deletes stays 0: they have no delete vectors.

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/lake/rowset.h"
 
+#include <algorithm>
 #include <future>
 #include <unordered_set>
 
@@ -771,8 +772,11 @@ int64_t Rowset::data_size_after_deletion() const {
     if (num_rows() == 0 || data_size() == 0) {
         return 0;
     }
-    // data size * (num_rows - num_deleted_rows) / num_rows
-    return (int64_t)(data_size() * ((double)(num_rows() - num_dels()) / num_rows()));
+    // data size * (num_rows - num_deleted_rows) / num_rows. Clamp live rows to 0 to
+    // guard against callers that observe an inflated num_dels (e.g. pre-fix reshard
+    // children that inherited the parent's full delvec cardinality).
+    int64_t live_rows = std::max<int64_t>(0, num_rows() - num_dels());
+    return (int64_t)(data_size() * ((double)live_rows / num_rows()));
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -186,8 +186,16 @@ Status update_canonical(RowsetMetadataPB* canonical_rowset, const RowsetMetadata
                          tablet_reshard_helper::union_range(canonical_rowset->range(), duplicate_rowset.range()));
         canonical_rowset->mutable_range()->CopyFrom(merged_range);
     }
+    // Each merge input carries a proportional num_dels slice written by
+    // tablet_splitter.cpp / tablet_reshard_helper.cpp with num_dels <= num_rows.
+    // Summation therefore preserves that invariant on the canonical rowset, so no
+    // clamp is needed. Tablet merge is greenfield; there is no legacy state with
+    // the parent's full num_dels inherited by every child to guard against.
+    DCHECK_LE(canonical_rowset->num_dels(), canonical_rowset->num_rows());
+    DCHECK_LE(duplicate_rowset.num_dels(), duplicate_rowset.num_rows());
     canonical_rowset->set_num_rows(canonical_rowset->num_rows() + duplicate_rowset.num_rows());
     canonical_rowset->set_data_size(canonical_rowset->data_size() + duplicate_rowset.data_size());
+    canonical_rowset->set_num_dels(canonical_rowset->num_dels() + duplicate_rowset.num_dels());
     return Status::OK();
 }
 

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/tablet_reshard_helper.h"
 
+#include <algorithm>
+
 #include "storage/tablet_range.h"
 
 namespace starrocks::lake::tablet_reshard_helper {
@@ -211,6 +213,11 @@ void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int
     if (rowset->has_data_size()) {
         int64_t data_size = rowset->data_size();
         rowset->set_data_size(data_size / split_count + (split_index < data_size % split_count ? 1 : 0));
+    }
+    if (rowset->has_num_dels()) {
+        int64_t num_dels = rowset->num_dels();
+        int64_t scaled_num_dels = num_dels / split_count + (split_index < num_dels % split_count ? 1 : 0);
+        rowset->set_num_dels(std::min<int64_t>(scaled_num_dels, rowset->num_rows()));
     }
 }
 

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -22,8 +22,10 @@
 #include <vector>
 
 #include "common/logging.h"
+#include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reshard_helper.h"
+#include "storage/lake/update_manager.h"
 #include "storage/tablet_range.h"
 
 extern bvar::Adder<int64_t> g_tablet_reshard_split_fallback_total;
@@ -269,6 +271,7 @@ namespace {
 struct Statistic {
     int64_t num_rows = 0;
     int64_t data_size = 0;
+    int64_t num_dels = 0;
 };
 
 struct TabletRangeInfo {
@@ -276,8 +279,67 @@ struct TabletRangeInfo {
     std::unordered_map<uint32_t, Statistic> rowset_stats;
 };
 
-Status get_tablet_split_ranges(const TabletMetadataPtr& tablet_metadata, int32_t split_count,
-                               std::vector<TabletRangeInfo>* split_ranges) {
+// Split the parent rowset's total_num_dels across the split groups proportional to
+// each group's share of the rowset's rows, using the Hare-Niemeyer (largest-remainder)
+// method. Writes the result into TabletRangeInfo.rowset_stats[source_id].num_dels.
+// Guarantees the sum of allocated values equals total_num_dels when at least one
+// group has rows for this source.
+//
+// Each split child keeps the same shared segment files and inherits the parent's
+// delvec cardinality, so without this proportional estimate get_tablet_stats would
+// subtract the full parent num_dels from each child's partial num_rows and collapse
+// the partition's live-row count (see lake_service.cpp:1166).
+void allocate_rowset_num_dels_across_splits(uint32_t source_id, int64_t total_num_dels,
+                                            std::vector<TabletRangeInfo>* split_ranges) {
+    if (total_num_dels <= 0 || split_ranges == nullptr || split_ranges->empty()) {
+        return;
+    }
+
+    int64_t total_rows = 0;
+    for (auto& split_range : *split_ranges) {
+        auto it = split_range.rowset_stats.find(source_id);
+        if (it != split_range.rowset_stats.end()) {
+            total_rows += it->second.num_rows;
+        }
+    }
+    if (total_rows <= 0) {
+        return;
+    }
+
+    std::vector<int64_t> allocated(split_ranges->size(), 0);
+    std::vector<std::pair<int64_t, size_t>> fractional_remainders;
+    fractional_remainders.reserve(split_ranges->size());
+    int64_t sum_allocated = 0;
+    for (size_t i = 0; i < split_ranges->size(); ++i) {
+        auto it = (*split_ranges)[i].rowset_stats.find(source_id);
+        if (it == (*split_ranges)[i].rowset_stats.end() || it->second.num_rows <= 0) continue;
+        // Use 128-bit intermediate: both operands can realistically reach 1e10 on very
+        // large rowsets, whose product overflows int64_t. base fits because it is
+        // bounded by total_num_dels; fractional_remainder fits because it is < total_rows.
+        __int128 numerator = static_cast<__int128>(total_num_dels) * static_cast<__int128>(it->second.num_rows);
+        int64_t base = static_cast<int64_t>(numerator / total_rows);
+        int64_t fractional_remainder = static_cast<int64_t>(numerator % total_rows);
+        allocated[i] = base;
+        sum_allocated += base;
+        fractional_remainders.emplace_back(fractional_remainder, i);
+    }
+
+    std::sort(fractional_remainders.begin(), fractional_remainders.end(),
+              [](const auto& a, const auto& b) { return a.first > b.first; });
+    int64_t leftover = total_num_dels - sum_allocated;
+    for (size_t k = 0; k < fractional_remainders.size() && leftover > 0; ++k, --leftover) {
+        allocated[fractional_remainders[k].second]++;
+    }
+
+    for (size_t i = 0; i < split_ranges->size(); ++i) {
+        if (allocated[i] > 0) {
+            (*split_ranges)[i].rowset_stats[source_id].num_dels = allocated[i];
+        }
+    }
+}
+
+Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
+                               int32_t split_count, std::vector<TabletRangeInfo>* split_ranges) {
     if (split_count < 2) {
         return Status::InvalidArgument("Invalid split count, it is less than 2");
     }
@@ -365,6 +427,23 @@ Status get_tablet_split_ranges(const TabletMetadataPtr& tablet_metadata, int32_t
         return Status::InvalidArgument("Not enough split ranges available");
     }
 
+    // Only PK tablets maintain delete vectors; duplicate/aggregate keys never populate
+    // num_dels so there is nothing to scale.
+    if (is_primary_key(*tablet_metadata)) {
+        for (const auto& rowset : tablet_metadata->rowsets()) {
+            int64_t total_num_dels = 0;
+            if (rowset.has_num_dels()) {
+                total_num_dels = rowset.num_dels();
+            } else if (tablet_manager != nullptr) {
+                // Legacy metadata without num_dels: derive from the delvec. This costs
+                // one delvec read per rowset, acceptable on the one-shot split path.
+                total_num_dels = static_cast<int64_t>(
+                        tablet_manager->update_mgr()->get_rowset_num_deletes(*tablet_metadata, rowset));
+            }
+            allocate_rowset_num_dels_across_splits(rowset.id(), total_num_dels, split_ranges);
+        }
+    }
+
     return Status::OK();
 }
 
@@ -383,7 +462,8 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     std::unordered_map<int64_t, MutableTabletMetadataPtr> new_metadatas;
 
     std::vector<TabletRangeInfo> split_ranges;
-    Status status = get_tablet_split_ranges(old_tablet_metadata, splitting_tablet.new_tablet_ids_size(), &split_ranges);
+    Status status = get_tablet_split_ranges(tablet_manager, old_tablet_metadata, splitting_tablet.new_tablet_ids_size(),
+                                            &split_ranges);
     if (!status.ok()) {
         g_tablet_reshard_split_fallback_total << 1;
         LOG(WARNING) << "Failed to get tablet split ranges, will not split this tablet: " << old_tablet_metadata->id()
@@ -418,11 +498,14 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
             RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_range(&rowset_metadata, split_ranges[i].range));
             const auto it = split_ranges[i].rowset_stats.find(rowset_metadata.id());
             if (it != split_ranges[i].rowset_stats.end()) {
+                int64_t scaled_num_dels = std::min<int64_t>(it->second.num_dels, it->second.num_rows);
                 rowset_metadata.set_num_rows(it->second.num_rows);
                 rowset_metadata.set_data_size(it->second.data_size);
+                rowset_metadata.set_num_dels(scaled_num_dels);
             } else {
                 rowset_metadata.set_num_rows(0);
                 rowset_metadata.set_data_size(0);
+                rowset_metadata.set_num_dels(0);
             }
         }
 

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1272,17 +1272,25 @@ TEST_F(LakeServiceTest, test_splitting_tablet_pk_with_delvec_stats) {
 
     int64_t total_rows = 0;
     int64_t total_size = 0;
+    int64_t total_num_dels = 0;
     for (auto new_tablet_id : new_tablet_ids) {
         ASSIGN_OR_ABORT(auto new_metadata, _tablet_mgr->get_tablet_metadata(new_tablet_id, metadata->version() + 1));
         ASSERT_EQ(1, new_metadata->rowsets_size());
-        EXPECT_GT(new_metadata->rowsets(0).num_rows(), 0);
-        EXPECT_GT(new_metadata->rowsets(0).data_size(), 0);
-        total_rows += new_metadata->rowsets(0).num_rows();
-        total_size += new_metadata->rowsets(0).data_size();
+        const auto& child_rowset = new_metadata->rowsets(0);
+        EXPECT_GT(child_rowset.num_rows(), 0);
+        EXPECT_GT(child_rowset.data_size(), 0);
+        EXPECT_TRUE(child_rowset.has_num_dels()) << "split must write num_dels on PK children";
+        EXPECT_LE(child_rowset.num_dels(), child_rowset.num_rows());
+        total_rows += child_rowset.num_rows();
+        total_size += child_rowset.data_size();
+        total_num_dels += child_rowset.num_dels();
     }
-    // Split metadata keeps the raw rowset stats. Delete vectors are applied later by get_tablet_stats().
     EXPECT_EQ(150, total_rows);
     EXPECT_EQ(1500, total_size);
+    // Parent had 40 deletes on seg_0 and 10 on seg_1 = 50 total. The split reads those
+    // through UpdateManager::get_rowset_num_deletes (num_dels unset on the parent rowset)
+    // and the largest-remainder allocator must conserve the sum.
+    EXPECT_EQ(50, total_num_dels);
 }
 
 TEST_F(LakeServiceTest, test_splitting_tablet_split_count_too_large_fallback) {

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -135,6 +135,41 @@ protected:
     std::shared_ptr<Schema> _schema;
 };
 
+// Rowset::data_size_after_deletion must never return a negative value. Before the fix,
+// a reshard child could inherit an inflated num_dels (the parent's full delvec
+// cardinality) while its num_rows was only its proportional share, so num_rows-num_dels
+// went negative and compaction tasks consumed a nonsense (int64 cast) data-size.
+TEST_F(LakeRowsetTest, test_data_size_after_deletion_clamps_negative_live_rows) {
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(next_id());
+    auto* schema = metadata->mutable_schema();
+    schema->set_keys_type(DUP_KEYS);
+    auto* r = metadata->add_rowsets();
+    r->set_id(1);
+    r->set_num_rows(3);
+    r->set_data_size(300);
+    r->set_num_dels(10); // pathological: deletes > rows (post-split pre-fix pattern)
+
+    Rowset rs(_tablet_mgr.get(), metadata, 0, /*compaction_segment_limit=*/0);
+    EXPECT_EQ(0, rs.data_size_after_deletion());
+}
+
+// Sanity-check: when num_dels <= num_rows the formula keeps its original arithmetic.
+TEST_F(LakeRowsetTest, test_data_size_after_deletion_scales_by_live_fraction) {
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(next_id());
+    auto* schema = metadata->mutable_schema();
+    schema->set_keys_type(DUP_KEYS);
+    auto* r = metadata->add_rowsets();
+    r->set_id(1);
+    r->set_num_rows(10);
+    r->set_data_size(1000);
+    r->set_num_dels(4);
+
+    Rowset rs(_tablet_mgr.get(), metadata, 0, /*compaction_segment_limit=*/0);
+    EXPECT_EQ(600, rs.data_size_after_deletion());
+}
+
 TEST_F(LakeRowsetTest, test_load_segments) {
     create_rowsets_for_testing();
 

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/lake/tablet_reshard_helper.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace starrocks::lake {
@@ -251,6 +252,89 @@ TEST_F(TabletReshardHelperTest, test_set_all_data_files_shared_covers_op_replica
         ASSERT_EQ(op_write.ssts_size(), 1);
         EXPECT_TRUE(op_write.ssts(0).shared());
     }
+}
+
+// Verify update_rowset_data_stats scales num_dels alongside num_rows / data_size so that
+// children of a split tablet do not inherit the parent's full delete cardinality. Without
+// this, get_tablet_stats subtracts the full D from each child's partial num_rows and the
+// partition row count collapses to 0.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_scales_num_dels) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(10);
+    rowset.set_data_size(1000);
+    rowset.set_num_dels(7);
+
+    // Split into 3 children: num_dels = 7/3 + remainder -> children get 3, 2, 2.
+    std::vector<int64_t> child_num_dels;
+    int64_t total_num_dels = 0;
+    for (int i = 0; i < 3; ++i) {
+        RowsetMetadataPB child = rowset;
+        update_rowset_data_stats(&child, /*split_count=*/3, /*split_index=*/i);
+        child_num_dels.push_back(child.num_dels());
+        total_num_dels += child.num_dels();
+        EXPECT_LE(child.num_dels(), child.num_rows()) << "child " << i;
+    }
+    EXPECT_EQ(7, total_num_dels);
+    EXPECT_THAT(child_num_dels, ::testing::ElementsAre(3, 2, 2));
+}
+
+// When num_dels/split_count would exceed num_rows (extreme case, e.g. parent with almost
+// all rows deleted and uneven row split), the child must clamp num_dels to its share of
+// rows so that live_rows = num_rows - num_dels stays >= 0 downstream.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_clamps_num_dels_to_num_rows) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(3);
+    rowset.set_data_size(300);
+    rowset.set_num_dels(9); // pathologically large
+
+    RowsetMetadataPB child = rowset;
+    update_rowset_data_stats(&child, /*split_count=*/3, /*split_index=*/0);
+    EXPECT_EQ(1, child.num_rows());
+    // 9/3 = 3, clamped to num_rows=1.
+    EXPECT_EQ(1, child.num_dels());
+}
+
+// Verify update_txn_log_data_stats scales num_dels across every op_* branch that already
+// scales num_rows / data_size (op_write / op_compaction / op_schema_change / op_replication /
+// op_parallel_compaction). Parallel tests pin down the set of branches that produce output
+// rowsets during split's cross-publish, so dropping any branch here would resurrect the
+// original bug for that flow.
+TEST_F(TabletReshardHelperTest, test_update_txn_log_data_stats_scales_num_dels_all_branches) {
+    auto make_rowset = [](RowsetMetadataPB* r) {
+        r->set_num_rows(8);
+        r->set_data_size(800);
+        r->set_num_dels(4);
+    };
+
+    TxnLogPB txn_log;
+    make_rowset(txn_log.mutable_op_write()->mutable_rowset());
+    make_rowset(txn_log.mutable_op_compaction()->mutable_output_rowset());
+    make_rowset(txn_log.mutable_op_schema_change()->add_rowsets());
+    make_rowset(txn_log.mutable_op_replication()->add_op_writes()->mutable_rowset());
+    make_rowset(txn_log.mutable_op_parallel_compaction()->add_subtask_compactions()->mutable_output_rowset());
+
+    // split_count=2 split_index=0 -> num_dels should halve to 2 everywhere.
+    update_txn_log_data_stats(&txn_log, /*split_count=*/2, /*split_index=*/0);
+
+    EXPECT_EQ(2, txn_log.op_write().rowset().num_dels());
+    EXPECT_EQ(2, txn_log.op_compaction().output_rowset().num_dels());
+    EXPECT_EQ(2, txn_log.op_schema_change().rowsets(0).num_dels());
+    EXPECT_EQ(2, txn_log.op_replication().op_writes(0).rowset().num_dels());
+    EXPECT_EQ(2, txn_log.op_parallel_compaction().subtask_compactions(0).output_rowset().num_dels());
+}
+
+// Rowsets that predate the num_dels field (has_num_dels() == false) must not be written
+// at split time; otherwise the new child would record "0 deletes" and permanently lose
+// the parent's accurate-mode fallback, masking a pre-existing replication / recover bug
+// whose fix is tracked separately.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_skips_when_num_dels_absent) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(10);
+    rowset.set_data_size(1000);
+    // num_dels intentionally unset.
+
+    update_rowset_data_stats(&rowset, /*split_count=*/2, /*split_index=*/0);
+    EXPECT_FALSE(rowset.has_num_dels());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -473,6 +473,155 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_keeps_raw_rowset_stats) {
     EXPECT_EQ(800, total_child_data_size);
 }
 
+// Verify PK split scales num_dels across children proportional to per-child rows. Without
+// this, each child inherits the parent's full delvec cardinality and live_rows drops to 0
+// in get_tablet_stats (see lake_service.cpp:1166-1184).
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_scales_num_dels) {
+    const int64_t base_version = 2;
+    const int64_t new_version = 3;
+    const int64_t tablet_id = next_id();
+
+    prepare_tablet_dirs(tablet_id);
+
+    TabletMetadataPB metadata;
+    metadata.set_id(tablet_id);
+    metadata.set_version(base_version);
+    set_primary_key_schema(&metadata, 1);
+    add_historical_schema(&metadata, 1);
+
+    auto* rowset = metadata.add_rowsets();
+    rowset->set_id(2);
+    rowset->set_overlapped(true);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(1000);
+    rowset->set_num_dels(6);
+
+    rowset->add_segments("segment_0.dat");
+    rowset->add_segment_size(500);
+    auto* segment_meta0 = rowset->add_segment_metas();
+    segment_meta0->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    segment_meta0->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+    segment_meta0->set_num_rows(5);
+
+    rowset->add_segments("segment_1.dat");
+    rowset->add_segment_size(500);
+    auto* segment_meta1 = rowset->add_segment_metas();
+    segment_meta1->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+    segment_meta1->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+    segment_meta1->set_num_rows(5);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& splitting_tablet = *resharding_tablet.mutable_splitting_tablet_info();
+    splitting_tablet.set_old_tablet_id(tablet_id);
+    const int64_t new_tablet_id_1 = next_id();
+    const int64_t new_tablet_id_2 = next_id();
+    splitting_tablet.add_new_tablet_ids(new_tablet_id_1);
+    splitting_tablet.add_new_tablet_ids(new_tablet_id_2);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    int64_t total_child_num_rows = 0;
+    int64_t total_child_num_dels = 0;
+    for (auto new_tablet_id : {new_tablet_id_1, new_tablet_id_2}) {
+        auto it = tablet_metadatas.find(new_tablet_id);
+        ASSERT_TRUE(it != tablet_metadatas.end());
+        ASSERT_EQ(1, it->second->rowsets_size());
+        const auto& child_rowset = it->second->rowsets(0);
+        EXPECT_TRUE(child_rowset.has_num_dels()) << "split must always write num_dels on PK children";
+        EXPECT_LE(child_rowset.num_dels(), child_rowset.num_rows()) << "num_dels must not exceed child num_rows";
+        total_child_num_rows += child_rowset.num_rows();
+        total_child_num_dels += child_rowset.num_dels();
+    }
+
+    EXPECT_EQ(10, total_child_num_rows);
+    // Largest-remainder allocation is exact for in-range rows: Σ child.num_dels must equal D.
+    EXPECT_EQ(6, total_child_num_dels);
+}
+
+// Verify the fallback path: when the parent rowset predates num_dels (has_num_dels() ==
+// false), split derives D from the persisted delvec. A child rowset that cannot retrieve
+// D through either path must still carry an explicit num_dels (0) so that the Step 2
+// router in lake_service sees has_range() but has_num_dels() -> defaults to zero dels.
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_fallback_reads_delvec_for_num_dels) {
+    const int64_t base_version = 2;
+    const int64_t new_version = 3;
+    const int64_t tablet_id = next_id();
+
+    prepare_tablet_dirs(tablet_id);
+
+    TabletMetadataPB metadata;
+    metadata.set_id(tablet_id);
+    metadata.set_version(base_version);
+    set_primary_key_schema(&metadata, 1);
+    add_historical_schema(&metadata, 1);
+
+    auto* rowset = metadata.add_rowsets();
+    rowset->set_id(2);
+    rowset->set_overlapped(true);
+    rowset->set_num_rows(8);
+    rowset->set_data_size(800);
+    // num_dels intentionally not set -> exercises get_rowset_num_deletes fallback.
+
+    rowset->add_segments("segment_0.dat");
+    rowset->add_segment_size(400);
+    auto* segment_meta0 = rowset->add_segment_metas();
+    segment_meta0->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    segment_meta0->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+    segment_meta0->set_num_rows(4);
+
+    rowset->add_segments("segment_1.dat");
+    rowset->add_segment_size(400);
+    auto* segment_meta1 = rowset->add_segment_metas();
+    segment_meta1->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+    segment_meta1->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+    segment_meta1->set_num_rows(4);
+
+    DelVector delvec;
+    const uint32_t deleted_rows[] = {0, 1, 2, 3};
+    delvec.init(base_version, deleted_rows, 4);
+    add_delvec(&metadata, tablet_id, base_version, rowset->id(), "test.delvec", delvec.save());
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& splitting_tablet = *resharding_tablet.mutable_splitting_tablet_info();
+    splitting_tablet.set_old_tablet_id(tablet_id);
+    const int64_t new_tablet_id_1 = next_id();
+    const int64_t new_tablet_id_2 = next_id();
+    splitting_tablet.add_new_tablet_ids(new_tablet_id_1);
+    splitting_tablet.add_new_tablet_ids(new_tablet_id_2);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    int64_t total_child_num_dels = 0;
+    for (auto new_tablet_id : {new_tablet_id_1, new_tablet_id_2}) {
+        auto it = tablet_metadatas.find(new_tablet_id);
+        ASSERT_TRUE(it != tablet_metadatas.end());
+        ASSERT_EQ(1, it->second->rowsets_size());
+        const auto& child_rowset = it->second->rowsets(0);
+        EXPECT_TRUE(child_rowset.has_num_dels());
+        total_child_num_dels += child_rowset.num_dels();
+    }
+    // Σ child.num_dels should equal the delvec cardinality recovered via fallback (4).
+    EXPECT_EQ(4, total_child_num_dels);
+}
+
 TEST_F(LakeTabletReshardTest, test_merge_rowsets_reorder_by_predicate_version) {
     const int64_t base_version = 2;
     const int64_t new_version = 3;
@@ -1635,6 +1784,69 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_then_merge) {
     EXPECT_EQ(0, out_sst.rssid_offset());
     // max_rss_rowid high part should match projected shared_rssid
     EXPECT_EQ((static_cast<uint64_t>(out_sst.shared_rssid()) << 32) | 99, out_sst.max_rss_rowid());
+}
+
+// Verify merge-back accumulates num_dels alongside num_rows / data_size. Without this,
+// update_canonical would keep only the first child's per-range num_dels slice so the
+// merged rowset loses (N-1)/N of the parent's deletes and get_tablet_stats over-reports
+// live rows after a merge-back.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_accumulates_num_dels) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id, int64_t num_rows, int64_t data_size, int64_t num_dels) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(num_rows);
+        rowset->set_data_size(data_size);
+        rowset->set_num_dels(num_dels);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(data_size);
+        rowset->add_shared_segments(true);
+        return meta;
+    };
+
+    // Parent rowset was 10 rows / 6 dels / 100 bytes. Split gave A 4/3 and B 6/3.
+    auto meta_a = make_child(child_a, /*num_rows=*/4, /*data_size=*/40, /*num_dels=*/3);
+    auto meta_b = make_child(child_b, /*num_rows=*/6, /*data_size=*/60, /*num_dels=*/3);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(child_a);
+    merging_tablet.add_old_tablet_ids(child_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(10, merged->rowsets(0).num_rows());
+    EXPECT_EQ(100, merged->rowsets(0).data_size());
+    EXPECT_EQ(6, merged->rowsets(0).num_dels());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_upsert_delete) {


### PR DESCRIPTION
## Why I'm doing:

Range-distribution split on shared-data PK tables copies the parent's segment
and delvec files to each child tablet and only scales `num_rows` / `data_size`
by the range-overlap ratio. The rowset's `num_dels` stays at the parent's full
cardinality, and the shared delvec still reports the full delete set for every
child, so `get_tablet_stats` computes `live_rows = child.num_rows - parent.num_dels`,
clamps the negative result to 0, and collapses the partition row count after
every split. Downstream consumers (`SHOW PARTITIONS`, compaction picker,
`data_size_after_deletion`) then see incorrect values.

## What I'm doing:

- `be/src/storage/lake/tablet_splitter.cpp`: read each rowset's total `num_dels`
  (falling back to `UpdateManager::get_rowset_num_deletes` when the field is
  absent) and allocate it across split groups proportional to each group's row
  share, using largest-remainder (Hare-Niemeyer). Use a 128-bit intermediate so
  the product `num_dels * num_rows` never overflows for large PK rowsets. Write
  the per-child `num_dels` alongside `num_rows` and `data_size` in `split_tablet`,
  clamped to the child's `num_rows`.
- `be/src/storage/lake/tablet_reshard_helper.cpp`: in `update_rowset_data_stats`
  scale `num_dels` the same way we already scale `num_rows` / `data_size`, so the
  cross-publish path (op_write / op_compaction / op_schema_change / op_replication
  / op_parallel_compaction) behaves consistently.
- `be/src/service/service_be/lake_service.cpp`: in `get_tablet_stats`, route
  rowsets with `has_range()` (the reliable "this rowset went through a reshard"
  signal) to the pre-scaled `num_dels` so reshard children never re-read the
  shared delvec and over-subtract. Non-reshard rowsets retain the existing
  accurate / approximate behavior.
- `be/src/storage/lake/tablet_merger.cpp`: `update_canonical` sums `num_dels`
  alongside `num_rows` and `data_size` so merge-back is a true inverse of split.
  DCHECK the `num_dels <= num_rows` invariant upheld by Step 1a's write-back
  clamp; no release-build clamp needed because tablet merge is greenfield (no
  deployed tablets carry the pre-fix legacy shape).
- `be/src/storage/lake/rowset.cpp`: clamp live rows to 0 in
  `Rowset::data_size_after_deletion` so callers that still observe an inflated
  `num_dels` (legacy reshard data, other paths fixed in follow-ups) do not see
  negative byte counts.
- Tests: new unit tests cover split `num_dels` conservation and fallback,
  cross-publish scaling across every op branch, merge-back accumulation, the
  `data_size_after_deletion` clamp, and the end-to-end PK split stats path in
  `lake_service_test`.

### Known limitations (follow-up PRs)

- Shared delvec file size is counted once per child in `data_size`, so
  partition-level `Σ data_size` overcounts by `(N-1) * shared_delvec_size`.
  Delvec files are typically small compared to segments; left as documented
  approximation.
- `replication_txn_manager.cpp:444` sets `num_dels = get_num_delete_files()`
  (file count, not delete cardinality). If such a rowset later gets a range
  via split cross-publish, the new `has_range()` route in `get_tablet_stats`
  will trust that stale count. Fixing the replication semantic is out of scope
  here and tracked separately.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
