### PR TITLE
[Enhancement] Rebuild .cols file on column conflict in shared-data tablet merge

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/tablet_merger.h"
 
+#include <bvar/bvar.h>
+
 #include <algorithm>
 #include <limits>
 #include <map>
@@ -24,13 +26,36 @@
 
 #include "base/hash/crc32c.h"
 #include "base/testutil/sync_point.h"
+#include "column/column_helper.h"
+#include "common/config_rowset_fwd.h"
+#include "fs/fs_factory.h"
+#include "fs/fs_util.h"
+#include "fs/key_cache.h"
+#include "storage/chunk_helper.h"
 #include "storage/del_vector.h"
+#include "storage/delta_column_group.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/update_manager.h"
+#include "storage/olap_common.h"
 #include "storage/options.h"
+#include "storage/rowset/column_iterator.h"
+#include "storage/rowset/segment.h"
+#include "storage/rowset/segment_iterator.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/tablet_schema.h"
+
+namespace {
+
+bvar::Adder<int64_t> g_tablet_merge_dcg_rebuild_total("tablet_merge_dcg_rebuild_total");
+bvar::Adder<int64_t> g_tablet_merge_dcg_rebuild_fallback_not_supported_total(
+        "tablet_merge_dcg_rebuild_fallback_not_supported_total");
+
+} // namespace
 
 namespace starrocks::lake {
 
@@ -321,63 +346,634 @@ Status verify_dcg_entry_consistency(const DeltaColumnGroupVerPB& existing, int j
     return Status::OK();
 }
 
-Status merge_dcg_meta(const std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata) {
-    auto* new_dcgs = new_metadata->mutable_dcg_meta()->mutable_dcgs();
+// ---------------------------------------------------------------------------
+// merge_dcg_meta: two-pass entry-level merge with per-target .cols rebuild.
+//
+// Pass 1 collects per-target "surviving" entries (after exact-dedup by .cols
+// filename) and per-target source-rowset references (the child rowsets that
+// reference target rssid T through get_rssid/map_rssid). Ranges are captured
+// from each source-child rowset BEFORE merge_rowsets() has widened shared
+// ranges via union_range, so a coverage gap between child ranges cannot be
+// masked by the merged rowset's convex hull.
+//
+// Pass 2 classifies each target's entries: columns claimed by only one entry
+// are non-conflicting and pass through unchanged; columns claimed by >= 2
+// entries trigger rebuild. Rebuild folds ALL columns of every conflicting
+// entry into a single new .cols file so the reader's first-entry-wins rule
+// never leaks stale values from a leftover entry that shares any column with
+// the rebuilt set.
+//
+// Per-target rebuild (rebuild_dcg_for_target_segment) implements Steps A-F of the
+// design: locate base segment via get_rssid scan, resolve merged schema,
+// compute row windows per source-child rowset using the existing range ->
+// SeekRange -> rowid-range pipeline, validate coverage, assemble rebuilt
+// chunk (donor file per column + updater-child window overrides), write a
+// new .cols file, install one entry into new_dcgs[T].
 
-    for (const auto& ctx : merge_contexts) {
-        if (!ctx.metadata()->has_dcg_meta()) continue;
+struct DcgSurvivingEntry {
+    size_t child_index;
+    uint32_t original_segment_id;
+    int entry_index;
+    // Single-entry normalized copy of the source DCG entry (all 5 fields at
+    // index 0 of the resulting PB). Keeping entries in single-entry form keeps
+    // bookkeeping and downstream emission uniform.
+    DeltaColumnGroupVerPB single_entry;
+};
 
-        for (const auto& [segment_id, dcg_value] : ctx.metadata()->dcg_meta().dcgs()) {
-            ASSIGN_OR_RETURN(uint32_t target, ctx.map_rssid(segment_id));
+struct DcgSourceRowsetReference {
+    size_t child_index;
+    const RowsetMetadataPB* rowset = nullptr;
+    int segment_position = 0;
+    const TabletRangePB* effective_range = nullptr; // rowset.range() else ctx tablet range; null = unbounded
+};
 
-            // Validate + normalize incoming (copy because dcg_value is const)
-            DeltaColumnGroupVerPB incoming = dcg_value;
-            RETURN_IF_ERROR(validate_dcg_shape(incoming));
-            normalize_dcg_optional_fields(&incoming);
+struct DcgTargetWorkItem {
+    std::vector<DcgSurvivingEntry> entries;
+    std::vector<DcgSourceRowsetReference> source_refs;
+};
 
-            auto it = new_dcgs->find(target);
-            if (it == new_dcgs->end()) {
-                (*new_dcgs)[target] = std::move(incoming);
-                continue;
-            }
+DeltaColumnGroupVerPB make_single_entry_dcg(const DeltaColumnGroupVerPB& source, int entry_index) {
+    DeltaColumnGroupVerPB out;
+    out.add_column_files(source.column_files(entry_index));
+    out.add_unique_column_ids()->CopyFrom(source.unique_column_ids(entry_index));
+    out.add_versions(source.versions(entry_index));
+    out.add_encryption_metas(source.encryption_metas(entry_index));
+    out.add_shared_files(source.shared_files(entry_index));
+    return out;
+}
 
-            // Entry-level merge into existing DCG
-            auto& existing = it->second;
+// Pass 1 — walk each child's dcg_meta and rowsets, dedup by filename across
+// children, and accumulate source-rowset refs per target T.
+Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContext>& merge_contexts,
+                                             std::map<uint32_t, DcgTargetWorkItem>* work_by_target) {
+    // Track which .cols filenames we have already observed per target so that
+    // subsequent children with the same filename are deduped (and verified).
+    // Store size_t indexes into DcgTargetWorkItem::entries (NOT raw pointers),
+    // since push_back can reallocate the vector and invalidate pointers.
+    std::map<uint32_t, std::unordered_map<std::string, size_t>> seen_files_by_target;
 
-            for (int i = 0; i < incoming.column_files_size(); ++i) {
-                const auto& new_file = incoming.column_files(i);
+    for (size_t child_index = 0; child_index < merge_contexts.size(); ++child_index) {
+        const auto& context = merge_contexts[child_index];
 
-                // Step 1: exact dedup — same .cols filename
-                bool found_dup = false;
-                for (int j = 0; j < existing.column_files_size(); ++j) {
-                    if (existing.column_files(j) == new_file) {
-                        RETURN_IF_ERROR(verify_dcg_entry_consistency(existing, j, incoming, i));
-                        found_dup = true;
-                        break;
-                    }
+        // (a) Accumulate source-rowset references from every rowset that
+        // references any target via get_rssid -> context.map_rssid.
+        for (const auto& rowset : context.metadata()->rowsets()) {
+            for (int segment_position = 0; segment_position < rowset.segments_size(); ++segment_position) {
+                uint32_t original_rssid = get_rssid(rowset, segment_position);
+                auto target_or = context.map_rssid(original_rssid);
+                if (!target_or.ok()) continue;
+                uint32_t target_rssid = *target_or;
+                DcgSourceRowsetReference source_reference;
+                source_reference.child_index = child_index;
+                source_reference.rowset = &rowset;
+                source_reference.segment_position = segment_position;
+                if (rowset.has_range()) {
+                    source_reference.effective_range = &rowset.range();
+                } else if (context.metadata()->has_range()) {
+                    source_reference.effective_range = &context.metadata()->range();
+                } else {
+                    source_reference.effective_range = nullptr; // unbounded: full segment
                 }
-                if (found_dup) continue;
-
-                // Step 2: column overlap check
-                for (int j = 0; j < existing.unique_column_ids_size(); ++j) {
-                    for (auto e_cid : existing.unique_column_ids(j).column_ids()) {
-                        for (auto n_cid : incoming.unique_column_ids(i).column_ids()) {
-                            if (e_cid == n_cid) {
-                                return Status::NotSupported(
-                                        "DCG conflict: same column updated independently by different split children");
-                            }
-                        }
-                    }
-                }
-
-                // Step 3: disjoint columns — append entry (all 5 fields)
-                existing.add_column_files(new_file);
-                existing.add_unique_column_ids()->CopyFrom(incoming.unique_column_ids(i));
-                existing.add_versions(incoming.versions(i));
-                existing.add_encryption_metas(incoming.encryption_metas(i));
-                existing.add_shared_files(incoming.shared_files(i));
+                (*work_by_target)[target_rssid].source_refs.push_back(std::move(source_reference));
             }
         }
+
+        // (b) Walk dcg_meta: validate, normalize, split into single-entry
+        // records, dedup by .cols filename.
+        if (!context.metadata()->has_dcg_meta()) continue;
+        for (const auto& [segment_id, dcg_value] : context.metadata()->dcg_meta().dcgs()) {
+            ASSIGN_OR_RETURN(uint32_t target_rssid, context.map_rssid(segment_id));
+
+            DeltaColumnGroupVerPB normalized = dcg_value;
+            RETURN_IF_ERROR(validate_dcg_shape(normalized));
+            normalize_dcg_optional_fields(&normalized);
+
+            for (int entry_index = 0; entry_index < normalized.column_files_size(); ++entry_index) {
+                const std::string& file_name = normalized.column_files(entry_index);
+
+                auto& target_work = (*work_by_target)[target_rssid];
+                auto& seen_files = seen_files_by_target[target_rssid];
+                auto seen_iter = seen_files.find(file_name);
+                if (seen_iter != seen_files.end()) {
+                    // Exact dedup across children: verify entry-level consistency
+                    // against the previously stored entry. Index lookup is safe
+                    // even if the vector reallocated between insertions.
+                    RETURN_IF_ERROR(verify_dcg_entry_consistency(target_work.entries[seen_iter->second].single_entry, 0,
+                                                                 normalized, entry_index));
+                    continue;
+                }
+
+                DcgSurvivingEntry entry;
+                entry.child_index = child_index;
+                entry.original_segment_id = segment_id;
+                entry.entry_index = entry_index;
+                entry.single_entry = make_single_entry_dcg(normalized, entry_index);
+
+                const size_t new_entry_index = target_work.entries.size();
+                target_work.entries.push_back(std::move(entry));
+                seen_files[file_name] = new_entry_index;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+// For a merged rowset, find the segment position such that
+// get_rssid(rowset, position) == target. Returns -1 if not found.
+int find_segment_position_in_rowset(const RowsetMetadataPB& rowset, uint32_t target_rssid) {
+    for (int segment_position = 0; segment_position < rowset.segments_size(); ++segment_position) {
+        if (get_rssid(rowset, segment_position) == target_rssid) {
+            return segment_position;
+        }
+    }
+    return -1;
+}
+
+// Step A — locate the merged rowset + segment position that owns the target rssid.
+StatusOr<std::pair<const RowsetMetadataPB*, int>> locate_target_in_merged_metadata(const TabletMetadataPB& new_metadata,
+                                                                                   uint32_t target_rssid) {
+    for (const auto& rowset : new_metadata.rowsets()) {
+        int segment_position = find_segment_position_in_rowset(rowset, target_rssid);
+        if (segment_position >= 0) return std::make_pair(&rowset, segment_position);
+    }
+    return Status::InternalError(
+            fmt::format("DCG rebuild: target rssid {} not found in merged metadata", target_rssid));
+}
+
+// Step B — resolve the merged tablet schema PB for a given rowset.
+const TabletSchemaPB* resolve_rowset_schema_pb(const TabletMetadataPB& new_metadata, const RowsetMetadataPB& rowset) {
+    const auto& rowset_to_schema = new_metadata.rowset_to_schema();
+    const auto schema_id_iter = rowset_to_schema.find(rowset.id());
+    if (schema_id_iter != rowset_to_schema.end()) {
+        const auto& historical_schemas = new_metadata.historical_schemas();
+        auto schema_iter = historical_schemas.find(schema_id_iter->second);
+        if (schema_iter != historical_schemas.end()) return &schema_iter->second;
+    }
+    if (new_metadata.has_schema()) return &new_metadata.schema();
+    return nullptr;
+}
+
+struct DcgRowWindow {
+    size_t child_index;
+    Range<rowid_t> range;
+};
+
+// Step C — compute row windows in the target segment for every source-child
+// rowset that references it. Coverage over [0, num_rows_of_target) is validated.
+Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int64_t new_tablet_id,
+                                              const RowsetMetadataPB& target_rowset, int target_segment_position,
+                                              const TabletSchemaCSPtr& full_tablet_schema,
+                                              const std::vector<DcgSourceRowsetReference>& source_references,
+                                              std::vector<DcgRowWindow>* out_windows) {
+    // Open base segment for index lookups.
+    FileInfo base_segment_file_info;
+    base_segment_file_info.path =
+            tablet_manager->segment_location(new_tablet_id, target_rowset.segments(target_segment_position));
+    if (target_rowset.segment_size_size() > target_segment_position) {
+        base_segment_file_info.size = target_rowset.segment_size(target_segment_position);
+    }
+    if (target_rowset.bundle_file_offsets_size() > target_segment_position) {
+        base_segment_file_info.bundle_file_offset = target_rowset.bundle_file_offsets(target_segment_position);
+    }
+    if (target_rowset.segment_encryption_metas_size() > target_segment_position) {
+        base_segment_file_info.encryption_meta = target_rowset.segment_encryption_metas(target_segment_position);
+    }
+
+    ASSIGN_OR_RETURN(auto file_system, FileSystemFactory::CreateSharedFromString(base_segment_file_info.path));
+    ASSIGN_OR_RETURN(auto base_segment,
+                     Segment::open(file_system, base_segment_file_info, /*segment_id=*/0, full_tablet_schema,
+                                   /*footer_length_hint=*/nullptr, /*partial_rowset_footer=*/nullptr,
+                                   /*lake_io_opts=*/LakeIOOptions{}, tablet_manager));
+
+    const rowid_t num_rows_in_target = static_cast<rowid_t>(base_segment->num_rows());
+
+    out_windows->clear();
+    out_windows->reserve(source_references.size());
+
+    for (const auto& source_reference : source_references) {
+        Range<rowid_t> window{0, num_rows_in_target};
+        if (source_reference.effective_range != nullptr) {
+            ASSIGN_OR_RETURN(auto seek_range, TabletRangeHelper::create_seek_range_from(
+                                                      *source_reference.effective_range, full_tablet_schema,
+                                                      /*mem_pool=*/nullptr));
+            LakeIOOptions lake_io_options{.fill_data_cache = false};
+            ASSIGN_OR_RETURN(auto rowid_range_opt,
+                             segment_seek_range_to_rowid_range(base_segment, seek_range, lake_io_options));
+            if (!rowid_range_opt.has_value()) {
+                continue; // empty window
+            }
+            window = *rowid_range_opt;
+            // Clip to [0, num_rows_in_target)
+            window = Range<rowid_t>(std::max<rowid_t>(window.begin(), 0),
+                                    std::min<rowid_t>(window.end(), num_rows_in_target));
+            if (window.begin() >= window.end()) {
+                continue;
+            }
+        }
+        out_windows->push_back({source_reference.child_index, window});
+    }
+
+    if (out_windows->empty()) {
+        return Status::NotSupported(fmt::format(
+                "DCG rebuild: no valid row windows computed for target rssid (num_rows={})", num_rows_in_target));
+    }
+
+    // Dedup windows that belong to the SAME child AND have the same range
+    // (e.g., a child's shared rowset surfaced twice through different scans).
+    // Do NOT dedup windows from different children even if the range matches:
+    // those represent distinct authoritative updaters for the same rows and
+    // must surface as an overlap failure, not be silently collapsed.
+    std::sort(out_windows->begin(), out_windows->end(), [](const DcgRowWindow& left, const DcgRowWindow& right) {
+        if (left.range.begin() != right.range.begin()) return left.range.begin() < right.range.begin();
+        if (left.range.end() != right.range.end()) return left.range.end() < right.range.end();
+        return left.child_index < right.child_index;
+    });
+    std::vector<DcgRowWindow> deduped_windows;
+    deduped_windows.reserve(out_windows->size());
+    for (auto& window : *out_windows) {
+        if (!deduped_windows.empty() && deduped_windows.back().range.begin() == window.range.begin() &&
+            deduped_windows.back().range.end() == window.range.end() &&
+            deduped_windows.back().child_index == window.child_index) {
+            continue; // same child + same range: safe to collapse
+        }
+        deduped_windows.push_back(window);
+    }
+    *out_windows = std::move(deduped_windows);
+
+    // Coverage validation: windows must be contiguous and cover [0, num_rows_in_target).
+    if ((*out_windows)[0].range.begin() != 0) {
+        return Status::NotSupported(
+                fmt::format("DCG rebuild: row window coverage gap at the start (first.begin={}, expect 0)",
+                            (*out_windows)[0].range.begin()));
+    }
+    for (size_t index = 0; index + 1 < out_windows->size(); ++index) {
+        if ((*out_windows)[index].range.end() != (*out_windows)[index + 1].range.begin()) {
+            return Status::NotSupported(fmt::format("DCG rebuild: row window coverage gap or overlap ({}->{} vs {})",
+                                                    (*out_windows)[index].range.begin(),
+                                                    (*out_windows)[index].range.end(),
+                                                    (*out_windows)[index + 1].range.begin()));
+        }
+    }
+    if (out_windows->back().range.end() != num_rows_in_target) {
+        return Status::NotSupported(
+                fmt::format("DCG rebuild: row window coverage gap at the end (last.end={}, expect {})",
+                            out_windows->back().range.end(), num_rows_in_target));
+    }
+    return Status::OK();
+}
+
+// Helper: open a source .cols file as a Segment (projection = entry's
+// unique_column_ids restricted subset of the merged tablet schema).
+StatusOr<std::shared_ptr<Segment>> open_source_dcg_segment(TabletManager* tablet_manager, int64_t owner_tablet_id,
+                                                           const std::string& relative_path,
+                                                           const std::string& encryption_meta,
+                                                           const TabletSchemaCSPtr& entry_schema) {
+    FileInfo file_info;
+    file_info.path = tablet_manager->segment_location(owner_tablet_id, relative_path);
+    file_info.encryption_meta = encryption_meta;
+    ASSIGN_OR_RETURN(auto file_system, FileSystemFactory::CreateSharedFromString(file_info.path));
+    return Segment::open(file_system, file_info, /*segment_id=*/0, entry_schema, /*footer_length_hint=*/nullptr,
+                         /*partial_rowset_footer=*/nullptr, /*lake_io_opts=*/LakeIOOptions{}, tablet_manager);
+}
+
+// Helper: read [row_begin, row_end) rows of |column_unique_id| from |segment|,
+// previously opened with |entry_schema| which must contain that UID. The
+// column values are appended to |destination|.
+Status read_column_range_from_segment(const std::shared_ptr<Segment>& segment, const TabletSchemaCSPtr& entry_schema,
+                                      uint32_t column_unique_id, rowid_t row_begin, rowid_t row_end,
+                                      Column* destination) {
+    const int32_t column_index = entry_schema->field_index(static_cast<ColumnUID>(column_unique_id));
+    if (column_index < 0) {
+        return Status::Corruption(
+                fmt::format("DCG rebuild: source segment schema is missing column UID {}", column_unique_id));
+    }
+    const auto& tablet_column = entry_schema->column(column_index);
+    OlapReaderStatistics reader_statistics;
+
+    ASSIGN_OR_RETURN(auto column_iterator, segment->new_column_iterator(tablet_column, /*path=*/nullptr));
+
+    // Build a RandomAccessFile for the segment's file (required by
+    // ColumnIteratorOptions::read_file). Segment's new_iterator path is too
+    // heavy for a single-column read, so we build a dedicated handle here.
+    ASSIGN_OR_RETURN(auto file_system, FileSystemFactory::CreateSharedFromString(segment->file_info().path));
+    RandomAccessFileOptions random_access_file_options;
+    if (!segment->file_info().encryption_meta.empty()) {
+        ASSIGN_OR_RETURN(auto encryption_info,
+                         KeyCache::instance().unwrap_encryption_meta(segment->file_info().encryption_meta));
+        random_access_file_options.encryption_info = std::move(encryption_info);
+    }
+    ASSIGN_OR_RETURN(auto random_access_file, file_system->new_random_access_file_with_bundling(
+                                                      random_access_file_options, segment->file_info()));
+
+    ColumnIteratorOptions column_iterator_options;
+    column_iterator_options.read_file = random_access_file.get();
+    column_iterator_options.stats = &reader_statistics;
+    column_iterator_options.lake_io_opts = LakeIOOptions{.fill_data_cache = false};
+    column_iterator_options.chunk_size = std::max<int>(1, static_cast<int>(row_end - row_begin));
+    RETURN_IF_ERROR(column_iterator->init(column_iterator_options));
+    RETURN_IF_ERROR(column_iterator->seek_to_ordinal(row_begin));
+
+    size_t remaining_rows = row_end - row_begin;
+    while (remaining_rows > 0) {
+        size_t batch_size = remaining_rows;
+        RETURN_IF_ERROR(column_iterator->next_batch(&batch_size, destination));
+        if (batch_size == 0) {
+            return Status::InternalError("DCG rebuild: column iterator returned 0 rows before exhausting range");
+        }
+        remaining_rows -= batch_size;
+    }
+    return Status::OK();
+}
+
+// Per-target rebuild — Steps A-F.
+// Returns the single-entry PB describing the newly written .cols file.
+StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
+        TabletManager* tablet_manager, const std::vector<TabletMergeContext>& merge_contexts, int64_t new_tablet_id,
+        int64_t new_version, int64_t txn_id, const TabletMetadataPB& new_metadata, uint32_t target_rssid,
+        const std::vector<uint32_t>& rebuild_columns, const std::vector<const DcgSurvivingEntry*>& conflicting_entries,
+        const std::vector<DcgSourceRowsetReference>& source_references) {
+    TEST_SYNC_POINT_CALLBACK("merge_dcg_meta:before_rebuild", &target_rssid);
+
+    // Step A — locate merged rowset + segment position for target rssid.
+    ASSIGN_OR_RETURN(auto located_pair, locate_target_in_merged_metadata(new_metadata, target_rssid));
+    const RowsetMetadataPB& target_rowset = *located_pair.first;
+    const int target_segment_position = located_pair.second;
+
+    // Step B — resolve full tablet schema + rebuild schema.
+    const TabletSchemaPB* schema_pb = resolve_rowset_schema_pb(new_metadata, target_rowset);
+    if (schema_pb == nullptr) {
+        return Status::NotSupported(
+                fmt::format("DCG rebuild: no tablet schema available for rowset {}", target_rowset.id()));
+    }
+    TabletSchemaCSPtr full_tablet_schema = TabletSchema::create(*schema_pb);
+    if (full_tablet_schema->sort_key_idxes().empty()) {
+        return Status::NotSupported("DCG rebuild: tablet schema has no sort key");
+    }
+    std::vector<ColumnUID> rebuild_unique_ids;
+    rebuild_unique_ids.reserve(rebuild_columns.size());
+    for (uint32_t unique_id : rebuild_columns) rebuild_unique_ids.push_back(static_cast<ColumnUID>(unique_id));
+    TabletSchemaCSPtr rebuild_schema = TabletSchema::create_with_uid(full_tablet_schema, rebuild_unique_ids);
+    // create_with_uid silently drops UIDs not found in the base schema. If the
+    // merged historical schema is missing any conflict UID, the rebuilt file
+    // would otherwise omit that column silently. Fail fast instead.
+    if (rebuild_schema->num_columns() != rebuild_columns.size()) {
+        return Status::NotSupported(fmt::format(
+                "DCG rebuild: merged tablet schema is missing one or more rebuild column UIDs (expected {} columns, "
+                "got {}); cannot safely rebuild .cols",
+                rebuild_columns.size(), rebuild_schema->num_columns()));
+    }
+
+    // Step C — compute row windows.
+    std::vector<DcgRowWindow> windows;
+    RETURN_IF_ERROR(compute_row_windows_for_source_rowsets(tablet_manager, new_tablet_id, target_rowset,
+                                                           target_segment_position, full_tablet_schema,
+                                                           source_references, &windows));
+    const rowid_t num_rows_in_target = windows.back().range.end();
+
+    // For each rebuild column, pick:
+    // - default donor: any conflicting entry that claims the UID (first found).
+    // - per-child overrides: the conflicting entry from the child that claims
+    //   the UID, to be used for rows in that child's owner window.
+    struct ColumnSourceInfo {
+        const DcgSurvivingEntry* default_donor = nullptr;
+        std::unordered_map<size_t, const DcgSurvivingEntry*> override_by_child_index;
+    };
+    std::unordered_map<uint32_t, ColumnSourceInfo> column_source_info_by_unique_id;
+    for (uint32_t unique_id : rebuild_columns) {
+        for (const DcgSurvivingEntry* entry : conflicting_entries) {
+            bool entry_claims_this_column = false;
+            for (auto claimed_unique_id : entry->single_entry.unique_column_ids(0).column_ids()) {
+                if (claimed_unique_id == unique_id) {
+                    entry_claims_this_column = true;
+                    break;
+                }
+            }
+            if (!entry_claims_this_column) continue;
+            auto& info = column_source_info_by_unique_id[unique_id];
+            if (info.default_donor == nullptr) info.default_donor = entry;
+            info.override_by_child_index[entry->child_index] = entry;
+        }
+        if (column_source_info_by_unique_id[unique_id].default_donor == nullptr) {
+            return Status::InternalError(fmt::format("DCG rebuild: no donor found for column UID {}", unique_id));
+        }
+    }
+
+    // Open each referenced source .cols segment (cached per entry address).
+    std::unordered_map<const DcgSurvivingEntry*, std::shared_ptr<Segment>> opened_source_segments;
+    std::unordered_map<const DcgSurvivingEntry*, TabletSchemaCSPtr> entry_schemas;
+
+    auto get_source_segment = [&](const DcgSurvivingEntry* entry) -> StatusOr<std::shared_ptr<Segment>> {
+        auto cache_iter = opened_source_segments.find(entry);
+        if (cache_iter != opened_source_segments.end()) return cache_iter->second;
+        std::vector<ColumnUID> entry_unique_ids;
+        for (auto column_id : entry->single_entry.unique_column_ids(0).column_ids()) {
+            entry_unique_ids.push_back(static_cast<ColumnUID>(column_id));
+        }
+        TabletSchemaCSPtr entry_schema = TabletSchema::create_with_uid(full_tablet_schema, entry_unique_ids);
+        int64_t owner_tablet_id = merge_contexts[entry->child_index].metadata()->id();
+        const std::string& file_name = entry->single_entry.column_files(0);
+        const std::string& encryption_meta = entry->single_entry.encryption_metas(0);
+        ASSIGN_OR_RETURN(auto segment, open_source_dcg_segment(tablet_manager, owner_tablet_id, file_name,
+                                                               encryption_meta, entry_schema));
+        entry_schemas[entry] = entry_schema;
+        opened_source_segments[entry] = segment;
+        return segment;
+    };
+
+    TEST_SYNC_POINT_CALLBACK("merge_dcg_meta:after_open_sources", &target_rssid);
+
+    // Step D — assemble columns IN rebuild_schema ORDER. TabletSchema::create_with_uid
+    // preserves the base schema's column order, which can differ from the
+    // insertion order of |rebuild_columns|. Chunk binds columns positionally,
+    // so we must iterate schema positions, not UID insertion order, to avoid
+    // writing column data into the wrong (UID, type) slot.
+    //
+    // Full-column materialization keeps this code path simple and correct;
+    // DCG files are already at segment size, so the peak is bounded by a
+    // single rebuilt column over the full segment. Row-batch streaming is a
+    // future optimization.
+    const size_t num_columns = rebuild_schema->num_columns();
+    Columns rebuilt_columns(num_columns);
+    std::vector<uint32_t> ordered_unique_ids;
+    ordered_unique_ids.reserve(num_columns);
+    for (size_t column_index = 0; column_index < num_columns; ++column_index) {
+        const auto& tablet_column = rebuild_schema->column(column_index);
+        const uint32_t unique_id = static_cast<uint32_t>(tablet_column.unique_id());
+        ordered_unique_ids.push_back(unique_id);
+
+        auto source_info_iter = column_source_info_by_unique_id.find(unique_id);
+        if (source_info_iter == column_source_info_by_unique_id.end()) {
+            return Status::InternalError(
+                    fmt::format("DCG rebuild: rebuild_schema has UID {} with no source", unique_id));
+        }
+        const auto& source_info = source_info_iter->second;
+
+        auto field = ChunkHelper::convert_field(column_index, tablet_column);
+        MutableColumnPtr output_column = ChunkHelper::column_from_field(field);
+        output_column->reserve(num_rows_in_target);
+
+        for (const auto& window : windows) {
+            const DcgSurvivingEntry* selected_source = nullptr;
+            auto override_iter = source_info.override_by_child_index.find(window.child_index);
+            selected_source = (override_iter != source_info.override_by_child_index.end()) ? override_iter->second
+                                                                                           : source_info.default_donor;
+            ASSIGN_OR_RETURN(auto source_segment, get_source_segment(selected_source));
+            RETURN_IF_ERROR(read_column_range_from_segment(source_segment, entry_schemas[selected_source], unique_id,
+                                                           window.range.begin(), window.range.end(),
+                                                           output_column.get()));
+        }
+
+        if (output_column->size() != static_cast<size_t>(num_rows_in_target)) {
+            return Status::InternalError(fmt::format("DCG rebuild: column UID {} size {} != num_rows {}", unique_id,
+                                                     output_column->size(), num_rows_in_target));
+        }
+        rebuilt_columns[column_index] = std::move(output_column);
+    }
+
+    // Step F — write new .cols file.
+    Schema output_schema = ChunkHelper::convert_schema(rebuild_schema);
+    auto output_chunk = std::make_shared<Chunk>(std::move(rebuilt_columns), std::make_shared<Schema>(output_schema));
+
+    const std::string new_file_basename = gen_cols_filename(txn_id);
+    const std::string new_file_path = tablet_manager->segment_location(new_tablet_id, new_file_basename);
+    WritableFileOptions writable_file_options{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    SegmentWriterOptions segment_writer_options;
+    if (new_metadata.has_flat_json_config()) {
+        segment_writer_options.flat_json_config = std::make_shared<FlatJsonConfig>();
+        segment_writer_options.flat_json_config->update(new_metadata.flat_json_config());
+    }
+    if (config::enable_transparent_data_encryption) {
+        ASSIGN_OR_RETURN(auto encryption_meta_pair,
+                         KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+        writable_file_options.encryption_info = encryption_meta_pair.info;
+        segment_writer_options.encryption_meta = std::move(encryption_meta_pair.encryption_meta);
+    }
+    ASSIGN_OR_RETURN(auto writable_file, fs::new_writable_file(writable_file_options, new_file_path));
+    auto segment_writer = std::make_unique<SegmentWriter>(std::move(writable_file), /*segment_id=*/0, rebuild_schema,
+                                                          segment_writer_options);
+    RETURN_IF_ERROR(segment_writer->init(false));
+    RETURN_IF_ERROR(segment_writer->append_chunk(*output_chunk));
+    uint64_t written_file_size = 0;
+    uint64_t written_index_size = 0;
+    uint64_t written_footer_position = 0;
+    RETURN_IF_ERROR(segment_writer->finalize(&written_file_size, &written_index_size, &written_footer_position));
+
+    TEST_SYNC_POINT_CALLBACK("merge_dcg_meta:after_write_cols", const_cast<std::string*>(&new_file_basename));
+
+    // Step E — build single-entry PB for the rebuilt file. Emit unique_column_ids
+    // in the SAME order as the written chunk's columns (rebuild_schema order).
+    // Mismatched order would cause reader schema binding to mismatch the physical
+    // column positions in the .cols segment.
+    DeltaColumnGroupVerPB rebuilt;
+    rebuilt.add_column_files(new_file_basename);
+    auto* unique_column_ids_pb = rebuilt.add_unique_column_ids();
+    for (uint32_t unique_id : ordered_unique_ids) unique_column_ids_pb->add_column_ids(unique_id);
+    rebuilt.add_versions(new_version);
+    rebuilt.add_encryption_metas(segment_writer->encryption_meta());
+    rebuilt.add_shared_files(false);
+    return rebuilt;
+}
+
+Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMergeContext>& merge_contexts,
+                      int64_t new_tablet_id, int64_t new_version, int64_t txn_id, TabletMetadataPB* new_metadata) {
+    std::map<uint32_t, DcgTargetWorkItem> work_by_target;
+    RETURN_IF_ERROR(dcg_pass1_collect_entries_and_sources(merge_contexts, &work_by_target));
+
+    auto* merged_dcgs = new_metadata->mutable_dcg_meta()->mutable_dcgs();
+
+    // Track full paths of rebuilt .cols files so we can best-effort clean them
+    // up if a later target's rebuild fails partway through. Downstream failures
+    // (merge_delvecs/merge_sstables/publish) still rely on standard orphan-file
+    // vacuum, which matches the pattern used by merge_delvec_files.
+    std::vector<std::string> rebuilt_file_paths;
+    auto cleanup_on_failure = [&]() {
+        for (const auto& path : rebuilt_file_paths) {
+            auto status = fs::delete_file(path);
+            LOG_IF(WARNING, !status.ok() && !status.is_not_found())
+                    << "failed to clean up partial DCG rebuild file " << path << ": " << status;
+        }
+        rebuilt_file_paths.clear();
+    };
+
+    for (auto& [target_rssid, target_work] : work_by_target) {
+        if (target_work.entries.empty()) continue;
+
+        // Build column UID -> entries index (stable indices, not pointers).
+        std::unordered_map<uint32_t, std::vector<size_t>> entry_indices_by_unique_id;
+        for (size_t entry_index = 0; entry_index < target_work.entries.size(); ++entry_index) {
+            for (auto unique_id : target_work.entries[entry_index].single_entry.unique_column_ids(0).column_ids()) {
+                entry_indices_by_unique_id[unique_id].push_back(entry_index);
+            }
+        }
+
+        // Identify conflicting entries: any entry claiming a UID shared with another entry.
+        std::vector<bool> entry_is_conflicting(target_work.entries.size(), false);
+        for (auto& [unique_id, entry_indices] : entry_indices_by_unique_id) {
+            if (entry_indices.size() > 1) {
+                for (size_t entry_index : entry_indices) entry_is_conflicting[entry_index] = true;
+            }
+        }
+
+        DeltaColumnGroupVerPB final_dcg;
+
+        // Emit non-conflicting entries unchanged.
+        for (size_t entry_index = 0; entry_index < target_work.entries.size(); ++entry_index) {
+            if (entry_is_conflicting[entry_index]) continue;
+            const auto& entry = target_work.entries[entry_index];
+            final_dcg.add_column_files(entry.single_entry.column_files(0));
+            final_dcg.add_unique_column_ids()->CopyFrom(entry.single_entry.unique_column_ids(0));
+            final_dcg.add_versions(entry.single_entry.versions(0));
+            final_dcg.add_encryption_metas(entry.single_entry.encryption_metas(0));
+            final_dcg.add_shared_files(entry.single_entry.shared_files(0));
+        }
+
+        bool any_entry_is_conflicting = false;
+        for (bool conflicting : entry_is_conflicting) any_entry_is_conflicting |= conflicting;
+
+        if (any_entry_is_conflicting) {
+            // Fold ALL columns of every conflicting entry into rebuild_columns
+            // so the reader's first-entry-wins rule can't leak stale values.
+            std::vector<uint32_t> rebuild_columns;
+            std::unordered_set<uint32_t> seen_rebuild_columns;
+            std::vector<const DcgSurvivingEntry*> conflicting_entries;
+            for (size_t entry_index = 0; entry_index < target_work.entries.size(); ++entry_index) {
+                if (!entry_is_conflicting[entry_index]) continue;
+                conflicting_entries.push_back(&target_work.entries[entry_index]);
+                for (auto unique_id : target_work.entries[entry_index].single_entry.unique_column_ids(0).column_ids()) {
+                    if (seen_rebuild_columns.insert(unique_id).second) {
+                        rebuild_columns.push_back(unique_id);
+                    }
+                }
+            }
+
+            StatusOr<DeltaColumnGroupVerPB> rebuilt_or_status = rebuild_dcg_for_target_segment(
+                    tablet_manager, merge_contexts, new_tablet_id, new_version, txn_id, *new_metadata, target_rssid,
+                    rebuild_columns, conflicting_entries, target_work.source_refs);
+            if (!rebuilt_or_status.ok()) {
+                if (rebuilt_or_status.status().is_not_supported()) {
+                    g_tablet_merge_dcg_rebuild_fallback_not_supported_total << 1;
+                }
+                cleanup_on_failure();
+                return rebuilt_or_status.status();
+            }
+            const auto& rebuilt_entry = *rebuilt_or_status;
+            rebuilt_file_paths.push_back(
+                    tablet_manager->segment_location(new_tablet_id, rebuilt_entry.column_files(0)));
+            final_dcg.add_column_files(rebuilt_entry.column_files(0));
+            final_dcg.add_unique_column_ids()->CopyFrom(rebuilt_entry.unique_column_ids(0));
+            final_dcg.add_versions(rebuilt_entry.versions(0));
+            final_dcg.add_encryption_metas(rebuilt_entry.encryption_metas(0));
+            final_dcg.add_shared_files(rebuilt_entry.shared_files(0));
+            g_tablet_merge_dcg_rebuild_total << 1;
+        }
+
+        if (final_dcg.column_files_size() == 0) continue;
+        auto shape_status = validate_dcg_shape(final_dcg);
+        if (!shape_status.ok()) {
+            cleanup_on_failure();
+            return shape_status;
+        }
+        (*merged_dcgs)[target_rssid] = std::move(final_dcg);
     }
 
     return Status::OK();
@@ -772,8 +1368,13 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // Phase 2: Merge rowsets (version-driven k-way merge with dedup)
     RETURN_IF_ERROR(merge_rowsets(merge_contexts, new_tablet_metadata.get()));
 
+    // Phase 2.5: Merge schemas (must run before merge_dcg_meta, which needs
+    // historical_schemas to locate rebuild schemas for shared-segment rebuild).
+    merge_schemas(merge_contexts, new_tablet_metadata.get());
+
     // Phase 3: Projections (map_rssid uses shared_rssid_map + rssid_offset)
-    RETURN_IF_ERROR(merge_dcg_meta(merge_contexts, new_tablet_metadata.get()));
+    RETURN_IF_ERROR(merge_dcg_meta(tablet_manager, merge_contexts, merging_tablet.new_tablet_id(), new_version,
+                                   txn_info.txn_id(), new_tablet_metadata.get()));
 
     if (is_primary_key(*new_tablet_metadata)) {
         RETURN_IF_ERROR(merge_delvecs(tablet_manager, merge_contexts, new_version, txn_info.txn_id(),
@@ -783,7 +1384,6 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     RETURN_IF_ERROR(merge_sstables(tablet_manager, merge_contexts, new_tablet_metadata.get()));
 
     // Phase 4: Finalize
-    merge_schemas(merge_contexts, new_tablet_metadata.get());
     update_next_rowset_id(new_tablet_metadata.get());
 
     return new_tablet_metadata;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -34,6 +34,7 @@
 #include "common/config_storage_fwd.h"
 #include "common/status.h"
 #include "fs/fs.h"
+#include "fs/fs_factory.h"
 #include "glog/logging.h"
 #include "gutil/casts.h"
 #include "gutil/stl_util.h"
@@ -121,6 +122,14 @@ public:
     ~SegmentIterator() override = default;
 
     void close() override;
+
+    // Public entry point used by segment_seek_range_to_rowid_range(). The caller
+    // must ensure the segment's short-key index has already been loaded; this
+    // does not touch any other iterator state, so it is safe to invoke before
+    // do_init() / do_get_next().
+    StatusOr<std::optional<Range<>>> resolve_range_to_rowid_range(const SeekRange& range) {
+        return _seek_range_to_rowid_range(range);
+    }
 
 protected:
     Status do_get_next(Chunk* chunk) override;
@@ -3960,6 +3969,41 @@ ChunkIteratorPtr new_segment_iterator(const std::shared_ptr<Segment>& segment, c
         auto seg_iter = std::make_shared<SegmentIterator>(segment, ordered_schema, options);
         return new_projection_iterator(schema, seg_iter);
     }
+}
+
+StatusOr<std::optional<Range<rowid_t>>> segment_seek_range_to_rowid_range(const std::shared_ptr<Segment>& segment,
+                                                                          const SeekRange& range,
+                                                                          const LakeIOOptions& lake_io_opts) {
+    if (segment == nullptr) {
+        return Status::InvalidArgument("segment is null");
+    }
+    RETURN_IF_ERROR(segment->load_index(lake_io_opts));
+
+    // Schema is only used by the iterator's constructor; _seek_range_to_rowid_range
+    // picks the right schema from range.lower()/range.upper() on each side.
+    Schema iterator_schema;
+    if (!range.upper().empty()) {
+        iterator_schema = range.upper().schema();
+    } else if (!range.lower().empty()) {
+        iterator_schema = range.lower().schema();
+    } else {
+        // (-inf, +inf): the full segment.
+        return std::optional<Range<rowid_t>>{Range<rowid_t>{0, segment->num_rows()}};
+    }
+
+    // SegmentReadOptions::stats is documented as required by ColumnIterator init
+    // (sanity_check() CHECK_NOTNULLs it). SegmentReadOptions::fs is required by
+    // _init_column_iterator_by_cid, which opens a RandomAccessFile on the
+    // segment's file. Supply both from locals — nothing downstream inspects the
+    // accumulated stats here.
+    OlapReaderStatistics local_stats;
+    ASSIGN_OR_RETURN(auto file_system, FileSystemFactory::CreateSharedFromString(segment->file_info().path));
+    SegmentReadOptions read_options;
+    read_options.lake_io_opts = lake_io_opts;
+    read_options.stats = &local_stats;
+    read_options.fs = std::move(file_system);
+    SegmentIterator iterator(segment, iterator_schema, read_options);
+    return iterator.resolve_range_to_rowid_range(range);
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.h
+++ b/be/src/storage/rowset/segment_iterator.h
@@ -15,18 +15,33 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <vector>
 
+#include "common/statusor.h"
 #include "storage/chunk_iterator.h"
+#include "storage/olap_common.h"
+#include "storage/range.h"
 
 namespace starrocks {
 class Segment;
+class SeekRange;
 
 class ColumnPredicate;
 class Schema;
 class SegmentReadOptions;
+struct LakeIOOptions;
 
 ChunkIteratorPtr new_segment_iterator(const std::shared_ptr<Segment>& segment, const Schema& schema,
                                       const SegmentReadOptions& options);
+
+// Resolve a key-space SeekRange to the corresponding rowid range within |segment|.
+// Wraps the lookup machinery of SegmentIterator so callers outside the
+// iterator scan path can convert a TabletRangePB-derived SeekRange into a
+// contiguous [lower, upper) rowid window.
+// Returns std::nullopt when the range is empty on this segment.
+StatusOr<std::optional<Range<rowid_t>>> segment_seek_range_to_rowid_range(const std::shared_ptr<Segment>& segment,
+                                                                          const SeekRange& range,
+                                                                          const LakeIOOptions& lake_io_opts);
 
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -25,19 +25,30 @@
 #include "base/testutil/id_generator.h"
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
+#include "column/column_helper.h"
 #include "common/config_storage_fwd.h"
 #include "fs/fs.h"
+#include "fs/fs_factory.h"
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"
+#include "storage/chunk_helper.h"
 #include "storage/del_vector.h"
+#include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
+#include "storage/rowset/segment.h"
+#include "storage/rowset/segment_iterator.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/seek_range.h"
+#include "storage/tablet_schema.h"
 #include "storage/variant_tuple.h"
 
 namespace starrocks {
@@ -182,6 +193,194 @@ protected:
         }
         dcg.add_versions(version);
         dcg.add_shared_files(true);
+    }
+
+    // Build a two-column INT primary-key tablet schema in |metadata|'s
+    // `schema` field. `c0` is the key (also the sort key); `c1` is a plain
+    // data column. The returned (c0_uid, c1_uid) can be used to cross-
+    // reference the columns from DCG metadata.
+    std::pair<int32_t, int32_t> set_two_column_pk_schema(TabletMetadataPB* metadata, int64_t schema_id) {
+        auto* schema = metadata->mutable_schema();
+        schema->set_keys_type(PRIMARY_KEYS);
+        schema->set_id(schema_id);
+        schema->set_num_short_key_columns(1);
+        schema->set_num_rows_per_row_block(65535);
+        auto* c0 = schema->add_column();
+        const int32_t c0_uid = 1001;
+        c0->set_unique_id(c0_uid);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+        auto* c1 = schema->add_column();
+        const int32_t c1_uid = 1002;
+        c1->set_unique_id(c1_uid);
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        c1->set_aggregation("REPLACE");
+        return {c0_uid, c1_uid};
+    }
+
+    // Write a real Segment file with num_rows rows: c0 = [0..num_rows), c1 = source_value_of(c0).
+    // Returns the segment file size on disk. The file is placed under
+    // tablet_id's segment directory as |segment_name|.
+    uint64_t write_two_column_segment(int64_t tablet_id, const std::string& segment_name, int num_rows,
+                                      const std::function<int(int)>& source_value_of) {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(PRIMARY_KEYS);
+        schema_pb.set_id(2001);
+        schema_pb.set_num_short_key_columns(1);
+        schema_pb.set_num_rows_per_row_block(65535);
+        auto* c0 = schema_pb.add_column();
+        c0->set_unique_id(1001);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+        auto* c1 = schema_pb.add_column();
+        c1->set_unique_id(1002);
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        c1->set_aggregation("REPLACE");
+
+        auto tablet_schema = TabletSchema::create(schema_pb);
+        auto segment_path = _tablet_manager->segment_location(tablet_id, segment_name);
+
+        WritableFileOptions fopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        auto wfile_or = fs::new_writable_file(fopts, segment_path);
+        CHECK_OK(wfile_or.status());
+
+        SegmentWriterOptions opts;
+        SegmentWriter writer(std::move(wfile_or.value()), 0, tablet_schema, opts);
+        CHECK_OK(writer.init());
+
+        auto col0 = Int32Column::create();
+        auto col1 = Int32Column::create();
+        std::vector<int> v0(num_rows), v1(num_rows);
+        for (int i = 0; i < num_rows; ++i) {
+            v0[i] = i;
+            v1[i] = source_value_of(i);
+        }
+        col0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        col1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        auto chunk_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+        auto chunk = std::make_shared<Chunk>(Columns{std::move(col0), std::move(col1)}, chunk_schema);
+        CHECK_OK(writer.append_chunk(*chunk));
+
+        uint64_t segment_file_size = 0, index_size = 0, footer_position = 0;
+        CHECK_OK(writer.finalize(&segment_file_size, &index_size, &footer_position));
+        return segment_file_size;
+    }
+
+    // Write a real .cols file for column c1 only, with `num_rows` entries.
+    // cell_value(row) supplies the c1 value at segment row |row|.
+    uint64_t write_c1_only_cols_file(int64_t tablet_id, const std::string& cols_filename, int num_rows,
+                                     const std::function<int(int)>& cell_value) {
+        TabletSchemaPB full_pb;
+        full_pb.set_keys_type(PRIMARY_KEYS);
+        full_pb.set_id(3001);
+        full_pb.set_num_short_key_columns(1);
+        full_pb.set_num_rows_per_row_block(65535);
+        auto* c0 = full_pb.add_column();
+        c0->set_unique_id(1001);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+        auto* c1 = full_pb.add_column();
+        c1->set_unique_id(1002);
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        c1->set_aggregation("REPLACE");
+
+        auto full_schema = TabletSchema::create(full_pb);
+        auto cols_schema = TabletSchema::create_with_uid(full_schema, std::vector<ColumnUID>{1002});
+
+        auto cols_path = _tablet_manager->segment_location(tablet_id, cols_filename);
+        WritableFileOptions fopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        auto wfile_or = fs::new_writable_file(fopts, cols_path);
+        CHECK_OK(wfile_or.status());
+
+        SegmentWriterOptions opts;
+        SegmentWriter writer(std::move(wfile_or.value()), 0, cols_schema, opts);
+        CHECK_OK(writer.init(false));
+
+        auto col = Int32Column::create();
+        std::vector<int> values(num_rows);
+        for (int i = 0; i < num_rows; ++i) values[i] = cell_value(i);
+        col->append_numbers(values.data(), values.size() * sizeof(int));
+        auto chunk_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(cols_schema));
+        auto chunk = std::make_shared<Chunk>(Columns{std::move(col)}, chunk_schema);
+        CHECK_OK(writer.append_chunk(*chunk));
+
+        uint64_t segment_file_size = 0, index_size = 0, footer_position = 0;
+        CHECK_OK(writer.finalize(&segment_file_size, &index_size, &footer_position));
+        return segment_file_size;
+    }
+
+    // Open a .cols file that contains only column c1 (UID 1002) and return
+    // its materialized integer values.
+    std::vector<int32_t> read_c1_only_cols_file(int64_t tablet_id, const std::string& cols_filename) {
+        TabletSchemaPB full_pb;
+        full_pb.set_keys_type(PRIMARY_KEYS);
+        full_pb.set_id(3002);
+        full_pb.set_num_short_key_columns(1);
+        full_pb.set_num_rows_per_row_block(65535);
+        auto* c0 = full_pb.add_column();
+        c0->set_unique_id(1001);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+        auto* c1 = full_pb.add_column();
+        c1->set_unique_id(1002);
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        c1->set_aggregation("REPLACE");
+
+        auto full_schema = TabletSchema::create(full_pb);
+        auto cols_schema = TabletSchema::create_with_uid(full_schema, std::vector<ColumnUID>{1002});
+
+        FileInfo file_info;
+        file_info.path = _tablet_manager->segment_location(tablet_id, cols_filename);
+        auto fs_or = FileSystemFactory::CreateSharedFromString(file_info.path);
+        CHECK_OK(fs_or.status());
+        auto segment_or = Segment::open(fs_or.value(), file_info, 0, cols_schema);
+        CHECK_OK(segment_or.status());
+        auto segment = segment_or.value();
+
+        SegmentReadOptions read_options;
+        OlapReaderStatistics stats;
+        read_options.stats = &stats;
+        ASSIGN_OR_ABORT(read_options.fs, FileSystemFactory::CreateSharedFromString(file_info.path));
+        read_options.tablet_id = tablet_id;
+        read_options.rowset_id = 0;
+        read_options.version = 1;
+        Schema iter_schema = ChunkHelper::convert_schema(cols_schema);
+        auto iter_or = segment->new_iterator(iter_schema, read_options);
+        CHECK_OK(iter_or.status());
+
+        std::vector<int32_t> result;
+        auto chunk = ChunkHelper::new_chunk(iter_schema, 4096);
+        while (true) {
+            chunk->reset();
+            auto status = iter_or.value()->get_next(chunk.get());
+            if (status.is_end_of_file()) break;
+            CHECK_OK(status);
+            auto col = chunk->get_column_by_index(0);
+            for (size_t i = 0; i < col->size(); ++i) {
+                result.push_back(col->get(i).get_int32());
+            }
+        }
+        return result;
     }
 
     std::unique_ptr<starrocks::lake::TabletManager> _tablet_manager;
@@ -3943,6 +4142,21 @@ TxnLogPtr make_op_compaction_log(int64_t source_tablet_id) {
     return log;
 }
 
+// Helper: build a PK tablet metadata where `rowset_id`'s segment is marked
+// shared across children (mirrors split-family structure). Returns the rowset.
+RowsetMetadataPB* add_shared_rowset(TabletMetadataPB* metadata, uint32_t rowset_id, int64_t version,
+                                    const std::string& segment_filename) {
+    auto* rowset = metadata->add_rowsets();
+    rowset->set_id(rowset_id);
+    rowset->set_version(version);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(100);
+    rowset->add_segments(segment_filename);
+    rowset->add_segment_size(100);
+    rowset->add_shared_segments(true);
+    return rowset;
+}
+
 } // namespace
 
 TEST_F(LakeTabletReshardTest, test_convert_txn_log_merging_op_write_only_passthrough) {
@@ -4608,5 +4822,642 @@ TEST_F(LakeTabletReshardTest, test_publish_resharding_tablet_slot_dedup) {
         EXPECT_TRUE(st.is_resource_busy()) << st;
     }
 }
+
+// Shared rowset with identical .cols filenames across children collapses to
+// a single DCG entry via exact dedup — no rebuild.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup_preserves_passthrough) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(10);
+    set_primary_key_schema(meta1.get(), 1001);
+    add_shared_rowset(meta1.get(), /*rowset_id=*/1, /*version=*/1, "shared_seg.dat");
+    (*meta1->mutable_rowset_to_schema())[1] = 1001;
+    add_dcg_with_columns(meta1.get(), /*segment_id=*/1, "shared.cols", {101, 102}, 1);
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(10);
+    set_primary_key_schema(meta2.get(), 1001);
+    add_shared_rowset(meta2.get(), /*rowset_id=*/1, /*version=*/1, "shared_seg.dat");
+    (*meta2->mutable_rowset_to_schema())[1] = 1001;
+    add_dcg_with_columns(meta2.get(), /*segment_id=*/1, "shared.cols", {101, 102}, 1);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(77);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    auto merged = tablet_metadatas.at(new_tablet_id);
+
+    ASSERT_EQ(1, merged->dcg_meta().dcgs_size());
+    const auto& entry = merged->dcg_meta().dcgs().begin()->second;
+    ASSERT_EQ(1, entry.column_files_size());
+    EXPECT_EQ("shared.cols", entry.column_files(0));
+    ASSERT_EQ(1, entry.unique_column_ids_size());
+    ASSERT_EQ(2, entry.unique_column_ids(0).column_ids_size());
+    EXPECT_EQ(1, entry.versions(0));
+}
+
+// Disjoint columns on a shared rowset append as two entries; no rebuild.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_disjoint_columns_append) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(10);
+    set_primary_key_schema(meta1.get(), 2001);
+    add_shared_rowset(meta1.get(), 1, 1, "shared_seg.dat");
+    (*meta1->mutable_rowset_to_schema())[1] = 2001;
+    add_dcg_with_columns(meta1.get(), 1, "a.cols", {201, 202}, 1);
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(10);
+    set_primary_key_schema(meta2.get(), 2001);
+    add_shared_rowset(meta2.get(), 1, 1, "shared_seg.dat");
+    (*meta2->mutable_rowset_to_schema())[1] = 2001;
+    add_dcg_with_columns(meta2.get(), 1, "b.cols", {301, 302}, 1);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(78);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    auto merged = tablet_metadatas.at(new_tablet_id);
+
+    ASSERT_EQ(1, merged->dcg_meta().dcgs_size());
+    const auto& entry = merged->dcg_meta().dcgs().begin()->second;
+    ASSERT_EQ(2, entry.column_files_size());
+    ASSERT_EQ(2, entry.unique_column_ids_size());
+    std::set<uint32_t> seen;
+    for (int i = 0; i < entry.unique_column_ids_size(); ++i) {
+        for (auto uid : entry.unique_column_ids(i).column_ids()) {
+            EXPECT_TRUE(seen.insert(uid).second);
+        }
+    }
+}
+
+// Conflicting columns on a shared rowset trigger the rebuild dispatch path.
+// Source .cols files don't exist on disk in this fixture, so rebuild
+// surfaces an I/O error — critically NOT the legacy "same column updated
+// independently" NotSupported message the old code produced.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_triggers_rebuild_dispatch) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(10);
+    set_primary_key_schema(meta1.get(), 3001);
+    add_shared_rowset(meta1.get(), 1, 1, "shared_seg.dat");
+    (*meta1->mutable_rowset_to_schema())[1] = 3001;
+    add_dcg_with_columns(meta1.get(), 1, "child1.cols", {401, 402}, 1);
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(10);
+    set_primary_key_schema(meta2.get(), 3001);
+    add_shared_rowset(meta2.get(), 1, 1, "shared_seg.dat");
+    (*meta2->mutable_rowset_to_schema())[1] = 3001;
+    // Column 401 overlaps with child1.cols => rebuild triggered.
+    add_dcg_with_columns(meta2.get(), 1, "child2.cols", {401, 403}, 1);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(79);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(std::string::npos, st.to_string().find("same column updated independently")) << st.to_string();
+}
+
+// Extracted Segment helper — calling segment_seek_range_to_rowid_range with
+// an unbounded SeekRange returns [0, num_rows) without touching the short
+// key index (fast path).
+TEST_F(LakeTabletReshardTest, test_segment_seek_range_to_rowid_range_unbounded) {
+    // With an empty SeekRange (default-constructed = (-inf, +inf)), the helper
+    // takes the early return branch and does not dereference the segment's
+    // short key index. A null segment is invalid and must fail fast.
+    SeekRange empty_range;
+    LakeIOOptions io_opts;
+    auto st = segment_seek_range_to_rowid_range(/*segment=*/nullptr, empty_range, io_opts);
+    EXPECT_FALSE(st.ok());
+}
+
+// Exercise the real bounded path: open a Segment from disk and ask the helper
+// to resolve an [lower, upper) SeekRange to a rowid window. This exercises
+// load_index() + _lookup_ordinal() in the extracted helper.
+TEST_F(LakeTabletReshardTest, test_segment_seek_range_to_rowid_range_real_bounded) {
+    const int64_t tablet_id = next_id();
+    prepare_tablet_dirs(tablet_id);
+
+    const int num_rows = 100;
+    const std::string segment_name = "range_lookup_seg.dat";
+    write_two_column_segment(tablet_id, segment_name, num_rows, [](int i) { return i * 10; });
+
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_id(2001);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_num_rows_per_row_block(65535);
+    auto* c0 = schema_pb.add_column();
+    c0->set_unique_id(1001);
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+    auto* c1 = schema_pb.add_column();
+    c1->set_unique_id(1002);
+    c1->set_name("c1");
+    c1->set_type("INT");
+    c1->set_is_key(false);
+    c1->set_is_nullable(false);
+    c1->set_aggregation("REPLACE");
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    FileInfo file_info;
+    file_info.path = _tablet_manager->segment_location(tablet_id, segment_name);
+    ASSIGN_OR_ABORT(auto file_system, FileSystemFactory::CreateSharedFromString(file_info.path));
+    ASSIGN_OR_ABORT(auto segment, Segment::open(file_system, file_info, 0, tablet_schema));
+
+    // Build SeekRange [30, 70): keys 30..69 inclusive lower, exclusive upper.
+    TabletRangePB range_pb;
+    range_pb.set_lower_bound_included(true);
+    range_pb.set_upper_bound_included(false);
+    *range_pb.mutable_lower_bound() = generate_sort_key(30);
+    *range_pb.mutable_upper_bound() = generate_sort_key(70);
+    ASSIGN_OR_ABORT(auto seek_range, lake::TabletRangeHelper::create_seek_range_from(range_pb, tablet_schema, nullptr));
+
+    LakeIOOptions io_opts{.fill_data_cache = false};
+    ASSIGN_OR_ABORT(auto rowid_range_opt, segment_seek_range_to_rowid_range(segment, seek_range, io_opts));
+    ASSERT_TRUE(rowid_range_opt.has_value());
+    EXPECT_EQ(30u, rowid_range_opt->begin());
+    EXPECT_EQ(70u, rowid_range_opt->end());
+
+    // A range strictly past the segment end must resolve to an empty window.
+    TabletRangePB above_pb;
+    above_pb.set_lower_bound_included(true);
+    above_pb.set_upper_bound_included(false);
+    *above_pb.mutable_lower_bound() = generate_sort_key(500);
+    *above_pb.mutable_upper_bound() = generate_sort_key(600);
+    ASSIGN_OR_ABORT(auto above_range,
+                    lake::TabletRangeHelper::create_seek_range_from(above_pb, tablet_schema, nullptr));
+    ASSIGN_OR_ABORT(auto above_rowid_opt, segment_seek_range_to_rowid_range(segment, above_range, io_opts));
+    if (above_rowid_opt.has_value()) {
+        EXPECT_EQ(above_rowid_opt->begin(), above_rowid_opt->end());
+    }
+}
+
+// Full end-to-end rebuild: two children each update column c1 on the same
+// shared segment, with disjoint row windows. Merge must produce a single new
+// .cols file whose row-by-row c1 values match each owner child's updates.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_two_children_same_column_end_to_end) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    constexpr int kNumRows = 100;
+    constexpr int kBoundary = 50; // child A owns [0, 50), child B owns [50, 100)
+    constexpr uint32_t kSegmentRssid = 1;
+    constexpr int64_t kTxnId = 777;
+
+    // 1. Write the shared base segment under the merged tablet dir. Both
+    //    children's metadata references "shared_seg.dat" and (in production
+    //    object storage) resolves to the same physical file.
+    auto source_value_of = [](int row) { return row * 10; };
+    const std::string shared_segment_name = "shared_seg.dat";
+    const uint64_t base_segment_size =
+            write_two_column_segment(merged_tablet, shared_segment_name, kNumRows, source_value_of);
+
+    // 2. Each child writes its own .cols file for column c1. A's file has
+    //    updates for rows [0, kBoundary) and source copy-through for
+    //    [kBoundary, kNumRows); B is the mirror. Filenames match the
+    //    gen_cols_filename format so that subsequent ingests can't collide.
+    auto child_a_update = [](int row) { return row + 100000; };
+    auto child_b_update = [](int row) { return row + 200000; };
+    const std::string cols_a_name = lake::gen_cols_filename(kTxnId);
+    const std::string cols_b_name = lake::gen_cols_filename(kTxnId + 1);
+    auto a_cell = [&](int row) { return row < kBoundary ? child_a_update(row) : source_value_of(row); };
+    auto b_cell = [&](int row) { return row >= kBoundary ? child_b_update(row) : source_value_of(row); };
+    write_c1_only_cols_file(child_a, cols_a_name, kNumRows, a_cell);
+    write_c1_only_cols_file(child_b, cols_b_name, kNumRows, b_cell);
+
+    // 3. Build the two children's metadata. Both share the base segment; each
+    //    owns a different key range on column c0 (the sort key).
+    auto build_child = [&](int64_t tablet_id, int lower_key, int upper_key, const std::string& cols_filename) {
+        auto metadata = std::make_shared<TabletMetadataPB>();
+        metadata->set_id(tablet_id);
+        metadata->set_version(base_version);
+        metadata->set_next_rowset_id(10);
+        const auto [c0_uid, c1_uid] = set_two_column_pk_schema(metadata.get(), 4001);
+        (void)c0_uid;
+
+        auto* tablet_range = metadata->mutable_range();
+        tablet_range->set_lower_bound_included(true);
+        tablet_range->set_upper_bound_included(false);
+        *tablet_range->mutable_lower_bound() = generate_sort_key(lower_key);
+        *tablet_range->mutable_upper_bound() = generate_sort_key(upper_key);
+
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(/*rowset_id=*/kSegmentRssid);
+        rowset->set_version(1);
+        rowset->set_num_rows(kNumRows);
+        rowset->set_data_size(base_segment_size);
+        rowset->add_segments(shared_segment_name);
+        rowset->add_segment_size(base_segment_size);
+        rowset->add_shared_segments(true);
+        *rowset->mutable_range()->mutable_lower_bound() = generate_sort_key(lower_key);
+        *rowset->mutable_range()->mutable_upper_bound() = generate_sort_key(upper_key);
+        rowset->mutable_range()->set_lower_bound_included(true);
+        rowset->mutable_range()->set_upper_bound_included(false);
+        (*metadata->mutable_rowset_to_schema())[kSegmentRssid] = 4001;
+
+        // DCG entry claims column c1 on segment kSegmentRssid.
+        auto& dcg = (*metadata->mutable_dcg_meta()->mutable_dcgs())[kSegmentRssid];
+        dcg.add_column_files(cols_filename);
+        dcg.add_unique_column_ids()->add_column_ids(c1_uid);
+        dcg.add_versions(1);
+        dcg.add_shared_files(false); // each child's local .cols
+        return metadata;
+    };
+
+    auto meta_a = build_child(child_a, 0, kBoundary, cols_a_name);
+    auto meta_b = build_child(child_b, kBoundary, kNumRows, cols_b_name);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    // 4. Run merge.
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(child_a);
+    merging_tablet.add_old_tablet_ids(child_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(kTxnId + 2);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+
+    // 5. Inspect merged metadata: exactly one DCG entry for the target
+    //    segment, one new .cols file, claims c1, shared=false.
+    ASSERT_EQ(1, merged->dcg_meta().dcgs_size());
+    const auto& dcgs = merged->dcg_meta().dcgs();
+    auto dcg_it = dcgs.find(kSegmentRssid);
+    ASSERT_TRUE(dcg_it != dcgs.end());
+    const auto& rebuilt_entry = dcg_it->second;
+    ASSERT_EQ(1, rebuilt_entry.column_files_size());
+    EXPECT_NE(cols_a_name, rebuilt_entry.column_files(0));
+    EXPECT_NE(cols_b_name, rebuilt_entry.column_files(0));
+    ASSERT_EQ(1, rebuilt_entry.unique_column_ids_size());
+    ASSERT_EQ(1, rebuilt_entry.unique_column_ids(0).column_ids_size());
+    EXPECT_EQ(1002, rebuilt_entry.unique_column_ids(0).column_ids(0));
+    ASSERT_EQ(1, rebuilt_entry.versions_size());
+    EXPECT_EQ(new_version, rebuilt_entry.versions(0));
+    ASSERT_EQ(1, rebuilt_entry.shared_files_size());
+    EXPECT_FALSE(rebuilt_entry.shared_files(0));
+
+    // 6. Read the rebuilt .cols back and assert row values reflect each
+    //    owner child's updates.
+    auto values = read_c1_only_cols_file(merged_tablet, rebuilt_entry.column_files(0));
+    ASSERT_EQ(kNumRows, static_cast<int>(values.size()));
+    for (int row = 0; row < kBoundary; ++row) {
+        EXPECT_EQ(child_a_update(row), values[row]) << "row " << row << " should carry child A's update";
+    }
+    for (int row = kBoundary; row < kNumRows; ++row) {
+        EXPECT_EQ(child_b_update(row), values[row]) << "row " << row << " should carry child B's update";
+    }
+}
+
+// When two children's DCG entries share a .cols filename but the entry
+// metadata (column set, version, encryption, etc.) disagrees, exact dedup
+// must reject the merge with Corruption via verify_dcg_entry_consistency.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup_consistency_failure) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t tablet_a = next_id();
+    const int64_t tablet_b = next_id();
+    const int64_t merged_tablet = next_id();
+    prepare_tablet_dirs(tablet_a);
+    prepare_tablet_dirs(tablet_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id, const std::vector<uint32_t>& dcg_columns) {
+        auto metadata = std::make_shared<TabletMetadataPB>();
+        metadata->set_id(tablet_id);
+        metadata->set_version(base_version);
+        metadata->set_next_rowset_id(10);
+        set_primary_key_schema(metadata.get(), 5001);
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        (*metadata->mutable_rowset_to_schema())[1] = 5001;
+        add_dcg_with_columns(metadata.get(), 1, "inconsistent.cols", dcg_columns, 1);
+        return metadata;
+    };
+
+    // Same .cols filename on the same shared target, but different columns.
+    auto meta_a = make_child(tablet_a, {601, 602});
+    auto meta_b = make_child(tablet_b, {603}); // differs from A
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(tablet_a);
+    merging_tablet.add_old_tablet_ids(tablet_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(91);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_corruption()) << st;
+    EXPECT_NE(std::string::npos, st.to_string().find("unique_column_ids")) << st.to_string();
+}
+
+// When the schema resolved from merged metadata is missing one of the
+// rebuild column UIDs, TabletSchema::create_with_uid silently drops it.
+// The rebuild must fail fast with NotSupported (via the num_columns
+// mismatch guard) instead of producing a .cols file with a silently
+// missing column.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_missing_uid_falls_back) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Schema registers only UIDs {1001, 1002}. DCG entries below claim UID
+    // 9999 which does not exist in the merged tablet schema.
+    auto make_child = [&](int64_t tablet_id, const std::string& cols_filename) {
+        auto metadata = std::make_shared<TabletMetadataPB>();
+        metadata->set_id(tablet_id);
+        metadata->set_version(base_version);
+        metadata->set_next_rowset_id(10);
+        (void)set_two_column_pk_schema(metadata.get(), 6001);
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        (*metadata->mutable_rowset_to_schema())[1] = 6001;
+        auto& dcg = (*metadata->mutable_dcg_meta()->mutable_dcgs())[1];
+        dcg.add_column_files(cols_filename);
+        dcg.add_unique_column_ids()->add_column_ids(9999);
+        dcg.add_versions(1);
+        dcg.add_shared_files(false);
+        return metadata;
+    };
+    auto meta_a = make_child(child_a, "a_missing.cols");
+    auto meta_b = make_child(child_b, "b_missing.cols");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(child_a);
+    merging_tablet.add_old_tablet_ids(child_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(92);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_not_supported()) << st;
+    // The guard message mentions missing column UIDs.
+    EXPECT_NE(std::string::npos, st.to_string().find("missing one or more rebuild column UIDs")) << st.to_string();
+}
+
+// Two conflicting shared rowsets on DIFFERENT target segments. The first
+// target rebuild writes a real .cols file; the second target fails because
+// its base segment does not exist on disk. The cleanup path must delete
+// the first target's .cols so it does not leak on publish failure.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_cleanup_on_failure) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    constexpr int kNumRows = 20;
+    constexpr int kBoundary = 10;
+    constexpr uint32_t kGoodSegmentRssid = 1;
+    constexpr uint32_t kBadSegmentRssid = 2;
+    constexpr int64_t kTxnId = 555;
+
+    // Set up target rssid=1 with a real base segment + real .cols files.
+    const std::string good_segment = "good_shared.dat";
+    auto source_value_of = [](int row) { return row * 7; };
+    const uint64_t good_seg_size = write_two_column_segment(merged_tablet, good_segment, kNumRows, source_value_of);
+    const std::string cols_a = lake::gen_cols_filename(kTxnId);
+    const std::string cols_b = lake::gen_cols_filename(kTxnId + 1);
+    auto a_cell = [&](int row) { return row < kBoundary ? row + 50000 : source_value_of(row); };
+    auto b_cell = [&](int row) { return row >= kBoundary ? row + 60000 : source_value_of(row); };
+    write_c1_only_cols_file(child_a, cols_a, kNumRows, a_cell);
+    write_c1_only_cols_file(child_b, cols_b, kNumRows, b_cell);
+
+    // Set up target rssid=2 pointing to a base segment that does NOT exist
+    // on disk. Rebuild on this target will fail when compute_row_windows
+    // tries to open the segment.
+    const std::string bad_segment = "does_not_exist.dat";
+
+    auto build_child = [&](int64_t tablet_id, int lower_key, int upper_key, const std::string& good_cols_name,
+                           const std::string& bad_cols_name) {
+        auto metadata = std::make_shared<TabletMetadataPB>();
+        metadata->set_id(tablet_id);
+        metadata->set_version(base_version);
+        metadata->set_next_rowset_id(10);
+        const auto [c0_uid, c1_uid] = set_two_column_pk_schema(metadata.get(), 7001);
+        (void)c0_uid;
+
+        auto* tablet_range = metadata->mutable_range();
+        tablet_range->set_lower_bound_included(true);
+        tablet_range->set_upper_bound_included(false);
+        *tablet_range->mutable_lower_bound() = generate_sort_key(lower_key);
+        *tablet_range->mutable_upper_bound() = generate_sort_key(upper_key);
+
+        // Good target rowset.
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(kGoodSegmentRssid);
+        rowset->set_version(1);
+        rowset->set_num_rows(kNumRows);
+        rowset->add_segments(good_segment);
+        rowset->add_segment_size(good_seg_size);
+        rowset->add_shared_segments(true);
+        *rowset->mutable_range()->mutable_lower_bound() = generate_sort_key(lower_key);
+        *rowset->mutable_range()->mutable_upper_bound() = generate_sort_key(upper_key);
+        rowset->mutable_range()->set_lower_bound_included(true);
+        rowset->mutable_range()->set_upper_bound_included(false);
+        (*metadata->mutable_rowset_to_schema())[kGoodSegmentRssid] = 7001;
+
+        // Bad target rowset (base segment file does not exist).
+        auto* bad_rowset = metadata->add_rowsets();
+        bad_rowset->set_id(kBadSegmentRssid);
+        bad_rowset->set_version(1);
+        bad_rowset->set_num_rows(10);
+        bad_rowset->add_segments(bad_segment);
+        bad_rowset->add_segment_size(100);
+        bad_rowset->add_shared_segments(true);
+        *bad_rowset->mutable_range()->mutable_lower_bound() = generate_sort_key(lower_key);
+        *bad_rowset->mutable_range()->mutable_upper_bound() = generate_sort_key(upper_key);
+        bad_rowset->mutable_range()->set_lower_bound_included(true);
+        bad_rowset->mutable_range()->set_upper_bound_included(false);
+        (*metadata->mutable_rowset_to_schema())[kBadSegmentRssid] = 7001;
+
+        auto& good_dcg = (*metadata->mutable_dcg_meta()->mutable_dcgs())[kGoodSegmentRssid];
+        good_dcg.add_column_files(good_cols_name);
+        good_dcg.add_unique_column_ids()->add_column_ids(c1_uid);
+        good_dcg.add_versions(1);
+        good_dcg.add_shared_files(false);
+        auto& bad_dcg = (*metadata->mutable_dcg_meta()->mutable_dcgs())[kBadSegmentRssid];
+        bad_dcg.add_column_files(bad_cols_name);
+        bad_dcg.add_unique_column_ids()->add_column_ids(c1_uid);
+        bad_dcg.add_versions(1);
+        bad_dcg.add_shared_files(false);
+        return metadata;
+    };
+
+    auto meta_a = build_child(child_a, 0, kBoundary, cols_a, "bad_a.cols");
+    auto meta_b = build_child(child_b, kBoundary, kNumRows, cols_b, "bad_b.cols");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    // Snapshot merged tablet's segment dir so we can detect leftover files.
+    const std::string merged_segment_dir = _location_provider->segment_root_location(merged_tablet);
+    std::set<std::string> pre_files;
+    {
+        auto status = FileSystem::Default()->iterate_dir(merged_segment_dir, [&](std::string_view name) {
+            pre_files.emplace(name);
+            return true;
+        });
+        EXPECT_TRUE(status.ok()) << status;
+    }
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(child_a);
+    merging_tablet.add_old_tablet_ids(child_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(kTxnId + 2);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    ASSERT_FALSE(st.ok()) << "expected failure on bad target rebuild";
+
+    // After cleanup, the merged tablet's segment dir should not contain any
+    // newly written .cols files (gen_cols_filename pattern uses txn id).
+    std::set<std::string> post_files;
+    {
+        auto status = FileSystem::Default()->iterate_dir(merged_segment_dir, [&](std::string_view name) {
+            post_files.emplace(name);
+            return true;
+        });
+        EXPECT_TRUE(status.ok()) << status;
+    }
+    for (const auto& file : post_files) {
+        if (pre_files.count(file) > 0) continue; // pre-existing
+        EXPECT_EQ(std::string::npos, file.find(".cols")) << "leftover .cols file after cleanup: " << file;
+    }
+}
+
 
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -5459,5 +5459,4 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_cleanup_on_failure
     }
 }
 
-
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, range-distribution tablet split creates N children that share the same physical segment/delvec/dcg files, marked `shared`. When those children are merged back, `merge_dcg_meta()` previously returned `Status::NotSupported` whenever two children had independently updated the **same column** on a shared segment. That restriction is the last gap in the merge path described in `tablet_merge.md` §4.

## What I'm doing:

Replace the `NotSupported` path with a physical rebuild that produces one consolidated `.cols` file per (target segment, conflicting-column-set). The rebuild exploits the invariant that range split assigns each child a contiguous row window of the shared segment, and any `.cols` file carries the source value for rows outside its updater's range — so per-column default-donor + updater-child window overrides reconstruct the correct post-merge column values.

Key mechanics:
- Two-pass classification of per-target DCG entries: exact dedup by `.cols` filename → non-conflicting columns pass through → conflicting columns fold into a physical rebuild.
- Source-of-truth for row-window coverage is each **source-child rowset's** range (captured in Pass 1 before `merge_rowsets()`'s `union_range` collapses shared ranges into the convex hull). This prevents a real coverage gap between child ranges from being silently masked.
- Sparse-segment-id-safe base-segment lookup via `get_rssid` scan (not arithmetic).
- Sort-key layout sourced from merged `historical_schemas` — `merge_schemas()` is reordered to run before `merge_dcg_meta()` so the schema is available.
- Donor-first column assembly with updater-child window overrides; iteration is in `rebuild_schema` positional order (`TabletSchema::create_with_uid` preserves base-schema column order) so `Chunk` column binding and the emitted `unique_column_ids` stay aligned with the written file.
- New public helper `segment_seek_range_to_rowid_range()` in `segment_iterator.h/cpp` wrapping the existing private `SegmentIterator::_seek_range_to_rowid_range` so the merge path can reuse the short-key-index + `_lookup_ordinal` machinery without duplicating it.
- Two new `bvar::Adder` counters for observability: `tablet_merge_dcg_rebuild_total` and `tablet_merge_dcg_rebuild_fallback_not_supported_total`.
- Basename-only path validation on metadata-derived filenames before `TabletManager::segment_location` joins them with a segment root.
- Best-effort cleanup of partially rebuilt `.cols` files if a later target's rebuild fails within `merge_dcg_meta()`; downstream failures still rely on standard orphan-file vacuum (matching the existing `merge_delvec_files` pattern).
- Missing-UID guard after `create_with_uid` to fail fast if the merged schema lacks a rebuild column (otherwise the UID would be silently dropped).

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Tablet merge has not shipped to users; this only tightens the set of merge cases the internal code path handles. No SQL syntax, user-visible config, or external-interface change.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4