### PR TITLE
[Doc] new admonition syntax

### DIFF
--- a/docs/en/_assets/commonMarkdown/_beta.mdx
+++ b/docs/en/_assets/commonMarkdown/_beta.mdx
@@ -1,5 +1,5 @@
 
-:::beta beta feature
+:::beta[Beta feature]
 [Advice on use of Beta features](../../introduction/maturity.md)
 :::
 

--- a/docs/en/_assets/commonMarkdown/_experimental.mdx
+++ b/docs/en/_assets/commonMarkdown/_experimental.mdx
@@ -1,5 +1,5 @@
 
-:::experimental experimental feature
+:::experimental[Experimental feature]
 [Advice on use of experimental features](../../introduction/maturity.md)
 :::
 

--- a/docs/en/data_source/feature-support-data-lake-analytics.md
+++ b/docs/en/data_source/feature-support-data-lake-analytics.md
@@ -197,7 +197,9 @@ Reading Hive transactional tables is not supported.
 
 StarRocks supports querying Hive views from v3.1.0 onwards.
 
-:::note While StarRocks executes queries against a Hive view, it will try to parse the definition of the view using the syntax of StarRocks and Trino. An error will be returned if StarRocks cannot parse the definition of the view. There is a possibility that StarRocks failed to parse the Hive views created with functions exclusive to Hive or Spark.
+:::note
+
+While StarRocks executes queries against a Hive view, it will try to parse the definition of the view using the syntax of StarRocks and Trino. An error will be returned if StarRocks cannot parse the definition of the view. There is a possibility that StarRocks failed to parse the Hive views created with functions exclusive to Hive or Spark.
 
 :::
 

--- a/docs/ja/_assets/commonMarkdown/_beta.mdx
+++ b/docs/ja/_assets/commonMarkdown/_beta.mdx
@@ -1,3 +1,3 @@
-:::beta ベータ機能
+:::beta[ベータ機能]
  [ベータ機能の使用に関するアドバイス](../../introduction/maturity.md)
 :::

--- a/docs/ja/_assets/commonMarkdown/_experimental.mdx
+++ b/docs/ja/_assets/commonMarkdown/_experimental.mdx
@@ -1,3 +1,3 @@
-:::experimental experimental feature
+:::experimental[実験的機能]
 [実験的機能の使用に関するアドバイス](../../introduction/maturity.md)
 :::

--- a/docs/zh/_assets/commonMarkdown/_beta.mdx
+++ b/docs/zh/_assets/commonMarkdown/_beta.mdx
@@ -1,3 +1,3 @@
-:::beta beta feature
+:::beta[Beta 功能]
 [关于 Beta 功能的使用建议](../../introduction/maturity.md)
 :::

--- a/docs/zh/_assets/commonMarkdown/_experimental.mdx
+++ b/docs/zh/_assets/commonMarkdown/_experimental.mdx
@@ -1,3 +1,3 @@
-:::experimental 实验性功能
+:::experimental[实验性功能]
 [关于使用实验性功能的建议](../../introduction/maturity.md)
 :::

--- a/docs/zh/data_source/feature-support-data-lake-analytics.md
+++ b/docs/zh/data_source/feature-support-data-lake-analytics.md
@@ -195,7 +195,9 @@ TEXT 格式的 Hive 表不支持 MAP 和 STRUCT 类型。
 
 StarRocks 从 v3.1.0 版本开始支持查询 Hive 视图。
 
-:::note 当 StarRocks 执行 Hive 视图的查询时，会尝试使用 StarRocks 和 Trino 的语法解析视图定义。如果 StarRocks 无法解析视图定义，将返回错误。使用 Hive 或 Spark 独有函数创建的 Hive 视图可能无法被 StarRocks 解析。
+:::note
+
+当 StarRocks 执行 Hive 视图的查询时，会尝试使用 StarRocks 和 Trino 的语法解析视图定义。如果 StarRocks 无法解析视图定义，将返回错误。使用 Hive 或 Spark 独有函数创建的 Hive 视图可能无法被 StarRocks 解析。
 
 :::
 


### PR DESCRIPTION
## Why I'm doing:

In Docusaurus 3.10 optional admonition titles go in square brackets

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4