### PR TITLE
[Feature] support jdbc native query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -49,6 +49,8 @@ public class JDBCTable extends Table {
     private String jdbcTable;
     @SerializedName(value = "rn")
     private String resourceName;
+    @SerializedName(value = "qt")
+    private boolean queryTable;
 
     private Map<String, String> connectInfo;
     private String catalogName;
@@ -110,14 +112,6 @@ public class JDBCTable extends Table {
         return partitionColumns;
     }
 
-    public Map<String, Integer> getOriginalJdbcColumnTypes() {
-        return originalJdbcColumnTypes;
-    }
-
-    public void setOriginalJdbcColumnTypes(Map<String, Integer> originalJdbcColumnTypes) {
-        this.originalJdbcColumnTypes = originalJdbcColumnTypes;
-    }
-
     public Map<String, String> getConnectInfo() {
         if (connectInfo == null) {
             this.connectInfo = new HashMap<>();
@@ -146,6 +140,88 @@ public class JDBCTable extends Table {
     public boolean isMySQLCompatible() {
         String uri = getJdbcUri();
         return uri != null && (uri.startsWith("jdbc:mysql") || uri.startsWith("jdbc:mariadb"));
+    }
+
+    public Map<String, Integer> getOriginalJdbcColumnTypes() {
+        if (originalJdbcColumnTypes == null) {
+            originalJdbcColumnTypes = new HashMap<>();
+        }
+        return originalJdbcColumnTypes;
+    }
+
+    public void setOriginalJdbcColumnTypes(Map<String, Integer> originalJdbcColumnTypes) {
+        if (originalJdbcColumnTypes == null) {
+            this.originalJdbcColumnTypes = new HashMap<>();
+        } else {
+            this.originalJdbcColumnTypes = new HashMap<>(originalJdbcColumnTypes);
+        }
+    }
+
+    public boolean isQueryTable() {
+        return queryTable;
+    }
+
+    public void setPassThroughQuery(String query) {
+        jdbcTable = "(" + normalizePassThroughQuery(query) + ") starrocks_query";
+        queryTable = true;
+    }
+
+    public static String normalizePassThroughQuery(String query) {
+        String normalizedQuery = StringUtils.trimToEmpty(query);
+        while (normalizedQuery.endsWith(";")) {
+            normalizedQuery = StringUtils.stripEnd(normalizedQuery.substring(0, normalizedQuery.length() - 1), null);
+        }
+        if (normalizedQuery.isEmpty()) {
+            throw new IllegalArgumentException("pass-through query cannot be empty");
+        }
+        validatePassThroughQuery(normalizedQuery);
+        return normalizedQuery;
+    }
+
+    private static void validatePassThroughQuery(String query) {
+        String leadingSql = stripLeadingComments(query);
+        if (!startsWithSqlKeyword(leadingSql, "select")) {
+            throw new IllegalArgumentException("JDBC query table function only supports SELECT queries");
+        }
+    }
+
+    private static String stripLeadingComments(String query) {
+        int offset = 0;
+        while (offset < query.length()) {
+            char ch = query.charAt(offset);
+            if (Character.isWhitespace(ch)) {
+                offset++;
+                continue;
+            }
+            if (ch == '-' && offset + 1 < query.length() && query.charAt(offset + 1) == '-') {
+                offset += 2;
+                while (offset < query.length() && query.charAt(offset) != '\n' && query.charAt(offset) != '\r') {
+                    offset++;
+                }
+                continue;
+            }
+            if (ch == '/' && offset + 1 < query.length() && query.charAt(offset + 1) == '*') {
+                int commentEnd = query.indexOf("*/", offset + 2);
+                if (commentEnd < 0) {
+                    throw new IllegalArgumentException("JDBC query table function only supports SELECT queries");
+                }
+                offset = commentEnd + 2;
+                continue;
+            }
+            break;
+        }
+        return query.substring(offset);
+    }
+
+    private static boolean startsWithSqlKeyword(String query, String keyword) {
+        if (!query.regionMatches(true, 0, keyword, 0, keyword.length())) {
+            return false;
+        }
+        if (query.length() == keyword.length()) {
+            return true;
+        }
+        char next = query.charAt(keyword.length());
+        return !Character.isLetterOrDigit(next) && next != '_';
     }
 
     private void validate(Map<String, String> properties) throws DdlException {
@@ -251,7 +327,7 @@ public class JDBCTable extends Table {
             tJDBCTable.setJdbc_driver_checksum(connectInfo.get(JDBCResource.CHECK_SUM));
             tJDBCTable.setJdbc_driver_class(connectInfo.get(JDBCResource.DRIVER_CLASS));
 
-            if (connectInfo.get(JDBC_TABLENAME) != null) {
+            if (connectInfo.get(JDBC_TABLENAME) != null || queryTable || Strings.isNullOrEmpty(dbName)) {
                 tJDBCTable.setJdbc_url(uri);
             } else {
                 int delimiterIndex = uri.indexOf("?");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -154,6 +154,11 @@ public class CatalogConnectorMetadata implements ConnectorMetadata, DelegatingCo
     }
 
     @Override
+    public Table getTableFromQuery(ConnectContext context, String dbName, String query) {
+        return normal.getTableFromQuery(context, dbName, query);
+    }
+
+    @Override
     public TvrTableSnapshot getCurrentTvrSnapshot(String dbName, Table table) {
         ConnectorMetadata metadata = metadataOfTable(table);
         if (metadata == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -132,6 +132,13 @@ public interface ConnectorMetadata {
     }
 
     /**
+     * Build a temporary table from a pass-through query when the connector can infer the result schema.
+     */
+    default Table getTableFromQuery(ConnectContext context, String dbName, String query) {
+        return null;
+    }
+
+    /**
      * Get the Time Varying Relation (TVR) version range for the table between the specified versions.
      */
     default TvrVersionRange getTableVersionRange(String dbName, Table table,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -41,6 +41,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -352,6 +353,38 @@ public class JDBCMetadata implements ConnectorMetadata {
                         return null;
                     }
                 });
+    }
+
+    @Override
+    public Table getTableFromQuery(ConnectContext context, String dbName, String query) {
+        String normalizedQuery = JDBCTable.normalizePassThroughQuery(query);
+        String metadataQuery = "SELECT * FROM (" + normalizedQuery + ") starrocks_query WHERE 1 = 0";
+        try (Connection connection = getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(metadataQuery)) {
+            int queryTimeoutSeconds = schemaResolver.getQueryTimeoutSeconds();
+            if (queryTimeoutSeconds > 0) {
+                preparedStatement.setQueryTimeout(queryTimeoutSeconds);
+            }
+
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                Map<String, Integer> originalJdbcTypes = new HashMap<>();
+                List<Column> fullSchema = schemaResolver.convertToSRTable(resultSet.getMetaData(), originalJdbcTypes);
+                if (fullSchema.isEmpty()) {
+                    throw new StarRocksConnectorException("pass-through query returned no columns");
+                }
+
+                int tableId = ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt();
+                JDBCTable queryTable = new JDBCTable(tableId, "_query_" + tableId, fullSchema, dbName, catalogName,
+                        properties);
+                queryTable.setPassThroughQuery(normalizedQuery);
+                if (!originalJdbcTypes.isEmpty()) {
+                    queryTable.setOriginalJdbcColumnTypes(originalJdbcTypes);
+                }
+                return queryTable;
+            }
+        } catch (SQLException | DdlException e) {
+            throw new StarRocksConnectorException("get query table for JDBC catalog fail!", e);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -28,6 +28,7 @@ import com.starrocks.type.Type;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
@@ -186,10 +187,39 @@ public abstract class JDBCSchemaResolver {
                 }
             } catch (SQLException ignored) { }
 
-            fullSchema.add(new Column(columnName, type,
+            fullSchema.add(new Column(normalizeColumnName(columnSet.getString("COLUMN_NAME")), type,
                     columnSet.getString("IS_NULLABLE").equals(SchemaConstants.YES), comment));
         }
         return fullSchema;
+    }
+
+    public List<Column> convertToSRTable(ResultSetMetaData metaData) throws SQLException {
+        return convertToSRTable(metaData, null);
+    }
+
+    public List<Column> convertToSRTable(ResultSetMetaData metaData, Map<String, Integer> originalJdbcTypes)
+            throws SQLException {
+        List<Column> fullSchema = Lists.newArrayList();
+        for (int i = 1; i <= metaData.getColumnCount(); i++) {
+            Type type = convertColumnType(metaData.getColumnType(i),
+                    metaData.getColumnTypeName(i),
+                    metaData.getPrecision(i),
+                    metaData.getScale(i));
+            String columnName = metaData.getColumnLabel(i);
+            if (columnName == null || columnName.isEmpty()) {
+                columnName = metaData.getColumnName(i);
+            }
+            if (originalJdbcTypes != null) {
+                originalJdbcTypes.put(columnName.toLowerCase(java.util.Locale.ROOT), metaData.getColumnType(i));
+            }
+            boolean nullable = metaData.isNullable(i) != ResultSetMetaData.columnNoNulls;
+            fullSchema.add(new Column(normalizeColumnName(columnName), type, nullable));
+        }
+        return fullSchema;
+    }
+
+    protected String normalizeColumnName(String columnName) {
+        return columnName;
     }
 
     public Type convertColumnType(int dataType, String typeName, int columnSize, int digits) throws SQLException {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -81,13 +81,19 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
                 }
             } catch (SQLException ignored) { }
 
-            if (!columnName.equals(columnName.toLowerCase())) {
-                columnName = "\"" + columnName + "\"";
-            }
+            columnName = normalizeColumnName(columnSet.getString("COLUMN_NAME"));
             fullSchema.add(new Column(columnName, type,
                     columnSet.getString("IS_NULLABLE").equals(SchemaConstants.YES), comment));
         }
         return fullSchema;
+    }
+
+    @Override
+    protected String normalizeColumnName(String columnName) {
+        if (!columnName.equals(columnName.toLowerCase())) {
+            return "\"" + columnName + "\"";
+        }
+        return columnName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -104,8 +104,12 @@ public class JDBCScanNode extends ScanNode {
     public JDBCScanNode(PlanNodeId id, TupleDescriptor desc, JDBCTable tbl) {
         super(id, desc, "SCAN JDBC");
         table = tbl;
-        String objectIdentifier = getIdentifierSymbol();
-        tableName = wrapWithIdentifier(tbl.getCatalogTableName(), objectIdentifier);
+        if (tbl.isQueryTable()) {
+            tableName = tbl.getCatalogTableName();
+        } else {
+            String objectIdentifier = getIdentifierSymbol();
+            tableName = wrapWithIdentifier(tbl.getCatalogTableName(), objectIdentifier);
+        }
     }
 
     private String wrapWithIdentifier(String name, String identifier) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -83,6 +83,7 @@ import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterViewClause;
 import com.starrocks.sql.ast.AlterViewStmt;
 import com.starrocks.sql.ast.AnalyzeStmt;
+import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.BackupStmt;
 import com.starrocks.sql.ast.BaseCreateAlterUserStmt;
@@ -146,6 +147,7 @@ import com.starrocks.sql.ast.InstallPluginStmt;
 import com.starrocks.sql.ast.KillAnalyzeStmt;
 import com.starrocks.sql.ast.KillStmt;
 import com.starrocks.sql.ast.LoadStmt;
+import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
 import com.starrocks.sql.ast.PauseRoutineLoadStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RecoverDbStmt;
@@ -215,6 +217,7 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.StopRoutineLoadStmt;
 import com.starrocks.sql.ast.SubmitTaskStmt;
 import com.starrocks.sql.ast.SystemVariable;
+import com.starrocks.sql.ast.TableFunctionRelation;
 import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.UninstallPluginStmt;
@@ -256,6 +259,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -373,7 +377,54 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
     }
 
     public void checkSelectTableAction(ConnectContext context, QueryStatement statement, List<TableName> excludeTables) {
+        checkNativeQueryCatalogUsage(context, statement);
         ColumnPrivilege.check(context, statement, excludeTables);
+    }
+
+    private void checkNativeQueryCatalogUsage(ConnectContext context, QueryStatement statement) {
+        if (statement == null) {
+            return;
+        }
+
+        Set<String> catalogs = new HashSet<>();
+        new NativeQueryCatalogCollector(catalogs).visit(statement);
+        for (String catalog : catalogs) {
+            try {
+                Authorizer.checkCatalogAction(context, catalog, PrivilegeType.USAGE);
+            } catch (AccessDeniedException e) {
+                AccessDeniedException.reportAccessDenied(
+                        catalog,
+                        context.getCurrentUserIdentity(),
+                        context.getCurrentRoleIds(),
+                        PrivilegeType.USAGE.name(),
+                        ObjectType.CATALOG.name(),
+                        catalog);
+            }
+        }
+    }
+
+    private static class NativeQueryCatalogCollector extends AstTraverser<Void, Void> {
+        private final Set<String> catalogs;
+
+        private NativeQueryCatalogCollector(Set<String> catalogs) {
+            this.catalogs = catalogs;
+        }
+
+        @Override
+        public Void visitNormalizedTableFunction(NormalizedTableFunctionRelation node, Void context) {
+            if (node.getRight() != null) {
+                visit(node.getRight(), context);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitTableFunction(TableFunctionRelation node, Void context) {
+            if (node.getQueryTable() != null) {
+                catalogs.add(node.getQueryTable().getCatalogName());
+            }
+            return null;
+        }
     }
 
     // --------------------------------- Routine Load Statement ---------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -28,6 +28,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -45,6 +46,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -97,6 +99,7 @@ import com.starrocks.sql.ast.expression.FunctionParams;
 import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.LiteralExprFactory;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.dump.HiveMetaStoreTableDumpInfo;
@@ -134,6 +137,9 @@ import static com.starrocks.thrift.PlanNodesConstants.CACHE_STATS_TABLET_ID_COLU
 import static com.starrocks.thrift.PlanNodesConstants.CACHE_STATS_TOTAL_BYTES_COLUMN_NAME;
 
 public class QueryAnalyzer {
+    private static final String JDBC_QUERY_TABLE_FUNCTION_USAGE =
+            "JDBC query table function only supports TABLE(<catalog>.native_query('<sql>'))";
+
     private final ConnectContext session;
     private final MetadataMgr metadataMgr;
 
@@ -156,9 +162,9 @@ public class QueryAnalyzer {
     }
 
     /**
-     * Pre-resolve external (non-internal catalog) table relations without touching internal table metadata.
+     * Pre-resolve external (non-internal catalog) relations without touching internal table metadata.
      * This is used to avoid holding PlannerMetaLock while doing potentially slow connector metadata fetch
-     * (e.g. JDBC).
+     * (e.g. JDBC external tables and JDBC native_query schema inference).
      */
     public void analyzeExternalTablesOnly(StatementBase node) {
         new ExternalTablesOnlyVisitor().process(node);
@@ -166,6 +172,93 @@ public class QueryAnalyzer {
 
     public void analyze(StatementBase node, Scope parent) {
         new Visitor().process(node, parent);
+    }
+
+    private static class JdbcQueryTableFunctionName {
+        private final String catalogName;
+
+        private JdbcQueryTableFunctionName(String catalogName) {
+            this.catalogName = catalogName;
+        }
+    }
+
+    private static JdbcQueryTableFunctionName tryParseCanonicalJdbcQueryTableFunctionName(String functionName) {
+        List<String> parts = Arrays.stream(functionName.split("\\."))
+                .filter(part -> !part.isEmpty())
+                .collect(Collectors.toList());
+        if (parts.size() == 2 && parts.get(1).equalsIgnoreCase("native_query")) {
+            return new JdbcQueryTableFunctionName(parts.get(0));
+        }
+        return null;
+    }
+
+    private static JdbcQueryTableFunctionName tryParseJdbcQueryTableFunctionName(String functionName) {
+        List<String> parts = Arrays.stream(functionName.split("\\."))
+                .filter(part -> !part.isEmpty())
+                .collect(Collectors.toList());
+        if (parts.isEmpty()) {
+            return null;
+        }
+
+        String lastPart = parts.get(parts.size() - 1);
+        if (lastPart.equalsIgnoreCase("native_query")) {
+            if (parts.size() == 2) {
+                return new JdbcQueryTableFunctionName(parts.get(0));
+            }
+
+            throw new SemanticException(JDBC_QUERY_TABLE_FUNCTION_USAGE);
+        }
+
+        if (lastPart.equalsIgnoreCase("query") && parts.size() == 3
+                && parts.get(1).equalsIgnoreCase("system")) {
+            throw new SemanticException(JDBC_QUERY_TABLE_FUNCTION_USAGE);
+        }
+
+        return null;
+    }
+
+    private JDBCTable resolveJdbcQueryTable(JdbcQueryTableFunctionName functionName, String passThroughQuery) {
+        Optional<ConnectorMetadata> metadata = metadataMgr.getOptionalMetadata(functionName.catalogName);
+        if (metadata.isEmpty()) {
+            throw new SemanticException("Unknown catalog '%s'", functionName.catalogName);
+        }
+
+        String currentDb = null;
+        if (functionName.catalogName.equalsIgnoreCase(session.getCurrentCatalog())) {
+            currentDb = session.getDatabase();
+        }
+
+        Table table;
+        try {
+            table = metadata.get().getTableFromQuery(session, currentDb, passThroughQuery);
+        } catch (RuntimeException e) {
+            throw new SemanticException("Failed to resolve JDBC query table function: %s", e.getMessage());
+        }
+
+        if (!(table instanceof JDBCTable jdbcTable) || !jdbcTable.isQueryTable()) {
+            throw new SemanticException("Catalog '%s' does not support JDBC query table function",
+                    functionName.catalogName);
+        }
+        return jdbcTable;
+    }
+
+    private Scope buildJdbcQueryTableScope(TableFunctionRelation node, JDBCTable jdbcTable) {
+        node.setQueryTable(jdbcTable);
+        TableName relationName = node.getResolveTableName();
+        ImmutableList.Builder<Field> fields = ImmutableList.builder();
+        for (Column column : jdbcTable.getFullSchema()) {
+            String columnName = column.getName();
+            fields.add(new Field(columnName,
+                    column.getType(),
+                    relationName,
+                    new SlotRef(relationName, columnName, columnName),
+                    true,
+                    column.isAllowNull()));
+        }
+
+        Scope outputScope = new Scope(RelationId.of(node), new RelationFields(fields.build()));
+        node.setScope(outputScope);
+        return outputScope;
     }
 
     private class GeneratedColumnExprMappingCollector implements AstVisitorExtendInterface<Void, Scope> {
@@ -1734,6 +1827,11 @@ public class QueryAnalyzer {
                 AnalyzerUtils.verifyNoGroupingFunctions(args.get(i), "Table Function");
             }
             List<String> names = node.getFunctionParams().getExprsNames();
+            Scope queryTableScope = tryResolveJdbcQueryTableFunction(node, names);
+            if (queryTableScope != null) {
+                return queryTableScope;
+            }
+
             String[] namesArray = null;
             if (names != null && !names.isEmpty()) {
                 namesArray = names.toArray(String[]::new);
@@ -1823,6 +1921,45 @@ public class QueryAnalyzer {
             return node.getScope();
         }
 
+        private Scope tryResolveJdbcQueryTableFunction(TableFunctionRelation node, List<String> argNames) {
+            JdbcQueryTableFunctionName functionName = tryParseJdbcQueryTableFunctionName(
+                    node.getFunctionName().getFunction());
+            if (functionName == null) {
+                return null;
+            }
+
+            if (node.getColumnOutputNames() != null) {
+                throw new SemanticException("column aliases are not supported for JDBC query table function");
+            }
+
+            List<Expr> args = node.getFunctionParams().exprs();
+            if (args.size() != 1) {
+                throw new SemanticException("JDBC query table function requires exactly one query argument");
+            }
+            if (argNames != null && !argNames.isEmpty()) {
+                throw new SemanticException(JDBC_QUERY_TABLE_FUNCTION_USAGE);
+            }
+
+            Expr queryExpr = args.get(0);
+            if (!(queryExpr instanceof StringLiteral)) {
+                throw new SemanticException("JDBC query table function argument must be a string literal");
+            }
+            String passThroughQuery;
+            try {
+                passThroughQuery = JDBCTable.normalizePassThroughQuery(((StringLiteral) queryExpr).getStringValue());
+            } catch (IllegalArgumentException e) {
+                throw new SemanticException(e.getMessage());
+            }
+
+            node.setChildExpressions(args);
+
+            JDBCTable jdbcTable = node.getQueryTable();
+            if (jdbcTable == null) {
+                jdbcTable = resolveJdbcQueryTable(functionName, passThroughQuery);
+            }
+            return buildJdbcQueryTableScope(node, jdbcTable);
+        }
+
         private List<Expr> appendPositionalDefaultArgExprs(FunctionParams functionParams, Function fn) {
             List<Expr> result = Lists.newArrayList(functionParams.exprs());
             List<Expr> lastDefaults = fn.getLastDefaultsFromN(functionParams.exprs().size());
@@ -1863,9 +2000,10 @@ public class QueryAnalyzer {
     }
 
     /**
-     * A lightweight visitor that pre-resolves only external (non-internal catalog) TableRelation,
+     * A lightweight visitor that pre-resolves external (non-internal catalog) relations,
      * so connector metadata fetch is done without holding PlannerMetaLock.
-     * Similar to TableCollector but inverts the logic: skips internal tables, pre-resolves external tables.
+     * Similar to TableCollector but inverts the logic: skips internal tables, pre-resolves external
+     * TableRelation and JDBC native_query table functions.
      */
     private class ExternalTablesOnlyVisitor extends AstTraverser<Void, Void> {
         private final Deque<Set<String>> cteNameStack = new ArrayDeque<>();
@@ -1972,6 +2110,61 @@ public class QueryAnalyzer {
             if (statement.getQueryStatement() != null) {
                 visit(statement.getQueryStatement());
             }
+            return null;
+        }
+
+        @Override
+        public Void visitNormalizedTableFunction(NormalizedTableFunctionRelation node, Void context) {
+            if (node.getRight() != null) {
+                visit(node.getRight(), context);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitTableFunction(TableFunctionRelation node, Void context) {
+            if (node.getQueryTable() != null) {
+                return null;
+            }
+
+            JdbcQueryTableFunctionName functionName =
+                    tryParseCanonicalJdbcQueryTableFunctionName(node.getFunctionName().getFunction());
+            if (functionName == null) {
+                return null;
+            }
+
+            if (node.getColumnOutputNames() != null) {
+                return null;
+            }
+
+            List<Expr> args = node.getFunctionParams().exprs();
+            List<String> argNames = node.getFunctionParams().getExprsNames();
+            if (args.size() != 1 || (argNames != null && !argNames.isEmpty())) {
+                return null;
+            }
+
+            Expr queryExpr = args.get(0);
+            if (!(queryExpr instanceof StringLiteral)) {
+                return null;
+            }
+
+            String passThroughQuery;
+            try {
+                passThroughQuery = JDBCTable.normalizePassThroughQuery(((StringLiteral) queryExpr).getStringValue());
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+
+            Optional<ConnectorMetadata> metadata = metadataMgr.getOptionalMetadata(functionName.catalogName);
+            if (metadata.isEmpty()) {
+                return null;
+            }
+
+            JDBCTable jdbcTable;
+            try (Timer ignored = Tracers.watchScope("AnalyzeTable")) {
+                jdbcTable = resolveJdbcQueryTable(functionName, passThroughQuery);
+            }
+            node.setQueryTable(jdbcTable);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableFunctionRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableFunctionRelation.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.catalog.FunctionName;
+import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.TableName;
 import com.starrocks.sql.ast.expression.Expr;
@@ -40,6 +41,7 @@ public class TableFunctionRelation extends Relation {
     private final FunctionParams functionParams;
     private TableFunction tableFunction;
     private List<Expr> childExpressions;
+    private JDBCTable queryTable;
 
     private boolean isLeftJoin = false;
 
@@ -84,6 +86,14 @@ public class TableFunctionRelation extends Relation {
 
     public void setChildExpressions(List<Expr> childExpressions) {
         this.childExpressions = childExpressions;
+    }
+
+    public JDBCTable getQueryTable() {
+        return queryTable;
+    }
+
+    public void setQueryTable(JDBCTable queryTable) {
+        this.queryTable = queryTable;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -51,7 +51,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -459,7 +458,7 @@ public class AST2SQLVisitor extends AST2StringVisitor {
         sqlBuilder.append("(");
         sqlBuilder.append(
                 Optional.ofNullable(tableFunction.getChildExpressions())
-                        .orElse(Collections.emptyList()).stream().map(this::visit)
+                        .orElse(tableFunction.getFunctionParams().exprs()).stream().map(this::visit)
                         .collect(Collectors.joining(",")));
         sqlBuilder.append(")");
         sqlBuilder.append(")"); // TABLE(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
@@ -79,6 +79,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -307,7 +308,8 @@ public class DesensitizedSQLBuilder {
             sqlBuilder.append(node.getFunctionName());
             sqlBuilder.append("(");
 
-            List<String> childSql = node.getChildExpressions().stream().map(this::visit).collect(toList());
+            List<String> childSql = Optional.ofNullable(node.getChildExpressions())
+                    .orElse(node.getFunctionParams().exprs()).stream().map(this::visit).collect(toList());
             sqlBuilder.append(Joiner.on(",").join(childSql));
 
             sqlBuilder.append(")");
@@ -334,7 +336,9 @@ public class DesensitizedSQLBuilder {
             sqlBuilder.append(tableFunction.getFunctionName());
             sqlBuilder.append("(");
             sqlBuilder.append(
-                    tableFunction.getChildExpressions().stream().map(this::visit).collect(Collectors.joining(",")));
+                    Optional.ofNullable(tableFunction.getChildExpressions())
+                            .orElse(tableFunction.getFunctionParams().exprs()).stream().map(this::visit)
+                            .collect(Collectors.joining(",")));
             sqlBuilder.append(")");
             sqlBuilder.append(")"); // TABLE(
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJDBCScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJDBCScanOperator.java
@@ -27,7 +27,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import java.util.Map;
 
 public class LogicalJDBCScanOperator extends LogicalScanOperator {
-
     public LogicalJDBCScanOperator(Table table,
                                    Map<ColumnRefOperator, Column> columnRefOperatorColumnMap,
                                    Map<Column, ColumnRefOperator> columnMetaToColRefMap,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionNames;
 import com.starrocks.catalog.Table;
@@ -1158,6 +1159,10 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
 
     @Override
     public LogicalPlan visitTableFunction(TableFunctionRelation node, ExpressionMapping context) {
+        if (node.getQueryTable() != null) {
+            return buildJdbcQueryTablePlan(node);
+        }
+
         List<ColumnRefOperator> outputColumns = new ArrayList<>();
         TableFunction tableFunction = node.getTableFunction();
 
@@ -1197,8 +1202,50 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
                 null, List.of());
     }
 
+    private LogicalPlan buildJdbcQueryTablePlan(TableFunctionRelation node) {
+        JDBCTable table = node.getQueryTable();
+        List<Field> relationFields = node.getRelationFields().getAllFields();
+        List<Column> fullSchema = table.getFullSchema();
+        Preconditions.checkState(relationFields.size() == fullSchema.size());
+
+        ImmutableMap.Builder<ColumnRefOperator, Column> colRefToColumnMetaMapBuilder =
+                ImmutableMap.builderWithExpectedSize(fullSchema.size());
+        ImmutableMap.Builder<Column, ColumnRefOperator> columnMetaToColRefMapBuilder =
+                ImmutableMap.builderWithExpectedSize(fullSchema.size());
+        ImmutableList.Builder<ColumnRefOperator> outputVariablesBuilder =
+                ImmutableList.builderWithExpectedSize(fullSchema.size());
+
+        int relationId = columnRefFactory.getNextRelationId();
+        for (int i = 0; i < fullSchema.size(); i++) {
+            Column column = fullSchema.get(i);
+            Field field = relationFields.get(i);
+            ColumnRefOperator columnRef = columnRefFactory.create(field.getName(), field.getType(), column.isAllowNull());
+            columnRefFactory.updateColumnToRelationIds(columnRef.getId(), relationId);
+            columnRefFactory.updateColumnRefToColumns(columnRef, column, table);
+            outputVariablesBuilder.add(columnRef);
+            colRefToColumnMetaMapBuilder.put(columnRef, column);
+            columnMetaToColRefMapBuilder.put(column, columnRef);
+        }
+
+        List<ColumnRefOperator> outputVariables = outputVariablesBuilder.build();
+        LogicalScanOperator scanOperator = new LogicalJDBCScanOperator(table,
+                colRefToColumnMetaMapBuilder.build(),
+                columnMetaToColRefMapBuilder.build(),
+                Operator.DEFAULT_LIMIT,
+                null,
+                null);
+        return new LogicalPlan(new OptExprBuilder(scanOperator, Collections.emptyList(),
+                new ExpressionMapping(new Scope(RelationId.of(node), node.getRelationFields()), outputVariables)),
+                outputVariables, List.of());
+    }
+
     @Override
     public LogicalPlan visitNormalizedTableFunction(NormalizedTableFunctionRelation node, ExpressionMapping context) {
+        if (node.getRight() instanceof TableFunctionRelation
+                && ((TableFunctionRelation) node.getRight()).getQueryTable() != null) {
+            return visit(node.getRight(), context);
+        }
+
         LogicalPlan plan = visitJoin(node, context);
         // Column prune, only the table function columns should be returned.
         OptExprBuilder rootBuilder = plan.getRootBuilder();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -170,6 +171,50 @@ public class JDBCTableTest {
         Assertions.assertEquals(jdbcTable.getJdbc_driver_class(), jdbcProperties.get(JDBCResource.DRIVER_CLASS));
         Assertions.assertEquals(jdbcTable.getJdbc_user(), jdbcProperties.get(JDBCResource.USER));
         Assertions.assertEquals(jdbcTable.getJdbc_passwd(), jdbcProperties.get(JDBCResource.PASSWORD));
+    }
+
+    @Test
+    public void testQueryTableToThriftKeepsOriginalJdbcUrl(@Mocked GlobalStateMgr globalStateMgr,
+                                                           @Mocked ResourceMgr resourceMgr) throws Exception {
+        String uri = "jdbc:oracle:thin:@//127.0.0.1:1521/xe";
+        Map<String, String> jdbcProperties = getMockedJDBCProperties(uri);
+        JDBCTable table = new JDBCTable(1000, "jdbc_table", columns, null, "catalog0", jdbcProperties);
+        table.setPassThroughQuery("select * from system.t2");
+
+        TTableDescriptor tableDescriptor = table.toThrift(null);
+        TJDBCTable jdbcTable = tableDescriptor.getJdbcTable();
+        Assertions.assertEquals(uri, jdbcTable.getJdbc_url());
+        Assertions.assertEquals("(select * from system.t2) starrocks_query", jdbcTable.getJdbc_table());
+    }
+
+    @Test
+    public void testOriginalJdbcColumnTypesAccessor() throws Exception {
+        Map<String, String> jdbcProperties = getMockedJDBCProperties("jdbc:mysql://127.0.0.1:3306");
+        JDBCTable table = new JDBCTable(1000, "jdbc_table", columns, "db0", "catalog0", jdbcProperties);
+        Map<String, Integer> originalTypes = new HashMap<>();
+        originalTypes.put("col1", java.sql.Types.BIGINT);
+
+        table.setOriginalJdbcColumnTypes(originalTypes);
+
+        Assertions.assertEquals(java.sql.Types.BIGINT, table.getOriginalJdbcColumnTypes().get("col1"));
+    }
+
+    @Test
+    public void testNormalizePassThroughQueryRejectsInsert() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> JDBCTable.normalizePassThroughQuery("insert into t values (1)"));
+    }
+
+    @Test
+    public void testNormalizePassThroughQueryRejectsDdl() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> JDBCTable.normalizePassThroughQuery("create table t (id int)"));
+    }
+
+    @Test
+    public void testNormalizePassThroughQueryRejectsWithQuery() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> JDBCTable.normalizePassThroughQuery("with cte as (select 1) select * from cte;"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.Test;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
@@ -60,6 +62,10 @@ public class JDBCMetadataTest {
     DatabaseMetaData metaData;
     @Mocked
     PreparedStatement preparedStatement;
+    @Mocked
+    ResultSet queryResultSet;
+    @Mocked
+    ResultSetMetaData queryResultSetMetaData;
     MockResultSet partitionsInfoTablesResult;
     private Map<String, String> properties;
     private MockResultSet dbResult;
@@ -391,6 +397,81 @@ public class JDBCMetadataTest {
         Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
         Assertions.assertNotNull(table);
         Assertions.assertEquals("jdbc table comment", table.getComment());
+    }
+
+    @Test
+    public void testGetTableFromQuery() throws SQLException {
+        new Expectations() {
+            {
+                connection.prepareStatement("SELECT * FROM (SELECT 1 AS id, 'abc' AS name) starrocks_query WHERE 1 = 0");
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = queryResultSet;
+                minTimes = 1;
+
+                queryResultSet.getMetaData();
+                result = queryResultSetMetaData;
+                minTimes = 1;
+
+                queryResultSetMetaData.getColumnCount();
+                result = 2;
+                minTimes = 1;
+
+                queryResultSetMetaData.getColumnType(1);
+                result = Types.INTEGER;
+                minTimes = 1;
+                queryResultSetMetaData.getColumnTypeName(1);
+                result = "INTEGER";
+                minTimes = 1;
+                queryResultSetMetaData.getPrecision(1);
+                result = 4;
+                minTimes = 1;
+                queryResultSetMetaData.getScale(1);
+                result = 0;
+                minTimes = 1;
+                queryResultSetMetaData.getColumnLabel(1);
+                result = "id";
+                minTimes = 1;
+                queryResultSetMetaData.isNullable(1);
+                result = ResultSetMetaData.columnNoNulls;
+                minTimes = 1;
+
+                queryResultSetMetaData.getColumnType(2);
+                result = Types.VARCHAR;
+                minTimes = 1;
+                queryResultSetMetaData.getColumnTypeName(2);
+                result = "VARCHAR";
+                minTimes = 1;
+                queryResultSetMetaData.getPrecision(2);
+                result = 20;
+                minTimes = 1;
+                queryResultSetMetaData.getScale(2);
+                result = 0;
+                minTimes = 1;
+                queryResultSetMetaData.getColumnLabel(2);
+                result = "name";
+                minTimes = 1;
+                queryResultSetMetaData.isNullable(2);
+                result = ResultSetMetaData.columnNullable;
+                minTimes = 1;
+            }
+        };
+
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        Table table = jdbcMetadata.getTableFromQuery(new ConnectContext(), "test", "SELECT 1 AS id, 'abc' AS name;");
+        Assertions.assertInstanceOf(JDBCTable.class, table);
+        JDBCTable jdbcTable = (JDBCTable) table;
+        Assertions.assertTrue(jdbcTable.isQueryTable());
+        Assertions.assertEquals("(SELECT 1 AS id, 'abc' AS name) starrocks_query", jdbcTable.getCatalogTableName());
+        Assertions.assertEquals(2, jdbcTable.getFullSchema().size());
+        Assertions.assertEquals("id", jdbcTable.getFullSchema().get(0).getName());
+        Assertions.assertEquals(Types.INTEGER, jdbcTable.getOriginalJdbcColumnTypes().get("id"));
+        Assertions.assertEquals(Types.VARCHAR, jdbcTable.getOriginalJdbcColumnTypes().get("name"));
+        Assertions.assertEquals(IntegerType.INT, jdbcTable.getFullSchema().get(0).getType());
+        Assertions.assertEquals("name", jdbcTable.getFullSchema().get(1).getName());
+        Assertions.assertEquals(TypeFactory.createVarcharType(20), jdbcTable.getFullSchema().get(1).getType());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.jdbc;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
@@ -27,9 +28,11 @@ import com.starrocks.type.CharType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -155,6 +158,24 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public Table getTableFromQuery(ConnectContext context, String dbName, String query) {
+        readLock();
+        try {
+            String normalizedQuery = JDBCTable.normalizePassThroughQuery(query);
+            long tableId = idGen.incrementAndGet();
+            String resolvedDbName = dbName == null ? MOCKED_PARTITIONED_DB_NAME : dbName;
+            JDBCTable queryTable = new JDBCTable(tableId, "_query_" + tableId, getQuerySchema(normalizedQuery),
+                    resolvedDbName, getCatalogName(), properties);
+            queryTable.setPassThroughQuery(normalizedQuery);
+            return queryTable;
+        } catch (DdlException e) {
+            throw new RuntimeException(e);
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @Override
     public Database getDb(ConnectContext context, String dbName) {
         readLock();
         try {
@@ -202,6 +223,150 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
         } finally {
             readUnlock();
         }
+    }
+
+    private String getCatalogName() {
+        String jdbcUri = properties.get(JDBCResource.URI);
+        if (jdbcUri != null && (jdbcUri.startsWith("jdbc:postgresql") || jdbcUri.startsWith("jdbc:postgres"))) {
+            return MOCKED_JDBC_PG_CATALOG_NAME;
+        }
+        return MOCKED_JDBC_CATALOG_NAME;
+    }
+
+    private List<Column> getQuerySchema(String query) {
+        String projection = extractProjection(query);
+        if (projection == null || projection.isEmpty() || projection.contains("*")) {
+            return getSchema(MOCKED_PARTITIONED_TABLE_NAME0);
+        }
+
+        List<Column> querySchema = new ArrayList<>();
+        List<Column> defaultSchema = getSchema(MOCKED_PARTITIONED_TABLE_NAME0);
+        for (String item : splitProjectionItems(projection)) {
+            String columnName = extractProjectionColumnName(item);
+            if (columnName.isEmpty()) {
+                continue;
+            }
+
+            String lookupName = stripIdentifierQuote(columnName);
+            Column template = defaultSchema.stream()
+                    .filter(column -> column.getName().equalsIgnoreCase(lookupName))
+                    .findFirst()
+                    .orElse(new Column(columnName, VarcharType.VARCHAR));
+            querySchema.add(new Column(columnName, template.getType()));
+        }
+        return querySchema.isEmpty() ? defaultSchema : querySchema;
+    }
+
+    private String extractProjection(String query) {
+        String lowerQuery = query.toLowerCase(Locale.ROOT);
+        int selectIndex = lowerQuery.indexOf("select");
+        if (selectIndex < 0) {
+            return null;
+        }
+
+        int projectionStart = selectIndex + "select".length();
+        int fromIndex = findTopLevelKeyword(lowerQuery, "from", projectionStart);
+        return query.substring(projectionStart, fromIndex >= 0 ? fromIndex : query.length()).trim();
+    }
+
+    private List<String> splitProjectionItems(String projection) {
+        List<String> items = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        int parentheses = 0;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBackticks = false;
+        for (int i = 0; i < projection.length(); i++) {
+            char ch = projection.charAt(i);
+            if (ch == '\'' && !inDoubleQuote && !inBackticks) {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch == '"' && !inSingleQuote && !inBackticks) {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch == '`' && !inSingleQuote && !inDoubleQuote) {
+                inBackticks = !inBackticks;
+            } else if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
+                if (ch == '(') {
+                    parentheses++;
+                } else if (ch == ')') {
+                    parentheses = Math.max(0, parentheses - 1);
+                } else if (ch == ',' && parentheses == 0) {
+                    items.add(current.toString().trim());
+                    current.setLength(0);
+                    continue;
+                }
+            }
+            current.append(ch);
+        }
+        if (current.length() > 0) {
+            items.add(current.toString().trim());
+        }
+        return items;
+    }
+
+    private String extractProjectionColumnName(String item) {
+        String trimmedItem = item.trim();
+        if (trimmedItem.isEmpty()) {
+            return "";
+        }
+
+        String lowerItem = trimmedItem.toLowerCase(Locale.ROOT);
+        int asIndex = findTopLevelKeyword(lowerItem, "as", 0);
+        if (asIndex >= 0) {
+            return trimmedItem.substring(asIndex + 2).trim();
+        }
+
+        int dotIndex = trimmedItem.lastIndexOf('.');
+        if (dotIndex >= 0 && dotIndex < trimmedItem.length() - 1) {
+            return trimmedItem.substring(dotIndex + 1).trim();
+        }
+        return trimmedItem;
+    }
+
+    private int findTopLevelKeyword(String sql, String keyword, int startIndex) {
+        int parentheses = 0;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBackticks = false;
+        for (int i = startIndex; i <= sql.length() - keyword.length(); i++) {
+            char ch = sql.charAt(i);
+            if (ch == '\'' && !inDoubleQuote && !inBackticks) {
+                inSingleQuote = !inSingleQuote;
+            } else if (ch == '"' && !inSingleQuote && !inBackticks) {
+                inDoubleQuote = !inDoubleQuote;
+            } else if (ch == '`' && !inSingleQuote && !inDoubleQuote) {
+                inBackticks = !inBackticks;
+            } else if (!inSingleQuote && !inDoubleQuote && !inBackticks) {
+                if (ch == '(') {
+                    parentheses++;
+                } else if (ch == ')') {
+                    parentheses = Math.max(0, parentheses - 1);
+                }
+            }
+
+            if (inSingleQuote || inDoubleQuote || inBackticks || parentheses != 0) {
+                continue;
+            }
+
+            if (sql.startsWith(keyword, i)
+                    && (i == 0 || Character.isWhitespace(sql.charAt(i - 1)))
+                    && (i + keyword.length() == sql.length()
+                    || Character.isWhitespace(sql.charAt(i + keyword.length())))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private String stripIdentifierQuote(String name) {
+        String trimmed = name.trim();
+        if (trimmed.length() >= 2) {
+            char first = trimmed.charAt(0);
+            char last = trimmed.charAt(trimmed.length() - 1);
+            if ((first == '"' && last == '"') || (first == '`' && last == '`')) {
+                return trimmed.substring(1, trimmed.length() - 1);
+            }
+        }
+        return trimmed;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
@@ -612,4 +612,42 @@ public class MySqlAndJDBCScanNodeTest {
         // Should wrap each part separately
         Assertions.assertTrue(nodeString.contains("\"mydb\".\"public\".\"users\""), nodeString);
     }
+
+    @Test
+    public void testPassThroughQueryInJDBCScanNode() throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "root");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:mysql://localhost:3306");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "com.mysql.jdbc.Driver");
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", VarcharType.VARCHAR),
+                new Column("name", VarcharType.VARCHAR)
+        );
+        JDBCTable queryTable = new JDBCTable(1, "query_table", columns, properties);
+        queryTable.setPassThroughQuery("select id, name from remote_table");
+
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(queryTable);
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), "id", VarcharType.VARCHAR, true);
+        idSlot.setColumn(columns.get(0));
+        idSlot.setIsMaterialized(true);
+        tupleDesc.addSlot(idSlot);
+        SlotDescriptor nameSlot = new SlotDescriptor(new SlotId(2), "name", VarcharType.VARCHAR, true);
+        nameSlot.setColumn(columns.get(1));
+        nameSlot.setIsMaterialized(true);
+        tupleDesc.addSlot(nameSlot);
+
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, queryTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains("TABLE: (select id, name from remote_table) starrocks_query"),
+                nodeString);
+        Assertions.assertTrue(nodeString.contains("SELECT `id`, `name` FROM " +
+                        "(select id, name from remote_table) starrocks_query"), nodeString);
+        Assertions.assertFalse(nodeString.contains("FROM `(select id, name from remote_table) starrocks_query`"),
+                nodeString);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
@@ -71,6 +71,34 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
         }
     }
 
+    private static class BlockingJDBCQueryMetadata extends MockedJDBCMetadata {
+        private final CountDownLatch started;
+        private final CountDownLatch allowReturn;
+        private final AtomicInteger getTableFromQueryCalls;
+
+        public BlockingJDBCQueryMetadata(Map<String, String> properties,
+                                         CountDownLatch started,
+                                         CountDownLatch allowReturn,
+                                         AtomicInteger getTableFromQueryCalls) {
+            super(properties);
+            this.started = started;
+            this.allowReturn = allowReturn;
+            this.getTableFromQueryCalls = getTableFromQueryCalls;
+        }
+
+        @Override
+        public Table getTableFromQuery(ConnectContext context, String dbName, String query) {
+            getTableFromQueryCalls.incrementAndGet();
+            started.countDown();
+            try {
+                allowReturn.await(20, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return super.getTableFromQuery(context, dbName, query);
+        }
+    }
+
     @Test
     public void testCTEWithInternalTable() throws Exception {
         // Test that CTE with internal table works correctly
@@ -189,6 +217,70 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
         Assertions.assertTrue(lockCalled.get());
         // Analyzer should reuse pre-resolved external table; metadata getTable must not be called twice.
         Assertions.assertEquals(1, getTableCalls.get());
+    }
+
+    @Test
+    public void testMixedQueryNativeQueryMetadataNotUnderLock() throws Exception {
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch allowReturn = new CountDownLatch(1);
+        AtomicInteger getTableFromQueryCalls = new AtomicInteger();
+
+        GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) gsm.getMetadataMgr();
+        Map<String, String> props = new HashMap<>();
+        props.put(JDBCResource.TYPE, "jdbc");
+        props.put(JDBCResource.DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+        props.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
+        props.put(JDBCResource.USER, "root");
+        props.put(JDBCResource.PASSWORD, "123456");
+        props.put(JDBCResource.CHECK_SUM, "xxxx");
+        props.put(JDBCResource.DRIVER_URL, "xxxx");
+        BlockingJDBCQueryMetadata blocking =
+                new BlockingJDBCQueryMetadata(props, started, allowReturn, getTableFromQueryCalls);
+        metadataMgr.registerMockedMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME, blocking);
+
+        String sql = "select * from t0 join table(jdbc0.native_query('select * from remote_table')) q on true";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+
+        AtomicBoolean lockCalled = new AtomicBoolean(false);
+        PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt) {
+            @Override
+            public void lock() {
+                lockCalled.set(true);
+            }
+
+            @Override
+            public void unlock() {
+                // no-op
+            }
+        };
+
+        AtomicBoolean finished = new AtomicBoolean(false);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+                finished.set(true);
+            } catch (Throwable t0) {
+                error.set(t0);
+            }
+        });
+        t.start();
+
+        Assertions.assertTrue(started.await(10, TimeUnit.SECONDS));
+        Assertions.assertFalse(lockCalled.get(),
+                "Meta lock was acquired while JDBC native_query metadata was blocked.");
+
+        allowReturn.countDown();
+        t.join(TimeUnit.SECONDS.toMillis(20));
+
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+        Assertions.assertTrue(finished.get());
+        Assertions.assertTrue(lockCalled.get());
+        Assertions.assertEquals(1, getTableFromQueryCalls.get(),
+                "getTableFromQuery was called " + getTableFromQueryCalls.get() + " times, expected 1.");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JDBCIdentifierQuoteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JDBCIdentifierQuoteTest.java
@@ -14,6 +14,10 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -40,5 +44,77 @@ public class JDBCIdentifierQuoteTest extends ConnectorPlanTestBase {
         assertContains(plan, "SCAN JDBC");
         assertContains(plan, "TABLE: `tbl0`");
         assertContains(plan, "QUERY: SELECT `a`, `b` FROM `tbl0`");
+    }
+
+    @Test
+    public void testMySQLPassThroughQueryTableFunction() throws Exception {
+        String sql = "select a from table(jdbc0.native_query('select a, b from remote_table')) t " +
+                "where b = 'x'";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "SCAN JDBC");
+        assertContains(plan, "TABLE: (select a, b from remote_table) starrocks_query");
+        assertContains(plan, "QUERY: SELECT `a`, `b` FROM (select a, b from remote_table) " +
+                "starrocks_query WHERE (`b` = 'x')");
+    }
+
+    @Test
+    public void testMySQLPassThroughQueryTableFunctionSelectStar() throws Exception {
+        String sql = "select * from table(jdbc0.native_query('select * from remote_table'))";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "SCAN JDBC");
+        assertContains(plan, "TABLE: (select * from remote_table) starrocks_query");
+        assertContains(plan, "QUERY: SELECT `a`, `b`, `c`, `d` FROM (select * from remote_table) starrocks_query");
+    }
+
+    @Test
+    public void testMySQLPassThroughQueryTableFunctionInitializesChildExpressions() throws Exception {
+        String sql = "select * from table(jdbc0.native_query('select * from remote_table'))";
+        StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        Assertions.assertDoesNotThrow(() -> AnalyzerUtils.collectAllSelectTableColumns(statement));
+    }
+
+    @Test
+    public void testMySQLPassThroughQueryTableFunctionRejectsColumnAlias() {
+        String sql = "select * from table(jdbc0.native_query('select a from remote_table')) t(x)";
+        assertExceptionMsgContains(sql, "column aliases are not supported for JDBC query table function");
+    }
+
+    @Test
+    public void testMySQLPassThroughQueryTableFunctionRejectsNamedArgument() {
+        String sql = "select * from table(jdbc0.native_query(query => 'select a from remote_table'))";
+        assertExceptionMsgContains(sql,
+                "JDBC query table function only supports TABLE(<catalog>.native_query('<sql>'))");
+    }
+
+    @Test
+    public void testMySQLPassThroughQueryTableFunctionDoesNotReserveTwoPartQueryName() {
+        String sql = "select * from table(jdbc0.query('select a from remote_table'))";
+        assertExceptionMsgContains(sql,
+                "Unknown table function 'jdbc0.query(");
+    }
+
+    @Test
+    public void testMySQLPassThroughQueryTableFunctionRejectsLegacySystemQueryName() {
+        String sql = "select * from table(jdbc0.system.query('select a from remote_table'))";
+        assertExceptionMsgContains(sql,
+                "JDBC query table function only supports TABLE(<catalog>.native_query('<sql>'))");
+    }
+
+    @Test
+    public void testMySQLPassThroughQueryTableFunctionRejectsInsert() {
+        String sql = "select * from table(jdbc0.native_query('insert into remote_table values (1)'))";
+        assertExceptionMsgContains(sql, "JDBC query table function only supports SELECT queries");
+    }
+
+    @Test
+    public void testMySQLPassThroughQueryTableFunctionRejectsDdl() {
+        String sql = "select * from table(jdbc0.native_query('create table remote_table(id int)'))";
+        assertExceptionMsgContains(sql, "JDBC query table function only supports SELECT queries");
+    }
+
+    @Test
+    public void testMySQLPassThroughQueryTableFunctionRejectsWithQuery() {
+        String sql = "select * from table(jdbc0.native_query('with cte as (select 1) select * from cte'))";
+        assertExceptionMsgContains(sql, "JDBC query table function only supports SELECT queries");
     }
 }

--- a/test/sql/test_jdbc_catalog/R/test_native_query
+++ b/test/sql/test_jdbc_catalog/R/test_native_query
@@ -1,0 +1,75 @@
+-- name: test_jdbc_catalog_native_query
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database if exists db_native_query_${uuid0}; create database db_native_query_${uuid0};'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_native_query_${uuid0}; CREATE TABLE native_query_base (id int not null, name varchar(20), score int, category varchar(20));'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_native_query_${uuid0}; INSERT INTO native_query_base VALUES (1,"alpha",10,"red"),(2,"beta",20,"blue"),(3,"gamma",30,"red"),(4,"delta",40,"blue");'
+-- result:
+0
+
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create external catalog jdbc_native_query_${uuid0}
+properties
+(
+    "type"="jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="${udf_url}/starrocks-jdbc%2Fmysql-connector-java-5.1.37.jar",
+    "driver_class"="com.mysql.jdbc.Driver"
+);
+-- result:
+-- !result
+select id, name, doubled_score
+from table(jdbc_native_query_${uuid0}.native_query('/* native query */ select id, name, score * 2 as doubled_score from db_native_query_${uuid0}.native_query_base where score >= 20;')) q
+where doubled_score < 70
+order by id;
+-- result:
+2	beta	40
+3	gamma	60
+-- !result
+select category, sum(score) as total_score
+from table(jdbc_native_query_${uuid0}.native_query('select category, score from db_native_query_${uuid0}.native_query_base where id <= 4')) q
+group by category
+order by category;
+-- result:
+blue	60
+red	40
+-- !result
+select * from table(jdbc_native_query_${uuid0}.native_query('select id from db_native_query_${uuid0}.native_query_base')) q(id_alias);
+-- result:
+[REGEX].*column aliases are not supported for JDBC query table function.*
+-- !result
+select * from table(jdbc_native_query_${uuid0}.native_query(query => 'select id from db_native_query_${uuid0}.native_query_base'));
+-- result:
+[REGEX].*JDBC query table function only supports TABLE\(<catalog>\.native_query\('<sql>'\)\).*
+-- !result
+select * from table(jdbc_native_query_${uuid0}.system.query('select id from db_native_query_${uuid0}.native_query_base'));
+-- result:
+[REGEX].*JDBC query table function only supports TABLE\(<catalog>\.native_query\('<sql>'\)\).*
+-- !result
+select * from table(jdbc_native_query_${uuid0}.native_query('insert into db_native_query_${uuid0}.native_query_base values (5, "bad", 50, "red")'));
+-- result:
+[REGEX].*JDBC query table function only supports SELECT queries.*
+-- !result
+select * from table(jdbc_native_query_${uuid0}.native_query('with cte as (select id from db_native_query_${uuid0}.native_query_base) select * from cte'));
+-- result:
+[REGEX].*JDBC query table function only supports SELECT queries.*
+-- !result
+drop catalog jdbc_native_query_${uuid0};
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database db_native_query_${uuid0};'
+-- result:
+0
+
+-- !result

--- a/test/sql/test_jdbc_catalog/T/test_native_query
+++ b/test/sql/test_jdbc_catalog/T/test_native_query
@@ -1,0 +1,45 @@
+-- name: test_jdbc_catalog_native_query
+-- prepare external MySQL table
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database if exists db_native_query_${uuid0}; create database db_native_query_${uuid0};'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_native_query_${uuid0}; CREATE TABLE native_query_base (id int not null, name varchar(20), score int, category varchar(20));'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_native_query_${uuid0}; INSERT INTO native_query_base VALUES (1,"alpha",10,"red"),(2,"beta",20,"blue"),(3,"gamma",30,"red"),(4,"delta",40,"blue");'
+
+-- create catalog
+set catalog default_catalog;
+create external catalog jdbc_native_query_${uuid0}
+properties
+(
+    "type"="jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="${udf_url}/starrocks-jdbc%2Fmysql-connector-java-5.1.37.jar",
+    "driver_class"="com.mysql.jdbc.Driver"
+);
+
+-- query table function can infer columns from the pass-through query and apply outer predicates.
+select id, name, doubled_score
+from table(jdbc_native_query_${uuid0}.native_query('/* native query */ select id, name, score * 2 as doubled_score from db_native_query_${uuid0}.native_query_base where score >= 20;')) q
+where doubled_score < 70
+order by id;
+
+-- query table function works as a regular relation for aggregation.
+select category, sum(score) as total_score
+from table(jdbc_native_query_${uuid0}.native_query('select category, score from db_native_query_${uuid0}.native_query_base where id <= 4')) q
+group by category
+order by category;
+
+-- unsupported forms are rejected during analysis.
+select * from table(jdbc_native_query_${uuid0}.native_query('select id from db_native_query_${uuid0}.native_query_base')) q(id_alias);
+
+select * from table(jdbc_native_query_${uuid0}.native_query(query => 'select id from db_native_query_${uuid0}.native_query_base'));
+
+select * from table(jdbc_native_query_${uuid0}.system.query('select id from db_native_query_${uuid0}.native_query_base'));
+
+select * from table(jdbc_native_query_${uuid0}.native_query('insert into db_native_query_${uuid0}.native_query_base values (5, "bad", 50, "red")'));
+
+
+select * from table(jdbc_native_query_${uuid0}.native_query('with cte as (select id from db_native_query_${uuid0}.native_query_base) select * from cte'));
+-- cleanup
+drop catalog jdbc_native_query_${uuid0};
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database db_native_query_${uuid0};'


### PR DESCRIPTION
## Why I'm doing:

Users sometimes need to query JDBC data through database-native SQL that StarRocks cannot naturally express against a single external table, such as complex joins, views, vendor-specific syntax, or pre-filtered subqueries. The native_query table function provides a controlled pass-through path for those cases while still exposing the result as a normal StarRocks relation, so users can continue to apply StarRocks-side filters, joins, and aggregations on top of it.

## What I'm doing:

Add JDBC native query table function support with the syntax `TABLE(<catalog>.native_query('<sql>'))`.

This allows StarRocks to infer the result schema from a JDBC pass-through `SELECT` query, expose it as a normal table relation, and then apply StarRocks-side predicates, joins, aggregations, and projections on top of it. To keep the pass-through path narrow, the implementation rejects unsupported forms such as `WITH` queries, named arguments, column aliases, non-`SELECT` SQL, and the legacy `system.query` alias. In addition, the analyzer now initializes `TableFunctionRelation.childExpressions` for `native_query` relations so analyzer visitors and column-collection utilities can walk these relations safely, and query-table schema inference now preserves original JDBC column types for downstream JDBC scan rewrites.

Fixes [#70852](https://github.com/StarRocks/starrocks/issues/70852)

StarrocksTest: https://github.com/StarRocks/StarRocksTest/pull/11260

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
