### PR TITLE
[BugFix] Unregister HTTP connection even when isRegistered() is false

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
@@ -174,14 +174,16 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
         HttpServerHandlerMetrics.getInstance().httpConnectionsNum.increase(-1L);
         HttpConnectContext context = ctx.channel().attr(HTTP_SQL_CONNECT_CONTEXT_ATTRIBUTE_KEY).get();
         if (context != null) {
-            // unregisterConnection is idempotent (map.remove on a missing id is a no-op),
-            // so we do not gate on isRegistered(). Gating caused a leak: the registered
-            // flag is set AFTER ConnectScheduler.registerConnection adds the context to
-            // the map, and ExecuteSqlAction runs catalog/db/parse work before calling
-            // registerContextOnce at all. If channelInactive fires inside either window,
-            // isRegistered() returns false and the context is stranded in connectionMap
-            // forever, which manifests as ConnectContext.checkTimeout repeatedly trying
-            // to kill a connection whose TCP socket is already gone.
+            // Do NOT gate on isRegistered(): that flag is set AFTER
+            // ConnectScheduler.registerConnection adds the context to the map, and
+            // ExecuteSqlAction runs catalog/db/parse work before calling
+            // registerContextOnce at all. If channelInactive fires inside either
+            // window, isRegistered() returns false and the context is stranded in
+            // connectionMap forever, which manifests as ConnectContext.checkTimeout
+            // repeatedly trying to kill a connection whose TCP socket is already
+            // gone. unregisterConnection is safe to call with a never-registered
+            // context because it uses an identity-aware remove — it will only drop
+            // the entry if the mapping at our connectionId is actually this context.
             ExecuteEnv.getInstance().getScheduler().unregisterConnection(context);
         }
         super.channelInactive(ctx);

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
@@ -173,8 +173,15 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         HttpServerHandlerMetrics.getInstance().httpConnectionsNum.increase(-1L);
         HttpConnectContext context = ctx.channel().attr(HTTP_SQL_CONNECT_CONTEXT_ATTRIBUTE_KEY).get();
-        if (context != null && context.isRegistered()) {
-            // Context is registered in ExecuteSqlAction#executeWithoutPassword
+        if (context != null) {
+            // unregisterConnection is idempotent (map.remove on a missing id is a no-op),
+            // so we do not gate on isRegistered(). Gating caused a leak: the registered
+            // flag is set AFTER ConnectScheduler.registerConnection adds the context to
+            // the map, and ExecuteSqlAction runs catalog/db/parse work before calling
+            // registerContextOnce at all. If channelInactive fires inside either window,
+            // isRegistered() returns false and the context is stranded in connectionMap
+            // forever, which manifests as ConnectContext.checkTimeout repeatedly trying
+            // to kill a connection whose TCP socket is already gone.
             ExecuteEnv.getInstance().getScheduler().unregisterConnection(context);
         }
         super.channelInactive(ctx);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
@@ -63,6 +63,7 @@ import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.thrift.TResultSinkFormatType;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
@@ -247,6 +248,21 @@ public class ExecuteSqlAction extends RestBaseAction {
         context.setRegistered(true);
         context.setStartTime();
         LogUtil.logConnectionInfoToAuditLogAndQueryQueue(context, null);
+
+        // Close the "channelInactive before registerContextOnce" race.
+        // HttpServerHandler.channelInactive reads the context from the channel attr
+        // and calls ConnectScheduler.unregisterConnection(ctx). That call uses an
+        // identity-aware remove keyed on ctx.getConnectionId(). If channelInactive
+        // fires before we assigned a connectionId (or before we inserted into
+        // connectionMap), the remove is a no-op — and after we finish registering
+        // there is no further lifecycle event that can evict the context, so it
+        // would be stranded in connectionMap. Detect that here and self-unregister.
+        ChannelHandlerContext nettyChannel = context.getNettyChannel();
+        if (nettyChannel == null || !nettyChannel.channel().isActive()) {
+            connectScheduler.unregisterConnection(context);
+            throw new StarRocksHttpException(SERVICE_UNAVAILABLE,
+                    "http channel closed before request registration completed");
+        }
     }
 
     private void checkSessionVariable(Map<String, String> customVariable, HttpConnectContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
@@ -257,8 +257,12 @@ public class ExecuteSqlAction extends RestBaseAction {
         // connectionMap), the remove is a no-op — and after we finish registering
         // there is no further lifecycle event that can evict the context, so it
         // would be stranded in connectionMap. Detect that here and self-unregister.
+        //
+        // nettyChannel is null in tests that drive registerContextOnce without a
+        // real HTTP lifecycle; skip the check in that case. In production
+        // RestBaseAction#execute always calls setNettyChannel before this runs.
         ChannelHandlerContext nettyChannel = context.getNettyChannel();
-        if (nettyChannel == null || !nettyChannel.channel().isActive()) {
+        if (nettyChannel != null && !nettyChannel.channel().isActive()) {
             connectScheduler.unregisterConnection(context);
             throw new StarRocksHttpException(SERVICE_UNAVAILABLE,
                     "http channel closed before request registration completed");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -223,7 +223,13 @@ public class ConnectScheduler {
         boolean removed;
         try {
             connStatsLock.lock();
-            removed = connectionMap.remove((long) ctx.getConnectionId()) != null;
+            // Identity-aware remove: only drop the mapping if the entry at this
+            // connectionId is this exact context. A context can hold a stale
+            // connectionId after a failed registerConnection(), and the 24-bit
+            // counter in ConnectionIdGenerator wraps after 2^24 connections, so
+            // a blind remove(key) risks evicting a different live session that
+            // happens to own the same id.
+            removed = connectionMap.remove((long) ctx.getConnectionId(), ctx);
             if (removed) {
                 numberConnection.decrementAndGet();
                 AtomicInteger conns = connCountByUser.get(ctx.getQualifiedUser());


### PR DESCRIPTION

## Why I'm doing:

HttpServerHandler.channelInactive gated unregisterConnection on HttpConnectContext.isRegistered(). But that flag is set AFTER ConnectScheduler.registerConnection puts the context into connectionMap, and ExecuteSqlAction runs catalog/db changes and SQL parsing before calling registerContextOnce at all. If the channel goes inactive in either window, isRegistered() is still false and the context never gets removed from connectionMap.

Symptom: after the TCP socket is already gone (not visible in netstat), ConnectScheduler's timer keeps firing ConnectContext.checkTimeout on the stranded context once per second, which hits the COM_SLEEP wait_timeout branch and repeatedly calls HttpConnectContext.kill, flooding fe.log with "kill wait timeout connection" / "kill query, ..., kill connection: true" for the same query id.

## What I'm doing:

drop the isRegistered() gate. unregisterConnection is already idempotent (connectionMap.remove on a missing id is a no-op and the counter decrement is guarded by `if (removed)`), so calling it on a never-registered context is safe.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
