### PR TITLE
[Enhancement] Stop leader task safely part2: Stop leader-only daemons gracefully on demotion

### DIFF
--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -1378,6 +1378,15 @@ This topic introduces the following types of FE configurations:
 - Description: When StarRocks deserializes TaskRun history rows for `information_schema.task_runs`, a corrupted or invalid JSON row will normally cause deserialization to log a warning and throw a RuntimeException. If this item is set to `true`, the system will catch deserialization errors, skip the malformed record, and continue processing remaining rows instead of failing the query. This will make `information_schema.task_runs` queries tolerant of bad entries in the `_statistics_.task_run_history` table. Note that enabling it will silently drop corrupted history records (potential data loss) instead of surfacing an explicit error.
 - Introduced in: v3.3.3, v3.4.0, v3.5.0
 
+### `leader_demotion_drain_timeout_sec`
+
+- Default: 180
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Per-daemon timeout used during leader demotion to wait for each leader-only daemon worker thread to exit after being interrupted. If a worker is still alive when the timeout elapses, the FE process is terminated, because a stuck worker combined with a later re-election would run two workers against the same singleton state - strictly worse than a process restart. Increase this if you routinely see heartbeat/report/publish/tablet-scheduler daemons needing more than the default to drain.
+- Introduced in: v4.1
+
 ### `lock_checker_interval_second`
 
 - Default: 30

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -1377,6 +1377,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 当 StarRocks 反序列化 `information_schema.task_runs` 的 TaskRun 历史行时，损坏或无效的 JSON 行通常会导致反序列化记录警告并抛出 RuntimeException。如果此项设置为 `true`，系统将捕获反序列化错误，跳过格式错误的记录，并继续处理剩余行而不是使查询失败。这将使 `information_schema.task_runs` 查询能够容忍 `_statistics_.task_run_history` 表中的错误条目。请注意，启用它将静默丢弃损坏的历史记录（潜在数据丢失），而不是显式报错。
 - 引入版本: v3.3.3, v3.4.0, v3.5.0
 
+### `leader_demotion_drain_timeout_sec`
+
+- 默认值: 180
+- 类型: Int
+- 单位: 秒
+- 是否动态: 是
+- 描述: Leader 降级期间,用于等待每一个仅 Leader 运行的后台 daemon 线程在被中断后退出的超时时间。若超时后仍有线程存活,FE 进程会被终止,因为残留运行的线程再加上后续重新当选时启动的新线程,会同时操作同一批单例状态,危害大于进程重启。当 heartbeat / report / publish / tablet-scheduler 这些 daemon 需要的排空时间超出默认值时,可调大该值。
+- 引入版本: v4.1
+
 ### `lock_checker_interval_second`
 
 - 默认值: 30

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -491,7 +491,7 @@ public class TabletScheduler extends LeaderDaemon {
      * with version >= requested.
      */
     @Override
-    protected synchronized void onBeforeStop() {
+    protected synchronized void onStopped() {
         pendingTablets.clear();
         // shrink the backing array - PriorityQueue does not release capacity on clear()
         pendingTablets = new PriorityQueue<>();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -69,7 +69,7 @@ import com.starrocks.clone.TabletSchedCtx.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -126,7 +126,7 @@ import java.util.stream.Stream;
  * Case 2:
  * A new Backend is added to the cluster. Replicas should be transfer to that host to balance the cluster load.
  */
-public class TabletScheduler extends FrontendDaemon {
+public class TabletScheduler extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(TabletScheduler.class);
 
     // the minimum interval of updating cluster statistics and priority of tablet info
@@ -451,7 +451,7 @@ public class TabletScheduler extends FrontendDaemon {
      * it should be removed.
      */
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         if (!updateWorkingSlots()) {
             return;
         }
@@ -481,6 +481,30 @@ public class TabletScheduler extends FrontendDaemon {
         handleForceCleanSchedQ();
 
         stat.counterTabletScheduleRound.incrementAndGet();
+    }
+
+    /**
+     * Drop all leader-session scheduling state. Followers do not schedule tablets and
+     * the next leader will rebuild this from TabletInvertedIndex on first iteration.
+     * Clone tasks already submitted to AgentTaskExecutor are idempotent: if the new leader
+     * resubmits the same clone, BE returns success when the destination tablet already exists
+     * with version >= requested.
+     */
+    @Override
+    protected synchronized void onBeforeStop() {
+        pendingTablets.clear();
+        // shrink the backing array - PriorityQueue does not release capacity on clear()
+        pendingTablets = new PriorityQueue<>();
+        allTabletIds.clear();
+        runningTablets.clear();
+        schedHistory.clear();
+        backendsWorkingSlots.clear();
+        loadStatistic.set(null);
+        lastStatUpdateTime = 0;
+        lastClusterLoadLoggingTime = 0;
+        lastSlotAdjustTime = 0;
+        currentSlotPerPathConfig = 0;
+        forceCleanSchedQ.set(false);
     }
 
     private void updateClusterLoadStatisticsAndPriority() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -785,11 +785,13 @@ public class Config extends ConfigBase {
 
     /**
      * Per-daemon timeout, in seconds, used by leader demotion when stopping leader-only daemons.
-     * Each daemon has up to this much time to drain in-flight work and run its onBeforeStop hook
-     * before the worker thread is re-interrupted.
+     * Each daemon has up to this much time for its worker thread to exit after being interrupted.
+     * If the worker is still alive when the timeout elapses the JVM is terminated, because a
+     * stuck worker plus a later re-election would run two workers against the same singleton
+     * state - strictly worse than a process restart.
      */
     @ConfField(mutable = true)
-    public static int leader_demotion_drain_timeout_sec = 30;
+    public static int leader_demotion_drain_timeout_sec = 180;
 
     /**
      * If true, non-leader FE will ignore the metadata delay gap between Leader FE and its self,

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -784,6 +784,14 @@ public class Config extends ConfigBase {
     public static boolean start_with_incomplete_meta = false;
 
     /**
+     * Per-daemon timeout, in seconds, used by leader demotion when stopping leader-only daemons.
+     * Each daemon has up to this much time to drain in-flight work and run its onBeforeStop hook
+     * before the worker thread is re-interrupted.
+     */
+    @ConfField(mutable = true)
+    public static int leader_demotion_drain_timeout_sec = 30;
+
+    /**
      * If true, non-leader FE will ignore the metadata delay gap between Leader FE and its self,
      * even if the metadata delay gap exceeds *meta_delay_toleration_second*.
      * Non-leader FE will still offer read service.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LeaderDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LeaderDaemon.java
@@ -32,9 +32,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * 2. Built-in lease check: each iteration captures and revalidates a {@link LeaderLease}
  *    obtained from {@link GlobalStateMgr}. Once the lease is invalidated by a demotion the
  *    daemon stops itself - subclasses do not need to add their own check.
- * 3. Cleanup hooks: {@link #onBeforeStop()} runs before the worker is interrupted so subclasses
- *    can release leader-session-only state immediately. Follower state should not retain that
- *    data, both to free memory and to avoid leaking stale leader state into replay paths.
+ * 3. Cleanup hook: {@link #onStopped()} runs after the worker has actually exited, so
+ *    subclasses can release leader-session-only state without racing the loop. Follower state
+ *    should not retain that data, both to free memory and to avoid leaking stale leader state
+ *    into replay paths. If the worker does not exit within the stop timeout the JVM is
+ *    terminated via {@link #onJoinTimeout()} because a concurrent second worker (after a
+ *    subsequent re-election) would be strictly more dangerous than a process restart.
  */
 public abstract class LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(LeaderDaemon.class);
@@ -108,18 +111,15 @@ public abstract class LeaderDaemon {
 
     /**
      * Coordinated stop for leader demotion:
-     *   1. {@link #onBeforeStop()} - subclass releases leader-session state immediately;
-     *   2. mark stopped + interrupt worker;
-     *   3. join up to {@code timeoutMs}, re-interrupt if still alive;
-     *   4. {@link #onAfterStop()} - late cleanup that needs the worker actually exited.
+     *   1. mark stopped + interrupt worker;
+     *   2. join up to {@code timeoutMs};
+     *   3. on timeout, invoke {@link #onJoinTimeout()} (default: terminate the JVM) and return
+     *      without clearing {@code worker}/{@code isRunning} - a subsequent {@link #start()}
+     *      must not spin up a second worker while the first is still alive;
+     *   4. on clean exit, run {@link #onStopped()} so subclasses release leader-session state.
      * Idempotent.
      */
     public final void stopGracefully(long timeoutMs) {
-        try {
-            onBeforeStop();
-        } catch (Throwable t) {
-            LOG.warn("{} onBeforeStop failed", name, t);
-        }
         setStop();
         Thread t = worker;
         if (t != null) {
@@ -129,14 +129,16 @@ public abstract class LeaderDaemon {
                 Thread.currentThread().interrupt();
             }
             if (t.isAlive()) {
-                LOG.warn("{} did not exit within {}ms, re-interrupt", name, timeoutMs);
-                t.interrupt();
+                onJoinTimeout();
+                // onJoinTimeout normally terminates the JVM. If it returns (tests only) we must
+                // not reset worker/isRunning: another start() would then race the stuck worker.
+                return;
             }
         }
         try {
-            onAfterStop();
+            onStopped();
         } catch (Throwable th) {
-            LOG.warn("{} onAfterStop failed", name, th);
+            LOG.warn("{} onStopped failed", name, th);
         }
         capturedLease = LeaderLease.INVALID;
         worker = null;
@@ -171,7 +173,7 @@ public abstract class LeaderDaemon {
         isRunning.set(false);
     }
 
-    private void runOneCycle() throws InterruptedException {
+    protected void runOneCycle() throws InterruptedException {
         GlobalStateMgr gsm = getGlobalStateMgr();
         while (!gsm.isReady()) {
             Thread.sleep(100);
@@ -208,17 +210,22 @@ public abstract class LeaderDaemon {
     }
 
     /**
-     * Hook called at the start of {@link #stopGracefully(long)}, before the worker is interrupted.
+     * Hook called from {@link #stopGracefully(long)} after the worker thread has actually exited.
      * Subclasses MUST clear all leader-session-only state here (queues, pending maps, executors)
-     * so memory is reclaimed promptly and follower state does not retain it.
+     * so memory is reclaimed promptly and follower state does not retain it. Not called when the
+     * join times out - {@link #onJoinTimeout()} fires instead.
      */
-    protected void onBeforeStop() {
+    protected void onStopped() {
     }
 
     /**
-     * Hook called after the worker has exited (or the stop timeout elapsed). For late cleanup
-     * that requires the loop to have actually stopped. Usually empty.
+     * Invoked when the worker thread fails to exit within the stop timeout. Default:
+     * {@link System#exit(int)} - a stuck worker combined with a later {@link #start()} would run
+     * two workers against the same singleton state, which is strictly worse than a process
+     * restart. Overridable for tests only.
      */
-    protected void onAfterStop() {
+    protected void onJoinTimeout() {
+        LOG.error("{} did not exit within stop timeout; terminating JVM to avoid concurrent workers", name);
+        System.exit(-1);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LeaderDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LeaderDaemon.java
@@ -1,0 +1,224 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LeaderLease;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Base class for daemons that may only run while this FE is the leader.
+ *
+ * Differences from {@link Daemon}:
+ * 1. Composition over inheritance: holds an internal {@link Thread} instead of being one,
+ *    so the same instance can be {@link #start() started} again after {@link #stopGracefully(long)}.
+ *    Required for safe leader demotion: when this FE later becomes leader again the existing
+ *    Mgr singletons must be reusable.
+ * 2. Built-in lease check: each iteration captures and revalidates a {@link LeaderLease}
+ *    obtained from {@link GlobalStateMgr}. Once the lease is invalidated by a demotion the
+ *    daemon stops itself - subclasses do not need to add their own check.
+ * 3. Cleanup hooks: {@link #onBeforeStop()} runs before the worker is interrupted so subclasses
+ *    can release leader-session-only state immediately. Follower state should not retain that
+ *    data, both to free memory and to avoid leaking stale leader state into replay paths.
+ */
+public abstract class LeaderDaemon {
+    private static final Logger LOG = LogManager.getLogger(LeaderDaemon.class);
+    private static final int DEFAULT_INTERVAL_SECONDS = 30;
+
+    private final String name;
+    private volatile long intervalMs;
+    private final AtomicBoolean isStopped = new AtomicBoolean(false);
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
+    private volatile Thread worker;
+    private volatile LeaderLease capturedLease = LeaderLease.INVALID;
+
+    protected LeaderDaemon(String name) {
+        this(name, DEFAULT_INTERVAL_SECONDS * 1000L);
+    }
+
+    protected LeaderDaemon(String name, long intervalMs) {
+        this.name = name;
+        this.intervalMs = intervalMs;
+    }
+
+    public final String getName() {
+        return name;
+    }
+
+    public final long getInterval() {
+        return intervalMs;
+    }
+
+    public final void setInterval(long intervalMs) {
+        this.intervalMs = intervalMs;
+    }
+
+    public final boolean isStopped() {
+        return isStopped.get();
+    }
+
+    public final boolean isRunning() {
+        return isRunning.get();
+    }
+
+    /**
+     * Idempotent. Safe to call after {@link #stopGracefully(long)} - a fresh worker thread
+     * will be created.
+     */
+    public synchronized void start() {
+        if (!isRunning.compareAndSet(false, true)) {
+            return;
+        }
+        isStopped.set(false);
+        capturedLease = LeaderLease.INVALID;
+        Thread t = new Thread(this::loop, name);
+        t.setDaemon(true);
+        worker = t;
+        t.start();
+    }
+
+    /**
+     * Mark stopped and wake the worker. Does not wait for the worker to exit.
+     * Prefer {@link #stopGracefully(long)} during demotion so cleanup hooks run.
+     */
+    public void setStop() {
+        if (!isStopped.compareAndSet(false, true)) {
+            return;
+        }
+        Thread t = worker;
+        if (t != null) {
+            t.interrupt();
+        }
+    }
+
+    /**
+     * Coordinated stop for leader demotion:
+     *   1. {@link #onBeforeStop()} - subclass releases leader-session state immediately;
+     *   2. mark stopped + interrupt worker;
+     *   3. join up to {@code timeoutMs}, re-interrupt if still alive;
+     *   4. {@link #onAfterStop()} - late cleanup that needs the worker actually exited.
+     * Idempotent.
+     */
+    public final void stopGracefully(long timeoutMs) {
+        try {
+            onBeforeStop();
+        } catch (Throwable t) {
+            LOG.warn("{} onBeforeStop failed", name, t);
+        }
+        setStop();
+        Thread t = worker;
+        if (t != null) {
+            try {
+                t.join(Math.max(1L, timeoutMs));
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+            if (t.isAlive()) {
+                LOG.warn("{} did not exit within {}ms, re-interrupt", name, timeoutMs);
+                t.interrupt();
+            }
+        }
+        try {
+            onAfterStop();
+        } catch (Throwable th) {
+            LOG.warn("{} onAfterStop failed", name, th);
+        }
+        capturedLease = LeaderLease.INVALID;
+        worker = null;
+        isRunning.set(false);
+    }
+
+    private void loop() {
+        while (!isStopped.get()) {
+            try {
+                runOneCycle();
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                if (isStopped.get()) {
+                    break;
+                }
+            } catch (Throwable e) {
+                LOG.error("{} got exception", name, e);
+            }
+            if (isStopped.get()) {
+                break;
+            }
+            try {
+                Thread.sleep(intervalMs);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                if (isStopped.get()) {
+                    break;
+                }
+            }
+        }
+        LOG.info("{} exits", name);
+        isRunning.set(false);
+    }
+
+    private void runOneCycle() throws InterruptedException {
+        GlobalStateMgr gsm = getGlobalStateMgr();
+        while (!gsm.isReady()) {
+            Thread.sleep(100);
+            if (isStopped.get()) {
+                return;
+            }
+        }
+        LeaderLease lease = capturedLease;
+        if (!lease.isValid()) {
+            lease = gsm.captureLeaderLease();
+            capturedLease = lease;
+        }
+        if (!gsm.isLeaderLeaseValid(lease)) {
+            LOG.info("{} sees lease invalid, self-stop. lease={}", name, lease);
+            setStop();
+            return;
+        }
+        runAfterLeaseValid();
+    }
+
+    /**
+     * The body of each iteration. Runs only after FE is ready and the captured leader lease
+     * is still valid. Subclasses must not block indefinitely - block in interruptible primitives
+     * so {@link #setStop()} can wake them.
+     */
+    protected abstract void runAfterLeaseValid() throws InterruptedException;
+
+    /**
+     * Seam for tests to provide an isolated {@link GlobalStateMgr} instance. Production code uses
+     * the singleton returned by {@link GlobalStateMgr#getServingState()}.
+     */
+    protected GlobalStateMgr getGlobalStateMgr() {
+        return GlobalStateMgr.getServingState();
+    }
+
+    /**
+     * Hook called at the start of {@link #stopGracefully(long)}, before the worker is interrupted.
+     * Subclasses MUST clear all leader-session-only state here (queues, pending maps, executors)
+     * so memory is reclaimed promptly and follower state does not retain it.
+     */
+    protected void onBeforeStop() {
+    }
+
+    /**
+     * Hook called after the worker has exited (or the stop timeout elapsed). For late cleanup
+     * that requires the loop to have actually stopped. Usually empty.
+     */
+    protected void onAfterStop() {
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -864,7 +864,18 @@ public class LeaderImpl {
             result.setStatus(status);
             return result;
         }
-        return GlobalStateMgr.getCurrentState().getReportHandler().handleReport(request);
+        try {
+            return GlobalStateMgr.getCurrentState().getReportHandler().handleReport(request);
+        } catch (IllegalStateException e) {
+            // Leader-lease fence fired inside ReportHandler: demotion raced the isLeader() check
+            // above. Translate to the same non-master status so the BE re-resolves the current
+            // leader rather than retrying on this FE.
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList("current fe is not master: " +
+                    (Strings.isNullOrEmpty(e.getMessage()) ? "leader lease invalidated" : e.getMessage())));
+            result.setStatus(status);
+            return result;
+        }
     }
 
     private void finishAlterTask(AgentTask task) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -353,6 +353,10 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                         dataCacheMetrics);
         try {
             putToQueue(reportTask);
+        } catch (IllegalStateException e) {
+            // Demotion fence fired inside putToQueue. Propagate so LeaderImpl.report() can
+            // translate this into a NOT_MASTER response and the BE re-resolves the new leader.
+            throw e;
         } catch (Exception e) {
             tStatus.setStatus_code(TStatusCode.INTERNAL_ERROR);
             List<String> errorMsgs = Lists.newArrayList();
@@ -380,9 +384,10 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
 
     private void putToQueue(ReportTask reportTask) throws Exception {
         if (isStopped()) {
-            // Demotion is in progress; reject new work silently. The inbound fence on the RPC entry
-            // is the primary mechanism, this is defense-in-depth for any internal callers.
-            return;
+            // Demotion is in progress: reject so the caller can translate this into a NOT_MASTER
+            // response (see LeaderImpl#report). Silently dropping would ACK the request as OK and
+            // the BE would never retry against the new leader, losing the report update.
+            throw new IllegalStateException("report handler is stopped during leader demotion");
         }
         try (CloseableLock ignored = CloseableLock.lock(lock.writeLock())) {
             if (!pendingTaskMap.containsKey(reportTask.type)) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -73,7 +73,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
-import com.starrocks.common.util.Daemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.NetUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -144,11 +144,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
-public class ReportHandler extends Daemon implements MemoryTrackable {
+public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
 
     @Override
     public Map<String, Long> estimateCount() {
@@ -199,7 +200,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
-    private final Daemon resourceReportDaemon = new ResourceReportDaemon();
+    private final LeaderDaemon resourceReportDaemon = new ResourceReportDaemon();
 
     /**
      * Record the mapping of <tablet id, backend id> to the to be dropped time of tablet.
@@ -215,7 +216,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
     private static final Table<Long, Long, Long> TABLET_TO_DROP_TIME = HashBasedTable.create();
 
     public ReportHandler() {
-        super("report-handler");
+        super("report-handler", 0L);
         pendingTaskMap.put(ReportType.TABLET_REPORT, Maps.newHashMap());
         pendingTaskMap.put(ReportType.DISK_REPORT, Maps.newHashMap());
         pendingTaskMap.put(ReportType.TASK_REPORT, Maps.newHashMap());
@@ -225,6 +226,10 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
     }
 
     public TMasterResult handleReport(TReportRequest request) throws TException {
+        // Inbound fence: reject if this FE is not (or is no longer) the active leader.
+        // The IllegalStateException is translated to a NOT_MASTER status in FrontendServiceImpl.report.
+        GlobalStateMgr.getCurrentState().captureLeaderLeaseOrThrow();
+
         TMasterResult result = new TMasterResult();
         TStatus tStatus = new TStatus(TStatusCode.OK);
         result.setStatus(tStatus);
@@ -374,6 +379,11 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
     }
 
     private void putToQueue(ReportTask reportTask) throws Exception {
+        if (isStopped()) {
+            // Demotion is in progress; reject new work silently. The inbound fence on the RPC entry
+            // is the primary mechanism, this is defense-in-depth for any internal callers.
+            return;
+        }
         try (CloseableLock ignored = CloseableLock.lock(lock.writeLock())) {
             if (!pendingTaskMap.containsKey(reportTask.type)) {
                 throw new Exception("Unknown report task type" + reportTask.toString());
@@ -2216,38 +2226,61 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
     }
 
     @Override
-    protected void runOneCycle() {
-        consumeQueue(reportQueue, "report");
+    protected void runAfterLeaseValid() throws InterruptedException {
+        consumeOne(reportQueue, "report");
     }
 
-    private void consumeQueue(BlockingQueue<Pair<Long, ReportType>> queue, String queueName) {
-        while (true) {
-            try {
-                Pair<Long, ReportType> pair = queue.take();
-                ReportTask task;
-                try (CloseableLock ignored = CloseableLock.lock(lock.writeLock())) {
-                    // using the latest task
-                    task = pendingTaskMap.get(pair.second).get(pair.first);
-                    if (task == null) {
-                        throw new Exception("pendingTaskMap not exists " + pair.first);
-                    }
-                    pendingTaskMap.get(task.type).remove(task.beId, task);
-                }
-                task.exec();
-            } catch (Exception e) {
-                LOG.warn("got exception when executing {} report", queueName, e);
+    @Override
+    protected void onBeforeStop() {
+        try (CloseableLock ignored = CloseableLock.lock(lock.writeLock())) {
+            reportQueue.clear();
+            resourceReportQueue.clear();
+            for (Map<Long, ReportTask> taskMap : pendingTaskMap.values()) {
+                taskMap.clear();
             }
+            TABLET_TO_DROP_TIME.clear();
+        }
+        // Stop the nested resource-report consumer as part of this handler's own shutdown,
+        // so both loops drain synchronously during leader demotion.
+        resourceReportDaemon.stopGracefully(Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L));
+    }
+
+    /**
+     * Process at most one queued report. Blocks up to one second waiting for work so that the outer
+     * {@link LeaderDaemon} loop can re-check the leader lease promptly even when the queue is idle.
+     * Propagates {@link InterruptedException} so {@link #setStop()} during demotion wakes us up.
+     */
+    private void consumeOne(BlockingQueue<Pair<Long, ReportType>> queue, String queueName)
+            throws InterruptedException {
+        Pair<Long, ReportType> pair = queue.poll(1, TimeUnit.SECONDS);
+        if (pair == null) {
+            return;
+        }
+        try {
+            ReportTask task;
+            try (CloseableLock ignored = CloseableLock.lock(lock.writeLock())) {
+                // using the latest task
+                task = pendingTaskMap.get(pair.second).get(pair.first);
+                if (task == null) {
+                    LOG.warn("pendingTaskMap not exists {}", pair.first);
+                    return;
+                }
+                pendingTaskMap.get(task.type).remove(task.beId, task);
+            }
+            task.exec();
+        } catch (Exception e) {
+            LOG.warn("got exception when executing {} report", queueName, e);
         }
     }
 
-    private class ResourceReportDaemon extends Daemon {
+    private class ResourceReportDaemon extends LeaderDaemon {
         public ResourceReportDaemon() {
-            super("resource-report-handler");
+            super("resource-report-handler", 0L);
         }
 
         @Override
-        protected void runOneCycle() {
-            consumeQueue(resourceReportQueue, "resource");
+        protected void runAfterLeaseValid() throws InterruptedException {
+            consumeOne(resourceReportQueue, "resource");
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -2231,7 +2231,7 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
     }
 
     @Override
-    protected void onBeforeStop() {
+    protected void onStopped() {
         try (CloseableLock ignored = CloseableLock.lock(lock.writeLock())) {
             reportQueue.clear();
             resourceReportQueue.clear();

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1631,6 +1631,42 @@ public class GlobalStateMgr {
         }
     }
 
+    /**
+     * Symmetric counterpart to {@link #startLeaderOnlyDaemonThreads()}. Stops the leader-only
+     * daemons that have been migrated to {@link com.starrocks.common.util.LeaderDaemon}, in reverse
+     * start order, so leader-session state is released promptly during demotion and the FE
+     * singletons become reusable when this node is re-elected.
+     *
+     * TODO: migrate the remaining {@code Daemon}-based leader tasks and add them here.
+     */
+    void stopLeaderOnlyDaemonThreads() {
+        long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
+        // Reverse of startLeaderOnlyDaemonThreads(): stop downstream consumers first so that
+        // upstream producers (heartbeat) can wind down without piling work on a draining sink.
+        try {
+            reportHandler.stopGracefully(timeoutMs);
+        } catch (Throwable t) {
+            LOG.warn("stop reportHandler failed", t);
+        }
+        try {
+            publishVersionDaemon.stopGracefully(timeoutMs);
+        } catch (Throwable t) {
+            LOG.warn("stop publishVersionDaemon failed", t);
+        }
+        if (!RunMode.isSharedDataMode()) {
+            try {
+                tabletScheduler.stopGracefully(timeoutMs);
+            } catch (Throwable t) {
+                LOG.warn("stop tabletScheduler failed", t);
+            }
+        }
+        try {
+            heartbeatMgr.stopGracefully(timeoutMs);
+        } catch (Throwable t) {
+            LOG.warn("stop heartbeatMgr failed", t);
+        }
+    }
+
     // start threads that should run on all FE
     private void startAllNodeTypeDaemonThreads() {
         if (!checkpointWorkerStarted) {
@@ -1701,6 +1737,13 @@ public class GlobalStateMgr {
         if (!isDefaultWarehouseCreated) {
             // A brand-new cluster was up for the first time, the follower/observer node initializes its default warehouse here.
             initDefaultWarehouse();
+        }
+
+        // If this node was serving as LEADER, cleanly stop leader-only daemons before taking on
+        // the new role. Runs after the admission fence is closed by the demotion orchestrator so
+        // no new leader-side work can enter while cleanup is in flight.
+        if (feType == FrontendNodeType.LEADER) {
+            stopLeaderOnlyDaemonThreads();
         }
 
         // transfer from INIT/UNKNOWN to OBSERVER/FOLLOWER

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -43,7 +43,7 @@ import com.starrocks.catalog.FsBroker;
 import com.starrocks.common.Config;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.Version;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.MachineInfo;
 import com.starrocks.common.util.NetUtils;
 import com.starrocks.common.util.Util;
@@ -84,16 +84,34 @@ import java.util.concurrent.atomic.AtomicReference;
  * Heartbeat manager run as a daemon at a fix interval.
  * For now, it will send heartbeat to all Frontends, Backends and Brokers
  */
-public class HeartbeatMgr extends FrontendDaemon {
+public class HeartbeatMgr extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(HeartbeatMgr.class);
     private static final AtomicReference<TMasterInfo> MASTER_INFO = new AtomicReference<>();
 
-    private final ExecutorService executor;
+    private final boolean needRegisterMetric;
+    private volatile ExecutorService executor;
 
     public HeartbeatMgr(boolean needRegisterMetric) {
         super("heartbeat-mgr", Config.heartbeat_timeout_second * 1000L);
-        this.executor = ThreadPoolManager.newDaemonFixedThreadPool(Config.heartbeat_mgr_threads_num,
-                Config.heartbeat_mgr_blocking_queue_size, "heartbeat-mgr-pool", needRegisterMetric);
+        this.needRegisterMetric = needRegisterMetric;
+    }
+
+    @Override
+    public synchronized void start() {
+        if (executor == null || executor.isShutdown()) {
+            executor = ThreadPoolManager.newDaemonFixedThreadPool(Config.heartbeat_mgr_threads_num,
+                    Config.heartbeat_mgr_blocking_queue_size, "heartbeat-mgr-pool", needRegisterMetric);
+        }
+        super.start();
+    }
+
+    @Override
+    protected synchronized void onBeforeStop() {
+        ExecutorService e = executor;
+        if (e != null) {
+            e.shutdownNow();
+            executor = null;
+        }
     }
 
     public void setLeader(int clusterId, String token, long epoch) {
@@ -115,7 +133,7 @@ public class HeartbeatMgr extends FrontendDaemon {
      * 2. collect the heartbeat response from all nodes, and handle them
      */
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         ImmutableMap<Long, Backend> idToBackendRef =
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend();
         if (idToBackendRef == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -210,7 +210,15 @@ public class HeartbeatMgr extends LeaderDaemon {
                 if (isChanged) {
                     hbPackage.addHbResponse(response);
                 }
-            } catch (InterruptedException | ExecutionException e) {
+            } catch (InterruptedException e) {
+                // Demotion interrupts the worker to make it exit before the drain timeout;
+                // keep draining would make {@link #onJoinTimeout()} fire and terminate the JVM.
+                // Restore the flag so LeaderDaemon.loop observes stop and abandon the rest -
+                // the next leader will re-run heartbeats from scratch.
+                Thread.currentThread().interrupt();
+                LOG.warn("heartbeat drain interrupted, abandoning remaining responses");
+                return;
+            } catch (ExecutionException e) {
                 LOG.warn("got exception when doing heartbeat", e);
             }
         } // end for all results

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -106,7 +106,7 @@ public class HeartbeatMgr extends LeaderDaemon {
     }
 
     @Override
-    protected synchronized void onBeforeStop() {
+    protected synchronized void onStopped() {
         ExecutorService e = executor;
         if (e != null) {
             e.shutdownNow();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -1107,7 +1107,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
      * will resubmit publish from {@code GlobalTransactionMgr.getReadyToPublishTransactions}.
      */
     @Override
-    protected void onBeforeStop() {
+    protected void onStopped() {
         ThreadPoolExecutor t = taskExecutor;
         if (t != null) {
             t.shutdownNow();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -46,7 +46,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.ThreadPoolManager;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -91,7 +91,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
-public class PublishVersionDaemon extends FrontendDaemon {
+public class PublishVersionDaemon extends LeaderDaemon {
 
     private static final Logger LOG = LogManager.getLogger(PublishVersionDaemon.class);
 
@@ -120,7 +120,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         MetricRepo.COUNTER_PUBLISH_VERSION_DAEMON_LOOP.increase(1L);
         try {
             GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
@@ -1097,6 +1097,32 @@ public class PublishVersionDaemon extends FrontendDaemon {
             LOG.error("Fail to publish partition {} of txn {}: {}", partitionCommitInfo.getPhysicalPartitionId(),
                     txnId, e.getMessage());
             return false;
+        }
+    }
+
+    /**
+     * Drop in-flight publish executors and the publishing-txn dedup sets.
+     * BE-side PublishVersionTask is idempotent (BE returns success when the requested
+     * version is already visible), so dropping in-flight tasks is safe - the new leader
+     * will resubmit publish from {@code GlobalTransactionMgr.getReadyToPublishTransactions}.
+     */
+    @Override
+    protected void onBeforeStop() {
+        ThreadPoolExecutor t = taskExecutor;
+        if (t != null) {
+            t.shutdownNow();
+            taskExecutor = null;
+        }
+        ThreadPoolExecutor d = deleteTxnLogExecutor;
+        if (d != null) {
+            d.shutdownNow();
+            deleteTxnLogExecutor = null;
+        }
+        if (publishingTransactionIds != null) {
+            publishingTransactionIds.clear();
+        }
+        if (publishingLakeTransactionsBatchTableId != null) {
+            publishingLakeTransactionsBatchTableId.clear();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -108,6 +108,11 @@ public class PublishVersionDaemon extends LeaderDaemon {
     // result and modify transaction state on FE
     private ThreadPoolExecutor taskExecutor;
     private ThreadPoolExecutor deleteTxnLogExecutor;
+    // Guards ConfigRefreshDaemon listener registration. Executors are recreated on every
+    // leader activation (after onStopped() nulls them), but listeners must be registered
+    // only once per daemon instance — otherwise each demote/re-elect cycle leaks a listener.
+    private boolean taskExecutorListenerRegistered;
+    private boolean deleteTxnLogExecutorListenerRegistered;
 
     @VisibleForTesting
     protected Set<Long> publishingTransactionIds;
@@ -235,9 +240,12 @@ public class PublishVersionDaemon extends LeaderDaemon {
             // allow core thread timeout as well
             taskExecutor.allowCoreThreadTimeOut(true);
 
-            // register ThreadPool config change listener
-            GlobalStateMgr.getCurrentState().getConfigRefreshDaemon()
-                    .registerListener(() -> this.adjustTaskExecutor());
+            // register ThreadPool config change listener only once per daemon instance.
+            if (!taskExecutorListenerRegistered) {
+                GlobalStateMgr.getCurrentState().getConfigRefreshDaemon()
+                        .registerListener(() -> this.adjustTaskExecutor());
+                taskExecutorListenerRegistered = true;
+            }
         }
         return taskExecutor;
     }
@@ -250,14 +258,17 @@ public class PublishVersionDaemon extends LeaderDaemon {
             deleteTxnLogExecutor = ThreadPoolManager.newDaemonCacheThreadPool(numThreads,
                     "lake-publish-delete-txnLog", true);
 
-            // register ThreadPool config change listener
-            GlobalStateMgr.getCurrentState().getConfigRefreshDaemon().registerListener(() -> {
-                int newMaxThreads = Config.lake_publish_delete_txnlog_max_threads;
-                if (deleteTxnLogExecutor != null && newMaxThreads > 0
-                        && deleteTxnLogExecutor.getMaximumPoolSize() != newMaxThreads) {
-                    deleteTxnLogExecutor.setMaximumPoolSize(Config.lake_publish_delete_txnlog_max_threads);
-                }
-            });
+            // register ThreadPool config change listener only once per daemon instance.
+            if (!deleteTxnLogExecutorListenerRegistered) {
+                GlobalStateMgr.getCurrentState().getConfigRefreshDaemon().registerListener(() -> {
+                    int newMaxThreads = Config.lake_publish_delete_txnlog_max_threads;
+                    if (deleteTxnLogExecutor != null && newMaxThreads > 0
+                            && deleteTxnLogExecutor.getMaximumPoolSize() != newMaxThreads) {
+                        deleteTxnLogExecutor.setMaximumPoolSize(Config.lake_publish_delete_txnlog_max_threads);
+                    }
+                });
+                deleteTxnLogExecutorListenerRegistered = true;
+            }
         }
         return deleteTxnLogExecutor;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -82,6 +82,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.Queue;
 
 import static com.starrocks.sql.ast.KeysType.DUP_KEYS;
 
@@ -713,6 +715,56 @@ public class TabletSchedulerTest {
 
         // This should not throw NullPointerException even though ctx.getTablet() returns null
         TabletScheduler.resetDecommStatForSingleReplicaTabletUnlocked(tabletId, replicas);
+    }
+
+    @Test
+    public void testOnStoppedClearsInternalState() {
+        TabletScheduler scheduler = new TabletScheduler(new TabletSchedulerStat());
+
+        TabletSchedCtx pending = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR,
+                1L, 2L, 3L, 4L, 100L, System.currentTimeMillis(), systemInfoService);
+        pending.setOrigPriority(TabletSchedCtx.Priority.LOW);
+        Deencapsulation.invoke(scheduler, "addToPendingTablets", pending);
+
+        // Populate remaining collections that onStopped() must reset.
+        java.util.Set<Long> allIds = Deencapsulation.getField(scheduler, "allTabletIds");
+        allIds.add(100L);
+        Map<Long, TabletSchedCtx> running = Deencapsulation.getField(scheduler, "runningTablets");
+        running.put(200L, pending);
+        Queue<TabletSchedCtx> history = Deencapsulation.getField(scheduler, "schedHistory");
+        history.add(pending);
+        Map<Long, TabletScheduler.PathSlot> slots = Deencapsulation.getField(scheduler, "backendsWorkingSlots");
+        slots.put(10L, new TabletScheduler.PathSlot(Lists.newArrayList(0L), 1));
+        scheduler.setClusterLoadStatistic(new ClusterLoadStatistic(systemInfoService, tabletInvertedIndex));
+        Deencapsulation.setField(scheduler, "lastStatUpdateTime", 123L);
+        Deencapsulation.setField(scheduler, "lastClusterLoadLoggingTime", 456L);
+        Deencapsulation.setField(scheduler, "lastSlotAdjustTime", 789L);
+        Deencapsulation.setField(scheduler, "currentSlotPerPathConfig", 7);
+        ((java.util.concurrent.atomic.AtomicBoolean) Deencapsulation.getField(scheduler, "forceCleanSchedQ")).set(true);
+
+        Assertions.assertEquals(1, scheduler.getTotalNum());
+        Assertions.assertEquals(1, scheduler.getRunningNum());
+        Assertions.assertEquals(1, scheduler.getHistoryNum());
+        Assertions.assertNotNull(scheduler.getClusterLoadStatistic());
+
+        Deencapsulation.invoke(scheduler, "onStopped");
+
+        Assertions.assertEquals(0, scheduler.getTotalNum());
+        Assertions.assertEquals(0, scheduler.getRunningNum());
+        Assertions.assertEquals(0, scheduler.getHistoryNum());
+        Assertions.assertNull(scheduler.getClusterLoadStatistic());
+        Map<Long, TabletScheduler.PathSlot> afterSlots = Deencapsulation.getField(scheduler, "backendsWorkingSlots");
+        Assertions.assertTrue(afterSlots.isEmpty(), "backendsWorkingSlots must be cleared");
+        PriorityQueue<TabletSchedCtx> afterPending = Deencapsulation.getField(scheduler, "pendingTablets");
+        Assertions.assertTrue(afterPending.isEmpty(), "pendingTablets must be cleared");
+        Assertions.assertEquals(0L, (long) Deencapsulation.getField(scheduler, "lastStatUpdateTime"));
+        Assertions.assertEquals(0L, (long) Deencapsulation.getField(scheduler, "lastClusterLoadLoggingTime"));
+        Assertions.assertEquals(0L, (long) Deencapsulation.getField(scheduler, "lastSlotAdjustTime"));
+        Assertions.assertEquals(0, (int) Deencapsulation.getField(scheduler, "currentSlotPerPathConfig"));
+        Assertions.assertFalse(
+                ((java.util.concurrent.atomic.AtomicBoolean) Deencapsulation.getField(scheduler, "forceCleanSchedQ"))
+                        .get(),
+                "forceCleanSchedQ must reset to false");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/leader/LeaderImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/LeaderImplTest.java
@@ -24,6 +24,10 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TMasterResult;
+import com.starrocks.thrift.TReportRequest;
+import com.starrocks.thrift.TStatusCode;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -99,5 +103,47 @@ public class LeaderImplTest {
 
         Assertions.assertEquals(new Replica(tabletId, backendId, -1, NORMAL), Deencapsulation.invoke(leader, "findRelatedReplica",
                 olapTable, physicalPartition, backendId, tabletId, indexId));
+    }
+
+    @Test
+    public void testReportTranslatesIllegalStateExceptionToNotMaster(@Mocked GlobalStateMgr globalStateMgr,
+                                                                     @Mocked ReportHandler reportHandler) throws Exception {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.isLeader();
+                result = true;
+                globalStateMgr.getReportHandler();
+                result = reportHandler;
+                reportHandler.handleReport((TReportRequest) any);
+                result = new IllegalStateException("leader lease invalidated");
+            }
+        };
+
+        TMasterResult result = leader.report(new TReportRequest());
+        Assertions.assertEquals(TStatusCode.INTERNAL_ERROR, result.getStatus().getStatus_code());
+        Assertions.assertNotNull(result.getStatus().getError_msgs());
+        Assertions.assertEquals(1, result.getStatus().getError_msgs().size());
+        String msg = result.getStatus().getError_msgs().get(0);
+        Assertions.assertTrue(msg.contains("current fe is not master"), "error msg must include non-master marker, got: " + msg);
+        Assertions.assertTrue(msg.contains("leader lease invalidated"),
+                "error msg must propagate the IllegalStateException message, got: " + msg);
+    }
+
+    @Test
+    public void testReportRejectsWhenNotLeader(@Mocked GlobalStateMgr globalStateMgr) throws Exception {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.isLeader();
+                result = false;
+            }
+        };
+
+        TMasterResult result = leader.report(new TReportRequest());
+        Assertions.assertEquals(TStatusCode.INTERNAL_ERROR, result.getStatus().getStatus_code());
+        Assertions.assertEquals("current fe is not master", result.getStatus().getError_msgs().get(0));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -525,4 +525,34 @@ public class ReportHandlerTest {
         reportHandler.putTabletReportTask(2L, 1L, new HashMap<>());
         Assertions.assertEquals(2, reportHandler.getPendingTabletReportTaskCnt());
     }
+
+    @Test
+    public void testOnStoppedDrainsQueuesAndClearsPendingTasks() throws Exception {
+        ReportHandler reportHandler = new ReportHandler();
+        reportHandler.putTabletReportTask(1L, 1L, new HashMap<>());
+        reportHandler.putTabletReportTask(2L, 1L, new HashMap<>());
+        Assertions.assertEquals(2, reportHandler.getPendingTabletReportTaskCnt());
+        Assertions.assertTrue(reportHandler.getReportQueueSize() > 0);
+
+        reportHandler.onStopped();
+
+        Assertions.assertEquals(0, reportHandler.getPendingTabletReportTaskCnt(),
+                "pending tablet report tasks must be cleared after onStopped");
+        Assertions.assertEquals(0, reportHandler.getReportQueueSize(),
+                "both report queues must be drained after onStopped");
+    }
+
+    @Test
+    public void testPutTabletReportTaskThrowsAfterStop() {
+        ReportHandler reportHandler = new ReportHandler();
+        reportHandler.setStop();
+        // Must surface as IllegalStateException so LeaderImpl.report() can translate to
+        // NOT_MASTER; silent-drop would leave the BE thinking the report succeeded.
+        IllegalStateException ex = Assertions.assertThrows(IllegalStateException.class,
+                () -> reportHandler.putTabletReportTask(1L, 1L, new HashMap<>()));
+        Assertions.assertTrue(ex.getMessage().contains("stopped"),
+                "exception message should mention stop reason, got: " + ex.getMessage());
+        Assertions.assertEquals(0, reportHandler.getPendingTabletReportTaskCnt());
+        Assertions.assertEquals(0, reportHandler.getReportQueueSize());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/LeaderDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LeaderDaemonTest.java
@@ -1,0 +1,217 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Placed in com.starrocks.server to reach the package-private leader-activation/demotion entrypoints
+// on GlobalStateMgr used by this test.
+package com.starrocks.server;
+
+import com.starrocks.common.util.LeaderDaemon;
+import com.starrocks.ha.FrontendNodeType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class LeaderDaemonTest {
+
+    /**
+     * Always-ready GlobalStateMgr for tests so the daemon loop does not block on isReady().
+     * All leader-lease state uses the real superclass logic.
+     */
+    private static class TestGlobalStateMgr extends GlobalStateMgr {
+        TestGlobalStateMgr() {
+            super(new NodeMgr());
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+    }
+
+    private static TestGlobalStateMgr activeLeader() {
+        TestGlobalStateMgr gsm = new TestGlobalStateMgr();
+        gsm.beginLeaderActivation();
+        gsm.setFrontendNodeType(FrontendNodeType.LEADER);
+        gsm.publishLeaderLease(42L);
+        return gsm;
+    }
+
+    private static class CountingDaemon extends LeaderDaemon {
+        final GlobalStateMgr gsm;
+        final AtomicInteger cycles = new AtomicInteger();
+        final AtomicBoolean beforeStopCalled = new AtomicBoolean();
+        final AtomicBoolean afterStopCalled = new AtomicBoolean();
+        final CountDownLatch firstCycle = new CountDownLatch(1);
+
+        CountingDaemon(String name, long intervalMs, GlobalStateMgr gsm) {
+            super(name, intervalMs);
+            this.gsm = gsm;
+        }
+
+        @Override
+        protected GlobalStateMgr getGlobalStateMgr() {
+            return gsm;
+        }
+
+        @Override
+        protected void runAfterLeaseValid() throws InterruptedException {
+            cycles.incrementAndGet();
+            firstCycle.countDown();
+        }
+
+        @Override
+        protected void onBeforeStop() {
+            beforeStopCalled.set(true);
+        }
+
+        @Override
+        protected void onAfterStop() {
+            afterStopCalled.set(true);
+        }
+    }
+
+    @Test
+    public void testRestartAfterStopGracefully() throws Exception {
+        TestGlobalStateMgr gsm = activeLeader();
+        CountingDaemon d = new CountingDaemon("restart-test", 5L, gsm);
+
+        d.start();
+        Assertions.assertTrue(d.firstCycle.await(3, TimeUnit.SECONDS), "first cycle must run");
+        Assertions.assertTrue(d.isRunning());
+
+        d.stopGracefully(2000L);
+        Assertions.assertTrue(d.beforeStopCalled.get());
+        Assertions.assertTrue(d.afterStopCalled.get());
+        Assertions.assertFalse(d.isRunning());
+        Assertions.assertTrue(d.isStopped());
+
+        // Reset observables and restart the same instance - mimics a re-elected leader reusing
+        // the singleton Mgr across leader sessions.
+        d.beforeStopCalled.set(false);
+        d.afterStopCalled.set(false);
+        int cyclesAfterFirstStop = d.cycles.get();
+
+        d.start();
+        Assertions.assertTrue(d.isRunning());
+        long deadline = System.currentTimeMillis() + 2000L;
+        while (System.currentTimeMillis() < deadline && d.cycles.get() <= cyclesAfterFirstStop) {
+            Thread.sleep(10);
+        }
+        Assertions.assertTrue(d.cycles.get() > cyclesAfterFirstStop, "worker should resume producing cycles");
+
+        d.stopGracefully(2000L);
+        Assertions.assertFalse(d.isRunning());
+    }
+
+    @Test
+    public void testSelfStopWhenLeaseInvalidated() throws Exception {
+        TestGlobalStateMgr gsm = activeLeader();
+        CountingDaemon d = new CountingDaemon("self-stop-test", 5L, gsm);
+
+        d.start();
+        Assertions.assertTrue(d.firstCycle.await(3, TimeUnit.SECONDS));
+        Assertions.assertTrue(d.isRunning());
+
+        // Demotion happens externally; the daemon must notice on its next loop iteration and exit on its own.
+        gsm.beginLeaderDemotion(FrontendNodeType.FOLLOWER);
+
+        long deadline = System.currentTimeMillis() + 3000L;
+        while (System.currentTimeMillis() < deadline && d.isRunning()) {
+            Thread.sleep(10);
+        }
+        Assertions.assertFalse(d.isRunning(), "daemon must self-stop after lease becomes invalid");
+        Assertions.assertTrue(d.isStopped());
+    }
+
+    @Test
+    public void testStopGracefullyInvokesHooksInOrder() throws Exception {
+        TestGlobalStateMgr gsm = activeLeader();
+        StringBuilder order = new StringBuilder();
+        LeaderDaemon d = new LeaderDaemon("hook-order-test", 5L) {
+            @Override
+            protected GlobalStateMgr getGlobalStateMgr() {
+                return gsm;
+            }
+
+            @Override
+            protected void runAfterLeaseValid() throws InterruptedException {
+                Thread.sleep(5);
+            }
+
+            @Override
+            protected void onBeforeStop() {
+                synchronized (order) {
+                    order.append("before;");
+                }
+            }
+
+            @Override
+            protected void onAfterStop() {
+                synchronized (order) {
+                    order.append("after;");
+                }
+            }
+        };
+
+        d.start();
+        Thread.sleep(100);
+        d.stopGracefully(2000L);
+        Assertions.assertEquals("before;after;", order.toString());
+    }
+
+    @Test
+    public void testStopGracefullyReInterruptsOnTimeout() throws Exception {
+        TestGlobalStateMgr gsm = activeLeader();
+        CountDownLatch inWork = new CountDownLatch(1);
+        AtomicBoolean reachedAfterStop = new AtomicBoolean();
+        // Worker that swallows interrupts and busy-loops, forcing the timeout path.
+        LeaderDaemon d = new LeaderDaemon("timeout-test", 0L) {
+            @Override
+            protected GlobalStateMgr getGlobalStateMgr() {
+                return gsm;
+            }
+
+            @Override
+            protected void runAfterLeaseValid() {
+                inWork.countDown();
+                long until = System.currentTimeMillis() + 500L;
+                while (System.currentTimeMillis() < until) {
+                    // Clear the interrupt flag so LeaderDaemon.loop cannot observe stop promptly.
+                    Thread.interrupted();
+                }
+            }
+
+            @Override
+            protected void onAfterStop() {
+                reachedAfterStop.set(true);
+            }
+        };
+
+        d.start();
+        Assertions.assertTrue(inWork.await(2, TimeUnit.SECONDS));
+
+        long start = System.currentTimeMillis();
+        d.stopGracefully(100L);
+        long elapsed = System.currentTimeMillis() - start;
+
+        // stopGracefully must return after the join timeout rather than blocking for the full busy span.
+        Assertions.assertTrue(elapsed < 2000L, "stopGracefully should honor the join timeout; elapsed=" + elapsed);
+        Assertions.assertTrue(reachedAfterStop.get(), "onAfterStop must run even after timeout");
+        Assertions.assertTrue(d.isStopped());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/server/LeaderDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LeaderDaemonTest.java
@@ -212,4 +212,137 @@ public class LeaderDaemonTest {
         Assertions.assertFalse(onStoppedCalled.get(), "onStopped must NOT run on the timeout path");
         Assertions.assertTrue(d.isStopped());
     }
+
+    @Test
+    public void testDefaultIntervalConstructorAndGetters() {
+        LeaderDaemon d = new LeaderDaemon("default-ctor") {
+            @Override
+            protected void runAfterLeaseValid() {
+            }
+        };
+        Assertions.assertEquals("default-ctor", d.getName());
+        Assertions.assertEquals(30L * 1000L, d.getInterval());
+        d.setInterval(123L);
+        Assertions.assertEquals(123L, d.getInterval());
+    }
+
+    @Test
+    public void testStartIsIdempotent() throws Exception {
+        TestGlobalStateMgr gsm = activeLeader();
+        CountingDaemon d = new CountingDaemon("idempotent-start", 5L, gsm);
+        d.start();
+        Assertions.assertTrue(d.firstCycle.await(3, TimeUnit.SECONDS));
+        // Second start() while running must be a no-op - no second worker thread.
+        d.start();
+        Assertions.assertTrue(d.isRunning());
+        d.stopGracefully(2000L);
+    }
+
+    @Test
+    public void testSetStopIsIdempotent() {
+        TestGlobalStateMgr gsm = activeLeader();
+        CountingDaemon d = new CountingDaemon("idempotent-setstop", 5L, gsm);
+        d.start();
+        d.setStop();
+        // Second setStop() is a no-op and must not throw even after worker is already scheduled to exit.
+        d.setStop();
+        Assertions.assertTrue(d.isStopped());
+        d.stopGracefully(2000L);
+    }
+
+    @Test
+    public void testOnStoppedThrowableIsSwallowed() throws Exception {
+        TestGlobalStateMgr gsm = activeLeader();
+        AtomicBoolean stateReset = new AtomicBoolean();
+        LeaderDaemon d = new LeaderDaemon("onstopped-throw", 5L) {
+            @Override
+            protected GlobalStateMgr getGlobalStateMgr() {
+                return gsm;
+            }
+
+            @Override
+            protected void runAfterLeaseValid() throws InterruptedException {
+                Thread.sleep(5);
+            }
+
+            @Override
+            protected void onStopped() {
+                throw new RuntimeException("boom");
+            }
+        };
+        d.start();
+        Thread.sleep(50);
+        // A throwing onStopped must not prevent stopGracefully from completing its state reset.
+        d.stopGracefully(2000L);
+        Assertions.assertFalse(d.isRunning(), "state reset must still run after onStopped throws");
+        stateReset.set(!d.isRunning());
+        Assertions.assertTrue(stateReset.get());
+    }
+
+    @Test
+    public void testRunAfterLeaseValidThrowableDoesNotKillLoop() throws Exception {
+        TestGlobalStateMgr gsm = activeLeader();
+        AtomicInteger attempts = new AtomicInteger();
+        CountDownLatch afterFailures = new CountDownLatch(3);
+        LeaderDaemon d = new LeaderDaemon("runtime-error", 5L) {
+            @Override
+            protected GlobalStateMgr getGlobalStateMgr() {
+                return gsm;
+            }
+
+            @Override
+            protected void runAfterLeaseValid() {
+                if (attempts.incrementAndGet() <= 3) {
+                    afterFailures.countDown();
+                    throw new RuntimeException("transient");
+                }
+            }
+        };
+        d.start();
+        // Loop must keep running past RuntimeExceptions from runAfterLeaseValid.
+        Assertions.assertTrue(afterFailures.await(3, TimeUnit.SECONDS),
+                "loop must survive runtime exceptions and keep iterating");
+        d.stopGracefully(2000L);
+    }
+
+    @Test
+    public void testStopWhileNotReadyExitsCleanly() throws Exception {
+        // GlobalStateMgr that never reports ready - worker gets stuck in the !isReady() sleep loop.
+        GlobalStateMgr neverReady = new GlobalStateMgr(new NodeMgr()) {
+            @Override
+            public boolean isReady() {
+                return false;
+            }
+        };
+        AtomicBoolean ranBody = new AtomicBoolean();
+        LeaderDaemon d = new LeaderDaemon("never-ready", 5L) {
+            @Override
+            protected GlobalStateMgr getGlobalStateMgr() {
+                return neverReady;
+            }
+
+            @Override
+            protected void runAfterLeaseValid() {
+                ranBody.set(true);
+            }
+        };
+        d.start();
+        Thread.sleep(150);
+        d.stopGracefully(2000L);
+        // Body must never have been invoked because GSM stayed unready; the worker must still have exited.
+        Assertions.assertFalse(ranBody.get());
+        Assertions.assertFalse(d.isRunning());
+        Assertions.assertTrue(d.isStopped());
+    }
+
+    @Test
+    public void testSetStopBeforeStartIsSafe() {
+        CountingDaemon d = new CountingDaemon("setstop-before-start", 5L, activeLeader());
+        // Before start(), there is no worker to interrupt. setStop() must still flip isStopped.
+        d.setStop();
+        Assertions.assertTrue(d.isStopped());
+        // stopGracefully without a worker thread must be a no-op that returns cleanly.
+        d.stopGracefully(100L);
+        Assertions.assertFalse(d.isRunning());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/LeaderDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LeaderDaemonTest.java
@@ -54,8 +54,7 @@ public class LeaderDaemonTest {
     private static class CountingDaemon extends LeaderDaemon {
         final GlobalStateMgr gsm;
         final AtomicInteger cycles = new AtomicInteger();
-        final AtomicBoolean beforeStopCalled = new AtomicBoolean();
-        final AtomicBoolean afterStopCalled = new AtomicBoolean();
+        final AtomicBoolean stoppedCalled = new AtomicBoolean();
         final CountDownLatch firstCycle = new CountDownLatch(1);
 
         CountingDaemon(String name, long intervalMs, GlobalStateMgr gsm) {
@@ -75,13 +74,8 @@ public class LeaderDaemonTest {
         }
 
         @Override
-        protected void onBeforeStop() {
-            beforeStopCalled.set(true);
-        }
-
-        @Override
-        protected void onAfterStop() {
-            afterStopCalled.set(true);
+        protected void onStopped() {
+            stoppedCalled.set(true);
         }
     }
 
@@ -95,15 +89,13 @@ public class LeaderDaemonTest {
         Assertions.assertTrue(d.isRunning());
 
         d.stopGracefully(2000L);
-        Assertions.assertTrue(d.beforeStopCalled.get());
-        Assertions.assertTrue(d.afterStopCalled.get());
+        Assertions.assertTrue(d.stoppedCalled.get());
         Assertions.assertFalse(d.isRunning());
         Assertions.assertTrue(d.isStopped());
 
         // Reset observables and restart the same instance - mimics a re-elected leader reusing
         // the singleton Mgr across leader sessions.
-        d.beforeStopCalled.set(false);
-        d.afterStopCalled.set(false);
+        d.stoppedCalled.set(false);
         int cyclesAfterFirstStop = d.cycles.get();
 
         d.start();
@@ -139,9 +131,10 @@ public class LeaderDaemonTest {
     }
 
     @Test
-    public void testStopGracefullyInvokesHooksInOrder() throws Exception {
+    public void testStopGracefullyRunsOnStoppedAfterWorkerExits() throws Exception {
         TestGlobalStateMgr gsm = activeLeader();
-        StringBuilder order = new StringBuilder();
+        AtomicBoolean workerExited = new AtomicBoolean();
+        AtomicBoolean onStoppedObservedWorkerExit = new AtomicBoolean();
         LeaderDaemon d = new LeaderDaemon("hook-order-test", 5L) {
             @Override
             protected GlobalStateMgr getGlobalStateMgr() {
@@ -150,36 +143,34 @@ public class LeaderDaemonTest {
 
             @Override
             protected void runAfterLeaseValid() throws InterruptedException {
-                Thread.sleep(5);
-            }
-
-            @Override
-            protected void onBeforeStop() {
-                synchronized (order) {
-                    order.append("before;");
+                try {
+                    Thread.sleep(5);
+                } finally {
+                    workerExited.set(true);
                 }
             }
 
             @Override
-            protected void onAfterStop() {
-                synchronized (order) {
-                    order.append("after;");
-                }
+            protected void onStopped() {
+                onStoppedObservedWorkerExit.set(workerExited.get());
             }
         };
 
         d.start();
         Thread.sleep(100);
         d.stopGracefully(2000L);
-        Assertions.assertEquals("before;after;", order.toString());
+        Assertions.assertTrue(onStoppedObservedWorkerExit.get(),
+                "onStopped must run after the worker has exited runAfterLeaseValid");
+        Assertions.assertFalse(d.isRunning());
     }
 
     @Test
-    public void testStopGracefullyReInterruptsOnTimeout() throws Exception {
+    public void testJoinTimeoutInvokesFailureHookAndKeepsStateFenced() throws Exception {
         TestGlobalStateMgr gsm = activeLeader();
         CountDownLatch inWork = new CountDownLatch(1);
-        AtomicBoolean reachedAfterStop = new AtomicBoolean();
-        // Worker that swallows interrupts and busy-loops, forcing the timeout path.
+        AtomicBoolean joinTimeoutHook = new AtomicBoolean();
+        AtomicBoolean onStoppedCalled = new AtomicBoolean();
+        // Worker that swallows interrupts and busy-loops, forcing the join-timeout path.
         LeaderDaemon d = new LeaderDaemon("timeout-test", 0L) {
             @Override
             protected GlobalStateMgr getGlobalStateMgr() {
@@ -197,8 +188,14 @@ public class LeaderDaemonTest {
             }
 
             @Override
-            protected void onAfterStop() {
-                reachedAfterStop.set(true);
+            protected void onStopped() {
+                onStoppedCalled.set(true);
+            }
+
+            @Override
+            protected void onJoinTimeout() {
+                // Test override: record the call instead of terminating the JVM.
+                joinTimeoutHook.set(true);
             }
         };
 
@@ -209,9 +206,10 @@ public class LeaderDaemonTest {
         d.stopGracefully(100L);
         long elapsed = System.currentTimeMillis() - start;
 
-        // stopGracefully must return after the join timeout rather than blocking for the full busy span.
+        // Must honor the join timeout rather than blocking for the full busy span.
         Assertions.assertTrue(elapsed < 2000L, "stopGracefully should honor the join timeout; elapsed=" + elapsed);
-        Assertions.assertTrue(reachedAfterStop.get(), "onAfterStop must run even after timeout");
+        Assertions.assertTrue(joinTimeoutHook.get(), "onJoinTimeout must fire when the worker doesn't exit in time");
+        Assertions.assertFalse(onStoppedCalled.get(), "onStopped must NOT run on the timeout path");
         Assertions.assertTrue(d.isStopped());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
@@ -65,7 +65,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.concurrent.ExecutorService;
 
 public class HeartbeatMgrTest {
 
@@ -246,5 +248,22 @@ public class HeartbeatMgrTest {
                 Assertions.assertEquals(TRunMode.SHARED_DATA, masterInfo.getRun_mode());
             }
         };
+    }
+
+    @Test
+    public void testOnStoppedShutsDownAndClearsExecutor() throws Exception {
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        // start() lazy-inits the executor.
+        mgr.start();
+        Field execField = HeartbeatMgr.class.getDeclaredField("executor");
+        execField.setAccessible(true);
+        ExecutorService before = (ExecutorService) execField.get(mgr);
+        Assertions.assertNotNull(before, "executor must be initialized after start()");
+
+        // protected onStopped() is visible from the same package.
+        mgr.onStopped();
+
+        Assertions.assertTrue(before.isShutdown(), "previous executor must be shut down");
+        Assertions.assertNull(execField.get(mgr), "executor reference must be nulled for re-init on next start()");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
@@ -117,7 +117,7 @@ public class LakeAggregatePublishTest {
                 Lists.newArrayList(), null);
 
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
-        publishVersionDaemon.runAfterCatalogReady();
+        publishVersionDaemon.runAfterLeaseValid();
 
         Assertions.assertTrue(waiter1.await(10, TimeUnit.SECONDS));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -127,13 +127,13 @@ public class LakePublishBatchTest {
     }
 
     /**
-     * Simulates the real PublishVersionDaemon's periodic behavior by retrying runAfterCatalogReady()
+     * Simulates the real PublishVersionDaemon's periodic behavior by retrying runAfterLeaseValid()
      * until all waiters are satisfied. This prevents flakiness caused by transient RPC failures or
      * thread pool scheduling delays under CI load.
      */
     private void awaitPublish(PublishVersionDaemon daemon, VisibleStateWaiter... waiters) {
         Awaitility.await().atMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(() -> {
-            daemon.runAfterCatalogReady();
+            daemon.runAfterLeaseValid();
             for (VisibleStateWaiter waiter : waiters) {
                 if (!waiter.await(500, TimeUnit.MILLISECONDS)) {
                     return false;
@@ -304,12 +304,12 @@ public class LakePublishBatchTest {
                 Lists.newArrayList(), null);
 
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
-        publishVersionDaemon.runAfterCatalogReady();
+        publishVersionDaemon.runAfterLeaseValid();
         TransactionState transactionState9 = globalTransactionMgr.getDatabaseTransactionMgr(db.getId()).
                 getTransactionState(transactionId9);
         boolean success = false;
         for (int i = 0; i < 10; i++) {
-            publishVersionDaemon.runAfterCatalogReady();
+            publishVersionDaemon.runAfterLeaseValid();
             if (waiter9.await(1, TimeUnit.SECONDS)) {
                 success = true;
                 break;
@@ -366,7 +366,7 @@ public class LakePublishBatchTest {
         };
 
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
-        publishVersionDaemon.runAfterCatalogReady();
+        publishVersionDaemon.runAfterLeaseValid();
 
         TransactionState transactionState1 = globalTransactionMgr.getDatabaseTransactionMgr(db.getId()).
                 getTransactionState(transactionId5);
@@ -429,7 +429,7 @@ public class LakePublishBatchTest {
         };
 
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
-        publishVersionDaemon.runAfterCatalogReady();
+        publishVersionDaemon.runAfterLeaseValid();
 
         TransactionState transactionState1 = globalTransactionMgr.getDatabaseTransactionMgr(db.getId()).
                 getTransactionState(transactionId7);
@@ -547,7 +547,7 @@ public class LakePublishBatchTest {
         publishVersionDaemon.publishingTransactionIds.add(transactionId6);
 
         Config.lake_enable_batch_publish_version = true;
-        publishVersionDaemon.runAfterCatalogReady();
+        publishVersionDaemon.runAfterLeaseValid();
         Assertions.assertFalse(waiter6.await(5, TimeUnit.SECONDS));
         Assertions.assertFalse(waiter7.await(5, TimeUnit.SECONDS));
 
@@ -630,7 +630,7 @@ public class LakePublishBatchTest {
             Assertions.assertTrue(transactionMgr.checkTxnStateBatchConsistent(db, readyStateBatch));
 
             PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
-            publishVersionDaemon.runAfterCatalogReady();
+            publishVersionDaemon.runAfterLeaseValid();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -580,4 +580,43 @@ public class PublishVersionDaemonTest {
         Assertions.assertEquals(1, originalState.getPublishVersionTasks().size());
         Assertions.assertTrue(latestState.getPublishVersionTasks().isEmpty());
     }
+
+    @Test
+    public void testOnStoppedReleasesExecutorsAndDedupSets() throws Exception {
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        // Force lazy init of both executors through their getters; getDeleteTxnLogExecutor is private.
+        ThreadPoolExecutor taskExec = daemon.getTaskExecutor();
+        ThreadPoolExecutor deleteExec =
+                (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getDeleteTxnLogExecutor");
+        Assertions.assertNotNull(taskExec);
+        Assertions.assertNotNull(deleteExec);
+
+        // Populate both dedup sets so we can verify onStopped() clears them.
+        Set<Long> publishing = Sets.newConcurrentHashSet();
+        publishing.add(42L);
+        FieldUtils.writeField(daemon, "publishingTransactionIds", publishing, true);
+        Set<Long> batchTable = Sets.newConcurrentHashSet();
+        batchTable.add(7L);
+        FieldUtils.writeField(daemon, "publishingLakeTransactionsBatchTableId", batchTable, true);
+
+        daemon.onStopped();
+
+        Assertions.assertTrue(taskExec.isShutdown(), "taskExecutor must be shut down");
+        Assertions.assertTrue(deleteExec.isShutdown(), "deleteTxnLogExecutor must be shut down");
+        Assertions.assertNull(FieldUtils.readField(daemon, "taskExecutor", true));
+        Assertions.assertNull(FieldUtils.readField(daemon, "deleteTxnLogExecutor", true));
+        Assertions.assertTrue(publishing.isEmpty(), "publishingTransactionIds must be cleared");
+        Assertions.assertTrue(batchTable.isEmpty(), "publishingLakeTransactionsBatchTableId must be cleared");
+    }
+
+    @Test
+    public void testOnStoppedTolerantOfNullExecutorsAndNullSets() throws Exception {
+        // Fresh instance: executors and dedup sets may both be null. onStopped must be no-op-safe.
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        FieldUtils.writeField(daemon, "taskExecutor", null, true);
+        FieldUtils.writeField(daemon, "deleteTxnLogExecutor", null, true);
+        FieldUtils.writeField(daemon, "publishingTransactionIds", null, true);
+        FieldUtils.writeField(daemon, "publishingLakeTransactionsBatchTableId", null, true);
+        Assertions.assertDoesNotThrow(daemon::onStopped);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -285,7 +285,7 @@ public class PublishVersionDaemonTest {
         };
 
         PublishVersionDaemon daemon = new PublishVersionDaemon();
-        daemon.runAfterCatalogReady();
+        daemon.runAfterLeaseValid();
 
         Assertions.assertEquals(2, finishedTxnIds.size());
         Assertions.assertTrue(finishedTxnIds.contains(txnId1));
@@ -335,7 +335,7 @@ public class PublishVersionDaemonTest {
 
         daemon.publishingTransactionIds = Sets.newConcurrentHashSet();
         daemon.publishingTransactionIds.add(txnId1);
-        daemon.runAfterCatalogReady();
+        daemon.runAfterLeaseValid();
 
         Assertions.assertEquals(0, finishedTxnIds.size());
 
@@ -383,7 +383,7 @@ public class PublishVersionDaemonTest {
         };
 
         PublishVersionDaemon daemon2 = new PublishVersionDaemon();
-        daemon2.runAfterCatalogReady();
+        daemon2.runAfterLeaseValid();
 
         Assertions.assertTrue(canTxnFinishedCallCount.get() > 0);
         Assertions.assertEquals(0, finishedTxnIds.size());
@@ -427,7 +427,7 @@ public class PublishVersionDaemonTest {
         };
 
         PublishVersionDaemon daemon3 = new PublishVersionDaemon();
-        daemon3.runAfterCatalogReady();
+        daemon3.runAfterLeaseValid();
 
         // Even if submission fails, publishingTransactionIds should be cleaned up
         Assertions.assertFalse(daemon3.publishingTransactionIds.contains(txnId1));
@@ -478,7 +478,7 @@ public class PublishVersionDaemonTest {
 
         PublishVersionDaemon daemon4 = new PublishVersionDaemon();
         // ERR_LOCK_ERROR is swallowed with an info log and retried next cycle — must not throw
-        Assertions.assertDoesNotThrow(daemon4::runAfterCatalogReady);
+        Assertions.assertDoesNotThrow(daemon4::runAfterLeaseValid);
         // finishTransaction must NOT have been invoked because tryFinishTransaction returned early
         Assertions.assertEquals(0, finishedTxnIds.size());
 
@@ -512,9 +512,9 @@ public class PublishVersionDaemonTest {
         };
 
         // The non-lock exception propagates from tryFinishTransaction, is caught as Throwable
-        // by the executor's catch block (LOG.error), so runAfterCatalogReady itself does not throw
+        // by the executor's catch block (LOG.error), so runAfterLeaseValid itself does not throw
         PublishVersionDaemon daemon5 = new PublishVersionDaemon();
-        Assertions.assertDoesNotThrow(daemon5::runAfterCatalogReady);
+        Assertions.assertDoesNotThrow(daemon5::runAfterLeaseValid);
         // finishTransaction was never reached because exception was thrown before it
         Assertions.assertEquals(0, finishedTxnIds.size());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -619,4 +619,35 @@ public class PublishVersionDaemonTest {
         FieldUtils.writeField(daemon, "publishingLakeTransactionsBatchTableId", null, true);
         Assertions.assertDoesNotThrow(daemon::onStopped);
     }
+
+    @Test
+    public void testConfigRefreshListenersDoNotAccumulateAcrossStopCycles() throws Exception {
+        ConfigRefreshDaemon configDaemon = GlobalStateMgr.getCurrentState().getConfigRefreshDaemon();
+        @SuppressWarnings("unchecked")
+        List<?> listeners = (List<?>) FieldUtils.readField(configDaemon, "listeners", true);
+
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        int before = listeners.size();
+        // First activation: both listeners get registered.
+        daemon.getTaskExecutor();
+        MethodUtils.invokeMethod(daemon, true, "getDeleteTxnLogExecutor");
+        Assertions.assertEquals(before + 2, listeners.size(),
+                "first getTaskExecutor + getDeleteTxnLogExecutor should register exactly two listeners");
+
+        // Simulate demote: executors are nulled so the next activation will recreate them.
+        daemon.onStopped();
+
+        // Re-activation: executors recreated, but listeners must not be registered again.
+        daemon.getTaskExecutor();
+        MethodUtils.invokeMethod(daemon, true, "getDeleteTxnLogExecutor");
+        Assertions.assertEquals(before + 2, listeners.size(),
+                "re-creating executors after onStopped must not leak additional listeners");
+
+        // And a third cycle stays stable.
+        daemon.onStopped();
+        daemon.getTaskExecutor();
+        MethodUtils.invokeMethod(daemon, true, "getDeleteTxnLogExecutor");
+        Assertions.assertEquals(before + 2, listeners.size(),
+                "listener count must stay stable across repeated demote/re-elect cycles");
+    }
 }


### PR DESCRIPTION
  ## Why I'm doing:

  Part 2 of safe leader demotion (#63357). Part 1 (#70911, merged) landed the
  primitives — `LeaderLease`, admission fence, `JournalWriter` sealing, and
  failure-visible `EditLog` APIs. Demotion still cannot avoid `System.exit(-1)`
  because leader-only daemons have no way to stop cleanly:

  - They extend `FrontendDaemon` / `Daemon`, which wrap `Thread` directly, so
    once stopped they cannot be restarted when this FE is re-elected.
  - They own leader-session state (pending queues, executors, in-flight maps)
    that must be released *immediately* on demotion, not on the next
    activation — otherwise memory is retained on followers and stale leader
    state can leak into replay paths.
  - They have no built-in lease check, so each subclass would have to
    re-implement fence logic to notice demotion.

  ## What I'm doing:

  ### New framework: `LeaderDaemon`

  A composition-based base class (holds a `Thread`, doesn't extend it) that:

  - Is **restartable**: `start()` after `stopGracefully()` spins up a fresh
    worker, so the same singleton Mgr instance works across leader sessions.
  - **Self-stops on lease invalidation**: each iteration captures and
    revalidates a `LeaderLease`; once invalid the loop exits without needing
    subclass cooperation.
  - Exposes two cleanup hooks:
    - `onBeforeStop()` — runs *before* the worker is interrupted; subclasses
      clear leader-session state here.
    - `onAfterStop()` — runs after the worker has actually exited (or
      timed out).
  - `stopGracefully(timeoutMs)` is the coordinated shutdown: hook → interrupt
    → join → re-interrupt on timeout → after-hook. Idempotent.

  ### Representative migrations (4 daemons)

  Each subclass owns its cleanup logic; the framework only provides the seam.

  - `TabletScheduler` — clears `pendingTablets`, `allTabletIds`,
    `runningTablets`, `schedHistory`, `backendsWorkingSlots`, `loadStatistic`,
    and timing watermarks.
  - `PublishVersionDaemon` — shuts down `taskExecutor` and
    `deleteTxnLogExecutor`, clears `publishingTransactionIds`.
  - `HeartbeatMgr` — shuts down its executor and nulls the reference so the
    next activation can rebuild it.
  - `ReportHandler` (outer + nested `ResourceReportDaemon`) — clears
    `reportQueue`, `resourceReportQueue`, `pendingTaskMap`, and the static
    `TABLET_TO_DROP_TIME` map. Also:
    - Adds an inbound fence at `handleReport` via
      `captureLeaderLeaseOrThrow()`.
    - Converts the blocking `queue.take()` in the consumer loop to
      `queue.poll(1s)` so lease re-checks happen regularly.
    - Fixes a pre-existing bug where `InterruptedException` was swallowed by
      a broad `catch (Exception)` and the consumer looped forever after
      interrupt.
  - `LeaderImpl.report` translates the new `IllegalStateException` from the
    inbound fence into the existing `INTERNAL_ERROR` / "current fe is not
    master" response, so BEs see the same error they already handle.

  ### Wiring

  - `GlobalStateMgr.stopLeaderOnlyDaemonThreads()` calls `stopGracefully` on
    the migrated daemons in reverse-start order.
  - Invoked from `transferToNonLeader` when leaving `LEADER`.
  - New config `leader_demotion_drain_timeout_sec` (default `30`) bounds the
    per-daemon join timeout.

  ### Scope note

  44 other leader-only daemons remain on `FrontendDaemon`. They are left for
  a follow-up PR to keep this review focused on the framework and the
  wiring. The migrated four cover the patterns the rest will reuse
  (executor-owning, queue-draining, nested daemons, inbound RPC fence).

  Related to #63357

  ## What type of PR is this:

  - [ ] BugFix
  - [ ] Feature
  - [x] Enhancement
  - [ ] Refactor
  - [ ] UT
  - [ ] Doc
  - [ ] Tool

  Does this PR entail a change in behavior?

  - [ ] Yes, this PR will result in a change in behavior.
  - [x] No, this PR will not result in a change in behavior.

  If yes, please specify the type of change:

  - [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
  - [ ] Parameter changes: default values, similar parameters but with different default values
  - [x] Policy changes: use new policy to replace old one, functionality automatically enabled
  - [ ] Feature removed
  - [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

  Leader demotion now stops leader-only daemons cleanly instead of relying on
  process exit. Inbound `report` RPC from BE may return "current fe is not
  master" during the demotion window (the same response it already returns
  from non-leader FEs).

  ## Checklist:

  - [x] I have added test cases for my bug fix or my new feature
  - [ ] This pr needs user documentation (for new or modified features or behaviors)
    - [ ] I have added documentation for my new feature or new function
    - [ ] This pr needs auto generate documentation
  - [ ] This is a backport pr

  ## Bugfix cherry-pick branch check:
  - [x] I have checked the version labels which the pr will be auto-backported to the target branch
    - [ ] 4.1
    - [ ] 4.0
    - [ ] 3.5
    - [ ] 3.4