### PR TITLE
[BugFix] Create missing Hive partition directory before INSERT overwrite commit (backport #71810)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -301,6 +301,16 @@ public class RemoteFileOperations {
         return HiveWriteUtils.pathExists(path, conf);
     }
 
+    /**
+     * Creates {@code path} as an empty directory (including parents) when it does not exist.
+     * Used when HMS lists a partition but the warehouse path is missing on the filesystem.
+     */
+    public void ensureDirectoryExists(Path path) {
+        if (!pathExists(path)) {
+            createDirectory(path, conf);
+        }
+    }
+
     public boolean deleteIfExists(Path path, boolean recursive) {
         return HiveWriteUtils.deleteIfExists(path, recursive, conf);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
@@ -296,6 +296,12 @@ public class HiveCommitter {
             Path oldPartitionStagingPath = new Path(targetPath.getParent(), "_temp_" + targetPath.getName()
                     + "_" + ConnectContext.get().getQueryId().toString());
 
+            if (!fileOps.pathExists(targetPath)) {
+                LOG.warn("Partition location {} does not exist before overwrite; creating empty directory for rename",
+                        targetPath);
+                fileOps.ensureDirectoryExists(targetPath);
+            }
+
             fileOps.renameDirectory(
                     targetPath,
                     oldPartitionStagingPath,
@@ -394,8 +400,10 @@ public class HiveCommitter {
         String dbName = firstPartition.getDatabaseName();
         String tableName = firstPartition.getTableName();
         List<List<String>> rollbackFailedPartitions = addPartitionsTask.rollback(hmsOps);
-        LOG.error("Failed to rollback: add_partition for partition values {}.{}.{}",
-                dbName, tableName, rollbackFailedPartitions);
+        if (!rollbackFailedPartitions.isEmpty()) {
+            LOG.error("Failed to rollback: add_partition for partition values {}.{}.{}",
+                    dbName, tableName, rollbackFailedPartitions);
+        }
     }
 
     private void waitAsyncFsTaskSuppressThrowable() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -207,6 +207,11 @@ public class HiveMetastore implements IHiveMetastore {
         ImmutableMap.Builder<String, Partition> resultBuilder = ImmutableMap.builder();
         for (Map.Entry<String, List<String>> entry : partitionNameToPartitionValues.entrySet()) {
             Partition partition = partitionValuesToPartition.get(entry.getValue());
+            if (partition == null) {
+                throw new StarRocksConnectorException(
+                        "Hive metastore did not return partition [%s] for table %s.%s (requested %s partitions, got %s)",
+                        entry.getKey(), dbName, tblName, partitionNames.size(), partitions.size());
+            }
             resultBuilder.put(entry.getKey(), partition);
         }
         return resultBuilder.build();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
@@ -183,6 +184,63 @@ public class RemoteFileOperationsTest {
                     ops.asyncRenameFiles(futures, new AtomicBoolean(false), writePath, targetPath, fileNames);
                     getFutureValue(futures.get(0), StarRocksConnectorException.class);
                 });
+    }
+
+    @Test
+    public void testEnsureDirectoryExistsCreatesWhenMissing() {
+        AtomicInteger createCount = new AtomicInteger(0);
+        new MockUp<HiveUtils>() {
+            @Mock
+            public boolean pathExists(Path path, Configuration conf) {
+                return false;
+            }
+
+            @Mock
+            public void createDirectory(Path path, Configuration conf) {
+                createCount.incrementAndGet();
+            }
+        };
+
+        HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
+        hiveRemoteFileIO.setFileSystem(new MockedRemoteFileSystem(HDFS_HIVE_TABLE));
+        FeConstants.runningUnitTest = true;
+        ExecutorService executorToRefresh = Executors.newSingleThreadExecutor();
+        ExecutorService executorToLoad = Executors.newSingleThreadExecutor();
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 0.1);
+        RemoteFileOperations ops = new RemoteFileOperations(cachingFileIO, executorToLoad, executorToLoad,
+                false, true, new Configuration());
+
+        Path p = new Path("hdfs://127.0.0.1:9000/warehouse/missing/part");
+        ops.ensureDirectoryExists(p);
+        Assertions.assertEquals(1, createCount.get());
+    }
+
+    @Test
+    public void testEnsureDirectoryExistsNoOpWhenPresent() {
+        AtomicInteger createCount = new AtomicInteger(0);
+        new MockUp<HiveUtils>() {
+            @Mock
+            public boolean pathExists(Path path, Configuration conf) {
+                return true;
+            }
+
+            @Mock
+            public void createDirectory(Path path, Configuration conf) {
+                createCount.incrementAndGet();
+            }
+        };
+
+        HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
+        hiveRemoteFileIO.setFileSystem(new MockedRemoteFileSystem(HDFS_HIVE_TABLE));
+        FeConstants.runningUnitTest = true;
+        ExecutorService executorToRefresh = Executors.newSingleThreadExecutor();
+        ExecutorService executorToLoad = Executors.newSingleThreadExecutor();
+        CachingRemoteFileIO cachingFileIO = new CachingRemoteFileIO(hiveRemoteFileIO, executorToRefresh, 10, 10, 0.1);
+        RemoteFileOperations ops = new RemoteFileOperations(cachingFileIO, executorToLoad, executorToLoad,
+                false, true, new Configuration());
+
+        ops.ensureDirectoryExists(new Path("hdfs://127.0.0.1:9000/warehouse/exists"));
+        Assertions.assertEquals(0, createCount.get());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.HiveRemoteFileIO;
+import com.starrocks.connector.hive.HiveUtils;
 import com.starrocks.connector.hive.HiveWriteUtils;
 import com.starrocks.connector.hive.MockedRemoteFileSystem;
 import com.starrocks.connector.hive.Partition;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -25,7 +25,6 @@ import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.HiveRemoteFileIO;
-import com.starrocks.connector.hive.HiveUtils;
 import com.starrocks.connector.hive.HiveWriteUtils;
 import com.starrocks.connector.hive.MockedRemoteFileSystem;
 import com.starrocks.connector.hive.Partition;
@@ -190,7 +189,7 @@ public class RemoteFileOperationsTest {
     @Test
     public void testEnsureDirectoryExistsCreatesWhenMissing() {
         AtomicInteger createCount = new AtomicInteger(0);
-        new MockUp<HiveUtils>() {
+        new MockUp<HiveWriteUtils>() {
             @Mock
             public boolean pathExists(Path path, Configuration conf) {
                 return false;
@@ -219,7 +218,7 @@ public class RemoteFileOperationsTest {
     @Test
     public void testEnsureDirectoryExistsNoOpWhenPresent() {
         AtomicInteger createCount = new AtomicInteger(0);
-        new MockUp<HiveUtils>() {
+        new MockUp<HiveWriteUtils>() {
             @Mock
             public boolean pathExists(Path path, Configuration conf) {
                 return true;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -532,6 +532,11 @@ public class HiveMetadataTest {
 
         new MockUp<RemoteFileOperations>() {
             @Mock
+            public boolean pathExists(Path path) {
+                return true;
+            }
+
+            @Mock
             public void renameDirectory(Path source, Path target, Runnable runWhenPathNotExist) {
             }
         };
@@ -787,6 +792,113 @@ public class HiveMetadataTest {
 
             java.lang.reflect.Method method = HiveCommitter.class.getDeclaredMethod(
                     "prepareOverwriteTable", PartitionUpdate.class, HivePartitionStats.class);
+            method.setAccessible(true);
+            method.invoke(hiveCommitter, partitionUpdate, HivePartitionStats.fromCommonStats(1, 1, 1));
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
+    public void testPrepareOverwritePartitionEnsuresDirWhenTargetMissing(@Mocked HiveMetastoreOperations hmsOps,
+                                                                         @Mocked RemoteFileOperations fileOps,
+                                                                         @Mocked HiveTable hiveTable) throws Exception {
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setQueryId(UUIDUtil.genUUID());
+        ctx.setThreadLocalInfo();
+        try {
+            Path targetPath = new Path("hdfs://127.0.0.1:10000/warehouse/db/table/dt=1");
+            Path writePath = new Path("hdfs://127.0.0.1:10000/staging/q1");
+            PartitionUpdate partitionUpdate = new PartitionUpdate("dt=1", writePath, targetPath,
+                    Lists.newArrayList("file"), 1, 1);
+            HiveCommitter hiveCommitter = new HiveCommitter(hmsOps, fileOps, Executors.newSingleThreadExecutor(),
+                    Executors.newSingleThreadExecutor(), hiveTable, new Path("hdfs://127.0.0.1/staging"));
+
+            Path oldPartitionStagingPath = new Path(targetPath.getParent(), "_temp_" + targetPath.getName() + "_"
+                    + ctx.getQueryId().toString());
+
+            new Expectations() {
+                {
+                    hiveTable.isUnPartitioned();
+                    result = false;
+                    minTimes = 0;
+
+                    fileOps.pathExists(targetPath);
+                    result = false;
+                    times = 1;
+
+                    fileOps.ensureDirectoryExists(targetPath);
+                    times = 1;
+
+                    fileOps.renameDirectory(targetPath, oldPartitionStagingPath, (Runnable) any);
+                    times = 1;
+
+                    fileOps.renameDirectory(writePath, targetPath, (Runnable) any);
+                    times = 1;
+
+                    hiveTable.getCatalogDBName();
+                    result = "db";
+                    minTimes = 0;
+                    hiveTable.getCatalogTableName();
+                    result = "tbl";
+                    minTimes = 0;
+                }
+            };
+
+            java.lang.reflect.Method method = HiveCommitter.class.getDeclaredMethod(
+                    "prepareOverwritePartition", PartitionUpdate.class, HivePartitionStats.class);
+            method.setAccessible(true);
+            method.invoke(hiveCommitter, partitionUpdate, HivePartitionStats.fromCommonStats(1, 1, 1));
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
+    public void testPrepareOverwritePartitionSkipsEnsureDirWhenTargetExists(@Mocked HiveMetastoreOperations hmsOps,
+                                                                            @Mocked RemoteFileOperations fileOps,
+                                                                            @Mocked HiveTable hiveTable) throws Exception {
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setQueryId(UUIDUtil.genUUID());
+        ctx.setThreadLocalInfo();
+        try {
+            Path targetPath = new Path("hdfs://127.0.0.1:10000/warehouse/db/table/dt=1");
+            Path writePath = new Path("hdfs://127.0.0.1:10000/staging/q1");
+            PartitionUpdate partitionUpdate = new PartitionUpdate("dt=1", writePath, targetPath,
+                    Lists.newArrayList("file"), 1, 1);
+            HiveCommitter hiveCommitter = new HiveCommitter(hmsOps, fileOps, Executors.newSingleThreadExecutor(),
+                    Executors.newSingleThreadExecutor(), hiveTable, new Path("hdfs://127.0.0.1/staging"));
+
+            Path oldPartitionStagingPath = new Path(targetPath.getParent(), "_temp_" + targetPath.getName() + "_"
+                    + ctx.getQueryId().toString());
+
+            new Expectations() {
+                {
+                    hiveTable.isUnPartitioned();
+                    result = false;
+                    minTimes = 0;
+
+                    fileOps.pathExists(targetPath);
+                    result = true;
+                    times = 1;
+
+                    fileOps.renameDirectory(targetPath, oldPartitionStagingPath, (Runnable) any);
+                    times = 1;
+
+                    fileOps.renameDirectory(writePath, targetPath, (Runnable) any);
+                    times = 1;
+
+                    hiveTable.getCatalogDBName();
+                    result = "db";
+                    minTimes = 0;
+                    hiveTable.getCatalogTableName();
+                    result = "tbl";
+                    minTimes = 0;
+                }
+            };
+
+            java.lang.reflect.Method method = HiveCommitter.class.getDeclaredMethod(
+                    "prepareOverwritePartition", PartitionUpdate.class, HivePartitionStats.class);
             method.setAccessible(true);
             method.invoke(hiveCommitter, partitionUpdate, HivePartitionStats.fromCommonStats(1, 1, 1));
         } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -181,6 +181,22 @@ public class HiveMetastoreTest {
     }
 
     @Test
+    public void testGetPartitionsByNamesThrowsWhenHmsReturnsPartialList() {
+        HiveMetaClient client = new MockedHiveMetaClient() {
+            @Override
+            public List<Partition> getPartitionsByNames(String dbName, String tblName, List<String> partitionNames) {
+                return super.getPartitionsByNames(dbName, tblName, Lists.newArrayList(partitionNames.get(0)));
+            }
+        };
+        HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
+        List<String> partitionNames = Lists.newArrayList("col1=1", "col1=2");
+        StarRocksConnectorException e = Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> metastore.getPartitionsByNames("db1", "table1", partitionNames));
+        Assertions.assertTrue(e.getMessage().contains("Hive metastore did not return partition"));
+        Assertions.assertTrue(e.getMessage().contains("requested 2 partitions, got 1"));
+    }
+
+    @Test
     public void testGetTableStatistics() {
         HiveMetaClient client = new MockedHiveMetaClient();
         HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);


### PR DESCRIPTION
## Why I'm doing:
Hive dynamic partition `INSERT` overwrite commits the staged data by renaming the existing partition directory to a temporary path, then renaming the staged directory into place. In some environments the metastore still lists a partition whose **location does not exist on the filesystem** (for example, metadata drift or manual cleanup). In that case the first rename fails and the insert cannot complete. Also, when building the partition map from HMS responses, a missing entry could surface later as a confusing failure; failing fast with context makes diagnosis easier. Finally, rollback logging should not emit an error when there was nothing to roll back.

## What I'm doing:
- Add `RemoteFileOperations.ensureDirectoryExists(Path)` to create the partition location (and parents) when it is absent, reusing existing path existence and directory creation helpers.
- In `HiveCommitter`, before the overwrite rename, if the target partition path is missing, log a warning and ensure the directory exists so the rename-based commit can proceed.
- In `HiveMetastore`, if a requested partition is missing from the HMS result map, throw `StarRocksConnectorException` with table, partition name, and requested vs returned counts.
- Only log the rollback failure at error level when `rollbackFailedPartitions` is non-empty.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
<hr>This is an automatic backport of pull request #71810 done by [Mergify](https://mergify.com).

