### PR TITLE
[Enhancement] Support condition update for lake column-mode partial update

### DIFF
--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -223,9 +223,14 @@ static Status read_chunk_from_update_file(const ChunkIteratorPtr& iter, const Ch
 }
 
 // read from upt files and update rows in source chunk.
+// When condition_idx_in_partial_schema >= 0, pairs where the old condition value is
+// strictly greater than the new one are dropped before applying the update, so the
+// corresponding source rows keep their previous values. Equal values let the new row
+// win, matching the existing upsert/row-mode condition-update semantics (see
+// UpdateManager::_process_single_chunk_update_with_condition).
 Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidToRowidPairs& upt_id_to_rowid_pairs,
-                                                                   const Schema& partial_schema,
-                                                                   ChunkPtr* source_chunk) {
+                                                                   const Schema& partial_schema, ChunkPtr* source_chunk,
+                                                                   int32_t condition_idx_in_partial_schema) {
     TRACE_COUNTER_SCOPE_LATENCY_US("pcu_update_source_by_upt_us");
     // build iterators
     OlapReaderStatistics stats;
@@ -251,6 +256,34 @@ Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidTo
         // Sort source rowid -> upt rowid pairs by source rowid.
         split_rowid_pairs(each.second, &sorted_source_rowids, &unsorted_upt_rowids, nullptr);
         DCHECK(sorted_source_rowids.size() == unsorted_upt_rowids.size());
+
+        // When condition update is enabled, compare the condition column value in
+        // source chunk vs upt chunk and keep winners (old <= new); equal values let
+        // the new row win, matching the upsert path.
+        if (condition_idx_in_partial_schema >= 0) {
+            const auto& source_cond = (*source_chunk)->get_column_by_index(condition_idx_in_partial_schema);
+            const auto& upt_cond = upt_chunk->get_column_by_index(condition_idx_in_partial_schema);
+            const size_t original_size = sorted_source_rowids.size();
+            std::vector<uint32_t> filtered_source_rowids;
+            std::vector<uint32_t> filtered_upt_rowids;
+            filtered_source_rowids.reserve(original_size);
+            filtered_upt_rowids.reserve(original_size);
+            for (size_t i = 0; i < original_size; ++i) {
+                const uint32_t src_rowid = sorted_source_rowids[i];
+                const uint32_t upt_rowid = unsorted_upt_rowids[i];
+                if (source_cond->compare_at(src_rowid, upt_rowid, *upt_cond, -1) <= 0) {
+                    filtered_source_rowids.push_back(src_rowid);
+                    filtered_upt_rowids.push_back(upt_rowid);
+                }
+            }
+            sorted_source_rowids.swap(filtered_source_rowids);
+            unsorted_upt_rowids.swap(filtered_upt_rowids);
+            TRACE_COUNTER_INCREMENT("pcu_condition_kept_cnt", sorted_source_rowids.size());
+            TRACE_COUNTER_INCREMENT("pcu_condition_dropped_cnt", original_size - sorted_source_rowids.size());
+        }
+        if (sorted_source_rowids.empty()) {
+            continue;
+        }
         auto tmp_chunk = ChunkHelper::new_chunk(partial_schema, unsorted_upt_rowids.size());
         TRY_CATCH_BAD_ALLOC(
                 tmp_chunk->append_selective(*upt_chunk, unsorted_upt_rowids.data(), 0, unsorted_upt_rowids.size()));
@@ -271,6 +304,35 @@ static std::vector<T> append_fixed_batch(const std::vector<T>& base_array, size_
 static void padding_char_columns(const Schema& schema, const TabletSchemaCSPtr& tschema, Chunk* chunk) {
     auto char_field_indexes = ChunkHelper::get_char_field_indexes(schema);
     ChunkHelper::padding_char_columns(char_field_indexes, schema, tschema, chunk);
+}
+
+StatusOr<int32_t> ColumnModePartialUpdateHandler::_resolve_condition_cid(const RowsetTxnMetaPB& txn_meta,
+                                                                         const TabletSchema& tschema) {
+    if (txn_meta.merge_condition().empty()) {
+        return -1;
+    }
+    for (size_t i = 0; i < tschema.num_columns(); ++i) {
+        if (tschema.column(i).name() == txn_meta.merge_condition()) {
+            return static_cast<int32_t>(i);
+        }
+    }
+    return Status::InvalidArgument(
+            strings::Substitute("merge_condition column '$0' not found in tablet schema", txn_meta.merge_condition()));
+}
+
+StatusOr<int32_t> ColumnModePartialUpdateHandler::_locate_condition_idx_in_partial_schema(
+        const std::vector<ColumnId>& selective_update_column_ids, int32_t condition_cid) {
+    DCHECK_GE(condition_cid, 0);
+    for (size_t i = 0; i < selective_update_column_ids.size(); ++i) {
+        if (selective_update_column_ids[i] == static_cast<ColumnId>(condition_cid)) {
+            return static_cast<int32_t>(i);
+        }
+    }
+    // delta_writer has validated that the condition column is in the partial column set, and
+    // execute() forces a single batch so all partial columns land here — missing means a logic
+    // bug somewhere upstream; fail loudly rather than silently disabling condition filtering.
+    return Status::InternalError(strings::Substitute(
+            "merge_condition column id $0 is missing from the partial column batch", condition_cid));
 }
 
 Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& params, MetaFileBuilder* builder,
@@ -304,7 +366,17 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
     }
 
     DCHECK(update_column_ids.size() == unique_update_column_ids.size());
-    const size_t BATCH_HANDLE_COLUMN_CNT = config::vertical_compaction_max_columns_per_group;
+
+    // When condition update is enabled together with column-mode PCU, delta_writer has validated
+    // that the condition column is part of the partial column set; we force a single column batch
+    // so the condition column and the rest of the partial columns share one `partial_schema` (and
+    // one .col file), and compare_at is then performed inline inside _update_source_chunk_by_upt
+    // against the already-read source/upt chunks.
+    ASSIGN_OR_RETURN(int32_t condition_cid, _resolve_condition_cid(txn_meta, *params.tablet_schema));
+    const size_t BATCH_HANDLE_COLUMN_CNT =
+            (condition_cid >= 0 && !update_column_ids.empty())
+                    ? update_column_ids.size()
+                    : static_cast<size_t>(config::vertical_compaction_max_columns_per_group);
 
     // 2. getter all rss_rowid_to_update_rowid, and prepare .col writer by the way
     // rss_id -> update file id -> <rowid, update rowid>
@@ -349,6 +421,14 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
         auto partial_tschema = TabletSchema::create_with_uid(params.tablet_schema, selective_unique_update_column_ids);
         Schema partial_schema = ChunkHelper::convert_schema(params.tablet_schema, selective_update_column_ids);
 
+        // When condition update is enabled, the single-batch invariant ensures the condition column
+        // is present in this batch's partial schema; locate its index for inline compare_at.
+        int32_t condition_idx_in_partial_schema = -1;
+        if (condition_cid >= 0) {
+            ASSIGN_OR_RETURN(condition_idx_in_partial_schema,
+                             _locate_condition_idx_in_partial_schema(selective_update_column_ids, condition_cid));
+        }
+
         // Create thread pool token for segment-level parallelism
         std::unique_ptr<ThreadPoolToken> token;
         if (config::enable_pk_index_parallel_execution) {
@@ -368,8 +448,8 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
             const auto* upt_pairs_ptr = &each.second;
 
             auto func = [this, &params, &partial_schema, &partial_tschema, &selective_unique_update_column_ids, rssid,
-                         upt_pairs_ptr, &dcg_column_ids, &dcg_column_file_with_encryption_metas, &result_mutex,
-                         &shared_status]() {
+                         upt_pairs_ptr, condition_idx_in_partial_schema, &dcg_column_ids,
+                         &dcg_column_file_with_encryption_metas, &result_mutex, &shared_status]() {
                 // 3.3 read from source segment
                 auto source_chunk_or = _read_from_source_segment(params, partial_schema, rssid);
                 if (!source_chunk_or.ok()) {
@@ -383,7 +463,8 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
                 DeferOp tracker_defer([&]() { _tracker->release(source_chunk_size); });
 
                 // 3.4 read from update segment and apply updates
-                auto st = _update_source_chunk_by_upt(*upt_pairs_ptr, partial_schema, &source_chunk_ptr);
+                auto st = _update_source_chunk_by_upt(*upt_pairs_ptr, partial_schema, &source_chunk_ptr,
+                                                      condition_idx_in_partial_schema);
                 if (!st.ok()) {
                     std::lock_guard<std::mutex> l(result_mutex);
                     shared_status.update(st);

--- a/be/src/storage/lake/column_mode_partial_update_handler.h
+++ b/be/src/storage/lake/column_mode_partial_update_handler.h
@@ -45,9 +45,18 @@ private:
     StatusOr<std::unique_ptr<SegmentWriter>> _prepare_delta_column_group_writer(
             const RowsetUpdateStateParams& params, const std::shared_ptr<TabletSchema>& tschema);
     Status _update_source_chunk_by_upt(const UptidToRowidPairs& upt_id_to_rowid_pairs, const Schema& partial_schema,
-                                       ChunkPtr* source_chunk);
+                                       ChunkPtr* source_chunk, int32_t condition_idx_in_partial_schema);
     StatusOr<ChunkPtr> _read_from_source_segment(const RowsetUpdateStateParams& params, const Schema& schema,
                                                  uint32_t rssid);
+    // Resolve txn_meta.merge_condition() to a column id in `tschema`.
+    // Returns -1 when no condition is set, or an error when the named column is missing from the schema.
+    static StatusOr<int32_t> _resolve_condition_cid(const RowsetTxnMetaPB& txn_meta, const TabletSchema& tschema);
+    // Locate `condition_cid` inside a per-batch partial column id list. Returns an error when the
+    // condition column is not present in the batch — with the single-batch invariant this indicates
+    // a logic bug (delta_writer should have rejected it), so propagate it loudly rather than silently
+    // falling back to the no-condition path.
+    static StatusOr<int32_t> _locate_condition_idx_in_partial_schema(
+            const std::vector<ColumnId>& selective_update_column_ids, int32_t condition_cid);
 
 private:
     // params

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -826,11 +826,18 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
     op_write->mutable_rowset()->set_data_size(_tablet_writer->data_size());
     op_write->mutable_rowset()->set_overlapped(op_write->rowset().segments_size() > 1);
 
-    // We can support partial update with row mode to be used with condition update at the same time.
+    // Column-mode PCU combined with condition update requires the condition column to be part of
+    // the partial update column set: the handler compares old vs new values from the partial chunk
+    // itself and cannot read the new value otherwise.
     if (is_partial_update() && !_merge_condition.empty() &&
         (_partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE ||
          _partial_update_mode == PartialUpdateMode::COLUMN_UPSERT_MODE)) {
-        return Status::NotSupported("partial update with column mode and condition update at the same time");
+        if (_write_schema->field_index(_merge_condition) == static_cast<size_t>(-1)) {
+            return Status::NotSupported(fmt::format(
+                    "partial update with column mode requires merge_condition column '{}' to be included in the "
+                    "partial update column set",
+                    _merge_condition));
+        }
     }
 
     // handle partial update

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -407,10 +407,6 @@ TEST_P(LakePartialUpdateTest, test_dcg_then_row_mode_with_default_and_expr_overr
 }
 
 TEST_P(LakePartialUpdateTest, test_partial_update_with_condition) {
-    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
-        return;
-    }
-
     auto chunk0 = generate_data(kChunkSize, 0, false, 3);
     std::vector<Chunk> chunks(3);
     chunks[0] = generate_data(kChunkSize, 0, true, 2);
@@ -481,6 +477,63 @@ TEST_P(LakePartialUpdateTest, test_partial_update_with_condition) {
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
+}
+
+// Validates that column-mode partial update rejects a merge_condition when the condition column
+// is not part of the partial update column set — the handler cannot read the new condition value
+// otherwise and must refuse rather than silently producing wrong results.
+TEST_P(LakePartialUpdateTest, test_column_mode_condition_missing_column_rejected) {
+    if (GetParam().partial_update_mode != PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        return;
+    }
+
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 2);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // Baseline full write.
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Partial update set is (c0, c1), but merge_condition references c2 which is NOT in the set.
+    auto txn_id = next_id();
+    ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .set_slot_descriptors(&_slot_pointers)
+                                               .set_partial_update_mode(PartialUpdateMode::COLUMN_UPDATE_MODE)
+                                               .set_merge_condition("c2")
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+    auto st = delta_writer->finish_with_txnlog().status();
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_not_supported()) << st;
+    delta_writer->close();
 }
 
 TEST_P(LakePartialUpdateTest, test_dcg_not_found_and_fallback_to_segment) {

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update
@@ -275,3 +275,242 @@ select * from site_access;
 drop database test_column_partial_update_with_condition_update;
 -- result:
 -- !result
+
+
+
+
+-- name: test_lake_column_partial_update_with_condition_update @sequential @cloud
+create database test_lake_column_partial_update_with_condition_update;
+-- result:
+-- !result
+use test_lake_column_partial_update_with_condition_update;
+-- result:
+-- !result
+CREATE TABLE tab1 (
+  k INT NOT NULL,
+  ver INT NOT NULL,
+  v1 INT NULL,
+  v2 INT NULL
+) ENGINE=OLAP
+PRIMARY KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into tab1 values (1, 10, 100, 1000), (2, 20, 200, 2000);
+-- result:
+-- !result
+select * from tab1 order by k;
+-- result:
+1	10	100	1000
+2	20	200	2000
+-- !result
+shell: curl --location-trusted -u root: -d "1,5,999|2,30,888" -XPUT -H label:lake_pcu_cond_ok -H column_separator:, -H row_delimiter:| -H partial_update:true -H partial_update_mode:column -H merge_condition:ver -H columns:k,ver,v1 ${url}/api/test_lake_column_partial_update_with_condition_update/tab1/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from tab1 order by k;
+-- result:
+1	10	100	1000
+2	30	888	2000
+-- !result
+shell: curl --location-trusted -u root: -d "1,5,999|2,30,888" -XPUT -H label:lake_pcu_cond_bad -H column_separator:, -H row_delimiter:| -H partial_update:true -H partial_update_mode:column -H merge_condition:v2 -H columns:k,ver,v1 ${url}/api/test_lake_column_partial_update_with_condition_update/tab1/_stream_load
+-- result:
+0
+{
+    "Status": "Fail",
+    "Message": "Merge condition column v2 does not exist. If you are doing partial update with condition update, please check condition column is in the given update columns. Otherwise please check condition column is in table tab1"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from tab1 order by k;
+-- result:
+1	10	100	1000
+2	30	888	2000
+-- !result
+drop database test_lake_column_partial_update_with_condition_update;
+-- result:
+-- !result
+
+
+
+
+
+-- name: test_lake_column_pcu_condition_after_drop_column @sequential @cloud
+create database test_lake_column_pcu_condition_after_drop_column;
+-- result:
+-- !result
+use test_lake_column_pcu_condition_after_drop_column;
+-- result:
+-- !result
+CREATE TABLE tab1 (
+  k INT NOT NULL,
+  v1 INT NULL,
+  v2 INT NULL,
+  v3 INT NULL,
+  ver INT NOT NULL,
+  v4 INT NULL
+) ENGINE=OLAP
+PRIMARY KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into tab1 values (1, 1, 1, 1, 10, 1), (2, 2, 2, 2, 20, 2);
+-- result:
+-- !result
+select * from tab1 order by k;
+-- result:
+1	1	1	1	10	1
+2	2	2	2	20	2
+-- !result
+alter table tab1 drop column v2;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1 order by k;
+-- result:
+1	1	1	10	1
+2	2	2	20	2
+-- !result
+shell: curl --location-trusted -u root: -d "1,5,777|2,30,888" -XPUT -H label:lake_pcu_cond_drop -H column_separator:, -H row_delimiter:| -H partial_update:true -H partial_update_mode:column -H merge_condition:ver -H columns:k,ver,v3 ${url}/api/test_lake_column_pcu_condition_after_drop_column/tab1/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from tab1 order by k;
+-- result:
+1	1	1	10	1
+2	2	888	30	2
+-- !result
+drop database test_lake_column_pcu_condition_after_drop_column;
+-- result:
+-- !result
+
+
+
+
+
+
+
+-- name: test_lake_column_pcu_condition_after_add_column @sequential @cloud
+create database test_lake_column_pcu_condition_after_add_column;
+-- result:
+-- !result
+use test_lake_column_pcu_condition_after_add_column;
+-- result:
+-- !result
+CREATE TABLE tab1 (
+  k INT NOT NULL,
+  ver INT NOT NULL,
+  v1 INT NULL
+) ENGINE=OLAP
+PRIMARY KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into tab1 values (1, 10, 100), (2, 20, 200);
+-- result:
+-- !result
+select * from tab1 order by k;
+-- result:
+1	10	100
+2	20	200
+-- !result
+alter table tab1 add column v2 INT NULL DEFAULT "999";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1 order by k;
+-- result:
+1	10	100	999
+2	20	200	999
+-- !result
+shell: curl --location-trusted -u root: -d "1,5,777|2,30,888|3,50,555" -XPUT -H label:lake_pcu_cond_add -H column_separator:, -H row_delimiter:| -H partial_update:true -H partial_update_mode:column -H merge_condition:ver -H columns:k,ver,v1 ${url}/api/test_lake_column_pcu_condition_after_add_column/tab1/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from tab1 order by k;
+-- result:
+1	10	100	999
+2	30	888	999
+3	50	555	999
+-- !result
+drop database test_lake_column_pcu_condition_after_add_column;
+-- result:
+-- !result
+
+
+-- name: test_lake_column_pcu_condition_with_order_by @sequential @cloud
+create database test_lake_column_pcu_condition_with_order_by;
+-- result:
+-- !result
+use test_lake_column_pcu_condition_with_order_by;
+-- result:
+-- !result
+CREATE TABLE tab1 (
+  k INT NOT NULL,
+  ver INT NOT NULL,
+  v1 INT NULL,
+  v2 INT NULL
+) ENGINE=OLAP
+PRIMARY KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+ORDER BY (ver)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into tab1 values (1, 10, 100, 1000), (2, 20, 200, 2000);
+-- result:
+-- !result
+select * from tab1 order by k;
+-- result:
+1	10	100	1000
+2	20	200	2000
+-- !result
+shell: curl --location-trusted -u root: -d "1,5,999|2,30,888" -XPUT -H label:lake_pcu_cond_orderby -H column_separator:, -H row_delimiter:| -H partial_update:true -H partial_update_mode:column -H merge_condition:ver -H columns:k,ver,v1 ${url}/api/test_lake_column_pcu_condition_with_order_by/tab1/_stream_load 2>/dev/null | grep -oE '"Status": *"Fail"|partial update on table with sort key must provide all sort key columns' | sort -u
+-- result:
+0
+partial update on table with sort key must provide all sort key columns
+"Status": "Fail"
+-- !result
+sync;
+-- result:
+-- !result
+select * from tab1 order by k;
+-- result:
+1	10	100	1000
+2	20	200	2000
+-- !result
+drop database test_lake_column_pcu_condition_with_order_by;
+-- result:
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update
@@ -142,3 +142,149 @@ select * from site_access;
 
 drop database test_column_partial_update_with_condition_update;
 
+
+-- name: test_lake_column_partial_update_with_condition_update @sequential @cloud
+create database test_lake_column_partial_update_with_condition_update;
+use test_lake_column_partial_update_with_condition_update;
+
+CREATE TABLE tab1 (
+  k INT NOT NULL,
+  ver INT NOT NULL,
+  v1 INT NULL,
+  v2 INT NULL
+) ENGINE=OLAP
+PRIMARY KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+insert into tab1 values (1, 10, 100, 1000), (2, 20, 200, 2000);
+select * from tab1 order by k;
+
+-- Happy path: column-mode PCU + merge_condition on ver. Only (k, ver, v1) are in the
+-- partial column set; rows where new ver > old ver should update, others should stay.
+-- Inline rows: (1,5,999) → rejected (5 < 10);  (2,30,888) → applied (30 > 20).
+shell: curl --location-trusted -u root: -d "1,5,999|2,30,888" -XPUT -H label:lake_pcu_cond_ok -H column_separator:, -H row_delimiter:| -H partial_update:true -H partial_update_mode:column -H merge_condition:ver -H columns:k,ver,v1 ${url}/api/test_lake_column_partial_update_with_condition_update/tab1/_stream_load
+sync;
+select * from tab1 order by k;
+
+-- Error path: merge_condition references v2 which is NOT in the partial column set (k, ver, v1).
+-- Stream load is rejected during FE-side validation (Load.checkMergeCondition) with a
+-- "Merge condition column ... does not exist" message; BE never gets to run its matching check here.
+shell: curl --location-trusted -u root: -d "1,5,999|2,30,888" -XPUT -H label:lake_pcu_cond_bad -H column_separator:, -H row_delimiter:| -H partial_update:true -H partial_update_mode:column -H merge_condition:v2 -H columns:k,ver,v1 ${url}/api/test_lake_column_partial_update_with_condition_update/tab1/_stream_load
+sync;
+select * from tab1 order by k;
+
+drop database test_lake_column_partial_update_with_condition_update;
+
+
+-- name: test_lake_column_pcu_condition_after_drop_column @sequential @cloud
+-- Verify that dropping a column ahead of the condition column (which shifts the condition
+-- column's column-id) does not break column-mode PCU + merge_condition. The handler resolves
+-- the condition column by NAME against the publish-time schema, so the post-drop cid is what
+-- gets used end-to-end (no stale write-time cid leaks in).
+create database test_lake_column_pcu_condition_after_drop_column;
+use test_lake_column_pcu_condition_after_drop_column;
+
+CREATE TABLE tab1 (
+  k INT NOT NULL,
+  v1 INT NULL,
+  v2 INT NULL,
+  v3 INT NULL,
+  ver INT NOT NULL,
+  v4 INT NULL
+) ENGINE=OLAP
+PRIMARY KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+insert into tab1 values (1, 1, 1, 1, 10, 1), (2, 2, 2, 2, 20, 2);
+select * from tab1 order by k;
+
+-- Drop v2: ver shifts from cid 4 → 3, v3 from 3 → 2, v4 from 5 → 4.
+alter table tab1 drop column v2;
+function: wait_alter_table_finish()
+select * from tab1 order by k;
+
+-- Stream load: partial cols (k, ver, v3), merge_condition=ver.
+-- (1, 5, 777)  → ver=5 < current 10  → reject; row 1 keeps (1, 1, 1, 10, 1).
+-- (2, 30, 888) → ver=30 > current 20 → apply; row 2 becomes (2, 2, 888, 30, 2).
+shell: curl --location-trusted -u root: -d "1,5,777|2,30,888" -XPUT -H label:lake_pcu_cond_drop -H column_separator:, -H row_delimiter:| -H partial_update:true -H partial_update_mode:column -H merge_condition:ver -H columns:k,ver,v3 ${url}/api/test_lake_column_pcu_condition_after_drop_column/tab1/_stream_load
+sync;
+select * from tab1 order by k;
+
+drop database test_lake_column_pcu_condition_after_drop_column;
+
+
+-- name: test_lake_column_pcu_condition_after_add_column @sequential @cloud
+-- Verify column-mode PCU + merge_condition still behaves correctly after ALTER TABLE ADD COLUMN.
+-- ADD COLUMN appends a column with a new uid at the tail; existing column-ids are unchanged,
+-- so this is the easy direction of schema evolution. The test pins:
+--   - existing rows: condition compare is unaffected by the appended column;
+--   - new rows (UPSERT path): the appended column gets its declared default.
+create database test_lake_column_pcu_condition_after_add_column;
+use test_lake_column_pcu_condition_after_add_column;
+
+CREATE TABLE tab1 (
+  k INT NOT NULL,
+  ver INT NOT NULL,
+  v1 INT NULL
+) ENGINE=OLAP
+PRIMARY KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+insert into tab1 values (1, 10, 100), (2, 20, 200);
+select * from tab1 order by k;
+
+-- Append a new nullable column with a non-NULL default.
+alter table tab1 add column v2 INT NULL DEFAULT "999";
+function: wait_alter_table_finish()
+select * from tab1 order by k;
+
+-- Stream load: partial cols (k, ver, v1), merge_condition=ver. Inline rows:
+--   (1, 5, 777)  → ver=5 < 10  → reject; row 1 stays unchanged.
+--   (2, 30, 888) → ver=30 > 20 → apply; row 2 v1=888, ver=30; v2 untouched (still default 999).
+--   (3, 50, 555) → new PK     → insert via UPSERT path; v2 takes the column default 999.
+shell: curl --location-trusted -u root: -d "1,5,777|2,30,888|3,50,555" -XPUT -H label:lake_pcu_cond_add -H column_separator:, -H row_delimiter:| -H partial_update:true -H partial_update_mode:column -H merge_condition:ver -H columns:k,ver,v1 ${url}/api/test_lake_column_pcu_condition_after_add_column/tab1/_stream_load
+sync;
+select * from tab1 order by k;
+
+drop database test_lake_column_pcu_condition_after_add_column;
+
+
+-- name: test_lake_column_pcu_condition_with_order_by @sequential @cloud
+-- Document the pre-existing BE restriction that blocks column-mode (UPSERT path used by
+-- stream load) partial updates on a primary-key table with a non-PK sort key:
+-- a non-PK sort-key column can neither be omitted (sort key must be present to order new
+-- rows) nor included (column-mode UPDATE forbids touching sort-key columns), so any
+-- column-mode stream-load partial update on such a table is rejected upstream of the
+-- condition-update logic this PR adds. The condition-update plumbing therefore never runs
+-- for this case, but the test pins the rejection so a future change to either restriction
+-- shows up here.
+create database test_lake_column_pcu_condition_with_order_by;
+use test_lake_column_pcu_condition_with_order_by;
+
+CREATE TABLE tab1 (
+  k INT NOT NULL,
+  ver INT NOT NULL,
+  v1 INT NULL,
+  v2 INT NULL
+) ENGINE=OLAP
+PRIMARY KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+ORDER BY (ver)
+PROPERTIES ("replication_num" = "1");
+
+insert into tab1 values (1, 10, 100, 1000), (2, 20, 200, 2000);
+select * from tab1 order by k;
+
+-- Expect BE to reject with the pre-existing sort-key conflict error.
+-- Filter the message through grep so the BE/CN IP prefix (which varies between runs) is
+-- stripped from the recorded result.
+shell: curl --location-trusted -u root: -d "1,5,999|2,30,888" -XPUT -H label:lake_pcu_cond_orderby -H column_separator:, -H row_delimiter:| -H partial_update:true -H partial_update_mode:column -H merge_condition:ver -H columns:k,ver,v1 ${url}/api/test_lake_column_pcu_condition_with_order_by/tab1/_stream_load 2>/dev/null | grep -oE '"Status": *"Fail"|partial update on table with sort key must provide all sort key columns' | sort -u
+sync;
+-- Data must be unchanged.
+select * from tab1 order by k;
+
+drop database test_lake_column_pcu_condition_with_order_by;
+


### PR DESCRIPTION
## Why I'm doing:

Lake (shared-data) primary-key tables previously rejected the combination of column-mode partial column update (PCU) and `merge_condition` at the backend with a `NotSupported` status, even though both features were already supported in isolation. Users who want conditional upsert semantics (e.g. "only overwrite when the new version column is larger") on wide tables had to fall back to row-mode PCU, which rewrites whole rows and wastes I/O.

## What I'm doing:

Wire condition evaluation into the lake column-mode PCU handler and lift the hard block:

- `be/src/storage/lake/delta_writer.cpp`: replace the `NotSupported` guard with a validation — when `merge_condition` is set together with `COLUMN_UPDATE_MODE` / `COLUMN_UPSERT_MODE`, the condition column must be part of the partial update column set; otherwise the handler has no new value to compare against.
- `be/src/storage/lake/column_mode_partial_update_handler.{h,cpp}`:
  - `execute()` parses `txn_meta.merge_condition()` and, when set, forces a single column batch so the condition column and the rest of the partial columns share one `partial_schema` and one DCG, avoiding multi-DCG ambiguity.
  - `_update_source_chunk_by_upt()` takes the condition column index inside the partial schema; for each `(source_rowid, upt_rowid)` pair it does `compare_at` between the already-read source chunk and the upt chunk and drops losing pairs (`old > new`), so source rows that lose keep their previous values instead of being partially overwritten. Equal values let the new row win, matching `UpdateManager::_process_single_chunk_update_with_condition`.
  - Two static helpers (`_resolve_condition_cid`, `_locate_condition_idx_in_partial_schema`) keep `execute()` short and surface `Status` errors loudly instead of silently falling back to the no-condition path in release builds.

The change reuses the source/upt chunks that column-mode PCU already reads — no extra I/O is introduced for the condition check.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Test plan

### BE unit tests (`be/test/storage/lake/partial_update_test.cpp`)
- `test_partial_update_with_condition` extended to run under `COLUMN_UPDATE_MODE` — covers `new<old` reject, `new==old` (values identical so visible state unchanged), `new>old` apply.
- New `test_column_mode_condition_missing_column_rejected` — covers the validation error when the merge_condition column is not in the partial set.

### SQL regression (`test/sql/test_partial_update_column_mode/{T,R}/test_partial_update`)
End-to-end on a shared-data TSP cluster (build 1186, FE 172.26.80.2):

- `test_lake_column_partial_update_with_condition_update` — happy path + missing-condition-column error path via stream load.
- `test_lake_column_pcu_condition_after_drop_column` — schema evolution: drop a non-PK, non-condition column (which shifts the merge_condition column's column-id), then run PCU + merge_condition. Pins that `_resolve_condition_cid` (by name) and `_locate_condition_idx_in_partial_schema` (within the same publish-time cid space) stay correct under cid shifts.
- `test_lake_column_pcu_condition_after_add_column` — schema evolution: append a nullable column with a non-NULL default, then run PCU + merge_condition over a mix of rejected, applied, and newly-inserted (UPSERT) rows. Pins that the appended column gets its declared default for both pre-existing rows and new UPSERT rows.
- `test_lake_column_pcu_condition_with_order_by` — pins the pre-existing BE rule that column-mode UPSERT (the path used by stream-load PCU) on a primary-key table with a non-PK sort key is rejected upstream of the new condition-update logic.