### PR TITLE
[Enhancement] Cache base-version metadata in lake PK compaction delvec loader

### DIFF
--- a/be/src/storage/lake/lake_delvec_loader.cpp
+++ b/be/src/storage/lake/lake_delvec_loader.cpp
@@ -44,7 +44,10 @@ Status LakeDelvecLoader::load_from_file(const TabletSegmentId& tsid, int64_t ver
     *pdelvec = std::make_shared<DelVector>();
     // 2. find in delvec file
     TabletMetadataPtr metadata;
-    if (_lake_io_opts.location_provider) {
+    if (_cached_metadata != nullptr && _cached_metadata->id() == tsid.tablet_id &&
+        _cached_metadata->version() == version) {
+        metadata = _cached_metadata;
+    } else if (_lake_io_opts.location_provider) {
         const std::string filepath = _lake_io_opts.location_provider->tablet_metadata_location(tsid.tablet_id, version);
         ASSIGN_OR_RETURN(metadata, _tablet_manager->get_tablet_metadata(filepath, _fill_cache, 0, _lake_io_opts.fs));
     } else {

--- a/be/src/storage/lake/lake_delvec_loader.h
+++ b/be/src/storage/lake/lake_delvec_loader.h
@@ -26,11 +26,12 @@ namespace starrocks::lake {
 class LakeDelvecLoader : public DelvecLoader {
 public:
     LakeDelvecLoader(TabletManager* tablet_manager, const MetaFileBuilder* pk_builder, bool fill_cache,
-                     LakeIOOptions lake_io_opts)
+                     LakeIOOptions lake_io_opts, TabletMetadataPtr cached_metadata = nullptr)
             : _tablet_manager(tablet_manager),
               _pk_builder(pk_builder),
               _fill_cache(fill_cache),
-              _lake_io_opts(std::move(lake_io_opts)) {}
+              _lake_io_opts(std::move(lake_io_opts)),
+              _cached_metadata(std::move(cached_metadata)) {}
     Status load(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec) override;
     Status load_from_meta(const TabletMetadataPtr& metadata, const DelvecPagePB& delvec_page, DelVectorPtr* pdelvec);
     Status load_from_file(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec);
@@ -40,6 +41,9 @@ private:
     const MetaFileBuilder* _pk_builder = nullptr;
     bool _fill_cache = false;
     LakeIOOptions _lake_io_opts;
+    // Reused across load_from_file calls whose (tablet_id, version) match, to skip
+    // get_tablet_metadata and its TabletMetadataPB deep copy on the hot path.
+    TabletMetadataPtr _cached_metadata;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
@@ -76,8 +76,12 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
     // init delvec loader
     LakeIOOptions lake_io_opts{.fill_data_cache = true, .skip_disk_cache = false};
 
-    auto delvec_loader =
-            std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, false /* fill cache */, lake_io_opts);
+    // Cache the base-version metadata once so per-rssid delvec loads skip get_tablet_metadata
+    // and its TabletMetadataPB deep copy (hot when one compaction merges hundreds of rowsets).
+    ASSIGN_OR_RETURN(auto base_metadata,
+                     _tablet_mgr->get_tablet_metadata(_rowset->tablet_id(), _base_version, true /* fill_cache */));
+    auto delvec_loader = std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, true /* fill cache */, lake_io_opts,
+                                                            std::move(base_metadata));
     // init params
     CompactConflictResolveParams params;
     params.tablet_id = _rowset->tablet_id();
@@ -102,8 +106,11 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
     // init delvec loader
     LakeIOOptions lake_io_opts{.fill_data_cache = true, .skip_disk_cache = false};
 
-    auto delvec_loader =
-            std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, false /* fill cache */, lake_io_opts);
+    // See the overload above: cache base-version metadata once to skip per-rssid deep copy.
+    ASSIGN_OR_RETURN(auto base_metadata,
+                     _tablet_mgr->get_tablet_metadata(_rowset->tablet_id(), _base_version, true /* fill_cache */));
+    auto delvec_loader = std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, true /* fill cache */, lake_io_opts,
+                                                            std::move(base_metadata));
     // init params
     CompactConflictResolveParams params;
     params.tablet_id = _rowset->tablet_id();

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -797,9 +797,9 @@ Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, co
         TRACE_COUNTER_SCOPE_LATENCY_US("delvec_file_read_latency_us");
         std::unique_ptr<RandomAccessFile> rf;
         if (lake_io_opts.fs && lake_io_opts.location_provider) {
-            ASSIGN_OR_RETURN(rf, lake_io_opts.fs->new_random_access_file(
-                                         opts, lake_io_opts.location_provider->delvec_location(metadata.id(),
-                                                                                               delvec_name)));
+            ASSIGN_OR_RETURN(
+                    rf, lake_io_opts.fs->new_random_access_file(
+                                opts, lake_io_opts.location_provider->delvec_location(metadata.id(), delvec_name)));
         } else {
             ASSIGN_OR_RETURN(rf,
                              fs::new_random_access_file(opts, tablet_mgr->delvec_location(metadata.id(), delvec_name)));

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -793,15 +793,19 @@ Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, co
     }
     const auto& delvec_name = iter->second.name();
     RandomAccessFileOptions opts{.skip_fill_local_cache = !lake_io_opts.fill_data_cache};
-    std::unique_ptr<RandomAccessFile> rf;
-    if (lake_io_opts.fs && lake_io_opts.location_provider) {
-        ASSIGN_OR_RETURN(rf,
-                         lake_io_opts.fs->new_random_access_file(
-                                 opts, lake_io_opts.location_provider->delvec_location(metadata.id(), delvec_name)));
-    } else {
-        ASSIGN_OR_RETURN(rf, fs::new_random_access_file(opts, tablet_mgr->delvec_location(metadata.id(), delvec_name)));
+    {
+        TRACE_COUNTER_SCOPE_LATENCY_US("delvec_file_read_latency_us");
+        std::unique_ptr<RandomAccessFile> rf;
+        if (lake_io_opts.fs && lake_io_opts.location_provider) {
+            ASSIGN_OR_RETURN(rf, lake_io_opts.fs->new_random_access_file(
+                                         opts, lake_io_opts.location_provider->delvec_location(metadata.id(),
+                                                                                               delvec_name)));
+        } else {
+            ASSIGN_OR_RETURN(rf,
+                             fs::new_random_access_file(opts, tablet_mgr->delvec_location(metadata.id(), delvec_name)));
+        }
+        RETURN_IF_ERROR(rf->read_at_fully(delvec_page.offset(), buf.data(), delvec_page.size()));
     }
-    RETURN_IF_ERROR(rf->read_at_fully(delvec_page.offset(), buf.data(), delvec_page.size()));
     if (delvec_page.has_crc32c() && delvec_page.crc32c_gen_version() == delvec_page.version()) {
         // check crc32c
         uint32_t crc32c = crc32c::Value(buf.data(), delvec_page.size());

--- a/be/test/storage/lake/lake_delvec_loader_test.cpp
+++ b/be/test/storage/lake/lake_delvec_loader_test.cpp
@@ -23,6 +23,7 @@
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/metacache.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/update_manager.h"
@@ -221,6 +222,90 @@ TEST_F(LakeDelvecLoaderTest, test_load_from_file_normal) {
 
     st = loader.load_from_file(tsid, version, &pdelvec);
     ASSERT_TRUE(st.ok());
+    ASSERT_TRUE(pdelvec != nullptr);
+    EXPECT_EQ(expected_delvec, pdelvec->save());
+}
+
+// Test that load_from_file reuses the cached metadata when (tablet_id, version) matches.
+// The on-disk tablet metadata file and the metacache entry are both removed before loading, so
+// a fallback to get_tablet_metadata would fail with NotFound. Successful load therefore proves
+// the cached-metadata fast path is taken.
+TEST_F(LakeDelvecLoaderTest, test_load_from_file_with_cached_metadata) {
+    const int64_t tablet_id = 10006;
+    const uint32_t segment_id = 600;
+    const int64_t version = 15;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(version);
+    metadata->set_next_rowset_id(110);
+    metadata->mutable_schema()->set_keys_type(PRIMARY_KEYS);
+
+    MetaFileBuilder builder(*tablet, metadata);
+    DelVector dv;
+    dv.set_empty();
+    std::shared_ptr<DelVector> ndv;
+    std::vector<uint32_t> dels = {7, 14, 21};
+    dv.add_dels_as_new_version(dels, version, &ndv);
+    std::string expected_delvec = ndv->save();
+
+    builder.append_delvec(ndv, segment_id);
+    ASSERT_TRUE(builder.finalize(next_id()).ok());
+
+    ASSIGN_OR_ABORT(auto cached_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    auto meta_path = _tablet_manager->tablet_metadata_location(tablet_id, version);
+    ASSERT_TRUE(FileSystem::Default()->delete_file(meta_path).ok());
+    _tablet_manager->metacache()->erase(meta_path);
+
+    DelVectorPtr pdelvec;
+    TabletSegmentId tsid(tablet_id, segment_id);
+
+    LakeIOOptions lake_io_opts;
+    LakeDelvecLoader loader(_tablet_manager.get(), nullptr, false /* fill_cache */, lake_io_opts, cached_metadata);
+
+    ASSERT_TRUE(loader.load_from_file(tsid, version, &pdelvec).ok());
+    ASSERT_TRUE(pdelvec != nullptr);
+    EXPECT_EQ(expected_delvec, pdelvec->save());
+}
+
+// Test that load_from_file ignores the cached metadata when its (tablet_id, version) does not
+// match the request, and still succeeds by falling back to get_tablet_metadata from disk.
+TEST_F(LakeDelvecLoaderTest, test_load_from_file_with_mismatched_cached_metadata) {
+    const int64_t tablet_id = 10007;
+    const uint32_t segment_id = 700;
+    const int64_t version = 16;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(version);
+    metadata->set_next_rowset_id(110);
+    metadata->mutable_schema()->set_keys_type(PRIMARY_KEYS);
+
+    MetaFileBuilder builder(*tablet, metadata);
+    DelVector dv;
+    dv.set_empty();
+    std::shared_ptr<DelVector> ndv;
+    std::vector<uint32_t> dels = {11, 22, 33};
+    dv.add_dels_as_new_version(dels, version, &ndv);
+    std::string expected_delvec = ndv->save();
+
+    builder.append_delvec(ndv, segment_id);
+    ASSERT_TRUE(builder.finalize(next_id()).ok());
+
+    // Cached metadata is for a different version; the loader must fall back to disk read.
+    auto stale_metadata = std::make_shared<TabletMetadata>();
+    stale_metadata->set_id(tablet_id);
+    stale_metadata->set_version(version + 1);
+
+    DelVectorPtr pdelvec;
+    TabletSegmentId tsid(tablet_id, segment_id);
+
+    LakeIOOptions lake_io_opts;
+    LakeDelvecLoader loader(_tablet_manager.get(), nullptr, true /* fill_cache */, lake_io_opts, stale_metadata);
+
+    ASSERT_TRUE(loader.load_from_file(tsid, version, &pdelvec).ok());
     ASSERT_TRUE(pdelvec != nullptr);
     EXPECT_EQ(expected_delvec, pdelvec->save());
 }


### PR DESCRIPTION
## Why I'm doing:

In shared-data (lake) mode, `PrimaryKeyCompactionConflictResolver` loads one delvec per input rowset segment via `LakeDelvecLoader::load_from_file`. That path calls `TabletManager::get_tablet_metadata(tablet_id, base_version)` on every rssid, and `get_tablet_metadata` deep-copies the whole `TabletMetadataPB` even on cache hits. When a single compaction merges hundreds of rowsets (observed at >300 in real-time import tests), this becomes a visible contributor to `compaction_delvec_loader_latency_us`.

The loader is also constructed with `fill_cache=false`, so the delvecs read from remote storage never populate the metacache — they get refetched every compaction.

## What I'm doing:

- Plumb an optional cached `TabletMetadataPtr` into `LakeDelvecLoader` and reuse it in `load_from_file` whenever `(tablet_id, version)` matches, so one compaction performs one `get_tablet_metadata` instead of N.
- In `LakePrimaryKeyCompactionConflictResolver::segment_iterator` (both overloads), fetch the `base_version` metadata once with `fill_cache=true` and hand it to the loader; also flip the loader's own `fill_cache` to `true` so loaded delvecs land in metacache and can be reused across subsequent compactions.
- Add a `delvec_file_read_latency_us` `TRACE_COUNTER` scope in `get_del_vec` around the remote `new_random_access_file` + `read_at_fully`, so the remainder of `compaction_delvec_loader_latency_us` can be attributed to actual I/O vs. metadata bookkeeping.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4