### PR TITLE
[BugFix] Fix stream load profile collection when table property enable_load_profile is used

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1454,7 +1454,16 @@ public class DefaultCoordinator extends Coordinator {
 
     @Override
     public boolean isEnableLoadProfile() {
-        return connectContext != null && connectContext.getSessionVariable().isEnableLoadProfile();
+        // Check both session variable and the query option set during planning.
+        // When stream load is sent directly to CN, the ConnectContext is created
+        // with empty session variables, but StreamLoadPlanner may have set
+        // enable_profile=true in TQueryOptions based on the table's
+        // enable_load_profile property.  Without checking the query option,
+        // the profile collected by BE would be silently discarded by FE.
+        if (connectContext != null && connectContext.getSessionVariable().isEnableLoadProfile()) {
+            return true;
+        }
+        return jobSpec.getQueryOptions().isSetEnable_profile() && jobSpec.getQueryOptions().isEnable_profile();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -96,6 +96,7 @@ import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TQueryOptions;
 import com.starrocks.thrift.TQueryType;
 import com.starrocks.thrift.TReportAuditStatisticsParams;
 import com.starrocks.thrift.TReportExecStatusParams;
@@ -1454,16 +1455,16 @@ public class DefaultCoordinator extends Coordinator {
 
     @Override
     public boolean isEnableLoadProfile() {
-        // Check both session variable and the query option set during planning.
-        // When stream load is sent directly to CN, the ConnectContext is created
-        // with empty session variables, but StreamLoadPlanner may have set
-        // enable_profile=true in TQueryOptions based on the table's
-        // enable_load_profile property.  Without checking the query option,
-        // the profile collected by BE would be silently discarded by FE.
+        // For stream loads sent directly to CN the ConnectContext is created with
+        // empty session variables, so also honor enable_profile on the JobSpec's
+        // query options — StreamLoadPlanner sets it when the table's
+        // enable_load_profile property is on, and JobSpec.fromSyncStreamLoadSpec
+        // propagates it into the coordinator's query options.
         if (connectContext != null && connectContext.getSessionVariable().isEnableLoadProfile()) {
             return true;
         }
-        return jobSpec.getQueryOptions().isSetEnable_profile() && jobSpec.getQueryOptions().isEnable_profile();
+        TQueryOptions queryOptions = jobSpec.getQueryOptions();
+        return queryOptions != null && queryOptions.isSetEnable_profile() && queryOptions.isEnable_profile();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -235,6 +235,18 @@ public class JobSpec {
             TQueryOptions queryOptions = new TQueryOptions();
             queryOptions.setQuery_type(TQueryType.LOAD);
             queryOptions.setLoad_job_type(TLoadJobType.STREAM_LOAD);
+            // Propagate enable_profile decided by StreamLoadPlanner (e.g. from the
+            // table's enable_load_profile property) so that FE respects it when the
+            // ConnectContext session variable is not set, as is the case for stream
+            // loads sent directly to CN.
+            TQueryOptions plannerOptions = params.getQuery_options();
+            if (plannerOptions != null && plannerOptions.isSetEnable_profile()
+                    && plannerOptions.isEnable_profile()) {
+                queryOptions.setEnable_profile(true);
+                if (plannerOptions.isSetLoad_profile_collect_second()) {
+                    queryOptions.setLoad_profile_collect_second(plannerOptions.getLoad_profile_collect_second());
+                }
+            }
 
             return new Builder()
                     .queryId(queryId)

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
@@ -42,6 +42,7 @@ import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TPlanFragmentExecParams;
+import com.starrocks.thrift.TQueryOptions;
 import com.starrocks.thrift.TQueryType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWorkGroup;
@@ -403,6 +404,35 @@ public class JobSpecTest extends SchedulerTestBase {
         Assertions.assertEquals(queryId, jobSpec.getQueryId());
         Assertions.assertFalse(jobSpec.isEnablePipeline());
         Assertions.assertNull(jobSpec.getResourceGroup());
+        Assertions.assertFalse(jobSpec.getQueryOptions().isSetEnable_profile());
+        Assertions.assertFalse(coordinator.isEnableLoadProfile());
+    }
 
+    @Test
+    public void testFromSyncStreamLoadSpecEnableProfile(@Mocked StreamLoadPlanner planner) throws Exception {
+        TUniqueId queryId = new TUniqueId(2, 3);
+        TQueryOptions plannerOptions = new TQueryOptions();
+        plannerOptions.setEnable_profile(true);
+        plannerOptions.setLoad_profile_collect_second(42);
+        TExecPlanFragmentParams params = new TExecPlanFragmentParams()
+                .setParams(new TPlanFragmentExecParams().setFragment_instance_id(queryId))
+                .setQuery_options(plannerOptions);
+        new Expectations(planner) {
+            {
+                planner.getExecPlanFragmentParams();
+                result = params;
+                planner.getConnectContext();
+                result = new ConnectContext();
+            }
+        };
+
+        DefaultCoordinator coordinator = COORDINATOR_FACTORY.createSyncStreamLoadScheduler(planner, new TNetworkAddress());
+        JobSpec jobSpec = coordinator.getJobSpec();
+
+        Assertions.assertTrue(jobSpec.getQueryOptions().isEnable_profile());
+        Assertions.assertEquals(42, jobSpec.getQueryOptions().getLoad_profile_collect_second());
+        // isEnableLoadProfile must honor the planner-decided enable_profile even though the
+        // ConnectContext has an empty SessionVariable (the direct-CN stream-load path).
+        Assertions.assertTrue(coordinator.isEnableLoadProfile());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When `enable_load_profile=true` is set on a table and stream load is sent directly to CN (port 8040), the load profile is silently discarded by FE even though BE correctly collects and reports it.

**Root cause**: `DefaultCoordinator.isEnableLoadProfile()` only checks the ConnectContext session variable, but for stream loads sent directly to CN, `FrontendServiceImpl.streamLoadPut()` creates a new ConnectContext with empty session variables. The table property `enable_load_profile=true` is correctly read by `StreamLoadPlanner` and sets `TQueryOptions.enable_profile=true`, but this flag is never checked when FE decides whether to store the profile in `StreamLoadTask.unprotectedWaitCoordFinish()`.

## What I'm doing:

In `DefaultCoordinator.isEnableLoadProfile()`, also check `jobSpec.getQueryOptions().isEnable_profile()` so the table property setting is respected end-to-end.

**Before**: Only `connectContext.getSessionVariable().isEnableLoadProfile()` checked → false for direct CN stream loads → profile discarded.

**After**: Also checks `jobSpec.getQueryOptions().isEnable_profile()` → true when table property is set → profile stored correctly.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4