### PR TITLE
[Enhancement] IVM commit owner guard + snapshot observability

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/IVMInsertLoadTxnCallback.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/IVMInsertLoadTxnCallback.java
@@ -43,6 +43,8 @@ public class IVMInsertLoadTxnCallback implements InsertLoadTxnCallback {
     private long dbId;
     private MaterializedView mv;
     private final Map<BaseTableInfo, TvrVersionRange> baseTableInfoTvrDeltaMap = Maps.newConcurrentMap();
+    // Owner captured in beforeCommitted; afterCommitted refuses to clear on mismatch.
+    private String capturedOwner;
 
     public IVMInsertLoadTxnCallback(long dbId, long tableId) {
         this.dbId = dbId;
@@ -69,6 +71,7 @@ public class IVMInsertLoadTxnCallback implements InsertLoadTxnCallback {
                     "skip update version range", mv.getName());
             return;
         }
+        this.capturedOwner = asyncRefreshContext.getTempTvrOwnerStartTaskRunId();
 
         // apply the delta into baseTableInfoTvrDeltaMap
         Map<BaseTableInfo, TvrVersionRange> mvBaseTableInfoTvrDeltaMap =
@@ -108,8 +111,14 @@ public class IVMInsertLoadTxnCallback implements InsertLoadTxnCallback {
 
         // update mv's base table info tvr version range map
         mvBaseTableInfoTvrDeltaMap.putAll(baseTableInfoTvrDeltaMap);
-        // clear the temp map and owner tag together
-        asyncRefreshContext.clearTempBaseTableInfoTvrDeltaState();
+        // Only clear if we still own the slot — guard against takeover between the two callbacks.
+        String currentOwner = asyncRefreshContext.getTempTvrOwnerStartTaskRunId();
+        if (currentOwner == null || currentOwner.equals(capturedOwner)) {
+            asyncRefreshContext.clearTempBaseTableInfoTvrDeltaState();
+        } else {
+            LOG.warn("Skip clearTempBaseTableInfoTvrDeltaState in IVM afterCommitted: " +
+                    "captured owner={}, current owner={}", capturedOwner, currentOwner);
+        }
 
         long maxChangedTableRefreshTime = mv.getRefreshScheme().getLastRefreshTime();
         copiedScheme.setLastRefreshTime(maxChangedTableRefreshTime);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -81,6 +81,7 @@ import com.starrocks.sql.plan.ExecPlan;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -298,6 +299,17 @@ public abstract class BaseMVRefreshProcessor {
         }
         logger.info("setup pinned context for {} base tables, owner={}",
                 pinnedMap.size(), mv.getRefreshScheme().getAsyncRefreshContext().getTempTvrOwnerStartTaskRunId());
+
+        // Expose snapshot ids on task run extra message for post-mortem debugging via
+        // information_schema.task_runs.EXTRA_MESSAGE.
+        if (!pinnedMap.isEmpty()) {
+            Map<String, Long> snapshotIds = new HashMap<>(pinnedMap.size());
+            for (Map.Entry<String, TvrVersionRange> e : pinnedMap.entrySet()) {
+                snapshotIds.put(e.getKey(), e.getValue().end().orElse(-1L));
+            }
+            updateTaskRunStatus(status ->
+                    status.getMvTaskRunExtraMessage().setPinnedSnapshotIdMap(snapshotIds));
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -77,6 +77,11 @@ public class MVTaskRunExtraMessage implements Writable {
     @SerializedName("refreshMode")
     public String refreshMode = "";
 
+    // For pinned PCT batches: base-table identifier -> frozen Iceberg snapshot id.
+    // Serialized into information_schema.task_runs.EXTRA_MESSAGE for post-mortem debugging.
+    @SerializedName("pinnedSnapshotIdMap")
+    private Map<String, Long> pinnedSnapshotIdMap = Maps.newHashMap();
+
     public MVTaskRunExtraMessage() {
     }
 
@@ -206,6 +211,15 @@ public class MVTaskRunExtraMessage implements Writable {
 
     public void setAdaptivePartitionRefreshNumber(int adaptivePartitionRefreshNumber) {
         this.adaptivePartitionRefreshNumber = adaptivePartitionRefreshNumber;
+    }
+
+    public Map<String, Long> getPinnedSnapshotIdMap() {
+        return pinnedSnapshotIdMap;
+    }
+
+    public void setPinnedSnapshotIdMap(Map<String, Long> pinnedSnapshotIdMap) {
+        this.pinnedSnapshotIdMap = MvUtils.shrinkToSize(pinnedSnapshotIdMap,
+                Config.max_mv_task_run_meta_message_values_length);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -25,6 +25,7 @@ import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
+import com.starrocks.load.loadv2.IVMInsertLoadTxnCallback;
 import com.starrocks.scheduler.MVTaskRunProcessor;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
@@ -1206,5 +1207,77 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         Assertions.assertNotNull(batch2Plan,
                 "Unrelated pure PCT batch must not be early-SKIPped by orphaned pinning owner " +
                         "state — an exec plan should have been built");
+    }
+
+    /**
+     * Regression for IVM commit owner-match guard: if the pinning owner is overwritten between
+     * {@code beforeCommitted} and {@code afterCommitted} (e.g. leader fail-over + schedule of a
+     * different job), {@code afterCommitted} must NOT call {@code clearTempBaseTableInfoTvrDeltaState}.
+     * Otherwise the newer job's pending TVR state would be wiped and its subsequent batches
+     * would promote incorrect / empty TVR.
+     */
+    @Test
+    public void testIVMCallbackDoesNotClearNewerJobOwner() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0`;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+
+        // Manually stage "IVM has written its delta but transaction commit has not yet fired".
+        MaterializedView.AsyncRefreshContext asyncCtx = mv.getRefreshScheme().getAsyncRefreshContext();
+        String ownerA = "jobA-" + com.starrocks.common.util.UUIDUtil.genUUID();
+        Map<BaseTableInfo, TvrVersionRange> jobAFrozen =
+                Map.of(mv.getBaseTableInfos().get(0), TvrTableSnapshot.of(2L));
+        asyncCtx.replaceTempBaseTableInfoTvrDeltaMap(ownerA, jobAFrozen);
+
+        // Build a callback + capture owner A via beforeCommitted.
+        IVMInsertLoadTxnCallback callback =
+                new IVMInsertLoadTxnCallback(mv.getMvId().getDbId(), mv.getId());
+        callback.beforeCommitted(null);
+
+        // Simulate a newer job taking over ownership between beforeCommitted and afterCommitted.
+        String ownerB = "jobB-" + com.starrocks.common.util.UUIDUtil.genUUID();
+        asyncCtx.replaceTempBaseTableInfoTvrDeltaMap(ownerB,
+                Map.copyOf(asyncCtx.getTempBaseTableInfoTvrDeltaMap()));
+
+        // afterCommitted must detect the owner change and skip clearTempBaseTableInfoTvrDeltaState
+        // so the newer job's pending state survives.
+        callback.afterCommitted(null);
+
+        MaterializedView afterMv = getMv("test_mv1");
+        MaterializedView.AsyncRefreshContext ctxAfter = afterMv.getRefreshScheme().getAsyncRefreshContext();
+        Assertions.assertEquals(ownerB, ctxAfter.getTempTvrOwnerStartTaskRunId(),
+                "Newer job's pinning owner must not be cleared by the stale IVM callback");
+        Assertions.assertFalse(ctxAfter.getTempBaseTableInfoTvrDeltaMap().isEmpty(),
+                "Newer job's pending TVR delta map must not be wiped by the stale IVM callback");
+    }
+
+    /**
+     * Verify pinned snapshot id per base table is recorded on the task run's extra message so
+     * it is visible via information_schema.task_runs.EXTRA_MESSAGE for post-mortem debugging.
+     */
+    @Test
+    public void testPinnedSnapshotIdMapRecordedOnExtraMessage() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto",
+                "`date`", Map.of("partition_refresh_number", "1"));
+
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits();
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+        TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
+        MVTaskRunProcessor processor = getMVTaskRunProcessor(taskRun);
+        Assertions.assertTrue(processor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+
+        // After fallback batch 1, setupPinnedRangesIfNeeded should have written the snapshot id
+        // into the task run's MVTaskRunExtraMessage. Pure PCT / non-pinned runs leave it empty.
+        MVTaskRunExtraMessage extraMessage =
+                processor.getMvTaskRunContext().getStatus().getMvTaskRunExtraMessage();
+        Map<String, Long> pinnedSnapshotIdMap = extraMessage.getPinnedSnapshotIdMap();
+        Assertions.assertFalse(pinnedSnapshotIdMap.isEmpty(),
+                "pinnedSnapshotIdMap should be populated on a pinned fallback batch");
+        // Value must equal the PCT-synced snapshot (version 2).
+        Long snapshotId = pinnedSnapshotIdMap.values().iterator().next();
+        Assertions.assertEquals(2L, snapshotId.longValue(),
+                "pinnedSnapshotIdMap value should match the PCT-synced snapshot id");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


### IVM commit owner guard

IVMInsertLoadTxnCallback previously called clearTempBaseTableInfoTvrDeltaState unconditionally in afterCommitted. If the pinning owner on AsyncRefreshContext was overwritten by a newer refresh job between beforeCommitted and afterCommitted (e.g. leader fail-over + schedule of a different job), the unconditional clear would wipe the newer job's pending TVR state.

Scheduler-level serialization of TaskRuns on the same MV (TaskRunScheduler.canTaskRunBeScheduled) makes this unlikely in normal runtime, but the guard is required for leader fail-over / editlog replay paths and matches the pattern already applied in
MVPCTBasedRefreshProcessor.updateVersionMeta.

* capturedOwner field captures the observed owner in beforeCommitted.
* afterCommitted re-reads the live owner; only clears when it still matches (or no owner remains). Mismatch logs WARN with both owners.

Test: testIVMCallbackDoesNotClearNewerJobOwner manually stages the takeover scenario — owner=A installed, callback captures via beforeCommitted, owner overwritten to B, callback runs afterCommitted. Asserts B's owner and pending map survive.

### Pinned snapshot observability

Pinned PCT batches previously left no trace of which frozen snapshot they scanned — diagnosis required grepping refresh logs. Now the per-base-table frozen snapshot id is exposed on task run extra message:

* MVTaskRunExtraMessage.pinnedSnapshotIdMap: Map<String, Long> keyed by BaseTableInfo.getTableIdentifier(), value is the frozen snapshot id.
* BaseMVRefreshProcessor.setupPinnedRangesIfNeeded populates it alongside the runtime pinnedTvrMap hydration.

Visible via:
  SELECT extra_message FROM information_schema.task_runs WHERE task_name = 'mv-<id>' ORDER BY create_time DESC LIMIT 10;

The JSON will contain e.g.
  "pinnedSnapshotIdMap": {"iceberg0.db.t1:uuid-xyz": 2}

Pure PCT / non-pinned runs leave it empty, matching the existing refBasePartitionsToRefreshMap pattern.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
