### PR TITLE
[BugFix] Fix kB comment in mem_info

### DIFF
--- a/be/src/common/system/mem_info.cpp
+++ b/be/src/common/system/mem_info.cpp
@@ -108,9 +108,9 @@ void MemInfo::init() {
         auto mem_total_kb = StringParser::string_to_int<int64_t>(fields[1].data(), fields[1].size(), &result);
 
         if (result == StringParser::PARSE_SUCCESS) {
-            // Entries in /proc/meminfo are in KB.
-            if (_s_physical_mem <= 0 || _s_physical_mem > mem_total_kb * 1000L) {
-                _s_physical_mem = mem_total_kb * 1000L;
+            // Entries in /proc/meminfo are in kB(which is same as KiB).
+            if (_s_physical_mem <= 0 || _s_physical_mem > mem_total_kb * 1024L) {
+                _s_physical_mem = mem_total_kb * 1024L;
             }
         }
 

--- a/be/src/common/system/mem_info.cpp
+++ b/be/src/common/system/mem_info.cpp
@@ -109,8 +109,8 @@ void MemInfo::init() {
 
         if (result == StringParser::PARSE_SUCCESS) {
             // Entries in /proc/meminfo are in KB.
-            if (_s_physical_mem <= 0 || _s_physical_mem > mem_total_kb * 1024L) {
-                _s_physical_mem = mem_total_kb * 1024L;
+            if (_s_physical_mem <= 0 || _s_physical_mem > mem_total_kb * 1000L) {
+                _s_physical_mem = mem_total_kb * 1000L;
             }
         }
 


### PR DESCRIPTION
## Why I'm doing:

~The conversion from kb to bytes is wrong when computing the memory limit which causes overestimation in the available memory in the system~
The comment reads like KiloBytes whereas the value reported is indeed KibiBytes

## What I'm doing:
~Fixing the conversion from kb to bytes~
Update the comment
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
