### PR TITLE
[BugFix] Remove testOnQueryFinished_clearsListeners UT wrongly backported into branch-3.5 (backport #69917)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -422,22 +422,6 @@ public class ConnectContextTest {
     }
 
     @Test
-    public void testOnQueryFinished_clearsListeners() {
-        ConnectContext ctx = new ConnectContext(connection);
-
-        ConnectContext.Listener listener = Mockito.mock(ConnectContext.Listener.class);
-        ctx.registerListener(listener);
-
-        // First call
-        ctx.onQueryFinished();
-        Mockito.verify(listener, Mockito.times(1)).onQueryFinished(ctx);
-
-        // Second call - listener should not be called again (cleared after first call)
-        ctx.onQueryFinished();
-        Mockito.verify(listener, Mockito.times(1)).onQueryFinished(ctx);
-    }
-
-    @Test
     public void testOnQueryFinished_withoutListeners() {
         ConnectContext ctx = new ConnectContext(connection);
 


### PR DESCRIPTION
## Why I'm doing:

Branch-3.5 CI unit tests are failing due to a stray UT `testOnQueryFinished_clearsListeners` in `ConnectContextTest.java`. This test was incorrectly introduced by backport PR #69917 (backport of #69834 + #69901, "Wait for journal replay in changeCatalogDb on follower FE"). The original #69834 did not contain this test.

The test actually originates from #65802 ("Fix query queue allocation time and pending timeout"), which was **never merged into branch-3.5**. The corresponding source-side change in `ConnectContext.onQueryFinished()` (clearing listeners after dispatch) is not present on 3.5, so the test's second-call assertion (`Mockito.verify(listener, times(1))`) will always fail on this branch.

## What I'm doing:

Remove `testOnQueryFinished_clearsListeners` from `fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java` on `branch-3.5` only. The actual journal-replay fix (#69834) that #69917 was meant to backport is untouched.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4