### PR TITLE
[BugFix] Preserve Iceberg column stats in manifest data file cache

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -251,6 +251,8 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
     }
 
     private CloseableIterable<ManifestEntry<F>> entries(boolean onlyLive) {
+        boolean shouldCacheDataFiles = shouldCacheDataFiles();
+        boolean shouldCacheDeleteFiles = shouldCacheDeleteFiles();
         if (hasRowFilter() || hasPartitionFilter() || partitionSet != null) {
             Evaluator evaluator = evaluator();
             InclusiveMetricsEvaluator metricsEvaluator = metricsEvaluator();
@@ -259,9 +261,10 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
             boolean requireStatsProjection = requireStatsProjection(rowFilter, columns);
             Collection<String> projectColumns =
                     requireStatsProjection ? withStatsColumns(columns) : columns;
+            projectColumns = withStatsColumnsForDataFileCache(projectColumns, shouldCacheDataFiles);
             CloseableIterable<ManifestEntry<F>> entries =
                     open(projection(fileSchema, fileProjection, projectColumns, caseSensitive));
-            entries = fillCacheIfNeeded(entries);
+            entries = fillCacheIfNeeded(entries, shouldCacheDataFiles, shouldCacheDeleteFiles);
             return CloseableIterable.filter(
                     content == FileType.DATA_FILES
                             ? scanMetrics.skippedDataFiles()
@@ -273,20 +276,17 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
                                     && metricsEvaluator.eval(entry.file())
                                     && inPartitionSet(entry.file()));
         } else {
+            Collection<String> projectColumns = withStatsColumnsForDataFileCache(columns, shouldCacheDataFiles);
             CloseableIterable<ManifestEntry<F>> entries =
-                    open(projection(fileSchema, fileProjection, columns, caseSensitive));
-            entries = fillCacheIfNeeded(entries);
+                    open(projection(fileSchema, fileProjection, projectColumns, caseSensitive));
+            entries = fillCacheIfNeeded(entries, shouldCacheDataFiles, shouldCacheDeleteFiles);
             return onlyLive ? filterLiveEntries(entries) : entries;
         }
     }
 
     // when the identifier field ids is null, it will copy all metrics.
-    private CloseableIterable<ManifestEntry<F>> fillCacheIfNeeded(CloseableIterable<ManifestEntry<F>> entries) {
-        boolean shouldCacheDataFiles =
-                dataFileCache != null && content == FileType.DATA_FILES && dataFileCache.getIfPresent(file.location()) != null;
-        boolean shouldCacheDeleteFiles =
-                deleteFileCache != null && content == FileType.DELETE_FILES &&
-                        deleteFileCache.getIfPresent(file.location()) != null;
+    private CloseableIterable<ManifestEntry<F>> fillCacheIfNeeded(
+            CloseableIterable<ManifestEntry<F>> entries, boolean shouldCacheDataFiles, boolean shouldCacheDeleteFiles) {
         if (!shouldCacheDataFiles && !shouldCacheDeleteFiles) {
             return entries;
         }
@@ -363,6 +363,23 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
                 }
             }
         };
+    }
+
+    private boolean shouldCacheDataFiles() {
+        return dataFileCache != null && content == FileType.DATA_FILES && dataFileCache.getIfPresent(file.location()) != null;
+    }
+
+    private boolean shouldCacheDeleteFiles() {
+        return deleteFileCache != null && content == FileType.DELETE_FILES &&
+                deleteFileCache.getIfPresent(file.location()) != null;
+    }
+
+    private Collection<String> withStatsColumnsForDataFileCache(
+            Collection<String> projectColumns, boolean shouldCacheDataFiles) {
+        if (shouldCacheDataFiles && dataFileCacheWithMetrics && projectColumns != null) {
+            return withStatsColumns(projectColumns);
+        }
+        return projectColumns;
     }
 
     private boolean hasRowFilter() {

--- a/fe/fe-core/src/test/java/org/apache/iceberg/ManifestReaderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/iceberg/ManifestReaderTest.java
@@ -22,6 +22,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import org.mockito.Mockito;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -45,6 +47,16 @@ public class ManifestReaderTest {
             new Schema(required(1, "id", Types.IntegerType.get()), required(2, "data", Types.StringType.get()));
     private static final PartitionSpec TEST_SPEC = PartitionSpec.unpartitioned();
     private static final FileIO FILE_IO = new LocalFileIO();
+    private static final List<String> SCAN_COLUMNS_WITHOUT_STATS = List.of(
+            DataFile.CONTENT.name(),
+            DataFile.FILE_PATH.name(),
+            DataFile.FILE_FORMAT.name(),
+            DataFile.PARTITION_NAME,
+            DataFile.RECORD_COUNT.name(),
+            DataFile.FILE_SIZE.name(),
+            DataFile.SPLIT_OFFSETS.name(),
+            DataFile.SORT_ORDER_ID.name(),
+            DataFile.SPEC_ID.name());
 
     @TempDir
     Path tempDir;
@@ -88,6 +100,45 @@ public class ManifestReaderTest {
         Assertions.assertNotNull(cachedFilesRef.get(), "a fully materialized cache entry should be published on close");
         Assertions.assertEquals(Set.of(file1.location(), file2.location()),
                 cachedFilesRef.get().stream().map(DataFile::location).collect(Collectors.toSet()));
+    }
+
+    @Test
+    public void testFillCacheWithMetricsProjectsStatsWhenScanDoesNotRequestStats() throws IOException {
+        DataFile file = newDataFileWithStats("data-file-with-stats.parquet", 10L);
+        ManifestFile manifest = writeManifest("cache-with-stats.avro", file);
+
+        @SuppressWarnings("unchecked")
+        Cache<String, Set<DataFile>> dataFileCache = Mockito.mock(Cache.class);
+        Set<DataFile> placeholder = ConcurrentHashMap.newKeySet();
+        Mockito.when(dataFileCache.getIfPresent(manifest.path())).thenReturn(placeholder);
+
+        AtomicReference<Set<DataFile>> cachedFilesRef = new AtomicReference<>();
+        Mockito.doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            Set<DataFile> cachedFiles = invocation.getArgument(1);
+            cachedFilesRef.set(cachedFiles);
+            return null;
+        }).when(dataFileCache).put(Mockito.eq(manifest.path()), Mockito.anySet());
+
+        ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO, Map.of(TEST_SPEC.specId(), TEST_SPEC))
+                .select(SCAN_COLUMNS_WITHOUT_STATS)
+                .dataFileCache(dataFileCache)
+                .cacheWithMetrics(true);
+
+        try (CloseableIterable<ManifestEntry<DataFile>> entries = reader.liveEntries();
+                CloseableIterator<ManifestEntry<DataFile>> iterator = entries.iterator()) {
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+        }
+
+        Assertions.assertNotNull(cachedFilesRef.get(), "cache entry should be published after full consumption");
+        DataFile cachedFile = cachedFilesRef.get().iterator().next();
+        Assertions.assertNotNull(cachedFile.lowerBounds(), "cached data file should keep lower bounds");
+        Assertions.assertEquals(file.lowerBounds(), cachedFile.lowerBounds());
+        Assertions.assertEquals(file.upperBounds(), cachedFile.upperBounds());
+        Assertions.assertEquals(file.valueCounts(), cachedFile.valueCounts());
+        Assertions.assertEquals(file.nullValueCounts(), cachedFile.nullValueCounts());
     }
 
     @Test
@@ -136,6 +187,23 @@ public class ManifestReaderTest {
                 .withPath(tempDir.resolve(fileName).toString())
                 .withFileSizeInBytes(64L)
                 .withRecordCount(recordCount)
+                .build();
+    }
+
+    private DataFile newDataFileWithStats(String fileName, long recordCount) {
+        Metrics metrics = new Metrics(
+                recordCount,
+                Map.of(1, 4L),
+                Map.of(1, recordCount),
+                Map.of(1, 0L),
+                null,
+                Map.of(1, Conversions.toByteBuffer(Types.IntegerType.get(), 1)),
+                Map.of(1, Conversions.toByteBuffer(Types.IntegerType.get(), 10)));
+        return DataFiles.builder(TEST_SPEC)
+                .withPath(tempDir.resolve(fileName).toString())
+                .withFileSizeInBytes(64L)
+                .withRecordCount(recordCount)
+                .withMetrics(metrics)
                 .build();
     }
 

--- a/test/sql/test_iceberg/R/test_iceberg_min_max_opt
+++ b/test/sql/test_iceberg/R/test_iceberg_min_max_opt
@@ -1,5 +1,5 @@
 -- name: test_iceberg_min_max_opt
-create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="false");
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
 -- result:
 -- !result
 create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
@@ -58,6 +58,19 @@ INSERT INTO ice_tbl_0 (
 (9, 90, 900, 9000, true, 9.9, 10.1, 90.000000000000000009, '2025-06-29 09:20:00', 'iota', '2025-07-07', '09:20:00'),
 (10, 100, 1000, 10000, false, 10.1, 11.2, 100.000000000000000010, '2025-06-29 09:30:00', 'kappa', '2025-07-08', '09:30:00');
 -- result:
+-- !result
+select c_tinyint from ice_tbl_0 order by c_tinyint;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
 -- !result
 set enable_min_max_optimization = true;
 -- result:
@@ -192,6 +205,20 @@ INSERT INTO ice_tbl_0 (
 (null, 10, 100, null, true, 1.1, 2.2, 10.000000000000000001, '2025-06-29 08:00:00', 'alpha', '2025-06-29', '08:00:00');
 -- result:
 -- !result
+select c_tinyint from ice_tbl_0 order by c_tinyint;
+-- result:
+None
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+-- !result
 set enable_min_max_optimization = true;
 -- result:
 -- !result
@@ -261,6 +288,10 @@ INSERT overwrite ice_tbl_0 (
 (null, 10, 100, null, true, 1.1, 2.2, 10.000000000000000001, '2025-06-29 08:00:00', 'alpha', '2025-06-29', '08:00:00');
 -- result:
 -- !result
+select c_tinyint from ice_tbl_0 order by c_tinyint;
+-- result:
+None
+-- !result
 set enable_min_max_optimization = true;
 -- result:
 -- !result
@@ -328,6 +359,12 @@ INSERT INTO ice_tbl_dt (c_int, c_datetime) VALUES
 (3, '2025-06-29 10:20:00');
 -- result:
 -- !result
+select c_int from ice_tbl_dt order by c_int;
+-- result:
+1
+2
+3
+-- !result
 set enable_min_max_optimization = true;
 -- result:
 -- !result
@@ -391,6 +428,10 @@ INSERT INTO ice_tbl_1 (
 (null, null);
 -- result:
 -- !result
+select c_int from ice_tbl_1 order by c_int;
+-- result:
+None
+-- !result
 select min(c_int), max(c_int), min(c_bigint), max(c_bigint) from ice_tbl_1;
 -- result:
 None	None	None	None
@@ -415,6 +456,11 @@ INSERT INTO ice_tbl_2 (
 (10, '2021-01-01 13:00:00'),
 (20, '2022-01-01 14:00:00');
 -- result:
+-- !result
+select c_int from ice_tbl_2 order by c_int;
+-- result:
+10
+20
 -- !result
 select min(c_int), max(c_int) from ice_tbl_2;
 -- result:
@@ -450,6 +496,14 @@ INSERT INTO ice_tbl_3 (id, name) VALUES
 (4, 'dave'),
 (5, 'eve');
 -- result:
+-- !result
+select id from ice_tbl_3 order by id;
+-- result:
+1
+2
+3
+4
+5
 -- !result
 select min(id), max(id) from ice_tbl_3;
 -- result:

--- a/test/sql/test_iceberg/T/test_iceberg_min_max_opt
+++ b/test/sql/test_iceberg/T/test_iceberg_min_max_opt
@@ -1,6 +1,6 @@
 -- name: test_iceberg_min_max_opt
 
-create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="false");
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
 
 create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 set catalog iceberg_sql_test_${uuid0};
@@ -8,6 +8,10 @@ use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 
 set enable_profile = true;
 set enable_async_profile = false;
+
+-- In each test case, after inserting data, we will run a simple query to fill data files cache and metadata cache on purpose
+-- we don't request column stats in this scan, we need to make sure the file stats are loaded in cache for later tests.
+-- if it does not, then following queries can not use column stats and will trigger io read.
 
 -- ============================================================
 -- Case 1: all supported types (tinyint/smallint/int/bigint/bool/float/double/date).
@@ -53,6 +57,8 @@ INSERT INTO ice_tbl_0 (
 (8, 80, 800, 8000, false, 8.8, 9.9, 80.000000000000000008, '2025-06-29 09:10:00', 'theta', '2025-07-06', '09:10:00'),
 (9, 90, 900, 9000, true, 9.9, 10.1, 90.000000000000000009, '2025-06-29 09:20:00', 'iota', '2025-07-07', '09:20:00'),
 (10, 100, 1000, 10000, false, 10.1, 11.2, 100.000000000000000010, '2025-06-29 09:30:00', 'kappa', '2025-07-08', '09:30:00');
+
+select c_tinyint from ice_tbl_0 order by c_tinyint;
 
 set enable_min_max_optimization = true;
 select min(c_tinyint) as min_tinyint, 
@@ -173,6 +179,8 @@ INSERT INTO ice_tbl_0 (
 ) VALUES
 (null, 10, 100, null, true, 1.1, 2.2, 10.000000000000000001, '2025-06-29 08:00:00', 'alpha', '2025-06-29', '08:00:00');
 
+select c_tinyint from ice_tbl_0 order by c_tinyint;
+
 set enable_min_max_optimization = true;
 select min(c_tinyint) as min_tinyint, 
        max(c_tinyint) as max_tinyint,
@@ -233,6 +241,8 @@ INSERT overwrite ice_tbl_0 (
 ) VALUES
 (null, 10, 100, null, true, 1.1, 2.2, 10.000000000000000001, '2025-06-29 08:00:00', 'alpha', '2025-06-29', '08:00:00');
 
+select c_tinyint from ice_tbl_0 order by c_tinyint;
+
 set enable_min_max_optimization = true;
 select min(c_tinyint) as min_tinyint, 
        max(c_tinyint) as max_tinyint,
@@ -291,6 +301,8 @@ INSERT INTO ice_tbl_dt (c_int, c_datetime) VALUES
 (2, '2025-06-29 09:10:00'),
 (3, '2025-06-29 10:20:00');
 
+select c_int from ice_tbl_dt order by c_int;
+
 set enable_min_max_optimization = true;
 set time_zone = 'UTC';
 select min(c_datetime), max(c_datetime) from ice_tbl_dt;
@@ -326,6 +338,8 @@ INSERT INTO ice_tbl_1 (
 ) VALUES
 (null, null);
 
+select c_int from ice_tbl_1 order by c_int;
+
 select min(c_int), max(c_int), min(c_bigint), max(c_bigint) from ice_tbl_1;
 select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
 
@@ -346,6 +360,8 @@ INSERT INTO ice_tbl_2 (
 ) VALUES
 (10, '2021-01-01 13:00:00'),
 (20, '2022-01-01 14:00:00');
+
+select c_int from ice_tbl_2 order by c_int;
 
 select min(c_int), max(c_int) from ice_tbl_2;
 select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';
@@ -373,6 +389,8 @@ INSERT INTO ice_tbl_3 (id, name) VALUES
 (3, 'carol'),
 (4, 'dave'),
 (5, 'eve');
+
+select id from ice_tbl_3 order by id;
 
 select min(id), max(id) from ice_tbl_3;
 select * from (select line from table(unnest(split(get_query_profile(last_query_id()),"\n"))) t(line)) v where v.line like '%RowsRead: 0%';


### PR DESCRIPTION
## Why

When `iceberg_manifest_cache_with_column_statistics` is enabled, StarRocks expects cached Iceberg `DataFile` objects to preserve column statistics.

However, if the first query against a table does not request column stats, for example `SELECT * FROM t`, the manifest reader may fill the data file cache with `DataFile` objects that do not contain stats. Later queries such as `SELECT min(id) FROM t` can reuse that cache entry and miss the column stats.

## What

This change makes the manifest reader include stats columns when filling the data file cache with metrics enabled.

It also adds a unit test to verify that the data file cache keeps lower bounds, upper bounds, value counts, and null value counts even when the scan projection itself does not request stats.

## Behavior

```text
Iceberg manifest
    |
    v
ManifestReader
    |
    |-- iceberg_manifest_cache_with_column_statistics=true
    |      -> read stats columns while filling dataFileCache
    |
    |-- iceberg_manifest_cache_with_column_statistics=false
           -> cache DataFile without stats

dataFileCache
    |
    v
Query planning / optimization
    |
    |-- enable_iceberg_column_statistics=true
    |      -> optimizer may use cached Iceberg column stats
    |
    |-- enable_iceberg_column_statistics=false
           -> stats may exist in cache, but optimizer does not use them

Catalog property:
  iceberg_manifest_cache_with_column_statistics
    Controls what is stored in the manifest data file cache.

Session variable:
  enable_iceberg_column_statistics
    Controls whether query planning uses Iceberg column stats.

Query behavior:
  SELECT * FROM t
    Can fill cache, but does not need stats itself.

  SELECT min(id) FROM t
    May use column stats if enabled and available.

```

Fixes #67158

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
