### PR TITLE
[Enhancement] support cn free tablet creation

### DIFF
--- a/be/src/storage/lake/metadata_iterator.cpp
+++ b/be/src/storage/lake/metadata_iterator.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/lake/metadata_iterator.h"
 
+#include "storage/lake/filenames.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
@@ -23,7 +24,15 @@ namespace starrocks::lake {
 template <>
 StatusOr<TabletMetadataPtr> MetadataIterator<TabletMetadataPtr>::get_metadata_from_tablet_manager(
         const std::string& path) {
-    ASSIGN_OR_RETURN(auto tablet_metadata, _manager->get_tablet_metadata(path, false));
+    TabletMetadataPtr tablet_metadata;
+    // For initial metadata path (tablet_id=0 in filename), route to the (tablet_id, version)
+    // overload using the real tablet_id held by this iterator, so that cn-free tablet creation
+    // fallback can be triggered with the correct tablet_id.
+    if (is_tablet_initial_metadata(basename(path))) {
+        ASSIGN_OR_RETURN(tablet_metadata, _manager->get_tablet_metadata(_tablet_id, 1, false));
+    } else {
+        ASSIGN_OR_RETURN(tablet_metadata, _manager->get_tablet_metadata(path, false));
+    }
 
     if (tablet_metadata->gtid() < _max_gtid) {
         return Status::NotFound("no more element");

--- a/be/src/storage/lake/table_schema_service.cpp
+++ b/be/src/storage/lake/table_schema_service.cpp
@@ -417,8 +417,10 @@ bvar::Adder<int64_t> g_initial_metadata_fetch_error("table_schema_service", "ini
 // Number of retry attempts for initial metadata fetches (excludes the initial attempt).
 bvar::Adder<int64_t> g_initial_metadata_fetch_retries("table_schema_service", "initial_metadata_fetch_retries");
 
-StatusOr<TGetTabletInitialMetadataResponse> TableSchemaService::get_tablet_initial_metadata(
-        int64_t tablet_id, int64_t table_id, int64_t partition_id, int64_t index_id) {
+StatusOr<TGetTabletInitialMetadataResponse> TableSchemaService::get_tablet_initial_metadata(int64_t tablet_id,
+                                                                                            int64_t table_id,
+                                                                                            int64_t partition_id,
+                                                                                            int64_t index_id) {
     g_initial_metadata_fetch_count << 1;
     auto start = butil::gettimeofday_us();
     DeferOp defer([&]() { g_initial_metadata_fetch_latency_us << (butil::gettimeofday_us() - start); });
@@ -436,11 +438,9 @@ StatusOr<TGetTabletInitialMetadataResponse> TableSchemaService::get_tablet_initi
 
         auto& result = sf_result->result;
 
-        VLOG(2) << "get_tablet_initial_metadata, tablet_id: " << tablet_id
-                << ", table_id: " << table_id << ", partition_id: " << partition_id
-                << ", index_id: " << index_id
-                << ", attempt: " << attempt + 1 << "/" << max_retries
-                << ", status: " << result.status();
+        VLOG(2) << "get_tablet_initial_metadata, tablet_id: " << tablet_id << ", table_id: " << table_id
+                << ", partition_id: " << partition_id << ", index_id: " << index_id << ", attempt: " << attempt + 1
+                << "/" << max_retries << ", status: " << result.status();
 
         if (result.ok()) {
             return result;
@@ -468,8 +468,10 @@ StatusOr<TGetTabletInitialMetadataResponse> TableSchemaService::get_tablet_initi
     return Status::InternalError("get_tablet_initial_metadata result is null");
 }
 
-TableSchemaService::InitialMetadataSFResultPtr TableSchemaService::_fetch_initial_metadata_via_rpc(
-        int64_t tablet_id, int64_t table_id, int64_t partition_id, int64_t index_id) {
+TableSchemaService::InitialMetadataSFResultPtr TableSchemaService::_fetch_initial_metadata_via_rpc(int64_t tablet_id,
+                                                                                                   int64_t table_id,
+                                                                                                   int64_t partition_id,
+                                                                                                   int64_t index_id) {
     TBatchGetTabletInitialMetadataRequest batch_req;
     TGetTabletInitialMetadataRequest req;
     req.__set_tablet_id(tablet_id);
@@ -504,11 +506,9 @@ TableSchemaService::InitialMetadataSFResultPtr TableSchemaService::_fetch_initia
     auto result = std::make_shared<InitialMetadataSFResult>();
 
     if (!rpc_status.ok()) {
-        LOG(WARNING) << "get_tablet_initial_metadata rpc failed, tablet_id: " << tablet_id
-                     << ", table_id: " << table_id
-                     << ", partition_id: " << partition_id << ", index_id: " << index_id
-                     << ", fe: " << fe.hostname << ":" << fe.port
-                     << ", latency: " << rpc_latency_us << "us, error: " << rpc_status;
+        LOG(WARNING) << "get_tablet_initial_metadata rpc failed, tablet_id: " << tablet_id << ", table_id: " << table_id
+                     << ", partition_id: " << partition_id << ", index_id: " << index_id << ", fe: " << fe.hostname
+                     << ":" << fe.port << ", latency: " << rpc_latency_us << "us, error: " << rpc_status;
         result->result = rpc_status;
         return result;
     }
@@ -516,8 +516,7 @@ TableSchemaService::InitialMetadataSFResultPtr TableSchemaService::_fetch_initia
     Status batch_status(batch_resp.status);
     if (!batch_status.ok()) {
         LOG(WARNING) << "get_tablet_initial_metadata batch failed, tablet_id: " << tablet_id
-                     << ", table_id: " << table_id
-                     << ", partition_id: " << partition_id << ", index_id: " << index_id
+                     << ", table_id: " << table_id << ", partition_id: " << partition_id << ", index_id: " << index_id
                      << ", error: " << batch_status;
         result->result = batch_status;
         return result;
@@ -525,8 +524,7 @@ TableSchemaService::InitialMetadataSFResultPtr TableSchemaService::_fetch_initia
 
     if (!batch_resp.__isset.responses || batch_resp.responses.empty()) {
         LOG(WARNING) << "get_tablet_initial_metadata empty response, tablet_id: " << tablet_id
-                     << ", table_id: " << table_id
-                     << ", partition_id: " << partition_id << ", index_id: " << index_id;
+                     << ", table_id: " << table_id << ", partition_id: " << partition_id << ", index_id: " << index_id;
         result->result = Status::InternalError("empty response");
         return result;
     }
@@ -534,18 +532,15 @@ TableSchemaService::InitialMetadataSFResultPtr TableSchemaService::_fetch_initia
     auto& resp = batch_resp.responses[0];
     Status resp_status(resp.status);
     if (!resp_status.ok()) {
-        LOG(INFO) << "get_tablet_initial_metadata failed, tablet_id: " << tablet_id
-                  << ", table_id: " << table_id
-                  << ", partition_id: " << partition_id << ", index_id: " << index_id
-                  << ", error: " << resp_status;
+        LOG(INFO) << "get_tablet_initial_metadata failed, tablet_id: " << tablet_id << ", table_id: " << table_id
+                  << ", partition_id: " << partition_id << ", index_id: " << index_id << ", error: " << resp_status;
         result->result = resp_status;
         return result;
     }
 
-    VLOG(2) << "get_tablet_initial_metadata success, tablet_id: " << tablet_id
-            << ", table_id: " << table_id
-            << ", partition_id: " << partition_id << ", index_id: " << index_id
-            << ", latency: " << rpc_latency_us << "us";
+    VLOG(2) << "get_tablet_initial_metadata success, tablet_id: " << tablet_id << ", table_id: " << table_id
+            << ", partition_id: " << partition_id << ", index_id: " << index_id << ", latency: " << rpc_latency_us
+            << "us";
     result->result = std::move(resp);
     return result;
 }

--- a/be/src/storage/lake/table_schema_service.cpp
+++ b/be/src/storage/lake/table_schema_service.cpp
@@ -404,4 +404,150 @@ StatusOr<TabletSchemaPtr> TableSchemaService::_fallback_load_to_schema_file(int6
     return tablet_schema;
 }
 
+// ---- CN-Free Tablet Creation: initial metadata fetch ----
+
+// Latency (in microseconds) for get_tablet_initial_metadata calls (end-to-end including SingleFlight wait).
+bvar::LatencyRecorder g_initial_metadata_fetch_latency_us("table_schema_service", "initial_metadata_fetch_us");
+// Latency (in microseconds) for individual RPC calls to FE for initial metadata fetching.
+bvar::LatencyRecorder g_initial_metadata_rpc_latency_us("table_schema_service", "initial_metadata_rpc_us");
+// Number of initial metadata fetch requests.
+bvar::Adder<int64_t> g_initial_metadata_fetch_count("table_schema_service", "initial_metadata_fetch_count");
+// Number of initial metadata fetch failures.
+bvar::Adder<int64_t> g_initial_metadata_fetch_error("table_schema_service", "initial_metadata_fetch_error");
+// Number of retry attempts for initial metadata fetches (excludes the initial attempt).
+bvar::Adder<int64_t> g_initial_metadata_fetch_retries("table_schema_service", "initial_metadata_fetch_retries");
+
+StatusOr<TGetTabletInitialMetadataResponse> TableSchemaService::get_tablet_initial_metadata(
+        int64_t tablet_id, int64_t table_id, int64_t partition_id, int64_t index_id) {
+    g_initial_metadata_fetch_count << 1;
+    auto start = butil::gettimeofday_us();
+    DeferOp defer([&]() { g_initial_metadata_fetch_latency_us << (butil::gettimeofday_us() - start); });
+
+    const int max_retries = std::max(1, config::table_schema_service_max_retries);
+    InitialMetadataSFResultPtr sf_result;
+    // Use (table_id, index_id) as SingleFlight key so concurrent requests
+    // for different tablets under the same index share one RPC.
+    std::string key = fmt::format("{}:{}", table_id, index_id);
+
+    for (int attempt = 0; attempt < max_retries; ++attempt) {
+        g_initial_metadata_fetch_retries << (attempt == 0 ? 0 : 1);
+        sf_result = _select_initial_metadata_sf_group(key).Do(
+                key, [&]() { return _fetch_initial_metadata_via_rpc(tablet_id, table_id, partition_id, index_id); });
+
+        auto& result = sf_result->result;
+
+        VLOG(2) << "get_tablet_initial_metadata, tablet_id: " << tablet_id
+                << ", table_id: " << table_id << ", partition_id: " << partition_id
+                << ", index_id: " << index_id
+                << ", attempt: " << attempt + 1 << "/" << max_retries
+                << ", status: " << result.status();
+
+        if (result.ok()) {
+            return result;
+        }
+
+        const auto& status = result.status();
+
+        // Permanent errors: do not retry
+        if (status.is_not_found() || status.is_table_not_exist()) {
+            break;
+        }
+        if (status.is_thrift_rpc_error()) {
+            break;
+        }
+
+        // Other errors (e.g. INTERNAL_ERROR): retry
+    }
+
+    if (sf_result != nullptr && !sf_result->result.ok()) {
+        g_initial_metadata_fetch_error << 1;
+    }
+    if (sf_result != nullptr) {
+        return sf_result->result;
+    }
+    return Status::InternalError("get_tablet_initial_metadata result is null");
+}
+
+TableSchemaService::InitialMetadataSFResultPtr TableSchemaService::_fetch_initial_metadata_via_rpc(
+        int64_t tablet_id, int64_t table_id, int64_t partition_id, int64_t index_id) {
+    TBatchGetTabletInitialMetadataRequest batch_req;
+    TGetTabletInitialMetadataRequest req;
+    req.__set_tablet_id(tablet_id);
+    req.__set_table_id(table_id);
+    req.__set_partition_id(partition_id);
+    req.__set_index_id(index_id);
+    batch_req.__set_requests({req});
+
+    TNetworkAddress fe = get_master_address();
+    TBatchGetTabletInitialMetadataResponse batch_resp;
+    Status rpc_status;
+    bool mock_thrift_rpc = false;
+
+#ifdef BE_TEST
+    std::array<void*, 4> test_ctx{(void*)&req, (void*)&batch_resp, (void*)&rpc_status, (void*)&mock_thrift_rpc};
+    TEST_SYNC_POINT_CALLBACK("TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", &test_ctx);
+#endif
+
+    int64_t rpc_latency_us = 0;
+    if (!mock_thrift_rpc) {
+        auto start = butil::gettimeofday_us();
+        rpc_status = ThriftRpcHelper::rpc<FrontendServiceClient>(
+                fe.hostname, fe.port,
+                [&batch_req, &batch_resp](FrontendServiceConnection& client) {
+                    client->getTabletInitialMetadata(batch_resp, batch_req);
+                },
+                config::thrift_rpc_timeout_ms);
+        rpc_latency_us = butil::gettimeofday_us() - start;
+    }
+    g_initial_metadata_rpc_latency_us << rpc_latency_us;
+
+    auto result = std::make_shared<InitialMetadataSFResult>();
+
+    if (!rpc_status.ok()) {
+        LOG(WARNING) << "get_tablet_initial_metadata rpc failed, tablet_id: " << tablet_id
+                     << ", table_id: " << table_id
+                     << ", partition_id: " << partition_id << ", index_id: " << index_id
+                     << ", fe: " << fe.hostname << ":" << fe.port
+                     << ", latency: " << rpc_latency_us << "us, error: " << rpc_status;
+        result->result = rpc_status;
+        return result;
+    }
+
+    Status batch_status(batch_resp.status);
+    if (!batch_status.ok()) {
+        LOG(WARNING) << "get_tablet_initial_metadata batch failed, tablet_id: " << tablet_id
+                     << ", table_id: " << table_id
+                     << ", partition_id: " << partition_id << ", index_id: " << index_id
+                     << ", error: " << batch_status;
+        result->result = batch_status;
+        return result;
+    }
+
+    if (!batch_resp.__isset.responses || batch_resp.responses.empty()) {
+        LOG(WARNING) << "get_tablet_initial_metadata empty response, tablet_id: " << tablet_id
+                     << ", table_id: " << table_id
+                     << ", partition_id: " << partition_id << ", index_id: " << index_id;
+        result->result = Status::InternalError("empty response");
+        return result;
+    }
+
+    auto& resp = batch_resp.responses[0];
+    Status resp_status(resp.status);
+    if (!resp_status.ok()) {
+        LOG(INFO) << "get_tablet_initial_metadata failed, tablet_id: " << tablet_id
+                  << ", table_id: " << table_id
+                  << ", partition_id: " << partition_id << ", index_id: " << index_id
+                  << ", error: " << resp_status;
+        result->result = resp_status;
+        return result;
+    }
+
+    VLOG(2) << "get_tablet_initial_metadata success, tablet_id: " << tablet_id
+            << ", table_id: " << table_id
+            << ", partition_id: " << partition_id << ", index_id: " << index_id
+            << ", latency: " << rpc_latency_us << "us";
+    result->result = std::move(resp);
+    return result;
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/table_schema_service.h
+++ b/be/src/storage/lake/table_schema_service.h
@@ -107,8 +107,7 @@ public:
      * Uses (table_id, index_id) as SingleFlight key so that concurrent requests for
      * different tablets under the same index share one RPC.
      */
-    StatusOr<TGetTabletInitialMetadataResponse> get_tablet_initial_metadata(int64_t tablet_id,
-                                                                            int64_t table_id = -1,
+    StatusOr<TGetTabletInitialMetadataResponse> get_tablet_initial_metadata(int64_t tablet_id, int64_t table_id = -1,
                                                                             int64_t partition_id = -1,
                                                                             int64_t index_id = -1);
 
@@ -230,7 +229,7 @@ private:
     using InitialMetadataSFGroup = bthreads::singleflight::Group<std::string, InitialMetadataSFResultPtr>;
 
     InitialMetadataSFResultPtr _fetch_initial_metadata_via_rpc(int64_t tablet_id, int64_t table_id,
-                                                                  int64_t partition_id, int64_t index_id);
+                                                               int64_t partition_id, int64_t index_id);
 
     InitialMetadataSFGroup& _select_initial_metadata_sf_group(const std::string& key) {
         const size_t h = std::hash<std::string>{}(key);

--- a/be/src/storage/lake/table_schema_service.h
+++ b/be/src/storage/lake/table_schema_service.h
@@ -96,6 +96,22 @@ public:
                                                   const TUniqueId& query_id, const TNetworkAddress& coordinator_fe,
                                                   const TabletMetadataPtr& tablet_meta = nullptr);
 
+    /**
+     * @brief Fetch tablet initial metadata from FE Leader for cn-free tablet creation.
+     *
+     * When cn_free_tablet_creation is enabled, DDL skips writing version 1 metadata to
+     * object storage. This method fetches the initial configuration (schema + table-level
+     * properties + tablet ranges) from FE so that the caller can construct version 1
+     * TabletMetadataPB on demand.
+     *
+     * Uses (table_id, index_id) as SingleFlight key so that concurrent requests for
+     * different tablets under the same index share one RPC.
+     */
+    StatusOr<TGetTabletInitialMetadataResponse> get_tablet_initial_metadata(int64_t tablet_id,
+                                                                            int64_t table_id = -1,
+                                                                            int64_t partition_id = -1,
+                                                                            int64_t index_id = -1);
+
 private:
     /**
      * @brief Context of the actual RPC executed by the SingleFlight leader.
@@ -206,8 +222,24 @@ private:
         return _single_flight_groups[h & (kSingleFlightGroupShards - 1)];
     }
 
+    // Initial metadata fetch for cn-free tablet creation
+    struct InitialMetadataSFResult {
+        StatusOr<TGetTabletInitialMetadataResponse> result;
+    };
+    using InitialMetadataSFResultPtr = std::shared_ptr<const InitialMetadataSFResult>;
+    using InitialMetadataSFGroup = bthreads::singleflight::Group<std::string, InitialMetadataSFResultPtr>;
+
+    InitialMetadataSFResultPtr _fetch_initial_metadata_via_rpc(int64_t tablet_id, int64_t table_id,
+                                                                  int64_t partition_id, int64_t index_id);
+
+    InitialMetadataSFGroup& _select_initial_metadata_sf_group(const std::string& key) {
+        const size_t h = std::hash<std::string>{}(key);
+        return _initial_metadata_sf_groups[h & (kSingleFlightGroupShards - 1)];
+    }
+
     TabletManager* _tablet_mgr;
     std::array<SingleFlightGroup, kSingleFlightGroupShards> _single_flight_groups;
+    std::array<InitialMetadataSFGroup, kSingleFlightGroupShards> _initial_metadata_sf_groups;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -280,8 +280,8 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
 // Parse (table_id, partition_id, index_id) from StarOS shard properties.
 // Extracted as a helper so it can be unit tested without a real g_worker.
 Status TabletManager::parse_shard_properties(int64_t tablet_id,
-                                               const std::unordered_map<std::string, std::string>& properties,
-                                               int64_t* table_id, int64_t* partition_id, int64_t* index_id) {
+                                             const std::unordered_map<std::string, std::string>& properties,
+                                             int64_t* table_id, int64_t* partition_id, int64_t* index_id) {
     *table_id = -1;
     *partition_id = -1;
     *index_id = -1;
@@ -324,12 +324,11 @@ StatusOr<TabletMetadataPtr> TabletManager::construct_initial_metadata(int64_t ta
     }
     auto shard_info_or = g_worker->retrieve_shard_info(tablet_id);
     if (!shard_info_or.ok()) {
-        return Status::InternalError(
-                fmt::format("fail to get shard info, tablet_id: {}, error: {}",
-                            tablet_id, shard_info_or.status().message()));
+        return Status::InternalError(fmt::format("fail to get shard info, tablet_id: {}, error: {}", tablet_id,
+                                                 shard_info_or.status().message()));
     }
-    RETURN_IF_ERROR(parse_shard_properties(tablet_id, shard_info_or.value().properties,
-                                             &table_id, &partition_id, &index_id));
+    RETURN_IF_ERROR(
+            parse_shard_properties(tablet_id, shard_info_or.value().properties, &table_id, &partition_id, &index_id));
 #else
     return Status::InternalError("cn-free tablet creation requires USE_STAROS");
 #endif
@@ -341,8 +340,8 @@ StatusOr<TabletMetadataPtr> TabletManager::construct_initial_metadata(int64_t ta
 
 // NOTE: if you add a new field to create_tablet(), also update this method and
 // TGetTabletInitialMetadataResponse in FrontendService.thrift to keep them in sync.
-StatusOr<TabletMetadataPtr> TabletManager::build_initial_metadata(
-        int64_t tablet_id, const TGetTabletInitialMetadataResponse& resp) {
+StatusOr<TabletMetadataPtr> TabletManager::build_initial_metadata(int64_t tablet_id,
+                                                                  const TGetTabletInitialMetadataResponse& resp) {
     auto metadata = std::make_shared<TabletMetadataPB>();
     metadata->set_id(tablet_id);
     metadata->set_version(kInitialVersion);
@@ -400,8 +399,7 @@ StatusOr<TabletMetadataPtr> TabletManager::build_initial_metadata(
             metadata->set_compaction_strategy(CompactionStrategyPB::REAL_TIME);
             break;
         default:
-            return Status::InternalError(
-                    strings::Substitute("Unknown compaction strategy, tabletId:$0", tablet_id));
+            return Status::InternalError(strings::Substitute("Unknown compaction strategy, tabletId:$0", tablet_id));
         }
     } else {
         metadata->set_compaction_strategy(CompactionStrategyPB::DEFAULT);

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -280,7 +280,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
 // Parse (table_id, partition_id, index_id) from StarOS shard properties.
 // Extracted as a helper so it can be unit tested without a real g_worker.
 Status TabletManager::parse_shard_properties(int64_t tablet_id,
-                                               const std::map<std::string, std::string>& properties,
+                                               const std::unordered_map<std::string, std::string>& properties,
                                                int64_t* table_id, int64_t* partition_id, int64_t* index_id) {
     *table_id = -1;
     *partition_id = -1;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -277,8 +277,34 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
     return put_tablet_metadata(std::move(tablet_metadata_pb));
 }
 
-// NOTE: if you add a new field to create_tablet(), also update this method and
-// TGetTabletInitialMetadataResponse in FrontendService.thrift to keep them in sync.
+// Parse (table_id, partition_id, index_id) from StarOS shard properties.
+// Extracted as a helper so it can be unit tested without a real g_worker.
+Status TabletManager::parse_shard_properties(int64_t tablet_id,
+                                               const std::map<std::string, std::string>& properties,
+                                               int64_t* table_id, int64_t* partition_id, int64_t* index_id) {
+    *table_id = -1;
+    *partition_id = -1;
+    *index_id = -1;
+    auto table_id_iter = properties.find("tableId");
+    if (table_id_iter != properties.end()) {
+        *table_id = std::atol(table_id_iter->second.data());
+    }
+    auto partition_id_iter = properties.find("partitionId");
+    if (partition_id_iter != properties.end()) {
+        *partition_id = std::atol(partition_id_iter->second.data());
+    }
+    auto index_id_iter = properties.find("indexId");
+    if (index_id_iter != properties.end()) {
+        *index_id = std::atol(index_id_iter->second.data());
+    }
+    if (*table_id <= 0 || *partition_id <= 0 || *index_id <= 0) {
+        return Status::InternalError(
+                fmt::format("incomplete shard properties, tablet_id: {}, table_id: {}, partition_id: {}, index_id: {}",
+                            tablet_id, *table_id, *partition_id, *index_id));
+    }
+    return Status::OK();
+}
+
 StatusOr<TabletMetadataPtr> TabletManager::construct_initial_metadata(int64_t tablet_id) {
     TEST_ERROR_POINT("TabletManager::construct_initial_metadata");
 #ifdef BE_TEST
@@ -293,42 +319,30 @@ StatusOr<TabletMetadataPtr> TabletManager::construct_initial_metadata(int64_t ta
     int64_t partition_id = -1;
     int64_t index_id = -1;
 #if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
-    if (g_worker != nullptr) {
-        auto shard_info_or = g_worker->retrieve_shard_info(tablet_id);
-        if (shard_info_or.ok()) {
-            const auto& properties = shard_info_or.value().properties;
-            auto table_id_iter = properties.find("tableId");
-            if (table_id_iter != properties.end()) {
-                table_id = std::atol(table_id_iter->second.data());
-            }
-            auto partition_id_iter = properties.find("partitionId");
-            if (partition_id_iter != properties.end()) {
-                partition_id = std::atol(partition_id_iter->second.data());
-            }
-            auto index_id_iter = properties.find("indexId");
-            if (index_id_iter != properties.end()) {
-                index_id = std::atol(index_id_iter->second.data());
-            }
-        } else {
-            return Status::InternalError(
-                    fmt::format("fail to get shard info, tablet_id: {}, error: {}",
-                                tablet_id, shard_info_or.status().message()));
-        }
-    } else {
+    if (g_worker == nullptr) {
         return Status::InternalError(fmt::format("starlet worker not initialized, tablet_id: {}", tablet_id));
     }
-    if (table_id <= 0 || partition_id <= 0 || index_id <= 0) {
+    auto shard_info_or = g_worker->retrieve_shard_info(tablet_id);
+    if (!shard_info_or.ok()) {
         return Status::InternalError(
-                fmt::format("incomplete shard properties, tablet_id: {}, table_id: {}, partition_id: {}, index_id: {}",
-                            tablet_id, table_id, partition_id, index_id));
+                fmt::format("fail to get shard info, tablet_id: {}, error: {}",
+                            tablet_id, shard_info_or.status().message()));
     }
+    RETURN_IF_ERROR(parse_shard_properties(tablet_id, shard_info_or.value().properties,
+                                             &table_id, &partition_id, &index_id));
 #else
     return Status::InternalError("cn-free tablet creation requires USE_STAROS");
 #endif
 
     ASSIGN_OR_RETURN(auto resp,
                      _table_schema_service->get_tablet_initial_metadata(tablet_id, table_id, partition_id, index_id));
+    return build_initial_metadata(tablet_id, resp);
+}
 
+// NOTE: if you add a new field to create_tablet(), also update this method and
+// TGetTabletInitialMetadataResponse in FrontendService.thrift to keep them in sync.
+StatusOr<TabletMetadataPtr> TabletManager::build_initial_metadata(
+        int64_t tablet_id, const TGetTabletInitialMetadataResponse& resp) {
     auto metadata = std::make_shared<TabletMetadataPB>();
     metadata->set_id(tablet_id);
     metadata->set_version(kInitialVersion);

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -207,6 +207,8 @@ UpdateManager* TabletManager::update_mgr() {
     return _update_mgr;
 }
 
+// NOTE: if you add a new field here, also update construct_initial_metadata() and
+// TGetTabletInitialMetadataResponse in FrontendService.thrift to keep them in sync.
 Status TabletManager::create_tablet(const TCreateTabletReq& req) {
     // generate tablet metadata pb
     auto tablet_metadata_pb = std::make_shared<TabletMetadataPB>();
@@ -273,6 +275,125 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
     }
 
     return put_tablet_metadata(std::move(tablet_metadata_pb));
+}
+
+// NOTE: if you add a new field to create_tablet(), also update this method and
+// TGetTabletInitialMetadataResponse in FrontendService.thrift to keep them in sync.
+StatusOr<TabletMetadataPtr> TabletManager::construct_initial_metadata(int64_t tablet_id) {
+    TEST_ERROR_POINT("TabletManager::construct_initial_metadata");
+#ifdef BE_TEST
+    // In unit test environment, starlet worker is not available. Return NOT_FOUND so
+    // that callers treat cn-free fallback as a normal "tablet not found" case.
+    return Status::NotFound(fmt::format("cn-free tablet creation disabled in unit test, tablet_id: {}", tablet_id));
+#endif
+    // Get (table_id, partition_id, index_id) from shard info.
+    // These are used for the FE RPC request and for SingleFlight grouping by (table_id, index_id),
+    // so concurrent requests for different tablets under the same index share one RPC.
+    int64_t table_id = -1;
+    int64_t partition_id = -1;
+    int64_t index_id = -1;
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
+    if (g_worker != nullptr) {
+        auto shard_info_or = g_worker->retrieve_shard_info(tablet_id);
+        if (shard_info_or.ok()) {
+            const auto& properties = shard_info_or.value().properties;
+            auto table_id_iter = properties.find("tableId");
+            if (table_id_iter != properties.end()) {
+                table_id = std::atol(table_id_iter->second.data());
+            }
+            auto partition_id_iter = properties.find("partitionId");
+            if (partition_id_iter != properties.end()) {
+                partition_id = std::atol(partition_id_iter->second.data());
+            }
+            auto index_id_iter = properties.find("indexId");
+            if (index_id_iter != properties.end()) {
+                index_id = std::atol(index_id_iter->second.data());
+            }
+        } else {
+            return Status::InternalError(
+                    fmt::format("fail to get shard info, tablet_id: {}, error: {}",
+                                tablet_id, shard_info_or.status().message()));
+        }
+    } else {
+        return Status::InternalError(fmt::format("starlet worker not initialized, tablet_id: {}", tablet_id));
+    }
+    if (table_id <= 0 || partition_id <= 0 || index_id <= 0) {
+        return Status::InternalError(
+                fmt::format("incomplete shard properties, tablet_id: {}, table_id: {}, partition_id: {}, index_id: {}",
+                            tablet_id, table_id, partition_id, index_id));
+    }
+#else
+    return Status::InternalError("cn-free tablet creation requires USE_STAROS");
+#endif
+
+    ASSIGN_OR_RETURN(auto resp,
+                     _table_schema_service->get_tablet_initial_metadata(tablet_id, table_id, partition_id, index_id));
+
+    auto metadata = std::make_shared<TabletMetadataPB>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(kInitialVersion);
+    metadata->set_next_rowset_id(1);
+    metadata->set_cumulative_point(0);
+    metadata->set_gtid(resp.gtid);
+
+    // schema
+    auto compress_type = resp.__isset.compression_type ? resp.compression_type : TCompressionType::LZ4_FRAME;
+    RETURN_IF_ERROR(convert_t_schema_to_pb_schema(resp.schema, compress_type, metadata->mutable_schema()));
+    auto compression_level = resp.__isset.compression_level ? resp.compression_level : -1;
+    metadata->mutable_schema()->set_compression_level(compression_level);
+
+    // range: look up this tablet's range from the tablet_ranges map
+    if (resp.__isset.tablet_ranges) {
+        auto it = resp.tablet_ranges.find(tablet_id);
+        if (it != resp.tablet_ranges.end()) {
+            ASSIGN_OR_RETURN(auto range_pb, TabletRangeHelper::convert_t_range_to_pb_range(it->second));
+            *metadata->mutable_range() = range_pb;
+        }
+    }
+
+    // persistent index
+    if (resp.__isset.enable_persistent_index) {
+        metadata->set_enable_persistent_index(resp.enable_persistent_index);
+        if (resp.__isset.persistent_index_type) {
+            switch (resp.persistent_index_type) {
+            case TPersistentIndexType::LOCAL:
+                metadata->set_persistent_index_type(PersistentIndexTypePB::LOCAL);
+                break;
+            case TPersistentIndexType::CLOUD_NATIVE:
+                metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+                break;
+            default:
+                return Status::InternalError(
+                        strings::Substitute("Unknown persistent index type, tabletId:$0", tablet_id));
+            }
+        }
+    }
+
+    // flat json config
+    if (resp.__isset.flat_json_config) {
+        FlatJsonConfig flat_json_config;
+        flat_json_config.update(resp.flat_json_config);
+        flat_json_config.to_pb(metadata->mutable_flat_json_config());
+    }
+
+    // compaction strategy
+    if (resp.__isset.compaction_strategy) {
+        switch (resp.compaction_strategy) {
+        case TCompactionStrategy::DEFAULT:
+            metadata->set_compaction_strategy(CompactionStrategyPB::DEFAULT);
+            break;
+        case TCompactionStrategy::REAL_TIME:
+            metadata->set_compaction_strategy(CompactionStrategyPB::REAL_TIME);
+            break;
+        default:
+            return Status::InternalError(
+                    strings::Substitute("Unknown compaction strategy, tabletId:$0", tablet_id));
+        }
+    } else {
+        metadata->set_compaction_strategy(CompactionStrategyPB::DEFAULT);
+    }
+
+    return metadata;
 }
 
 StatusOr<Tablet> TabletManager::get_tablet(int64_t tablet_id) {
@@ -575,6 +696,20 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
             auto metadata = const_cast<starrocks::TabletMetadataPB*>(metadata_or.value().get());
             metadata->set_id(tablet_id);
         }
+    }
+
+    // CN-Free Tablet Creation fallback: when cn_free_tablet_creation is enabled, DDL skips
+    // writing version 1 metadata to object storage. When a consumer first needs version 1
+    // metadata, we fetch the tablet's initial configuration from FE and construct the
+    // TabletMetadataPB on demand.
+    //
+    // The fs == nullptr check excludes cross-cluster replication reads, where |fs| points to
+    // the source cluster's object storage. Without this check, a source tablet_id that
+    // coincidentally matches a local tablet_id would cause us to fetch the wrong metadata
+    // from the local FE. Other local callers that pass non-null fs (e.g. LakeDelvecLoader)
+    // do not request version 1 in practice, since version 1 has no rowsets or delvecs.
+    if (metadata_or.status().is_not_found() && tablet_id != 0 && version == kInitialVersion && fs == nullptr) {
+        metadata_or = construct_initial_metadata(tablet_id);
     }
 
     if (!metadata_or.ok()) {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -308,8 +308,8 @@ private:
                                                        const TGetTabletInitialMetadataResponse& resp);
     // Parse (table_id, partition_id, index_id) from StarOS shard properties. Exposed for unit tests.
     static Status parse_shard_properties(int64_t tablet_id,
-                                          const std::unordered_map<std::string, std::string>& properties,
-                                          int64_t* table_id, int64_t* partition_id, int64_t* index_id);
+                                         const std::unordered_map<std::string, std::string>& properties,
+                                         int64_t* table_id, int64_t* partition_id, int64_t* index_id);
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);
     StatusOr<CombinedTxnLogPtr> load_combined_txn_log(const std::string& path, bool fill_cache);
     Status corrupted_tablet_meta_handler(const Status& s, const std::string& metadata_location);

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -308,7 +308,7 @@ private:
                                                        const TGetTabletInitialMetadataResponse& resp);
     // Parse (table_id, partition_id, index_id) from StarOS shard properties. Exposed for unit tests.
     static Status parse_shard_properties(int64_t tablet_id,
-                                          const std::map<std::string, std::string>& properties,
+                                          const std::unordered_map<std::string, std::string>& properties,
                                           int64_t* table_id, int64_t* partition_id, int64_t* index_id);
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);
     StatusOr<CombinedTxnLogPtr> load_combined_txn_log(const std::string& path, bool fill_cache);

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -39,6 +39,7 @@ struct TabletBasicInfo;
 class Segment;
 class TabletSchemaPB;
 class TCreateTabletReq;
+class TGetTabletInitialMetadataResponse;
 } // namespace starrocks
 
 namespace starrocks::lake {
@@ -302,6 +303,13 @@ private:
     StatusOr<TabletMetadataPtr> load_tablet_metadata(const std::string& metadata_location, bool fill_data_cache,
                                                      int64_t expected_gtid, const std::shared_ptr<FileSystem>& fs);
     StatusOr<TabletMetadataPtr> construct_initial_metadata(int64_t tablet_id);
+    // Build version 1 TabletMetadataPB from a FE response. Exposed for unit tests.
+    StatusOr<TabletMetadataPtr> build_initial_metadata(int64_t tablet_id,
+                                                       const TGetTabletInitialMetadataResponse& resp);
+    // Parse (table_id, partition_id, index_id) from StarOS shard properties. Exposed for unit tests.
+    static Status parse_shard_properties(int64_t tablet_id,
+                                          const std::map<std::string, std::string>& properties,
+                                          int64_t* table_id, int64_t* partition_id, int64_t* index_id);
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);
     StatusOr<CombinedTxnLogPtr> load_combined_txn_log(const std::string& path, bool fill_cache);
     Status corrupted_tablet_meta_handler(const Status& s, const std::string& metadata_location);

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -301,6 +301,7 @@ private:
     Status put_tablet_metadata(const TabletMetadataPtr& metadata, const std::string& metadata_location);
     StatusOr<TabletMetadataPtr> load_tablet_metadata(const std::string& metadata_location, bool fill_data_cache,
                                                      int64_t expected_gtid, const std::shared_ptr<FileSystem>& fs);
+    StatusOr<TabletMetadataPtr> construct_initial_metadata(int64_t tablet_id);
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);
     StatusOr<CombinedTxnLogPtr> load_combined_txn_log(const std::string& path, bool fill_cache);
     Status corrupted_tablet_meta_handler(const Status& s, const std::string& metadata_location);

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1431,7 +1431,8 @@ Status drop_tablet_cache(TabletManager* tablet_mgr, int64_t tablet_id, int64_t v
             VLOG(3) << "fail to get file system for tablet " << tablet_id << ", error: " << fs_or.status();
         }
     };
-    while (version > 0) {
+    // Skip version 1 which is the initial empty metadata (no rowsets, no delvecs to drop).
+    while (version > 1) {
         auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false /* No need to fill meta cache */,
                                                    false /* No need to fill data cache */);
         if (res.status().is_not_found()) {

--- a/be/test/storage/lake/table_schema_service_test.cpp
+++ b/be/test/storage/lake/table_schema_service_test.cpp
@@ -855,12 +855,12 @@ TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_not_found) {
 TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_rpc_error) {
     ScopedSyncPoint sync_point;
 
-    SyncPoint::GetInstance()->SetCallBack(
-            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
-                auto ctx = unpack_initial_metadata_hook_args(arg);
-                *ctx.mock_thrift_rpc = true;
-                *ctx.status = Status::ThriftRpcError("connection refused");
-            });
+    SyncPoint::GetInstance()->SetCallBack("TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook",
+                                          [&](void* arg) {
+                                              auto ctx = unpack_initial_metadata_hook_args(arg);
+                                              *ctx.mock_thrift_rpc = true;
+                                              *ctx.status = Status::ThriftRpcError("connection refused");
+                                          });
 
     auto result = _schema_service->get_tablet_initial_metadata(next_id(), next_id(), next_id(), next_id());
     ASSERT_FALSE(result.ok());

--- a/be/test/storage/lake/table_schema_service_test.cpp
+++ b/be/test/storage/lake/table_schema_service_test.cpp
@@ -1050,7 +1050,7 @@ TEST_F(TableSchemaServiceTest, parse_shard_properties) {
 
     // Case 1: all fields present and valid
     {
-        std::map<std::string, std::string> properties;
+        std::unordered_map<std::string, std::string> properties;
         properties["tableId"] = "100";
         properties["partitionId"] = "200";
         properties["indexId"] = "300";
@@ -1063,7 +1063,7 @@ TEST_F(TableSchemaServiceTest, parse_shard_properties) {
 
     // Case 2: missing required property
     {
-        std::map<std::string, std::string> properties;
+        std::unordered_map<std::string, std::string> properties;
         properties["tableId"] = "100";
         properties["partitionId"] = "200";
         // missing indexId

--- a/be/test/storage/lake/table_schema_service_test.cpp
+++ b/be/test/storage/lake/table_schema_service_test.cpp
@@ -867,9 +867,45 @@ TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_rpc_error) {
     ASSERT_TRUE(result.status().is_thrift_rpc_error());
 }
 
-TEST_F(TableSchemaServiceTest, construct_initial_metadata_fields_match_create_tablet) {
+TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_batch_error) {
     ScopedSyncPoint sync_point;
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+                // Batch-level status is not OK
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::INTERNAL_ERROR,
+                                                   "mocked batch error");
+            });
+
+    auto result = _schema_service->get_tablet_initial_metadata(next_id(), next_id(), next_id(), next_id());
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_internal_error());
+}
+
+TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_empty_response) {
+    ScopedSyncPoint sync_point;
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                // No responses set, empty batch response
+            });
+
+    auto result = _schema_service->get_tablet_initial_metadata(next_id(), next_id(), next_id(), next_id());
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_internal_error());
+    ASSERT_TRUE(result.status().message().find("empty response") != std::string::npos);
+}
+
+TEST_F(TableSchemaServiceTest, construct_initial_metadata_fields_match_create_tablet) {
     auto tablet_id_a = next_id();
+    auto tablet_id_b = next_id();
     auto schema_id = next_id();
 
     // 1. Build TCreateTabletReq and create tablet A via create_tablet()
@@ -890,56 +926,22 @@ TEST_F(TableSchemaServiceTest, construct_initial_metadata_fields_match_create_ta
     ASSERT_OK(_tablet_manager->create_tablet(create_req));
     ASSIGN_OR_ABORT(auto metadata_a, _tablet_manager->get_tablet_metadata(tablet_id_a, 1));
 
-    // 2. Mock RPC to return the same fields, then call get_tablet_initial_metadata directly
-    SyncPoint::GetInstance()->SetCallBack(
-            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
-                auto ctx = unpack_initial_metadata_hook_args(arg);
-                *ctx.mock_thrift_rpc = true;
-                *ctx.status = Status::OK();
+    // 2. Build a mocked FE response with the same field values
+    TGetTabletInitialMetadataResponse resp;
+    set_status(&resp.status, TStatusCode::OK);
+    resp.__set_schema(thrift_schema);
+    resp.__set_enable_persistent_index(true);
+    resp.__set_persistent_index_type(TPersistentIndexType::CLOUD_NATIVE);
+    resp.__set_compaction_strategy(TCompactionStrategy::REAL_TIME);
+    resp.__set_compression_type(TCompressionType::LZ4_FRAME);
+    resp.__set_compression_level(5);
+    resp.__set_gtid(99999);
 
-                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
-                ctx.response->__set_responses(std::vector<TGetTabletInitialMetadataResponse>{});
-                auto& resp = ctx.response->responses.emplace_back();
-                TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
-                resp.__set_schema(thrift_schema);
-                resp.__set_enable_persistent_index(true);
-                resp.__set_persistent_index_type(TPersistentIndexType::CLOUD_NATIVE);
-                resp.__set_compaction_strategy(TCompactionStrategy::REAL_TIME);
-                resp.__set_compression_type(TCompressionType::LZ4_FRAME);
-                resp.__set_compression_level(5);
-                resp.__set_gtid(99999);
-            });
-
-    // 3. Get response and manually build metadata_b the same way construct_initial_metadata does
-    auto tablet_id_b = next_id();
-    auto resp_or = _schema_service->get_tablet_initial_metadata(tablet_id_b, next_id(), next_id(), next_id());
-    ASSERT_TRUE(resp_or.ok());
-    auto& resp = resp_or.value();
-
-    auto metadata_b = std::make_shared<TabletMetadataPB>();
-    metadata_b->set_id(tablet_id_b);
-    metadata_b->set_version(1);
-    metadata_b->set_next_rowset_id(1);
-    metadata_b->set_cumulative_point(0);
-    metadata_b->set_gtid(resp.gtid);
-    auto compress_type = resp.__isset.compression_type ? resp.compression_type : TCompressionType::LZ4_FRAME;
-    ASSERT_OK(convert_t_schema_to_pb_schema(resp.schema, compress_type, metadata_b->mutable_schema()));
-    metadata_b->mutable_schema()->set_compression_level(resp.__isset.compression_level ? resp.compression_level : -1);
-    if (resp.__isset.enable_persistent_index) {
-        metadata_b->set_enable_persistent_index(resp.enable_persistent_index);
-    }
-    if (resp.__isset.persistent_index_type) {
-        metadata_b->set_persistent_index_type(resp.persistent_index_type == TPersistentIndexType::LOCAL
-                                                      ? PersistentIndexTypePB::LOCAL
-                                                      : PersistentIndexTypePB::CLOUD_NATIVE);
-    }
-    if (resp.__isset.compaction_strategy) {
-        metadata_b->set_compaction_strategy(resp.compaction_strategy == TCompactionStrategy::DEFAULT
-                                                    ? CompactionStrategyPB::DEFAULT
-                                                    : CompactionStrategyPB::REAL_TIME);
-    }
+    // 3. Directly call build_initial_metadata to test field assembly
+    ASSIGN_OR_ABORT(auto metadata_b, _tablet_manager->build_initial_metadata(tablet_id_b, resp));
 
     // 4. Compare fields
+    ASSERT_EQ(tablet_id_b, metadata_b->id());
     ASSERT_EQ(metadata_a->version(), metadata_b->version());
     ASSERT_EQ(metadata_a->next_rowset_id(), metadata_b->next_rowset_id());
     ASSERT_EQ(metadata_a->cumulative_point(), metadata_b->cumulative_point());
@@ -949,6 +951,126 @@ TEST_F(TableSchemaServiceTest, construct_initial_metadata_fields_match_create_ta
     ASSERT_EQ(metadata_a->compaction_strategy(), metadata_b->compaction_strategy());
     ASSERT_EQ(metadata_a->schema().id(), metadata_b->schema().id());
     ASSERT_EQ(metadata_a->schema().compression_level(), metadata_b->schema().compression_level());
+}
+
+TEST_F(TableSchemaServiceTest, build_initial_metadata) {
+    auto schema_id = next_id();
+
+    // Case 1: defaults (only schema set)
+    {
+        auto tablet_id = next_id();
+        TGetTabletInitialMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+        resp.__set_schema(make_thrift_schema(schema_id));
+
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
+        ASSERT_EQ(tablet_id, metadata->id());
+        ASSERT_EQ(1, metadata->version());
+        ASSERT_EQ(1, metadata->next_rowset_id());
+        ASSERT_EQ(0, metadata->cumulative_point());
+        ASSERT_FALSE(metadata->has_range());
+        ASSERT_FALSE(metadata->has_flat_json_config());
+        // compaction_strategy defaults to DEFAULT when not set
+        ASSERT_EQ(CompactionStrategyPB::DEFAULT, metadata->compaction_strategy());
+        // compression_level defaults to -1
+        ASSERT_EQ(-1, metadata->schema().compression_level());
+    }
+
+    // Case 2: LOCAL persistent index type
+    {
+        auto tablet_id = next_id();
+        TGetTabletInitialMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+        resp.__set_schema(make_thrift_schema(schema_id));
+        resp.__set_enable_persistent_index(true);
+        resp.__set_persistent_index_type(TPersistentIndexType::LOCAL);
+
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
+        ASSERT_TRUE(metadata->enable_persistent_index());
+        ASSERT_EQ(PersistentIndexTypePB::LOCAL, metadata->persistent_index_type());
+    }
+
+    // Case 3: tablet_ranges contains this tablet's range
+    {
+        auto tablet_id = next_id();
+        auto other_tablet_id = next_id();
+        TGetTabletInitialMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+        resp.__set_schema(make_thrift_schema(schema_id));
+
+        std::map<int64_t, TTabletRange> tablet_ranges;
+        TTabletRange range;
+        range.__set_lower_bound_included(true);
+        range.__set_upper_bound_included(false);
+        tablet_ranges[tablet_id] = range;
+        tablet_ranges[other_tablet_id] = TTabletRange();
+        resp.__set_tablet_ranges(tablet_ranges);
+
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
+        ASSERT_TRUE(metadata->has_range());
+        ASSERT_TRUE(metadata->range().lower_bound_included());
+        ASSERT_FALSE(metadata->range().upper_bound_included());
+    }
+
+    // Case 4: tablet_ranges set but does not contain this tablet
+    {
+        auto tablet_id = next_id();
+        TGetTabletInitialMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+        resp.__set_schema(make_thrift_schema(schema_id));
+        std::map<int64_t, TTabletRange> tablet_ranges;
+        tablet_ranges[next_id()] = TTabletRange();
+        resp.__set_tablet_ranges(tablet_ranges);
+
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
+        ASSERT_FALSE(metadata->has_range());
+    }
+
+    // Case 5: flat_json_config is set
+    {
+        auto tablet_id = next_id();
+        TGetTabletInitialMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+        resp.__set_schema(make_thrift_schema(schema_id));
+        TFlatJsonConfig flat_json;
+        flat_json.__set_flat_json_enable(true);
+        flat_json.__set_flat_json_null_factor(0.3);
+        flat_json.__set_flat_json_sparsity_factor(0.9);
+        flat_json.__set_flat_json_column_max(100);
+        resp.__set_flat_json_config(flat_json);
+
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
+        ASSERT_TRUE(metadata->has_flat_json_config());
+        ASSERT_TRUE(metadata->flat_json_config().flat_json_enable());
+    }
+}
+
+TEST_F(TableSchemaServiceTest, parse_shard_properties) {
+    int64_t tablet_id = next_id();
+
+    // Case 1: all fields present and valid
+    {
+        std::map<std::string, std::string> properties;
+        properties["tableId"] = "100";
+        properties["partitionId"] = "200";
+        properties["indexId"] = "300";
+        int64_t table_id = 0, partition_id = 0, index_id = 0;
+        ASSERT_OK(TabletManager::parse_shard_properties(tablet_id, properties, &table_id, &partition_id, &index_id));
+        ASSERT_EQ(100, table_id);
+        ASSERT_EQ(200, partition_id);
+        ASSERT_EQ(300, index_id);
+    }
+
+    // Case 2: missing required property
+    {
+        std::map<std::string, std::string> properties;
+        properties["tableId"] = "100";
+        properties["partitionId"] = "200";
+        // missing indexId
+        int64_t table_id = 0, partition_id = 0, index_id = 0;
+        auto st = TabletManager::parse_shard_properties(tablet_id, properties, &table_id, &partition_id, &index_id);
+        ASSERT_TRUE(st.is_internal_error());
+    }
 }
 
 TEST_F(TableSchemaServiceTest, cn_free_fallback_not_triggered_for_version_gt_1) {

--- a/be/test/storage/lake/table_schema_service_test.cpp
+++ b/be/test/storage/lake/table_schema_service_test.cpp
@@ -212,6 +212,23 @@ protected:
         out.mock_thrift_rpc = static_cast<bool*>((*arr)[3]);
         return out;
     }
+
+    struct InitialMetadataRpcHookArgs {
+        const TGetTabletInitialMetadataRequest* request = nullptr;
+        TBatchGetTabletInitialMetadataResponse* response = nullptr;
+        Status* status = nullptr;
+        bool* mock_thrift_rpc = nullptr;
+    };
+
+    static InitialMetadataRpcHookArgs unpack_initial_metadata_hook_args(void* arg) {
+        auto* arr = static_cast<std::array<void*, 4>*>(arg);
+        InitialMetadataRpcHookArgs out;
+        out.request = static_cast<const TGetTabletInitialMetadataRequest*>((*arr)[0]);
+        out.response = static_cast<TBatchGetTabletInitialMetadataResponse*>((*arr)[1]);
+        out.status = static_cast<Status*>((*arr)[2]);
+        out.mock_thrift_rpc = static_cast<bool*>((*arr)[3]);
+        return out;
+    }
     void clear_and_init_test_dir() {
         (void)fs::remove_all(_test_directory);
         CHECK_OK(fs::create_directories(join_path(_test_directory, kSegmentDirectoryName)));
@@ -344,6 +361,14 @@ protected:
         setup_rpc_test_hook([](const RpcHookArgs& ctx) {
             *ctx.mock_thrift_rpc = true;
             *ctx.status = Status::ThriftRpcError("Invalid method name 'getTableSchema'");
+        });
+    }
+
+    void setup_skip_construct_initial_metadata() {
+        SyncPoint::GetInstance()->SetCallBack("TabletManager::construct_initial_metadata", [](void* arg) {
+            // Return NOT_FOUND to simulate tablet not existing, because construct_initial_metadata
+            // requires g_worker (StarOS) which is unavailable in unit tests.
+            *static_cast<Status*>(arg) = Status::NotFound("skipped by test");
         });
     }
 
@@ -504,7 +529,10 @@ TEST_F(TableSchemaServiceTest, remote_error_handling) {
 
     const std::vector<Case> cases{
             {"method_not_found_maps_to_not_supported",
-             [](TableSchemaServiceTest* t) { t->setup_rpc_method_not_found(); },
+             [](TableSchemaServiceTest* t) {
+                 t->setup_rpc_method_not_found();
+                 t->setup_skip_construct_initial_metadata();
+             },
              [](const Status& st) { ASSERT_TRUE(st.is_not_found()) << st; }},
             {"other_thrift_rpc_error_fail_fast", [](TableSchemaServiceTest* t) { t->setup_rpc_other_thrift_error(); },
              [](const Status& st) { ASSERT_TRUE(st.is_thrift_rpc_error()) << st; }},
@@ -607,6 +635,8 @@ TEST_F(TableSchemaServiceTest, load_fallback_to_tablet_schema) {
 
         setup_rpc_method_not_found();
         mock_tablet_schema_by_id(Status::NotFound("mocked not found"));
+        // Mock cn-free fallback RPC to return NOT_FOUND, otherwise it tries real RPC
+        setup_skip_construct_initial_metadata();
 
         auto result = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), tablet_id, 1);
         ASSERT_TRUE(result.status().is_not_found());
@@ -759,6 +789,216 @@ TEST_F(TableSchemaServiceTest, query_interference) {
     ASSERT_FALSE(barrier.timed_out()) << "Timed out waiting for follower to join singleflight group";
     ASSERT_TRUE((r1.ok() && !r2.ok()) || (!r1.ok() && r2.ok()));
     ASSERT_GE(rpc_call_count.load(), 2);
+}
+
+TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_success) {
+    ScopedSyncPoint sync_point;
+    auto schema_id = next_id();
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                ctx.response->__set_responses(std::vector<TGetTabletInitialMetadataResponse>{});
+                auto& resp = ctx.response->responses.emplace_back();
+                TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+                resp.__set_schema(TableSchemaServiceTest::make_thrift_schema(schema_id));
+                resp.__set_enable_persistent_index(true);
+                resp.__set_persistent_index_type(TPersistentIndexType::CLOUD_NATIVE);
+                resp.__set_compaction_strategy(TCompactionStrategy::REAL_TIME);
+                resp.__set_compression_type(TCompressionType::LZ4_FRAME);
+                resp.__set_compression_level(3);
+                resp.__set_gtid(12345);
+            });
+
+    auto tablet_id = next_id();
+    auto table_id = next_id();
+    auto partition_id = next_id();
+    auto index_id = next_id();
+    auto result = _schema_service->get_tablet_initial_metadata(tablet_id, table_id, partition_id, index_id);
+    ASSERT_TRUE(result.ok());
+
+    auto& resp = result.value();
+    ASSERT_TRUE(resp.__isset.schema);
+    ASSERT_EQ(schema_id, resp.schema.id);
+    ASSERT_TRUE(resp.enable_persistent_index);
+    ASSERT_EQ(TPersistentIndexType::CLOUD_NATIVE, resp.persistent_index_type);
+    ASSERT_EQ(TCompactionStrategy::REAL_TIME, resp.compaction_strategy);
+    ASSERT_EQ(TCompressionType::LZ4_FRAME, resp.compression_type);
+    ASSERT_EQ(3, resp.compression_level);
+    ASSERT_EQ(12345, resp.gtid);
+}
+
+TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_not_found) {
+    ScopedSyncPoint sync_point;
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                ctx.response->__set_responses(std::vector<TGetTabletInitialMetadataResponse>{});
+                auto& resp = ctx.response->responses.emplace_back();
+                TableSchemaServiceTest::set_status(&resp.status, TStatusCode::NOT_FOUND, "tablet not found");
+            });
+
+    auto result = _schema_service->get_tablet_initial_metadata(next_id(), next_id(), next_id(), next_id());
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_not_found());
+}
+
+TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_rpc_error) {
+    ScopedSyncPoint sync_point;
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::ThriftRpcError("connection refused");
+            });
+
+    auto result = _schema_service->get_tablet_initial_metadata(next_id(), next_id(), next_id(), next_id());
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_thrift_rpc_error());
+}
+
+TEST_F(TableSchemaServiceTest, construct_initial_metadata_fields_match_create_tablet) {
+    ScopedSyncPoint sync_point;
+    auto tablet_id_a = next_id();
+    auto schema_id = next_id();
+
+    // 1. Build TCreateTabletReq and create tablet A via create_tablet()
+    TCreateTabletReq create_req;
+    create_req.tablet_id = tablet_id_a;
+    create_req.__set_version(1);
+    create_req.__set_enable_persistent_index(true);
+    create_req.__set_persistent_index_type(TPersistentIndexType::CLOUD_NATIVE);
+    create_req.__set_compaction_strategy(TCompactionStrategy::REAL_TIME);
+    create_req.__set_compression_type(TCompressionType::LZ4_FRAME);
+    create_req.__set_compression_level(5);
+    create_req.__set_gtid(99999);
+    create_req.__set_create_schema_file(false);
+
+    auto thrift_schema = make_thrift_schema(schema_id);
+    create_req.__set_tablet_schema(thrift_schema);
+
+    ASSERT_OK(_tablet_manager->create_tablet(create_req));
+    ASSIGN_OR_ABORT(auto metadata_a, _tablet_manager->get_tablet_metadata(tablet_id_a, 1));
+
+    // 2. Mock RPC to return the same fields, then call get_tablet_initial_metadata directly
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                ctx.response->__set_responses(std::vector<TGetTabletInitialMetadataResponse>{});
+                auto& resp = ctx.response->responses.emplace_back();
+                TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+                resp.__set_schema(thrift_schema);
+                resp.__set_enable_persistent_index(true);
+                resp.__set_persistent_index_type(TPersistentIndexType::CLOUD_NATIVE);
+                resp.__set_compaction_strategy(TCompactionStrategy::REAL_TIME);
+                resp.__set_compression_type(TCompressionType::LZ4_FRAME);
+                resp.__set_compression_level(5);
+                resp.__set_gtid(99999);
+            });
+
+    // 3. Get response and manually build metadata_b the same way construct_initial_metadata does
+    auto tablet_id_b = next_id();
+    auto resp_or = _schema_service->get_tablet_initial_metadata(tablet_id_b, next_id(), next_id(), next_id());
+    ASSERT_TRUE(resp_or.ok());
+    auto& resp = resp_or.value();
+
+    auto metadata_b = std::make_shared<TabletMetadataPB>();
+    metadata_b->set_id(tablet_id_b);
+    metadata_b->set_version(1);
+    metadata_b->set_next_rowset_id(1);
+    metadata_b->set_cumulative_point(0);
+    metadata_b->set_gtid(resp.gtid);
+    auto compress_type = resp.__isset.compression_type ? resp.compression_type : TCompressionType::LZ4_FRAME;
+    ASSERT_OK(convert_t_schema_to_pb_schema(resp.schema, compress_type, metadata_b->mutable_schema()));
+    metadata_b->mutable_schema()->set_compression_level(resp.__isset.compression_level ? resp.compression_level : -1);
+    if (resp.__isset.enable_persistent_index) {
+        metadata_b->set_enable_persistent_index(resp.enable_persistent_index);
+    }
+    if (resp.__isset.persistent_index_type) {
+        metadata_b->set_persistent_index_type(resp.persistent_index_type == TPersistentIndexType::LOCAL
+                                                      ? PersistentIndexTypePB::LOCAL
+                                                      : PersistentIndexTypePB::CLOUD_NATIVE);
+    }
+    if (resp.__isset.compaction_strategy) {
+        metadata_b->set_compaction_strategy(resp.compaction_strategy == TCompactionStrategy::DEFAULT
+                                                    ? CompactionStrategyPB::DEFAULT
+                                                    : CompactionStrategyPB::REAL_TIME);
+    }
+
+    // 4. Compare fields
+    ASSERT_EQ(metadata_a->version(), metadata_b->version());
+    ASSERT_EQ(metadata_a->next_rowset_id(), metadata_b->next_rowset_id());
+    ASSERT_EQ(metadata_a->cumulative_point(), metadata_b->cumulative_point());
+    ASSERT_EQ(metadata_a->gtid(), metadata_b->gtid());
+    ASSERT_EQ(metadata_a->enable_persistent_index(), metadata_b->enable_persistent_index());
+    ASSERT_EQ(metadata_a->persistent_index_type(), metadata_b->persistent_index_type());
+    ASSERT_EQ(metadata_a->compaction_strategy(), metadata_b->compaction_strategy());
+    ASSERT_EQ(metadata_a->schema().id(), metadata_b->schema().id());
+    ASSERT_EQ(metadata_a->schema().compression_level(), metadata_b->schema().compression_level());
+}
+
+TEST_F(TableSchemaServiceTest, cn_free_fallback_not_triggered_for_version_gt_1) {
+    ScopedSyncPoint sync_point;
+    std::atomic<int> rpc_calls{0};
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                rpc_calls.fetch_add(1);
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                ctx.response->__set_responses(std::vector<TGetTabletInitialMetadataResponse>{});
+                auto& resp = ctx.response->responses.emplace_back();
+                TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+                resp.__set_schema(make_thrift_schema(next_id()));
+            });
+
+    // version 2 not found should NOT trigger cn-free fallback
+    auto result = _tablet_manager->get_tablet_metadata(next_id(), 2);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_not_found());
+    ASSERT_EQ(0, rpc_calls.load());
+}
+
+TEST_F(TableSchemaServiceTest, cn_free_fallback_not_triggered_with_external_fs) {
+    ScopedSyncPoint sync_point;
+    std::atomic<int> rpc_calls{0};
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                rpc_calls.fetch_add(1);
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                ctx.response->__set_responses(std::vector<TGetTabletInitialMetadataResponse>{});
+                auto& resp = ctx.response->responses.emplace_back();
+                TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+                resp.__set_schema(make_thrift_schema(next_id()));
+            });
+
+    // version 1 not found with non-null fs should NOT trigger cn-free fallback
+    auto external_fs = std::shared_ptr<FileSystem>(FileSystem::Default(), [](FileSystem*) {});
+    auto tablet_id = next_id();
+    auto result = _tablet_manager->get_tablet_metadata(tablet_id, 1, true, 0, external_fs);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_not_found());
+    ASSERT_EQ(0, rpc_calls.load());
 }
 
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -491,7 +491,7 @@ public class CatalogUtils {
         int backendNum = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds().size();
 
         if (RunMode.isSharedDataMode()) {
-            backendNum = backendNum + GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAliveComputeNodeNumber();
+            backendNum = backendNum + GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalComputeNodeNumber();
         }
 
         return divisibleBucketNum(backendNum);
@@ -501,7 +501,7 @@ public class CatalogUtils {
         int backendNum = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds().size();
 
         if (RunMode.isSharedDataMode()) {
-            backendNum = backendNum + GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAliveComputeNodeNumber();
+            backendNum = backendNum + GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalComputeNodeNumber();
         }
 
         // When POC, the backends is not greater than three most of the time.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2065,6 +2065,16 @@ public class OlapTable extends Table {
         return tableProperty.enablePersistentIndex();
     }
 
+    public boolean isCnFreeTabletCreation() {
+        return tableProperty.cnFreeTabletCreation();
+    }
+
+    public void setCnFreeTabletCreation(boolean cnFreeTabletCreation) {
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_CN_FREE_TABLET_CREATION,
+                Boolean.valueOf(cnFreeTabletCreation).toString());
+        tableProperty.buildCnFreeTabletCreation();
+    }
+
     public int primaryIndexCacheExpireSec() {
         return tableProperty.primaryIndexCacheExpireSec();
     }
@@ -3005,6 +3015,11 @@ public class OlapTable extends Table {
         if (getCompactionStrategy() != TCompactionStrategy.DEFAULT) {
             properties.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY,
                     TableProperty.compactionStrategyToString(getCompactionStrategy()));
+        }
+
+        if (isCloudNativeTable()) {
+            properties.put(PropertyAnalyzer.PROPERTIES_CN_FREE_TABLET_CREATION,
+                    Boolean.toString(isCnFreeTabletCreation()));
         }
 
         // lake_compaction_max_parallel (only for cloud native table, only show when not default)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -252,6 +252,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // Only meaningful when enablePersistentIndex = true.
     TPersistentIndexType persistentIndexType;
 
+    private boolean cnFreeTabletCreation = false;
+
     private int primaryIndexCacheExpireSec = 0;
 
     /*
@@ -383,6 +385,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         this.mvTransparentRewriteMode = other.mvTransparentRewriteMode;
         this.enablePersistentIndex = other.enablePersistentIndex;
         this.persistentIndexType = other.persistentIndexType;
+        this.cnFreeTabletCreation = other.cnFreeTabletCreation;
         this.primaryIndexCacheExpireSec = other.primaryIndexCacheExpireSec;
         this.storageVolume = other.storageVolume;
         this.storageCoolDownTTL = other.storageCoolDownTTL;
@@ -879,6 +882,12 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildCnFreeTabletCreation() {
+        cnFreeTabletCreation = Boolean.parseBoolean(
+                properties.getOrDefault(PropertyAnalyzer.PROPERTIES_CN_FREE_TABLET_CREATION, "false"));
+        return this;
+    }
+
     public TableProperty buildPrimaryIndexCacheExpireSec() {
         primaryIndexCacheExpireSec = Integer.parseInt(properties.getOrDefault(
                 PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC, "0"));
@@ -1209,6 +1218,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return enablePersistentIndex;
     }
 
+    public boolean cnFreeTabletCreation() {
+        return cnFreeTabletCreation;
+    }
+
     public boolean isFileBundling() {
         return fileBundling;
     }
@@ -1431,6 +1444,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildStorageCoolDownTTL();
         buildEnablePersistentIndex();
         buildPersistentIndexType();
+        buildCnFreeTabletCreation();
         buildPrimaryIndexCacheExpireSec();
         buildCompressionType();
         buildWriteQuorum();

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3713,6 +3713,14 @@ public class Config extends ConfigBase {
     public static boolean enable_cloud_native_persistent_index_by_default = true;
 
     /**
+     * Whether to enable cn-free tablet creation by default for newly created cloud native tables.
+     * When enabled, DDL operations skip CreateReplicaTask and no version 1 metadata is written to
+     * object storage during tablet creation. The initial metadata is fetched from FE on demand.
+     */
+    @ConfField(mutable = true)
+    public static boolean lake_enable_cn_free_tablet_creation = true;
+
+    /**
      * timeout for external table commit
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -158,6 +158,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_ENABLE_PERSISTENT_INDEX = "enable_persistent_index";
 
+    public static final String PROPERTIES_CN_FREE_TABLET_CREATION = "cn_free_tablet_creation";
+
     public static final String PROPERTIES_LABELS_LOCATION = "labels.location";
 
     public static final String PROPERTIES_PERSISTENT_INDEX_TYPE = "persistent_index_type";

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2033,7 +2033,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 }
             }
         }
-        if (numAliveNodes == 0) {
+        if (numAliveNodes == 0 && !table.isCnFreeTabletCreation()) {
             if (RunMode.isSharedDataMode()) {
                 throw new DdlException("no alive compute nodes");
             } else {
@@ -2272,7 +2272,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(index.getId()));
         final long warehouseId = computeResource.getWarehouseId();
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-        if (!warehouseManager.isResourceAvailable(computeResource)) {
+        // cn-free tablet creation skips CreateReplicaTask and does not need a live CN,
+        // so skip checking compute resource to allow table creation when all CNs are down.
+        if (!table.isCnFreeTabletCreation() && !warehouseManager.isResourceAvailable(computeResource)) {
             Warehouse warehouse = warehouseManager.getWarehouse(warehouseId);
             throw ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -404,6 +404,13 @@ public class OlapTableFactory implements AbstractTableFactory {
             }
 
             if (table.isCloudNativeTable()) {
+                boolean cnFreeTabletCreation = PropertyAnalyzer.analyzeBooleanProp(
+                        properties, PropertyAnalyzer.PROPERTIES_CN_FREE_TABLET_CREATION,
+                        Config.lake_enable_cn_free_tablet_creation);
+                table.setCnFreeTabletCreation(cnFreeTabletCreation);
+            }
+
+            if (table.isCloudNativeTable()) {
                 TCompactionStrategy compactionStrategy;
                 try {
                     compactionStrategy = PropertyAnalyzer.analyzecompactionStrategy(properties);
@@ -806,8 +813,10 @@ public class OlapTableFactory implements AbstractTableFactory {
             // if failed in any step, use this set to do clear things
             Set<Long> tabletIdSet = new HashSet<Long>();
 
+            // cn-free tablet creation skips CreateReplicaTask and does not need a live CN,
+            // so skip acquiring compute resource to allow table creation when all CNs are down.
             ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
-            if (ConnectContext.get() != null) {
+            if (ConnectContext.get() != null && !table.isCnFreeTabletCreation()) {
                 ConnectContext connectContext = ConnectContext.get();
                 computeResource = connectContext.getCurrentComputeResource();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -53,10 +53,12 @@ import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -65,6 +67,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.Tablet;
@@ -199,6 +202,8 @@ import com.starrocks.thrift.TAuthInfo;
 import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TBatchGetTableSchemaRequest;
 import com.starrocks.thrift.TBatchGetTableSchemaResponse;
+import com.starrocks.thrift.TBatchGetTabletInitialMetadataRequest;
+import com.starrocks.thrift.TBatchGetTabletInitialMetadataResponse;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TBeginRemoteTxnRequest;
@@ -274,6 +279,8 @@ import com.starrocks.thrift.TGetTablesInfoRequest;
 import com.starrocks.thrift.TGetTablesInfoResponse;
 import com.starrocks.thrift.TGetTablesParams;
 import com.starrocks.thrift.TGetTablesResult;
+import com.starrocks.thrift.TGetTabletInitialMetadataRequest;
+import com.starrocks.thrift.TGetTabletInitialMetadataResponse;
 import com.starrocks.thrift.TGetTabletScheduleRequest;
 import com.starrocks.thrift.TGetTabletScheduleResponse;
 import com.starrocks.thrift.TGetTaskInfoResult;
@@ -373,6 +380,7 @@ import com.starrocks.thrift.TTablePrivDesc;
 import com.starrocks.thrift.TTableReplicationRequest;
 import com.starrocks.thrift.TTableReplicationResponse;
 import com.starrocks.thrift.TTabletLocation;
+import com.starrocks.thrift.TTabletRange;
 import com.starrocks.thrift.TTabletReshardJobsRequest;
 import com.starrocks.thrift.TTabletReshardJobsResponse;
 import com.starrocks.thrift.TTaskInfo;
@@ -3585,6 +3593,126 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
         }
         return batchResponse;
+    }
+
+    @Override
+    public TBatchGetTabletInitialMetadataResponse getTabletInitialMetadata(
+            TBatchGetTabletInitialMetadataRequest batchRequest) {
+        TBatchGetTabletInitialMetadataResponse batchResponse = new TBatchGetTabletInitialMetadataResponse();
+        batchResponse.setStatus(new TStatus(OK));
+        if (batchRequest.isSetRequests()) {
+            for (TGetTabletInitialMetadataRequest request : batchRequest.getRequests()) {
+                batchResponse.addToResponses(handleGetTabletInitialMetadata(request));
+            }
+        }
+        return batchResponse;
+    }
+
+    private TGetTabletInitialMetadataResponse handleGetTabletInitialMetadata(
+            TGetTabletInitialMetadataRequest request) {
+        TGetTabletInitialMetadataResponse response = new TGetTabletInitialMetadataResponse();
+        long tableId = request.getTable_id();
+        long partitionId = request.getPartition_id();
+        long indexId = request.getIndex_id();
+
+        // 1. Use tablet_id to look up dbId via TabletInvertedIndex
+        long tabletId = request.getTablet_id();
+        TabletMeta tabletMeta = GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getTabletMeta(tabletId);
+        if (tabletMeta == null) {
+            TStatus status = new TStatus(TStatusCode.NOT_FOUND);
+            status.addToError_msgs("tablet not found: " + tabletId);
+            response.setStatus(status);
+            return response;
+        }
+        long dbId = tabletMeta.getDbId();
+
+        // 2. Look up table
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, tableId);
+        if (table == null) {
+            TStatus status = new TStatus(TStatusCode.NOT_FOUND);
+            status.addToError_msgs("table not found, db_id: " + dbId + ", table_id: " + tableId);
+            response.setStatus(status);
+            return response;
+        }
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs("not a cloud native table, table_id: " + tableId);
+            response.setStatus(status);
+            return response;
+        }
+        OlapTable olapTable = (OlapTable) table;
+        try (AutoCloseableLock ignore = new AutoCloseableLock(
+                new Locker(), dbId, Collections.singletonList(tableId), LockType.READ)) {
+            // 2. Find MaterializedIndex and its meta
+            PhysicalPartition partition = olapTable.getPhysicalPartition(partitionId);
+            if (partition == null) {
+                TStatus status = new TStatus(TStatusCode.NOT_FOUND);
+                status.addToError_msgs("partition not found: " + partitionId);
+                response.setStatus(status);
+                return response;
+            }
+
+            MaterializedIndex index = partition.getIndex(indexId);
+            if (index == null) {
+                TStatus status = new TStatus(TStatusCode.NOT_FOUND);
+                status.addToError_msgs("index not found: " + indexId);
+                response.setStatus(status);
+                return response;
+            }
+
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(index.getMetaId());
+            if (indexMeta == null) {
+                TStatus status = new TStatus(TStatusCode.NOT_FOUND);
+                status.addToError_msgs("index meta not found for metaId: " + index.getMetaId());
+                response.setStatus(status);
+                return response;
+            }
+
+            // 3. Build schema
+            long indexMetaId = index.getMetaId();
+            SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(olapTable, indexMetaId, indexMeta);
+            response.setSchema(schemaInfo.toTabletSchema());
+
+            // 4. Table-level properties
+            response.setEnable_persistent_index(olapTable.enablePersistentIndex());
+            if (olapTable.getPersistentIndexType() != null) {
+                response.setPersistent_index_type(olapTable.getPersistentIndexType());
+            }
+            response.setCompaction_strategy(olapTable.getCompactionStrategy());
+            FlatJsonConfig flatJsonConfig = olapTable.getFlatJsonConfig();
+            if (flatJsonConfig != null) {
+                response.setFlat_json_config(flatJsonConfig.toTFlatJsonConfig());
+            }
+            if (olapTable.getCompressionType() != null) {
+                response.setCompression_type(olapTable.getCompressionType());
+            }
+            response.setCompression_level(olapTable.getCompressionLevel());
+
+            // 5. All tablet ranges for this index (only for range distribution)
+            if (olapTable.isRangeDistribution()) {
+                Map<Long, TTabletRange> tabletRanges = new java.util.HashMap<>();
+                for (Tablet tablet : index.getTablets()) {
+                    if (tablet.getRange() != null) {
+                        tabletRanges.put(tablet.getId(), tablet.getRange().toThrift());
+                    }
+                }
+                if (!tabletRanges.isEmpty()) {
+                    response.setTablet_ranges(tabletRanges);
+                }
+            }
+
+            // 6. GTID
+            response.setGtid(0);
+
+            response.setStatus(new TStatus(TStatusCode.OK));
+        } catch (Exception e) {
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs("failed to get tablet initial metadata, table_id: " + tableId
+                    + ", partition_id: " + partitionId + ", index_id: " + indexId
+                    + ", error: " + e.getMessage());
+            response.setStatus(status);
+        }
+        return response;
     }
 
     private static class CreatePartitionMetrics {

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -91,6 +91,9 @@ public class TabletTaskExecutor {
                                                    int numBackends,
                                                    ComputeResource computeResource,
                                                    CreateTabletOption option) throws DdlException {
+        if (table.isCnFreeTabletCreation()) {
+            return;
+        }
         // Try to bundle at least 200 CreateReplicaTask's in a single AgentBatchTask.
         // The number 200 is just an experiment value that seems to work without obvious problems, feel free to
         // change it if you have a better choice.
@@ -122,6 +125,9 @@ public class TabletTaskExecutor {
                                                    int numBackends,
                                                    ComputeResource computeResource,
                                                    CreateTabletOption option) throws DdlException {
+        if (table.isCnFreeTabletCreation()) {
+            return;
+        }
         long start = System.currentTimeMillis();
         int timeout = Math.max(1, numReplicas / numBackends) * Config.tablet_create_timeout_second;
         int numIndexes = partitions.stream().mapToInt(

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -740,6 +740,51 @@ public class CreateLakeTableTest {
             Assertions.assertEquals(TStatusCode.NOT_FOUND, resp.getStatus().getStatus_code());
         }
 
+        // table_id not exist (tablet_id valid but table dropped): returns NOT_FOUND
+        {
+            TGetTabletInitialMetadataRequest req = new TGetTabletInitialMetadataRequest();
+            req.setTable_id(999999999L);
+            req.setPartition_id(partition.getDefaultPhysicalPartition().getId());
+            req.setIndex_id(index.getId());
+            req.setTablet_id(tabletId);
+            TBatchGetTabletInitialMetadataRequest batchReq = new TBatchGetTabletInitialMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletInitialMetadataResponse batchResp = impl.getTabletInitialMetadata(batchReq);
+
+            TGetTabletInitialMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.NOT_FOUND, resp.getStatus().getStatus_code());
+        }
+
+        // partition_id not exist: returns NOT_FOUND
+        {
+            TGetTabletInitialMetadataRequest req = new TGetTabletInitialMetadataRequest();
+            req.setTable_id(lakeTable.getId());
+            req.setPartition_id(999999999L);
+            req.setIndex_id(index.getId());
+            req.setTablet_id(tabletId);
+            TBatchGetTabletInitialMetadataRequest batchReq = new TBatchGetTabletInitialMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletInitialMetadataResponse batchResp = impl.getTabletInitialMetadata(batchReq);
+
+            TGetTabletInitialMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.NOT_FOUND, resp.getStatus().getStatus_code());
+        }
+
+        // index_id not exist: returns NOT_FOUND
+        {
+            TGetTabletInitialMetadataRequest req = new TGetTabletInitialMetadataRequest();
+            req.setTable_id(lakeTable.getId());
+            req.setPartition_id(partition.getDefaultPhysicalPartition().getId());
+            req.setIndex_id(999999999L);
+            req.setTablet_id(tabletId);
+            TBatchGetTabletInitialMetadataRequest batchReq = new TBatchGetTabletInitialMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletInitialMetadataResponse batchResp = impl.getTabletInitialMetadata(batchReq);
+
+            TGetTabletInitialMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.NOT_FOUND, resp.getStatus().getStatus_code());
+        }
+
         // empty request
         {
             TBatchGetTabletInitialMetadataRequest batchReq = new TBatchGetTabletInitialMetadataRequest();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
@@ -33,10 +34,17 @@ import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.service.FrontendServiceImpl;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.storagevolume.StorageVolume;
+import com.starrocks.thrift.TBatchGetTabletInitialMetadataRequest;
+import com.starrocks.thrift.TBatchGetTabletInitialMetadataResponse;
+import com.starrocks.thrift.TGetTabletInitialMetadataRequest;
+import com.starrocks.thrift.TGetTabletInitialMetadataResponse;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TTabletRange;
 import com.starrocks.utframe.UtFrameUtils;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
@@ -527,6 +535,7 @@ public class CreateLakeTableTest {
                 "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
                 "PROPERTIES (\n" +
                 "\"cloud_native_fast_schema_evolution_v2\" = \"true\",\n" +
+                "\"cn_free_tablet_creation\" = \"true\",\n" +
                 "\"compression\" = \"LZ4\",\n" +
                 "\"datacache.enable\" = \"true\",\n" +
                 "\"enable_async_write_back\" = \"false\",\n" +
@@ -580,5 +589,163 @@ public class CreateLakeTableTest {
                 snapshot, engine, metastore);
         LightWeightDeltaLakeTable light = new LightWeightDeltaLakeTable(table);
         Assertions.assertThrows(UnsupportedOperationException.class, light::getDeltaSnapshot);
+    }
+
+    @Test
+    public void testCnFreeTabletCreation() throws Exception {
+        // default: enabled for lake table
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.cn_free_default\n" +
+                        "(c0 int, c1 string)\n" +
+                        "duplicate key(c0)\n" +
+                        "distributed by hash(c0) buckets 2"));
+        Assertions.assertTrue(getLakeTable("lake_test", "cn_free_default").isCnFreeTabletCreation());
+
+        // explicit false
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.cn_free_false\n" +
+                        "(c0 int, c1 string)\n" +
+                        "duplicate key(c0)\n" +
+                        "distributed by hash(c0) buckets 2\n" +
+                        "properties('cn_free_tablet_creation' = 'false')"));
+        Assertions.assertFalse(getLakeTable("lake_test", "cn_free_false").isCnFreeTabletCreation());
+
+        // explicit true
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.cn_free_true\n" +
+                        "(c0 int, c1 string)\n" +
+                        "duplicate key(c0)\n" +
+                        "distributed by hash(c0) buckets 2\n" +
+                        "properties('cn_free_tablet_creation' = 'true')"));
+        Assertions.assertTrue(getLakeTable("lake_test", "cn_free_true").isCnFreeTabletCreation());
+
+        // config disabled: default becomes false
+        boolean saved = Config.lake_enable_cn_free_tablet_creation;
+        try {
+            Config.lake_enable_cn_free_tablet_creation = false;
+            ExceptionChecker.expectThrowsNoException(() -> createTable(
+                    "create table lake_test.cn_free_config_off\n" +
+                            "(c0 int, c1 string)\n" +
+                            "duplicate key(c0)\n" +
+                            "distributed by hash(c0) buckets 2"));
+            Assertions.assertFalse(getLakeTable("lake_test", "cn_free_config_off").isCnFreeTabletCreation());
+        } finally {
+            Config.lake_enable_cn_free_tablet_creation = saved;
+        }
+
+        // show create table contains the property
+        String sql = "show create table lake_test.cn_free_default";
+        ShowCreateTableStmt showCreateTableStmt =
+                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        ShowResultSet resultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
+        List<List<String>> result = resultSet.getResultRows();
+        Assertions.assertFalse(result.isEmpty());
+        Assertions.assertTrue(result.get(0).get(1).contains("\"cn_free_tablet_creation\" = \"true\""));
+    }
+
+    @Test
+    public void testGetTabletInitialMetadata() throws Exception {
+        // create a table to get real tablet ids
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.cn_free_rpc_test\n" +
+                        "(c0 int, c1 string)\n" +
+                        "duplicate key(c0)\n" +
+                        "distributed by hash(c0) buckets 2\n" +
+                        "properties('cn_free_tablet_creation' = 'true')"));
+        LakeTable lakeTable = getLakeTable("lake_test", "cn_free_rpc_test");
+        Partition partition = lakeTable.getPartitions().stream().findFirst().get();
+        MaterializedIndex index = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
+        long tabletId = index.getTablets().get(0).getId();
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(null);
+
+        // hash distribution tablet: returns OK with schema, no range
+        {
+            TGetTabletInitialMetadataRequest req = new TGetTabletInitialMetadataRequest();
+            req.setTable_id(lakeTable.getId());
+            req.setPartition_id(partition.getDefaultPhysicalPartition().getId());
+            req.setIndex_id(index.getId());
+            req.setTablet_id(tabletId);
+            TBatchGetTabletInitialMetadataRequest batchReq = new TBatchGetTabletInitialMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletInitialMetadataResponse batchResp = impl.getTabletInitialMetadata(batchReq);
+
+            Assertions.assertEquals(TStatusCode.OK, batchResp.getStatus().getStatus_code());
+            Assertions.assertEquals(1, batchResp.getResponsesSize());
+            TGetTabletInitialMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.OK, resp.getStatus().getStatus_code());
+            Assertions.assertTrue(resp.isSetSchema());
+            Assertions.assertTrue(resp.isSetCompression_type());
+            // hash distribution table should not have tablet_ranges set
+            Assertions.assertFalse(resp.isSetTablet_ranges());
+        }
+
+        // range distribution tablet: tablet_ranges should contain all tablets' ranges
+        {
+            boolean savedRangeDistribution = Config.enable_range_distribution;
+            try {
+                Config.enable_range_distribution = true;
+                connectContext.getSessionVariable().setEnableRangeDistribution(true);
+                ExceptionChecker.expectThrowsNoException(() -> createTable(
+                        "create table lake_test.cn_free_range_test\n" +
+                                "(c0 int, c1 string)\n" +
+                                "PRIMARY KEY(c0)\n" +
+                                "properties('cn_free_tablet_creation' = 'true')"));
+                LakeTable rangeTable = getLakeTable("lake_test", "cn_free_range_test");
+                Assertions.assertTrue(rangeTable.isRangeDistribution());
+
+                Partition rangePart = rangeTable.getPartitions().stream().findFirst().get();
+                MaterializedIndex rangeIndex = rangePart.getDefaultPhysicalPartition().getLatestBaseIndex();
+                int numTablets = rangeIndex.getTablets().size();
+                long rangeTabletId = rangeIndex.getTablets().get(0).getId();
+                TGetTabletInitialMetadataRequest req = new TGetTabletInitialMetadataRequest();
+                req.setTable_id(rangeTable.getId());
+                req.setPartition_id(rangePart.getDefaultPhysicalPartition().getId());
+                req.setIndex_id(rangeIndex.getId());
+                req.setTablet_id(rangeTabletId);
+                TBatchGetTabletInitialMetadataRequest batchReq = new TBatchGetTabletInitialMetadataRequest();
+                batchReq.addToRequests(req);
+                TBatchGetTabletInitialMetadataResponse batchResp = impl.getTabletInitialMetadata(batchReq);
+
+                TGetTabletInitialMetadataResponse resp = batchResp.getResponses().get(0);
+                Assertions.assertEquals(TStatusCode.OK, resp.getStatus().getStatus_code());
+                Assertions.assertTrue(resp.isSetTablet_ranges());
+                // tablet_ranges should contain all tablets in this index
+                Assertions.assertEquals(numTablets, resp.getTablet_ranges().size());
+                // this tablet's range should be present
+                Assertions.assertTrue(resp.getTablet_ranges().containsKey(rangeTabletId));
+                // initial range is Range.all(), so bounds are not set
+                TTabletRange tabletRange = resp.getTablet_ranges().get(rangeTabletId);
+                Assertions.assertFalse(tabletRange.isSetLower_bound());
+                Assertions.assertFalse(tabletRange.isSetUpper_bound());
+            } finally {
+                Config.enable_range_distribution = savedRangeDistribution;
+                connectContext.getSessionVariable().setEnableRangeDistribution(false);
+            }
+        }
+
+        // non-existent tablet: returns NOT_FOUND
+        {
+            TGetTabletInitialMetadataRequest req = new TGetTabletInitialMetadataRequest();
+            req.setTable_id(999999999L);
+            req.setPartition_id(1L);
+            req.setIndex_id(1L);
+            req.setTablet_id(999999999L);
+            TBatchGetTabletInitialMetadataRequest batchReq = new TBatchGetTabletInitialMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletInitialMetadataResponse batchResp = impl.getTabletInitialMetadata(batchReq);
+
+            Assertions.assertEquals(TStatusCode.OK, batchResp.getStatus().getStatus_code());
+            TGetTabletInitialMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.NOT_FOUND, resp.getStatus().getStatus_code());
+        }
+
+        // empty request
+        {
+            TBatchGetTabletInitialMetadataRequest batchReq = new TBatchGetTabletInitialMetadataRequest();
+            TBatchGetTabletInitialMetadataResponse batchResp = impl.getTabletInitialMetadata(batchReq);
+            Assertions.assertEquals(TStatusCode.OK, batchResp.getStatus().getStatus_code());
+            Assertions.assertFalse(batchResp.isSetResponses());
+        }
     }
 }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -140,6 +140,12 @@ struct TCreateTabletReq {
     25: optional TFlatJsonConfig flat_json_config;
     26: optional TCompactionStrategy compaction_strategy;
     27: optional Types.TTabletRange range;
+
+    // New fields should be added above this comment.
+    // NOTE: If you add a new field here that
+    // create_tablet() writes into TabletMetadataPB, also update
+    // TGetTabletInitialMetadataResponse in FrontendService.thrift,
+    // construct_initial_metadata() and handleGetTabletInitialMetadata() to keep them in sync.
 }
 
 struct TDropTabletReq {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2294,6 +2294,35 @@ struct TBatchGetTableSchemaResponse {
     2: optional list<TGetTableSchemaResponse> responses;
 }
 
+struct TGetTabletInitialMetadataRequest {
+    1: optional i64 tablet_id;
+    2: optional i64 table_id;
+    3: optional i64 partition_id;
+    4: optional i64 index_id;
+}
+
+struct TGetTabletInitialMetadataResponse {
+    1: optional Status.TStatus status;
+    2: optional AgentService.TTabletSchema schema;
+    3: optional bool enable_persistent_index;
+    4: optional AgentService.TPersistentIndexType persistent_index_type;
+    5: optional AgentService.TCompactionStrategy compaction_strategy;
+    6: optional AgentService.TFlatJsonConfig flat_json_config;
+    7: optional map<i64, Types.TTabletRange> tablet_ranges;
+    8: optional i64 gtid;
+    9: optional Types.TCompressionType compression_type;
+    10: optional i32 compression_level;
+}
+
+struct TBatchGetTabletInitialMetadataRequest {
+    1: optional list<TGetTabletInitialMetadataRequest> requests;
+}
+
+struct TBatchGetTabletInitialMetadataResponse {
+    1: optional Status.TStatus status;
+    2: optional list<TGetTabletInitialMetadataResponse> responses;
+}
+
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)
     TGetTablesResult getTableNames(1:TGetTablesParams params)
@@ -2445,4 +2474,6 @@ service FrontendService {
     TRefreshConnectionsResponse refreshConnections(1: TRefreshConnectionsRequest request)
 
     TBatchGetTableSchemaResponse getTableSchema(1: TBatchGetTableSchemaRequest request)
+
+    TBatchGetTabletInitialMetadataResponse getTabletInitialMetadata(1: optional TBatchGetTabletInitialMetadataRequest request)
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
When cn_free_tablet_creation is enabled, DDL operations skip sending
  CreateReplicaTask to CN and no version 1 metadata is written to object
  storage during tablet creation. When a consumer first needs version 1
  metadata (e.g. publish, query, schema change), CN fetches the initial
  configuration from FE via RPC and constructs the TabletMetadataPB on
  demand.

  This decouples DDL availability from CN state, allowing table creation
  to succeed even when no CN is alive.

  Key changes:
  - Add cn_free_tablet_creation table property for cloud native tables,
    controlled by FE config lake_enable_cn_free_tablet_creation (default true)
  - Add getTabletInitialMetadata RPC: FE returns schema, table-level
    properties, and all tablet ranges for an index in a single response
  - Skip CreateReplicaTask in TabletTaskExecutor when property is enabled
  - Add cn-free fallback in TabletManager::get_tablet_metadata: when
    version 1 is not found and fs is null, call construct_initial_metadata
    to build TabletMetadataPB from FE response
  - CN uses (table_id, index_id) as SingleFlight key so concurrent
    requests for different tablets under the same index share one RPC
  - Add retry logic and monitoring metrics for initial metadata fetch
  - Handle MetadataIterator initial path routing for cn-free tablets
  - Allow table creation with zero CN nodes when cn-free is enabled

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
