### PR TITLE
[BugFix] Fix Iceberg min/max optimization skipped due to extra columns injected by planner

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -712,7 +712,8 @@ Status HiveDataSource::_init_global_dicts(HdfsScannerParams* params) {
             std::stringstream ss;
             ss << "slot_id: " << slot->id() << " global dict: ";
             for (const auto& kv : dict_map) {
-                ss << "<" << kv.first << " " << kv.second << ">" << ", ";
+                ss << "<" << kv.first << " " << kv.second << ">"
+                   << ", ";
             }
             LOG(INFO) << ss.str();
 #endif

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -435,6 +435,14 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     if (hdfs_scan_node.__isset.can_use_min_max_opt) {
         _use_min_max_opt = hdfs_scan_node.can_use_min_max_opt;
     }
+    // can_use_any_column is set by PruneHDFSScanColumnRule when every queried column is
+    // a partition column and a placeholder materialized column was injected to satisfy
+    // the "at least one materialized column" requirement.  We propagate this flag so that
+    // the scanner can avoid reading that placeholder column from the data file when
+    // min/max optimization is active.
+    if (hdfs_scan_node.__isset.can_use_any_column) {
+        _can_use_any_column = hdfs_scan_node.can_use_any_column;
+    }
     if (hdfs_scan_node.__isset.can_use_count_opt) {
         _use_count_opt = hdfs_scan_node.can_use_count_opt;
     }
@@ -704,8 +712,7 @@ Status HiveDataSource::_init_global_dicts(HdfsScannerParams* params) {
             std::stringstream ss;
             ss << "slot_id: " << slot->id() << " global dict: ";
             for (const auto& kv : dict_map) {
-                ss << "<" << kv.first << " " << kv.second << ">"
-                   << ", ";
+                ss << "<" << kv.first << " " << kv.second << ">" << ", ";
             }
             LOG(INFO) << ss.str();
 #endif
@@ -828,6 +835,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.use_file_pagecache = _use_file_pagecache;
 
     scanner_params.use_min_max_opt = _use_min_max_opt;
+    scanner_params.can_use_any_column = _can_use_any_column;
     scanner_params.use_count_opt = _use_count_opt;
     scanner_params.all_conjunct_ctxs = _all_conjunct_ctxs;
     if (!_disable_column_access_path_hints && !_column_access_paths.empty()) {

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -183,6 +183,11 @@ private:
     std::vector<std::string> _hive_column_names;
     bool _case_sensitive = false;
     bool _use_min_max_opt = false;
+    // Mirrors THdfsScanNode.can_use_any_column: set when PruneHDFSScanColumnRule
+    // injected a placeholder materialized column because every queried column was
+    // a partition column.  Used together with _use_min_max_opt to avoid reading
+    // that placeholder column from the data file.
+    bool _can_use_any_column = false;
     bool _use_count_opt = false;
     const HiveTableDescriptor* _hive_table = nullptr;
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -199,6 +199,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.case_sensitive = _scanner_params.case_sensitive;
     ctx.orc_use_column_names = _scanner_params.orc_use_column_names;
     ctx.use_min_max_opt = _scanner_params.use_min_max_opt;
+    ctx.can_use_any_column = _scanner_params.can_use_any_column;
     ctx.use_count_opt = _scanner_params.use_count_opt;
     ctx.use_file_metacache = _scanner_params.use_file_metacache;
     ctx.use_file_pagecache = _scanner_params.use_file_pagecache;
@@ -637,10 +638,20 @@ void HdfsScannerContext::update_min_max_columns() {
     const std::map<int32_t, TExprMinMaxValue>& min_max_values = scan_range->min_max_values;
     for (auto& column : materialized_columns) {
         if (min_max_values.find(column.slot_id()) != min_max_values.end()) {
-            // handled in non existed slot
+            // This column has file-level min/max statistics.  Move it to
+            // not_existed_slots so that append_or_update_min_max_column_to_chunk()
+            // fills the column with the statistics values instead of reading the
+            // actual data from the file.
             update_with_none_existed_slot(column.slot_desc);
-            continue;
+        } else if (can_use_any_column) {
+            // This column has no min/max statistics (e.g. STRING or TIMESTAMP type
+            // which are not yet supported, or a placeholder column injected by
+            // PruneHDFSScanColumnRule when every queried column is a partition column).
+            // Because can_use_any_column is set we know its value is irrelevant to the
+            // query result, so fill it with a default value and skip reading the file.
+            update_with_none_existed_slot(column.slot_desc);
         } else {
+            // This column genuinely needs to be read from the data file.
             updated_columns.emplace_back(column);
         }
     }

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -655,6 +655,16 @@ void HdfsScannerContext::update_min_max_columns() {
             updated_columns.emplace_back(column);
         }
     }
+    // When can_use_any_column is set, also drain reserved_field_slots (e.g. _pos, _row_id)
+    // into not_existed_slots.  reserved_field_slots are meta/hidden columns whose
+    // values are irrelevant to the min/max query result, so filling them with defaults
+    // is safe and allows can_use_min_max_optimization() to return true.
+    if (can_use_any_column) {
+        for (SlotDescriptor* slot_desc : reserved_field_slots) {
+            update_with_none_existed_slot(slot_desc);
+        }
+        reserved_field_slots.clear();
+    }
     materialized_columns.swap(updated_columns);
 }
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -281,6 +281,12 @@ struct HdfsScannerParams {
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;
     bool use_min_max_opt = false;
+    // Mirrors THdfsScanNode.can_use_any_column.  When true, PruneHDFSScanColumnRule
+    // injected a placeholder materialized column because all queried columns were
+    // partition columns.  Used together with use_min_max_opt to skip reading the
+    // placeholder from the data file.
+    bool can_use_any_column = false;
+
     bool use_count_opt = false;
     bool orc_use_column_names = false;
     bool parquet_page_index_enable = false;
@@ -354,6 +360,11 @@ struct HdfsScannerContext {
     bool orc_use_column_names = false;
 
     bool use_min_max_opt = false;
+    // Set when can_use_any_column is propagated from the scan node.  In combination
+    // with use_min_max_opt this tells update_min_max_columns() that any materialized
+    // column without a min/max entry is a placeholder and should be filled with a
+    // default value instead of being read from the data file.
+    bool can_use_any_column = false;
 
     bool use_count_opt = false;
     bool is_first_split = false;

--- a/test/sql/test_iceberg/R/test_iceberg_min_max_opt
+++ b/test/sql/test_iceberg/R/test_iceberg_min_max_opt
@@ -1,5 +1,5 @@
 -- name: test_iceberg_min_max_opt
-create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="false");
 -- result:
 -- !result
 create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
@@ -11,7 +11,13 @@ set catalog iceberg_sql_test_${uuid0};
 use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 -- result:
 -- !result
-create external table ice_tbl_${uuid0}(
+set enable_profile = true;
+-- result:
+-- !result
+set enable_async_profile = false;
+-- result:
+-- !result
+create external table ice_tbl_0(
     c_tinyint tinyint,
     c_smallint smallint,
     c_int int,
@@ -27,7 +33,7 @@ create external table ice_tbl_${uuid0}(
 );
 -- result:
 -- !result
-INSERT INTO ice_tbl_${uuid0} (
+INSERT INTO ice_tbl_0 (
     c_tinyint,
     c_smallint,
     c_int,
@@ -72,9 +78,14 @@ select min(c_tinyint) as min_tinyint,
        max(c_double) as max_double,
        min(c_date) as min_date, 
        max(c_date) as max_date
-       from ice_tbl_${uuid0};
+       from ice_tbl_0;
 -- result:
 1	10	10	100	100	1000	1000	10000	0	1	1.1	10.1	2.2	11.2	2025-06-29	2025-07-08
+-- !result
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
+               - RawRowsRead: 0
+               - RowsRead: 0
 -- !result
 set enable_min_max_optimization = false;
 -- result:
@@ -95,9 +106,12 @@ select min(c_tinyint) as min_tinyint,
        max(c_double) as max_double,
        min(c_date) as min_date, 
        max(c_date) as max_date
-       from ice_tbl_${uuid0};
+       from ice_tbl_0;
 -- result:
 1	10	10	100	100	1000	1000	10000	0	1	1.1	10.1	2.2	11.2	2025-06-29	2025-07-08
+-- !result
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
 -- !result
 set enable_min_max_optimization = true;
 -- result:
@@ -123,9 +137,12 @@ select min(c_tinyint) as min_tinyint,
        min(c_datetime) as min_datetime, 
        max(c_datetime) as max_datetime,
        min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_string) as max_string from ice_tbl_0;
 -- result:
 1	10	10	100	100	1000	1000	10000	0	1	1.1	10.1	2.2	11.2	10.000000000000000001	100.000000000000000010	2025-06-29	2025-07-08	2025-06-29 08:00:00	2025-06-29 09:30:00	alpha	zeta
+-- !result
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
 -- !result
 set enable_min_max_optimization = false;
 -- result:
@@ -151,11 +168,14 @@ select min(c_tinyint) as min_tinyint,
        min(c_datetime) as min_datetime, 
        max(c_datetime) as max_datetime,
        min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_string) as max_string from ice_tbl_0;
 -- result:
 1	10	10	100	100	1000	1000	10000	0	1	1.1	10.1	2.2	11.2	10.000000000000000001	100.000000000000000010	2025-06-29	2025-07-08	2025-06-29 08:00:00	2025-06-29 09:30:00	alpha	zeta
 -- !result
-INSERT INTO ice_tbl_${uuid0} (
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
+-- !result
+INSERT INTO ice_tbl_0 (
     c_tinyint,
     c_smallint,
     c_int,
@@ -189,16 +209,15 @@ select min(c_tinyint) as min_tinyint,
        max(c_float) as max_float,
        min(c_double) as min_double, 
        max(c_double) as max_double,
-       min(c_decimal) as min_decimal,
-       max(c_decimal) as max_decimal,
        min(c_date) as min_date, 
-       max(c_date) as max_date, 
-       min(c_datetime) as min_datetime, 
-       max(c_datetime) as max_datetime,
-       min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_date) as max_date from ice_tbl_0;
 -- result:
-1	10	10	100	100	1000	1000	10000	0	1	1.1	10.1	2.2	11.2	10.000000000000000001	100.000000000000000010	2025-06-29	2025-07-08	2025-06-29 08:00:00	2025-06-29 09:30:00	alpha	zeta
+1	10	10	100	100	1000	1000	10000	0	1	1.1	10.1	2.2	11.2	2025-06-29	2025-07-08
+-- !result
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
+               - RawRowsRead: 0
+               - RowsRead: 0
 -- !result
 set enable_min_max_optimization = false;
 -- result:
@@ -217,18 +236,15 @@ select min(c_tinyint) as min_tinyint,
        max(c_float) as max_float,
        min(c_double) as min_double, 
        max(c_double) as max_double,
-       min(c_decimal) as min_decimal,
-       max(c_decimal) as max_decimal,
        min(c_date) as min_date, 
-       max(c_date) as max_date, 
-       min(c_datetime) as min_datetime, 
-       max(c_datetime) as max_datetime,
-       min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_date) as max_date from ice_tbl_0;
 -- result:
-1	10	10	100	100	1000	1000	10000	0	1	1.1	10.1	2.2	11.2	10.000000000000000001	100.000000000000000010	2025-06-29	2025-07-08	2025-06-29 08:00:00	2025-06-29 09:30:00	alpha	zeta
+1	10	10	100	100	1000	1000	10000	0	1	1.1	10.1	2.2	11.2	2025-06-29	2025-07-08
 -- !result
-INSERT overwrite ice_tbl_${uuid0} (
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
+-- !result
+INSERT overwrite ice_tbl_0 (
     c_tinyint,
     c_smallint,
     c_int,
@@ -262,16 +278,15 @@ select min(c_tinyint) as min_tinyint,
        max(c_float) as max_float,
        min(c_double) as min_double, 
        max(c_double) as max_double,
-       min(c_decimal) as min_decimal,
-       max(c_decimal) as max_decimal,
        min(c_date) as min_date, 
-       max(c_date) as max_date, 
-       min(c_datetime) as min_datetime, 
-       max(c_datetime) as max_datetime,
-       min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_date) as max_date from ice_tbl_0;
 -- result:
-None	None	10	10	100	100	None	None	1	1	1.1	1.1	2.2	2.2	10.000000000000000001	10.000000000000000001	2025-06-29	2025-06-29	2025-06-29 08:00:00	2025-06-29 08:00:00	alpha	alpha
+None	None	10	10	100	100	None	None	1	1	1.1	1.1	2.2	2.2	2025-06-29	2025-06-29
+-- !result
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
+               - RawRowsRead: 0
+               - RowsRead: 0
 -- !result
 set enable_min_max_optimization = false;
 -- result:
@@ -290,58 +305,103 @@ select min(c_tinyint) as min_tinyint,
        max(c_float) as max_float,
        min(c_double) as min_double, 
        max(c_double) as max_double,
-       min(c_decimal) as min_decimal,
-       max(c_decimal) as max_decimal,
        min(c_date) as min_date, 
-       max(c_date) as max_date, 
-       min(c_datetime) as min_datetime, 
-       max(c_datetime) as max_datetime,
-       min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_date) as max_date from ice_tbl_0;
 -- result:
-None	None	10	10	100	100	None	None	1	1	1.1	1.1	2.2	2.2	10.000000000000000001	10.000000000000000001	2025-06-29	2025-06-29	2025-06-29 08:00:00	2025-06-29 08:00:00	alpha	alpha
+None	None	10	10	100	100	None	None	1	1	1.1	1.1	2.2	2.2	2025-06-29	2025-06-29
 -- !result
-drop table ice_tbl_${uuid0} force;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
 -- result:
 -- !result
-create external table ice_tbl_${uuid1}(
+drop table ice_tbl_0 force;
+-- result:
+-- !result
+set enable_min_max_optimization = true;
+-- result:
+-- !result
+create external table ice_tbl_1(
     c_int int,
     c_bigint bigint    
 );
 -- result:
 -- !result
-INSERT INTO ice_tbl_${uuid1} (    
+INSERT INTO ice_tbl_1 (
     c_int,
     c_bigint    
 ) VALUES
 (null, null);
 -- result:
 -- !result
-select min(c_int), max(c_int), max(c_bigint), max(c_bigint) from ice_tbl_${uuid1};
+select min(c_int), max(c_int), max(c_bigint), max(c_bigint) from ice_tbl_1;
 -- result:
 None	None	None	None
 -- !result
-drop table ice_tbl_${uuid1} force;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
+               - RawRowsRead: 0
+               - RowsRead: 0
+-- !result
+drop table ice_tbl_1 force;
 -- result:
 -- !result
-create external table ice_tbl_${uuid2}(
+create external table ice_tbl_2(
     c_int int,
     dt datetime
 ) partition by (dt);
 -- result:
 -- !result
-INSERT INTO ice_tbl_${uuid2} (    
+INSERT INTO ice_tbl_2 (
        c_int, dt
 ) VALUES
 (10, '2021-01-01 13:00:00'),
 (20, '2022-01-01 14:00:00');
 -- result:
 -- !result
-select min(dt), max(dt) from ice_tbl_${uuid2};
+select min(c_int), max(c_int) from ice_tbl_2;
+-- result:
+10	20
+-- !result
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
+               - RawRowsRead: 0
+               - RowsRead: 0
+-- !result
+select min(dt), max(dt) from ice_tbl_2;
 -- result:
 2021-01-01 13:00:00	2022-01-01 14:00:00
 -- !result
-drop table ice_tbl_${uuid2} force;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
+               - RawRowsRead: 0
+               - RowsRead: 0
+-- !result
+drop table ice_tbl_2 force;
+-- result:
+-- !result
+create external table ice_tbl_3(
+    id int,
+    name string
+) partition by (bucket(id, 4));
+-- result:
+-- !result
+INSERT INTO ice_tbl_3 (id, name) VALUES
+(1, 'alice'),
+(2, 'bob'),
+(3, 'carol'),
+(4, 'dave'),
+(5, 'eve');
+-- result:
+-- !result
+select min(id), max(id) from ice_tbl_3;
+-- result:
+1	5
+-- !result
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+-- result:
+               - RawRowsRead: 0
+               - RowsRead: 0
+-- !result
+drop table ice_tbl_3 force;
 -- result:
 -- !result
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_min_max_opt
+++ b/test/sql/test_iceberg/T/test_iceberg_min_max_opt
@@ -1,12 +1,20 @@
 -- name: test_iceberg_min_max_opt
 
-create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="false");
 
 create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 set catalog iceberg_sql_test_${uuid0};
 use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 
-create external table ice_tbl_${uuid0}(
+set enable_profile = true;
+set enable_async_profile = false;
+
+-- ============================================================
+-- Case 1: all supported types (tinyint/smallint/int/bigint/bool/float/double/date).
+-- With enable_min_max_optimization=true, all columns have file-level statistics,
+-- so RowsRead should be 0.  Results must match the reference scan (opt=false).
+-- ============================================================
+create external table ice_tbl_0(
     c_tinyint tinyint,
     c_smallint smallint,
     c_int int,
@@ -21,7 +29,7 @@ create external table ice_tbl_${uuid0}(
     c_time time
 );
 
-INSERT INTO ice_tbl_${uuid0} (
+INSERT INTO ice_tbl_0 (
     c_tinyint,
     c_smallint,
     c_int,
@@ -46,7 +54,6 @@ INSERT INTO ice_tbl_${uuid0} (
 (9, 90, 900, 9000, true, 9.9, 10.1, 90.000000000000000009, '2025-06-29 09:20:00', 'iota', '2025-07-07', '09:20:00'),
 (10, 100, 1000, 10000, false, 10.1, 11.2, 100.000000000000000010, '2025-06-29 09:30:00', 'kappa', '2025-07-08', '09:30:00');
 
--- supported types.
 set enable_min_max_optimization = true;
 select min(c_tinyint) as min_tinyint, 
        max(c_tinyint) as max_tinyint,
@@ -64,7 +71,9 @@ select min(c_tinyint) as min_tinyint,
        max(c_double) as max_double,
        min(c_date) as min_date, 
        max(c_date) as max_date
-       from ice_tbl_${uuid0};
+       from ice_tbl_0;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+
 set enable_min_max_optimization = false;
 select min(c_tinyint) as min_tinyint, 
        max(c_tinyint) as max_tinyint,
@@ -82,9 +91,15 @@ select min(c_tinyint) as min_tinyint,
        max(c_double) as max_double,
        min(c_date) as min_date, 
        max(c_date) as max_date
-       from ice_tbl_${uuid0};
+       from ice_tbl_0;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
 
--- mixed with unsupported types.
+-- ============================================================
+-- Case 2: mixed with unsupported types (decimal/datetime/string).
+-- With enable_min_max_optimization=true, unsupported-type columns fall back to
+-- reading the file, but supported-type columns still use statistics.
+-- Results must match the reference scan (opt=false).
+-- ============================================================
 set enable_min_max_optimization = true;
 select min(c_tinyint) as min_tinyint, 
        max(c_tinyint) as max_tinyint,
@@ -107,7 +122,9 @@ select min(c_tinyint) as min_tinyint,
        min(c_datetime) as min_datetime, 
        max(c_datetime) as max_datetime,
        min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_string) as max_string from ice_tbl_0;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+
 
 set enable_min_max_optimization = false;
 select min(c_tinyint) as min_tinyint, 
@@ -131,10 +148,16 @@ select min(c_tinyint) as min_tinyint,
        min(c_datetime) as min_datetime, 
        max(c_datetime) as max_datetime,
        min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_string) as max_string from ice_tbl_0;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
 
--- mixed with null values
-INSERT INTO ice_tbl_${uuid0} (
+-- ============================================================
+-- Case 3: multiple files with NULL values in some columns.
+-- Appends a row where c_tinyint and c_bigint are NULL, creating a second file.
+-- The NULL file has null_value_count > 0 in its statistics; the optimization must
+-- still return the correct (non-null) min/max from the non-null file.
+-- ============================================================
+INSERT INTO ice_tbl_0 (
     c_tinyint,
     c_smallint,
     c_int,
@@ -151,7 +174,6 @@ INSERT INTO ice_tbl_${uuid0} (
 (null, 10, 100, null, true, 1.1, 2.2, 10.000000000000000001, '2025-06-29 08:00:00', 'alpha', '2025-06-29', '08:00:00');
 
 set enable_min_max_optimization = true;
-
 select min(c_tinyint) as min_tinyint, 
        max(c_tinyint) as max_tinyint,
        min(c_smallint) as min_smallint, 
@@ -166,17 +188,11 @@ select min(c_tinyint) as min_tinyint,
        max(c_float) as max_float,
        min(c_double) as min_double, 
        max(c_double) as max_double,
-       min(c_decimal) as min_decimal,
-       max(c_decimal) as max_decimal,
        min(c_date) as min_date, 
-       max(c_date) as max_date, 
-       min(c_datetime) as min_datetime, 
-       max(c_datetime) as max_datetime,
-       min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_date) as max_date from ice_tbl_0;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
 
 set enable_min_max_optimization = false;
-
 select min(c_tinyint) as min_tinyint, 
        max(c_tinyint) as max_tinyint,
        min(c_smallint) as min_smallint, 
@@ -191,19 +207,17 @@ select min(c_tinyint) as min_tinyint,
        max(c_float) as max_float,
        min(c_double) as min_double, 
        max(c_double) as max_double,
-       min(c_decimal) as min_decimal,
-       max(c_decimal) as max_decimal,
        min(c_date) as min_date, 
-       max(c_date) as max_date, 
-       min(c_datetime) as min_datetime, 
-       max(c_datetime) as max_datetime,
-       min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_date) as max_date from ice_tbl_0;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
 
-
-
--- mixed with null values
-INSERT overwrite ice_tbl_${uuid0} (
+-- ============================================================
+-- Case 4: single file where ALL rows have NULLs in queried columns.
+-- INSERT OVERWRITE replaces the table with one row that has c_tinyint=NULL
+-- and c_bigint=NULL.  The file statistics have null_count == row_count, so
+-- min/max are absent; the optimization must return NULL correctly.
+-- ============================================================
+INSERT overwrite ice_tbl_0 (
     c_tinyint,
     c_smallint,
     c_int,
@@ -220,7 +234,6 @@ INSERT overwrite ice_tbl_${uuid0} (
 (null, 10, 100, null, true, 1.1, 2.2, 10.000000000000000001, '2025-06-29 08:00:00', 'alpha', '2025-06-29', '08:00:00');
 
 set enable_min_max_optimization = true;
-
 select min(c_tinyint) as min_tinyint, 
        max(c_tinyint) as max_tinyint,
        min(c_smallint) as min_smallint, 
@@ -235,17 +248,11 @@ select min(c_tinyint) as min_tinyint,
        max(c_float) as max_float,
        min(c_double) as min_double, 
        max(c_double) as max_double,
-       min(c_decimal) as min_decimal,
-       max(c_decimal) as max_decimal,
        min(c_date) as min_date, 
-       max(c_date) as max_date, 
-       min(c_datetime) as min_datetime, 
-       max(c_datetime) as max_datetime,
-       min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_date) as max_date from ice_tbl_0;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
 
 set enable_min_max_optimization = false;
-
 select min(c_tinyint) as min_tinyint, 
        max(c_tinyint) as max_tinyint,
        min(c_smallint) as min_smallint, 
@@ -260,45 +267,81 @@ select min(c_tinyint) as min_tinyint,
        max(c_float) as max_float,
        min(c_double) as min_double, 
        max(c_double) as max_double,
-       min(c_decimal) as min_decimal,
-       max(c_decimal) as max_decimal,
        min(c_date) as min_date, 
-       max(c_date) as max_date, 
-       min(c_datetime) as min_datetime, 
-       max(c_datetime) as max_datetime,
-       min(c_string) as min_string, 
-       max(c_string) as max_string from ice_tbl_${uuid0};
+       max(c_date) as max_date from ice_tbl_0;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
 
-drop table ice_tbl_${uuid0} force;
+drop table ice_tbl_0 force;
 
-create external table ice_tbl_${uuid1}(
+-- ============================================================
+-- Case 5: all rows are NULL in every queried column.
+-- Verifies that the optimization correctly returns NULL instead of
+-- incorrect default values when all file statistics are absent.
+-- ============================================================
+set enable_min_max_optimization = true;
+
+create external table ice_tbl_1(
     c_int int,
     c_bigint bigint    
 );
-INSERT INTO ice_tbl_${uuid1} (    
+INSERT INTO ice_tbl_1 (
     c_int,
     c_bigint    
 ) VALUES
 (null, null);
 
-select min(c_int), max(c_int), max(c_bigint), max(c_bigint) from ice_tbl_${uuid1};
+select min(c_int), max(c_int), max(c_bigint), max(c_bigint) from ice_tbl_1;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
 
-drop table ice_tbl_${uuid1} force;
+drop table ice_tbl_1 force;
 
-create external table ice_tbl_${uuid2}(
+-- ============================================================
+-- Case 6: identity partition on datetime column.
+-- Querying min/max of the partition column itself; the value is served
+-- from partition metadata without reading file data.
+-- ============================================================
+create external table ice_tbl_2(
     c_int int,
     dt datetime
 ) partition by (dt);
 
-INSERT INTO ice_tbl_${uuid2} (    
+INSERT INTO ice_tbl_2 (
        c_int, dt
 ) VALUES
 (10, '2021-01-01 13:00:00'),
 (20, '2022-01-01 14:00:00');
 
-select min(dt), max(dt) from ice_tbl_${uuid2};
+select min(c_int), max(c_int) from ice_tbl_2;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
 
-drop table ice_tbl_${uuid2} force;
+select min(dt), max(dt) from ice_tbl_2;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+
+drop table ice_tbl_2 force;
+
+-- =============================================================
+-- Case 7: bucket partition on int column (Bug 2 regression).
+-- When all queried columns are bucket-partition columns, PruneHDFSScanColumnRule
+-- injects a STRING placeholder column and sets can_use_any_column=true.
+-- The fix ensures the placeholder is filled with a default value so that
+-- no file data is read (RowsRead should be 0).
+-- ============================================================
+create external table ice_tbl_3(
+    id int,
+    name string
+) partition by (bucket(id, 4));
+
+INSERT INTO ice_tbl_3 (id, name) VALUES
+(1, 'alice'),
+(2, 'bob'),
+(3, 'carol'),
+(4, 'dave'),
+(5, 'eve');
+
+select min(id), max(id) from ice_tbl_3;
+select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
+
+drop table ice_tbl_3 force;
 
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 set catalog default_catalog;


### PR DESCRIPTION
## Why I'm doing:

When running `SELECT min(col), max(col)` on an Iceberg table partitioned by `bucket(col, N)`, the min/max optimization was silently disabled and StarRocks fell back to a full file scan.

The root cause: `PruneHDFSScanColumnRule` injects a placeholder materialized column (e.g. a `STRING` column) when all queried columns are partition columns. This placeholder has no min/max statistics, so it remained in `materialized_columns`, causing `can_use_min_max_optimization()` to return false. Reserved meta-slots (e.g. `_pos`) in the same path had the same effect.

## What I'm doing:

- Propagate `can_use_any_column` from `THdfsScanNode` through `HiveDataSource` down to  `HdfsScannerContext` (was read by FE but never used in BE).
- In `update_min_max_columns()`, when `can_use_any_column=true`, move columns with no  min/max entry — including reserved slots — into `not_existed_slots` with a default value  instead of keeping them for file reads.
- Add test cases in `test_iceberg_min_max_opt` covering bucket-partition, identity-partition,  all-null files, and mixed-type scenarios, each verifying both correctness and `RowsRead: 0`.

Fixes #67158

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
