### PR TITLE
[Refactor] Remove operator back-reference from spill memory manager

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -90,7 +90,7 @@ bool SpillableHashJoinProbeOperator::has_output() const {
     }
 
     if (_processing_partitions.empty()) {
-        as_mutable()->_acquire_next_partitions();
+        as_mutable()->_acquire_next_partitions(get_factory()->runtime_state());
         _update_status(as_mutable()->_load_all_partition_build_side(get_factory()->runtime_state()));
         return false;
     }
@@ -155,7 +155,7 @@ bool SpillableHashJoinProbeOperator::need_input() const {
     }
 
     if (_processing_partitions.empty()) {
-        as_mutable()->_acquire_next_partitions();
+        as_mutable()->_acquire_next_partitions(get_factory()->runtime_state());
         _update_status(as_mutable()->_load_all_partition_build_side(get_factory()->runtime_state()));
         return false;
     }
@@ -504,7 +504,7 @@ bool SpillableHashJoinProbeOperator::spilled() const {
     return _join_builder->spiller()->spilled();
 }
 
-void SpillableHashJoinProbeOperator::_acquire_next_partitions() {
+void SpillableHashJoinProbeOperator::_acquire_next_partitions(RuntimeState* state) {
     // get all spill partition
     if (_build_partitions.empty()) {
         _join_builder->spiller()->get_all_partitions(&_build_partitions);
@@ -517,14 +517,14 @@ void SpillableHashJoinProbeOperator::_acquire_next_partitions() {
     }
 
     size_t bytes_usage = 0;
-    size_t avaliable_bytes =
-            std::min<size_t>(_mem_resource_manager.operator_avaliable_memory_bytes(),
+    size_t available_bytes =
+            std::min<size_t>(spill::OperatorMemoryResourceManager::compute_available_memory_bytes(*state),
                              static_cast<size_t>(_spill_hash_join_probe_op_max_bytes / _degree_of_parallelism));
     // process the partition in memory firstly
     if (_processing_partitions.empty()) {
         for (auto partition : _build_partitions) {
             if (partition->in_mem && !_processed_partitions.count(partition->partition_id)) {
-                if ((partition->mem_size + bytes_usage < avaliable_bytes || _processing_partitions.empty()) &&
+                if ((partition->mem_size + bytes_usage < available_bytes || _processing_partitions.empty()) &&
                     std::find(_processing_partitions.begin(), _processing_partitions.end(), partition) ==
                             _processing_partitions.end()) {
                     _processing_partitions.emplace_back(partition);
@@ -540,7 +540,7 @@ void SpillableHashJoinProbeOperator::_acquire_next_partitions() {
     if (_processing_partitions.empty()) {
         for (const auto* partition : _build_partitions) {
             if (!partition->in_mem && !_processed_partitions.count(partition->partition_id)) {
-                if ((partition->bytes + bytes_usage < avaliable_bytes || _processing_partitions.empty()) &&
+                if ((partition->bytes + bytes_usage < available_bytes || _processing_partitions.empty()) &&
                     std::find(_processing_partitions.begin(), _processing_partitions.end(), partition) ==
                             _processing_partitions.end()) {
                     _processing_partitions.emplace_back(partition);

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
@@ -91,7 +91,7 @@ private:
     SpillableHashJoinProbeOperator* as_mutable() const { return const_cast<SpillableHashJoinProbeOperator*>(this); }
 
     // acquire next build-side partitions
-    void _acquire_next_partitions();
+    void _acquire_next_partitions(RuntimeState* state);
 
     bool _all_loaded_partition_data_ready();
 

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 
 #include "base/failpoint/fail_point.h"
+#include "common/config_exec_flow_fwd.h"
 #include "common/logging.h"
 #include "common/runtime_profile.h"
 #include "exec/pipeline/operator_factory.h"
@@ -73,7 +74,13 @@ Status Operator::prepare(RuntimeState* state) {
     FAIL_POINT_TRIGGER_RETURN_ERROR(random_error);
 
     if (state->query_ctx() && state->query_ctx()->spill_manager()) {
-        _mem_resource_manager.prepare(this, state->query_ctx()->spill_manager());
+        size_t reserved_bytes = 0;
+        if (spillable()) {
+            reserved_bytes = spill::OperatorMemoryResourceManager::compute_available_memory_bytes(*state);
+        } else if (releaseable()) {
+            reserved_bytes = config::local_exchange_buffer_mem_limit_per_driver;
+        }
+        _mem_resource_manager.prepare(state->query_ctx()->spill_manager(), spillable(), releaseable(), reserved_bytes);
     }
 
     return Status::OK();

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -199,7 +199,7 @@ public:
     void set_prepare_time(int64_t cost_ns);
     void set_local_prepare_time(int64_t cost_ns);
 
-    // Adjusts the execution mode of the operator (will only be called by the OperatorMemoryResourceManager component)
+    // Adjusts the execution mode of the operator after spill memory heuristics request low-memory mode.
     virtual void set_execute_mode(int performance_level) {}
     // @TODO(silverbullet233): for an operator, the way to reclaim memory is either spill
     // or push the buffer data to the downstream operator.

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -648,7 +648,9 @@ void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* track
         static thread_local std::mt19937_64 generator{std::random_device{}()};
         static std::uniform_real_distribution<double> distribution(0.0, 1.0);
         if (distribution(generator) < state->spill_rand_ratio()) {
-            mem_resource_mgr.to_low_memory_mode();
+            if (mem_resource_mgr.enter_low_memory_mode()) {
+                op->set_execute_mode(spill::MEM_RESOURCE_LOW_MEMORY);
+            }
         }
         return;
     }
@@ -658,7 +660,9 @@ void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* track
 
     // force mark operator to low memory mode
     if (state->spill_revocable_max_bytes() > 0 && op->revocable_mem_bytes() > state->spill_revocable_max_bytes()) {
-        mem_resource_mgr.to_low_memory_mode();
+        if (mem_resource_mgr.enter_low_memory_mode()) {
+            op->set_execute_mode(spill::MEM_RESOURCE_LOW_MEMORY);
+        }
         return;
     }
 
@@ -676,7 +680,9 @@ void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* track
         bool need_spill = false;
         if (!tls_thread_status.try_mem_reserve(request_reserved, shared_reserved)) {
             need_spill = true;
-            mem_resource_mgr.to_low_memory_mode();
+            if (mem_resource_mgr.enter_low_memory_mode()) {
+                op->set_execute_mode(spill::MEM_RESOURCE_LOW_MEMORY);
+            }
         }
 
         const auto& query_mem_tracker = _query_ctx->mem_tracker();
@@ -712,7 +718,9 @@ void PipelineDriver::_try_to_release_buffer(RuntimeState* state, OperatorPtr& op
                             << ", release buffer threshold: "
                             << static_cast<int64_t>(spill_mem_threshold * release_buffer_mem_ratio)
                             << ", spill mem threshold: " << static_cast<int64_t>(spill_mem_threshold);
-            mem_resource_mgr.to_low_memory_mode();
+            if (mem_resource_mgr.enter_low_memory_mode()) {
+                op->set_execute_mode(spill::MEM_RESOURCE_LOW_MEMORY);
+            }
         }
     }
 }

--- a/be/src/exec/spill/operator_mem_resource_manager.cpp
+++ b/be/src/exec/spill/operator_mem_resource_manager.cpp
@@ -14,47 +14,38 @@
 
 #include "exec/spill/operator_mem_resource_manager.h"
 
-#include "common/config_exec_flow_fwd.h"
-#include "exec/pipeline/operator.h"
-#include "exec/pipeline/operator_factory.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::spill {
-void OperatorMemoryResourceManager::prepare(OP* op, QuerySpillManager* query_spill_manager) {
-    _op = op;
-    _spillable = op->spillable();
-    _releaseable = op->releaseable();
-    _releaseable |= _spillable;
+void OperatorMemoryResourceManager::prepare(QuerySpillManager* query_spill_manager, bool spillable, bool releaseable,
+                                            size_t reserved_bytes) {
+    _performance_level = MEM_RESOURCE_DEFAULE_MEMORY;
+    _spillable = spillable;
+    _releaseable = releaseable || spillable;
     _query_spill_manager = query_spill_manager;
     if (_spillable) {
         DCHECK(_query_spill_manager != nullptr);
         _res_guard.inc_spillable_operators();
     }
     if (_query_spill_manager != nullptr) {
-        size_t reserved_bytes = 0;
-        if (_spillable) {
-            reserved_bytes = operator_avaliable_memory_bytes();
-        } else if (op->releaseable()) {
-            reserved_bytes = config::local_exchange_buffer_mem_limit_per_driver;
-        }
         _res_guard.inc_reserve_bytes(reserved_bytes);
     }
 }
 
-void OperatorMemoryResourceManager::to_low_memory_mode() {
+bool OperatorMemoryResourceManager::enter_low_memory_mode() {
     if (_performance_level < MEM_RESOURCE_LOW_MEMORY) {
         _performance_level = MEM_RESOURCE_LOW_MEMORY;
-        _op->set_execute_mode(_performance_level);
+        return true;
     }
+    return false;
 }
 
-size_t OperatorMemoryResourceManager::operator_avaliable_memory_bytes() {
+size_t OperatorMemoryResourceManager::compute_available_memory_bytes(const RuntimeState& runtime_state) {
     // TODO: think about multi-operators
-    auto* runtime_state = _op->get_factory()->runtime_state();
-    size_t avaliable = runtime_state->spill_mem_table_size() * runtime_state->spill_mem_table_num();
-    avaliable = std::max<size_t>(avaliable, runtime_state->spill_operator_min_bytes());
-    avaliable = std::min<size_t>(avaliable, runtime_state->spill_operator_max_bytes());
-    return avaliable;
+    size_t available = runtime_state.spill_mem_table_size() * runtime_state.spill_mem_table_num();
+    available = std::max<size_t>(available, runtime_state.spill_operator_min_bytes());
+    available = std::min<size_t>(available, runtime_state.spill_operator_max_bytes());
+    return available;
 }
 
 void OperatorMemoryResourceManager::close() {

--- a/be/src/exec/spill/operator_mem_resource_manager.h
+++ b/be/src/exec/spill/operator_mem_resource_manager.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include "exec/pipeline/pipeline_fwd.h"
 #include "exec/spill/query_spill_manager.h"
+#include "runtime/runtime_state_fwd.h"
 
 namespace starrocks::spill {
 enum MEM_RESOURCE {
@@ -42,9 +42,7 @@ public:
         OperatorMemoryResourceManager& _manager;
     };
 
-    using OP = pipeline::Operator;
-
-    void prepare(OP* op, QuerySpillManager* query_spill_manager);
+    void prepare(QuerySpillManager* query_spill_manager, bool spillable, bool releaseable, size_t reserved_bytes);
 
     void close();
 
@@ -52,10 +50,10 @@ public:
 
     bool spillable() const { return _spillable; }
 
-    void to_low_memory_mode();
+    bool enter_low_memory_mode();
 
-    // For the current operator available memory (estimated value)
-    size_t operator_avaliable_memory_bytes();
+    // For the current operator available memory (estimated value).
+    static size_t compute_available_memory_bytes(const RuntimeState& runtime_state);
 
     QuerySpillManager* query_spill_manager() const { return _query_spill_manager; }
 
@@ -65,7 +63,6 @@ private:
     int _performance_level = MEM_RESOURCE_DEFAULE_MEMORY;
     bool _spillable = false;
     bool _releaseable = false;
-    OP* _op = nullptr;
     QuerySpillManager* _query_spill_manager = nullptr;
     ResGuard _res_guard{*this};
 };

--- a/be/test/exec/query_spill_manager_test.cpp
+++ b/be/test/exec/query_spill_manager_test.cpp
@@ -17,60 +17,10 @@
 #include <gtest/gtest.h>
 
 #include "base/uid_util.h"
-#include "exec/pipeline/operator.h"
-#include "exec/pipeline/operator_factory.h"
 #include "exec/spill/operator_mem_resource_manager.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::spill {
-using namespace starrocks::pipeline;
-
-class MockedDummyOperatrator final : public pipeline::Operator {
-public:
-    MockedDummyOperatrator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
-                           bool spillable, bool releaseable)
-            : Operator(factory, id, "mocked_dummy_operator", plan_node_id, false, driver_sequence),
-              _spillable(spillable),
-              _releaseable(releaseable) {}
-    bool spillable() const override { return _spillable; }
-    bool releaseable() const override { return _releaseable; }
-    // dummy functions:
-    bool has_output() const override { return false; }
-    bool need_input() const override { return true; }
-    bool is_finished() const override { return false; }
-
-    Status prepare(RuntimeState* state) override { return Status::OK(); }
-    void close(RuntimeState* state) override {}
-    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override { return Status::OK(); }
-    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override { return nullptr; }
-
-private:
-    bool _spillable = false;
-    bool _releaseable = false;
-};
-
-class MockedDummyOperatorFactory final : public pipeline::OperatorFactory {
-public:
-    MockedDummyOperatorFactory(int32_t id, int32_t plan_node_id, RuntimeState* state, bool spillable = false,
-                               bool releaseable = false)
-            : pipeline::OperatorFactory(id, "mocked_dummy_operator_factory", plan_node_id),
-              _spillable(spillable),
-              _releaseable(releaseable) {
-        set_runtime_state(state);
-    }
-    ~MockedDummyOperatorFactory() override = default;
-    Status prepare(RuntimeState* state) override { return Status::OK(); }
-    void close(RuntimeState* state) override {}
-    pipeline::OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<MockedDummyOperatrator>(this, _id, _plan_node_id, driver_sequence, _spillable,
-                                                        _releaseable);
-    }
-
-private:
-    bool _spillable = false;
-    bool _releaseable = false;
-};
-
 class QuerySpillManagerTest : public ::testing::Test {
 public:
     void SetUp() override { dummy_query_id = generate_uuid(); }
@@ -86,18 +36,43 @@ protected:
 TEST_F(QuerySpillManagerTest, test_inc) {
     QuerySpillManager query_spill_manager_1(dummy_query_id, &_global_mgr);
 
-    auto factory_1 = std::make_unique<MockedDummyOperatorFactory>(1, 1, &_dummy_state, true, true);
-    auto op = factory_1->create(1, 1);
-
     OperatorMemoryResourceManager op_mem_res_mgr;
-    op_mem_res_mgr.prepare(op.get(), &query_spill_manager_1);
+    op_mem_res_mgr.prepare(&query_spill_manager_1, true, true, 128);
     EXPECT_EQ(_global_mgr.spillable_operators(), 1);
+    EXPECT_EQ(_global_mgr.spill_expected_reserved_bytes(), 128);
 
-    auto factory_2 = std::make_unique<MockedDummyOperatorFactory>(1, 1, &_dummy_state, false, true);
-    auto op2 = factory_2->create(1, 1);
     OperatorMemoryResourceManager op_mem_res_mgr_2;
-    op_mem_res_mgr_2.prepare(op2.get(), nullptr);
+    op_mem_res_mgr_2.prepare(&query_spill_manager_1, false, true, 256);
     EXPECT_EQ(_global_mgr.spillable_operators(), 1);
+    EXPECT_EQ(_global_mgr.spill_expected_reserved_bytes(), 384);
+
+    op_mem_res_mgr.close();
+    EXPECT_EQ(_global_mgr.spillable_operators(), 0);
+    EXPECT_EQ(_global_mgr.spill_expected_reserved_bytes(), 256);
+
+    op_mem_res_mgr_2.close();
+    EXPECT_EQ(_global_mgr.spillable_operators(), 0);
+    EXPECT_EQ(_global_mgr.spill_expected_reserved_bytes(), 0);
+}
+
+TEST_F(QuerySpillManagerTest, test_low_memory_transition_is_idempotent) {
+    QuerySpillManager query_spill_manager(dummy_query_id, &_global_mgr);
+    OperatorMemoryResourceManager op_mem_res_mgr;
+    op_mem_res_mgr.prepare(&query_spill_manager, false, true, 64);
+
+    EXPECT_TRUE(op_mem_res_mgr.releaseable());
+    EXPECT_TRUE(op_mem_res_mgr.enter_low_memory_mode());
+    EXPECT_FALSE(op_mem_res_mgr.releaseable());
+    EXPECT_FALSE(op_mem_res_mgr.enter_low_memory_mode());
+}
+
+TEST_F(QuerySpillManagerTest, test_compute_available_memory_bytes_matches_runtime_state) {
+    const size_t expected =
+            std::min<size_t>(std::max<size_t>(_dummy_state.spill_mem_table_size() * _dummy_state.spill_mem_table_num(),
+                                              _dummy_state.spill_operator_min_bytes()),
+                             _dummy_state.spill_operator_max_bytes());
+
+    EXPECT_EQ(expected, OperatorMemoryResourceManager::compute_available_memory_bytes(_dummy_state));
 }
 
 } // namespace starrocks::spill


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
