### PR TITLE
[BugFix] Jdbc fix oracle nls format (backport #71412)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -53,6 +53,10 @@ public class JDBCTable extends Table {
     private String dbName;
     private List<Column> partitionColumns;
 
+    // Transient: original JDBC column types (java.sql.Types) from the external database.
+    // Used for Oracle datetime predicate pushdown to determine TO_DATE/TO_TIMESTAMP wrapping.
+    private transient Map<String, Integer> originalJdbcColumnTypes;
+
     public JDBCTable() {
         super(TableType.JDBC);
     }
@@ -102,6 +106,14 @@ public class JDBCTable extends Table {
     @Override
     public List<Column> getPartitionColumns() {
         return partitionColumns;
+    }
+
+    public Map<String, Integer> getOriginalJdbcColumnTypes() {
+        return originalJdbcColumnTypes;
+    }
+
+    public void setOriginalJdbcColumnTypes(Map<String, Integer> originalJdbcColumnTypes) {
+        this.originalJdbcColumnTypes = originalJdbcColumnTypes;
     }
 
     public Map<String, String> getConnectInfo() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.Logger;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -244,7 +245,8 @@ public class JDBCMetadata implements ConnectorMetadata {
                 k -> {
                     try (Connection connection = getConnection();
                             ResultSet columnSet = schemaResolver.getColumns(connection, dbName, tblName)) {
-                        List<Column> fullSchema = schemaResolver.convertToSRTable(columnSet);
+                        Map<String, Integer> originalJdbcTypes = new HashMap<>();
+                        List<Column> fullSchema = schemaResolver.convertToSRTable(columnSet, originalJdbcTypes);
                         List<Column> partitionColumns = Lists.newArrayList();
                         if (schemaResolver.isSupportPartitionInformation()) {
                             partitionColumns = listPartitionColumns(dbName, tblName, fullSchema);
@@ -259,6 +261,9 @@ public class JDBCMetadata implements ConnectorMetadata {
                                 partitionColumns, dbName, catalogName, properties);
                         if (table != null) {
                             table.setComment(schemaResolver.getTableComment(connection, dbName, tblName));
+                            if (table instanceof JDBCTable && !originalJdbcTypes.isEmpty()) {
+                                ((JDBCTable) table).setOriginalJdbcColumnTypes(originalJdbcTypes);
+                            }
                         }
                         return table;
                     } catch (SQLException | DdlException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -161,12 +161,22 @@ public abstract class JDBCSchemaResolver {
     }
 
     public List<Column> convertToSRTable(ResultSet columnSet) throws SQLException {
+        return convertToSRTable(columnSet, null);
+    }
+
+    public List<Column> convertToSRTable(ResultSet columnSet, Map<String, Integer> originalJdbcTypes) throws SQLException {
         List<Column> fullSchema = Lists.newArrayList();
         while (columnSet.next()) {
-            Type type = convertColumnType(columnSet.getInt("DATA_TYPE"),
+            int dataType = columnSet.getInt("DATA_TYPE");
+            String columnName = columnSet.getString("COLUMN_NAME");
+            Type type = convertColumnType(dataType,
                     columnSet.getString("TYPE_NAME"),
                     columnSet.getInt("COLUMN_SIZE"),
                     columnSet.getInt("DECIMAL_DIGITS"));
+
+            if (originalJdbcTypes != null) {
+                originalJdbcTypes.put(columnName.toLowerCase(java.util.Locale.ROOT), dataType);
+            }
 
             String comment = "";
             // Add try-cache to prevent exceptions when the metadata of some databases does not contain REMARKS
@@ -176,7 +186,7 @@ public abstract class JDBCSchemaResolver {
                 }
             } catch (SQLException ignored) { }
 
-            fullSchema.add(new Column(columnSet.getString("COLUMN_NAME"), type,
+            fullSchema.add(new Column(columnName, type,
                     columnSet.getString("IS_NULLABLE").equals(SchemaConstants.YES), comment));
         }
         return fullSchema;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -58,13 +58,20 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
     }
 
     @Override
-    public List<Column> convertToSRTable(ResultSet columnSet) throws SQLException {
+    public List<Column> convertToSRTable(ResultSet columnSet, java.util.Map<String, Integer> originalJdbcTypes)
+            throws SQLException {
         List<Column> fullSchema = Lists.newArrayList();
         while (columnSet.next()) {
-            Type type = convertColumnType(columnSet.getInt("DATA_TYPE"),
+            int dataType = columnSet.getInt("DATA_TYPE");
+            String columnName = columnSet.getString("COLUMN_NAME");
+            Type type = convertColumnType(dataType,
                     columnSet.getString("TYPE_NAME"),
                     columnSet.getInt("COLUMN_SIZE"),
                     columnSet.getInt("DECIMAL_DIGITS"));
+
+            if (originalJdbcTypes != null) {
+                originalJdbcTypes.put(columnName.toLowerCase(java.util.Locale.ROOT), dataType);
+            }
 
             String comment = "";
             // Add try-cache to prevent exceptions when the metadata of some databases does not contain REMARKS
@@ -74,7 +81,6 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
                 }
             } catch (SQLException ignored) { }
 
-            String columnName = columnSet.getString("COLUMN_NAME");
             if (!columnName.equals(columnName.toLowerCase())) {
                 columnName = "\"" + columnName + "\"";
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -18,13 +18,21 @@ package com.starrocks.planner;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.BetweenPredicate;
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ExprSubstitutionMap;
+import com.starrocks.analysis.InPredicate;
+import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
@@ -34,18 +42,70 @@ import com.starrocks.thrift.TPlanNode;
 import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.thrift.TScanRangeLocations;
 
+import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * full scan on JDBC table.
  */
 public class JDBCScanNode extends ScanNode {
-
     private final List<String> columns = new ArrayList<>();
     private final List<String> filters = new ArrayList<>();
     private String tableName;
     private JDBCTable table;
+
+    private static final class OracleTemporalLiteralExpr extends LiteralExpr {
+        private final String sqlLiteral;
+
+        private OracleTemporalLiteralExpr(String sqlLiteral) {
+            super();
+            this.sqlLiteral = sqlLiteral;
+            this.type = Type.VARCHAR;
+            analysisDone();
+        }
+
+        private OracleTemporalLiteralExpr(OracleTemporalLiteralExpr other) {
+            super(other);
+            this.sqlLiteral = other.sqlLiteral;
+        }
+
+        @Override
+        public Expr clone() {
+            return new OracleTemporalLiteralExpr(this);
+        }
+
+        @Override
+        public String toSqlImpl() {
+            return sqlLiteral;
+        }
+
+        @Override
+        public boolean isMinValue() {
+            return false;
+        }
+
+        @Override
+        public int compareLiteral(LiteralExpr expr) {
+            return getStringValue().compareTo(expr.getStringValue());
+        }
+
+        @Override
+        public Object getRealObjectValue() {
+            return sqlLiteral;
+        }
+
+        @Override
+        public String getStringValue() {
+            return sqlLiteral;
+        }
+    }
 
     public JDBCScanNode(PlanNodeId id, TupleDescriptor desc, JDBCTable tbl) {
         super(id, desc, "SCAN JDBC");
@@ -165,6 +225,171 @@ public class JDBCScanNode extends ScanNode {
         return "";
     }
 
+    private boolean isOracleJdbcUri() {
+        String jdbcUri = getJdbcUri();
+        return jdbcUri != null && jdbcUri.toLowerCase(Locale.ROOT).startsWith("jdbc:oracle");
+    }
+
+    private static String normalizeColumnName(String columnName) {
+        if (columnName == null) {
+            return "";
+        }
+        if (columnName.length() >= 2) {
+            char first = columnName.charAt(0);
+            char last = columnName.charAt(columnName.length() - 1);
+            if ((first == '"' && last == '"') || (first == '`' && last == '`')) {
+                columnName = columnName.substring(1, columnName.length() - 1);
+            }
+        }
+        return columnName.toLowerCase(Locale.ROOT);
+    }
+
+    private static final int ORACLE_TIMESTAMP_WITH_LOCAL_TZ = -102;
+    private static final int ORACLE_TIMESTAMP_WITH_TZ = -101;
+
+    private static PrimitiveType mapJdbcTypeToTemporalType(int jdbcType) {
+        switch (jdbcType) {
+            case Types.DATE:
+                return PrimitiveType.DATE;
+            case Types.TIMESTAMP:
+            case ORACLE_TIMESTAMP_WITH_LOCAL_TZ:
+            case ORACLE_TIMESTAMP_WITH_TZ:
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return PrimitiveType.DATETIME;
+            default:
+                return null;
+        }
+    }
+
+    private Map<String, PrimitiveType> collectOracleTemporalColumns() {
+        Map<String, PrimitiveType> temporalColumns = new HashMap<>();
+
+        // Prefer original JDBC types from the cached column schema (covers TIMESTAMP -> VARCHAR mapping)
+        Map<String, Integer> originalJdbcTypes = table.getOriginalJdbcColumnTypes();
+        if (originalJdbcTypes != null && !originalJdbcTypes.isEmpty()) {
+            for (Map.Entry<String, Integer> entry : originalJdbcTypes.entrySet()) {
+                PrimitiveType temporalType = mapJdbcTypeToTemporalType(entry.getValue());
+                if (temporalType != null) {
+                    temporalColumns.put(normalizeColumnName(entry.getKey()), temporalType);
+                }
+            }
+            return temporalColumns;
+        }
+        return temporalColumns;
+    }
+
+    private Expr rewriteOracleTemporalPredicateExpr(Expr expr, Map<String, PrimitiveType> temporalColumns) {
+        for (int i = 0; i < expr.getChildren().size(); i++) {
+            expr.setChild(i, rewriteOracleTemporalPredicateExpr(expr.getChild(i), temporalColumns));
+        }
+
+        if (expr instanceof BetweenPredicate) {
+            Expr left = expr.getChild(0);
+            Expr low = expr.getChild(1);
+            Expr high = expr.getChild(2);
+            if (!(left instanceof SlotRef) || low == null || high == null || !low.isConstant() || !high.isConstant()) {
+                return expr;
+            }
+
+            SlotRef slotRef = (SlotRef) left;
+            String slotColumnName = slotRef.getColumnName() != null ? slotRef.getColumnName() : slotRef.getLabel();
+            PrimitiveType slotType = temporalColumns.get(normalizeColumnName(slotColumnName));
+            if (slotType == null) {
+                return expr;
+            } else if (slotType != PrimitiveType.DATE && slotType != PrimitiveType.DATETIME) {
+                return expr;
+            }
+
+            Expr lowLiteralExpr = buildOracleTemporalLiteralExpr(low);
+            Expr highLiteralExpr = buildOracleTemporalLiteralExpr(high);
+            if (lowLiteralExpr == null || highLiteralExpr == null) {
+                return expr;
+            }
+            expr.setChild(1, lowLiteralExpr);
+            expr.setChild(2, highLiteralExpr);
+            return expr;
+        }
+
+        if (expr instanceof InPredicate) {
+            Expr left = expr.getChild(0);
+            if (!(left instanceof SlotRef)) {
+                return expr;
+            }
+
+            SlotRef slotRef = (SlotRef) left;
+            String slotColumnName = slotRef.getColumnName() != null ? slotRef.getColumnName() : slotRef.getLabel();
+            PrimitiveType slotType = temporalColumns.get(normalizeColumnName(slotColumnName));
+            if (slotType == null) {
+                return expr;
+            } else if (slotType != PrimitiveType.DATE && slotType != PrimitiveType.DATETIME) {
+                return expr;
+            }
+
+            List<Expr> rewrittenItems = new ArrayList<>(expr.getChildren().size() - 1);
+            for (int i = 1; i < expr.getChildren().size(); i++) {
+                Expr item = expr.getChild(i);
+                if (item == null || !item.isConstant()) {
+                    return expr;
+                }
+                Expr rewrittenItem = buildOracleTemporalLiteralExpr(item);
+                if (rewrittenItem == null) {
+                    return expr;
+                }
+                rewrittenItems.add(rewrittenItem);
+            }
+            for (int i = 0; i < rewrittenItems.size(); i++) {
+                expr.setChild(i + 1, rewrittenItems.get(i));
+            }
+            return expr;
+        }
+
+        if (!(expr instanceof BinaryPredicate)) {
+            return expr;
+        }
+
+        Expr left = expr.getChild(0);
+        Expr right = expr.getChild(1);
+        if (!(left instanceof SlotRef) || right == null || !right.isConstant()) {
+            return expr;
+        }
+
+        SlotRef slotRef = (SlotRef) left;
+        String slotColumnName = slotRef.getColumnName() != null ? slotRef.getColumnName() : slotRef.getLabel();
+        PrimitiveType slotType = temporalColumns.get(normalizeColumnName(slotColumnName));
+        if (slotType == null) {
+            return expr;
+        } else if (slotType != PrimitiveType.DATE && slotType != PrimitiveType.DATETIME) {
+            return expr;
+        }
+
+        Expr literalExpr = buildOracleTemporalLiteralExpr(right);
+        if (literalExpr == null) {
+            return expr;
+        }
+        expr.setChild(1, literalExpr);
+        return expr;
+    }
+
+    private static Expr buildOracleTemporalLiteralExpr(Expr constantExpr) {
+        String literalValue;
+        if (constantExpr instanceof StringLiteral) {
+            literalValue = ((StringLiteral) constantExpr).getStringValue();
+        } else if (constantExpr instanceof DateLiteral) {
+            literalValue = ((DateLiteral) constantExpr).getStringValue();
+        } else {
+            return null;
+        }
+        if (literalValue == null) {
+            return null;
+        }
+        Pattern p = Pattern.compile("^(\\d{4})-(\\d{1,2})-(\\d{1,2})$");
+        Matcher m = p.matcher(literalValue);
+        String keyword =
+                (literalValue.length() <= ("0000-00-00").length()) ? (m.matches() ? "date" : "") : "timestamp";
+        String escapedValue = literalValue.replace("'", "''");
+        return new OracleTemporalLiteralExpr(keyword + " '" + escapedValue + "'");
+    }
+
     private void createJDBCTableFilters() {
         if (conjuncts.isEmpty()) {
             return;
@@ -185,10 +410,19 @@ public class JDBCScanNode extends ScanNode {
         // would be unmatched after remove cast operator in PushDownPredicateTOExternalTableScanRule, which
         // would cause BE report error "VectorizedInPredicate type not same";
         conjuncts.clear();
+        Map<String, PrimitiveType> oracleTemporalColumns = Collections.emptyMap();
+        if (isOracleJdbcUri()) {
+            oracleTemporalColumns = collectOracleTemporalColumns();
+        }
+        List<String> originalFilters = new ArrayList<>(jdbcConjuncts.size());
         for (Expr p : jdbcConjuncts) {
             p = p.replaceLargeStringLiteral();
-            filters.add(AstToStringBuilder.toString(p));
+            if (!oracleTemporalColumns.isEmpty()) {
+                p = rewriteOracleTemporalPredicateExpr(p, oracleTemporalColumns);
+            }
+            originalFilters.add(AstToStringBuilder.toString(p));
         }
+        filters.addAll(originalFilters);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
@@ -15,6 +15,7 @@ package com.starrocks.planner;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+import com.starrocks.analysis.BetweenPredicate;
 import com.starrocks.analysis.BinaryPredicate;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.CompoundPredicate;
@@ -33,15 +34,51 @@ import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.thrift.TPlanNode;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Types;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class MySqlAndJDBCScanNodeTest {
+
+    private JDBCScanNode createOracleScanNode(List<Column> columns, List<SlotDescriptor> slots) throws DdlException {
+        return createOracleScanNode(columns, slots, null);
+    }
+
+    private JDBCScanNode createOracleScanNode(List<Column> columns, List<SlotDescriptor> slots,
+                                              Map<String, Integer> originalJdbcTypes) throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "oracle");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:oracle:thin:@localhost:1521:orcl");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "oracle.jdbc.driver.OracleDriver");
+
+        JDBCTable oracleTable = new JDBCTable(1, "orders", columns, properties);
+        if (originalJdbcTypes != null) {
+            oracleTable.setOriginalJdbcColumnTypes(originalJdbcTypes);
+        }
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(oracleTable);
+        for (SlotDescriptor slot : slots) {
+            tupleDesc.addSlot(slot);
+        }
+        return new JDBCScanNode(new PlanNodeId(1), tupleDesc, oracleTable);
+    }
+
+    private SlotDescriptor createSlotDescriptor(int slotId, Column column) {
+        SlotDescriptor slot = new SlotDescriptor(new SlotId(slotId), column.getName(), column.getType(), true);
+        slot.setColumn(column);
+        slot.setIsMaterialized(true);
+        return slot;
+    }
 
     private List<Expr> createConjuncts() {
         Expr slotRef = new SlotRef("col", new SlotDescriptor(new SlotId(1), "col", Type.VARCHAR, true));
@@ -157,6 +194,182 @@ public class MySqlAndJDBCScanNodeTest {
         String nodeString = scanNode.getExplainString();
         Assertions.assertTrue(nodeString.contains("TABLE: select"), nodeString);
         Assertions.assertTrue(nodeString.contains("FROM select"), nodeString);
+    }
+
+    @Test
+    public void testOracleRewriteDateColumnAsDateLiteral() throws DdlException {
+        Column dateColumn = new Column("date_col", Type.DATE);
+        SlotDescriptor dateSlot = createSlotDescriptor(1, dateColumn);
+        Map<String, Integer> originalJdbcTypes = new HashMap<>();
+        originalJdbcTypes.put("date_col", Types.DATE);
+        JDBCScanNode scanNode = createOracleScanNode(Collections.singletonList(dateColumn),
+                Collections.singletonList(dateSlot), originalJdbcTypes);
+        scanNode.getConjuncts().add(new BinaryPredicate(BinaryType.EQ,
+                new SlotRef("date_col", dateSlot), StringLiteral.create("2022-01-01")));
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains("date_col = date '2022-01-01'"), nodeString);
+    }
+
+    @Test
+    public void testOracleRewriteDatetimeColumnWithMicroseconds() throws DdlException {
+        Column datetimeColumn = new Column("ts_col", Type.DATETIME);
+        SlotDescriptor datetimeSlot = createSlotDescriptor(1, datetimeColumn);
+        Map<String, Integer> originalJdbcTypes = new HashMap<>();
+        originalJdbcTypes.put("ts_col", Types.TIMESTAMP);
+        JDBCScanNode scanNode = createOracleScanNode(Collections.singletonList(datetimeColumn),
+                Collections.singletonList(datetimeSlot), originalJdbcTypes);
+        scanNode.getConjuncts().add(new BinaryPredicate(BinaryType.EQ,
+                new SlotRef("ts_col", datetimeSlot), StringLiteral.create("2026-03-12 09:30:15.123456")));
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains(
+                        "ts_col = timestamp '2026-03-12 09:30:15.123456'"),
+                nodeString);
+    }
+
+    @Test
+    public void testOracleDoesNotRewriteLiteralColumnPredicate() throws DdlException {
+        Column datetimeColumn = new Column("ts_col", Type.DATETIME);
+        SlotDescriptor datetimeSlot = createSlotDescriptor(1, datetimeColumn);
+        JDBCScanNode scanNode = createOracleScanNode(Collections.singletonList(datetimeColumn),
+                Collections.singletonList(datetimeSlot));
+        scanNode.getConjuncts().add(new BinaryPredicate(BinaryType.EQ,
+                StringLiteral.create("2026-03-12 09:30:15"), new SlotRef("ts_col", datetimeSlot)));
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains(
+                        "'2026-03-12 09:30:15' = ts_col"),
+                nodeString);
+    }
+
+    @Test
+    public void testOracleRewriteBetweenPredicate() throws DdlException {
+        Column datetimeColumn = new Column("ts_col", Type.DATETIME);
+        SlotDescriptor datetimeSlot = createSlotDescriptor(1, datetimeColumn);
+        Map<String, Integer> originalJdbcTypes = new HashMap<>();
+        originalJdbcTypes.put("ts_col", Types.TIMESTAMP);
+        JDBCScanNode scanNode = createOracleScanNode(Collections.singletonList(datetimeColumn),
+                Collections.singletonList(datetimeSlot), originalJdbcTypes);
+        scanNode.getConjuncts().add(new BetweenPredicate(
+                new SlotRef("ts_col", datetimeSlot),
+                StringLiteral.create("2026-03-12 00:00:00"),
+                StringLiteral.create("2026-03-13 00:00:00"),
+                false));
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains(
+                        "ts_col BETWEEN timestamp '2026-03-12 00:00:00' AND timestamp '2026-03-13 00:00:00'"),
+                nodeString);
+    }
+
+    @Test
+    public void testOracleRewriteInPredicate() throws DdlException {
+        Column datetimeColumn = new Column("ts_col", Type.DATETIME);
+        SlotDescriptor datetimeSlot = createSlotDescriptor(1, datetimeColumn);
+        Map<String, Integer> originalJdbcTypes = new HashMap<>();
+        originalJdbcTypes.put("ts_col", Types.TIMESTAMP);
+        JDBCScanNode scanNode = createOracleScanNode(Collections.singletonList(datetimeColumn),
+                Collections.singletonList(datetimeSlot), originalJdbcTypes);
+        scanNode.getConjuncts().add(new InPredicate(
+                new SlotRef("ts_col", datetimeSlot),
+                Lists.newArrayList(StringLiteral.create("2026-03-12 09:30:15"),
+                        StringLiteral.create("2026-03-13 09:30:15")),
+                false));
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains(
+                        "ts_col IN (timestamp '2026-03-12 09:30:15', timestamp '2026-03-13 09:30:15')"),
+                nodeString);
+    }
+
+    @Test
+    public void testOracleRewriteTimestampMappedToVarcharWithOriginalJdbcTypes() throws DdlException {
+        // Oracle TIMESTAMP column mapped to VARCHAR (default behavior), but original JDBC type is available
+        Column varcharColumn = new Column("ts_col", Type.VARCHAR);
+        SlotDescriptor varcharSlot = createSlotDescriptor(1, varcharColumn);
+        Map<String, Integer> originalJdbcTypes = new HashMap<>();
+        originalJdbcTypes.put("ts_col", Types.TIMESTAMP);
+        JDBCScanNode scanNode = createOracleScanNode(Collections.singletonList(varcharColumn),
+                Collections.singletonList(varcharSlot), originalJdbcTypes);
+        scanNode.getConjuncts().add(new BinaryPredicate(BinaryType.EQ,
+                new SlotRef("ts_col", varcharSlot), StringLiteral.create("2026-03-12 09:30:15")));
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains(
+                        "ts_col = timestamp '2026-03-12 09:30:15'"),
+                nodeString);
+    }
+
+    @Test
+    public void testOracleRewriteDateColumnWithOriginalJdbcTypes() throws DdlException {
+        // Oracle DATE column with original JDBC type available
+        Column dateColumn = new Column("date_col", Type.DATE);
+        SlotDescriptor dateSlot = createSlotDescriptor(1, dateColumn);
+        Map<String, Integer> originalJdbcTypes = new HashMap<>();
+        originalJdbcTypes.put("date_col", Types.DATE);
+        JDBCScanNode scanNode = createOracleScanNode(Collections.singletonList(dateColumn),
+                Collections.singletonList(dateSlot), originalJdbcTypes);
+        scanNode.getConjuncts().add(new BinaryPredicate(BinaryType.EQ,
+                new SlotRef("date_col", dateSlot), StringLiteral.create("2026-03-12")));
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains(
+                        "date_col = date '2026-03-12'"),
+                nodeString);
+    }
+
+    @Test
+    public void testOracleOriginalJdbcDateTypeOverridesSlotType() throws DdlException {
+        // Slot is DATETIME but original JDBC type is DATE: should still use TO_DATE.
+        Column datetimeColumn = new Column("date_col", Type.DATETIME);
+        SlotDescriptor datetimeSlot = createSlotDescriptor(1, datetimeColumn);
+        Map<String, Integer> originalJdbcTypes = new HashMap<>();
+        originalJdbcTypes.put("date_col", Types.DATE);
+        JDBCScanNode scanNode = createOracleScanNode(Collections.singletonList(datetimeColumn),
+                Collections.singletonList(datetimeSlot), originalJdbcTypes);
+        scanNode.getConjuncts().add(new BinaryPredicate(BinaryType.EQ,
+                new SlotRef("date_col", datetimeSlot), StringLiteral.create("2026-03-12")));
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains(
+                        "date_col = date '2026-03-12'"),
+                nodeString);
+    }
+
+    @Test
+    public void testOracleDoesNotRewriteTemporalVarcharColumnByName() throws DdlException {
+        Column varcharColumn = new Column("tstz_col", Type.VARCHAR);
+        SlotDescriptor varcharSlot = createSlotDescriptor(1, varcharColumn);
+        JDBCScanNode scanNode = createOracleScanNode(Collections.singletonList(varcharColumn),
+                Collections.singletonList(varcharSlot));
+        scanNode.getConjuncts().add(new BinaryPredicate(BinaryType.EQ,
+                new SlotRef("tstz_col", varcharSlot), StringLiteral.create("2026-03-12 09:30:15.123456")));
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains(
+                        "tstz_col = '2026-03-12 09:30:15.123456'"),
+                nodeString);
+    }
+
+    @Test
+    public void testOracleRewriteFilterInThriftPayload() throws DdlException {
+        Column datetimeColumn = new Column("ts_col", Type.DATETIME);
+        SlotDescriptor datetimeSlot = createSlotDescriptor(1, datetimeColumn);
+        Map<String, Integer> originalJdbcTypes = new HashMap<>();
+        originalJdbcTypes.put("ts_col", Types.TIMESTAMP);
+        JDBCScanNode scanNode = createOracleScanNode(Collections.singletonList(datetimeColumn),
+                Collections.singletonList(datetimeSlot), originalJdbcTypes);
+        scanNode.getConjuncts().add(new BinaryPredicate(BinaryType.GE,
+                new SlotRef("ts_col", datetimeSlot), StringLiteral.create("2026-03-12 09:30:15")));
+        scanNode.computeColumnsAndFilters();
+
+        TPlanNode planNode = new TPlanNode();
+        scanNode.toThrift(planNode);
+        Assertions.assertTrue(planNode.isSetJdbc_scan_node());
+        Assertions.assertEquals(1, planNode.getJdbc_scan_node().getFiltersSize());
+        Assertions.assertTrue(planNode.getJdbc_scan_node().getFilters().get(0)
+                .contains("ts_col >= timestamp '2026-03-12 09:30:15'"));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
for oracle jdbc, the predicate c1 = '2022-01-1'  will be pushed down to oracle.

but the date format should match the nls format. so now an error will occur.


## What I'm doing:
add time keyword before the time literal string.
print the sql like
```
c1 = date '2022-01-01'
c1 = timestmap '2022-01-01 11:11:11'
```

Fixes https://github.com/StarRocks/starrocks/pull/71412

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Backport notes:
- Manual backport to `branch-4.0` because Mergify PR #71466 was closed after conflicts.
- Resolved branch-4.0 analyzer API differences by keeping `com.starrocks.analysis.*` / `com.starrocks.catalog.Type` and adding `toSqlImpl()` for the custom Oracle temporal literal.

