### PR TITLE
[BugFix] mask CVE-2026-2332 temporary, unblock build

### DIFF
--- a/trivy.yaml
+++ b/trivy.yaml
@@ -30,3 +30,5 @@ scan:
     - "**/parquet-jackson-1.15.2.jar"
     # from fe
     - "**/parquet-jackson-1.16.0.jar"
+    # CVE-2026-2332, ignore for now
+    - "**/jetty-http-9.4.57.v20241219.jar"


### PR DESCRIPTION
* there is no jetty-http-9.4.60 for the fix
* jetty-9.x/10.x/11.x are all EOL, the community will not publish new versions for the CVE fixes for the old releases

## Why I'm doing:

## What I'm doing:

Refs #71748

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
