### PR TITLE
[BugFix] Support Arrow dictionary values in parquet scanner

### DIFF
--- a/be/src/exec/file_scanner/parquet_scanner.cpp
+++ b/be/src/exec/file_scanner/parquet_scanner.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/file_scanner/parquet_scanner.h"
 
+#include <arrow/compute/api.h>
 #include <fmt/format.h>
 
 #include "base/simd/simd.h"
@@ -175,6 +176,12 @@ Status ParquetScanner::finalize_src_chunk(ChunkPtr* chunk) {
 Status ParquetScanner::build_dest(const arrow::DataType* arrow_type, const TypeDescriptor* type_desc, bool is_nullable,
                                   TypeDescriptor* raw_type_desc, ConvertFuncTree* conv_func, bool& need_cast,
                                   bool strict_mode) {
+    if (arrow_type->id() == ArrowTypeId::DICTIONARY) {
+        auto* dictionary_type = down_cast<const arrow::DictionaryType*>(arrow_type);
+        return build_dest(dictionary_type->value_type().get(), type_desc, is_nullable, raw_type_desc, conv_func,
+                          need_cast, strict_mode);
+    }
+
     auto at = arrow_type->id();
     auto lt = type_desc->type;
     conv_func->func = get_arrow_converter(at, lt, is_nullable, strict_mode);
@@ -323,6 +330,17 @@ Status ParquetScanner::convert_array_to_column(ConvertFuncTree* conv_func, size_
                                                const arrow::Array* array, Column* column, size_t batch_start_idx,
                                                size_t chunk_start_idx, Filter* chunk_filter,
                                                ArrowConvertContext* conv_ctx) {
+    if (array->type_id() == ArrowTypeId::DICTIONARY) {
+        auto* dictionary_type = down_cast<const arrow::DictionaryType*>(array->type().get());
+        auto sliced_array = array->Slice(batch_start_idx, num_elements);
+        auto decoded_array_res = arrow::compute::Cast(*sliced_array, dictionary_type->value_type());
+        if (!decoded_array_res.ok()) {
+            return Status::InternalError(decoded_array_res.status().ToString());
+        }
+        return convert_array_to_column(conv_func, num_elements, decoded_array_res->get(), column, 0, chunk_start_idx,
+                                       chunk_filter, conv_ctx);
+    }
+
     // for timestamp type, state->timezone which is specified by user. convert function
     // obtains timezone from array. thus timezone in array should be rectified to
     // state->timezone.

--- a/be/test/exec/file_scanner/parquet_scanner_test.cpp
+++ b/be/test/exec/file_scanner/parquet_scanner_test.cpp
@@ -14,8 +14,12 @@
 
 #include "exec/file_scanner/parquet_scanner.h"
 
+#include <arrow/builder.h>
+#include <arrow/io/file.h>
 #include <gtest/gtest.h>
+#include <parquet/arrow/writer.h>
 
+#include <filesystem>
 #include <memory>
 #include <utility>
 
@@ -34,6 +38,31 @@
 namespace starrocks {
 
 class ParquetScannerTest : public ::testing::Test {
+public:
+    static void SetUpTestSuite() {
+        const char* starrocks_home = getenv("STARROCKS_HOME");
+        ASSERT_NE(nullptr, starrocks_home);
+        _tmp_root_dir = std::filesystem::path(starrocks_home) / "be/test/exec/test_data/parquet_scanner/tmp";
+        ASSERT_FALSE(_tmp_root_dir.empty());
+        ASSERT_EQ(std::filesystem::path("tmp"), _tmp_root_dir.filename());
+
+        std::error_code ec;
+        std::filesystem::create_directories(_tmp_root_dir, ec);
+        ASSERT_FALSE(ec) << "failed to create directory " << _tmp_root_dir << ": " << ec.message();
+    }
+
+    static void TearDownTestSuite() {
+        ASSERT_FALSE(_tmp_root_dir.empty());
+        ASSERT_EQ(std::filesystem::path("tmp"), _tmp_root_dir.filename());
+        ASSERT_NE(std::filesystem::path(), _tmp_root_dir.parent_path());
+        ASSERT_EQ(std::filesystem::path("parquet_scanner"), _tmp_root_dir.parent_path().filename());
+
+        std::error_code ec;
+        std::filesystem::remove_all(_tmp_root_dir, ec);
+        ASSERT_FALSE(ec) << "failed to remove directory " << _tmp_root_dir << ": " << ec.message();
+    }
+
+private:
     std::vector<TBrokerRangeDesc> generate_ranges(const std::vector<std::string>& file_names,
                                                   int32_t num_columns_from_file,
                                                   const std::vector<std::string>& columns_from_path) {
@@ -101,12 +130,16 @@ class ParquetScannerTest : public ::testing::Test {
     std::unique_ptr<ParquetScanner> create_parquet_scanner(
             const std::string& timezone, DescriptorTbl* desc_tbl,
             const std::unordered_map<size_t, ::starrocks::TExpr>& dst_slot_exprs,
-            const std::vector<TBrokerRangeDesc>& ranges) {
+            const std::vector<TBrokerRangeDesc>& ranges, int32_t chunk_size = 0) {
         /// Init RuntimeState
+        TQueryOptions query_options;
+        if (chunk_size > 0) {
+            query_options.__set_batch_size(chunk_size);
+        }
         auto query_globals = TQueryGlobals();
         query_globals.time_zone = timezone;
         RuntimeState* state = _obj_pool.add(
-                new RuntimeState(TUniqueId(), TQueryOptions(), query_globals, static_cast<ExecEnv*>(nullptr)));
+                new RuntimeState(TUniqueId(), query_options, query_globals, static_cast<ExecEnv*>(nullptr)));
         state->set_desc_tbl(desc_tbl);
         state->init_instance_mem_tracker();
 
@@ -310,6 +343,131 @@ class ParquetScannerTest : public ::testing::Test {
         return result;
     }
 
+    void create_dictionary_string_parquet(const std::string& file_name, const std::vector<std::string>& values,
+                                          std::string* file_path) {
+        *file_path = (_tmp_root_dir / file_name).string();
+
+        arrow::StringDictionaryBuilder builder;
+        for (const auto& value : values) {
+            ASSERT_OK(builder.Append(value));
+        }
+
+        std::shared_ptr<arrow::Array> array;
+        ASSERT_OK(builder.Finish(&array));
+
+        auto schema = arrow::schema({arrow::field("zone", array->type(), true)});
+        auto table = arrow::Table::Make(schema, {array});
+
+        ASSERT_NE(nullptr, table);
+        ASSERT_EQ(values.size(), table->num_rows());
+
+        auto output_res = arrow::io::FileOutputStream::Open(*file_path);
+        ASSERT_TRUE(output_res.ok()) << output_res.status().ToString();
+        std::shared_ptr<arrow::io::FileOutputStream> output = output_res.ValueOrDie();
+
+        auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
+        auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
+                                                 parquet::default_writer_properties(), arrow_props);
+        ASSERT_TRUE(status.ok()) << status.ToString();
+        ASSERT_TRUE(output->Close().ok());
+    }
+
+    void create_nested_dictionary_parquet(const std::string& file_name,
+                                          const std::vector<std::vector<std::string>>& values, std::string* file_path) {
+        *file_path = (_tmp_root_dir / file_name).string();
+
+        arrow::ListBuilder list_builder(arrow::default_memory_pool(),
+                                        std::make_unique<arrow::StringDictionaryBuilder>(arrow::default_memory_pool()));
+        auto* dict_builder = down_cast<arrow::StringDictionaryBuilder*>(list_builder.value_builder());
+
+        for (const auto& list : values) {
+            ASSERT_OK(list_builder.Append());
+            for (const auto& val : list) {
+                ASSERT_OK(dict_builder->Append(val));
+            }
+        }
+
+        std::shared_ptr<arrow::Array> array;
+        ASSERT_OK(list_builder.Finish(&array));
+
+        auto schema = arrow::schema({arrow::field("nested_dict", array->type(), true)});
+        auto table = arrow::Table::Make(schema, {array});
+
+        auto output_res = arrow::io::FileOutputStream::Open(*file_path);
+        ASSERT_TRUE(output_res.ok()) << output_res.status().ToString();
+        std::shared_ptr<arrow::io::FileOutputStream> output = output_res.ValueOrDie();
+
+        auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
+        auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
+                                                 parquet::default_writer_properties(), arrow_props);
+        ASSERT_TRUE(status.ok()) << status.ToString();
+        ASSERT_TRUE(output->Close().ok());
+    }
+
+    void create_struct_dictionary_parquet(const std::string& file_name, const std::vector<std::string>& values,
+                                          std::string* file_path) {
+        *file_path = (_tmp_root_dir / file_name).string();
+
+        auto dict_builder = std::make_shared<arrow::StringDictionaryBuilder>(arrow::default_memory_pool());
+        auto struct_type = arrow::struct_({arrow::field("name", dict_builder->type(), true)});
+        arrow::StructBuilder struct_builder(struct_type, arrow::default_memory_pool(), {dict_builder});
+
+        for (const auto& value : values) {
+            ASSERT_OK(struct_builder.Append());
+            ASSERT_OK(dict_builder->Append(value));
+        }
+
+        std::shared_ptr<arrow::Array> array;
+        ASSERT_OK(struct_builder.Finish(&array));
+
+        auto schema = arrow::schema({arrow::field("struct_dict", array->type(), true)});
+        auto table = arrow::Table::Make(schema, {array});
+
+        auto output_res = arrow::io::FileOutputStream::Open(*file_path);
+        ASSERT_TRUE(output_res.ok()) << output_res.status().ToString();
+        std::shared_ptr<arrow::io::FileOutputStream> output = output_res.ValueOrDie();
+
+        auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
+        auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
+                                                 parquet::default_writer_properties(), arrow_props);
+        ASSERT_TRUE(status.ok()) << status.ToString();
+        ASSERT_TRUE(output->Close().ok());
+    }
+
+    void create_map_dictionary_parquet(const std::string& file_name,
+                                       const std::vector<std::vector<std::pair<std::string, std::string>>>& values,
+                                       std::string* file_path) {
+        *file_path = (_tmp_root_dir / file_name).string();
+
+        auto key_builder = std::make_shared<arrow::StringBuilder>(arrow::default_memory_pool());
+        auto item_builder = std::make_shared<arrow::StringDictionaryBuilder>(arrow::default_memory_pool());
+        arrow::MapBuilder map_builder(arrow::default_memory_pool(), key_builder, item_builder, false);
+
+        for (const auto& map_values : values) {
+            ASSERT_OK(map_builder.Append());
+            for (const auto& [key, value] : map_values) {
+                ASSERT_OK(key_builder->Append(key));
+                ASSERT_OK(item_builder->Append(value));
+            }
+        }
+
+        std::shared_ptr<arrow::Array> array;
+        ASSERT_OK(map_builder.Finish(&array));
+
+        auto schema = arrow::schema({arrow::field("map_dict", array->type(), true)});
+        auto table = arrow::Table::Make(schema, {array});
+
+        auto output_res = arrow::io::FileOutputStream::Open(*file_path);
+        ASSERT_TRUE(output_res.ok()) << output_res.status().ToString();
+        std::shared_ptr<arrow::io::FileOutputStream> output = output_res.ValueOrDie();
+
+        auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
+        auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
+                                                 parquet::default_writer_properties(), arrow_props);
+        ASSERT_TRUE(status.ok()) << status.ToString();
+        ASSERT_TRUE(output->Close().ok());
+    }
+
     void check_schema(const std::string& path,
                       const std::vector<std::pair<std::string, TypeDescriptor>>& expected_schema) {
         RuntimeProfile* profile = _obj_pool.add(new RuntimeProfile("test_prof", true));
@@ -377,6 +535,7 @@ class ParquetScannerTest : public ::testing::Test {
     }
 
 private:
+    inline static std::filesystem::path _tmp_root_dir;
     std::string test_exec_dir;
     RuntimeState* _runtime_state;
     ObjectPool _obj_pool;
@@ -641,6 +800,123 @@ TEST_F(ParquetScannerTest, test_selected_parquet_data) {
         }
     };
     validate(scanner, 36865, check);
+}
+
+TEST_F(ParquetScannerTest, test_dictionary_string_parquet_data) {
+    std::string parquet_file_name;
+    create_dictionary_string_parquet("dictionary_string.parquet", {"Center", "Edge", "Middle", "Center"},
+                                     &parquet_file_name);
+    DeferOp defer([&]() { std::filesystem::remove(parquet_file_name); });
+
+    SlotTypeDescInfoArray slot_infos = {{"zone", TypeDescriptor::create_varchar_type(1048576), true}};
+    auto ranges = generate_ranges({parquet_file_name}, slot_infos.size(), {});
+    auto* desc_tbl = DescTblHelper::generate_desc_tbl(_runtime_state, _obj_pool, {slot_infos, {}});
+    auto scanner = create_parquet_scanner("UTC", desc_tbl, {}, ranges);
+    auto check = [](const ChunkPtr& chunk) {
+        ASSERT_EQ(1, chunk->num_columns());
+        ASSERT_EQ(4, chunk->num_rows());
+        auto col = chunk->columns()[0];
+        EXPECT_EQ("'Center'", col->debug_item(0));
+        EXPECT_EQ("'Edge'", col->debug_item(1));
+        EXPECT_EQ("'Middle'", col->debug_item(2));
+        EXPECT_EQ("'Center'", col->debug_item(3));
+    };
+    validate(scanner, 4, check);
+}
+
+TEST_F(ParquetScannerTest, test_dictionary_string_parquet_data_with_small_chunk_size) {
+    std::string parquet_file_name;
+    create_dictionary_string_parquet("dictionary_string_small_chunk.parquet",
+                                     {"Center", "Edge", "Middle", "Center", "North"}, &parquet_file_name);
+    DeferOp defer([&]() { std::filesystem::remove(parquet_file_name); });
+
+    SlotTypeDescInfoArray slot_infos = {{"zone", TypeDescriptor::create_varchar_type(1048576), true}};
+    auto ranges = generate_ranges({parquet_file_name}, slot_infos.size(), {});
+    auto* desc_tbl = DescTblHelper::generate_desc_tbl(_runtime_state, _obj_pool, {slot_infos, {}});
+    auto scanner = create_parquet_scanner("UTC", desc_tbl, {}, ranges, 2);
+
+    std::vector<std::string> actual_values;
+    std::vector<size_t> chunk_rows;
+    auto check = [&](const ChunkPtr& chunk) {
+        ASSERT_EQ(1, chunk->num_columns());
+        chunk_rows.emplace_back(chunk->num_rows());
+        auto col = chunk->columns()[0];
+        for (size_t i = 0; i < col->size(); ++i) {
+            actual_values.emplace_back(col->debug_item(i));
+        }
+    };
+    validate(scanner, 5, check);
+
+    ASSERT_EQ(std::vector<size_t>({2, 2, 1}), chunk_rows);
+    ASSERT_EQ((std::vector<std::string>{"'Center'", "'Edge'", "'Middle'", "'Center'", "'North'"}), actual_values);
+}
+
+TEST_F(ParquetScannerTest, test_nested_dictionary_string_parquet) {
+    std::string parquet_file_name;
+    create_nested_dictionary_parquet("nested_dictionary.parquet", {{"a", "b"}, {"c"}}, &parquet_file_name);
+    DeferOp defer([&]() { std::filesystem::remove(parquet_file_name); });
+
+    TypeDescriptor type_list(TYPE_ARRAY);
+    type_list.children.emplace_back(TYPE_VARCHAR);
+    type_list.children.back().len = 1048576;
+
+    SlotTypeDescInfoArray slot_infos = {{"nested_dict", type_list, true}};
+    auto ranges = generate_ranges({parquet_file_name}, slot_infos.size(), {});
+    auto* desc_tbl = DescTblHelper::generate_desc_tbl(_runtime_state, _obj_pool, {slot_infos, {}});
+    auto scanner = create_parquet_scanner("UTC", desc_tbl, {}, ranges);
+
+    auto check = [](const ChunkPtr& chunk) {
+        ASSERT_EQ(1, chunk->num_columns());
+        ASSERT_EQ(2, chunk->num_rows());
+        auto col = chunk->columns()[0];
+        EXPECT_EQ("['a','b']", col->debug_item(0));
+        EXPECT_EQ("['c']", col->debug_item(1));
+    };
+    validate(scanner, 2, check);
+}
+
+TEST_F(ParquetScannerTest, test_struct_dictionary_string_parquet) {
+    std::string parquet_file_name;
+    create_struct_dictionary_parquet("struct_dictionary.parquet", {"a", "b"}, &parquet_file_name);
+    DeferOp defer([&]() { std::filesystem::remove(parquet_file_name); });
+
+    auto type_struct = TypeDescriptor::create_struct_type({"name"}, {TypeDescriptor::create_varchar_type(1048576)});
+    SlotTypeDescInfoArray slot_infos = {{"struct_dict", type_struct, true}};
+    auto ranges = generate_ranges({parquet_file_name}, slot_infos.size(), {});
+    auto* desc_tbl = DescTblHelper::generate_desc_tbl(_runtime_state, _obj_pool, {slot_infos, {}});
+    auto scanner = create_parquet_scanner("UTC", desc_tbl, {}, ranges);
+
+    auto check = [](const ChunkPtr& chunk) {
+        ASSERT_EQ(1, chunk->num_columns());
+        ASSERT_EQ(2, chunk->num_rows());
+        auto col = chunk->columns()[0];
+        EXPECT_EQ("{name:'a'}", col->debug_item(0));
+        EXPECT_EQ("{name:'b'}", col->debug_item(1));
+    };
+    validate(scanner, 2, check);
+}
+
+TEST_F(ParquetScannerTest, test_map_dictionary_string_parquet) {
+    std::string parquet_file_name;
+    create_map_dictionary_parquet("map_dictionary.parquet", {{{"k1", "a"}, {"k2", "b"}}, {{"k3", "c"}}},
+                                  &parquet_file_name);
+    DeferOp defer([&]() { std::filesystem::remove(parquet_file_name); });
+
+    auto type_map = TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(1048576),
+                                                    TypeDescriptor::create_varchar_type(1048576));
+    SlotTypeDescInfoArray slot_infos = {{"map_dict", type_map, true}};
+    auto ranges = generate_ranges({parquet_file_name}, slot_infos.size(), {});
+    auto* desc_tbl = DescTblHelper::generate_desc_tbl(_runtime_state, _obj_pool, {slot_infos, {}});
+    auto scanner = create_parquet_scanner("UTC", desc_tbl, {}, ranges);
+
+    auto check = [](const ChunkPtr& chunk) {
+        ASSERT_EQ(1, chunk->num_columns());
+        ASSERT_EQ(2, chunk->num_rows());
+        auto col = chunk->columns()[0];
+        EXPECT_EQ("{'k1':'a','k2':'b'}", col->debug_item(0));
+        EXPECT_EQ("{'k3':'c'}", col->debug_item(1));
+    };
+    validate(scanner, 2, check);
 }
 
 TEST_F(ParquetScannerTest, test_arrow_null) {


### PR DESCRIPTION
## Why I'm doing:

```
ERROR 1064 (HY000): Illegal converting from arrow type(dictionary) to StarRocks type(VARCHAR(1048576)): BE:10001
```

## What I'm doing:

Fix parquet scanner failures when Arrow returns dictionary-typed columns, including nested dictionary values inside array, struct, and map types.
  - unwrap `arrow::DictionaryType` during destination type planning in `ParquetScanner::build_dest`
  - decode dictionary arrays before conversion in `ParquetScanner::convert_array_to_column`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
