### PR TITLE
[Enhancement] Allow random distribution on agg tables via opt-in flag

### DIFF
--- a/docs/en/administration/management/FE_parameters/stats_storage.md
+++ b/docs/en/administration/management/FE_parameters/stats_storage.md
@@ -199,6 +199,15 @@ This topic introduces the following types of FE configurations:
   - If this parameter is set to `FALSE`, you need to manually specify the number of buckets when you create a table or add a partition. If you do not specify the bucket count when adding a new partition to a table, the new partition inherits the bucket count set at the creation of the table. However, you can also manually specify the number of buckets for the new partition.
 - Introduced in: v2.5.7
 
+### `enable_random_distribution_for_agg_table`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to allow `DISTRIBUTED BY RANDOM` on aggregate-key tables at CREATE TABLE and ALTER TABLE time. The default `false` matches the behavior introduced by the analyzer check that rejects random distribution on aggregate tables, because non-aggregation queries over such tables may return inconsistent results when tablets are split or merged. Enable this only if you accept that trade-off — for example, on tables that are created and altered dynamically by a UI layer where end-users cannot reliably choose hash columns. Tables declaring `REPLACE` / `REPLACE_IF_NOT_NULL` aggregate columns remain rejected even when this flag is enabled, because random distribution would break `REPLACE` semantics.
+- Introduced in: -
+
 ### `enable_experimental_rowstore`
 
 - Default: false

--- a/docs/zh/administration/management/FE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/FE_parameters/stats_storage.md
@@ -199,6 +199,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
   - 如果此参数设置为 `FALSE`，您在创建表或添加分区时需要手动指定 bucket 数量。如果您在向表添加新分区时不指定 bucket 数量，新分区将继承表创建时设置的 bucket 数量。但是，您也可以手动为新分区指定 bucket 数量。
 - 引入版本: v2.5.7
 
+### `enable_random_distribution_for_agg_table`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 是否允许在聚合模型（Aggregate Key）表上使用 `DISTRIBUTED BY RANDOM`（在 `CREATE TABLE` 和 `ALTER TABLE` 语句中）。默认值 `false` 与分析器当前行为一致，禁止对聚合表使用随机分布，因为当 tablet 发生 split/merge 时，非聚合查询可能返回不一致的结果。仅当您能接受这种一致性折衷时才启用该参数，例如通过 UI 动态创建和修改聚合表、终端用户无法可靠选择哈希列的场景。即使启用了该参数，声明了 `REPLACE` / `REPLACE_IF_NOT_NULL` 聚合列的表仍会被拒绝，因为随机分布会破坏 `REPLACE` 语义。
+- 引入版本: -
+
 ### `enable_experimental_rowstore`
 
 - 默认值: false

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4056,6 +4056,19 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long max_bucket_number_per_partition = 1024;
 
+    /**
+     * If true, {@code DISTRIBUTED BY RANDOM} is allowed on aggregate-key tables,
+     * both at CREATE TABLE and ALTER TABLE time. The default {@code false} matches
+     * the behavior introduced in #60702, which rejects random distribution on
+     * aggregate tables because non-aggregation queries may return inconsistent
+     * results when tablets are split/merged. Enable this only if your workload
+     * tolerates that trade-off and you rely on random distribution for
+     * dynamically-managed aggregate tables (e.g. tables created by a UI layer
+     * where end-users cannot reliably choose hash columns).
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_random_distribution_for_agg_table = false;
+
     @ConfField(mutable = true)
     public static int max_column_number_per_table = 10000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -39,6 +39,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -672,8 +673,11 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
         // analyze distribution
         DistributionDesc distributionDesc = clause.getDistributionDesc();
         if (distributionDesc != null) {
-            if (distributionDesc instanceof RandomDistributionDesc && targetKeysType != KeysType.DUP_KEYS) {
-                throw new SemanticException(targetKeysType.toSql() + " must use hash distribution", distributionDesc.getPos());
+            if (distributionDesc instanceof RandomDistributionDesc && targetKeysType != KeysType.DUP_KEYS
+                    && !(Config.enable_random_distribution_for_agg_table
+                            && targetKeysType == KeysType.AGG_KEYS && !hasReplace)) {
+                throw new SemanticException(targetKeysType.toSql() + (hasReplace ? " with replace " : "")
+                        + " must use hash distribution", distributionDesc.getPos());
             }
             DistributionDescAnalyzer.analyze(distributionDesc, columnSet);
             clause.setDistributionDesc(distributionDesc);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -734,8 +734,11 @@ public class CreateTableAnalyzer {
                     throw new SemanticException("Currently not support default distribution in " + keysDesc.getKeysType());
                 }
             }
-            if (distributionDesc instanceof RandomDistributionDesc && keysDesc.getKeysType() != KeysType.DUP_KEYS) {
+            if (distributionDesc instanceof RandomDistributionDesc && keysDesc.getKeysType() != KeysType.DUP_KEYS
+                    && !(Config.enable_random_distribution_for_agg_table
+                            && keysDesc.getKeysType() == KeysType.AGG_KEYS && !stmt.isHasReplace())) {
                 throw new SemanticException(keysDesc.getKeysType().toSql()
+                        + (stmt.isHasReplace() ? " with replace " : "")
                         + " cannot use random distribution", distributionDesc.getPos());
             }
             if (distributionDesc.getBuckets() > Config.max_bucket_number_per_partition && stmt.isOlapEngine()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.analyzer;
 
 import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
@@ -273,6 +274,49 @@ public class AnalyzeAlterTableStatementTest {
         analyzeSuccess(sql);
         sql = "alter table tmcwr drop column name";
         analyzeSuccess(sql);
+    }
+
+    @Test
+    public void testOptimizeRandomDistributionForAggTable() throws Exception {
+        AnalyzeTestUtil.getStarRocksAssert().withTable("CREATE TABLE test.agg_rand_opt (\n" +
+                "  k1 INT NOT NULL,\n" +
+                "  v1 BIGINT SUM\n" +
+                ") ENGINE=OLAP\n" +
+                "AGGREGATE KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+        AnalyzeTestUtil.getStarRocksAssert().withTable("CREATE TABLE test.dup_rand_opt (\n" +
+                "  k1 INT NOT NULL,\n" +
+                "  v1 BIGINT\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+        AnalyzeTestUtil.getStarRocksAssert().withTable("CREATE TABLE test.agg_rand_opt_repl (\n" +
+                "  k1 INT NOT NULL,\n" +
+                "  v1 BIGINT REPLACE\n" +
+                ") ENGINE=OLAP\n" +
+                "AGGREGATE KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        boolean original = Config.enable_random_distribution_for_agg_table;
+        try {
+            Config.enable_random_distribution_for_agg_table = false;
+            analyzeFail("alter table test.agg_rand_opt distributed by random buckets 10");
+            analyzeSuccess("alter table test.dup_rand_opt distributed by random buckets 10");
+
+            Config.enable_random_distribution_for_agg_table = true;
+            analyzeSuccess("alter table test.agg_rand_opt distributed by random buckets 10");
+            analyzeSuccess("alter table test.dup_rand_opt distributed by random buckets 10");
+            // REPLACE-family columns must stay rejected even with the flag on.
+            analyzeFail("alter table test.agg_rand_opt_repl distributed by random buckets 10");
+        } finally {
+            Config.enable_random_distribution_for_agg_table = original;
+            AnalyzeTestUtil.getStarRocksAssert().dropTable("test.agg_rand_opt");
+            AnalyzeTestUtil.getStarRocksAssert().dropTable("test.dup_rand_opt");
+            AnalyzeTestUtil.getStarRocksAssert().dropTable("test.agg_rand_opt_repl");
+        }
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.analyzer;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -313,6 +314,34 @@ public class AnalyzeCreateTableTest {
                 "distributed by random buckets 10");
         analyzeFail("create table table1 (col1 char(10) not null, col2 bigint REPLACE_IF_NOT_NULL) " +
                 "engine=olap aggregate key(col1) distributed by random buckets 10");
+    }
+
+    @Test
+    public void testRandomDistributionForAggKeyWithOptInFlag() {
+        boolean original = Config.enable_random_distribution_for_agg_table;
+        try {
+            Config.enable_random_distribution_for_agg_table = true;
+            analyzeSuccess("create table table1 (col1 char(10) not null, col2 bigint sum) engine=olap " +
+                    "aggregate key(col1) distributed by random");
+            analyzeSuccess("create table table1 (col1 char(10) not null, col2 bigint sum) engine=olap " +
+                    "aggregate key(col1) distributed by random buckets 10");
+            // REPLACE-family columns remain rejected even with the flag on: random distribution
+            // would break REPLACE semantics outright.
+            analyzeFail("create table table1 (col1 char(10) not null, col2 bigint replace) engine=olap " +
+                    "aggregate key(col1) distributed by random buckets 10");
+            analyzeFail("create table table1 (col1 char(10) not null, col2 bigint REPLACE_IF_NOT_NULL) " +
+                    "engine=olap aggregate key(col1) distributed by random buckets 10");
+            // Regression guard: non-aggregate key types are still forbidden.
+            analyzeFail("create table table1 (col1 char(10) not null, col2 int) engine=olap primary key(col1) " +
+                    "distributed by random buckets 10");
+            analyzeFail("create table table1 (col1 char(10) not null, col2 int) engine=olap unique key(col1) " +
+                    "distributed by random buckets 10");
+            // Regression guard: duplicate keys with random distribution always succeed.
+            analyzeSuccess("create table table1 (col1 char(10) not null) engine=olap duplicate key(col1) " +
+                    "distributed by random buckets 10");
+        } finally {
+            Config.enable_random_distribution_for_agg_table = original;
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

PR #60702 forbade `DISTRIBUTED BY RANDOM` on aggregate-key tables at both `CREATE TABLE` and `ALTER TABLE` time because non-aggregation queries against such tables could return inconsistent results when tablets are split or merged. That blanket rejection is correct for the general case, but it breaks a legitimate deployment pattern: tables that are created and altered dynamically by a UI layer where end-users cannot reliably pick meaningful hash columns. Operators in that situation currently patch #60702 out of every StarRocks release they consume, which blocks them from tracking vanilla releases.

This was raised upstream by Yves Burlot on the original PR: https://github.com/StarRocks/starrocks/pull/60702#issuecomment-3401832610. His suggestion was an opt-in flag defaulting to `false`, which is exactly what this PR implements.

## What I'm doing:

Adding a new FE config `enable_random_distribution_for_agg_table`, mutable, default `false`. When `false` (the default) the check added by #60702 applies unchanged, no behavior change versus today. When an operator sets it to `true`, `DISTRIBUTED BY RANDOM` is accepted on aggregate-key tables that do NOT declare `REPLACE` / `REPLACE_IF_NOT_NULL` columns, both at CREATE TABLE and ALTER TABLE (`OPTIMIZE`) time. REPLACE-family aggregate columns remain rejected even when the flag is on, because random distribution would break REPLACE semantics outright. This matches the pre-#60702 behavior, which also rejected `AGG_KEYS with replace`. The change is intentionally conservative: it restores exactly the set of cases that were legal before #60702, gated behind a single boolean, so users who accept the consistency trade-off can opt in and everyone else sees zero change.

The check sites live in two files, mirroring the pre-#60702 structure:

- `fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java` around line 737: the `CREATE TABLE` path, keyed on `stmt.isHasReplace()`.
- `fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java` around line 676: the `ALTER TABLE ... OPTIMIZE` path, keyed on the `hasReplace` local already computed from the new column defs at line 572.

Test coverage:

- `AnalyzeCreateTableTest.testRandomDistributionForAggKey` (unchanged) keeps proving the flag-off / current behavior.
- New `AnalyzeCreateTableTest.testRandomDistributionForAggKeyWithOptInFlag` flips the config on and asserts: `sum` aggregate succeeds, `replace` and `replace_if_not_null` still fail, `primary key` / `unique key` still fail (regression guard), `duplicate key` still succeeds.
- New `AnalyzeAlterTableStatementTest.testOptimizeRandomDistributionForAggTable` repeats the matrix against real OLAP tables via `ALTER TABLE ... DISTRIBUTED BY RANDOM`.
- Each test saves and restores `Config.enable_random_distribution_for_agg_table` in a `try`/`finally` so it does not leak into sibling tests.

Documentation:

- Added the new config entry in `docs/en/administration/management/FE_parameters/stats_storage.md` and its Chinese mirror, alphabetically placed next to `enable_auto_tablet_distribution`, documenting the consistency trade-off and the REPLACE caveat.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4