### PR TITLE
[BugFix] Fix condition race in ConnectorSinkPassthroughExchanger

### DIFF
--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/pipeline/exchange/local_exchange.h"
 
+#include <algorithm>
 #include <memory>
 #include <unordered_map>
 

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -432,12 +432,11 @@ Status ConnectorSinkPassthroughExchanger::accept(const ChunkPtr& chunk, const in
             _data_processed > _writer_count * config::writer_scaling_min_size_mb * 1024 * 1024) {
             _writer_count++;
         }
-        // set to default value in case of _source vector out of bound in multi thread
-        if (_writer_count > sources_num) {
-            _writer_count = sources_num;
-        }
-        _source->get_sources()[(_next_accept_source++) % _writer_count.load()]->add_chunk(chunk);
-        if (_writer_count < sources_num) {
+        // Snapshot and clamp locally so the index computation is immune to concurrent increments
+        // that may push _writer_count transiently above sources_num between the clamp write and use.
+        size_t writer_count = std::min(_writer_count.load(), sources_num);
+        _source->get_sources()[(_next_accept_source++) % writer_count]->add_chunk(chunk);
+        if (writer_count < sources_num) {
             _data_processed += chunk->bytes_usage();
         }
     }


### PR DESCRIPTION
## Why I'm doing:
  ConnectorSinkPassthroughExchanger::accept crashes with a SIGSEGV due to an out-of-bounds vector access caused by a race condition on _writer_count. 
```
*** SIGSEGV (@0x318) received by PID 71851 (TID 0x2b411bd36700) from PID 792; stack trace: ***
@ 0x2b3ff7c7b20b __pthread_once_slow
@ 0x7dc39a0 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
@ 0x2b3ff731735d os::Linux::chained_handler(int, siginfo*, void*)
@ 0x2b3ff731cf5f JVM_handle_linux_signal
@ 0x2b3ff730e968 signalHandler(int, siginfo*, void*)
@ 0x2b3ff7c84630 (/usr/lib64/libpthread-2.17.so+0xf62f)
@ 0x2b3ff7c7ed00 (/usr/lib64/libpthread-2.17.so+0x9cff)
@ 0x479f091 starrocks::pipeline::LocalExchangeSourceOperator::add_chunk(std::shared_ptr[starrocks::Chunk](https://www.google.com/search?q=starrocks::Chunk))
@ 0x4797ca2 starrocks::pipeline::ConnectorSinkPassthroughExchanger::accept(std::shared_ptr[starrocks::Chunk](https://www.google.com/search?q=starrocks::Chunk) const&, int)
@ 0x479ccd9 starrocks::pipeline::LocalExchangeSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr[starrocks::Chunk](https://www.google.com/search?q=starrocks::Chunk) const&)
@ 0x44f4c44 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
@ 0x47b8903 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
@ 0x398ec83 starrocks::ThreadPool::dispatch_thread()
@ 0x3986306 starrocks::Thread::supervise_thread(void*)
@ 0x2b3ff7c7cea5 start_thread
@ 0x2b3ff88b78dd __clone
```                                        
                                                                                                                                                                                              
  When multiple sink threads concurrently enter the scaling branch, two threads can both increment _writer_count before either runs the clamp check, pushing _writer_count transiently above  
  sources_num. The existing guard (if (_writer_count > sources_num) { _writer_count = sources_num; }) is ineffective because the clamp write and the subsequent _writer_count.load() used to  
  compute the index are three separate atomic operations with no mutual exclusion between them. A third thread reading _writer_count between another thread's increment and clamp will observe
   the out-of-range value and compute an index equal to sources_num, which is one past the end of the get_sources() vector.

  Crash timeline (example: sources_num=3, _writer_count starts at 2):                                                                                                                         
   
``` ┌──────┬───────────────────────────┬─────────────────────────────────────────────────┬─────────────────────────┐                                                                            
  │ Time │         Thread A          │                    Thread B                     │      _writer_count      │
  ├──────┼───────────────────────────┼─────────────────────────────────────────────────┼─────────────────────────┤                                                                            
  │ 1    │ _writer_count++           │                                                 │ 3                       │
  ├──────┼───────────────────────────┼─────────────────────────────────────────────────┼─────────────────────────┤                                                                            
  │ 2    │                           │ _writer_count++                                 │ 4 (exceeds sources_num) │
  ├──────┼───────────────────────────┼─────────────────────────────────────────────────┼─────────────────────────┤                                                                            
  │ 3    │                           │ _writer_count.load() → 4, idx = N % 4 = 3 → OOB │ 4                       │
  ├──────┼───────────────────────────┼─────────────────────────────────────────────────┼─────────────────────────┤                                                                            
  │ 4    │ clamp → _writer_count = 3 │                                                 │ 3 (too late)            │
  └──────┴───────────────────────────┴─────────────────────────────────────────────────┴─────────────────────────┘  
```
## What I'm doing:
  Replace the non-atomic clamp-then-read pattern with a single local snapshot that is clamped at read time:                                                                                   
                                                            
  // Before — three separate atomic ops, race window between them                                                                                                                             
  if (_writer_count > sources_num) {                                                                                                                                                          
      _writer_count = sources_num;
  }                                                                                                                                                                                           
  _source->get_sources()[(_next_accept_source++) % _writer_count.load()]->add_chunk(chunk);
                                                                                                                                                                                              
  // After — one snapshot, already bounded, no subsequent race possible                                                                                                                       
  size_t writer_count = std::min(_writer_count.load(), sources_num);                                                                                                                          
  _source->get_sources()[(_next_accept_source++) % writer_count]->add_chunk(chunk);                                                                                                           
                                                                                                                                                                                              
  _writer_count may still transiently exceed sources_num under concurrent increments, but std::min ensures the local variable used for modulo is always within [1, sources_num], making the   
  vector access unconditionally safe. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
