### PR TITLE
[UT] Set schema id in LakeRowsetTest data_size_after_deletion tests

### DIFF
--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -143,6 +143,7 @@ TEST_F(LakeRowsetTest, test_data_size_after_deletion_clamps_negative_live_rows) 
     auto metadata = std::make_shared<TabletMetadata>();
     metadata->set_id(next_id());
     auto* schema = metadata->mutable_schema();
+    schema->set_id(next_id()); // TabletSchemaMap::emplace DCHECKs id != invalid_id()
     schema->set_keys_type(DUP_KEYS);
     auto* r = metadata->add_rowsets();
     r->set_id(1);
@@ -159,6 +160,7 @@ TEST_F(LakeRowsetTest, test_data_size_after_deletion_scales_by_live_fraction) {
     auto metadata = std::make_shared<TabletMetadata>();
     metadata->set_id(next_id());
     auto* schema = metadata->mutable_schema();
+    schema->set_id(next_id()); // TabletSchemaMap::emplace DCHECKs id != invalid_id()
     schema->set_keys_type(DUP_KEYS);
     auto* r = metadata->add_rowsets();
     r->set_id(1);


### PR DESCRIPTION
## Why I'm doing:

The two tests added in #71845 (`test_data_size_after_deletion_clamps_negative_live_rows` and `test_data_size_after_deletion_scales_by_live_fraction`) construct a `TabletMetadata` by hand and set `keys_type` on the schema but leave `schema.id()` at the default `0`, which equals `TabletSchema::invalid_id()`. When `Rowset`'s constructor calls `TabletSchemaMap::emplace`, the `DCHECK(id != invalid_id())` aborts the test in DEBUG builds.

Main branch CI's BE UT runs without DCHECK enabled and did not catch this. The 4.1 backport PR #71956 runs `ut_build_DEBUG` and both tests crash, blocking the backport:

```
F20260421 07:03:07.540286 ... tablet_schema_map.cpp:65]  Check failed: TabletSchema::invalid_id() != id (0 vs. 0)
...
starrocks::TabletSchemaMap::emplace(starrocks::TabletSchemaPB const&)
starrocks::lake::Rowset::Rowset(...)
starrocks::lake::LakeRowsetTest_test_data_size_after_deletion_clamps_negative_live_rows_Test::TestBody()
```

## What I'm doing:

Assign a valid schema id in both test fixtures so the `TabletSchemaMap::emplace` precondition holds on every build type.

## Backport note

The 4.1 auto-backport is deliberately **not requested** here. #71956 already backports #71845 to 4.1 but its CI is failing for the same reason. The fix in this PR will be applied directly on `mergify/bp/branch-4.1/pr-71845` (the #71956 branch) so #71956 can merge cleanly. Once #71956 merges, this PR alone covers main; no separate 4.1 backport is needed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
