### PR TITLE
[Enhancement] Pin Iceberg snapshot across Hybrid PCT multi-batch refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.pct.PCTPartitionTopology;
 import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
@@ -31,6 +32,10 @@ public class MvTaskRunContext extends TaskRunContext {
     public static class MVRefreshRuntimeState {
         private final Map<Long, BaseTableSnapshotInfo> snapshotBaseTables = Maps.newHashMap();
 
+        // Pinned TvrVersionRange per base table, keyed by Table.getTableIdentifier() (stable across
+        // connector getTable() calls, unlike tableId for external tables).
+        private final Map<String, TvrVersionRange> pinnedTvrMap = Maps.newHashMap();
+
         public Map<Long, BaseTableSnapshotInfo> getSnapshotBaseTables() {
             return snapshotBaseTables;
         }
@@ -40,8 +45,13 @@ public class MvTaskRunContext extends TaskRunContext {
             this.snapshotBaseTables.putAll(snapshotBaseTables);
         }
 
+        public Map<String, TvrVersionRange> getPinnedTvrMap() {
+            return pinnedTvrMap;
+        }
+
         public void reset() {
             snapshotBaseTables.clear();
+            pinnedTvrMap.clear();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -74,6 +74,8 @@ public class TaskRun implements Comparable<TaskRun> {
     public static final String PARTITION_VALUES = "PARTITION_VALUES";
     public static final String FORCE = "FORCE";
     public static final String START_TASK_RUN_ID = "START_TASK_RUN_ID";
+    // Set on pinned-PCT batches only; value is the pinning job's START_TASK_RUN_ID.
+    public static final String PINNED_REFRESH_JOB_ID = "PINNED_REFRESH_JOB_ID";
     // Only used in FE's UT
     public static final String IS_TEST = "__IS_TEST__";
 
@@ -81,22 +83,25 @@ public class TaskRun implements Comparable<TaskRun> {
     // MV's task run can be generated from the last task run, those properties are not allowed to be copied from one task run
     // to another and must be only set specifically for each run but cannot be extended from the last task run.
     // eg: `FORCE` is only allowed to set in the first task run and cannot be copied into the following task run.
+    // `PINNED_REFRESH_JOB_ID` is re-set per batch based on pinning owner status — must not inherit.
     public static final Set<String> MV_UNCOPYABLE_PROPERTIES = ImmutableSet.of(
-            PARTITION_START, PARTITION_END, PARTITION_VALUES);
+            PARTITION_START, PARTITION_END, PARTITION_VALUES, PINNED_REFRESH_JOB_ID);
     // If there are many pending mv task runs, we can merge some of them by comparing the properties, those properties that are
     // used to check equality of task runs and we can ignore the other properties.
     // eg:
     // - `FORCE` is used to check equality of task runs because the refresh partitions are different for each task run.
     // - `PROPERTIES_WAREHOUSE`/`START_TASK_RUN_ID` is no need to check equality of task runs because they will not affect
     //  the task run's result.
+    // - `PINNED_REFRESH_JOB_ID` scopes merge isolation to pinned batches; pure PCT is unaffected.
     public static final Set<String> MV_COMPARABLE_PROPERTIES = ImmutableSet.of(
-            MV_ID, PARTITION_START, PARTITION_END, PARTITION_VALUES, FORCE);
+            MV_ID, PARTITION_START, PARTITION_END, PARTITION_VALUES, FORCE, PINNED_REFRESH_JOB_ID);
     // Properties that can be set in TaskRun which are used to distinguish other noisy properties from users' defined properties.
     // and will ignore other properties in the task run history.
     // This should be only used in the task run history table and should not used for checking task run's real properties
     // because this is not a complete list of task run properties.
     public static final Set<String> RESERVED_HISTORY_TASK_RUN_PROPERTIES = ImmutableSet.of(
-            MV_ID, PARTITION_START, PARTITION_END, FORCE, START_TASK_RUN_ID, PARTITION_VALUES, PROPERTIES_WAREHOUSE, IS_TEST);
+            MV_ID, PARTITION_START, PARTITION_END, FORCE, START_TASK_RUN_ID, PARTITION_VALUES, PROPERTIES_WAREHOUSE,
+            PINNED_REFRESH_JOB_ID, IS_TEST);
 
     public static final int INVALID_TASK_PROGRESS = -1;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -37,6 +37,7 @@ import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
@@ -255,6 +256,48 @@ public abstract class BaseMVRefreshProcessor {
 
     protected void setSnapshotBaseTables(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
         refreshRuntimeState.replaceSnapshotBaseTables(snapshotBaseTables);
+    }
+
+    // Current task run's START_TASK_RUN_ID (null when status is uninitialized, e.g. in tests).
+    protected String getStartTaskRunId() {
+        return mvContext.getStatus() != null ? mvContext.getStatus().getStartTaskRunId() : null;
+    }
+
+    // True when this task run owns the persistent pinning record — the fallback first batch right
+    // after afterSyncHook installs us, and every subsequent batch of the same job.
+    protected boolean isPinnedMode() {
+        String owner = mv.getRefreshScheme().getAsyncRefreshContext().getTempTvrOwnerStartTaskRunId();
+        return owner != null && owner.equals(getStartTaskRunId());
+    }
+
+    // Hydrate pinnedTvrMap and each PCTTableSnapshotInfo.pinnedRange from the persistent temp
+    // TVR map. Must run after syncAndCheckPCTPartitions (snapshotBaseTables ready) and after
+    // afterSyncHook (owner installed, if any). No-op for non-pinned runs.
+    protected void setupPinnedRangesIfNeeded() {
+        if (!isPinnedMode()) {
+            return;
+        }
+        final Map<BaseTableInfo, TvrVersionRange> frozen =
+                mv.getRefreshScheme().getAsyncRefreshContext().getTempBaseTableInfoTvrDeltaMap();
+        final Map<String, TvrVersionRange> pinnedMap = refreshRuntimeState.getPinnedTvrMap();
+        pinnedMap.clear();
+
+        for (BaseTableSnapshotInfo info : snapshotBaseTables.values()) {
+            final BaseTableInfo bti = info.getBaseTableInfo();
+            final TvrVersionRange tvr = frozen.get(bti);
+            if (tvr == null) {
+                // pure-PCT base table, no pinning
+                continue;
+            }
+            final TvrVersionRange pinned = TvrTableSnapshot.of(tvr.end());
+            pinnedMap.put(bti.getTableIdentifier(), pinned);
+
+            if (info instanceof PCTTableSnapshotInfo) {
+                ((PCTTableSnapshotInfo) info).setPinnedRange(pinned);
+            }
+        }
+        logger.info("setup pinned context for {} base tables, owner={}",
+                pinnedMap.size(), mv.getRefreshScheme().getAsyncRefreshContext().getTempTvrOwnerStartTaskRunId());
     }
 
     /**
@@ -836,8 +879,13 @@ public abstract class BaseMVRefreshProcessor {
         while (!checked && retryNum++ < Config.max_mv_check_base_table_change_retry_times) {
             mvEntity.increaseRefreshRetryMetaCount(1L);
             try (Timer ignored = Tracers.watchScope("MVRefreshExternalTable")) {
-                // refresh external table meta cache before sync partitions
-                refreshExternalTable(baseTableCandidatePartitions);
+                // Skip in pinned mode — subsequent batches reuse the cached metadata the pinning
+                // owner already collected, keeping a consistent job-wide view across base tables.
+                if (!isPinnedMode()) {
+                    refreshExternalTable(baseTableCandidatePartitions);
+                } else {
+                    logger.info("Skip refreshExternalTable in pinned PCT mode");
+                }
             }
 
             if (shouldSyncPartitionsAfterExternalRefresh(retryNum)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
@@ -100,40 +100,28 @@ public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor 
         // reset the task run id for pct
         this.mvContext.getCtx().setQueryId(UUIDUtil.genUUID());
 
-        // Clear stale temp TVR state from any prior attempt (explain-only, failed run, etc.)
-        // before starting a fresh complete-refresh cycle. Without this, a SKIPPED result below
-        // would leave the stale map/owner intact, risking incorrect TVR promotion by a later run.
+        // First-batch setup: drop stale state from any prior attempt and install the freeze hook.
+        // Subsequent batches reuse the persisted owner and do not enter this branch.
         if (mvRefreshParams.isCompleteRefresh()) {
             mv.getRefreshScheme().getAsyncRefreshContext().clearTempBaseTableInfoTvrDeltaState();
+            pctProcessor.setAfterSyncHook(() -> {
+                MaterializedView.AsyncRefreshContext refreshContext =
+                        mv.getRefreshScheme().getAsyncRefreshContext();
+                final Map<BaseTableInfo, TvrVersionRange> committedMap =
+                        refreshContext.getBaseTableInfoTvrVersionRangeMap();
+                final Map<BaseTableInfo, TvrVersionRange> frozen = Maps.newHashMap();
+                for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+                    TvrVersionRange changedVersionRange = ivmProcessor.getBaseTableMaxChangedDelta(
+                            snapshotInfo, committedMap);
+                    logger.info("Base table: {}, changed version range: {}",
+                            snapshotInfo.getBaseTableInfo().getTableName(), changedVersionRange);
+                    frozen.put(snapshotInfo.getBaseTableInfo(), changedVersionRange);
+                }
+                refreshContext.replaceTempBaseTableInfoTvrDeltaMap(getStartTaskRunId(), frozen);
+            });
         }
 
-        // ① Execute PCT first — this calls syncAndCheckPCTPartitions() internally,
-        //    which refreshes external tables and re-collects snapshotBaseTables.
-        //    After this returns, snapshotBaseTables reflects the snapshot that PCT will actually process.
-        ProcessExecPlan result = pctProcessor.getProcessExecPlan(taskRunContext);
-
-        // ② Freeze TVR from the SAME snapshotBaseTables that PCT uses.
-        //    This guarantees the persisted TVR matches the snapshot that PCT will scan.
-        //    Skip freeze if PCT found nothing to refresh (SKIPPED) — no subsequent batches will follow.
-        if (mvRefreshParams.isCompleteRefresh()
-                && result.state() == Constants.TaskRunState.SUCCESS) {
-            MaterializedView.AsyncRefreshContext refreshContext =
-                    mv.getRefreshScheme().getAsyncRefreshContext();
-            final Map<BaseTableInfo, TvrVersionRange> committedMap =
-                    refreshContext.getBaseTableInfoTvrVersionRangeMap();
-            Map<BaseTableInfo, TvrVersionRange> frozen = Maps.newHashMap();
-            for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
-                TvrVersionRange changedVersionRange = ivmProcessor.getBaseTableMaxChangedDelta(
-                        snapshotInfo, committedMap);
-                logger.info("Base table: {}, changed version range: {}",
-                        snapshotInfo.getBaseTableInfo().getTableName(), changedVersionRange);
-                frozen.put(snapshotInfo.getBaseTableInfo(), changedVersionRange);
-            }
-            String owner = mvContext.getStatus().getStartTaskRunId();
-            refreshContext.replaceTempBaseTableInfoTvrDeltaMap(owner, frozen);
-        }
-
-        return result;
+        return pctProcessor.getProcessExecPlan(taskRunContext);
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
@@ -74,11 +74,42 @@ import static com.starrocks.scheduler.TaskRun.MV_UNCOPYABLE_PROPERTIES;
  */
 public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
 
+    // One-shot callback invoked after syncAndCheckPCTPartitions and before plan building. Used by
+    // Hybrid fallback to freeze TVR so the pinned state is visible to the plan builder and differ.
+    private Runnable afterSyncHook;
+
+    // True when this is a subsequent pinned batch whose pinning owner has been overwritten by
+    // a newer job — we must SKIP to avoid touching the newer job's state.
+    //
+    // Gate on PINNED_REFRESH_JOB_ID to confirm the current run is actually a pinned batch.
+    // Without this, an unrelated partial refresh running while a prior pinning job's owner
+    // state has been left behind (e.g. failure/abort before final cleanup) would be falsely
+    // SKIPPED and its requested partitions would never refresh.
+    private boolean isStalePinnedBatch() {
+        if (mvRefreshParams.isCompleteRefresh()) {
+            return false;
+        }
+        if (mvContext.getProperties().get(TaskRun.PINNED_REFRESH_JOB_ID) == null) {
+            return false;
+        }
+        String owner = mv.getRefreshScheme().getAsyncRefreshContext().getTempTvrOwnerStartTaskRunId();
+        String startTaskRunId = getStartTaskRunId();
+        if (owner != null && !owner.equals(startTaskRunId)) {
+            logger.warn("Skip stale pinned batch: pinning owner={}, startTaskRunId={}", owner, startTaskRunId);
+            return true;
+        }
+        return false;
+    }
+
     public MVPCTBasedRefreshProcessor(Database db, MaterializedView mv,
                                       MvTaskRunContext mvContext,
                                       IMaterializedViewMetricsEntity mvEntity,
                                       MaterializedView.RefreshMode refreshMode) {
         super(db, mv, mvContext, mvEntity, refreshMode, MVPCTBasedRefreshProcessor.class);
+    }
+
+    public void setAfterSyncHook(Runnable afterSyncHook) {
+        this.afterSyncHook = afterSyncHook;
     }
 
     @Override
@@ -98,8 +129,21 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
 
     @Override
     public ProcessExecPlan getProcessExecPlan(TaskRunContext taskRunContext) throws Exception {
+        if (isStalePinnedBatch()) {
+            return new ProcessExecPlan(Constants.TaskRunState.SKIPPED, null, null);
+        }
+
         // sync and check partitions of base tables
         syncAndCheckPCTPartitions(taskRunContext);
+
+        // Clear-before-run: if the hook throws, the field is still nulled out on retry.
+        final Runnable hook = this.afterSyncHook;
+        this.afterSyncHook = null;
+        if (hook != null) {
+            hook.run();
+        }
+
+        setupPinnedRangesIfNeeded();
 
         // check to refresh partitions of mv and base tables
         try (Timer ignored = Tracers.watchScope("MVRefreshCheckMVToRefreshPartitions")) {
@@ -264,8 +308,14 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
             newProperties.put(TaskRun.PARTITION_START, mvContext.getNextPartitionStart());
             newProperties.put(TaskRun.PARTITION_END, mvContext.getNextPartitionEnd());
         }
-        if (mvContext.getStatus() != null) {
-            newProperties.put(TaskRun.START_TASK_RUN_ID, mvContext.getStatus().getStartTaskRunId());
+        String startTaskRunId = getStartTaskRunId();
+        if (startTaskRunId != null) {
+            newProperties.put(TaskRun.START_TASK_RUN_ID, startTaskRunId);
+            // Propagate pinned-job identity so the next batch runs in pinned mode and is not merged
+            // with other jobs' batches by TaskRunManager. Omitted for pure PCT to preserve merging.
+            if (isPinnedMode()) {
+                newProperties.put(TaskRun.PINNED_REFRESH_JOB_ID, startTaskRunId);
+            }
         }
         // warehouse
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_WAREHOUSE)) {
@@ -319,20 +369,41 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
     public void updateVersionMeta(ExecPlan execPlan,
                                   PCellSortedSet mvRefreshedPartitions,
                                   Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames) {
-        // Only promote TVR checkpoint on the last batch. Intermediate batches pass empty map
-        // to avoid committing TVR before all partitions are refreshed.
-        Map<BaseTableInfo, TvrVersionRange> tvrMap;
-        if (mvContext.hasNextBatchPartition()) {
-            tvrMap = Maps.newHashMap();
-        } else {
-            tvrMap = mv.getRefreshScheme().getAsyncRefreshContext().getTempBaseTableInfoTvrDeltaMap();
+        final String startTaskRunId = getStartTaskRunId();
+        final boolean isLastBatch = !mvContext.hasNextBatchPartition();
+
+        // Promote TVR only on the last batch, and only when we still own the pending state — a
+        // newer job that overwrote the owner must not have its delta replaced by ours.
+        Map<BaseTableInfo, TvrVersionRange> tvrMap = Maps.newHashMap();
+        if (isLastBatch) {
+            MaterializedView.AsyncRefreshContext ctxBefore = mv.getRefreshScheme().getAsyncRefreshContext();
+            if (ownsPinningState(ctxBefore, startTaskRunId)) {
+                tvrMap = ctxBefore.getTempBaseTableInfoTvrDeltaMap();
+            } else {
+                logger.warn("Skip TVR promotion: pinning owner={}, startTaskRunId={}",
+                        ctxBefore.getTempTvrOwnerStartTaskRunId(), startTaskRunId);
+            }
         }
+        // updatePCTMeta swaps the refresh scheme on the MV via copy-on-write + editlog replay,
+        // so re-read AsyncRefreshContext after this call — the previous reference is detached.
         updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, tvrMap);
-        // Clear temp map after the last batch promotes TVR, preventing stale data from being
-        // reused by subsequent unrelated refreshes (e.g., user-initiated partial refresh or
-        // explain-time planning that populates the temp map without executing).
-        if (!mvContext.hasNextBatchPartition()) {
-            mv.getRefreshScheme().getAsyncRefreshContext().clearTempBaseTableInfoTvrDeltaState();
+
+        // Clear only if we still own it (defence-in-depth behind the early-SKIP in
+        // getProcessExecPlan); otherwise a stale batch would wipe a newer job's pending state.
+        if (isLastBatch) {
+            MaterializedView.AsyncRefreshContext ctxAfter = mv.getRefreshScheme().getAsyncRefreshContext();
+            if (ownsPinningState(ctxAfter, startTaskRunId)) {
+                ctxAfter.clearTempBaseTableInfoTvrDeltaState();
+            } else {
+                logger.warn("Skip clearTempBaseTableInfoTvrDeltaState: pinning owner={}, startTaskRunId={}",
+                        ctxAfter.getTempTvrOwnerStartTaskRunId(), startTaskRunId);
+            }
         }
+    }
+
+    // True when the pinning slot is either unowned or owned by the current job — safe to mutate.
+    private static boolean ownsPinningState(MaterializedView.AsyncRefreshContext ctx, String startTaskRunId) {
+        String owner = ctx.getTempTvrOwnerStartTaskRunId();
+        return owner == null || owner.equals(startTaskRunId);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshListPartitioner.java
@@ -114,6 +114,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
 
         PartitionDiffResult result;
         try {
+            differ.setPinnedRanges(mvContext.getRefreshRuntimeState().getPinnedTvrMap());
             result = differ.computePartitionDiff(null);
             if (result == null) {
                 logger.warn("compute list partition diff failed, result is null");

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
@@ -125,6 +125,7 @@ public abstract class MVPCTRefreshPartitioner {
      */
     public abstract boolean syncAddOrDropPartitions() throws AnalysisException, LockTimeoutException;
 
+
     protected final void publishTopology(PCTPartitionTopology topology) {
         mvContext.setPartitionTopology(topology);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPlanBuilder.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.scheduler.MvTaskRunContext;
@@ -118,29 +119,53 @@ public class MVPCTRefreshPlanBuilder {
                                                 PCellSetMapping refTableRefreshPartitions,
                                                 ConnectContext ctx) throws AnalysisException {
         Analyzer.analyze(insertStmt, ctx);
-        InsertStmt newInsertStmt = buildInsertPlan(insertStmt, mvToRefreshedPartitions, refTableRefreshPartitions, ctx);
-        return newInsertStmt;
+        return buildInsertPlan(insertStmt, mvToRefreshedPartitions, refTableRefreshPartitions, ctx);
     }
 
     private InsertStmt buildInsertPlan(InsertStmt insertStmt,
                                        PCellSortedSet mvToRefreshedPartitions,
                                        PCellSetMapping refTableRefreshPartitions,
                                        ConnectContext ctx) throws AnalysisException {
+        // Collect table relations once — used by pinned-TVR injection (all pinned batches) and by
+        // partition-predicate push-down (partitioned MVs only).
+        QueryStatement queryStatement = insertStmt.getQueryStatement();
+        Multimap<String, TableRelation> tableRelations = AnalyzerUtils.collectAllTableRelation(queryStatement);
+
+        // Pinned PCT mode: inject the frozen snapshot into every TableRelation whose base table
+        // is currently pinned. pinnedMap is populated by setupPinnedRangesIfNeeded only for
+        // IVM-supported connectors (i.e. those whose scan operator honors TvrVersionRange), so
+        // the get() call is self-gating — unsupported types return null. Needed for batch 1 too —
+        // the analyzer's getTable() may see a fresher instance than snapshotBaseTables if the
+        // connector cache refreshed between sync and analyze.
+        Map<String, TvrVersionRange> pinnedMap = mvContext.getRefreshRuntimeState().getPinnedTvrMap();
+        for (Map.Entry<String, TableRelation> entry : tableRelations.entries()) {
+            TableRelation relation = entry.getValue();
+            Table table = relation.getTable();
+            // An unresolved/dropped base table is handled as a controlled AnalysisException later
+            // in the ref-base-table path; skip here to preserve that error surface (and avoid NPE).
+            if (table == null) {
+                continue;
+            }
+            TvrVersionRange pinned = pinnedMap.get(table.getTableIdentifier());
+            if (pinned != null) {
+                relation.setTvrVersionRange(pinned);
+                logger.info("Inject pinned TVR {} into table relation {} for scan",
+                        pinned, table.getName());
+            }
+        }
+
         // if the refTableRefreshPartitions is empty(not partitioned mv), no need to generate partition predicate
         if (refTableRefreshPartitions.isEmpty() || mvToRefreshedPartitions.isEmpty()) {
             logger.info("There is no ref table partitions to refresh, skip to generate partition predicates");
             return insertStmt;
         }
 
-        // after analyze, we could get the table meta info of the tableRelation.
-        QueryStatement queryStatement = insertStmt.getQueryStatement();
         // try to push down into query relation so can push down filter into both sides
         // NOTE: it's safe here to push the partition predicate into query relation directly because
         // partition predicates always belong to the relation output expressions and can be resolved
         // by the query analyzer.
         QueryRelation queryRelation = queryStatement.getQueryRelation();
         List<Expr> extraPartitionPredicates = Lists.newArrayList();
-        Multimap<String, TableRelation> tableRelations = AnalyzerUtils.collectAllTableRelation(queryStatement);
         Map<Table, List<SlotRef>> refBaseTablePartitionSlots = mv.getRefBaseTablePartitionSlots();
         if (CollectionUtils.sizeIsEmpty(refBaseTablePartitionSlots)) {
             throw new AnalysisException(String.format("Materialized view %s.%s refresh failed: " +

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshRangePartitioner.java
@@ -119,6 +119,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         Preconditions.checkState(partitionColumnOpt.isPresent());
         Column partitionColumn = partitionColumnOpt.get();
         Range<PartitionKey> rangeToInclude = SyncPartitionUtils.createRange(start, end, partitionColumn);
+        differ.setPinnedRanges(mvContext.getRefreshRuntimeState().getPinnedTvrMap());
         PartitionDiffResult result = differ.computePartitionDiff(rangeToInclude);
         if (result == null) {
             logger.warn("compute range partition diff failed: mv: {}", mv.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
@@ -25,6 +25,8 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.MVPartitionCellBuilder;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
@@ -53,12 +55,24 @@ public class PCTTableSnapshotInfo extends BaseTableSnapshotInfo {
     // partition's base info to be used in `updateMeta`
     private Map<String, MaterializedView.BasePartitionInfo> refreshedPartitionInfos = Maps.newHashMap();
 
+    // Pinned snapshot; non-null means updatePCTExternalPartitionInfos reads partition info at the
+    // frozen snapshot instead of the live current snapshot.
+    private TvrVersionRange pinnedRange;
+
     public PCTTableSnapshotInfo(BaseTableInfo baseTableInfo, Table baseTable) {
         super(baseTableInfo, baseTable);
     }
 
     public Map<String, MaterializedView.BasePartitionInfo> getRefreshedPartitionInfos() {
         return refreshedPartitionInfos;
+    }
+
+    public TvrVersionRange getPinnedRange() {
+        return pinnedRange;
+    }
+
+    public void setPinnedRange(TvrVersionRange pinnedRange) {
+        this.pinnedRange = pinnedRange;
     }
 
     @Override
@@ -139,6 +153,13 @@ public class PCTTableSnapshotInfo extends BaseTableSnapshotInfo {
             if (!partitionTableAndColumns.containsKey(baseTable)) {
                 return false;
             }
+            // In pinned mode, we're locked to a specific snapshot — partition-level DDL at newer
+            // snapshots is irrelevant to what we'll scan. Skip the comparison entirely.
+            TvrVersionRange frozen = mv.getRefreshScheme().getAsyncRefreshContext()
+                    .getTempBaseTableInfoTvrDeltaMap().get(baseTableInfo);
+            if (frozen != null) {
+                return false;
+            }
             List<Column> partitionColumns = partitionTableAndColumns.get(baseTable);
             Preconditions.checkArgument(partitionColumns.size() == 1,
                     "Only support one partition column in range partition");
@@ -192,9 +213,19 @@ public class PCTTableSnapshotInfo extends BaseTableSnapshotInfo {
         // different in selectedPartitionNames and partitions and will lead to infinite partition refresh.
         Collections.sort(refreshedPartitionNames);
 
-        List<com.starrocks.connector.PartitionInfo> partitions = GlobalStateMgr.getCurrentState()
-                .getMetadataMgr()
-                .getPartitions(baseTableInfo.getCatalogName(), table, refreshedPartitionNames);
+        // When pinnedRange is set, read partition info at the frozen snapshot.
+        List<com.starrocks.connector.PartitionInfo> partitions;
+        if (pinnedRange != null) {
+            ConnectorMetadatRequestContext rc = new ConnectorMetadatRequestContext();
+            rc.setTableVersionRange(pinnedRange);
+            partitions = GlobalStateMgr.getCurrentState()
+                    .getMetadataMgr()
+                    .getPartitions(baseTableInfo.getCatalogName(), table, refreshedPartitionNames, rc);
+        } else {
+            partitions = GlobalStateMgr.getCurrentState()
+                    .getMetadataMgr()
+                    .getPartitions(baseTableInfo.getCatalogName(), table, refreshedPartitionNames);
+        }
         if (partitions.size() != refreshedPartitionNames.size()) {
             LOG.warn("Partition names size {} does not match partitions size {} for table {}",
                     refreshedPartitionNames.size(), partitions.size(), table.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
@@ -327,7 +327,7 @@ public final class ListPartitionDiffer extends PartitionDiffer {
                 List<Column> refPartitionColumns = e.getValue();
                 // collect base table's partition cells by aligning with mv's partition column order
                 BaseToMVPartitionMapping mapping = MVPartitionCellBuilder.getPartitionCells(refBaseTable,
-                        refPartitionColumns);
+                        refPartitionColumns, pinnedRangeFor(refBaseTable));
                 refBaseTablePartitionMap.put(refBaseTable, mapping);
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -19,8 +19,10 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.mv.MVTimelinessArbiter;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -33,9 +35,21 @@ public abstract class PartitionDiffer {
     // consider partition_ttl_number and mv refresh will consider it to avoid creating too much partitions
     protected final MVTimelinessArbiter.QueryRewriteParams queryRewriteParams;
 
+    // Pinned ranges keyed by Table.getTableIdentifier(). Empty means no pinning.
+    protected Map<String, TvrVersionRange> pinnedRangeByTableIdentifier = Collections.emptyMap();
+
     public PartitionDiffer(MaterializedView mv, MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         this.mv = mv;
         this.queryRewriteParams = queryRewriteParams;
+    }
+
+    public void setPinnedRanges(Map<String, TvrVersionRange> pinnedRangeByTableIdentifier) {
+        this.pinnedRangeByTableIdentifier = pinnedRangeByTableIdentifier == null
+                ? Collections.emptyMap() : pinnedRangeByTableIdentifier;
+    }
+
+    protected TvrVersionRange pinnedRangeFor(Table table) {
+        return pinnedRangeByTableIdentifier.get(table.getTableIdentifier());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -241,7 +241,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
                 // Collect the ref base table's partition range map.
                 BaseToMVPartitionMapping mapping =
                         MVPartitionCellBuilder.getPartitionKeyRange(refBT, refBTPartitionColumns.get(0),
-                                mvPartitionExprOpt.get());
+                                mvPartitionExprOpt.get(), pinnedRangeFor(refBT));
                 if (mapping.cells() == null) {
                     return null;
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -33,6 +33,7 @@ import com.starrocks.scheduler.mv.hybrid.MVHybridBasedRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
 import org.junit.jupiter.api.Assertions;
@@ -906,5 +907,304 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     PlanTestBase.assertContains(planStr, "state_union");
                 }
         );
+    }
+
+    /**
+     * Verify that after IVM→PCT fallback's first batch, the pinning owner is installed on
+     * AsyncRefreshContext and the runtime pinnedTvrMap is hydrated. This is the precondition
+     * for subsequent batches to recognise themselves as pinned and consume pinned state at
+     * scan / partition enumeration / partition-info persistence.
+     */
+    @Test
+    public void testPinnedTvrMapHydratedOnFallbackFirstBatch() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto",
+                "`date`", Map.of("partition_refresh_number", "1"));
+
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits();
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+        TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
+        MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+
+        // First batch completed — inspect the runtime pinnedTvrMap hydrated by
+        // setupPinnedContextIfNeeded after the afterSyncHook installed the owner.
+        MvTaskRunContext mvTaskRunContext = mvTaskRunProcessor.getMvTaskRunContext();
+        Map<String, TvrVersionRange> pinnedMap = mvTaskRunContext.getRefreshRuntimeState().getPinnedTvrMap();
+        Assertions.assertFalse(pinnedMap.isEmpty(),
+                "pinnedTvrMap should be populated after fallback first batch hydrates pinned state");
+        // Value should be a TvrTableSnapshot pointing at the PCT-synced snapshot (version 2).
+        TvrVersionRange pinned = pinnedMap.values().iterator().next();
+        Assertions.assertTrue(pinned instanceof TvrTableSnapshot, "pinned range should be a TvrTableSnapshot");
+        Assertions.assertEquals(2L, pinned.to().getVersion(),
+                "pinned snapshot should match the PCT-synced version (2)");
+    }
+
+    /**
+     * Verify that when a pinned fallback job generates the next batch task run, the next task
+     * run's properties carry PINNED_REFRESH_JOB_ID set to the pinning job's START_TASK_RUN_ID.
+     * This is what makes TaskRunManager treat different pinned jobs as non-mergeable and what
+     * triggers pinned-mode behaviour on batch 2+ entry.
+     */
+    @Test
+    public void testPinnedRefreshJobIdPropagatedToSubsequentBatch() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto",
+                "`date`", Map.of("partition_refresh_number", "1"));
+
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits();
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+        TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
+        MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
+        MVHybridBasedRefreshProcessor hybrid =
+                (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+        MVPCTBasedRefreshProcessor pctProcessor =
+                (MVPCTBasedRefreshProcessor) hybrid.getCurrentProcessor();
+
+        // First batch should have generated a next batch (partition_refresh_number=1 on 4 partitions).
+        TaskRun nextTaskRun = pctProcessor.getNextTaskRun();
+        Assertions.assertNotNull(nextTaskRun, "Fallback first batch should generate a next batch task run");
+
+        // The next batch must carry PINNED_REFRESH_JOB_ID so:
+        //  (a) TaskRunManager treats it as non-mergeable with other jobs' batches (MV_COMPARABLE);
+        //  (b) on its own getProcessExecPlan, the early-SKIP / isPinnedMode paths resolve correctly.
+        String pinnedJobId = nextTaskRun.getProperties().get(TaskRun.PINNED_REFRESH_JOB_ID);
+        Assertions.assertNotNull(pinnedJobId,
+                "Subsequent pinned batch must carry PINNED_REFRESH_JOB_ID");
+
+        // The value must equal the current job's START_TASK_RUN_ID so the owner-match guard in
+        // updateVersionMeta (and the early-SKIP in getProcessExecPlan) will accept the batch.
+        MvTaskRunContext mvTaskRunContext = mvTaskRunProcessor.getMvTaskRunContext();
+        String expectedJobId = mvTaskRunContext.getStatus().getStartTaskRunId();
+        Assertions.assertEquals(expectedJobId, pinnedJobId,
+                "PINNED_REFRESH_JOB_ID should equal the pinning job's START_TASK_RUN_ID");
+
+        // Also verify the persisted pinning owner matches — this is what isPinnedMode() compares.
+        MaterializedView refreshedMv = getMv("test_mv1");
+        String persistedOwner = refreshedMv.getRefreshScheme()
+                .getAsyncRefreshContext()
+                .getTempTvrOwnerStartTaskRunId();
+        Assertions.assertEquals(expectedJobId, persistedOwner,
+                "Persisted pinning owner should match the job id carried on the next batch");
+    }
+
+    /**
+     * Verify that a stale subsequent batch whose pinning owner has been overwritten by a newer
+     * refresh job returns SKIPPED early, does not run syncAndCheckPCTPartitions, and does not
+     * clobber the newer job's pending state. This exercises the early-SKIP path in
+     * MVPCTBasedRefreshProcessor.getProcessExecPlan (Commit 1) together with the owner-match
+     * guard on clearTempBaseTableInfoTvrDeltaState (Commit 3).
+     */
+    @Test
+    public void testStalePinnedBatchDoesNotCorruptNewerJobState() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto",
+                "`date`", Map.of("partition_refresh_number", "1"));
+
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits();
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+
+        // Job A: first batch installs owner=A_jobId and creates nextTaskRun for batch 2.
+        TaskRun jobARun1 = withMVRefreshTaskRun(db.getFullName(), mv);
+        MVTaskRunProcessor jobARun1Processor = getMVTaskRunProcessor(jobARun1);
+        MVHybridBasedRefreshProcessor jobAHybrid =
+                (MVHybridBasedRefreshProcessor) jobARun1Processor.getMVRefreshProcessor();
+        MVPCTBasedRefreshProcessor jobAPct =
+                (MVPCTBasedRefreshProcessor) jobAHybrid.getCurrentProcessor();
+        TaskRun jobABatch2 = jobAPct.getNextTaskRun();
+        Assertions.assertNotNull(jobABatch2, "Job A should generate a batch 2");
+        String jobAId = jobARun1Processor.getMvTaskRunContext().getStatus().getStartTaskRunId();
+
+        // Simulate job B arriving: overwrite owner to a different value (a different random UUID)
+        // directly on AsyncRefreshContext. This mimics what a newer job's fallback first batch would do.
+        MaterializedView currentMv = getMv("test_mv1");
+        MaterializedView.AsyncRefreshContext asyncCtx = currentMv.getRefreshScheme().getAsyncRefreshContext();
+        Map<BaseTableInfo, TvrVersionRange> jobBFrozen = Map.copyOf(asyncCtx.getTempBaseTableInfoTvrDeltaMap());
+        String jobBId = com.starrocks.common.util.UUIDUtil.genUUID().toString();
+        asyncCtx.replaceTempBaseTableInfoTvrDeltaMap(jobBId, jobBFrozen);
+        Assertions.assertEquals(jobBId, asyncCtx.getTempTvrOwnerStartTaskRunId(),
+                "Setup: newer job B should have overwritten the pinning owner");
+
+        // Job A's stale batch 2 now runs. It must detect owner mismatch and return SKIPPED,
+        // NOT refresh external tables, NOT build a plan, and NOT clear the pending state.
+        initAndExecuteTaskRun(jobABatch2);
+
+        // After the stale batch: owner must still be job B (not cleared by stale batch),
+        // and the pending map must be intact. Job B's pending state is protected.
+        MaterializedView afterStaleMv = getMv("test_mv1");
+        MaterializedView.AsyncRefreshContext ctxAfter =
+                afterStaleMv.getRefreshScheme().getAsyncRefreshContext();
+        Assertions.assertEquals(jobBId, ctxAfter.getTempTvrOwnerStartTaskRunId(),
+                "Stale batch must not overwrite or clear the newer job's pinning owner");
+        Assertions.assertFalse(ctxAfter.getTempBaseTableInfoTvrDeltaMap().isEmpty(),
+                "Stale batch must not clear the newer job's pending TVR delta map");
+        // Sanity: the owner is not the stale batch's job id.
+        Assertions.assertNotEquals(jobAId, ctxAfter.getTempTvrOwnerStartTaskRunId(),
+                "Pinning owner should no longer be job A after job B overwrote it");
+    }
+
+    /**
+     * Verify Bug B core invariant: a subsequent pinned batch's scan plan pins to the frozen
+     * snapshot (S2) and NOT to a live snapshot (S3) that the catalog has advanced to between
+     * batches. This exercises the full pipeline from {@code afterSyncHook} (freeze) through
+     * {@code setupPinnedContextIfNeeded} (hydrate) through
+     * {@code MVPCTRefreshPlanBuilder.injectPinnedTvrForIcebergRelations} (scan-plan injection)
+     * down to {@code IcebergScanNode}'s {@code useSnapshot(snapshotId)} call.
+     * <p>
+     * Without scan-plan injection, batch 2 would pick up the live S3 via
+     * {@code TableRelation.getTable().getNativeTable().currentSnapshot()} and scan S3 data while
+     * the MV's partition-info / TVR record S2 — the exact divergence Bug B describes. The final
+     * TVR checkpoint would still be correct (S2), so existing multi-batch tests do not catch
+     * this regression.
+     */
+    @Test
+    public void testSubsequentBatchScanPlanUsesFrozenSnapshotNotLive() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto",
+                "`date`", Map.of("partition_refresh_number", "1"));
+
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits();
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+
+        // Batch 1: IVM fails -> Hybrid fallback to PCT -> afterSyncHook freezes at S2.
+        TaskRun batch1 = withMVRefreshTaskRun(db.getFullName(), mv);
+        MVTaskRunProcessor batch1Proc = getMVTaskRunProcessor(batch1);
+        MVHybridBasedRefreshProcessor hybrid =
+                (MVHybridBasedRefreshProcessor) batch1Proc.getMVRefreshProcessor();
+        MVPCTBasedRefreshProcessor pctProc =
+                (MVPCTBasedRefreshProcessor) hybrid.getCurrentProcessor();
+        TaskRun batch2 = pctProc.getNextTaskRun();
+        Assertions.assertNotNull(batch2, "Multi-batch fallback should generate batch 2");
+
+        // Simulate a background catalog refresh advancing the live Iceberg snapshot to S3 BEFORE
+        // batch 2 builds its plan. Batch 2 must still pin scan to S2 via pinnedTvrMap, not read
+        // the advanced current snapshot from TableRelation.getTable().
+        advanceTableVersionTo(3);
+
+        // Execute batch 2 and capture its exec plan.
+        initAndExecuteTaskRun(batch2);
+        MVTaskRunProcessor batch2Proc = getMVTaskRunProcessor(batch2);
+        MvTaskRunContext batch2Ctx = batch2Proc.getMvTaskRunContext();
+        ExecPlan batch2Plan = batch2Ctx.getExecPlan();
+        Assertions.assertNotNull(batch2Plan,
+                "Batch 2 should have built an exec plan in pinned PCT mode");
+
+        String planStr = batch2Plan.getExplainString(TExplainLevel.NORMAL);
+
+        // The scan operator must pin to version 2 via TvrTableSnapshot (set by
+        // injectPinnedTvrForIcebergRelations). TvrTableSnapshot's toString renders as
+        // "Snapshot@(<version>)"; MIN -> "MIN", concrete version -> "<n>".
+        PlanTestBase.assertContains(planStr, "TABLE VERSION:");
+        Assertions.assertTrue(planStr.contains("Snapshot@(2)"),
+                "Batch 2's scan must pin to S2 via TvrTableSnapshot(2); plan was:\n" + planStr);
+        Assertions.assertFalse(planStr.contains("Snapshot@(3)"),
+                "Batch 2 must not scan live S3 after background catalog advance; plan was:\n" + planStr);
+    }
+
+    /**
+     * Verify the dual of merge isolation: pure PCT multi-batch runs (refresh_mode="pct", not
+     * going through Hybrid) must NOT carry PINNED_REFRESH_JOB_ID on the next-batch task run.
+     * Only pinned batches should be marked non-mergeable across jobs; pure PCT batches must
+     * preserve their original merge semantics so high-frequency PCT MVs do not suffer queue
+     * dedup regressions.
+     */
+    @Test
+    public void testPurePCTBatchDoesNotCarryPinnedRefreshJobId() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "pct",
+                "`date`", Map.of("partition_refresh_number", "1"));
+        Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+
+        advanceTableVersionTo(2);
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+        TaskRun batch1 = withMVRefreshTaskRun(db.getFullName(), mv);
+        MVTaskRunProcessor batch1Proc = getMVTaskRunProcessor(batch1);
+
+        // refresh_mode=pct routes through MVPCTBasedRefreshProcessor directly, not Hybrid.
+        // Therefore no afterSyncHook is installed, no owner is written, and isPinnedMode()
+        // returns false on every batch of this job.
+        Assertions.assertTrue(batch1Proc.getMVRefreshProcessor() instanceof MVPCTBasedRefreshProcessor,
+                "refresh_mode=pct must use MVPCTBasedRefreshProcessor directly (not Hybrid)");
+        MVPCTBasedRefreshProcessor pctProc =
+                (MVPCTBasedRefreshProcessor) batch1Proc.getMVRefreshProcessor();
+
+        TaskRun batch2 = pctProc.getNextTaskRun();
+        Assertions.assertNotNull(batch2,
+                "Pure PCT multi-batch must still generate a next batch task run");
+
+        // The property must be absent; its presence would signal pinned-mode semantics to
+        // TaskRunManager (non-mergeable with batches of other jobs on the same range) and to
+        // the next batch's getProcessExecPlan (pinned consumer paths). Both would mis-behave
+        // for a pure PCT MV.
+        Assertions.assertNull(batch2.getProperties().get(TaskRun.PINNED_REFRESH_JOB_ID),
+                "Pure PCT batches must not carry PINNED_REFRESH_JOB_ID; " +
+                        "setting it would break merge behaviour for all pure-PCT MVs");
+
+        // Also verify nothing installed itself as the pinning owner during pure PCT.
+        MaterializedView refreshedMv = getMv("test_mv1");
+        MaterializedView.AsyncRefreshContext ctx = refreshedMv.getRefreshScheme().getAsyncRefreshContext();
+        Assertions.assertNull(ctx.getTempTvrOwnerStartTaskRunId(),
+                "Pure PCT must not install a pinning owner on AsyncRefreshContext");
+        Assertions.assertTrue(ctx.getTempBaseTableInfoTvrDeltaMap().isEmpty(),
+                "Pure PCT must not populate tempBaseTableInfoTvrDeltaMap");
+    }
+
+    /**
+     * Regression for isStalePinnedBatch correctness: an unrelated batch whose task run does NOT
+     * carry PINNED_REFRESH_JOB_ID must not be early-SKIPped just because some prior pinning
+     * owner was left behind (e.g. by a failed/aborted pinning job). Without the
+     * PINNED_REFRESH_JOB_ID gate, any partial-range refresh whose START_TASK_RUN_ID differed
+     * from the orphaned owner would be falsely SKIPPED and its requested partitions would
+     * never refresh.
+     */
+    @Test
+    public void testUnrelatedPCTBatchNotBlockedByOrphanedPinningOwner() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "pct",
+                "`date`", Map.of("partition_refresh_number", "1"));
+        Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
+
+        advanceTableVersionTo(2);
+
+        // Simulate leftover state from a hypothetical previous pinning job that aborted before
+        // clearing AsyncRefreshContext — owner is set to a UUID that no current or subsequent
+        // task run will match.
+        MaterializedView.AsyncRefreshContext asyncCtx = mv.getRefreshScheme().getAsyncRefreshContext();
+        String orphanedOwner = "orphaned-" + com.starrocks.common.util.UUIDUtil.genUUID();
+        asyncCtx.replaceTempBaseTableInfoTvrDeltaMap(orphanedOwner,
+                Map.of(mv.getBaseTableInfos().get(0), TvrTableSnapshot.of(99L)));
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+        TaskRun batch1 = withMVRefreshTaskRun(db.getFullName(), mv);
+        MVTaskRunProcessor batch1Proc = getMVTaskRunProcessor(batch1);
+        MVPCTBasedRefreshProcessor pctProc =
+                (MVPCTBasedRefreshProcessor) batch1Proc.getMVRefreshProcessor();
+        TaskRun batch2 = pctProc.getNextTaskRun();
+        Assertions.assertNotNull(batch2, "Pure PCT multi-batch must generate a next batch");
+        // Pure PCT never carries PINNED_REFRESH_JOB_ID, which is exactly what signals the
+        // isStalePinnedBatch check to skip this batch.
+        Assertions.assertNull(batch2.getProperties().get(TaskRun.PINNED_REFRESH_JOB_ID),
+                "Pure PCT batch must not carry PINNED_REFRESH_JOB_ID");
+
+        // Batch 2 has isCompleteRefresh=false (PARTITION_START/END set) and an orphaned owner
+        // exists on AsyncRefreshContext. Before the fix, isStalePinnedBatch would detect
+        // owner != startTaskRunId and return SKIPPED. After the fix, the PINNED_REFRESH_JOB_ID
+        // gate makes this a no-op for non-pinned runs.
+        initAndExecuteTaskRun(batch2);
+        MVTaskRunProcessor batch2Proc = getMVTaskRunProcessor(batch2);
+        ExecPlan batch2Plan = batch2Proc.getMvTaskRunContext().getExecPlan();
+        Assertions.assertNotNull(batch2Plan,
+                "Unrelated pure PCT batch must not be early-SKIPped by orphaned pinning owner " +
+                        "state — an exec plan should have been built");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Iceberg materialized views refreshing in Hybrid mode (IVM attempt + PCT fallback) could mix data from different Iceberg snapshots within a single refresh job when the PCT path splits work into multiple batches:

- Each batch independently called `refreshExternalTable()` and `syncPartitions()`. Background `CachingIcebergCatalog.refreshCatalog()`, concurrent MV refreshes, or cache TTL expiration could advance the cached Iceberg table between batches.
- Different batches would enumerate different partitions, scan different data, and produce an MV whose partitions reflect inconsistent Iceberg snapshots.
- The persisted TVR checkpoint became divorced from what was actually scanned, causing subsequent change detection to miss deltas.

## What I'm doing:

Introduce a **pinned PCT mode** that freezes one target Iceberg snapshot per base table for the whole refresh job. All partition enumeration, scan, and partition-info persistence operate against exactly that frozen snapshot — regardless of background catalog refreshes or newer refresh jobs.

### Infrastructure

- `MvTaskRunContext.MVRefreshRuntimeState.pinnedTvrMap`: runtime `Map<String, TvrVersionRange>` keyed by `BaseTableInfo.getTableIdentifier()` (stable for external tables, unlike `tableId`).
- `PCTTableSnapshotInfo.pinnedRange`: per-table frozen snapshot for partition-info persistence.
- `BaseMVRefreshProcessor.isPinnedMode()` / `setupPinnedRangesIfNeeded()`: state predicate + hydration.
- `BaseMVRefreshProcessor.getStartTaskRunId()`: shared null-safe accessor.

### Hook-based freeze timing

- `MVPCTBasedRefreshProcessor.afterSyncHook`: one-shot callback invoked right after `syncAndCheckPCTPartitions` and before plan building, with clear-before-run semantics so a throwing hook cannot leave a stale reference.
- `MVHybridBasedRefreshProcessor.switchToPCTRefresh` installs the freeze hook on `pctProcessor` instead of running after the delegate call — pinned TVR is visible to the plan builder for batch 1 too, whose `TableRelation.getTable()` may re-fetch a fresher instance than `snapshotBaseTables`.
- `MVPCTBasedRefreshProcessor.getProcessExecPlan` early-SKIPs stale batches whose pinning owner has been overwritten by a newer job.

### Consumers

- `syncAndCheckPCTPartitions` skips `refreshExternalTable` entirely in pinned mode.
- `PCTTableSnapshotInfo.updatePCTExternalPartitionInfos` reads partition info at the frozen snapshot when pinned.
- `PCTTableSnapshotInfo.checkBaseTableChanged` short-circuits in pinned mode — partition DDL at newer snapshots is irrelevant to what we scan.
- `MVPCTRefreshPlanBuilder.buildInsertPlan` injects frozen TVR into every `TableRelation`; the lookup is self-gating through `pinnedTvrMap` (only IVM-supported connectors populate it).
- `PartitionDiffer` + `RangePartitionDiffer` + `ListPartitionDiffer` accept pinned ranges via `setPinnedRanges`; partitioners feed them from runtime state before `computePartitionDiff`.

### Merge isolation + safety guards

- `TaskRun.PINNED_REFRESH_JOB_ID` set only on pinned batches; added to `MV_COMPARABLE_PROPERTIES` so pinned batches from different jobs do not merge in TaskRunManager queue dedup, and to `MV_UNCOPYABLE_PROPERTIES` so it cannot leak onto unrelated runs. **Pure PCT merge semantics are unchanged.**
- `MVPCTBasedRefreshProcessor.updateVersionMeta` has owner-match guards on both TVR promote and `clearTempBaseTableInfoTvrDeltaState`, re-reading `AsyncRefreshContext` after `updatePCTMeta`'s copy-on-write swap. A stale batch that somehow passed the early-SKIP cannot overwrite or clear a newer job's pending state.



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
