### PR TITLE
[BugFix] Fix aggregate-join-pushdown MV rewrite on Iceberg base tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ CMakeLists.txt
 .claude
 .clangd
 .cursor/
+.codex/
 .worktrees/
 handbook/plans/local/
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateJoinPushDownRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateJoinPushDownRule.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
 import com.google.api.client.util.Lists;
 import com.google.common.base.Predicate;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Table;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -150,14 +151,17 @@ public class AggregateJoinPushDownRule extends BaseMaterializedViewRewriteRule {
 
     private boolean validMv(MaterializationContext mvContext, List<LogicalScanOperator> scanOperators) {
         // mv is SPG, so there is only one baseTable
-        long baseTableId = mvContext.getBaseTables().get(0).getId();
+        // Use Table.equals rather than getId() so external tables (e.g. IcebergTable) that
+        // override equals() by catalog/db/tableIdentifier match correctly across plan rebuilds,
+        // where CONNECTOR_ID_GENERATOR may assign different numeric ids to the same logical table.
+        Table mvBaseTable = mvContext.getBaseTables().get(0);
         Set<ColumnRefOperator> mvUsedColRefs = MvUtils.collectScanColumn(mvContext.getMvExpression());
         Set<String> mvUsedColNames = mvUsedColRefs.stream()
                 .map(ColumnRefOperator::getName)
                 .collect(Collectors.toSet());
         boolean baseTableFoundInMv = false;
         for (LogicalScanOperator scanOperator : scanOperators) {
-            if (scanOperator.getTable().getId() != baseTableId) {
+            if (!mvBaseTable.equals(scanOperator.getTable())) {
                 continue;
             }
             baseTableFoundInMv = true;

--- a/test/conf/sr.conf
+++ b/test/conf/sr.conf
@@ -27,6 +27,11 @@
 [replace]
   url = http://${cluster.host}:${cluster.http_port}
   mysql_cmd = mysql -h${cluster.host} -P${cluster.port} -u${cluster.user}
+  # Backend used by create_iceberg_catalog("...", "${iceberg_sql_test_catalog_type}")
+  # Default "hive" matches CI. To run offline against a local-disk hadoop
+  # catalog, flip this to "hadoop" and uncomment iceberg_local_warehouse_root.
+  iceberg_sql_test_catalog_type = hive
+  #iceberg_local_warehouse_root = /tmp/starrocks-sql-test/iceberg
 
 [env]
   [.oss]

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -644,6 +644,65 @@ class StarrocksSQLApiLib(object):
     def use_database(self, db_name):
         return self.execute_sql("use %s" % db_name)
 
+    def create_iceberg_catalog(self, catalog_name, catalog_type):
+        """
+        Create an iceberg external catalog for SQL tests, dispatching to a
+        builder per backend type. Each builder reads its own sr.conf vars
+        and does whatever pre-setup that type needs (e.g. mkdir the
+        hadoop-file warehouse root).
+
+        :param catalog_name: catalog name (already ${uuid0}-resolved)
+        :param catalog_type: one of {"hive", "hadoop"}
+        """
+        builders = {
+            "hive": self._create_iceberg_catalog_hive,
+            "hadoop": self._create_iceberg_catalog_hadoop,
+        }
+        builder = builders.get(catalog_type)
+        tools.assert_is_not_none(builder, "unknown iceberg catalog type: %s" % catalog_type)
+        return builder(catalog_name)
+
+    def _create_iceberg_catalog_hive(self, catalog_name):
+        """
+        Hive-metastore-backed iceberg catalog over OSS S3. Consumes:
+          ${iceberg_catalog_hive_metastore_uris}, ${oss_ak}, ${oss_sk},
+          ${oss_endpoint} — all shipped in [env] of the stock sr.conf.
+        """
+        sql = (
+            'create external catalog %s properties ('
+            '"type" = "iceberg", '
+            '"iceberg.catalog.type" = "hive", '
+            '"iceberg.catalog.hive.metastore.uris" = "%s", '
+            '"aws.s3.access_key" = "%s", '
+            '"aws.s3.secret_key" = "%s", '
+            '"aws.s3.endpoint" = "%s")'
+        ) % (catalog_name, self.iceberg_catalog_hive_metastore_uris,
+             self.oss_ak, self.oss_sk, self.oss_endpoint)
+        res = self.execute_sql(sql)
+        tools.assert_true(res["status"], "create hive iceberg catalog failed: %s" % res.get("msg"))
+
+    def _create_iceberg_catalog_hadoop(self, catalog_name):
+        """
+        Local-disk hadoop iceberg catalog. Consumes:
+          ${iceberg_local_warehouse_root} + ${uuid0}.
+        ${iceberg_local_warehouse_root} is NOT shipped in sr.conf; local devs
+        wanting to run against hadoop-on-file add it to their [replace]:
+          iceberg_local_warehouse_root = /tmp/starrocks-sql-test/iceberg
+        The warehouse sub-directory is mkdir'd before FE initializes the
+        catalog, since Iceberg HadoopCatalog's FE-side validation expects the
+        warehouse path to exist.
+        """
+        warehouse = "%s/sql_test/%s" % (self.iceberg_local_warehouse_root, self.uuid0)
+        os.makedirs(warehouse, exist_ok=True)
+        sql = (
+            'create external catalog %s properties ('
+            '"type" = "iceberg", '
+            '"iceberg.catalog.type" = "hadoop", '
+            '"iceberg.catalog.warehouse" = "file://%s")'
+        ) % (catalog_name, warehouse)
+        res = self.execute_sql(sql)
+        tools.assert_true(res["status"], "create hadoop iceberg catalog failed: %s" % res.get("msg"))
+
     def create_database_and_table(self, catalog_name, database_name, table_name, table_sql_path=None,
                                   tolerate_exist=False):
         """

--- a/test/sql/test_materialized_view/R/test_mv_iceberg_agg_join_pushdown_rewrite
+++ b/test/sql/test_materialized_view/R/test_mv_iceberg_agg_join_pushdown_rewrite
@@ -1,0 +1,88 @@
+-- name: test_mv_iceberg_agg_join_pushdown_rewrite
+function: create_iceberg_catalog("iceberg_mv_${uuid0}", "${iceberg_sql_test_catalog_type}")
+-- result:
+None
+-- !result
+create database iceberg_mv_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+create table iceberg_mv_${uuid0}.ice_db_${uuid0}.f_driver_online_detail_h (
+    granularity string,
+    business    string,
+    city_id     int,
+    date_id     int,
+    online_seconds bigint,
+    driver_id   bigint
+) partition by (date_id) properties ("format-version" = "2");
+-- result:
+-- !result
+insert into iceberg_mv_${uuid0}.ice_db_${uuid0}.f_driver_online_detail_h values
+    ('WHEELS','Transport',1,20260101,3600,1001),
+    ('WHEELS','Transport',1,20260101,3600,1002),
+    ('WHEELS','Transport',2,20260102,3600,1003),
+    ('WHEELS','Transport',2,20260102,3600,1004);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database mv_rewrite_db_${uuid0};
+-- result:
+-- !result
+use mv_rewrite_db_${uuid0};
+-- result:
+-- !result
+create table d_city (
+    city_id int,
+    city_name string
+) duplicate key(city_id) distributed by hash(city_id) buckets 1
+properties ("replication_num" = "1");
+-- result:
+-- !result
+insert into d_city values (1,'Jakarta'), (2,'Bandung'), (3,'Surabaya');
+-- result:
+-- !result
+create materialized view mv_online_by_city
+distributed by hash(granularity, business) buckets 4
+refresh deferred manual
+properties (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "loose"
+) as
+select
+    granularity,
+    business,
+    city_id,
+    date_id,
+    sum(online_seconds) as s_online,
+    hll_union(hll_hash(driver_id)) as hll_driver
+from iceberg_mv_${uuid0}.ice_db_${uuid0}.f_driver_online_detail_h
+group by granularity, business, city_id, date_id;
+-- result:
+-- !result
+refresh materialized view mv_online_by_city with sync mode;
+set enable_materialized_view_rewrite = true;
+-- result:
+-- !result
+function: check_hit_materialized_view("select d.city_name, sum(f.online_seconds) from iceberg_mv_${uuid0}.ice_db_${uuid0}.f_driver_online_detail_h f left join d_city d on d.city_id = f.city_id where f.date_id >= 20260101 and f.date_id < 20260103 and f.business = 'Transport' and f.granularity = 'WHEELS' group by d.city_name", "mv_online_by_city")
+-- result:
+None
+-- !result
+drop materialized view mv_online_by_city;
+-- result:
+-- !result
+drop table d_city;
+-- result:
+-- !result
+drop database mv_rewrite_db_${uuid0};
+-- result:
+-- !result
+drop table iceberg_mv_${uuid0}.ice_db_${uuid0}.f_driver_online_detail_h;
+-- result:
+-- !result
+drop database iceberg_mv_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_mv_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_iceberg_agg_join_pushdown_rewrite
+++ b/test/sql/test_materialized_view/T/test_mv_iceberg_agg_join_pushdown_rewrite
@@ -1,0 +1,81 @@
+-- name: test_mv_iceberg_agg_join_pushdown_rewrite
+-- Test Point: aggregate-join-pushdown MV rewrite must trigger when the MV base
+--             table is an Iceberg table whose numeric id is unstable across
+--             plan rebuilds.
+-- Method: build an MV over an Iceberg fact, join it with a native dim, then
+--         assert check_hit_materialized_view matches the MV.
+-- Scope: AggregateJoinPushDownRule / MaterializationContext.prune (external
+--        table id-vs-equals comparison).
+-- Catalog: built via create_iceberg_catalog helper; backend type comes from
+--          ${iceberg_sql_test_catalog_type} in sr.conf. CI stays on hive;
+--          local devs can flip it to hadoop without editing the test.
+-- Related: https://github.com/StarRocks/starrocks/issues/71849
+
+function: create_iceberg_catalog("iceberg_mv_${uuid0}", "${iceberg_sql_test_catalog_type}")
+
+create database iceberg_mv_${uuid0}.ice_db_${uuid0};
+
+create table iceberg_mv_${uuid0}.ice_db_${uuid0}.f_driver_online_detail_h (
+    granularity string,
+    business    string,
+    city_id     int,
+    date_id     int,
+    online_seconds bigint,
+    driver_id   bigint
+) partition by (date_id) properties ("format-version" = "2");
+
+insert into iceberg_mv_${uuid0}.ice_db_${uuid0}.f_driver_online_detail_h values
+    ('WHEELS','Transport',1,20260101,3600,1001),
+    ('WHEELS','Transport',1,20260101,3600,1002),
+    ('WHEELS','Transport',2,20260102,3600,1003),
+    ('WHEELS','Transport',2,20260102,3600,1004);
+
+set catalog default_catalog;
+
+create database mv_rewrite_db_${uuid0};
+
+use mv_rewrite_db_${uuid0};
+
+create table d_city (
+    city_id int,
+    city_name string
+) duplicate key(city_id) distributed by hash(city_id) buckets 1
+properties ("replication_num" = "1");
+
+insert into d_city values (1,'Jakarta'), (2,'Bandung'), (3,'Surabaya');
+
+create materialized view mv_online_by_city
+distributed by hash(granularity, business) buckets 4
+refresh deferred manual
+properties (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "loose"
+) as
+select
+    granularity,
+    business,
+    city_id,
+    date_id,
+    sum(online_seconds) as s_online,
+    hll_union(hll_hash(driver_id)) as hll_driver
+from iceberg_mv_${uuid0}.ice_db_${uuid0}.f_driver_online_detail_h
+group by granularity, business, city_id, date_id;
+
+refresh materialized view mv_online_by_city with sync mode;
+
+-- The target rewrite path: AGGREGATE_JOIN_PUSH_DOWN_RULE rewrites the joined
+-- aggregation against an MV whose only base table is the Iceberg fact table.
+set enable_materialized_view_rewrite = true;
+function: check_hit_materialized_view("select d.city_name, sum(f.online_seconds) from iceberg_mv_${uuid0}.ice_db_${uuid0}.f_driver_online_detail_h f left join d_city d on d.city_id = f.city_id where f.date_id >= 20260101 and f.date_id < 20260103 and f.business = 'Transport' and f.granularity = 'WHEELS' group by d.city_name", "mv_online_by_city")
+
+drop materialized view mv_online_by_city;
+
+drop table d_city;
+
+drop database mv_rewrite_db_${uuid0};
+
+drop table iceberg_mv_${uuid0}.ice_db_${uuid0}.f_driver_online_detail_h;
+
+drop database iceberg_mv_${uuid0}.ice_db_${uuid0};
+
+drop catalog iceberg_mv_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
#71849
`AggregateJoinPushDownRule` matched the MV's base table against scan tables using `Table.getId()`. For external tables (e.g. `IcebergTable`), `CONNECTOR_ID_GENERATOR` can assign different numeric ids to the same logical table across plan rebuilds, so the id comparison silently skipped the rewrite and the aggregate-join pushdown MV rewrite failed to trigger on Iceberg base tables.

## What I'm doing:

- Switch the base-table match in `AggregateJoinPushDownRule` from `Table.getId()` to `Table.equals`, which external subclasses override to compare by catalog / db / `tableIdentifier`.
- Add a local-disk Iceberg Hadoop catalog SQL test scaffold (`iceberg_local_warehouse_root` in `test/conf/sr.conf`) plus a regression case exercising the rewrite path.
- Ignore `.codex/` in `.gitignore`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4