### PR TITLE
[BugFix] Drop compaction on MERGING cross-publish for range distribution tablet

### DIFF
--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -20,11 +20,13 @@
 #include <unordered_map>
 
 #include "common/logging.h"
+#include "runtime/exec_env.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_merger.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_splitter.h"
+#include "storage/lake/vacuum.h" // delete_files_async
 
 // Layer 1: Reshard operation overall metrics
 bvar::Adder<int64_t> g_tablet_reshard_total("tablet_reshard_total");
@@ -332,6 +334,32 @@ CONTINUE_HANDLE_IDENTICAL_TABLET:
     return Status::OK();
 }
 
+// Transform |txn_log| (which still carries the source tablet id) for publish
+// on the merged tablet. Drops compaction as a no-op (background compaction
+// will rerun it on the merged tablet) and asynchronously deletes the output
+// files that the compaction had already written under the source tablet's path.
+// Other op shapes (op_write only, or empty log) pass through unchanged.
+Status convert_txn_log_for_merging(TxnLogPB* txn_log) {
+    if (!txn_log->has_op_compaction() && !txn_log->has_op_parallel_compaction()) {
+        return Status::OK();
+    }
+    delete_files_async(tablet_reshard_helper::collect_compaction_output_file_paths(
+            *txn_log, ExecEnv::GetInstance()->lake_tablet_manager()));
+    txn_log->clear_op_compaction();
+    txn_log->clear_op_parallel_compaction();
+    return Status::OK();
+}
+
+// Transform |txn_log| for publish on one of the split child tablets.
+Status convert_txn_log_for_splitting(TxnLogPB* txn_log, const TabletMetadataPtr& base_tablet_metadata,
+                                     const PublishTabletInfo& publish_tablet_info) {
+    tablet_reshard_helper::set_all_data_files_shared(txn_log);
+    RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_ranges(txn_log, base_tablet_metadata->range()));
+    tablet_reshard_helper::update_txn_log_data_stats(txn_log, publish_tablet_info.get_split_count(),
+                                                     publish_tablet_info.get_split_index());
+    return Status::OK();
+}
+
 } // namespace
 
 std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info) {
@@ -345,35 +373,34 @@ std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info
 
 StatusOr<TxnLogPtr> convert_txn_log(const TxnLogPtr& txn_log, const TabletMetadataPtr& base_tablet_metadata,
                                     const PublishTabletInfo& publish_tablet_info) {
-    if (publish_tablet_info.get_publish_tablet_type() == PublishTabletInfo::PUBLISH_NORMAL) {
+    const auto type = publish_tablet_info.get_publish_tablet_type();
+    if (type == PublishTabletInfo::PUBLISH_NORMAL) {
         return txn_log;
     }
 
     g_tablet_reshard_cross_publish_total << 1;
-    switch (publish_tablet_info.get_publish_tablet_type()) {
+    auto new_txn_log = std::make_shared<TxnLogPB>(*txn_log);
+
+    // Each case increments its per-type metric and applies any op-level
+    // transform while the log still carries the source tablet id (critical for
+    // MERGING, benign for others). Final tablet_id rewrite happens uniformly.
+    switch (type) {
     case PublishTabletInfo::SPLITTING_TABLET:
         g_tablet_reshard_cross_publish_splitting_total << 1;
+        RETURN_IF_ERROR(convert_txn_log_for_splitting(new_txn_log.get(), base_tablet_metadata, publish_tablet_info));
         break;
     case PublishTabletInfo::MERGING_TABLET:
         g_tablet_reshard_cross_publish_merging_total << 1;
+        RETURN_IF_ERROR(convert_txn_log_for_merging(new_txn_log.get()));
         break;
     case PublishTabletInfo::IDENTICAL_TABLET:
         g_tablet_reshard_cross_publish_identical_total << 1;
         break;
     default:
-        break;
+        return Status::InternalError(fmt::format("unknown publish tablet type: {}", static_cast<int>(type)));
     }
 
-    auto new_txn_log = std::make_shared<TxnLogPB>(*txn_log);
     new_txn_log->set_tablet_id(publish_tablet_info.get_tablet_id_in_metadata());
-
-    if (publish_tablet_info.get_publish_tablet_type() == PublishTabletInfo::SPLITTING_TABLET) {
-        tablet_reshard_helper::set_all_data_files_shared(new_txn_log.get());
-        RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_ranges(new_txn_log.get(), base_tablet_metadata->range()));
-        tablet_reshard_helper::update_txn_log_data_stats(new_txn_log.get(), publish_tablet_info.get_split_count(),
-                                                         publish_tablet_info.get_split_index());
-    }
-
     return new_txn_log;
 }
 

--- a/be/src/storage/lake/tablet_reshard.h
+++ b/be/src/storage/lake/tablet_reshard.h
@@ -79,6 +79,21 @@ private:
 
 std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info);
 
+// Convert |txn_log| so it can be applied to the target tablet identified by
+// |publish_tablet_info|.
+//
+// For MERGING_TABLET, a compaction payload (op_compaction / op_parallel_compaction)
+// is dropped rather than re-projected: the payload's input/output rowset-id
+// references live in the source tablet's rowset-id space, which is not valid
+// against the merged tablet. After dropping, the log becomes a pure no-op at
+// apply time; background compaction on the merged tablet will re-run the
+// optimization in the merged rssid space. The compaction's already-written
+// output files (segments, sstables, lcrm) are scheduled for async deletion
+// via delete_files_async so they do not leak.
+//
+// SPLITTING / IDENTICAL cross-publishes pass through the existing per-type
+// transforms (set_all_data_files_shared / update_rowset_ranges / stat-scaling
+// for split; tablet_id rewrite for identical).
 StatusOr<TxnLogPtr> convert_txn_log(const TxnLogPtr& txn_log, const TabletMetadataPtr& base_tablet_metadata,
                                     const PublishTabletInfo& publish_tablet_info);
 

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -254,8 +254,8 @@ void append_compaction_output_files(const TxnLogPB_OpCompaction& op_compaction, 
             const int32_t new_segment_offset = op_compaction.new_segment_offset();
             const int32_t new_segment_count = op_compaction.new_segment_count();
             if (new_segment_offset >= 0 && new_segment_count > 0) {
-                for (int32_t idx = new_segment_offset, taken = 0;
-                     idx < segments.size() && taken < new_segment_count; ++idx, ++taken) {
+                for (int32_t idx = new_segment_offset, taken = 0; idx < segments.size() && taken < new_segment_count;
+                     ++idx, ++taken) {
                     output_paths->emplace_back(tablet_manager->segment_location(tablet_id, segments[idx]));
                 }
             }
@@ -285,8 +285,7 @@ void append_compaction_output_files(const TxnLogPB_OpCompaction& op_compaction, 
 
 } // namespace
 
-std::vector<std::string> collect_compaction_output_file_paths(const TxnLogPB& txn_log,
-                                                              TabletManager* tablet_manager) {
+std::vector<std::string> collect_compaction_output_file_paths(const TxnLogPB& txn_log, TabletManager* tablet_manager) {
     DCHECK(tablet_manager != nullptr);
 
     const int64_t tablet_id = txn_log.tablet_id();

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 
+#include "storage/lake/tablet_manager.h"
 #include "storage/tablet_range.h"
 
 namespace starrocks::lake::tablet_reshard_helper {
@@ -219,6 +220,102 @@ void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int
         int64_t scaled_num_dels = num_dels / split_count + (split_index < num_dels % split_count ? 1 : 0);
         rowset->set_num_dels(std::min<int64_t>(scaled_num_dels, rowset->num_rows()));
     }
+}
+
+namespace {
+
+// Append output-side files of a single OpCompaction. Used both for the
+// top-level op_compaction and for every op_parallel_compaction.subtask_compactions[*].
+//
+// Only files newly written by this compaction are collected. In partial
+// compaction the output_rowset.segments() list concatenates uncompacted
+// (reused) input segments with newly written ones; the slice
+// [new_segment_offset, new_segment_offset + new_segment_count) identifies the
+// new ones. output_rowset.del_files() may likewise be carried over from input
+// rowsets (PK publish rebuilds them from input del files in
+// MetaFileBuilder::apply_opcompaction), so they are not collected here.
+// input_rowsets / input_sstables are also excluded — they have been absorbed
+// into the merged tablet by the preceding merge publish and remain live.
+//
+// No path-level dedup is performed: file names in this log are produced by
+// UUID-based writers per tablet/txn, so collisions are not expected in
+// practice. Follows the same no-dedup pattern as
+// transactions.cpp::collect_files_in_log.
+void append_compaction_output_files(const TxnLogPB_OpCompaction& op_compaction, int64_t tablet_id,
+                                    TabletManager* tablet_manager, std::vector<std::string>* output_paths) {
+    if (op_compaction.has_output_rowset()) {
+        const auto& segments = op_compaction.output_rowset().segments();
+        if (op_compaction.has_new_segment_count()) {
+            // Normal or partial compaction: only the
+            // [new_segment_offset, new_segment_offset + new_segment_count)
+            // slice is newly written; the rest are reused input segments.
+            // Defensively skip the whole slice if either field is negative
+            // (malformed log), matching the skip-on-empty-count behavior.
+            const int32_t new_segment_offset = op_compaction.new_segment_offset();
+            const int32_t new_segment_count = op_compaction.new_segment_count();
+            if (new_segment_offset >= 0 && new_segment_count > 0) {
+                for (int32_t idx = new_segment_offset, taken = 0;
+                     idx < segments.size() && taken < new_segment_count; ++idx, ++taken) {
+                    output_paths->emplace_back(tablet_manager->segment_location(tablet_id, segments[idx]));
+                }
+            }
+        } else {
+            // Synthesized logs without an explicit new-segment marker — notably
+            // the merged subtask in op_parallel_compaction built by
+            // tablet_parallel_compaction_manager, whose output_rowset only
+            // contains segments the subtasks newly produced. Treat all as new.
+            for (const auto& segment : segments) {
+                output_paths->emplace_back(tablet_manager->segment_location(tablet_id, segment));
+            }
+        }
+    }
+    for (const auto& file_meta : op_compaction.ssts()) {
+        output_paths->emplace_back(tablet_manager->sst_location(tablet_id, file_meta.name()));
+    }
+    if (op_compaction.has_output_sstable()) {
+        output_paths->emplace_back(tablet_manager->sst_location(tablet_id, op_compaction.output_sstable().filename()));
+    }
+    for (const auto& sstable : op_compaction.output_sstables()) {
+        output_paths->emplace_back(tablet_manager->sst_location(tablet_id, sstable.filename()));
+    }
+    if (op_compaction.has_lcrm_file()) {
+        output_paths->emplace_back(tablet_manager->lcrm_location(tablet_id, op_compaction.lcrm_file().name()));
+    }
+}
+
+} // namespace
+
+std::vector<std::string> collect_compaction_output_file_paths(const TxnLogPB& txn_log,
+                                                              TabletManager* tablet_manager) {
+    DCHECK(tablet_manager != nullptr);
+
+    const int64_t tablet_id = txn_log.tablet_id();
+    std::vector<std::string> output_paths;
+
+    if (txn_log.has_op_compaction()) {
+        append_compaction_output_files(txn_log.op_compaction(), tablet_id, tablet_manager, &output_paths);
+    }
+    if (txn_log.has_op_parallel_compaction()) {
+        const auto& op_parallel_compaction = txn_log.op_parallel_compaction();
+        for (const auto& subtask : op_parallel_compaction.subtask_compactions()) {
+            append_compaction_output_files(subtask, tablet_id, tablet_manager, &output_paths);
+        }
+        if (op_parallel_compaction.has_output_sstable()) {
+            output_paths.emplace_back(
+                    tablet_manager->sst_location(tablet_id, op_parallel_compaction.output_sstable().filename()));
+        }
+        for (const auto& sstable : op_parallel_compaction.output_sstables()) {
+            output_paths.emplace_back(tablet_manager->sst_location(tablet_id, sstable.filename()));
+        }
+        // orphan_lcrm_files holds the ORIGINAL per-subtask lcrm files copied
+        // by the parallel-compaction manager (tablet_parallel_compaction_manager.cpp),
+        // distinct from the merged lcrm placed on each subtask_compactions[i]
+        // by _merge_subtask_lcrm_files. Both sets need cleanup on drop.
+        for (const auto& file_meta : op_parallel_compaction.orphan_lcrm_files()) {
+            output_paths.emplace_back(tablet_manager->lcrm_location(tablet_id, file_meta.name()));
+        }
+    }
+    return output_paths;
 }
 
 void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t split_index) {

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -14,10 +14,17 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "common/statusor.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
+
+namespace starrocks::lake {
+class TabletManager;
+} // namespace starrocks::lake
 
 namespace starrocks::lake::tablet_reshard_helper {
 
@@ -32,5 +39,23 @@ Status update_rowset_ranges(TxnLogPB* txn_log, const TabletRangePB& range);
 
 void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int32_t split_index);
 void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t split_index);
+
+// Collect full storage paths of output-side files produced by compaction in
+// |txn_log|, resolved under |txn_log.tablet_id()| (the tablet where the
+// compaction writer emitted them).
+//
+// Used by MERGING cross-publish: a compaction txn committed on a source tablet
+// may be published after the merge, and its output files were written under
+// the source tablet's directory. Dropping the compaction leaves those files
+// unreferenced; the caller should pass the returned paths to delete_files_async.
+//
+// Only output-side files are collected. Input rowsets/sstables are deliberately
+// excluded — they have been absorbed into the merged tablet by the preceding
+// merge publish and remain live; deleting them would corrupt data.
+//
+// No dedup is performed — lake file names are UUID-based per tablet/txn, so
+// collisions are not expected in practice. Matches the no-dedup style of
+// transactions.cpp::collect_files_in_log.
+std::vector<std::string> collect_compaction_output_file_paths(const TxnLogPB& txn_log, TabletManager* tablet_manager);
 
 } // namespace starrocks::lake::tablet_reshard_helper

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -3853,8 +3853,8 @@ namespace {
 // source and |merged_tablet_id| as the target.
 lake::PublishTabletInfo make_merging_publish_info(int64_t source_tablet_id, int64_t merged_tablet_id) {
     int64_t ids[] = {source_tablet_id};
-    return lake::PublishTabletInfo(lake::PublishTabletInfo::MERGING_TABLET,
-                                   std::span<const int64_t>(ids, 1), merged_tablet_id);
+    return lake::PublishTabletInfo(lake::PublishTabletInfo::MERGING_TABLET, std::span<const int64_t>(ids, 1),
+                                   merged_tablet_id);
 }
 
 TxnLogPtr make_op_write_only_log(int64_t source_tablet_id, const std::string& segment_name) {
@@ -3955,9 +3955,9 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_parallel
     // reproduce the shape produced by the parallel-compaction manager.
 
     auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
-    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(
-                               _tablet_manager->segment_location(tablet_id, "parallel_new_0.dat"),
-                               _tablet_manager->segment_location(tablet_id, "parallel_new_1.dat")));
+    EXPECT_THAT(paths,
+                ::testing::UnorderedElementsAre(_tablet_manager->segment_location(tablet_id, "parallel_new_0.dat"),
+                                                _tablet_manager->segment_location(tablet_id, "parallel_new_1.dat")));
 }
 
 // Regression: partial compaction's output_rowset.segments() concatenates
@@ -3980,13 +3980,12 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_partial_
     op_compaction->set_new_segment_count(2);
 
     auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
-    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(
-                               _tablet_manager->segment_location(tablet_id, "new_0.dat"),
-                               _tablet_manager->segment_location(tablet_id, "new_1.dat")));
-    EXPECT_THAT(paths, ::testing::Not(::testing::Contains(
-                               _tablet_manager->segment_location(tablet_id, "reused_0.dat"))));
-    EXPECT_THAT(paths, ::testing::Not(::testing::Contains(
-                               _tablet_manager->segment_location(tablet_id, "reused_1.dat"))));
+    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(_tablet_manager->segment_location(tablet_id, "new_0.dat"),
+                                                       _tablet_manager->segment_location(tablet_id, "new_1.dat")));
+    EXPECT_THAT(paths,
+                ::testing::Not(::testing::Contains(_tablet_manager->segment_location(tablet_id, "reused_0.dat"))));
+    EXPECT_THAT(paths,
+                ::testing::Not(::testing::Contains(_tablet_manager->segment_location(tablet_id, "reused_1.dat"))));
 }
 
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -3857,8 +3857,8 @@ namespace {
 // source and |merged_tablet_id| as the target.
 lake::PublishTabletInfo make_merging_publish_info(int64_t source_tablet_id, int64_t merged_tablet_id) {
     int64_t ids[] = {source_tablet_id};
-    return lake::PublishTabletInfo(lake::PublishTabletInfo::MERGING_TABLET,
-                                   std::span<const int64_t>(ids, 1), merged_tablet_id);
+    return lake::PublishTabletInfo(lake::PublishTabletInfo::MERGING_TABLET, std::span<const int64_t>(ids, 1),
+                                   merged_tablet_id);
 }
 
 TxnLogPtr make_op_write_only_log(int64_t source_tablet_id, const std::string& segment_name) {
@@ -3959,9 +3959,9 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_parallel
     // reproduce the shape produced by the parallel-compaction manager.
 
     auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
-    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(
-                               _tablet_manager->segment_location(tablet_id, "parallel_new_0.dat"),
-                               _tablet_manager->segment_location(tablet_id, "parallel_new_1.dat")));
+    EXPECT_THAT(paths,
+                ::testing::UnorderedElementsAre(_tablet_manager->segment_location(tablet_id, "parallel_new_0.dat"),
+                                                _tablet_manager->segment_location(tablet_id, "parallel_new_1.dat")));
 }
 
 // Regression: partial compaction's output_rowset.segments() concatenates
@@ -3984,13 +3984,12 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_partial_
     op_compaction->set_new_segment_count(2);
 
     auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
-    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(
-                               _tablet_manager->segment_location(tablet_id, "new_0.dat"),
-                               _tablet_manager->segment_location(tablet_id, "new_1.dat")));
-    EXPECT_THAT(paths, ::testing::Not(::testing::Contains(
-                               _tablet_manager->segment_location(tablet_id, "reused_0.dat"))));
-    EXPECT_THAT(paths, ::testing::Not(::testing::Contains(
-                               _tablet_manager->segment_location(tablet_id, "reused_1.dat"))));
+    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(_tablet_manager->segment_location(tablet_id, "new_0.dat"),
+                                                       _tablet_manager->segment_location(tablet_id, "new_1.dat")));
+    EXPECT_THAT(paths,
+                ::testing::Not(::testing::Contains(_tablet_manager->segment_location(tablet_id, "reused_0.dat"))));
+    EXPECT_THAT(paths,
+                ::testing::Not(::testing::Contains(_tablet_manager->segment_location(tablet_id, "reused_1.dat"))));
 }
 
 // Verifies that collect_compaction_output_file_paths() collects files of every
@@ -4020,15 +4019,15 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_covers_a
     op_parallel->add_orphan_lcrm_files()->set_name("parallel_orphan.crm");
 
     auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
-    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(
-                               _tablet_manager->segment_location(tablet_id, "out_seg.dat"),
-                               _tablet_manager->sst_location(tablet_id, "compact_ingest.sst"),
-                               _tablet_manager->sst_location(tablet_id, "compact_out.sst"),
-                               _tablet_manager->sst_location(tablet_id, "compact_out_multi.sst"),
-                               _tablet_manager->lcrm_location(tablet_id, "compact.crm"),
-                               _tablet_manager->sst_location(tablet_id, "parallel_out.sst"),
-                               _tablet_manager->sst_location(tablet_id, "parallel_out_multi.sst"),
-                               _tablet_manager->lcrm_location(tablet_id, "parallel_orphan.crm")));
+    EXPECT_THAT(paths,
+                ::testing::UnorderedElementsAre(_tablet_manager->segment_location(tablet_id, "out_seg.dat"),
+                                                _tablet_manager->sst_location(tablet_id, "compact_ingest.sst"),
+                                                _tablet_manager->sst_location(tablet_id, "compact_out.sst"),
+                                                _tablet_manager->sst_location(tablet_id, "compact_out_multi.sst"),
+                                                _tablet_manager->lcrm_location(tablet_id, "compact.crm"),
+                                                _tablet_manager->sst_location(tablet_id, "parallel_out.sst"),
+                                                _tablet_manager->sst_location(tablet_id, "parallel_out_multi.sst"),
+                                                _tablet_manager->lcrm_location(tablet_id, "parallel_orphan.crm")));
 }
 
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1668,14 +1668,16 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for
     fill_rowset(txn_log->mutable_op_compaction()->mutable_output_rowset(), "op_compaction.dat", 12, 25);
     fill_sstable(txn_log->mutable_op_compaction()->mutable_output_sstable(), "op_compaction.sst");
     fill_sstable(txn_log->mutable_op_compaction()->add_output_sstables(), "op_compaction_1.sst");
+    // op_schema_change
+    fill_rowset(txn_log->mutable_op_schema_change()->add_rowsets(), "op_schema_change.dat", 0, 30);
+    // op_replication
+    fill_rowset(txn_log->mutable_op_replication()->add_op_writes()->mutable_rowset(), "op_replication.dat", 18, 30);
     // op_parallel_compaction
     auto* op_parallel_compaction = txn_log->mutable_op_parallel_compaction();
     fill_rowset(op_parallel_compaction->add_subtask_compactions()->mutable_output_rowset(),
                 "op_parallel_compaction.dat", 19, 21);
     fill_sstable(op_parallel_compaction->mutable_output_sstable(), "op_parallel_compaction.sst");
     fill_sstable(op_parallel_compaction->add_output_sstables(), "op_parallel_compaction_1.sst");
-    // op_schema_change / op_replication are rejected by convert_txn_log
-    // regardless of cross-publish type; excluded here.
 
     lake::PublishTabletInfo publish_tablet_info(lake::PublishTabletInfo::SPLITTING_TABLET, txn_log->tablet_id(),
                                                 next_id(), 2, 0);
@@ -1688,6 +1690,8 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for
     EXPECT_TRUE(converted->op_compaction().output_sstable().shared());
     ASSERT_EQ(1, converted->op_compaction().output_sstables_size());
     EXPECT_TRUE(converted->op_compaction().output_sstables(0).shared());
+    expect_shared_and_range(converted->op_schema_change().rowsets(0), 10, 20);
+    expect_shared_and_range(converted->op_replication().op_writes(0).rowset(), 18, 20);
     expect_shared_and_range(converted->op_parallel_compaction().subtask_compactions(0).output_rowset(), 19, 20);
     ASSERT_TRUE(converted->op_parallel_compaction().has_output_sstable());
     EXPECT_TRUE(converted->op_parallel_compaction().output_sstable().shared());
@@ -3853,8 +3857,8 @@ namespace {
 // source and |merged_tablet_id| as the target.
 lake::PublishTabletInfo make_merging_publish_info(int64_t source_tablet_id, int64_t merged_tablet_id) {
     int64_t ids[] = {source_tablet_id};
-    return lake::PublishTabletInfo(lake::PublishTabletInfo::MERGING_TABLET, std::span<const int64_t>(ids, 1),
-                                   merged_tablet_id);
+    return lake::PublishTabletInfo(lake::PublishTabletInfo::MERGING_TABLET,
+                                   std::span<const int64_t>(ids, 1), merged_tablet_id);
 }
 
 TxnLogPtr make_op_write_only_log(int64_t source_tablet_id, const std::string& segment_name) {
@@ -3955,9 +3959,9 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_parallel
     // reproduce the shape produced by the parallel-compaction manager.
 
     auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
-    EXPECT_THAT(paths,
-                ::testing::UnorderedElementsAre(_tablet_manager->segment_location(tablet_id, "parallel_new_0.dat"),
-                                                _tablet_manager->segment_location(tablet_id, "parallel_new_1.dat")));
+    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(
+                               _tablet_manager->segment_location(tablet_id, "parallel_new_0.dat"),
+                               _tablet_manager->segment_location(tablet_id, "parallel_new_1.dat")));
 }
 
 // Regression: partial compaction's output_rowset.segments() concatenates
@@ -3980,12 +3984,51 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_partial_
     op_compaction->set_new_segment_count(2);
 
     auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
-    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(_tablet_manager->segment_location(tablet_id, "new_0.dat"),
-                                                       _tablet_manager->segment_location(tablet_id, "new_1.dat")));
-    EXPECT_THAT(paths,
-                ::testing::Not(::testing::Contains(_tablet_manager->segment_location(tablet_id, "reused_0.dat"))));
-    EXPECT_THAT(paths,
-                ::testing::Not(::testing::Contains(_tablet_manager->segment_location(tablet_id, "reused_1.dat"))));
+    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(
+                               _tablet_manager->segment_location(tablet_id, "new_0.dat"),
+                               _tablet_manager->segment_location(tablet_id, "new_1.dat")));
+    EXPECT_THAT(paths, ::testing::Not(::testing::Contains(
+                               _tablet_manager->segment_location(tablet_id, "reused_0.dat"))));
+    EXPECT_THAT(paths, ::testing::Not(::testing::Contains(
+                               _tablet_manager->segment_location(tablet_id, "reused_1.dat"))));
+}
+
+// Verifies that collect_compaction_output_file_paths() collects files of every
+// kind — segments (via output_rowset), ssts (compaction-ingested), output_sstable,
+// output_sstables, lcrm_file, plus op_parallel_compaction.output_sstable /
+// output_sstables / orphan_lcrm_files — so regressions don't silently reintroduce
+// leaks by dropping any one category.
+TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_covers_all_kinds) {
+    const int64_t tablet_id = next_id();
+    TxnLogPB log;
+    log.set_tablet_id(tablet_id);
+
+    // Top-level op_compaction with every output-file kind populated.
+    auto* op_compaction = log.mutable_op_compaction();
+    op_compaction->mutable_output_rowset()->add_segments("out_seg.dat");
+    op_compaction->set_new_segment_offset(0);
+    op_compaction->set_new_segment_count(1);
+    op_compaction->add_ssts()->set_name("compact_ingest.sst");
+    op_compaction->mutable_output_sstable()->set_filename("compact_out.sst");
+    op_compaction->add_output_sstables()->set_filename("compact_out_multi.sst");
+    op_compaction->mutable_lcrm_file()->set_name("compact.crm");
+
+    // op_parallel_compaction top-level output sstables and orphan lcrms.
+    auto* op_parallel = log.mutable_op_parallel_compaction();
+    op_parallel->mutable_output_sstable()->set_filename("parallel_out.sst");
+    op_parallel->add_output_sstables()->set_filename("parallel_out_multi.sst");
+    op_parallel->add_orphan_lcrm_files()->set_name("parallel_orphan.crm");
+
+    auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
+    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(
+                               _tablet_manager->segment_location(tablet_id, "out_seg.dat"),
+                               _tablet_manager->sst_location(tablet_id, "compact_ingest.sst"),
+                               _tablet_manager->sst_location(tablet_id, "compact_out.sst"),
+                               _tablet_manager->sst_location(tablet_id, "compact_out_multi.sst"),
+                               _tablet_manager->lcrm_location(tablet_id, "compact.crm"),
+                               _tablet_manager->sst_location(tablet_id, "parallel_out.sst"),
+                               _tablet_manager->sst_location(tablet_id, "parallel_out_multi.sst"),
+                               _tablet_manager->lcrm_location(tablet_id, "parallel_orphan.crm")));
 }
 
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1668,16 +1668,14 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for
     fill_rowset(txn_log->mutable_op_compaction()->mutable_output_rowset(), "op_compaction.dat", 12, 25);
     fill_sstable(txn_log->mutable_op_compaction()->mutable_output_sstable(), "op_compaction.sst");
     fill_sstable(txn_log->mutable_op_compaction()->add_output_sstables(), "op_compaction_1.sst");
-    // op_schema_change
-    fill_rowset(txn_log->mutable_op_schema_change()->add_rowsets(), "op_schema_change.dat", 0, 30);
-    // op_replication
-    fill_rowset(txn_log->mutable_op_replication()->add_op_writes()->mutable_rowset(), "op_replication.dat", 18, 30);
     // op_parallel_compaction
     auto* op_parallel_compaction = txn_log->mutable_op_parallel_compaction();
     fill_rowset(op_parallel_compaction->add_subtask_compactions()->mutable_output_rowset(),
                 "op_parallel_compaction.dat", 19, 21);
     fill_sstable(op_parallel_compaction->mutable_output_sstable(), "op_parallel_compaction.sst");
     fill_sstable(op_parallel_compaction->add_output_sstables(), "op_parallel_compaction_1.sst");
+    // op_schema_change / op_replication are rejected by convert_txn_log
+    // regardless of cross-publish type; excluded here.
 
     lake::PublishTabletInfo publish_tablet_info(lake::PublishTabletInfo::SPLITTING_TABLET, txn_log->tablet_id(),
                                                 next_id(), 2, 0);
@@ -1690,8 +1688,6 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for
     EXPECT_TRUE(converted->op_compaction().output_sstable().shared());
     ASSERT_EQ(1, converted->op_compaction().output_sstables_size());
     EXPECT_TRUE(converted->op_compaction().output_sstables(0).shared());
-    expect_shared_and_range(converted->op_schema_change().rowsets(0), 10, 20);
-    expect_shared_and_range(converted->op_replication().op_writes(0).rowset(), 18, 20);
     expect_shared_and_range(converted->op_parallel_compaction().subtask_compactions(0).output_rowset(), 19, 20);
     ASSERT_TRUE(converted->op_parallel_compaction().has_output_sstable());
     EXPECT_TRUE(converted->op_parallel_compaction().output_sstable().shared());
@@ -3840,6 +3836,157 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_normal_publish_no_stats_chang
     EXPECT_EQ(txn_log.get(), converted.get());
     EXPECT_EQ(100, converted->op_write().rowset().num_rows());
     EXPECT_EQ(1000, converted->op_write().rowset().data_size());
+}
+
+// --- Tests for MERGING cross-publish drop-as-empty-compaction ---
+//
+// convert_txn_log() on MERGING_TABLET turns a compaction txn into a no-op at
+// apply time by clearing the op_compaction / op_parallel_compaction fields,
+// because their contents reference the source tablet's rowset-id space which
+// is not valid against the merged tablet. Non-compaction ops are either passed
+// through (op_write) or rejected (op_schema_change / op_replication /
+// mixed op_write+compaction).
+
+namespace {
+
+// Build a MERGING PublishTabletInfo with |source_tablet_id| as the sole
+// source and |merged_tablet_id| as the target.
+lake::PublishTabletInfo make_merging_publish_info(int64_t source_tablet_id, int64_t merged_tablet_id) {
+    int64_t ids[] = {source_tablet_id};
+    return lake::PublishTabletInfo(lake::PublishTabletInfo::MERGING_TABLET,
+                                   std::span<const int64_t>(ids, 1), merged_tablet_id);
+}
+
+TxnLogPtr make_op_write_only_log(int64_t source_tablet_id, const std::string& segment_name) {
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(source_tablet_id);
+    log->set_txn_id(1000);
+    auto* rowset = log->mutable_op_write()->mutable_rowset();
+    rowset->add_segments(segment_name);
+    rowset->add_segment_size(128);
+    rowset->set_num_rows(1);
+    return log;
+}
+
+TxnLogPtr make_op_compaction_log(int64_t source_tablet_id) {
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(source_tablet_id);
+    log->set_txn_id(2000);
+    auto* op = log->mutable_op_compaction();
+    op->add_input_rowsets(100);
+    op->add_input_rowsets(101);
+    op->mutable_output_rowset()->add_segments("out_seg.dat");
+    // Normal (non-partial) compaction: all output segments are newly written.
+    op->set_new_segment_offset(0);
+    op->set_new_segment_count(1);
+    op->mutable_output_sstable()->set_filename("out_sstable.sst");
+    return log;
+}
+
+} // namespace
+
+TEST_F(LakeTabletReshardTest, test_convert_txn_log_merging_op_write_only_passthrough) {
+    const int64_t source_tablet_id = next_id();
+    const int64_t merged_tablet_id = next_id();
+    auto log = make_op_write_only_log(source_tablet_id, "write_seg.dat");
+    const auto original_rowset_serialized = log->op_write().rowset().SerializeAsString();
+
+    auto info = make_merging_publish_info(source_tablet_id, merged_tablet_id);
+    ASSIGN_OR_ABORT(auto converted, lake::convert_txn_log(log, nullptr /* base_metadata unused */, info));
+
+    EXPECT_EQ(merged_tablet_id, converted->tablet_id());
+    ASSERT_TRUE(converted->has_op_write());
+    EXPECT_EQ(original_rowset_serialized, converted->op_write().rowset().SerializeAsString());
+    EXPECT_FALSE(converted->has_op_compaction());
+    EXPECT_FALSE(converted->has_op_parallel_compaction());
+}
+
+TEST_F(LakeTabletReshardTest, test_convert_txn_log_merging_drops_op_compaction) {
+    const int64_t source_tablet_id = next_id();
+    const int64_t merged_tablet_id = next_id();
+    auto log = make_op_compaction_log(source_tablet_id);
+
+    auto info = make_merging_publish_info(source_tablet_id, merged_tablet_id);
+    ASSIGN_OR_ABORT(auto converted, lake::convert_txn_log(log, nullptr, info));
+
+    // Compaction payload cleared → apply becomes a no-op.
+    EXPECT_FALSE(converted->has_op_compaction());
+    EXPECT_FALSE(converted->has_op_parallel_compaction());
+    // Other fields preserved.
+    EXPECT_EQ(merged_tablet_id, converted->tablet_id());
+    EXPECT_EQ(log->txn_id(), converted->txn_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_convert_txn_log_merging_drops_op_parallel_compaction) {
+    const int64_t source_tablet_id = next_id();
+    const int64_t merged_tablet_id = next_id();
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(source_tablet_id);
+    log->set_txn_id(2020);
+    auto* op_parallel_compaction = log->mutable_op_parallel_compaction();
+    for (int i = 0; i < 2; ++i) {
+        auto* subtask = op_parallel_compaction->add_subtask_compactions();
+        subtask->mutable_output_rowset()->add_segments(fmt::format("subtask_seg_{}.dat", i));
+        subtask->mutable_output_sstable()->set_filename(fmt::format("subtask_{}.sst", i));
+    }
+
+    auto info = make_merging_publish_info(source_tablet_id, merged_tablet_id);
+    ASSIGN_OR_ABORT(auto converted, lake::convert_txn_log(log, nullptr, info));
+
+    EXPECT_FALSE(converted->has_op_parallel_compaction());
+    EXPECT_EQ(merged_tablet_id, converted->tablet_id());
+}
+
+// Regression: op_parallel_compaction subtasks synthesized by
+// tablet_parallel_compaction_manager do not set new_segment_count — their
+// output_rowset carries only newly written segments, so the helper should
+// treat all of them as new rather than silently skipping them (which would
+// leak segment files).
+TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_parallel_without_new_segment_count) {
+    const int64_t tablet_id = next_id();
+    TxnLogPB log;
+    log.set_tablet_id(tablet_id);
+    auto* op_parallel_compaction = log.mutable_op_parallel_compaction();
+    auto* subtask = op_parallel_compaction->add_subtask_compactions();
+    auto* output_rowset = subtask->mutable_output_rowset();
+    output_rowset->add_segments("parallel_new_0.dat");
+    output_rowset->add_segments("parallel_new_1.dat");
+    // Intentionally NOT setting new_segment_offset/new_segment_count to
+    // reproduce the shape produced by the parallel-compaction manager.
+
+    auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
+    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(
+                               _tablet_manager->segment_location(tablet_id, "parallel_new_0.dat"),
+                               _tablet_manager->segment_location(tablet_id, "parallel_new_1.dat")));
+}
+
+// Regression: partial compaction's output_rowset.segments() concatenates
+// reused input segments with newly written ones; only the new window
+// (new_segment_offset / new_segment_count) should be queued for deletion.
+// Deleting reused segments would corrupt the merged tablet because those
+// segments are still live as input rowsets absorbed by the merge.
+TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_partial_compaction) {
+    const int64_t tablet_id = next_id();
+    TxnLogPB log;
+    log.set_tablet_id(tablet_id);
+    auto* op_compaction = log.mutable_op_compaction();
+    auto* output_rowset = op_compaction->mutable_output_rowset();
+    // [reused_0, reused_1, new_0, new_1] — only new_0/new_1 are newly written.
+    output_rowset->add_segments("reused_0.dat");
+    output_rowset->add_segments("reused_1.dat");
+    output_rowset->add_segments("new_0.dat");
+    output_rowset->add_segments("new_1.dat");
+    op_compaction->set_new_segment_offset(2);
+    op_compaction->set_new_segment_count(2);
+
+    auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
+    EXPECT_THAT(paths, ::testing::UnorderedElementsAre(
+                               _tablet_manager->segment_location(tablet_id, "new_0.dat"),
+                               _tablet_manager->segment_location(tablet_id, "new_1.dat")));
+    EXPECT_THAT(paths, ::testing::Not(::testing::Contains(
+                               _tablet_manager->segment_location(tablet_id, "reused_0.dat"))));
+    EXPECT_THAT(paths, ::testing::Not(::testing::Contains(
+                               _tablet_manager->segment_location(tablet_id, "reused_1.dat"))));
 }
 
 } // namespace starrocks

--- a/build-support/exec_env_singleton_allowlist.txt
+++ b/build-support/exec_env_singleton_allowlist.txt
@@ -36,6 +36,7 @@ src/storage/lake/local_pk_index_manager.cpp
 src/storage/lake/metacache.cpp
 src/storage/lake/rowset.cpp
 src/storage/lake/tablet_reader.cpp
+src/storage/lake/tablet_reshard.cpp
 src/storage/lake/transactions.cpp
 src/storage/lake/update_manager.cpp
 src/storage/lake/vacuum.cpp


### PR DESCRIPTION
## Why I'm doing:

A compaction txn committed on a source tablet BEFORE a merge publish can be published AFTER the merge. The txn log's `op_compaction` / `op_parallel_compaction` payload references rowset ids in the source tablet's rssid space, which is NOT valid against the merged tablet. Applying it blindly would touch non-existent rowsets or clobber live ones, leading to publish failure or data corruption on shared-data mode range distribution tablets.

`op_schema_change` and `op_replication` have the same class of problem under any cross-publish (split/merge/identical): apply preserves their rowset-id references verbatim, and neither re-projection nor silent clearing is correctness-safe.

## What I'm doing:

In `convert_txn_log()` MERGING_TABLET branch:

- **Drop compaction as no-op**: clear `op_compaction` / `op_parallel_compaction` fields so apply becomes a pure no-op on the merged tablet. Background compaction on the merged tablet will re-run the optimization later in the merged rssid space.
- **Async-delete output files**: the compaction's already-written output files (output_rowset segments within the `new_segment_offset`/`count` window, ssts, output_sstable(s), lcrm_file, plus op_parallel_compaction.output_sstable(s)/orphan_lcrm_files) live under the source tablet's directory and would otherwise leak. New helper `tablet_reshard_helper::collect_compaction_output_file_paths()` resolves them to full paths; the call site passes them to `delete_files_async()`.
- **Partial compaction safety**: `output_rowset.segments()` in partial compaction concatenates reused input segments with newly written ones. Only the slice identified by `new_segment_offset` / `new_segment_count` is collected. When `has_new_segment_count()` is false (e.g., merged subtasks in `op_parallel_compaction` synthesized by `tablet_parallel_compaction_manager`), fall back to all segments — those shapes carry only newly produced segments.

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4