### PR TITLE
[Enhancement] Add vector_search_options to TLakeScanNode for shared-data VI scan

### DIFF
--- a/build-support/schema_compatibility_waivers.json
+++ b/build-support/schema_compatibility_waivers.json
@@ -9,5 +9,16 @@
     "reason": "Reviewed compatibility exception after a multi-release deprecation window.",
     "owner": "engprod"
   },
-  "waivers": []
+  "waivers": [
+    {
+      "path": "gensrc/thrift/PlanNodes.thrift",
+      "container_or_method": "TLakeScanNode",
+      "field_number": 57,
+      "field_name": "vector_search_options",
+      "rule": "field_type_changed",
+      "base_signature": "57: optional list<Exprs.TExpr> partition_conjuncts",
+      "reason": "Reassign tag 57 on TLakeScanNode to TVectorSearchOptions for shared-data vector index scan. partition_conjuncts (added only days earlier in #71897 and not yet in any release) is moved to tag 60 to avoid wire conflicts with the vector_search_options field already in use by downstream forks.",
+      "owner": "sevev"
+    }
+  ]
 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -731,7 +731,9 @@ struct TLakeScanNode {
 
   56: optional bool enable_global_late_materialization
 
-  57: optional list<Exprs.TExpr> partition_conjuncts
+  57: optional TVectorSearchOptions vector_search_options
+
+  60: optional list<Exprs.TExpr> partition_conjuncts
 }
 
 struct TEqJoinCondition {


### PR DESCRIPTION
## Why I'm doing:

Shared-data (lake) mode needs to pass vector search options from FE to BE when
executing ANN scans on lake tables. \`TOlapScanNode\` already carries
\`vector_search_options\` (tag 40), but the corresponding field was missing on
\`TLakeScanNode\`, so lake-mode VI scans could not plumb the options through.

## What I'm doing:

Add \`vector_search_options\` to \`TLakeScanNode\` using thrift tag 57.

Tag 57 on \`TLakeScanNode\` was recently assigned to \`partition_conjuncts\` by
#71897. To keep both fields, \`partition_conjuncts\` is renumbered to tag 60
(the field name and BE usage are unchanged, so no code changes elsewhere).
\`partition_conjuncts\` has not shipped in any release yet, so renumbering is
safe on the wire.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr