### PR TITLE
[Tool] fire backport conflict notification immediately on label

### DIFF
--- a/.github/workflows/ci-backport-checker.yml
+++ b/.github/workflows/ci-backport-checker.yml
@@ -8,6 +8,7 @@ on:
       - 'branch-[0-9].[0-9].[0-9]'
     types:
       - closed
+      - labeled
 
 env:
   PR_ID: ${{ github.event.number }}
@@ -17,16 +18,22 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
   FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
 jobs:
   backport-close:
     runs-on: [self-hosted, normal]
     if: >
-      github.event.pull_request.merged != true &&
       contains(github.event.pull_request.title, 'backport') &&
-      (contains(github.event.pull_request.labels.*.name, 'conflicts') ||
-      contains(github.event.pull_request.labels.*.name, 'conflict')) &&
-      startsWith(github.head_ref, 'mergify/bp')
+      startsWith(github.head_ref, 'mergify/bp') &&
+      (
+        (github.event.action == 'labeled' &&
+         (github.event.label.name == 'conflicts' || github.event.label.name == 'conflict')) ||
+        (github.event.action == 'closed' &&
+         github.event.pull_request.merged != true &&
+         (contains(github.event.pull_request.labels.*.name, 'conflicts') ||
+          contains(github.event.pull_request.labels.*.name, 'conflict')))
+      )
     env:
       STATUS: CONFLICT
 


### PR DESCRIPTION
## Why I'm doing:

Backport conflict PRs created by Mergify were not sending Feishu/Slack notifications until the PR was closed — causing a silent gap. In PR #71951, the PR was merged despite having the `conflicts` label, so the `closed` + `merged != true` condition was never satisfied and no notification was ever sent.

## What I'm doing:

- Add `labeled` to the `pull_request_target` trigger so the notification fires immediately when Mergify adds the `conflicts`/`conflict` label
- Keep the `closed` branch as a fallback
- Add `SLACK_BOT_TOKEN` to the job env so Slack DM is sent alongside the existing Feishu message (requires ci-tool PR #4066)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4