### PR TITLE
[BugFix] Fixing partial dictification in aggregates which accept multiple dictified inputs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -404,7 +404,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             for (CallOperator agg : aggregateExprs) {
                 if (agg.getColumnRefs().stream().map(ColumnRefOperator::getId)
                         .anyMatch(context.allStringColumns::contains)) {
-                    context.stringAggregateExprs.addAll(aggregateExprs);
+                    context.stringAggregateExprs.put(aggregateId, aggregateExprs);
                     context.allStringColumns.add(aggregateId);
                     break;
                 }
@@ -420,6 +420,12 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             info.inputStringColumns.intersect(alls);
             if (!info.isEmpty()) {
                 context.operatorDecodeInfo.put(operator, info);
+                if (operator instanceof PhysicalHashAggregateOperator hashAgg &&
+                        (hashAgg.getType().isLocal() || !hashAgg.isSplit())) {
+                    hashAgg.getAggregations().keySet().forEach(agg -> {
+                        context.aggIdToDecodeInfoMap.put(agg.getId(), info);
+                    });
+                }
             }
         }
         // Filling context's structOpToFieldUseStringRefMap and structRefToFieldUseStringRefMap with fields in

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -420,10 +420,22 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             info.inputStringColumns.intersect(alls);
             if (!info.isEmpty()) {
                 context.operatorDecodeInfo.put(operator, info);
-                if (operator instanceof PhysicalHashAggregateOperator hashAgg &&
-                        (hashAgg.getType().isLocal() || !hashAgg.isSplit())) {
+                if (operator instanceof PhysicalHashAggregateOperator hashAgg) {
                     hashAgg.getAggregations().keySet().forEach(agg -> {
-                        context.aggIdToDecodeInfoMap.put(agg.getId(), info);
+                        context.aggIdToSupportColumns.computeIfAbsent(agg.getId(), k -> new ColumnRefSet())
+                                .union(info.inputStringColumns);
+                    });
+                }
+                if (operator instanceof PhysicalWindowOperator window) {
+                    window.getAnalyticCall().keySet().forEach(agg -> {
+                        context.aggIdToSupportColumns.computeIfAbsent(agg.getId(), k -> new ColumnRefSet())
+                                .union(info.inputStringColumns);
+                    });
+                }
+                if (operator instanceof PhysicalTopNOperator topN && topN.getPreAggCall() != null) {
+                    topN.getPreAggCall().keySet().forEach(agg -> {
+                        context.aggIdToSupportColumns.computeIfAbsent(agg.getId(), k -> new ColumnRefSet())
+                                .union(info.inputStringColumns);
                     });
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
@@ -88,7 +89,9 @@ class DecodeContext {
     Map<Integer, List<ScalarOperator>> stringExprsMap = Maps.newHashMap();
 
     // all string aggregate expressions
-    List<CallOperator> stringAggregateExprs = Lists.newArrayList();
+    Map<Integer, List<CallOperator>> stringAggregateExprs = Maps.newHashMap();
+
+    Map<Integer, DecodeInfo> aggIdToDecodeInfoMap = Maps.newHashMap();
 
     // The string columns used by the operator
     // IdentityHashMap: use object == object, operator equals is not enough
@@ -239,10 +242,19 @@ class DecodeContext {
     private void rewriteStringAggregations() {
         // rewrite string aggregate expression
         AggregateRewriter rewriter = new AggregateRewriter();
-        for (CallOperator aggFn : stringAggregateExprs) {
-            CallOperator new1stAggFn = (CallOperator) (aggFn.accept(rewriter, null));
-            stringExprToDictExprMap.put(aggFn, new1stAggFn);
-        }
+        stringAggregateExprs.forEach((aggId, aggFns) -> {
+            DecodeInfo decodeInfo = aggIdToDecodeInfoMap.get(aggId);
+            if (decodeInfo == null) {
+                return;
+            }
+            ColumnRefSet supportColumns = decodeInfo.inputStringColumns.clone();
+            supportColumns.union(aggId);
+            rewriter.setSupportColumns(supportColumns);
+            for (CallOperator aggFn : aggFns) {
+                CallOperator new1stAggFn = (CallOperator) (aggFn.accept(rewriter, null));
+                stringExprToDictExprMap.put(aggFn, new1stAggFn);
+            }
+        });
     }
 
     // create a new dictionary column and assign the same property except for the type and column id
@@ -488,9 +500,12 @@ class DecodeContext {
     }
 
     private class AggregateRewriter extends BaseScalarOperatorShuttle {
+        private ColumnRefSet supportColumns;
+
         @Override
         public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void ignore) {
-            return stringRefToDictRefMap.getOrDefault(variable, variable);
+            return supportColumns.contains(variable) ?
+                    stringRefToDictRefMap.getOrDefault(variable, variable) : variable;
         }
 
         AggregateFunction buildAggregateFunction(AggregateFunction fn, List<ScalarOperator> newChildren,
@@ -569,6 +584,10 @@ class DecodeContext {
             Function fn = buildFunction(call.getFnName(), newChildren);
             return new CallOperator(call.getFnName(), fn.getReturnType(), newChildren, fn,
                     call.isDistinct(), call.isRemovedDistinct());
+        }
+
+        void setSupportColumns(ColumnRefSet supportColumns) {
+            this.supportColumns = supportColumns;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -91,7 +91,7 @@ class DecodeContext {
     // all string aggregate expressions
     Map<Integer, List<CallOperator>> stringAggregateExprs = Maps.newHashMap();
 
-    Map<Integer, DecodeInfo> aggIdToDecodeInfoMap = Maps.newHashMap();
+    Map<Integer, ColumnRefSet> aggIdToSupportColumns = Maps.newHashMap();
 
     // The string columns used by the operator
     // IdentityHashMap: use object == object, operator equals is not enough
@@ -243,12 +243,8 @@ class DecodeContext {
         // rewrite string aggregate expression
         AggregateRewriter rewriter = new AggregateRewriter();
         stringAggregateExprs.forEach((aggId, aggFns) -> {
-            DecodeInfo decodeInfo = aggIdToDecodeInfoMap.get(aggId);
-            if (decodeInfo == null) {
-                return;
-            }
-            ColumnRefSet supportColumns = decodeInfo.inputStringColumns.clone();
-            supportColumns.union(aggId);
+            ColumnRefSet supportColumns = aggIdToSupportColumns.get(aggId);
+            Preconditions.checkNotNull(supportColumns);
             rewriter.setSupportColumns(supportColumns);
             for (CallOperator aggFn : aggFns) {
                 CallOperator new1stAggFn = (CallOperator) (aggFn.accept(rewriter, null));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
@@ -593,4 +593,24 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "array_agg[([9: array_agg, struct<`col1` array<int(11)>, `col2` array<int(11)>>, true]); args: INT,INT;" +
                 " result: ARRAY<INT>; args nullable: true; result nullable: true]\n"), plan);
     }
+
+    @Test
+    public void testPartialEncoding() throws Exception {
+        String sql = """
+                select array_agg(VARCHAR_COL order by VARCHAR_COL2), array_agg(INTEGER_COL order by VARCHAR_COL2)
+                from T JOIN T2 ON (KEY_COL = KEY_COL2)
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("  9:Decode\n" +
+                "  |  <dict id 13> : <string id 9>\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  8:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: array_agg[([13: array_agg, struct<`col1` array<int(11)>, " +
+                "`col2` array<varchar(25)>>, true]); args: INT,VARCHAR; result: ARRAY<INT>; args nullable: true;" +
+                " result nullable: true], " +
+                "array_agg[([10: array_agg, struct<`col1` array<int(11)>, `col2` array<varchar(25)>>, true]); " +
+                "args: INT,VARCHAR; result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                "  |  cardinality: 1"), plan);
+    }
 }


### PR DESCRIPTION

## Why I'm doing:
Currently DecodeContext has an all or nothing behavior when dictifying inputs of aggregate functions. This can cause incorrect rewrites for aggregates which accept multiple dictified inputs as some inputs may have been decoded before the aggregation is reached (like ARRAY_AGG(varchar_col1 order by varchar_col2).

## What I'm doing:
Fixing the issue above by keeping track of DecodeContext for all aggregateExprs.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
