### PR TITLE
[Refactor] Rename ConnectorMetadataRequestContext

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/HMSTablePartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/HMSTablePartitionsProcDir.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
@@ -56,7 +56,7 @@ public class HMSTablePartitionsProcDir implements ProcDirInterface {
             try {
                 List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
                         .listPartitionNames(hmsTable.getCatalogName(), hmsTable.getCatalogDBName(),
-                                hmsTable.getCatalogTableName(), ConnectorMetadatRequestContext.DEFAULT);
+                                hmsTable.getCatalogTableName(), ConnectorMetadataRequestContext.DEFAULT);
                 for (String partitionName : partitionNames) {
                     result.addRow(Lists.newArrayList(partitionName));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PaimonTablePartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PaimonTablePartitionsProcDir.java
@@ -21,7 +21,7 @@ import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.paimon.Partition;
 import com.starrocks.server.GlobalStateMgr;
@@ -54,7 +54,7 @@ public class PaimonTablePartitionsProcDir extends PartitionsProcDir {
         List<List<Comparable>> partitionInfos = new ArrayList<List<Comparable>>();
         List<String> listPartitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
                 .listPartitionNames(table.getCatalogName(), paimonTable.getCatalogDBName(),
-                        paimonTable.getCatalogTableName(), ConnectorMetadatRequestContext.DEFAULT);
+                        paimonTable.getCatalogTableName(), ConnectorMetadataRequestContext.DEFAULT);
 
         List<PartitionInfo> tblPartitionInfo = GlobalStateMgr.getCurrentState().getMetadataMgr()
                 .getPartitions(table.getCatalogName(), table, listPartitionNames);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -132,7 +132,8 @@ public class CatalogConnectorMetadata implements ConnectorMetadata, DelegatingCo
     }
 
     @Override
-    public List<String> listPartitionNames(String databaseName, String tableName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String databaseName, String tableName,
+                                           ConnectorMetadataRequestContext requestContext) {
         return normal.listPartitionNames(databaseName, tableName, requestContext);
     }
 
@@ -226,7 +227,7 @@ public class CatalogConnectorMetadata implements ConnectorMetadata, DelegatingCo
 
     @Override
     public List<PartitionInfo> getPartitions(Table table, List<String> partitionNames,
-                                             ConnectorMetadatRequestContext requestContext) {
+                                             ConnectorMetadataRequestContext requestContext) {
         return normal.getPartitions(table, partitionNames, requestContext);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -103,7 +103,7 @@ public interface ConnectorMetadata {
      * @return a list of partition names
      */
     default List<String> listPartitionNames(String databaseName, String tableName,
-                                            ConnectorMetadatRequestContext requestContext) {
+                                            ConnectorMetadataRequestContext requestContext) {
         return Lists.newArrayList();
     }
 
@@ -211,7 +211,7 @@ public interface ConnectorMetadata {
      * Default implementation ignores the context and falls back to the live-snapshot variant.
      */
     default List<PartitionInfo> getPartitions(Table table, List<String> partitionNames,
-                                              ConnectorMetadatRequestContext requestContext) {
+                                              ConnectorMetadataRequestContext requestContext) {
         return getPartitions(table, partitionNames);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadataRequestContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadataRequestContext.java
@@ -17,8 +17,8 @@ package com.starrocks.connector;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 
-public class ConnectorMetadatRequestContext {
-    public static ConnectorMetadatRequestContext DEFAULT = new ConnectorMetadatRequestContext();
+public class ConnectorMetadataRequestContext {
+    public static ConnectorMetadataRequestContext DEFAULT = new ConnectorMetadataRequestContext();
     private TvrVersionRange tableVersionRange = TvrTableSnapshot.empty();
     private boolean queryMVRewrite = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -25,8 +25,8 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
@@ -115,7 +115,8 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String databaseName, String tableName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String databaseName, String tableName,
+                                           ConnectorMetadataRequestContext requestContext) {
         return deltaOps.getPartitionKeys(databaseName, tableName);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -34,8 +34,8 @@ import com.starrocks.common.Version;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
@@ -321,7 +321,7 @@ public class HiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tblName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String dbName, String tblName, ConnectorMetadataRequestContext requestContext) {
         return hmsOps.getPartitionKeys(dbName, tblName);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -23,8 +23,8 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
@@ -102,7 +102,7 @@ public class HudiMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tblName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String dbName, String tblName, ConnectorMetadataRequestContext requestContext) {
         return hmsOps.getPartitionKeys(dbName, tblName);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -23,7 +23,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorViewDefinition;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -334,7 +334,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     @Override
-    public List<String> listPartitionNames(IcebergTable icebergTable, ConnectorMetadatRequestContext requestContext,
+    public List<String> listPartitionNames(IcebergTable icebergTable, ConnectorMetadataRequestContext requestContext,
                                            ExecutorService executorService) {
         SessionVariable sv = ConnectContext.getSessionVariableOrDefault();
         // optimization for query mv rewrite, we can optionally return null to bypass it.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -19,7 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorViewDefinition;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -532,7 +532,7 @@ public interface IcebergCatalog extends MemoryTrackable {
     }
 
     default List<String> listPartitionNames(IcebergTable icebergTable,
-                                            ConnectorMetadatRequestContext requestContext,
+                                            ConnectorMetadataRequestContext requestContext,
                                             ExecutorService executorService) {
         Table nativeTable = icebergTable.getNativeTable();
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -42,8 +42,8 @@ import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.ConnectorType;
@@ -850,7 +850,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tblName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String dbName, String tblName, ConnectorMetadataRequestContext requestContext) {
         try (ConnectContext.ContextScope scope = ConnectContext.enterOnlyReadIcebergCacheScope(ConnectContext.get())) {
             Table table = getTable(scope.getContext(), dbName, tblName);
             return icebergCatalog.listPartitionNames((IcebergTable) table, requestContext, jobPlanningExecutor);
@@ -883,7 +883,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public List<PartitionInfo> getPartitions(Table table, List<String> partitionNames,
-                                             ConnectorMetadatRequestContext requestContext) {
+                                             ConnectorMetadataRequestContext requestContext) {
         long snapshotId = requestContext.getSnapshotId();
         List<Partition> ans =
                 icebergCatalog.getPartitionsByNames((IcebergTable) table, snapshotId, null, partitionNames);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -24,8 +24,8 @@ import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorTableId;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.PartitionUtil;
@@ -355,7 +355,8 @@ public class JDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String databaseName, String tableName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String databaseName, String tableName,
+                                           ConnectorMetadataRequestContext requestContext) {
         return partitionNamesCache.get(new JDBCTableName(null, databaseName, tableName),
                 k -> {
                     try (Connection connection = getConnection()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
@@ -46,8 +46,8 @@ import com.starrocks.catalog.OdpsTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorTableId;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.PartitionInfo;
@@ -223,7 +223,8 @@ public class OdpsMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String databaseName, String tableName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String databaseName, String tableName,
+                                           ConnectorMetadataRequestContext requestContext) {
         OdpsTableName odpsTableName = OdpsTableName.of(databaseName, tableName);
         // TODO: perhaps not good to support users to fetch whole tables?
         List<Partition> partitions = get(partitionCache, odpsTableName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -33,8 +33,8 @@ import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.ColumnTypeConverter;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.ConnectorViewDefinition;
@@ -286,7 +286,8 @@ public class PaimonMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String databaseName, String tableName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String databaseName, String tableName,
+                                           ConnectorMetadataRequestContext requestContext) {
         Identifier identifier = new Identifier(databaseName, tableName);
         updatePartitionInfo(databaseName, tableName);
         if (this.partitionInfos.get(identifier) == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -25,7 +25,7 @@ import com.starrocks.catalog.NullablePartitionKey;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.server.GlobalStateMgr;
@@ -87,7 +87,7 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
             return Lists.newArrayList(table.getName());
         }
 
-        ConnectorMetadatRequestContext requestContext = new ConnectorMetadatRequestContext();
+        ConnectorMetadataRequestContext requestContext = new ConnectorMetadataRequestContext();
         requestContext.setQueryMVRewrite(this.isQueryMVRewrite());
         return GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
                 table.getCatalogName(), getCatalogDBName(), getTableName(), requestContext);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
@@ -22,7 +22,7 @@ import com.starrocks.catalog.NullablePartitionKey;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.tvr.TvrTableSnapshot;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.server.GlobalStateMgr;
@@ -59,7 +59,7 @@ public class IcebergPartitionTraits extends DefaultTraits {
     public List<PartitionInfo> getPartitions(List<String> partitionNames) {
         IcebergTable icebergTable = (IcebergTable) table;
         if (pinnedVersionRange != null) {
-            ConnectorMetadatRequestContext ctx = new ConnectorMetadatRequestContext();
+            ConnectorMetadataRequestContext ctx = new ConnectorMetadataRequestContext();
             ctx.setTableVersionRange(pinnedVersionRange);
             return GlobalStateMgr.getCurrentState().getMetadataMgr().
                     getPartitions(icebergTable.getCatalogName(), table, partitionNames, ctx);
@@ -81,7 +81,7 @@ public class IcebergPartitionTraits extends DefaultTraits {
         }
 
         IcebergTable icebergTable = (IcebergTable) table;
-        ConnectorMetadatRequestContext requestContext = new ConnectorMetadatRequestContext();
+        ConnectorMetadataRequestContext requestContext = new ConnectorMetadataRequestContext();
         requestContext.setQueryMVRewrite(isQueryMVRewrite());
         if (pinnedVersionRange != null) {
             requestContext.setTableVersionRange(pinnedVersionRange);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -25,8 +25,8 @@ import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.DelegatingConnectorMetadata;
 import com.starrocks.connector.GetRemoteFilesParams;
@@ -168,7 +168,8 @@ public class UnifiedMetadata implements ConnectorMetadata, DelegatingConnectorMe
     }
 
     @Override
-    public List<String> listPartitionNames(String databaseName, String tableName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String databaseName, String tableName,
+                                           ConnectorMetadataRequestContext requestContext) {
         ConnectorMetadata metadata = metadataOfTable(databaseName, tableName);
         return metadata.listPartitionNames(databaseName, tableName, requestContext);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.connector.CatalogConnector;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
 import com.starrocks.connector.RemoteFileInfoSource;
@@ -196,7 +196,7 @@ public class DeltaLakeScanNode extends ScanNode {
 
             List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
                     deltaLakeTable.getCatalogName(), deltaLakeTable.getCatalogDBName(), deltaLakeTable.getCatalogTableName(),
-                    ConnectorMetadatRequestContext.DEFAULT);
+                    ConnectorMetadataRequestContext.DEFAULT);
 
             if (selectedPartitionCount == -1) {
                 if (scanRangeSource != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -19,7 +19,7 @@ import com.google.common.base.Preconditions;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.BucketProperty;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
@@ -350,7 +350,7 @@ public class IcebergScanNode extends ScanNode {
         }
 
         if (detailLevel == TExplainLevel.VERBOSE && !isResourceMappingCatalog(icebergTable.getCatalogName())) {
-            ConnectorMetadatRequestContext requestContext = new ConnectorMetadatRequestContext();
+            ConnectorMetadataRequestContext requestContext = new ConnectorMetadataRequestContext();
             requestContext.setTableVersionRange(tvrVersionRange);
             List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
                     icebergTable.getCatalogName(), icebergTable.getCatalogDBName(),

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -22,7 +22,7 @@ import com.starrocks.catalog.PaimonTable;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.CatalogConnector;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.paimon.PaimonRemoteFileDesc;
@@ -369,7 +369,7 @@ public class PaimonScanNode extends ScanNode {
 
         List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
                 paimonTable.getCatalogName(), paimonTable.getCatalogDBName(), paimonTable.getCatalogTableName(),
-                ConnectorMetadatRequestContext.DEFAULT);
+                ConnectorMetadataRequestContext.DEFAULT);
 
         output.append(prefix).append(
                 String.format("partitions=%s/%s", scanNodePredicates.getSelectedPartitionIds().size(),

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
@@ -26,7 +26,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.MVPartitionCellBuilder;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
@@ -216,7 +216,7 @@ public class PCTTableSnapshotInfo extends BaseTableSnapshotInfo {
         // When pinnedRange is set, read partition info at the frozen snapshot.
         List<com.starrocks.connector.PartitionInfo> partitions;
         if (pinnedRange != null) {
-            ConnectorMetadatRequestContext rc = new ConnectorMetadatRequestContext();
+            ConnectorMetadataRequestContext rc = new ConnectorMetadataRequestContext();
             rc.setTableVersionRange(pinnedRange);
             partitions = GlobalStateMgr.getCurrentState()
                     .getMetadataMgr()

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -49,9 +49,8 @@ import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.CatalogConnector;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.ConnectorTblMetaInfoMgr;
@@ -659,7 +658,7 @@ public class MetadataMgr {
     }
 
     public List<String> listPartitionNames(String catalogName, String dbName, String tableName,
-                                           ConnectorMetadatRequestContext requestContext) {
+                                           ConnectorMetadataRequestContext requestContext) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
         ImmutableSet.Builder<String> partitionNames = ImmutableSet.builder();
         if (connectorMetadata.isPresent()) {
@@ -862,7 +861,7 @@ public class MetadataMgr {
      * Get partition info at a specific snapshot identified by the request context.
      */
     public List<PartitionInfo> getPartitions(String catalogName, Table table, List<String> partitionNames,
-                                             ConnectorMetadatRequestContext requestContext) {
+                                             ConnectorMetadataRequestContext requestContext) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
         if (connectorMetadata.isPresent()) {
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPartitionEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPartitionEstimator.java
@@ -16,7 +16,7 @@ package com.starrocks.sql;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.RelationFields;
@@ -94,7 +94,7 @@ public class InsertPartitionEstimator {
                     .listPartitionNames(table.getCatalogName(),
                             table.getCatalogDBName(),
                             table.getCatalogTableName(),
-                            new ConnectorMetadatRequestContext());
+                            new ConnectorMetadataRequestContext());
             existingPartitionCount = partitionNames.size();
             metadataAvailable = true;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -28,7 +28,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -427,7 +427,7 @@ public class AnalyzeStmtAnalyzer {
                 } else {
                     List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
                             .listPartitionNames(tableName.getCatalog(), tableName.getDb(),
-                                    tableName.getTbl(), ConnectorMetadatRequestContext.DEFAULT);
+                                    tableName.getTbl(), ConnectorMetadataRequestContext.DEFAULT);
                     List<PartitionKey> keys = new ArrayList<>();
                     try {
                         for (String partName : partitionNames) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -29,7 +29,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DebugUtil;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.elasticsearch.EsShardPartitions;
@@ -333,7 +333,7 @@ public class OptExternalPartitionPruner {
                 } else {
                     partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
                             .listPartitionNames(table.getCatalogName(), table.getCatalogDBName(),
-                                    table.getCatalogTableName(), ConnectorMetadatRequestContext.DEFAULT);
+                                    table.getCatalogTableName(), ConnectorMetadataRequestContext.DEFAULT);
                 }
 
                 List<PartitionKey> keys = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -176,7 +176,7 @@ public class CatalogConnectorMetadataTest {
                 times = 1;
 
                 connectorMetadata.clear();
-                connectorMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                connectorMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
                 connectorMetadata.dropTable(ctx, null);
                 connectorMetadata.refreshTable("test_db", null, null, false);
                 connectorMetadata.alterMaterializedView(null);
@@ -213,7 +213,7 @@ public class CatalogConnectorMetadataTest {
         );
 
         catalogConnectorMetadata.clear();
-        catalogConnectorMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+        catalogConnectorMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
         catalogConnectorMetadata.dropTable(ctx, null);
         catalogConnectorMetadata.refreshTable("test_db", null, null, false);
         catalogConnectorMetadata.alterMaterializedView(null);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -274,7 +274,7 @@ public class PartitionUtilTest {
         new MockUp<MetadataMgr>() {
             @Mock
             public List<String> listPartitionNames(String catalogName, String dbName, String tableName,
-                                                   ConnectorMetadatRequestContext requestContext) {
+                                                   ConnectorMetadataRequestContext requestContext) {
                 return partitionNames;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -18,7 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.Table;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.DatabaseTableName;
@@ -185,7 +185,7 @@ public class DeltaLakeMetadataTest {
             }
         };
         List<String> partitionNames =
-                deltaLakeMetadata.listPartitionNames("db1", "table1", ConnectorMetadatRequestContext.DEFAULT);
+                deltaLakeMetadata.listPartitionNames("db1", "table1", ConnectorMetadataRequestContext.DEFAULT);
         Assertions.assertEquals(3, partitionNames.size());
         Assertions.assertEquals("ts=1999", partitionNames.get(0));
         Assertions.assertEquals("ts=2000", partitionNames.get(1));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -32,7 +32,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.CachingRemoteFileIO;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.GetRemoteFilesParams;
@@ -177,7 +177,7 @@ public class HiveMetadataTest {
     public void testGetPartitionKeys() {
         Assertions.assertEquals(
                 Lists.newArrayList("col1"),
-                hiveMetadata.listPartitionNames("db1", "tbl1", ConnectorMetadatRequestContext.DEFAULT));
+                hiveMetadata.listPartitionNames("db1", "tbl1", ConnectorMetadataRequestContext.DEFAULT));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -27,8 +27,8 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.connector.CachingRemoteFileIO;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionInfo;
@@ -131,7 +131,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tableName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String dbName, String tableName, ConnectorMetadataRequestContext requestContext) {
         readLock();
         try {
             return MOCK_TABLE_MAP.get(dbName).get(tableName).partitionNames;
@@ -164,7 +164,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     @Override
     public List<String> listPartitionNamesByValue(String databaseName, String tableName,
                                                   List<Optional<String>> partitionValues) {
-        List<String> partitionNames = listPartitionNames(databaseName, tableName, ConnectorMetadatRequestContext.DEFAULT);
+        List<String> partitionNames = listPartitionNames(databaseName, tableName, ConnectorMetadataRequestContext.DEFAULT);
         List<String> ret = new ArrayList<>();
         for (String p : partitionNames) {
             if (isPartitionNameValueMatched(p, partitionValues)) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/ReplayMetadataMgr.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/ReplayMetadataMgr.java
@@ -25,7 +25,7 @@ import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.ResourceMgr;
 import com.starrocks.catalog.Table;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.ConnectorTblMetaInfoMgr;
 import com.starrocks.connector.GetRemoteFilesParams;
@@ -143,7 +143,7 @@ public class ReplayMetadataMgr extends MetadataMgr {
 
     @Override
     public List<String> listPartitionNames(String catalogName, String dbName, String tableName,
-                                           ConnectorMetadatRequestContext requestContext) {
+                                           ConnectorMetadataRequestContext requestContext) {
         return replayTableMap.get(catalogName).get(dbName).get(tableName).partitionNames;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -18,7 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.CachingRemoteFileIO;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.HdfsEnvironment;
@@ -143,7 +143,7 @@ public class HudiMetadataTest {
     public void testGetPartitionKeys() {
         Assertions.assertEquals(
                 Lists.newArrayList("col1"),
-                hudiMetadata.listPartitionNames("db1", "tbl1", ConnectorMetadatRequestContext.DEFAULT));
+                hudiMetadata.listPartitionNames("db1", "tbl1", ConnectorMetadataRequestContext.DEFAULT));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.jmockit.Deencapsulation;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.CachingIcebergCatalog.IcebergTableName;
 import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
@@ -126,7 +126,7 @@ public class CachingIcebergCatalogTest {
 
         Assertions.assertFalse(nativeTable.spec().isUnpartitioned());
         {
-            ConnectorMetadatRequestContext requestContext = new ConnectorMetadatRequestContext();
+            ConnectorMetadataRequestContext requestContext = new ConnectorMetadataRequestContext();
             SessionVariable sv = ConnectContext.getSessionVariableOrDefault();
             sv.setEnableConnectorAsyncListPartitions(true);
             requestContext.setQueryMVRewrite(true);
@@ -134,7 +134,7 @@ public class CachingIcebergCatalogTest {
             Assertions.assertNull(res);
         }
         {
-            ConnectorMetadatRequestContext requestContext = new ConnectorMetadatRequestContext();
+            ConnectorMetadataRequestContext requestContext = new ConnectorMetadataRequestContext();
             SessionVariable sv = ConnectContext.getSessionVariableOrDefault();
             sv.setEnableConnectorAsyncListPartitions(false);
             requestContext.setQueryMVRewrite(true);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -36,8 +36,8 @@ import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersion;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.ConnectorType;
@@ -1659,7 +1659,7 @@ public class IcebergMetadataTest extends TableTestBase {
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
         TvrVersionRange version = TvrTableSnapshot.of(Optional.of(
                 mockedNativeTableB.currentSnapshot().snapshotId()));
-        ConnectorMetadatRequestContext requestContext = new ConnectorMetadatRequestContext();
+        ConnectorMetadataRequestContext requestContext = new ConnectorMetadataRequestContext();
         requestContext.setTableVersionRange(version);
         List<String> partitionNames = metadata.listPartitionNames("db", "table", requestContext);
         Assertions.assertEquals(2, partitionNames.size());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -29,8 +29,8 @@ import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersion;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorTableInfo;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.qe.ConnectContext;
@@ -587,7 +587,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tableName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String dbName, String tableName, ConnectorMetadataRequestContext requestContext) {
         readLock();
         try {
             return MOCK_TABLE_MAP.get(dbName).get(tableName).partitionNames;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
@@ -19,8 +19,8 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.type.CharType;
@@ -165,7 +165,7 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public List<String> listPartitionNames(String dbName, String tableName, ConnectorMetadatRequestContext requestContext) {
+    public List<String> listPartitionNames(String dbName, String tableName, ConnectorMetadataRequestContext requestContext) {
         readLock();
         try {
             if (tableName.equals(MOCKED_PARTITIONED_TABLE_NAME2)) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.common.DdlException;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.type.VarcharType;
@@ -143,7 +143,8 @@ public class MysqlSchemaResolverTest {
     public void testListPartitionNames() {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
+            List<String> partitionNames =
+                    jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadataRequestContext.DEFAULT);
             Assertions.assertFalse(partitionNames.isEmpty());
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
@@ -156,16 +157,16 @@ public class MysqlSchemaResolverTest {
             JDBCCacheTestUtil.openCacheEnable(connectContext);
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1",
-                    ConnectorMetadatRequestContext.DEFAULT);
+                    ConnectorMetadataRequestContext.DEFAULT);
             Assertions.assertFalse(partitionNames.isEmpty());
             List<String> partitionNamesWithCache =
-                    jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
+                    jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadataRequestContext.DEFAULT);
             Assertions.assertFalse(partitionNamesWithCache.isEmpty());
             JDBCCacheTestUtil.closeCacheEnable(connectContext);
             Map<String, String> properties = new HashMap<>();
             jdbcMetadata.refreshCache(properties);
             List<String> partitionNamesWithOutCache =
-                    jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
+                    jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadataRequestContext.DEFAULT);
             Assertions.assertTrue(partitionNamesWithOutCache.isEmpty());
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
@@ -183,7 +184,8 @@ public class MysqlSchemaResolverTest {
                 }
             };
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
+            List<String> partitionNames =
+                    jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadataRequestContext.DEFAULT);
             Assertions.assertTrue(partitionNames.size() == 0);
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
@@ -374,7 +376,7 @@ public class MysqlSchemaResolverTest {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1",
-                    ConnectorMetadatRequestContext.DEFAULT);
+                    ConnectorMetadataRequestContext.DEFAULT);
             // Assert that setQueryTimeout was called and the operation completed successfully
             Assertions.assertNotNull(partitionNames);
             Assertions.assertFalse(partitionNames.isEmpty());
@@ -400,7 +402,7 @@ public class MysqlSchemaResolverTest {
                 }
             };
             List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1",
-                    ConnectorMetadatRequestContext.DEFAULT);
+                    ConnectorMetadataRequestContext.DEFAULT);
             Assertions.assertNotNull(partitionNames);
             Assertions.assertEquals(1, expectedTimeout1, "100ms should round up to 1 second");
 
@@ -414,7 +416,7 @@ public class MysqlSchemaResolverTest {
                 }
             };
             partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1",
-                    ConnectorMetadatRequestContext.DEFAULT);
+                    ConnectorMetadataRequestContext.DEFAULT);
             Assertions.assertNotNull(partitionNames);
             Assertions.assertEquals(0, expectedTimeout2, "0ms should remain 0 (no limit)");
         } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/OracleSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/OracleSchemaResolverTest.java
@@ -21,7 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.type.ScalarType;
@@ -344,7 +344,7 @@ public class OracleSchemaResolverTest {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1",
-                    ConnectorMetadatRequestContext.DEFAULT);
+                    ConnectorMetadataRequestContext.DEFAULT);
             Assertions.assertFalse(partitionNames.isEmpty());
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
@@ -429,7 +429,7 @@ public class OracleSchemaResolverTest {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1",
-                    ConnectorMetadatRequestContext.DEFAULT);
+                    ConnectorMetadataRequestContext.DEFAULT);
             // Assert that setQueryTimeout was called and the operation completed successfully
             Assertions.assertNotNull(partitionNames);
             Assertions.assertFalse(partitionNames.isEmpty());
@@ -455,7 +455,7 @@ public class OracleSchemaResolverTest {
                 }
             };
             List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1",
-                    ConnectorMetadatRequestContext.DEFAULT);
+                    ConnectorMetadataRequestContext.DEFAULT);
             Assertions.assertNotNull(partitionNames);
             Assertions.assertEquals(1, expectedTimeout1, "100ms should round up to 1 second");
 
@@ -469,7 +469,7 @@ public class OracleSchemaResolverTest {
                 }
             };
             partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1",
-                    ConnectorMetadatRequestContext.DEFAULT);
+                    ConnectorMetadataRequestContext.DEFAULT);
             Assertions.assertNotNull(partitionNames);
             Assertions.assertEquals(0, expectedTimeout2, "0ms should remain 0 (no limit)");
         } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/OdpsMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/OdpsMetadataTest.java
@@ -22,8 +22,8 @@ import com.starrocks.catalog.OdpsTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
@@ -114,7 +114,7 @@ public class OdpsMetadataTest extends MockedBase {
     @Test
     public void testListPartitionNames() {
         List<String> partitionNames =
-                odpsMetadata.listPartitionNames("project", "tableName", ConnectorMetadatRequestContext.DEFAULT);
+                odpsMetadata.listPartitionNames("project", "tableName", ConnectorMetadataRequestContext.DEFAULT);
         Assertions.assertEquals(Collections.singletonList("p1=a/p2=b"), partitionNames);
     }
 
@@ -132,7 +132,7 @@ public class OdpsMetadataTest extends MockedBase {
     @Test
     public void testGetPartitions() {
         Table table = odpsMetadata.getTable(new ConnectContext(), "db", "tbl");
-        List<String> partitionNames = odpsMetadata.listPartitionNames("db", "tbl", ConnectorMetadatRequestContext.DEFAULT);
+        List<String> partitionNames = odpsMetadata.listPartitionNames("db", "tbl", ConnectorMetadataRequestContext.DEFAULT);
         List<PartitionInfo> partitions = odpsMetadata.getPartitions(table, partitionNames);
         Assertions.assertEquals(1, partitions.size());
         PartitionInfo partitionInfo = partitions.get(0);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -31,7 +31,7 @@ import com.starrocks.common.proc.ExternalSchemaProcNode;
 import com.starrocks.common.proc.ProcResult;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.ConnectorType;
@@ -349,7 +349,7 @@ public class PaimonMetadataTest {
                 result = Arrays.asList(partition1, partition2);
             }
         };
-        List<String> result = metadata.listPartitionNames("db1", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
+        List<String> result = metadata.listPartitionNames("db1", "tbl1", ConnectorMetadataRequestContext.DEFAULT);
         assertEquals(2, result.size());
         List<String> expectations = Lists.newArrayList("year=2020/month=1", "year=2020/month=2");
         Assertions.assertThat(result).hasSameElementsAs(expectations);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -27,7 +27,7 @@ import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.tvr.TvrTableSnapshot;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
@@ -180,7 +180,7 @@ public class UnifiedMetadataTest {
             }
 
             {
-                hiveMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                hiveMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
                 result = ImmutableList.of("test_part1", "test_part2");
                 times = 1;
             }
@@ -223,7 +223,7 @@ public class UnifiedMetadataTest {
         Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertTrue(table instanceof HiveTable);
         List<String> partitionNames =
-                unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
@@ -262,7 +262,7 @@ public class UnifiedMetadataTest {
             }
 
             {
-                icebergMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                icebergMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
                 result = ImmutableList.of("test_part1", "test_part2");
                 times = 1;
             }
@@ -317,7 +317,7 @@ public class UnifiedMetadataTest {
         Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertTrue(table instanceof IcebergTable);
         List<String> partitionNames =
-                unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
@@ -352,7 +352,7 @@ public class UnifiedMetadataTest {
             }
 
             {
-                hudiMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                hudiMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
                 result = ImmutableList.of("test_part1", "test_part2");
                 times = 1;
             }
@@ -395,7 +395,7 @@ public class UnifiedMetadataTest {
         Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertTrue(table instanceof HudiTable);
         List<String> partitionNames =
-                unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
@@ -433,7 +433,7 @@ public class UnifiedMetadataTest {
             }
 
             {
-                deltaLakeMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                deltaLakeMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
                 result = ImmutableList.of("test_part1", "test_part2");
                 times = 1;
             }
@@ -476,7 +476,7 @@ public class UnifiedMetadataTest {
         Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertTrue(table instanceof DeltaLakeTable);
         List<String> partitionNames =
-                unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
@@ -508,7 +508,7 @@ public class UnifiedMetadataTest {
             }
 
             {
-                kuduMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                kuduMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
                 result = ImmutableList.of("test_part1", "test_part2");
                 times = 1;
             }
@@ -535,7 +535,7 @@ public class UnifiedMetadataTest {
         Table table = unifiedMetadata.getTable(new ConnectContext(), "test_db", "test_tbl");
         assertTrue(table instanceof KuduTable);
         List<String> partitionNames =
-                unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadatRequestContext.DEFAULT);
+                unifiedMetadata.listPartitionNames("test_db", "test_tbl", ConnectorMetadataRequestContext.DEFAULT);
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
@@ -24,7 +24,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.MockedMetadataMgr;
 import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.server.GlobalStateMgr;
@@ -368,7 +368,7 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVTestBase {
 
         // get base table partitions
         List<String> baseParNames =
-                mockedJDBCMetadata.listPartitionNames("partitioned_db0", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
+                mockedJDBCMetadata.listPartitionNames("partitioned_db0", "tbl1", ConnectorMetadataRequestContext.DEFAULT);
         Assertions.assertEquals(4, baseParNames.size());
 
         Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/InsertPartitionEstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/InsertPartitionEstimatorTest.java
@@ -18,7 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.jmockit.Deencapsulation;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
@@ -144,7 +144,7 @@ public class InsertPartitionEstimatorTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = Lists.newArrayList();  // Empty partition list
                 minTimes = 0;
 
@@ -462,7 +462,7 @@ public class InsertPartitionEstimatorTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = Lists.newArrayList("p1", "p2");
                 minTimes = 0;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerTest.java
@@ -18,7 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.jmockit.Deencapsulation;
-import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
@@ -339,7 +339,7 @@ public class InsertPlannerTest {
 
                 // Return empty partition list
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = new ArrayList<String>();
                 minTimes = 0;
 
@@ -424,7 +424,7 @@ public class InsertPlannerTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = new ArrayList<String>(); // Empty partition list
                 minTimes = 0;
 
@@ -481,7 +481,7 @@ public class InsertPlannerTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = new Exception("Failed to get partitions");
                 minTimes = 0;
 
@@ -534,7 +534,7 @@ public class InsertPlannerTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = new ArrayList<String>();
                 minTimes = 0;
 
@@ -730,11 +730,11 @@ public class InsertPlannerTest {
 
                 // MetadataMgr setup for partition names
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = new Delegate<List<String>>() {
                     @SuppressWarnings("unused")
                     List<String> delegate(String catalog, String db, String table,
-                                          ConnectorMetadatRequestContext context) {
+                                          ConnectorMetadataRequestContext context) {
                         List<String> partitions = new ArrayList<>();
                         for (int i = 0; i < partitionCount; i++) {
                             partitions.add("p" + i);
@@ -836,7 +836,7 @@ public class InsertPlannerTest {
 
                 // 100 existing partitions
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = createPartitionList(100);
                 minTimes = 0;
 
@@ -919,7 +919,7 @@ public class InsertPlannerTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = createPartitionList(100);
                 minTimes = 0;
 
@@ -1032,7 +1032,7 @@ public class InsertPlannerTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = createPartitionList(100);
                 minTimes = 0;
 
@@ -1124,7 +1124,7 @@ public class InsertPlannerTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = createPartitionList(100);
                 minTimes = 0;
 
@@ -1219,7 +1219,7 @@ public class InsertPlannerTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = createPartitionList(100);
                 minTimes = 0;
 
@@ -1328,7 +1328,7 @@ public class InsertPlannerTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = createPartitionList(100);
                 minTimes = 0;
 
@@ -1438,7 +1438,7 @@ public class InsertPlannerTest {
                 minTimes = 0;
 
                 metadataMgr.listPartitionNames(anyString, anyString, anyString,
-                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                        withInstanceOf(ConnectorMetadataRequestContext.class));
                 result = createPartitionList(100);
                 minTimes = 0;
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request standardizes the naming of a context class used for connector metadata requests by correcting a typo in its name (`ConnectorMetadatRequestContext` → `ConnectorMetadataRequestContext`) throughout the codebase. It updates all relevant imports, method signatures, and usages to use the corrected class name, ensuring consistency and reducing the risk of confusion or errors.

These changes are purely refactorings for naming consistency and do not introduce any behavioral changes.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
