### PR TITLE
[Enhancement] Add range-colocate join planner support

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -480,6 +480,16 @@ public class ColocateTableIndex implements Writable {
         }
     }
 
+    public boolean isRangeColocateGroup(GroupId groupId) {
+        readLock();
+        try {
+            ColocateGroupSchema schema = group2Schema.get(groupId);
+            return schema != null && schema.isRangeColocate();
+        } finally {
+            readUnlock();
+        }
+    }
+
     public boolean isGroupExist(GroupId groupId) {
         readLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.HintNode;
+import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.optimizer.base.DistributionCol;
 import com.starrocks.sql.optimizer.base.DistributionProperty;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
@@ -27,6 +28,7 @@ import com.starrocks.sql.optimizer.base.EquivalentDescriptor;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
 import com.starrocks.sql.optimizer.base.RoundRobinDistributionSpec;
 import com.starrocks.sql.optimizer.cost.CostModel;
 import com.starrocks.sql.optimizer.operator.Operator;
@@ -96,6 +98,86 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
                 rightShuffleColumns);
 
     }
+
+    /**
+     * Range-colocate join gate. All gates must pass to skip the shuffle.
+     * <ol>
+     * <li>Join hint: user-specified {@code HINT_JOIN_SHUFFLE},
+     *     {@code HINT_JOIN_SKEW}, or {@code HINT_JOIN_BUCKET} disables
+     *     colocate. Only {@code null} or {@code HINT_JOIN_COLOCATE} lets
+     *     the range fast path proceed.
+     * <li>Join-type allowlist: INNER, LEFT OUTER, LEFT SEMI, LEFT ANTI.
+     *     Right-family and full-outer joins are rejected (NULL-key runtime
+     *     correctness validation deferred past P2).
+     * <li>{@code disable_colocate_join} session kill switch (shared with
+     *     hash colocate).
+     * <li>Structural {@link RangeDistributionSpec#canColocate}: same group,
+     *     both stable, non-empty partitions, same colocate column count.
+     * <li>Position-preserving join-key pairing: for each colocate column
+     *     index {@code i}, there must exist some equijoin-pair index
+     *     {@code k} such that left colocate[i] is equivalent to
+     *     leftShuffle[k] AND right colocate[i] is equivalent to
+     *     rightShuffle[k]. Same {@code k} on both sides blocks
+     *     swapped-column joins. Each side uses its own descriptor.
+     * </ol>
+     * {@code isConnected} argument order is {@code (required, existing)} —
+     * shuffle column is required, colocate column is existing — matching
+     * {@code checkChildDistributionSatisfyShuffle} and
+     * {@code HashDistributionSpec.isJoinEqColumnsCompatible}.
+     */
+    private boolean canRangeColocateJoin(String hint,
+                                         JoinOperator joinType,
+                                         RangeDistributionSpec leftSpec,
+                                         RangeDistributionSpec rightSpec,
+                                         List<DistributionCol> leftShuffleColumns,
+                                         List<DistributionCol> rightShuffleColumns) {
+        // User hint takes precedence over the range fast path. Mirrors the
+        // hash path (line 438 area) which enforces shuffle when the user asks
+        // for SHUFFLE/SKEW/BUCKET regardless of local-hash detection.
+        if (HintNode.HINT_JOIN_SHUFFLE.equals(hint)
+                || HintNode.HINT_JOIN_SKEW.equals(hint)
+                || HintNode.HINT_JOIN_BUCKET.equals(hint)) {
+            return false;
+        }
+        if (joinType != JoinOperator.INNER_JOIN
+                && joinType != JoinOperator.LEFT_OUTER_JOIN
+                && joinType != JoinOperator.LEFT_SEMI_JOIN
+                && joinType != JoinOperator.LEFT_ANTI_JOIN) {
+            return false;
+        }
+        if (ConnectContext.get().getSessionVariable().isDisableColocateJoin()) {
+            return false;
+        }
+        if (!leftSpec.canColocate(rightSpec)) {
+            return false;
+        }
+        if (leftShuffleColumns.size() != rightShuffleColumns.size()) {
+            return false;
+        }
+        List<DistributionCol> leftColocate = leftSpec.getColocateColumns();
+        List<DistributionCol> rightColocate = rightSpec.getColocateColumns();
+        if (leftColocate.size() != rightColocate.size()) {
+            return false;
+        }
+        EquivalentDescriptor leftDesc = leftSpec.getEquivalentDescriptor();
+        EquivalentDescriptor rightDesc = rightSpec.getEquivalentDescriptor();
+        for (int i = 0; i < leftColocate.size(); i++) {
+            DistributionCol leftColocateCol = leftColocate.get(i);
+            DistributionCol rightColocateCol = rightColocate.get(i);
+            boolean paired = false;
+            for (int k = 0; k < leftShuffleColumns.size(); k++) {
+                if (leftDesc.isConnected(leftShuffleColumns.get(k), leftColocateCol)
+                        && rightDesc.isConnected(rightShuffleColumns.get(k), rightColocateCol)) {
+                    paired = true;
+                    break;
+                }
+            }
+            if (!paired) {
+                return false;
+            }
+        }
+        return true;
+    }
     private boolean canColocate(HashDistributionSpec leftLocalDistributionSpec,
                                    HashDistributionSpec rightLocalDistributionSpec,
                                    List<DistributionCol> leftShuffleColumns,
@@ -137,6 +219,28 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
         DistributionSpec enforceDistributionSpec =
                 DistributionSpec.createHashDistributionSpec(new HashDistributionDesc(enforceNullStrict(shuffleColumns),
                         HashDistributionDesc.SourceType.SHUFFLE_ENFORCE));
+
+        Pair<GroupExpression, PhysicalPropertySet> pair =
+                enforceChildDistribution(enforceDistributionSpec, child, childOutputProperty);
+        PhysicalPropertySet newChildInputProperty = pair.second;
+
+        requiredChildrenProperties.set(childIndex, newChildInputProperty);
+        childrenOutputProperties.set(childIndex, newChildInputProperty);
+        return pair.first;
+    }
+
+    // Convert a RangeDistributionSpec child into a hash-shuffle child using
+    // SourceType SHUFFLE_JOIN (NOT SHUFFLE_ENFORCE). SHUFFLE_JOIN is what the
+    // downstream hash/hash compatibility branch expects — HashDistributionDesc.isShuffle()
+    // only returns true for SHUFFLE_JOIN / SHUFFLE_AGG; SHUFFLE_ENFORCE would
+    // fall through to checkState(false, "Children output property distribution error").
+    private GroupExpression convertRangeToHashShuffle(List<DistributionCol> shuffleColumns,
+                                                     GroupExpression child,
+                                                     PhysicalPropertySet childOutputProperty,
+                                                     int childIndex) {
+        DistributionSpec enforceDistributionSpec =
+                DistributionSpec.createHashDistributionSpec(new HashDistributionDesc(enforceNullStrict(shuffleColumns),
+                        HashDistributionDesc.SourceType.SHUFFLE_JOIN));
 
         Pair<GroupExpression, PhysicalPropertySet> pair =
                 enforceChildDistribution(enforceDistributionSpec, child, childOutputProperty);
@@ -331,11 +435,28 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
             return transToRoundRobinUnion(node, context);
         }
 
+        // Range-normalization pass: before any `isShuffle()` precondition or
+        // HashDistributionSpec cast, convert every RangeDistributionSpec child
+        // to a hash SHUFFLE_JOIN child. RangeDistributionSpec has type RANGE;
+        // it would fail the isShuffle() precondition at line
+        // `firstChildDistProperty.isShuffle()` below, so normalize first.
+        List<PhysicalPropertySet> setOpRequiredPropertySets =
+                PropertyDeriverBase.computeShuffleSetRequiredProperties(node);
+        for (int i = 0; i < childrenOutputProperties.size(); i++) {
+            DistributionSpec childSpec = childrenOutputProperties.get(i).getDistributionProperty().getSpec();
+            if (childSpec instanceof RangeDistributionSpec) {
+                List<DistributionCol> setShuffleCols =
+                        ((HashDistributionSpec) setOpRequiredPropertySets.get(i).getDistributionProperty().getSpec())
+                                .getShuffleColumns();
+                convertRangeToHashShuffle(setShuffleCols, childrenBestExprList.get(i),
+                        childrenOutputProperties.get(i), i);
+            }
+        }
+
         DistributionProperty firstChildDistProperty = childrenOutputProperties.get(0).getDistributionProperty();
         Preconditions.checkArgument(firstChildDistProperty.isShuffle());
         HashDistributionSpec firstHashDistSpec = (HashDistributionSpec) firstChildDistProperty.getSpec();
-        List<PhysicalPropertySet> childRequiredPropertySets =
-                PropertyDeriverBase.computeShuffleSetRequiredProperties(node);
+        List<PhysicalPropertySet> childRequiredPropertySets = setOpRequiredPropertySets;
 
         List<DistributionCol> firstShuffleColumns =
                 ((HashDistributionSpec) childRequiredPropertySets.get(0).getDistributionProperty()
@@ -423,6 +544,32 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
         List<DistributionCol> rightShuffleColumns =
                 ((HashDistributionSpec) requiredProperties.get(1).getDistributionProperty().getSpec())
                         .getShuffleColumns();
+
+        // Range-colocate dispatch:
+        // - both children range + canRangeColocateJoin → skip exchange (return).
+        // - otherwise, normalize any range child to hash SHUFFLE_JOIN via
+        //   convertRangeToHashShuffle, then fall through to the existing
+        //   hash/hash compatibility path unchanged.
+        DistributionSpec leftRawSpec = leftChildOutputProperty.getDistributionProperty().getSpec();
+        DistributionSpec rightRawSpec = rightChildOutputProperty.getDistributionProperty().getSpec();
+        boolean leftIsRange = leftRawSpec instanceof RangeDistributionSpec;
+        boolean rightIsRange = rightRawSpec instanceof RangeDistributionSpec;
+        if (leftIsRange && rightIsRange) {
+            if (canRangeColocateJoin(hint, node.getJoinType(),
+                    (RangeDistributionSpec) leftRawSpec,
+                    (RangeDistributionSpec) rightRawSpec,
+                    leftShuffleColumns, rightShuffleColumns)) {
+                return visitOperator(node, context);
+            }
+        }
+        if (leftIsRange) {
+            leftChild = convertRangeToHashShuffle(leftShuffleColumns, leftChild, leftChildOutputProperty, 0);
+            leftChildOutputProperty = childrenOutputProperties.get(0);
+        }
+        if (rightIsRange) {
+            rightChild = convertRangeToHashShuffle(rightShuffleColumns, rightChild, rightChildOutputProperty, 1);
+            rightChildOutputProperty = childrenOutputProperties.get(1);
+        }
 
         DistributionProperty leftChildDistributionProperty = leftChildOutputProperty.getDistributionProperty();
         DistributionProperty rightChildDistributionProperty = rightChildOutputProperty.getDistributionProperty();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -65,7 +65,9 @@ import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.DistributionSpecHelper;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -1194,7 +1196,11 @@ public class MvRewritePreprocessor {
         } else if (distributionInfo.getType() == DistributionInfoType.RANDOM) {
             distributionSpec = DistributionSpec.createAnyDistributionSpec();
         } else if (distributionInfo.getType() == DistributionInfoType.RANGE) {
-            distributionSpec = DistributionSpec.createAnyDistributionSpec();
+            RangeDistributionSpec rangeSpec = DistributionSpecHelper
+                    .buildRangeDistributionSpecSkeleton(mv, columnMetaToColRefMap);
+            distributionSpec = rangeSpec != null
+                    ? rangeSpec
+                    : DistributionSpec.createAnyDistributionSpec();
         }
 
         return distributionSpec;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -39,6 +39,7 @@ import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionDescBP;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
 import com.starrocks.sql.optimizer.base.SortProperty;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -186,14 +187,17 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
                                                            PhysicalPropertySet physicalPropertySet,
                                                            List<DistributionCol> leftOnPredicateColumns,
                                                            List<DistributionCol> rightOnPredicateColumns) {
-        // only HashDistributionSpec need update equivalentDescriptor
-        if (!physicalPropertySet.getDistributionProperty().isShuffle()) {
+        // Only specs carrying an EquivalentDescriptor need updating: hash
+        // (shuffle) and range (colocate). Other specs pass through unchanged.
+        DistributionSpec spec = physicalPropertySet.getDistributionProperty().getSpec();
+        EquivalentDescriptor equivDesc;
+        if (physicalPropertySet.getDistributionProperty().isShuffle()) {
+            equivDesc = ((HashDistributionSpec) spec).getEquivDesc();
+        } else if (spec instanceof RangeDistributionSpec) {
+            equivDesc = ((RangeDistributionSpec) spec).getEquivalentDescriptor();
+        } else {
             return physicalPropertySet;
         }
-
-        HashDistributionSpec distributionSpec = (HashDistributionSpec) physicalPropertySet.getDistributionProperty().getSpec();
-
-        EquivalentDescriptor equivDesc = distributionSpec.getEquivDesc();
 
         JoinOperator joinOperator = node.getJoinType();
         if (joinOperator.isAnyInnerJoin()) {
@@ -346,6 +350,18 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
         List<DistributionCol> leftOnPredicateColumns = joinHelper.getLeftCols();
         List<DistributionCol> rightOnPredicateColumns = joinHelper.getRightCols();
 
+        // Range-colocate join: both children are RangeDistributionSpec.
+        // ChildOutputPropertyGuarantor.canRangeColocateJoin already rejected
+        // right-family / full-outer joins, so the join type here is safe.
+        DistributionSpec leftRawSpec = leftChildOutputProperty.getDistributionProperty().getSpec();
+        DistributionSpec rightRawSpec = rightChildOutputProperty.getDistributionProperty().getSpec();
+        if (leftRawSpec instanceof RangeDistributionSpec && rightRawSpec instanceof RangeDistributionSpec) {
+            // Left-dominated output (inner / left-outer / left-semi / left-anti).
+            PhysicalPropertySet outputProperty = createPropertySetByDistribution(leftRawSpec);
+            return updateEquivalentDescriptor(node, outputProperty,
+                    leftOnPredicateColumns, rightOnPredicateColumns);
+        }
+
         DistributionProperty leftChildDistributionProperty = leftChildOutputProperty.getDistributionProperty();
         DistributionProperty rightChildDistributionProperty = rightChildOutputProperty.getDistributionProperty();
         if (leftChildDistributionProperty.isShuffle() && rightChildDistributionProperty.isShuffle()) {
@@ -473,18 +489,32 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
         // if RepeatColumnRef is (cola,colb),(cola), and childrenOutputProperties is hash(cola,colb)
         // since cola will be inserted with null value, it's unsafe to use hash(cola,colb)
         DistributionProperty outputDistribution = EmptyDistributionProperty.INSTANCE;
+        DistributionSpec childSpec = childDistribution.getSpec();
+        Set<Integer> commonRefs = subRefs.stream().map(ColumnRefOperator::getId).collect(Collectors.toSet());
         if (childDistribution.isShuffle()) {
             boolean canFollowChild = true;
-            HashDistributionSpec childDistributionSpec = (HashDistributionSpec) childDistribution.getSpec();
-            Set<Integer> commonRefs = subRefs.stream().map(ColumnRefOperator::getId).collect(Collectors.toSet());
-
+            HashDistributionSpec childDistributionSpec = (HashDistributionSpec) childSpec;
             for (DistributionCol col : childDistributionSpec.getHashDistributionDesc().getDistributionCols()) {
                 if (!commonRefs.contains(col.getColId())) {
                     canFollowChild = false;
                     break;
                 }
             }
-
+            if (canFollowChild) {
+                outputDistribution = childDistribution;
+            }
+        } else if (childSpec instanceof RangeDistributionSpec) {
+            // Range variant: use direct column-id intersection (not equivalence)
+            // because Repeat nulls out physical columns; equivalence through
+            // nulled columns is unsafe.
+            RangeDistributionSpec childRangeSpec = (RangeDistributionSpec) childSpec;
+            boolean canFollowChild = true;
+            for (DistributionCol col : childRangeSpec.getColocateColumns()) {
+                if (!commonRefs.contains(col.getColId())) {
+                    canFollowChild = false;
+                    break;
+                }
+            }
             if (canFollowChild) {
                 outputDistribution = childDistribution;
             }
@@ -503,6 +533,15 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
             return createPropertySetByDistribution(new HashDistributionSpec(
                     new HashDistributionDesc(((HashDistributionSpec) olapDistributionSpec).getShuffleColumns(),
                             HashDistributionDesc.SourceType.LOCAL), equivDesc));
+        } else if (olapDistributionSpec instanceof RangeDistributionSpec) {
+            // Rebuild with selected partitions (partition pruning ran between
+            // RelationTransformer skeleton construction and this point).
+            RangeDistributionSpec skeleton = (RangeDistributionSpec) olapDistributionSpec;
+            EquivalentDescriptor equivDesc = new EquivalentDescriptor(
+                    node.getTable().getId(), node.getSelectedPartitionId());
+            equivDesc.initDistributionUnionFind(skeleton.getColocateColumns());
+            return createPropertySetByDistribution(
+                    new RangeDistributionSpec(skeleton.getColocateColumns(), equivDesc));
         } else if (olapDistributionSpec.getType() == DistributionSpec.DistributionType.ANY) {
             return PhysicalPropertySet.EMPTY;
         } else {
@@ -701,14 +740,26 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
             return;
         }
 
-        if (!(oldProperty.getDistributionProperty().getSpec() instanceof HashDistributionSpec)) {
+        // Select the spec's colocate columns + its EquivalentDescriptor.
+        // Range spec uses the same EquivalentDescriptor plumbing as hash, so
+        // the same equivalence-union logic applies.
+        DistributionSpec spec = oldProperty.getDistributionProperty().getSpec();
+        List<DistributionCol> distributionCols;
+        EquivalentDescriptor equivDesc;
+        if (spec instanceof HashDistributionSpec) {
+            HashDistributionSpec hashSpec = (HashDistributionSpec) spec;
+            distributionCols = hashSpec.getShuffleColumns();
+            equivDesc = hashSpec.getEquivDesc();
+        } else if (spec instanceof RangeDistributionSpec) {
+            RangeDistributionSpec rangeSpec = (RangeDistributionSpec) spec;
+            distributionCols = rangeSpec.getColocateColumns();
+            equivDesc = rangeSpec.getEquivalentDescriptor();
+        } else {
             return;
         }
 
-        HashDistributionSpec distributionSpec =
-                (HashDistributionSpec) oldProperty.getDistributionProperty().getSpec();
         final Map<Integer, DistributionCol> idToDistributionCol = Maps.newHashMap();
-        distributionSpec.getShuffleColumns().forEach(e -> idToDistributionCol.put(e.getColId(), e));
+        distributionCols.forEach(e -> idToDistributionCol.put(e.getColId(), e));
 
         for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projection.getColumnRefMap().entrySet()) {
             ColumnRefSet usedCols = entry.getValue().getUsedColumns();
@@ -716,12 +767,12 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
             Optional<Boolean> nullStrictInfo = remainDistributionFunc(entry.getValue(), idToDistributionCol);
             if (nullStrictInfo.isPresent()) {
                 if (nullStrictInfo.get()) {
-                    distributionSpec.getEquivDesc().unionDistributionCols(
+                    equivDesc.unionDistributionCols(
                             new DistributionCol(entry.getKey().getId(), true),
                             idToDistributionCol.get(usedCols.getFirstId())
                     );
                 } else {
-                    distributionSpec.getEquivDesc().unionNullRelaxCols(
+                    equivDesc.unionNullRelaxCols(
                             new DistributionCol(entry.getKey().getId(), false),
                             idToDistributionCol.get(usedCols.getFirstId()).getNullRelaxCol()
                     );

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionProperty.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.base;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.Group;
 import com.starrocks.sql.optimizer.GroupExpression;
@@ -86,6 +87,12 @@ public class DistributionProperty implements PhysicalProperty {
     }
 
     public GroupExpression appendEnforcers(Group child) {
+        // RangeDistributionSpec is scan-local only; it must never be the
+        // required property of a distribution enforcer. Convert to a hash
+        // shuffle spec (see ChildOutputPropertyGuarantor.convertRangeToHashShuffle
+        // in PR-3) before attempting to enforce.
+        Preconditions.checkState(!(spec instanceof RangeDistributionSpec),
+                "RangeDistributionSpec must not be used as a distribution enforcer required property");
         return new GroupExpression(new PhysicalDistributionOperator(spec), Lists.newArrayList(child));
     }
 
@@ -97,6 +104,8 @@ public class DistributionProperty implements PhysicalProperty {
                         hashDistributionSpec.getEquivDesc()), isCTERequired);
             }
         }
+        // RangeDistributionSpec always builds colocate columns with
+        // nullStrict=true (see RangeDistributionSpec constructor); no conversion needed.
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionSpec.java
@@ -59,6 +59,7 @@ public class DistributionSpec {
         SHUFFLE,
         GATHER,
         ROUND_ROBIN,
+        RANGE_LOCAL,
         ;
 
         public TDistributionType toThrift() {
@@ -68,6 +69,10 @@ public class DistributionSpec {
                 return TDistributionType.BROADCAST;
             } else if (this == SHUFFLE) {
                 return TDistributionType.SHUFFLE;
+            } else if (this == RANGE_LOCAL) {
+                // RangeDistributionSpec is scan-local and must never reach thrift serialization.
+                throw new IllegalStateException(
+                        "DistributionType.RANGE_LOCAL must not be serialized to thrift");
             } else {
                 return TDistributionType.GATHER;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionSpecHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionSpecHelper.java
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.base;
+
+import com.starrocks.catalog.ColocateGroupSchema;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared helpers for building {@link DistributionSpec} instances from catalog
+ * metadata. Used by both {@code RelationTransformer.getTableDistributionSpec}
+ * and {@code MvRewritePreprocessor.getTableDistributionSpec} so that the
+ * range-colocate spec-construction logic has one implementation.
+ */
+public final class DistributionSpecHelper {
+    private DistributionSpecHelper() {
+    }
+
+    /**
+     * Build a skeleton {@link RangeDistributionSpec} for a range-distributed
+     * olap table when it belongs to a range-colocate group.
+     *
+     * <p>The returned spec has colocate columns resolved through the provided
+     * {@code columnMetaToColRefMap} but carries an empty
+     * {@link EquivalentDescriptor} (no partitions yet). Partition-aware
+     * rebuild happens later in
+     * {@code OutputPropertyDeriver.visitPhysicalOlapScan}, mirroring the hash
+     * pattern at {@code OutputPropertyDeriver.java:498}.
+     *
+     * @return a {@code RangeDistributionSpec} if the table is range-distributed
+     *         and part of a range-colocate group; {@code null} otherwise.
+     *         A {@code null} return lets callers fall back to
+     *         {@code AnyDistributionSpec}.
+     */
+    public static RangeDistributionSpec buildRangeDistributionSpecSkeleton(
+            OlapTable olapTable, Map<Column, ColumnRefOperator> columnMetaToColRefMap) {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long tableId = olapTable.getId();
+        if (!colocateTableIndex.isColocateTable(tableId)) {
+            return null;
+        }
+        ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(tableId);
+        if (groupId == null || !colocateTableIndex.isRangeColocateGroup(groupId)) {
+            return null;
+        }
+        ColocateGroupSchema groupSchema = colocateTableIndex.getGroupSchema(groupId);
+        if (groupSchema == null) {
+            // Metadata inconsistency (e.g. partial replay); fall back to ANY.
+            return null;
+        }
+        List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(olapTable);
+        int colocateCount = groupSchema.getColocateColumnCount();
+        if (sortKeyColumns.size() < colocateCount) {
+            // Defensive: catalog schema shorter than the colocate group expects.
+            // Fall back to ANY rather than throw during planning.
+            return null;
+        }
+        List<DistributionCol> colocateColumns = new ArrayList<>();
+        for (int i = 0; i < colocateCount; i++) {
+            Column column = sortKeyColumns.get(i);
+            ColumnRefOperator ref = columnMetaToColRefMap.get(column);
+            if (ref == null) {
+                // Some query shapes (sync MV, cache stats) may project away
+                // the colocate columns; fall back to ANY in the caller.
+                return null;
+            }
+            colocateColumns.add(new DistributionCol(ref.getId(), true));
+        }
+        EquivalentDescriptor emptyEquiv =
+                new EquivalentDescriptor(tableId, Collections.emptyList());
+        return new RangeDistributionSpec(colocateColumns, emptyEquiv);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/RangeDistributionSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/RangeDistributionSpec.java
@@ -1,0 +1,227 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.optimizer.base;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.server.GlobalStateMgr;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Distribution spec for lake tables that use range distribution with a
+ * colocate group. Scan-local only: carries the colocate columns and an
+ * {@link EquivalentDescriptor} so later optimizer phases can decide
+ * whether a range-colocate join avoids a shuffle.
+ *
+ * <h3>Satisfaction contract</h3>
+ * <ul>
+ * <li>{@link DistributionType#ANY} always satisfied.
+ * <li>Another {@code RangeDistributionSpec} — delegate to {@link #canColocate}
+ *     (structural check: same group, both stable, non-empty partitions,
+ *     equal colocate column count).
+ * <li>{@link HashDistributionSpec} with {@code SourceType.SHUFFLE_JOIN} —
+ *     satisfied when every colocate column is covered (set-based, via
+ *     {@code EquivalentDescriptor.isConnected(required, existing)}) by
+ *     some required shuffle column. {@code SHUFFLE_AGG},
+ *     {@code SHUFFLE_ENFORCE}, and {@code LOCAL} hash specs are rejected,
+ *     scoping cross-type satisfaction to hash-join contexts.
+ * <li>Anything else not satisfied.
+ * </ul>
+ *
+ * <h3>Invariants</h3>
+ * <ul>
+ * <li>{@link DistributionType#RANGE} never reaches thrift serialization;
+ *     {@code toThrift()} throws.
+ * <li>{@link DistributionProperty#appendEnforcers} refuses range —
+ *     {@code RangeDistributionSpec} must not be the required property of
+ *     a distribution enforcer. Use
+ *     {@code ChildOutputPropertyGuarantor.convertRangeToHashShuffle} to
+ *     materialize a hash shuffle exchange when needed.
+ * <li>{@code equals}/{@code hashCode} keyed on
+ *     {@code (DistributionType.RANGE_LOCAL, tableId, colocateColumns)}. The
+ *     mutable {@link EquivalentDescriptor} is intentionally excluded to
+ *     keep memo hash-key stable, mirroring {@code HashDistributionSpec}.
+ * </ul>
+ *
+ * <h3>Non-join defenses</h3>
+ * {@code SHUFFLE_JOIN} is emitted by set operations too
+ * ({@code PropertyDeriverBase.computeShuffleSetRequiredProperties}), so the
+ * source-type filter alone is not sufficient to restrict activation to
+ * joins. The set-op guarantor in
+ * {@code ChildOutputPropertyGuarantor.visitPhysicalSetOperation} runs a
+ * top-of-method range-normalization pass that converts every range child
+ * to hash {@code SHUFFLE_JOIN} before any {@code isShuffle()} precondition
+ * or {@code HashDistributionSpec} cast runs.
+ */
+public final class RangeDistributionSpec extends DistributionSpec {
+    private final List<DistributionCol> colocateColumns;
+    private final EquivalentDescriptor equivalentDescriptor;
+
+    public RangeDistributionSpec(List<DistributionCol> colocateColumns,
+                                 EquivalentDescriptor equivalentDescriptor) {
+        super(DistributionType.RANGE_LOCAL);
+        Preconditions.checkArgument(colocateColumns != null && !colocateColumns.isEmpty(),
+                "colocateColumns must be non-empty");
+        this.colocateColumns = ImmutableList.copyOf(colocateColumns);
+        this.equivalentDescriptor = Objects.requireNonNull(equivalentDescriptor);
+    }
+
+    public List<DistributionCol> getColocateColumns() {
+        return colocateColumns;
+    }
+
+    public EquivalentDescriptor getEquivalentDescriptor() {
+        return equivalentDescriptor;
+    }
+
+    /**
+     * Cross-type satisfaction.
+     *
+     * <ul>
+     * <li>ANY → always satisfied.
+     * <li>Another RangeDistributionSpec → {@link #canColocate}.
+     * <li>HashDistributionSpec with source type {@code SHUFFLE_JOIN} and
+     *     every colocate column covered by some required column via
+     *     {@link EquivalentDescriptor#isConnected} → satisfied.
+     *     {@code SHUFFLE_AGG}, {@code SHUFFLE_ENFORCE}, and {@code LOCAL}
+     *     hash specs are rejected, staging P2 to join contexts only.
+     * <li>Anything else → not satisfied.
+     * </ul>
+     *
+     * <p>Set operations also emit {@code SHUFFLE_JOIN}
+     * ({@code PropertyDeriverBase.computeShuffleSetRequiredProperties}), so
+     * this method alone is not sufficient to restrict P2 to joins — the
+     * second defense is the top-of-method range-normalization pass in
+     * {@code ChildOutputPropertyGuarantor.visitPhysicalSetOperation}.
+     */
+    @Override
+    public boolean isSatisfy(DistributionSpec spec) {
+        if (spec.getType() == DistributionType.ANY) {
+            return true;
+        }
+        if (spec instanceof RangeDistributionSpec) {
+            return canColocate((RangeDistributionSpec) spec);
+        }
+        if (spec instanceof HashDistributionSpec) {
+            return isSatisfyHashShuffle((HashDistributionSpec) spec);
+        }
+        return false;
+    }
+
+    /**
+     * Structural compatibility check. Each spec owns its own
+     * {@link EquivalentDescriptor} and the two are never merged, so
+     * cross-descriptor {@link EquivalentDescriptor#isConnected} would
+     * always return false and cannot be used here. Per-side
+     * colocate-vs-shuffle equivalence is checked in
+     * {@code ChildOutputPropertyGuarantor.canRangeColocateJoin}, which
+     * uses each side's own descriptor.
+     */
+    public boolean canColocate(RangeDistributionSpec other) {
+        ColocateTableIndex index = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long leftTableId = equivalentDescriptor.getTableId();
+        long rightTableId = other.equivalentDescriptor.getTableId();
+        if (!index.isSameGroup(leftTableId, rightTableId)) {
+            return false;
+        }
+        ColocateTableIndex.GroupId leftGroupId = index.getGroup(leftTableId);
+        ColocateTableIndex.GroupId rightGroupId = index.getGroup(rightTableId);
+        if (leftGroupId == null || rightGroupId == null) {
+            return false;
+        }
+        if (index.isGroupUnstable(leftGroupId) || index.isGroupUnstable(rightGroupId)) {
+            return false;
+        }
+        if (equivalentDescriptor.isEmptyPartition() || other.equivalentDescriptor.isEmptyPartition()) {
+            return false;
+        }
+        // Same ColocateGroupSchema guarantees identical colocate column count
+        // and types. The position-preserving pairing check in the join
+        // guarantor is what proves each pair is bound to the same equijoin.
+        Preconditions.checkState(colocateColumns.size() == other.colocateColumns.size(),
+                "colocate column count mismatch: %s vs %s",
+                colocateColumns.size(), other.colocateColumns.size());
+        return true;
+    }
+
+    /**
+     * Set-based cover check. Every colocate column must be equivalent to
+     * at least one required shuffle column; extras on the required side
+     * are fine. Order-independent. Matches hash precedent at
+     * {@code HashDistributionSpec.isJoinEqColumnsCompatible} with
+     * {@code isConnected(requiredCol, existingCol)} argument order.
+     */
+    private boolean isSatisfyHashShuffle(HashDistributionSpec hashSpec) {
+        HashDistributionDesc.SourceType sourceType =
+                hashSpec.getHashDistributionDesc().getSourceType();
+        if (sourceType != HashDistributionDesc.SourceType.SHUFFLE_JOIN) {
+            return false;
+        }
+        List<DistributionCol> requiredCols =
+                hashSpec.getHashDistributionDesc().getDistributionCols();
+        for (DistributionCol colocateCol : colocateColumns) {
+            boolean covered = requiredCols.stream()
+                    .anyMatch(req -> equivalentDescriptor.isConnected(req, colocateCol));
+            if (!covered) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Null-relaxed variant for symmetry with {@code HashDistributionSpec}.
+     * Not invoked by the P2 join planner because full-outer range colocate
+     * is rejected by the join-type allowlist; retained for parallelism and
+     * future phases.
+     */
+    public RangeDistributionSpec getNullRelaxSpec(EquivalentDescriptor descriptor) {
+        List<DistributionCol> relaxed = colocateColumns.stream()
+                .map(c -> new DistributionCol(c.getColId(), false))
+                .collect(Collectors.toUnmodifiableList());
+        return new RangeDistributionSpec(relaxed, descriptor);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof RangeDistributionSpec)) {
+            return false;
+        }
+        RangeDistributionSpec other = (RangeDistributionSpec) obj;
+        // equivalentDescriptor is mutable; exclude from equality to keep memo hash-key stable.
+        // Identity is (DistributionType.RANGE_LOCAL, tableId, colocateColumns) — mirrors HashDistributionSpec.
+        return equivalentDescriptor.getTableId() == other.equivalentDescriptor.getTableId()
+                && colocateColumns.equals(other.colocateColumns);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(DistributionType.RANGE_LOCAL,
+                equivalentDescriptor.getTableId(), colocateColumns);
+    }
+
+    @Override
+    public String toString() {
+        return "RANGE(" + colocateColumns + ")";
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -439,6 +439,14 @@ public class CostModel {
                 case ROUND_ROBIN:
                     result = CostEstimate.of(outputSize * factor, 0, outputSize * factor);
                     break;
+                case RANGE_LOCAL:
+                    // RangeDistributionSpec is scan-local only and must never
+                    // reach a PhysicalDistributionOperator (enforced by
+                    // DistributionProperty.appendEnforcers). Reaching the cost
+                    // model for RANGE_LOCAL is a bug.
+                    throw new StarRocksPlannerException(
+                            "RangeDistributionSpec cannot be the required property of an exchange",
+                            ErrorType.UNSUPPORTED);
                 default:
                     throw new StarRocksPlannerException(
                             "not support " + distributionSpec.getType() + "distribution type",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -42,6 +42,7 @@ import com.starrocks.sql.optimizer.base.EquivalentDescriptor;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -229,7 +230,7 @@ public class OptExpressionDuplicator {
             ImmutableMap<Column, ColumnRefOperator> newColumnMetaToColRefMap = columnMetaToColRefMapBuilder.build();
             scanBuilder.setColumnMetaToColRefMap(newColumnMetaToColRefMap);
 
-            // process HashDistributionSpec
+            // process HashDistributionSpec / RangeDistributionSpec
             if (scanOperator instanceof LogicalOlapScanOperator) {
                 LogicalOlapScanOperator olapScan = (LogicalOlapScanOperator) scanOperator;
                 LogicalOlapScanOperator.Builder olapScanBuilder = (LogicalOlapScanOperator.Builder) scanBuilder;
@@ -237,6 +238,10 @@ public class OptExpressionDuplicator {
                     HashDistributionSpec newHashDistributionSpec =
                             processHashDistributionSpec((HashDistributionSpec) olapScan.getDistributionSpec());
                     olapScanBuilder.setDistributionSpec(newHashDistributionSpec);
+                } else if (olapScan.getDistributionSpec() instanceof RangeDistributionSpec) {
+                    RangeDistributionSpec newRangeSpec =
+                            processRangeDistributionSpec((RangeDistributionSpec) olapScan.getDistributionSpec());
+                    olapScanBuilder.setDistributionSpec(newRangeSpec);
                 }
 
                 if (isResetSelectedPartitions) {
@@ -740,6 +745,26 @@ public class OptExpressionDuplicator {
             updateDistributionUnionFind(newEquivDesc.getNullRelaxUnionFind(), equivDesc.getNullStrictUnionFind());
             updateDistributionUnionFind(newEquivDesc.getNullStrictUnionFind(), equivDesc.getNullRelaxUnionFind());
             return new HashDistributionSpec(hashDistributionDesc, newEquivDesc);
+        }
+
+        // Rewrite colocate columns and the EquivalentDescriptor inside a
+        // RangeDistributionSpec, mirroring processHashDistributionSpec above.
+        // Column ids change when the scan is duplicated for MV rewrite.
+        private RangeDistributionSpec processRangeDistributionSpec(RangeDistributionSpec originSpec) {
+            final List<DistributionCol> newColumns = Lists.newArrayList();
+            for (DistributionCol col : originSpec.getColocateColumns()) {
+                final ColumnRefOperator newRefOperator = getNewDistributionColRef(col);
+                Preconditions.checkNotNull(newRefOperator);
+                newColumns.add(new DistributionCol(newRefOperator.getId(), col.isNullStrict()));
+            }
+            Preconditions.checkState(newColumns.size() == originSpec.getColocateColumns().size());
+
+            final EquivalentDescriptor equivDesc = originSpec.getEquivalentDescriptor();
+            final EquivalentDescriptor newEquivDesc = new EquivalentDescriptor(equivDesc.getTableId(),
+                    equivDesc.getPartitionIds());
+            updateDistributionUnionFind(newEquivDesc.getNullRelaxUnionFind(), equivDesc.getNullStrictUnionFind());
+            updateDistributionUnionFind(newEquivDesc.getNullStrictUnionFind(), equivDesc.getNullRelaxUnionFind());
+            return new RangeDistributionSpec(newColumns, newEquivDesc);
         }
 
         private void updateDistributionUnionFind(UnionFind<DistributionCol> newUnionFind,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -93,8 +93,10 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.DistributionSpecHelper;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.Ordering;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -588,7 +590,11 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
         } else if (distributionInfo.getType() == DistributionInfoType.RANDOM) {
             distributionSpec = DistributionSpec.createAnyDistributionSpec();
         } else if (distributionInfo.getType() == DistributionInfoType.RANGE) {
-            distributionSpec = DistributionSpec.createAnyDistributionSpec();
+            RangeDistributionSpec rangeSpec = DistributionSpecHelper
+                    .buildRangeDistributionSpecSkeleton(olapTable, columnMetaToColRefMap);
+            distributionSpec = rangeSpec != null
+                    ? rangeSpec
+                    : DistributionSpec.createAnyDistributionSpec();
         } else {
             throw new IllegalStateException("Unknown distribution type: " + distributionInfo.getType());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -155,6 +155,7 @@ import com.starrocks.sql.optimizer.base.HashDistributionDescBP;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.OrderSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -3335,15 +3336,20 @@ public class PlanFragmentBuilder {
         }
 
         private boolean isColocateJoin(OptExpression optExpression) {
-            // through the required properties type check if it is colocate join
+            // Colocate join detection: a required property is colocate when
+            // it is either a hash-LOCAL spec (classic colocate) or a
+            // RangeDistributionSpec (range colocate; scan-local by invariant).
             return optExpression.getRequiredProperties().stream().allMatch(
                     physicalPropertySet -> {
+                        DistributionSpec spec = physicalPropertySet.getDistributionProperty().getSpec();
+                        if (spec instanceof RangeDistributionSpec) {
+                            return true;
+                        }
                         if (!physicalPropertySet.getDistributionProperty().isShuffle()) {
                             return false;
                         }
                         HashDistributionDesc.SourceType hashSourceType =
-                                ((HashDistributionSpec) (physicalPropertySet.getDistributionProperty().getSpec()))
-                                        .getHashDistributionDesc().getSourceType();
+                                ((HashDistributionSpec) spec).getHashDistributionDesc().getSourceType();
                         return hashSourceType.equals(HashDistributionDesc.SourceType.LOCAL);
                     });
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlan2SQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlan2SQLBuilder.java
@@ -28,6 +28,7 @@ import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.SortPhase;
@@ -727,6 +728,16 @@ public class SPMPlan2SQLBuilder {
                     return HintNode.HINT_JOIN_BUCKET;
                 }
             } else {
+                // Colocate detection mirrors PlanFragmentBuilder.isColocateJoin:
+                // either hash-LOCAL on every required property, or a
+                // RangeDistributionSpec on every required property (range
+                // colocate; scan-local by invariant). Mixed or non-matching
+                // specs fall through to HINT_JOIN_SHUFFLE.
+                boolean allRange = optExpression.getRequiredProperties().stream()
+                        .allMatch(p -> p.getDistributionProperty().getSpec() instanceof RangeDistributionSpec);
+                if (allRange) {
+                    return HintNode.HINT_JOIN_COLOCATE;
+                }
                 Preconditions.checkState(optExpression.getRequiredProperties().stream()
                         .allMatch(p -> p.getDistributionProperty().isShuffle()));
                 if (optExpression.getRequiredProperties().stream().allMatch(p -> {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -1106,5 +1106,15 @@ public class ColocateTableIndexTest {
         // Verify via isGroupUnstable: for non-metaGroups, it checks unstableGroups (not MetaGroup).
         // Since we didn't mark it unstable, it should return false.
         Assertions.assertFalse(colocateTableIndex.isGroupUnstable(groupId));
+
+        // New in PR-1: isRangeColocateGroup distinguishes range vs hash groups.
+        Assertions.assertTrue(colocateTableIndex.isRangeColocateGroup(groupId));
+    }
+
+    @Test
+    public void testIsRangeColocateGroupForUnknownGroup() {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+        ColocateTableIndex.GroupId unknown = new ColocateTableIndex.GroupId(1L, 2L);
+        Assertions.assertFalse(colocateTableIndex.isRangeColocateGroup(unknown));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantorRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantorRangeTest.java
@@ -1,0 +1,330 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.HintNode;
+import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.optimizer.base.DistributionCol;
+import com.starrocks.sql.optimizer.base.EquivalentDescriptor;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
+import com.starrocks.sql.optimizer.task.TaskContext;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the PR-3 range-colocate-join gate in
+ * {@link ChildOutputPropertyGuarantor#canRangeColocateJoin}.
+ *
+ * <p>Covers:
+ * <ul>
+ * <li>Join-type allowlist (INNER, LEFT OUTER, LEFT SEMI, LEFT ANTI) —
+ *     RIGHT / FULL rejected.
+ * <li>Position-preserving pairing accepts identity join keys.
+ * <li>Position-preserving pairing rejects swapped-column joins.
+ * <li>Partial shuffle coverage rejected.
+ * <li>{@code disable_colocate_join} session kill.
+ * </ul>
+ */
+class ChildOutputPropertyGuarantorRangeTest {
+
+    private static RangeDistributionSpec buildSide(long tableId, int... colIds) {
+        EquivalentDescriptor descriptor = new EquivalentDescriptor(tableId, List.of(1L));
+        List<DistributionCol> cols = java.util.Arrays.stream(colIds)
+                .mapToObj(id -> new DistributionCol(id, true))
+                .collect(java.util.stream.Collectors.toList());
+        descriptor.initDistributionUnionFind(cols);
+        return new RangeDistributionSpec(cols, descriptor);
+    }
+
+    private static List<DistributionCol> cols(int... ids) {
+        return java.util.Arrays.stream(ids)
+                .mapToObj(id -> new DistributionCol(id, true))
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    private static ChildOutputPropertyGuarantor newGuarantor(@Mocked TaskContext taskContext) {
+        // ChildOutputPropertyGuarantor requires a TaskContext in its constructor;
+        // we only invoke the private helper canRangeColocateJoin via reflection,
+        // so the context internals are irrelevant.
+        return new ChildOutputPropertyGuarantor(taskContext, null, null, null, null, null, 0.0);
+    }
+
+    private static boolean invokeGate(ChildOutputPropertyGuarantor guarantor,
+                                      JoinOperator joinType,
+                                      RangeDistributionSpec left,
+                                      RangeDistributionSpec right,
+                                      List<DistributionCol> leftShuffle,
+                                      List<DistributionCol> rightShuffle) {
+        return invokeGate(guarantor, "", joinType, left, right, leftShuffle, rightShuffle);
+    }
+
+    private static boolean invokeGate(ChildOutputPropertyGuarantor guarantor,
+                                      String hint,
+                                      JoinOperator joinType,
+                                      RangeDistributionSpec left,
+                                      RangeDistributionSpec right,
+                                      List<DistributionCol> leftShuffle,
+                                      List<DistributionCol> rightShuffle) {
+        return Deencapsulation.invoke(guarantor, "canRangeColocateJoin",
+                hint, joinType, left, right, leftShuffle, rightShuffle);
+    }
+
+    @Test
+    void rejectsRightOuterJoin(@Mocked TaskContext taskContext) {
+        // Join-type allowlist is the earliest gate; no ConnectContext access.
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertFalse(invokeGate(newGuarantor(taskContext), JoinOperator.RIGHT_OUTER_JOIN,
+                left, right, cols(1, 2), cols(1, 2)));
+    }
+
+    @Test
+    void rejectsShuffleHint(@Mocked TaskContext taskContext) {
+        // User-specified HINT_JOIN_SHUFFLE must short-circuit before ConnectContext
+        // or canColocate — no ConnectContext expectations needed.
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertFalse(invokeGate(newGuarantor(taskContext),
+                HintNode.HINT_JOIN_SHUFFLE, JoinOperator.INNER_JOIN,
+                left, right, cols(1, 2), cols(1, 2)));
+    }
+
+    @Test
+    void rejectsSkewHint(@Mocked TaskContext taskContext) {
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertFalse(invokeGate(newGuarantor(taskContext),
+                HintNode.HINT_JOIN_SKEW, JoinOperator.INNER_JOIN,
+                left, right, cols(1, 2), cols(1, 2)));
+    }
+
+    @Test
+    void rejectsBucketHint(@Mocked TaskContext taskContext) {
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertFalse(invokeGate(newGuarantor(taskContext),
+                HintNode.HINT_JOIN_BUCKET, JoinOperator.INNER_JOIN,
+                left, right, cols(1, 2), cols(1, 2)));
+    }
+
+    @Test
+    void rejectsFullOuterJoin(@Mocked TaskContext taskContext) {
+        // Join-type allowlist is the earliest gate; no ConnectContext access.
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertFalse(invokeGate(newGuarantor(taskContext), JoinOperator.FULL_OUTER_JOIN,
+                left, right, cols(1, 2), cols(1, 2)));
+    }
+
+    @Test
+    void rejectsDisableColocateJoin(@Mocked TaskContext taskContext,
+                                    @Mocked ConnectContext connectContext,
+                                    @Mocked SessionVariable sessionVariable) {
+        new Expectations() {
+            {
+                ConnectContext.get();
+                result = connectContext;
+                connectContext.getSessionVariable();
+                result = sessionVariable;
+                sessionVariable.isDisableColocateJoin();
+                result = true;
+            }
+        };
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertFalse(invokeGate(newGuarantor(taskContext), JoinOperator.INNER_JOIN,
+                left, right, cols(1, 2), cols(1, 2)));
+    }
+
+    @Test
+    void rejectsDifferentShuffleArity(@Mocked TaskContext taskContext,
+                                      @Mocked ConnectContext connectContext,
+                                      @Mocked SessionVariable sessionVariable) {
+        new Expectations() {
+            {
+                ConnectContext.get();
+                result = connectContext;
+                connectContext.getSessionVariable();
+                result = sessionVariable;
+                sessionVariable.isDisableColocateJoin();
+                result = false;
+            }
+        };
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        // Left has 2 shuffle cols, right has 1 — mismatched arity.
+        assertFalse(invokeGate(newGuarantor(taskContext), JoinOperator.INNER_JOIN,
+                left, right, cols(1, 2), cols(1)));
+    }
+
+    @Test
+    void acceptsIdentityJoinOnColocateColumns(@Mocked TaskContext taskContext,
+                                              @Mocked ConnectContext connectContext,
+                                              @Mocked SessionVariable sessionVariable,
+                                              @Mocked GlobalStateMgr globalStateMgr,
+                                              @Mocked ColocateTableIndex colocateTableIndex) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 1L);
+        new Expectations() {
+            {
+                ConnectContext.get();
+                result = connectContext;
+                connectContext.getSessionVariable();
+                result = sessionVariable;
+                sessionVariable.isDisableColocateJoin();
+                result = false;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = true;
+                colocateTableIndex.getGroup(100L);
+                result = groupId;
+                colocateTableIndex.getGroup(200L);
+                result = groupId;
+                colocateTableIndex.isGroupUnstable(groupId);
+                result = false;
+            }
+        };
+        // Both sides: colocate = (1, 2); shuffle = (1, 2) — identity pairing.
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertTrue(invokeGate(newGuarantor(taskContext), JoinOperator.INNER_JOIN,
+                left, right, cols(1, 2), cols(1, 2)));
+    }
+
+    @Test
+    void rejectsSwappedColumnJoin(@Mocked TaskContext taskContext,
+                                  @Mocked ConnectContext connectContext,
+                                  @Mocked SessionVariable sessionVariable,
+                                  @Mocked GlobalStateMgr globalStateMgr,
+                                  @Mocked ColocateTableIndex colocateTableIndex) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 1L);
+        new Expectations() {
+            {
+                ConnectContext.get();
+                result = connectContext;
+                connectContext.getSessionVariable();
+                result = sessionVariable;
+                sessionVariable.isDisableColocateJoin();
+                result = false;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = true;
+                colocateTableIndex.getGroup(100L);
+                result = groupId;
+                colocateTableIndex.getGroup(200L);
+                result = groupId;
+                colocateTableIndex.isGroupUnstable(groupId);
+                result = false;
+            }
+        };
+        // Left colocate (1, 2); shuffle (1, 2) — OK.
+        // Right colocate (1, 2); shuffle (2, 1) — swapped:
+        //   rightColocate[0]=col1 paired with rightShuffle[0]=col2 (no match),
+        //   rightColocate[0]=col1 paired with rightShuffle[1]=col1 (match at k=1),
+        // but leftColocate[0]=col1 requires leftShuffle[k=1]=col2 which is not equivalent.
+        // → pair not found → rejected.
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertFalse(invokeGate(newGuarantor(taskContext), JoinOperator.INNER_JOIN,
+                left, right, cols(1, 2), cols(2, 1)));
+    }
+
+    @Test
+    void rejectsPartialShuffleCoverage(@Mocked TaskContext taskContext,
+                                       @Mocked ConnectContext connectContext,
+                                       @Mocked SessionVariable sessionVariable,
+                                       @Mocked GlobalStateMgr globalStateMgr,
+                                       @Mocked ColocateTableIndex colocateTableIndex) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 1L);
+        new Expectations() {
+            {
+                ConnectContext.get();
+                result = connectContext;
+                connectContext.getSessionVariable();
+                result = sessionVariable;
+                sessionVariable.isDisableColocateJoin();
+                result = false;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = true;
+                colocateTableIndex.getGroup(100L);
+                result = groupId;
+                colocateTableIndex.getGroup(200L);
+                result = groupId;
+                colocateTableIndex.isGroupUnstable(groupId);
+                result = false;
+            }
+        };
+        // Colocate cols = (1, 2); shuffle only covers (1) → partial coverage unsafe.
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertFalse(invokeGate(newGuarantor(taskContext), JoinOperator.INNER_JOIN,
+                left, right, cols(1), cols(1)));
+    }
+
+    @Test
+    void acceptsLeftSemiJoin(@Mocked TaskContext taskContext,
+                             @Mocked ConnectContext connectContext,
+                             @Mocked SessionVariable sessionVariable,
+                             @Mocked GlobalStateMgr globalStateMgr,
+                             @Mocked ColocateTableIndex colocateTableIndex) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 1L);
+        new Expectations() {
+            {
+                ConnectContext.get();
+                result = connectContext;
+                connectContext.getSessionVariable();
+                result = sessionVariable;
+                sessionVariable.isDisableColocateJoin();
+                result = false;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = true;
+                colocateTableIndex.getGroup(100L);
+                result = groupId;
+                colocateTableIndex.getGroup(200L);
+                result = groupId;
+                colocateTableIndex.isGroupUnstable(groupId);
+                result = false;
+            }
+        };
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertTrue(invokeGate(newGuarantor(taskContext), JoinOperator.LEFT_SEMI_JOIN,
+                left, right, cols(1, 2), cols(1, 2)));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OutputPropertyDeriverRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OutputPropertyDeriverRangeTest.java
@@ -1,0 +1,210 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.sql.optimizer.base.AnyDistributionSpec;
+import com.starrocks.sql.optimizer.base.DistributionCol;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.EquivalentDescriptor;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalRepeatOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.IntegerType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Direct unit tests for the range-aware branches of {@link OutputPropertyDeriver}:
+ * scan rebuild with partitions, Repeat preserve/drop, projection remap.
+ * {@code visitPhysicalJoin} range emission is exercised indirectly via
+ * {@link ChildOutputPropertyGuarantorRangeTest}; here we keep the tests
+ * constructor-driven to avoid a full {@code GroupExpression} fixture.
+ */
+class OutputPropertyDeriverRangeTest {
+
+    private static OutputPropertyDeriver newDeriver(List<PhysicalPropertySet> childrenOutputProperties) {
+        return new OutputPropertyDeriver(null, null, childrenOutputProperties);
+    }
+
+    private static RangeDistributionSpec buildRangeSkeleton(long tableId, int... colIds) {
+        EquivalentDescriptor descriptor = new EquivalentDescriptor(tableId, Collections.emptyList());
+        List<DistributionCol> cols = java.util.Arrays.stream(colIds)
+                .mapToObj(id -> new DistributionCol(id, true))
+                .collect(java.util.stream.Collectors.toList());
+        descriptor.initDistributionUnionFind(cols);
+        return new RangeDistributionSpec(cols, descriptor);
+    }
+
+    @Test
+    void visitPhysicalOlapScanRebuildsRangeSpecWithPartitions(
+            @Mocked PhysicalOlapScanOperator node,
+            @Mocked OlapTable table) {
+        RangeDistributionSpec skeleton = buildRangeSkeleton(100L, 1, 2);
+        List<Long> selectedPartitions = List.of(10L, 20L);
+        new Expectations() {
+            {
+                node.getDistributionSpec();
+                result = skeleton;
+                node.getTable();
+                result = table;
+                node.getSelectedPartitionId();
+                result = selectedPartitions;
+                table.getId();
+                result = 100L;
+            }
+        };
+
+        OutputPropertyDeriver deriver = newDeriver(Collections.emptyList());
+        // visitPhysicalOlapScan is public; call it directly. ExpressionContext
+        // is unused for the range branch.
+        PhysicalPropertySet output = deriver.visitPhysicalOlapScan(node, null);
+
+        DistributionSpec spec = output.getDistributionProperty().getSpec();
+        assertInstanceOf(RangeDistributionSpec.class, spec);
+        RangeDistributionSpec rebuilt = (RangeDistributionSpec) spec;
+        assertEquals(skeleton.getColocateColumns(), rebuilt.getColocateColumns());
+        assertEquals(100L, rebuilt.getEquivalentDescriptor().getTableId());
+        assertEquals(selectedPartitions, rebuilt.getEquivalentDescriptor().getPartitionIds());
+    }
+
+    @Test
+    void visitPhysicalRepeatPreservesRangeWhenIntersectionCoversColocateCols(
+            @Mocked PhysicalRepeatOperator node) {
+        // Repeat intersection includes every colocate column id → preserve.
+        RangeDistributionSpec childSpec = buildRangeSkeleton(100L, 1, 2);
+        PhysicalPropertySet childProperty =
+                new PhysicalPropertySet(
+                        com.starrocks.sql.optimizer.base.DistributionProperty.createProperty(childSpec));
+
+        ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "a", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, IntegerType.INT, "b", true);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, IntegerType.INT, "c", true);
+        // Both grouping subsets contain {1, 2} → intersection = {1, 2}.
+        new Expectations() {
+            {
+                node.getRepeatColumnRef();
+                result = java.util.Arrays.asList(
+                        com.google.common.collect.Lists.newArrayList(col1, col2),
+                        com.google.common.collect.Lists.newArrayList(col1, col2, col3));
+            }
+        };
+
+        OutputPropertyDeriver deriver = newDeriver(List.of(childProperty));
+        PhysicalPropertySet output = deriver.visitPhysicalRepeat(node, null);
+        assertInstanceOf(RangeDistributionSpec.class,
+                output.getDistributionProperty().getSpec());
+    }
+
+    @Test
+    void visitPhysicalRepeatDropsRangeWhenColocateColNotInIntersection(
+            @Mocked PhysicalRepeatOperator node) {
+        // Intersection drops column 2 (only in first subset) → range dropped.
+        RangeDistributionSpec childSpec = buildRangeSkeleton(100L, 1, 2);
+        PhysicalPropertySet childProperty =
+                new PhysicalPropertySet(
+                        com.starrocks.sql.optimizer.base.DistributionProperty.createProperty(childSpec));
+
+        ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "a", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, IntegerType.INT, "b", true);
+        new Expectations() {
+            {
+                node.getRepeatColumnRef();
+                result = java.util.Arrays.asList(
+                        com.google.common.collect.Lists.newArrayList(col1, col2),
+                        com.google.common.collect.Lists.newArrayList(col1));
+            }
+        };
+
+        OutputPropertyDeriver deriver = newDeriver(List.of(childProperty));
+        PhysicalPropertySet output = deriver.visitPhysicalRepeat(node, null);
+        // Output distribution should be EMPTY (AnyDistributionSpec); not range.
+        assertSame(AnyDistributionSpec.INSTANCE,
+                output.getDistributionProperty().getSpec());
+    }
+
+    @Test
+    void updatePropertyWithProjectionExtendsRangeEquivalenceOnAlias(
+            @Mocked Projection projection) {
+        RangeDistributionSpec childSpec = buildRangeSkeleton(100L, 1);
+        PhysicalPropertySet childProperty =
+                new PhysicalPropertySet(
+                        com.starrocks.sql.optimizer.base.DistributionProperty.createProperty(childSpec));
+
+        // Projection renames column 1 → column 100 (identity ref).
+        ColumnRefOperator aliased = new ColumnRefOperator(100, IntegerType.INT, "a_alias", true);
+        ColumnRefOperator existing = new ColumnRefOperator(1, IntegerType.INT, "a", true);
+        ImmutableMap<ColumnRefOperator, ScalarOperator> map = ImmutableMap.of(aliased, existing);
+        new Expectations() {
+            {
+                projection.getColumnRefMap();
+                result = map;
+            }
+        };
+
+        OutputPropertyDeriver deriver = newDeriver(Collections.emptyList());
+        Deencapsulation.invoke(deriver, "updatePropertyWithProjection", projection, childProperty);
+
+        // The range spec's EquivalentDescriptor should now link col 1 with col 100
+        // so a later lookup with col 100 finds col 1's class.
+        EquivalentDescriptor equivDesc = childSpec.getEquivalentDescriptor();
+        DistributionCol colocateCol = childSpec.getColocateColumns().get(0);
+        DistributionCol aliasCol = new DistributionCol(100, true);
+        org.junit.jupiter.api.Assertions.assertTrue(
+                equivDesc.isConnected(aliasCol, colocateCol),
+                "alias should be connected to the colocate column in the descriptor");
+    }
+
+    @Test
+    void updatePropertyWithProjectionNoOpOnNullProjection() throws Exception {
+        RangeDistributionSpec childSpec = buildRangeSkeleton(100L, 1);
+        PhysicalPropertySet childProperty =
+                new PhysicalPropertySet(
+                        com.starrocks.sql.optimizer.base.DistributionProperty.createProperty(childSpec));
+        OutputPropertyDeriver deriver = newDeriver(Collections.emptyList());
+        // null projection — early-return path. Use reflection directly since
+        // JMockit's Deencapsulation.invoke rejects null args.
+        Method method = OutputPropertyDeriver.class.getDeclaredMethod(
+                "updatePropertyWithProjection", Projection.class, PhysicalPropertySet.class);
+        method.setAccessible(true);
+        method.invoke(deriver, null, childProperty);
+        // No assertion needed beyond "did not throw".
+    }
+
+    @Test
+    void updatePropertyWithProjectionNoOpOnUnsupportedSpec(@Mocked Projection projection) {
+        // Pass an AnyDistributionSpec-backed property. updatePropertyWithProjection
+        // should return without touching projection.
+        PhysicalPropertySet childProperty = PhysicalPropertySet.EMPTY;
+        OutputPropertyDeriver deriver = newDeriver(Collections.emptyList());
+        Deencapsulation.invoke(deriver, "updatePropertyWithProjection", projection, childProperty);
+        // No assertion needed beyond "did not throw and did not read projection".
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/DistributionPropertyRangeInvariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/DistributionPropertyRangeInvariantTest.java
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.base;
+
+import com.starrocks.sql.optimizer.Group;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * PR-2 invariant tests: range-distribution spec must never reach
+ * distribution enforcement, and null-strict conversion is a no-op for range.
+ */
+class DistributionPropertyRangeInvariantTest {
+
+    private static RangeDistributionSpec buildRange() {
+        EquivalentDescriptor descriptor = new EquivalentDescriptor(100L, Collections.emptyList());
+        List<DistributionCol> cols = List.of(new DistributionCol(1, true));
+        descriptor.initDistributionUnionFind(cols);
+        return new RangeDistributionSpec(cols, descriptor);
+    }
+
+    @Test
+    void appendEnforcersRejectsRangeSpec() {
+        DistributionProperty property =
+                DistributionProperty.createProperty(buildRange(), false);
+        Group childGroup = Mockito.mock(Group.class);
+        assertThrows(IllegalStateException.class,
+                () -> property.appendEnforcers(childGroup));
+    }
+
+    @Test
+    void getNullStrictPropertyIsIdentityForRange() {
+        // Range colocate columns are always constructed with nullStrict=true.
+        // getNullStrictProperty should be a no-op (returns the same instance).
+        DistributionProperty property =
+                DistributionProperty.createProperty(buildRange(), false);
+        assertSame(property, property.getNullStrictProperty());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/DistributionSpecHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/DistributionSpecHelperTest.java
@@ -1,0 +1,264 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.base;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.ColocateGroupSchema;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.type.IntegerType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for {@link DistributionSpecHelper#buildRangeDistributionSpecSkeleton}.
+ * Covers the null-fallback paths (unknown group, non-range group, missing
+ * groupSchema, catalog-schema-too-short, column not in map) plus the happy path.
+ */
+class DistributionSpecHelperTest {
+
+    private static final long TABLE_ID = 100L;
+
+    private static Column col(String name) {
+        return new Column(name, IntegerType.INT);
+    }
+
+    private static Map<Column, ColumnRefOperator> mapping(Column... cs) {
+        ImmutableMap.Builder<Column, ColumnRefOperator> b = ImmutableMap.builder();
+        int nextId = 1;
+        for (Column c : cs) {
+            b.put(c, new ColumnRefOperator(nextId++, IntegerType.INT, c.getName(), true));
+        }
+        return b.build();
+    }
+
+    @Test
+    void nullWhenTableNotColocate(@Mocked OlapTable olapTable,
+                                  @Mocked GlobalStateMgr globalStateMgr,
+                                  @Mocked ColocateTableIndex colocateTableIndex) {
+        new Expectations() {
+            {
+                olapTable.getId();
+                result = TABLE_ID;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isColocateTable(TABLE_ID);
+                result = false;
+            }
+        };
+        assertNull(DistributionSpecHelper.buildRangeDistributionSpecSkeleton(
+                olapTable, mapping(col("a"))));
+    }
+
+    @Test
+    void nullWhenGroupIsNull(@Mocked OlapTable olapTable,
+                             @Mocked GlobalStateMgr globalStateMgr,
+                             @Mocked ColocateTableIndex colocateTableIndex) {
+        new Expectations() {
+            {
+                olapTable.getId();
+                result = TABLE_ID;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isColocateTable(TABLE_ID);
+                result = true;
+                colocateTableIndex.getGroup(TABLE_ID);
+                result = null;
+            }
+        };
+        assertNull(DistributionSpecHelper.buildRangeDistributionSpecSkeleton(
+                olapTable, mapping(col("a"))));
+    }
+
+    @Test
+    void nullWhenHashGroup(@Mocked OlapTable olapTable,
+                           @Mocked GlobalStateMgr globalStateMgr,
+                           @Mocked ColocateTableIndex colocateTableIndex) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 2L);
+        new Expectations() {
+            {
+                olapTable.getId();
+                result = TABLE_ID;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isColocateTable(TABLE_ID);
+                result = true;
+                colocateTableIndex.getGroup(TABLE_ID);
+                result = groupId;
+                colocateTableIndex.isRangeColocateGroup(groupId);
+                result = false;
+            }
+        };
+        assertNull(DistributionSpecHelper.buildRangeDistributionSpecSkeleton(
+                olapTable, mapping(col("a"))));
+    }
+
+    @Test
+    void nullWhenGroupSchemaMissing(@Mocked OlapTable olapTable,
+                                    @Mocked GlobalStateMgr globalStateMgr,
+                                    @Mocked ColocateTableIndex colocateTableIndex) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 2L);
+        new Expectations() {
+            {
+                olapTable.getId();
+                result = TABLE_ID;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isColocateTable(TABLE_ID);
+                result = true;
+                colocateTableIndex.getGroup(TABLE_ID);
+                result = groupId;
+                colocateTableIndex.isRangeColocateGroup(groupId);
+                result = true;
+                colocateTableIndex.getGroupSchema(groupId);
+                result = null;
+            }
+        };
+        assertNull(DistributionSpecHelper.buildRangeDistributionSpecSkeleton(
+                olapTable, mapping(col("a"))));
+    }
+
+    @Test
+    void nullWhenCatalogSchemaShorterThanColocateCount(@Mocked OlapTable olapTable,
+                                                        @Mocked GlobalStateMgr globalStateMgr,
+                                                        @Mocked ColocateTableIndex colocateTableIndex,
+                                                        @Mocked ColocateGroupSchema schema,
+                                                        @Mocked MetaUtils metaUtils) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 2L);
+        Column onlyCol = col("a");
+        new Expectations() {
+            {
+                olapTable.getId();
+                result = TABLE_ID;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isColocateTable(TABLE_ID);
+                result = true;
+                colocateTableIndex.getGroup(TABLE_ID);
+                result = groupId;
+                colocateTableIndex.isRangeColocateGroup(groupId);
+                result = true;
+                colocateTableIndex.getGroupSchema(groupId);
+                result = schema;
+                MetaUtils.getRangeDistributionColumns(olapTable);
+                result = List.of(onlyCol);
+                schema.getColocateColumnCount();
+                result = 2; // group expects 2 cols; catalog has 1 → fallback.
+            }
+        };
+        assertNull(DistributionSpecHelper.buildRangeDistributionSpecSkeleton(
+                olapTable, mapping(onlyCol)));
+    }
+
+    @Test
+    void nullWhenColumnMissingFromRefMap(@Mocked OlapTable olapTable,
+                                          @Mocked GlobalStateMgr globalStateMgr,
+                                          @Mocked ColocateTableIndex colocateTableIndex,
+                                          @Mocked ColocateGroupSchema schema,
+                                          @Mocked MetaUtils metaUtils) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 2L);
+        Column colA = col("a");
+        Column colB = col("b");
+        new Expectations() {
+            {
+                olapTable.getId();
+                result = TABLE_ID;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isColocateTable(TABLE_ID);
+                result = true;
+                colocateTableIndex.getGroup(TABLE_ID);
+                result = groupId;
+                colocateTableIndex.isRangeColocateGroup(groupId);
+                result = true;
+                colocateTableIndex.getGroupSchema(groupId);
+                result = schema;
+                MetaUtils.getRangeDistributionColumns(olapTable);
+                result = List.of(colA, colB);
+                schema.getColocateColumnCount();
+                result = 2;
+            }
+        };
+        // Provide mapping only for colA; colB missing → fallback to null.
+        assertNull(DistributionSpecHelper.buildRangeDistributionSpecSkeleton(
+                olapTable, mapping(colA)));
+    }
+
+    @Test
+    void buildsSkeletonSpecOnHappyPath(@Mocked OlapTable olapTable,
+                                       @Mocked GlobalStateMgr globalStateMgr,
+                                       @Mocked ColocateTableIndex colocateTableIndex,
+                                       @Mocked ColocateGroupSchema schema,
+                                       @Mocked MetaUtils metaUtils) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 2L);
+        Column colA = col("a");
+        Column colB = col("b");
+        Map<Column, ColumnRefOperator> map = mapping(colA, colB);
+        new Expectations() {
+            {
+                olapTable.getId();
+                result = TABLE_ID;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isColocateTable(TABLE_ID);
+                result = true;
+                colocateTableIndex.getGroup(TABLE_ID);
+                result = groupId;
+                colocateTableIndex.isRangeColocateGroup(groupId);
+                result = true;
+                colocateTableIndex.getGroupSchema(groupId);
+                result = schema;
+                MetaUtils.getRangeDistributionColumns(olapTable);
+                result = List.of(colA, colB);
+                schema.getColocateColumnCount();
+                result = 2;
+            }
+        };
+        RangeDistributionSpec spec =
+                DistributionSpecHelper.buildRangeDistributionSpecSkeleton(olapTable, map);
+        assertNotNull(spec);
+        assertEquals(2, spec.getColocateColumns().size());
+        assertEquals(map.get(colA).getId(), spec.getColocateColumns().get(0).getColId());
+        assertEquals(map.get(colB).getId(), spec.getColocateColumns().get(1).getColId());
+        assertEquals(TABLE_ID, spec.getEquivalentDescriptor().getTableId());
+        assertEquals(DistributionSpec.DistributionType.RANGE_LOCAL, spec.getType());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/RangeDistributionSpecTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/RangeDistributionSpecTest.java
@@ -1,0 +1,320 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.base;
+
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TDistributionType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link RangeDistributionSpec}.
+ * Covers both structural behavior (equals/hashCode/toString/toThrift) and
+ * the PR-3 set-based cross-type {@link RangeDistributionSpec#isSatisfy}
+ * and {@link RangeDistributionSpec#canColocate} logic.
+ */
+class RangeDistributionSpecTest {
+
+    private static RangeDistributionSpec build(long tableId, DistributionCol... cols) {
+        EquivalentDescriptor descriptor = new EquivalentDescriptor(tableId, List.of(1L));
+        List<DistributionCol> colocateColumns = List.of(cols);
+        descriptor.initDistributionUnionFind(colocateColumns);
+        return new RangeDistributionSpec(colocateColumns, descriptor);
+    }
+
+    private static RangeDistributionSpec buildEmptyPartitions(long tableId, DistributionCol... cols) {
+        EquivalentDescriptor descriptor = new EquivalentDescriptor(tableId, Collections.emptyList());
+        List<DistributionCol> colocateColumns = List.of(cols);
+        descriptor.initDistributionUnionFind(colocateColumns);
+        return new RangeDistributionSpec(colocateColumns, descriptor);
+    }
+
+    private static HashDistributionSpec hashShuffleJoin(int... colIds) {
+        List<DistributionCol> cols = java.util.Arrays.stream(colIds)
+                .mapToObj(id -> new DistributionCol(id, true))
+                .collect(java.util.stream.Collectors.toList());
+        HashDistributionDesc desc = new HashDistributionDesc(cols, HashDistributionDesc.SourceType.SHUFFLE_JOIN);
+        return new HashDistributionSpec(desc);
+    }
+
+    @Test
+    void emptyColocateColumnsRejected() {
+        EquivalentDescriptor descriptor = new EquivalentDescriptor(1L, Collections.emptyList());
+        assertThrows(IllegalArgumentException.class,
+                () -> new RangeDistributionSpec(Collections.emptyList(), descriptor));
+    }
+
+    @Test
+    void distributionTypeIsRange() {
+        RangeDistributionSpec spec = build(100L, new DistributionCol(1, true));
+        assertEquals(DistributionSpec.DistributionType.RANGE_LOCAL, spec.getType());
+    }
+
+    @Test
+    void isSatisfyAny() {
+        RangeDistributionSpec spec = build(100L, new DistributionCol(1, true));
+        assertTrue(spec.isSatisfy(AnyDistributionSpec.INSTANCE));
+    }
+
+    @Test
+    void isSatisfyRejectsOtherDistributionTypes() {
+        RangeDistributionSpec spec = build(100L, new DistributionCol(1, true));
+        assertFalse(spec.isSatisfy(new RoundRobinDistributionSpec()));
+        assertFalse(spec.isSatisfy(new ReplicatedDistributionSpec()));
+        assertFalse(spec.isSatisfy(new GatherDistributionSpec()));
+    }
+
+    @Test
+    void isSatisfyRejectsHashLocalAndShuffleAgg() {
+        RangeDistributionSpec spec = build(100L, new DistributionCol(1, true));
+        List<DistributionCol> cols = List.of(new DistributionCol(1, true));
+        HashDistributionSpec localHash = new HashDistributionSpec(
+                new HashDistributionDesc(cols, HashDistributionDesc.SourceType.LOCAL));
+        HashDistributionSpec aggShuffle = new HashDistributionSpec(
+                new HashDistributionDesc(cols, HashDistributionDesc.SourceType.SHUFFLE_AGG));
+        HashDistributionSpec enforceShuffle = new HashDistributionSpec(
+                new HashDistributionDesc(cols, HashDistributionDesc.SourceType.SHUFFLE_ENFORCE));
+        assertFalse(spec.isSatisfy(localHash));
+        assertFalse(spec.isSatisfy(aggShuffle));
+        assertFalse(spec.isSatisfy(enforceShuffle));
+    }
+
+    @Test
+    void isSatisfyHashShuffleJoinCoverage() {
+        // Colocate cols = [1, 2]; required shuffle covers [1, 2] exactly.
+        RangeDistributionSpec spec = build(100L, new DistributionCol(1, true), new DistributionCol(2, true));
+        assertTrue(spec.isSatisfy(hashShuffleJoin(1, 2)));
+        // Permuted required order is OK (set-based match).
+        assertTrue(spec.isSatisfy(hashShuffleJoin(2, 1)));
+        // Extra required columns beyond the colocate set are OK.
+        assertTrue(spec.isSatisfy(hashShuffleJoin(1, 2, 3)));
+    }
+
+    @Test
+    void isSatisfyHashShuffleJoinPartialCoverageRejected() {
+        // Colocate cols = [1, 2]; required only covers [1] → unsafe (GROUP BY a against colocate (a, b)).
+        RangeDistributionSpec spec = build(100L, new DistributionCol(1, true), new DistributionCol(2, true));
+        assertFalse(spec.isSatisfy(hashShuffleJoin(1)));
+    }
+
+    @Test
+    void canColocateSameGroupStable(@Mocked GlobalStateMgr globalStateMgr,
+                                    @Mocked ColocateTableIndex colocateTableIndex) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 1L);
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = true;
+                colocateTableIndex.getGroup(100L);
+                result = groupId;
+                colocateTableIndex.getGroup(200L);
+                result = groupId;
+                colocateTableIndex.isGroupUnstable(groupId);
+                result = false;
+            }
+        };
+        RangeDistributionSpec left = build(100L, new DistributionCol(1, true));
+        RangeDistributionSpec right = build(200L, new DistributionCol(2, true));
+        assertTrue(left.canColocate(right));
+    }
+
+    @Test
+    void canColocateRejectsDifferentGroup(@Mocked GlobalStateMgr globalStateMgr,
+                                          @Mocked ColocateTableIndex colocateTableIndex) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = false;
+            }
+        };
+        RangeDistributionSpec left = build(100L, new DistributionCol(1, true));
+        RangeDistributionSpec right = build(200L, new DistributionCol(2, true));
+        assertFalse(left.canColocate(right));
+    }
+
+    @Test
+    void canColocateRejectsUnstableGroup(@Mocked GlobalStateMgr globalStateMgr,
+                                         @Mocked ColocateTableIndex colocateTableIndex) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 1L);
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = true;
+                colocateTableIndex.getGroup(100L);
+                result = groupId;
+                colocateTableIndex.getGroup(200L);
+                result = groupId;
+                colocateTableIndex.isGroupUnstable(groupId);
+                result = true;
+            }
+        };
+        RangeDistributionSpec left = build(100L, new DistributionCol(1, true));
+        RangeDistributionSpec right = build(200L, new DistributionCol(2, true));
+        assertFalse(left.canColocate(right));
+    }
+
+    @Test
+    void canColocateRejectsEmptyPartition(@Mocked GlobalStateMgr globalStateMgr,
+                                          @Mocked ColocateTableIndex colocateTableIndex) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 1L);
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = true;
+                colocateTableIndex.getGroup(100L);
+                result = groupId;
+                colocateTableIndex.getGroup(200L);
+                result = groupId;
+                colocateTableIndex.isGroupUnstable(groupId);
+                result = false;
+            }
+        };
+        RangeDistributionSpec left = buildEmptyPartitions(100L, new DistributionCol(1, true));
+        RangeDistributionSpec right = build(200L, new DistributionCol(2, true));
+        assertFalse(left.canColocate(right));
+    }
+
+    @Test
+    void equalsAndHashCodeBasedOnTableAndColumns() {
+        RangeDistributionSpec a = build(100L, new DistributionCol(1, true), new DistributionCol(2, true));
+        RangeDistributionSpec b = build(100L, new DistributionCol(1, true), new DistributionCol(2, true));
+        RangeDistributionSpec differentTable = build(999L, new DistributionCol(1, true), new DistributionCol(2, true));
+        RangeDistributionSpec differentCols = build(100L, new DistributionCol(3, true), new DistributionCol(4, true));
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, differentTable);
+        assertNotEquals(a, differentCols);
+        assertNotEquals(a, new RoundRobinDistributionSpec());
+    }
+
+    @Test
+    void toStringIncludesColocateColumns() {
+        RangeDistributionSpec spec = build(100L, new DistributionCol(1, true));
+        assertTrue(spec.toString().startsWith("RANGE("));
+    }
+
+    @Test
+    void toThriftRangeThrows() {
+        assertThrows(IllegalStateException.class,
+                () -> DistributionSpec.DistributionType.RANGE_LOCAL.toThrift());
+    }
+
+    @Test
+    void toThriftRoundRobinFallsBackToGather() {
+        assertEquals(TDistributionType.GATHER,
+                DistributionSpec.DistributionType.ROUND_ROBIN.toThrift());
+    }
+
+    @Test
+    void toThriftKnownTypesUnchanged() {
+        assertEquals(TDistributionType.ANY,
+                DistributionSpec.DistributionType.ANY.toThrift());
+        assertEquals(TDistributionType.BROADCAST,
+                DistributionSpec.DistributionType.BROADCAST.toThrift());
+        assertEquals(TDistributionType.SHUFFLE,
+                DistributionSpec.DistributionType.SHUFFLE.toThrift());
+        assertEquals(TDistributionType.GATHER,
+                DistributionSpec.DistributionType.GATHER.toThrift());
+    }
+
+    @Test
+    void equalsIdentityShortCircuit() {
+        // Exercise the `this == obj` branch of equals.
+        RangeDistributionSpec spec = build(100L, new DistributionCol(1, true));
+        assertEquals(spec, spec);
+    }
+
+    @Test
+    void isSatisfyRangeDispatchesToCanColocate(@Mocked GlobalStateMgr globalStateMgr,
+                                                @Mocked ColocateTableIndex colocateTableIndex) {
+        // Exercise the `spec instanceof RangeDistributionSpec` branch of isSatisfy
+        // via mock of canColocate's dependencies. Different groups → false.
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = false;
+            }
+        };
+        RangeDistributionSpec left = build(100L, new DistributionCol(1, true));
+        RangeDistributionSpec right = build(200L, new DistributionCol(2, true));
+        assertFalse(left.isSatisfy(right));
+    }
+
+    @Test
+    void canColocateRejectsNullGroupId(@Mocked GlobalStateMgr globalStateMgr,
+                                       @Mocked ColocateTableIndex colocateTableIndex) {
+        // isSameGroup returns true but getGroup returns null (metadata inconsistency).
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = true;
+                colocateTableIndex.getGroup(100L);
+                result = null;
+                colocateTableIndex.getGroup(200L);
+                result = null;
+            }
+        };
+        RangeDistributionSpec left = build(100L, new DistributionCol(1, true));
+        RangeDistributionSpec right = build(200L, new DistributionCol(2, true));
+        assertFalse(left.canColocate(right));
+    }
+
+    @Test
+    void getNullRelaxSpecProducesNullRelaxColumns() {
+        RangeDistributionSpec spec = build(100L, new DistributionCol(1, true), new DistributionCol(2, true));
+        EquivalentDescriptor newDesc = new EquivalentDescriptor(100L, List.of(1L));
+        RangeDistributionSpec relaxed = spec.getNullRelaxSpec(newDesc);
+        assertEquals(spec.getColocateColumns().size(), relaxed.getColocateColumns().size());
+        for (DistributionCol col : relaxed.getColocateColumns()) {
+            assertFalse(col.isNullStrict(), "getNullRelaxSpec must produce nullStrict=false columns");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicatorRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicatorRangeTest.java
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.collect.Maps;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.DistributionCol;
+import com.starrocks.sql.optimizer.base.EquivalentDescriptor;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.type.IntegerType;
+import mockit.Mocked;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Direct unit test for
+ * {@code OptExpressionDuplicator.OptExpressionDuplicatorVisitor#processRangeDistributionSpec}.
+ * MV rewrite duplicates the scan with a new {@link ColumnRefFactory}; this
+ * helper rewires the colocate columns and equivalence descriptor.
+ */
+class OptExpressionDuplicatorRangeTest {
+
+    @Test
+    void processRangeDistributionSpecRewritesColumnIdsAndEquivalence(
+            @Mocked OptimizerContext optimizerContext) throws Exception {
+        // Arrange: prevColumnRefFactory has two column refs at ids 1 and 2.
+        ColumnRefFactory prevFactory = new ColumnRefFactory();
+        ColumnRefOperator oldA = prevFactory.create("a", IntegerType.INT, true);
+        ColumnRefOperator oldB = prevFactory.create("b", IntegerType.INT, true);
+
+        // Column mapping: old ref → new ref with a fresh id.
+        ColumnRefOperator newA = new ColumnRefOperator(1001, IntegerType.INT, "a", true);
+        ColumnRefOperator newB = new ColumnRefOperator(1002, IntegerType.INT, "b", true);
+        Map<ColumnRefOperator, ColumnRefOperator> columnMapping = Maps.newHashMap();
+        columnMapping.put(oldA, newA);
+        columnMapping.put(oldB, newB);
+
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(columnMapping);
+
+        // Original range spec uses the old column ids.
+        List<DistributionCol> oldCols = List.of(
+                new DistributionCol(oldA.getId(), true),
+                new DistributionCol(oldB.getId(), true));
+        EquivalentDescriptor oldDesc = new EquivalentDescriptor(100L, List.of(10L, 20L));
+        oldDesc.initDistributionUnionFind(oldCols);
+        RangeDistributionSpec oldSpec = new RangeDistributionSpec(oldCols, oldDesc);
+
+        // Construct the duplicator + access the inner visitor class.
+        OptExpressionDuplicator duplicator = new OptExpressionDuplicator(prevFactory, optimizerContext);
+        Class<?> visitorClass =
+                Class.forName("com.starrocks.sql.optimizer.rule.transformation.materialization."
+                        + "OptExpressionDuplicator$OptExpressionDuplicatorVisitor");
+        Object visitor = Deencapsulation.newInnerInstance(
+                visitorClass, duplicator,
+                optimizerContext, columnMapping, rewriter, prevFactory, false, false);
+
+        // Act: invoke the private helper.
+        RangeDistributionSpec newSpec =
+                Deencapsulation.invoke(visitor, "processRangeDistributionSpec", oldSpec);
+
+        // Assert: column ids remapped, descriptor carries new ids but same
+        // tableId and partition ids.
+        assertNotNull(newSpec);
+        assertEquals(2, newSpec.getColocateColumns().size());
+        assertEquals(newA.getId(), newSpec.getColocateColumns().get(0).getColId());
+        assertEquals(newB.getId(), newSpec.getColocateColumns().get(1).getColId());
+        assertEquals(100L, newSpec.getEquivalentDescriptor().getTableId());
+        assertEquals(List.of(10L, 20L), newSpec.getEquivalentDescriptor().getPartitionIds());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Range-distributed lake tables can already be placed into a colocate group
via P0/P1 (PACK shard groups), but the optimizer still emits a shuffle
exchange on every join because it has no spec to represent scan-local
range distribution. This PR (P2) teaches the planner about that locality
so qualifying joins skip the shuffle.

## What I'm doing:

Introduces optimizer-side support for range-colocate join, staged as a
single coherent change after ~14 rounds of design review.

**Core pieces**

- New `DistributionType.RANGE` (isolated from `SHUFFLE` to avoid the many
  `(HashDistributionSpec) shuffleSpec` casts in `PlanFragmentBuilder`).
  `toThrift()` on RANGE throws — this spec is scan-local only.
- `RangeDistributionSpec`: carries colocate columns + `EquivalentDescriptor`.
  `isSatisfy` returns true for `ANY`; for another range spec via `canColocate`
  (same group, both stable, non-empty partitions, equal colocate column
  count); for a `HashDistributionSpec(SHUFFLE_JOIN)` when every colocate
  column is covered (set-based equivalence, permutation-safe) by some
  required shuffle column. `SHUFFLE_AGG` / `SHUFFLE_ENFORCE` / `LOCAL`
  hash specs are rejected, scoping cross-type satisfaction to hash-join
  contexts.
- Spec production: `RelationTransformer` and `MvRewritePreprocessor`
  build a skeleton spec via `DistributionSpecHelper`;
  `OutputPropertyDeriver.visitPhysicalOlapScan` rebuilds with selected
  partitions (mirrors hash-local). `OptExpressionDuplicator` gets a
  `processRangeDistributionSpec` helper for MV-rewrite column rewiring.
- Framework invariants: `DistributionProperty.appendEnforcers` asserts
  range is never enforced; `getNullStrictProperty` is a no-op for range
  (columns are always `nullStrict=true`); `CostModel` case `RANGE` throws.
- `ChildOutputPropertyGuarantor.visitPhysicalJoin`: range dispatch runs
  before hash/hash. Both range + `canRangeColocateJoin` → skip exchange;
  otherwise convert range side(s) via `convertRangeToHashShuffle` and
  fall through. Gate order in `canRangeColocateJoin`: join-type allowlist
  (`INNER` / `LEFT OUTER` / `LEFT SEMI` / `LEFT ANTI`), `disable_colocate_join`,
  `canColocate` (structural), position-preserving pairing (same `k` on
  both sides — blocks swapped-column joins).
- `convertRangeToHashShuffle` emits `HashDistributionSpec(SHUFFLE_JOIN)`
  (not `SHUFFLE_ENFORCE`, which `HashDistributionDesc.isShuffle()` rejects).
- `visitPhysicalSetOperation`: top-of-method range-normalization pass
  converts every range child to hash `SHUFFLE_JOIN` before any
  `isShuffle()` precondition or `HashDistributionSpec` cast. Post-
  normalization: Union All → round-robin; Union Distinct → round-robin
  fallback; Intersect/Except → hash shuffle. All pre-P2 plan shapes.
- `OutputPropertyDeriver.visitPhysicalJoin`: emits left-dominated range
  output for range-range colocate join. `updateEquivalentDescriptor`
  type-dispatches on hash vs range. `visitPhysicalRepeat` preserves range
  only when every colocate column is in the repeat intersection (direct
  column-id intersection — equivalence through Repeat-nulled columns is
  unsafe). `updatePropertyWithProjection` extended with range branch.
- `PlanFragmentBuilder.isColocateJoin` accepts `RangeDistributionSpec`.
  `SPMPlan2SQLBuilder.getJoinDistributionHints` detects range colocate
  before the existing `HashDistributionSpec` cast.

**Rollout**

No new feature flag. Per-query kill uses the existing
`disable_colocate_join` session variable. Correctness of the emitted
colocate plan depends on the runtime dispatching scan ranges by PACK
shard group — this must land with the coordinator piece for the feature
to be usable at runtime. This PR is the FE planner side; the BE/coordinator
piece is tracked separately.

**Tests**

- `RangeDistributionSpecTest` (17): `isSatisfy` cross-type semantics;
  `canColocate` group / stability / partition / schema; `toThrift`
  throws for RANGE; permuted / partial shuffle coverage; `equals`/
  `hashCode` excludes mutable `EquivalentDescriptor`.
- `DistributionPropertyRangeInvariantTest` (2): `appendEnforcers` rejects
  range; `getNullStrictProperty` is identity for range.
- `ChildOutputPropertyGuarantorRangeTest` (8): join-type allowlist rejects
  right/full outer; `disable_colocate_join` kill; identity pairing
  accepts inner/left-semi; swapped-column join rejected; partial shuffle
  coverage rejected; shuffle-arity mismatch rejected.
- `ColocateTableIndexTest` +2: `isRangeColocateGroup` for known and
  unknown groups.
- Regression: `ColocateJoinTest` (44) and `JoinTest` (121) pass unchanged
  — hash colocate path is untouched.

Fixes https://github.com/StarRocks/starrocks/issues/64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4