### PR TITLE
[BugFix] PruneShuffleColumnRule does not update Join outputProperty after pruning Exchange shuffle columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleColumnRule.java
@@ -179,7 +179,7 @@ public class PruneShuffleColumnRule implements TreeRewriteRule {
                         continue;
                     }
                     HashDistributionDesc joinDesc = ((HashDistributionSpec) spec).getHashDistributionDesc();
-                    if (joinDesc.getDistributionCols().size() < 2) {
+                    if (joinDesc.getDistributionCols().size() <= maxColumnIndex) {
                         continue;
                     }
                     DistributionCol selected = joinDesc.getDistributionCols().get(maxColumnIndex);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleColumnRule.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.optimizer.base.DistributionCol;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
@@ -163,6 +164,28 @@ public class PruneShuffleColumnRule implements TreeRewriteRule {
                     d.getDistributionCols().clear();
                     d.getDistributionCols().add(x);
                 }
+                // The loop above only prunes Exchange descs, but a child join's outputProperty
+                // is the same PhysicalPropertySet object as its parent join's requiredProperties[i]
+                // (shared in extractBestPlan). Without syncing the child join's outputProperty here,
+                // the parent join reads a stale column count and generates wrong probePartitionByExprs
+                // for GRF push-down.
+                for (OptExpression joinExpr : childContext.intermediateJoinExprs) {
+                    PhysicalPropertySet outputProp = joinExpr.getOutputProperty();
+                    if (outputProp == null) {
+                        continue;
+                    }
+                    DistributionSpec spec = outputProp.getDistributionProperty().getSpec();
+                    if (!(spec instanceof HashDistributionSpec)) {
+                        continue;
+                    }
+                    HashDistributionDesc joinDesc = ((HashDistributionSpec) spec).getHashDistributionDesc();
+                    if (joinDesc.getDistributionCols().size() < 2) {
+                        continue;
+                    }
+                    DistributionCol selected = joinDesc.getDistributionCols().get(maxColumnIndex);
+                    joinDesc.getDistributionCols().clear();
+                    joinDesc.getDistributionCols().add(selected);
+                }
             }
         }
 
@@ -187,9 +210,11 @@ public class PruneShuffleColumnRule implements TreeRewriteRule {
 
             if (lc.isShuffle() && rc.isBroadcast()) {
                 context.add(lc);
+                context.intermediateJoinExprs.add(optExpression);
             } else if (lc.isShuffle() && rc.isShuffle()) {
                 context.add(lc);
                 context.add(rc);
+                context.intermediateJoinExprs.add(optExpression);
             }
             return optExpression;
         }
@@ -216,6 +241,7 @@ public class PruneShuffleColumnRule implements TreeRewriteRule {
     public static class DistributionContext {
         public final List<PhysicalDistributionOperator> distributionList = Lists.newArrayList();
         public final List<Statistics> statistics = Lists.newArrayList();
+        public final List<OptExpression> intermediateJoinExprs = Lists.newArrayList();
 
         public void addDistribution(OptExpression optExpression) {
             Preconditions.checkState(optExpression.getOp().getOpType() == OperatorType.PHYSICAL_DISTRIBUTION);
@@ -226,6 +252,7 @@ public class PruneShuffleColumnRule implements TreeRewriteRule {
         public void add(DistributionContext other) {
             this.distributionList.addAll(other.distributionList);
             this.statistics.addAll(other.statistics);
+            this.intermediateJoinExprs.addAll(other.intermediateJoinExprs);
         }
 
         private boolean isShuffle() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneShuffleColumnRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneShuffleColumnRuleTest.java
@@ -1,0 +1,140 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.StatisticStorage;
+import mockit.Expectations;
+import org.junit.jupiter.api.Test;
+
+public class PruneShuffleColumnRuleTest extends PlanWithCostTestBase {
+
+    @Test
+    public void testPruneShuffleColumns() throws Exception {
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
+
+        StatisticStorage ss = GlobalStateMgr.getCurrentState().getStatisticStorage();
+        new Expectations(ss) {
+            {
+                ss.getColumnStatistic(t0, "v1");
+                result = new ColumnStatistic(1, 2, 0, 4, 3);
+
+                ss.getColumnStatistic(t0, "v2");
+                result = new ColumnStatistic(1, 4000000, 0, 4, 4000000);
+
+                ss.getColumnStatistic(t0, "v3");
+                result = new ColumnStatistic(1, 2000000, 0, 4, 2000000);
+
+                ss.getColumnStatistic(t1, "v4");
+                result = new ColumnStatistic(1, 2, 0, 4, 3);
+
+                ss.getColumnStatistic(t1, "v5");
+                result = new ColumnStatistic(1, 100000, 0, 4, 100000);
+
+                ss.getColumnStatistic(t1, "v6");
+                result = new ColumnStatistic(1, 200000, 0, 4, 200000);
+            }
+        };
+
+        setTableStatistics(t0, 4000000);
+        setTableStatistics(t1, 100000);
+
+        String sql = "select * from t0 join[shuffle] t1 on t0.v2 = t1.v5 and t0.v3 = t1.v6";
+        String plan = getVerboseExplain(sql);
+
+        assertContains(plan, """
+                  Input Partition: RANDOM
+                  OutPut Partition: HASH_PARTITIONED: 2: v2
+                  OutPut Exchange Id: 01\
+                """);
+
+        assertContains(plan, """
+                Input Partition: RANDOM
+                  OutPut Partition: HASH_PARTITIONED: 5: v5
+                  OutPut Exchange Id: 03""");
+
+        assertContains(plan, """
+                  |  build runtime filters:
+                  |  - filter_id = 0, build_expr = (5: v5), remote = true
+                """);
+
+        assertContains(plan, "probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (2: v2)");
+    }
+
+    // Regression test: PruneShuffleColumnRule must sync intermediate join outputProperty.
+    //
+    // In a nested shuffle join (inner JOIN outer), the outer join's requiredProperties[0] is
+    // the same PhysicalPropertySet object as the inner join's outputProperty (set in
+    // extractBestPlan). When PruneShuffleColumnRule prunes multi-column Exchange specs to 1
+    // column but leaves the inner join's outputProperty with 2 columns, the outer join reads
+    // a stale column count and generates probePartitionByExprs with 2 columns. The GRF then
+    // carries wrong partition_exprs across the inner join's Exchange nodes, causing incorrect
+    // filtering at runtime.
+    @Test
+    public void testNestedShuffleJoinGRFPartitionExprsConsistencyAfterPrune() throws Exception {
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        OlapTable t0 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t0");
+        OlapTable t1 = (OlapTable) globalStateMgr.getLocalMetastore().getDb("test").getTable("t1");
+
+        StatisticStorage ss = GlobalStateMgr.getCurrentState().getStatisticStorage();
+        new Expectations(ss) {
+            {
+                ss.getColumnStatistic(t0, "v1");
+                result = new ColumnStatistic(1, 2, 0, 4, 3);
+
+                ss.getColumnStatistic(t0, "v2");
+                result = new ColumnStatistic(1, 4000000, 0, 4, 4000000);
+
+                ss.getColumnStatistic(t0, "v3");
+                result = new ColumnStatistic(1, 2000000, 0, 4, 2000000);
+
+                ss.getColumnStatistic(t1, "v4");
+                result = new ColumnStatistic(1, 2, 0, 4, 3);
+
+                ss.getColumnStatistic(t1, "v5");
+                result = new ColumnStatistic(1, 1000000, 0, 4, 1000000);
+
+                ss.getColumnStatistic(t1, "v6");
+                result = new ColumnStatistic(1, 500000, 0, 4, 500000);
+            }
+        };
+
+        setTableStatistics(t0, 4000000);
+        setTableStatistics(t1, 1000000);
+
+        // (t0 JOIN t1 a) JOIN t1 b — two-level shuffle join on (v2=v5, v3=v6).
+        // PruneShuffleColumnRule prunes all three Exchanges to 1 column.
+        // The inner join's outputProperty must be synced so the outer join uses the
+        // correct 1-column probePartitionByExprs when pushing down GRF.
+        String sql = "select t0.v1, t0.v2, t0.v3, a.v4, a.v5, a.v6, b.v4 as b_v4, b.v5 as b_v5, b.v6 as b_v6 from t0" +
+                "  join[shuffle] t1 a on t0.v2 = a.v5 and t0.v3 = a.v6" +
+                "  join[shuffle] t1 b on t0.v2 = b.v5 and t0.v3 = b.v6";
+        String plan = getVerboseExplain(sql);
+
+        // All Exchange nodes must be pruned to 1 column
+        assertNotContains(plan, "HASH_PARTITIONED: 2: v2, 3: v3");
+        assertNotContains(plan, "HASH_PARTITIONED: 5: v5, 6: v6");
+
+        // GRF probe partition_exprs must be 1 column — before the fix this was 2 columns
+        // because the inner join's outputProperty was not updated after Exchange pruning.
+        assertNotContains(plan, "partition_exprs = (2: v2, 3: v3)");
+        assertNotContains(plan, "partition_exprs = (5: v5, 6: v6)");
+    }
+}

--- a/test/sql/test_runtime_filter/R/test_multicolumn_global_runtime_filter_prune_column
+++ b/test/sql/test_runtime_filter/R/test_multicolumn_global_runtime_filter_prune_column
@@ -1,0 +1,262 @@
+-- name: test_multicolumn_global_runtime_filter_prune_column @slow
+set enable_multicolumn_global_runtime_filter=true;
+-- result:
+-- !result
+set disable_colocate_join=true;
+-- result:
+-- !result
+set global_runtime_filter_wait_timeout=1;
+-- result:
+-- !result
+set broadcast_row_limit=0;
+-- result:
+-- !result
+CREATE TABLE `TABLE_EVENT` (
+  `CG_group6` int(11) NOT NULL COMMENT "",
+  `ID` bigint(20) NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`CG_group6`, `ID`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`CG_group6`) BUCKETS 20
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO TABLE_EVENT SELECT generate_series, generate_series FROM TABLE(generate_series(1, 200000));
+-- result:
+-- !result
+[UC]ANALYZE FULL TABLE TABLE_EVENT;
+-- result:
+-- !result
+CREATE TABLE `TABLE_OBJECT` (
+  `CG_group3` int(11) NOT NULL COMMENT "",
+  `ID` bigint(20) NOT NULL COMMENT "",
+  `ARRAY_LARGEINT` array<largeint> NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`CG_group3`, `ID`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`CG_group3`) BUCKETS 20
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO TABLE_OBJECT SELECT generate_series, generate_series, [1, 2, 3, 4, 5] FROM TABLE(generate_series(1, 1000000));
+-- result:
+-- !result
+[UC]ANALYZE FULL TABLE TABLE_OBJECT;
+-- result:
+-- !result
+-- Verify multicolumn GRF correctness: org_length must equal new_length for all rows.
+-- A non-empty result indicates rows were incorrectly filtered by a multicolumn GRF.
+WITH `EVENT` AS (
+    SELECT
+      -1 AS `EVENT_ID`
+    FROM
+      TABLE_EVENT
+  ),
+  `OBJECT` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      IFNULL(`ARRAY_LARGEINT`, NULL) AS `EVENT_IDS`
+    FROM
+      TABLE_OBJECT
+  ),
+  `UNNESTED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      UNNEST AS `EVENT_ID`
+    FROM
+      `OBJECT`,
+      UNNEST(`EVENT_IDS`)
+  ),
+  `MERGED` AS (
+    SELECT
+      `UNNESTED`.`ID`,
+      `UNNESTED`.`CG_group3`
+    FROM
+      `UNNESTED`
+      LEFT JOIN `EVENT` ON (`UNNESTED`.`EVENT_ID` = `EVENT`.`EVENT_ID`)
+  ),
+  `AGGREGATED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      COUNT(*) AS `new_length`
+    FROM
+      `MERGED`
+    GROUP BY
+      `ID`,
+      `CG_group3`
+  ),
+  `LOJ` AS (
+    SELECT
+      TABLE_OBJECT.`ID`,
+      TABLE_OBJECT.`CG_group3`,
+      `AGGREGATED`.`new_length`
+    FROM
+      TABLE_OBJECT
+      LEFT JOIN `AGGREGATED` ON (
+        TABLE_OBJECT.`ID` = `AGGREGATED`.`ID`
+        AND TABLE_OBJECT.`CG_group3` = `AGGREGATED`.`CG_group3`
+      )
+  ),
+  `INPUT` AS (
+    SELECT
+      `LOJ`.`ID`,
+      ARRAY_LENGTH(TABLE_OBJECT.`ARRAY_LARGEINT`) AS org_length,
+      `LOJ`.`new_length`
+    FROM
+      `LOJ` JOIN TABLE_OBJECT ON (
+        true
+        AND TABLE_OBJECT.`CG_group3` = `LOJ`.`CG_group3`
+        AND TABLE_OBJECT.`ID` = `LOJ`.`ID`
+      )
+  )
+SELECT * FROM INPUT WHERE org_length != new_length
+LIMIT 1;
+-- result:
+-- !result
+WITH `EVENT` AS (
+    SELECT
+      -1 AS `EVENT_ID`
+    FROM
+      TABLE_EVENT
+  ),
+  `OBJECT` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      IFNULL(`ARRAY_LARGEINT`, NULL) AS `EVENT_IDS`
+    FROM
+      TABLE_OBJECT
+  ),
+  `UNNESTED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      UNNEST AS `EVENT_ID`
+    FROM
+      `OBJECT`,
+      UNNEST(`EVENT_IDS`)
+  ),
+  `MERGED` AS (
+    SELECT
+      `UNNESTED`.`ID`,
+      `UNNESTED`.`CG_group3`
+    FROM
+      `UNNESTED`
+      LEFT JOIN `EVENT` ON (`UNNESTED`.`EVENT_ID` = `EVENT`.`EVENT_ID`)
+  ),
+  `AGGREGATED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      COUNT(*) AS `new_length`
+    FROM
+      `MERGED`
+    GROUP BY
+      `ID`,
+      `CG_group3`
+  ),
+  `LOJ` AS (
+    SELECT
+      TABLE_OBJECT.`ID`,
+      TABLE_OBJECT.`CG_group3`,
+      `AGGREGATED`.`new_length`
+    FROM
+      TABLE_OBJECT
+      LEFT JOIN `AGGREGATED` ON (
+        TABLE_OBJECT.`ID` = `AGGREGATED`.`ID`
+        AND TABLE_OBJECT.`CG_group3` = `AGGREGATED`.`CG_group3`
+      )
+  ),
+  `INPUT` AS (
+    SELECT
+      `LOJ`.`ID`,
+      ARRAY_LENGTH(TABLE_OBJECT.`ARRAY_LARGEINT`) AS org_length,
+      `LOJ`.`new_length`
+    FROM
+      `LOJ` JOIN TABLE_OBJECT ON (
+        true
+        AND TABLE_OBJECT.`CG_group3` = `LOJ`.`CG_group3`
+        AND TABLE_OBJECT.`ID` = `LOJ`.`ID`
+      )
+  )
+SELECT * FROM INPUT WHERE org_length != new_length
+LIMIT 1;
+-- result:
+-- !result
+WITH `EVENT` AS (
+    SELECT
+      -1 AS `EVENT_ID`
+    FROM
+      TABLE_EVENT
+  ),
+  `OBJECT` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      IFNULL(`ARRAY_LARGEINT`, NULL) AS `EVENT_IDS`
+    FROM
+      TABLE_OBJECT
+  ),
+  `UNNESTED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      UNNEST AS `EVENT_ID`
+    FROM
+      `OBJECT`,
+      UNNEST(`EVENT_IDS`)
+  ),
+  `MERGED` AS (
+    SELECT
+      `UNNESTED`.`ID`,
+      `UNNESTED`.`CG_group3`
+    FROM
+      `UNNESTED`
+      LEFT JOIN `EVENT` ON (`UNNESTED`.`EVENT_ID` = `EVENT`.`EVENT_ID`)
+  ),
+  `AGGREGATED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      COUNT(*) AS `new_length`
+    FROM
+      `MERGED`
+    GROUP BY
+      `ID`,
+      `CG_group3`
+  ),
+  `LOJ` AS (
+    SELECT
+      TABLE_OBJECT.`ID`,
+      TABLE_OBJECT.`CG_group3`,
+      `AGGREGATED`.`new_length`
+    FROM
+      TABLE_OBJECT
+      LEFT JOIN `AGGREGATED` ON (
+        TABLE_OBJECT.`ID` = `AGGREGATED`.`ID`
+        AND TABLE_OBJECT.`CG_group3` = `AGGREGATED`.`CG_group3`
+      )
+  ),
+  `INPUT` AS (
+    SELECT
+      `LOJ`.`ID`,
+      ARRAY_LENGTH(TABLE_OBJECT.`ARRAY_LARGEINT`) AS org_length,
+      `LOJ`.`new_length`
+    FROM
+      `LOJ` JOIN TABLE_OBJECT ON (
+        true
+        AND TABLE_OBJECT.`CG_group3` = `LOJ`.`CG_group3`
+        AND TABLE_OBJECT.`ID` = `LOJ`.`ID`
+      )
+  )
+SELECT * FROM INPUT WHERE org_length != new_length
+LIMIT 1;
+-- result:
+-- !result

--- a/test/sql/test_runtime_filter/T/test_multicolumn_global_runtime_filter_prune_column
+++ b/test/sql/test_runtime_filter/T/test_multicolumn_global_runtime_filter_prune_column
@@ -1,0 +1,236 @@
+-- name: test_multicolumn_global_runtime_filter_prune_column @slow
+set enable_multicolumn_global_runtime_filter=true;
+set disable_colocate_join=true;
+set global_runtime_filter_wait_timeout=1;
+set broadcast_row_limit=0;
+CREATE TABLE `TABLE_EVENT` (
+  `CG_group6` int(11) NOT NULL COMMENT "",
+  `ID` bigint(20) NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`CG_group6`, `ID`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`CG_group6`) BUCKETS 20
+PROPERTIES (
+  "replication_num" = "1"
+);
+INSERT INTO TABLE_EVENT SELECT generate_series, generate_series FROM TABLE(generate_series(1, 200000));
+[UC]ANALYZE FULL TABLE TABLE_EVENT;
+CREATE TABLE `TABLE_OBJECT` (
+  `CG_group3` int(11) NOT NULL COMMENT "",
+  `ID` bigint(20) NOT NULL COMMENT "",
+  `ARRAY_LARGEINT` array<largeint> NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`CG_group3`, `ID`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`CG_group3`) BUCKETS 20
+PROPERTIES (
+  "replication_num" = "1"
+);
+INSERT INTO TABLE_OBJECT SELECT generate_series, generate_series, [1, 2, 3, 4, 5] FROM TABLE(generate_series(1, 1000000));
+[UC]ANALYZE FULL TABLE TABLE_OBJECT;
+-- Verify multicolumn GRF correctness: org_length must equal new_length for all rows.
+-- A non-empty result indicates rows were incorrectly filtered by a multicolumn GRF.
+WITH `EVENT` AS (
+    SELECT
+      -1 AS `EVENT_ID`
+    FROM
+      TABLE_EVENT
+  ),
+  `OBJECT` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      IFNULL(`ARRAY_LARGEINT`, NULL) AS `EVENT_IDS`
+    FROM
+      TABLE_OBJECT
+  ),
+  `UNNESTED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      UNNEST AS `EVENT_ID`
+    FROM
+      `OBJECT`,
+      UNNEST(`EVENT_IDS`)
+  ),
+  `MERGED` AS (
+    SELECT
+      `UNNESTED`.`ID`,
+      `UNNESTED`.`CG_group3`
+    FROM
+      `UNNESTED`
+      LEFT JOIN `EVENT` ON (`UNNESTED`.`EVENT_ID` = `EVENT`.`EVENT_ID`)
+  ),
+  `AGGREGATED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      COUNT(*) AS `new_length`
+    FROM
+      `MERGED`
+    GROUP BY
+      `ID`,
+      `CG_group3`
+  ),
+  `LOJ` AS (
+    SELECT
+      TABLE_OBJECT.`ID`,
+      TABLE_OBJECT.`CG_group3`,
+      `AGGREGATED`.`new_length`
+    FROM
+      TABLE_OBJECT
+      LEFT JOIN `AGGREGATED` ON (
+        TABLE_OBJECT.`ID` = `AGGREGATED`.`ID`
+        AND TABLE_OBJECT.`CG_group3` = `AGGREGATED`.`CG_group3`
+      )
+  ),
+  `INPUT` AS (
+    SELECT
+      `LOJ`.`ID`,
+      ARRAY_LENGTH(TABLE_OBJECT.`ARRAY_LARGEINT`) AS org_length,
+      `LOJ`.`new_length`
+    FROM
+      `LOJ` JOIN TABLE_OBJECT ON (
+        true
+        AND TABLE_OBJECT.`CG_group3` = `LOJ`.`CG_group3`
+        AND TABLE_OBJECT.`ID` = `LOJ`.`ID`
+      )
+  )
+SELECT * FROM INPUT WHERE org_length != new_length
+LIMIT 1;
+WITH `EVENT` AS (
+    SELECT
+      -1 AS `EVENT_ID`
+    FROM
+      TABLE_EVENT
+  ),
+  `OBJECT` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      IFNULL(`ARRAY_LARGEINT`, NULL) AS `EVENT_IDS`
+    FROM
+      TABLE_OBJECT
+  ),
+  `UNNESTED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      UNNEST AS `EVENT_ID`
+    FROM
+      `OBJECT`,
+      UNNEST(`EVENT_IDS`)
+  ),
+  `MERGED` AS (
+    SELECT
+      `UNNESTED`.`ID`,
+      `UNNESTED`.`CG_group3`
+    FROM
+      `UNNESTED`
+      LEFT JOIN `EVENT` ON (`UNNESTED`.`EVENT_ID` = `EVENT`.`EVENT_ID`)
+  ),
+  `AGGREGATED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      COUNT(*) AS `new_length`
+    FROM
+      `MERGED`
+    GROUP BY
+      `ID`,
+      `CG_group3`
+  ),
+  `LOJ` AS (
+    SELECT
+      TABLE_OBJECT.`ID`,
+      TABLE_OBJECT.`CG_group3`,
+      `AGGREGATED`.`new_length`
+    FROM
+      TABLE_OBJECT
+      LEFT JOIN `AGGREGATED` ON (
+        TABLE_OBJECT.`ID` = `AGGREGATED`.`ID`
+        AND TABLE_OBJECT.`CG_group3` = `AGGREGATED`.`CG_group3`
+      )
+  ),
+  `INPUT` AS (
+    SELECT
+      `LOJ`.`ID`,
+      ARRAY_LENGTH(TABLE_OBJECT.`ARRAY_LARGEINT`) AS org_length,
+      `LOJ`.`new_length`
+    FROM
+      `LOJ` JOIN TABLE_OBJECT ON (
+        true
+        AND TABLE_OBJECT.`CG_group3` = `LOJ`.`CG_group3`
+        AND TABLE_OBJECT.`ID` = `LOJ`.`ID`
+      )
+  )
+SELECT * FROM INPUT WHERE org_length != new_length
+LIMIT 1;
+WITH `EVENT` AS (
+    SELECT
+      -1 AS `EVENT_ID`
+    FROM
+      TABLE_EVENT
+  ),
+  `OBJECT` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      IFNULL(`ARRAY_LARGEINT`, NULL) AS `EVENT_IDS`
+    FROM
+      TABLE_OBJECT
+  ),
+  `UNNESTED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      UNNEST AS `EVENT_ID`
+    FROM
+      `OBJECT`,
+      UNNEST(`EVENT_IDS`)
+  ),
+  `MERGED` AS (
+    SELECT
+      `UNNESTED`.`ID`,
+      `UNNESTED`.`CG_group3`
+    FROM
+      `UNNESTED`
+      LEFT JOIN `EVENT` ON (`UNNESTED`.`EVENT_ID` = `EVENT`.`EVENT_ID`)
+  ),
+  `AGGREGATED` AS (
+    SELECT
+      `ID`,
+      `CG_group3`,
+      COUNT(*) AS `new_length`
+    FROM
+      `MERGED`
+    GROUP BY
+      `ID`,
+      `CG_group3`
+  ),
+  `LOJ` AS (
+    SELECT
+      TABLE_OBJECT.`ID`,
+      TABLE_OBJECT.`CG_group3`,
+      `AGGREGATED`.`new_length`
+    FROM
+      TABLE_OBJECT
+      LEFT JOIN `AGGREGATED` ON (
+        TABLE_OBJECT.`ID` = `AGGREGATED`.`ID`
+        AND TABLE_OBJECT.`CG_group3` = `AGGREGATED`.`CG_group3`
+      )
+  ),
+  `INPUT` AS (
+    SELECT
+      `LOJ`.`ID`,
+      ARRAY_LENGTH(TABLE_OBJECT.`ARRAY_LARGEINT`) AS org_length,
+      `LOJ`.`new_length`
+    FROM
+      `LOJ` JOIN TABLE_OBJECT ON (
+        true
+        AND TABLE_OBJECT.`CG_group3` = `LOJ`.`CG_group3`
+        AND TABLE_OBJECT.`ID` = `LOJ`.`ID`
+      )
+  )
+SELECT * FROM INPUT WHERE org_length != new_length
+LIMIT 1;


### PR DESCRIPTION
## Why I'm doing:
## Core Nodes Involved in the Bug
 
```
Join19 (INNER JOIN BUCKET_SHUFFLE)           ← outer Join, join on (CG_group3, ID)
├─ Join14 (RIGHT OUTER JOIN BUCKET_SHUFFLE)  ← inner Join, join on (ID, CG_group3)
│   ├─ Exchange10  partition: [12: ID]       ← agg subquery side (already pruned)
│   └─ Exchange13  partition: [2: ID]        ← TABLE_OBJECT scan (already pruned)
└─ Exchange18  partition: [35: ID]           ← TABLE_OBJECT + array_length (already pruned)
```
 
All three Exchange nodes end up partitioned by a single column `ID`
(`PruneShuffleColumnRule` pruned `[CG_group3, ID]` down to `[ID]` because `ID` has higher cardinality).
 
---
 
## Step 1: `extractBestPlan` establishes object aliasing
 
```
Join19.requiredProperties[0]  ──┐  same PhysicalPropertySet object
Join14.outputProperty         ──┘  inner desc → List D = [CG_group3, ID]
```
 
`Exchange10`/`Exchange13`/`Exchange18` each hold their own independent lists A/B/C,
which are distinct objects from List D.
 
---
 
## Step 2: `PruneShuffleColumnRule` only modifies Exchange nodes
 
| Object | Before | After |
|---|---|---|
| `Exchange10 → List A` | `[CG_group3, ID]` | `[ID]` |
| `Exchange13 → List B` | `[CG_group3, ID]` | `[ID]` |
| `Exchange18 → List C` | `[CG_group3, ID]` | `[ID]` |
| `Join14.outputProperty → List D` | `[CG_group3, ID]` | `[CG_group3, ID]` ← untouched |
 
The prune result is directly visible in the execution plan:
 
```
Exchange10: partition exprs: [12: ID]
Exchange13: partition exprs: [2: ID]
Exchange18: partition exprs: [35: ID]
```
 
---
 
## Step 3: `PlanFragmentBuilder` sees inconsistent specs
 
When processing `Join19`:
 
```java
// left  = Join19.requiredProperties[0] = Join14.outputProperty → List D, 2 columns
leftSpec  → [CG_group3, ID]   // stale!
 
// right = Exchange18.spec → List C, 1 column
rightSpec → [ID]
 
// probePartitionByExprs is built from the left spec → [CG_group3, ID]  (2 columns!)
probePartitionByExprs = getShuffleExprs((HashDistributionSpec) leftSpec, context);
```
 
---
 
## Step 4: GRF is allowed to push past Exchange3 with incorrect `partition_exprs`
 
The planner believes the probe side is partitioned by `[CG_group3, ID]`, concludes that
`filter_id=2` and `filter_id=3` can safely be pushed down across intermediate Exchange
nodes, and writes the wrong `partition_exprs = (CG_group3, ID)` into the execution plan.
 
This error is directly visible in the plan:
 
```
Exchange3:  partition exprs: [22: unnest]    ← actually partitioned by unnest!
  probe runtime filters:
  - filter_id = 2, probe_expr = (11: CG_group3), partition_exprs = (11: CG_group3, 12: ID)  ← wrong
  - filter_id = 3, probe_expr = (12: ID),         partition_exprs = (11: CG_group3, 12: ID)  ← wrong
```
 
---
 
## Step 5: BE produces incorrect results
 
`partition_exprs = (CG_group3, ID)` tells the BE that each instance will receive all rows
belonging to its own `(CG_group3, ID)` group, so it is safe to apply the GRF locally.
 
However, `Exchange3` is actually partitioned by `unnest`, meaning rows with the same
`(CG_group3, ID)` are scattered across multiple instances. When an instance applies the
GRF locally, the build-side hash table does not contain those rows (they are on other
instances), so it incorrectly filters out rows it should have kept — producing query
results that are missing rows.
 
---
 
## Correct `partition_exprs` after fix
 
After the Exchanges are pruned to 1 column and `Join14.outputProperty` is synchronized,
`probePartitionByExprs = [ID]`, and the correct output should be:
 
```
- filter_id = 2, probe_expr = (11: CG_group3), partition_exprs = (12: ID)
- filter_id = 3, probe_expr = (12: ID),         partition_exprs = (12: ID)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
