### PR TITLE
[Enhancement] Optimize locking in tablet replica handling with table-level locks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1096,9 +1096,8 @@ public class TabletScheduler extends FrontendDaemon {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
         Locker locker = new Locker();
-        List<Long> tableIds = Lists.newArrayList(tabletCtx.getTblId());
         try {
-            locker.lockTablesWithIntensiveDbLock(db.getId(), tableIds, LockType.WRITE);
+            locker.lockTableWithIntensiveDbLock(db.getId(), tabletCtx.getTblId(), LockType.WRITE);
             checkMetaExist(tabletCtx);
             if (deleteBackendDropped(tabletCtx, force)
                     || deleteBadReplica(tabletCtx, force)
@@ -1115,7 +1114,7 @@ public class TabletScheduler extends FrontendDaemon {
                 throw new SchedException(Status.FINISHED, "redundant replica is deleted");
             }
         } finally {
-            locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIds, LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tabletCtx.getTblId(), LockType.WRITE);
         }
         throw new SchedException(Status.UNRECOVERABLE, "unable to delete any redundant replicas. replicas: " +
                 tabletCtx.getTablet().getReplicaInfos());
@@ -1338,9 +1337,8 @@ public class TabletScheduler extends FrontendDaemon {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
         Locker locker = new Locker();
-        List<Long> tableIds = Lists.newArrayList(tabletCtx.getTblId());
         try {
-            locker.lockTablesWithIntensiveDbLock(db.getId(), tableIds, LockType.WRITE);
+            locker.lockTableWithIntensiveDbLock(db.getId(), tabletCtx.getTblId(), LockType.WRITE);
             checkMetaExist(tabletCtx);
             List<Replica> replicas = tabletCtx.getReplicas();
             for (Replica replica : replicas) {
@@ -1362,7 +1360,7 @@ public class TabletScheduler extends FrontendDaemon {
             throw new SchedException(Status.UNRECOVERABLE, "unable to delete any colocate redundant replicas. replicas: " +
                     tabletCtx.getTablet().getReplicaInfos() + ", backend set: " + backendSet);
         } finally {
-            locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIds, LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tabletCtx.getTblId(), LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1096,8 +1096,9 @@ public class TabletScheduler extends FrontendDaemon {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
         Locker locker = new Locker();
+        List<Long> tableIds = Lists.newArrayList(tabletCtx.getTblId());
         try {
-            locker.lockDatabase(db.getId(), LockType.WRITE);
+            locker.lockTablesWithIntensiveDbLock(db.getId(), tableIds, LockType.WRITE);
             checkMetaExist(tabletCtx);
             if (deleteBackendDropped(tabletCtx, force)
                     || deleteBadReplica(tabletCtx, force)
@@ -1114,7 +1115,7 @@ public class TabletScheduler extends FrontendDaemon {
                 throw new SchedException(Status.FINISHED, "redundant replica is deleted");
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIds, LockType.WRITE);
         }
         throw new SchedException(Status.UNRECOVERABLE, "unable to delete any redundant replicas. replicas: " +
                 tabletCtx.getTablet().getReplicaInfos());
@@ -1337,8 +1338,9 @@ public class TabletScheduler extends FrontendDaemon {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
         Locker locker = new Locker();
+        List<Long> tableIds = Lists.newArrayList(tabletCtx.getTblId());
         try {
-            locker.lockDatabase(db.getId(), LockType.WRITE);
+            locker.lockTablesWithIntensiveDbLock(db.getId(), tableIds, LockType.WRITE);
             checkMetaExist(tabletCtx);
             List<Replica> replicas = tabletCtx.getReplicas();
             for (Replica replica : replicas) {
@@ -1360,7 +1362,7 @@ public class TabletScheduler extends FrontendDaemon {
             throw new SchedException(Status.UNRECOVERABLE, "unable to delete any colocate redundant replicas. replicas: " +
                     tabletCtx.getTablet().getReplicaInfos() + ", backend set: " + backendSet);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIds, LockType.WRITE);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

The current implementation uses database-level write locks when handling redundant replicas in tablet scheduling. This can cause unnecessary contention when multiple tablets from different tables in the same database are being processed concurrently. By switching to table-level locks with intensive database locking, we can reduce lock contention while maintaining data consistency.

## What I'm doing:

Replace database-level locking with table-level locking in two tablet replica handling methods:
- `handleRedundantReplica()`: Changed from `lockDatabase()` to `lockTablesWithIntensiveDbLock()`
- `handleColocateRedundant()`: Changed from `lockDatabase()` to `lockTablesWithIntensiveDbLock()`

Both methods now:
1. Create a list containing only the specific table ID from the tablet context
2. Use the new locking method that acquires table-level locks instead of database-level locks
3. Use the corresponding unlock method for cleanup

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

https://claude.ai/code/session_01S8TUVrqBcGkftsxBQgjs5g