### PR TITLE
[BugFix] Fix pipeline event scheduler dispatch tautology

### DIFF
--- a/be/src/exec/pipeline/schedule/observer.cpp
+++ b/be/src/exec/pipeline/schedule/observer.cpp
@@ -59,9 +59,12 @@ void PipelineObserver::_do_update(int event) {
     }
 
     if (driver->is_in_blocked()) {
-        // In PRECONDITION state, has_output need_input may return false. In this case,
-        // we need to schedule the driver to INPUT_EMPTY/OUTPUT_FULL state.
-        bool pipeline_block = driver->driver_state() != DriverState::INPUT_EMPTY ||
+        // When the driver is blocked for a reason other than INPUT_EMPTY / OUTPUT_FULL
+        // (e.g. PRECONDITION_BLOCK), source->has_output() / sink->need_input() may
+        // return false while the driver still needs to be rescheduled. In that case
+        // we try_schedule directly; for INPUT_EMPTY / OUTPUT_FULL we dispatch to the
+        // event-specific handlers below.
+        bool pipeline_block = driver->driver_state() != DriverState::INPUT_EMPTY &&
                               driver->driver_state() != DriverState::OUTPUT_FULL;
         if (pipeline_block || _is_cancel_changed(event)) {
             driver->fragment_ctx()->event_scheduler()->try_schedule(driver);

--- a/be/src/exec/pipeline/schedule/pipeline_timer.cpp
+++ b/be/src/exec/pipeline/schedule/pipeline_timer.cpp
@@ -28,7 +28,11 @@ void PipelineTimerTask::waitUtilFinished() {
     if (_finished.load(std::memory_order_acquire)) {
         return;
     }
-    _has_consumer.store(true, std::memory_order_release);
+    // seq_cst is required: it pairs with the seq_cst load of _has_consumer in
+    // doRun() so that if doRun observes no consumer (and thus skips notify),
+    // this thread is guaranteed to observe _finished == true in the while-loop
+    // below and return without sleeping.
+    _has_consumer.store(true, std::memory_order_seq_cst);
     std::unique_lock lock(_mutex);
     while (!_finished) {
         _cv.wait(lock);

--- a/be/src/exec/pipeline/schedule/pipeline_timer.h
+++ b/be/src/exec/pipeline/schedule/pipeline_timer.h
@@ -49,7 +49,10 @@ public:
     void doRun() {
         Run();
         _finished.store(true, std::memory_order_seq_cst);
-        if (_has_consumer.load(std::memory_order_acquire)) {
+        // seq_cst pairs with the seq_cst store of _has_consumer in waitUtilFinished
+        // to guarantee that at least one of the two threads observes the other's
+        // write (Dekker-style), so no wakeup can be lost.
+        if (_has_consumer.load(std::memory_order_seq_cst)) {
             _cv.notify_one();
         }
     }


### PR DESCRIPTION


- observer.cpp: _do_update() used `state != INPUT_EMPTY || state != OUTPUT_FULL` which is always true, making the event-specific dispatch branches (source/sink/all) unreachable and forcing every wakeup through try_schedule. Flip to `&&` so the dispatch matches the intent described in the comment: take the fast path only when the driver is blocked for a reason other than INPUT_EMPTY / OUTPUT_FULL.

- pipeline_timer: PipelineTimerTask used release/acquire on _has_consumer paired with a seq_cst store on _finished, which is not enough for the Dekker-style handshake between doRun() and waitUtilFinished(). With acquire-release only, a producer whose load of _has_consumer is reordered before the consumer's release store can miss the consumer, while the consumer's acquire load of _finished in the while-loop need not observe the producer's store, causing a lost wakeup and a hang. Promote both _has_consumer accesses to seq_cst so at least one side always observes the other's write.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
