### PR TITLE
[Enhancement] Unify all incremental MVs as PK tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -324,7 +324,11 @@ public class AlterJobMgr {
         List<Column> newColumns = createStmt.getMvColumnItems().stream()
                 .sorted(Comparator.comparing(Column::getName))
                 .collect(Collectors.toList());
-        List<Column> existedColumns = materializedView.getOrderedOutputColumns(true).stream()
+        // Use baseSchemaWithoutGeneratedColumn (not getOrderedOutputColumns) because this
+        // compares the MV's full schema against createStmt.getMvColumnItems(). The latter
+        // includes storage-filled columns (e.g. AUTO_INCREMENT __ROW_ID__) which are not
+        // part of query output but are in the MV schema.
+        List<Column> existedColumns = materializedView.getBaseSchemaWithoutGeneratedColumn().stream()
                 .sorted(Comparator.comparing(Column::getName))
                 .collect(Collectors.toList());
         if (newColumns.size() != existedColumns.size()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -72,6 +72,7 @@ import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer;
+import com.starrocks.sql.analyzer.mv.RowIdStrategy;
 import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.ParseNode;
@@ -84,6 +85,7 @@ import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmOpUtils;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
@@ -879,11 +881,41 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     public String getTaskDefinition() {
-        return String.format("insert overwrite `%s` %s", getName(), getMVQueryDefinedSql());
+        return formatInsertSql("insert overwrite");
     }
 
     public String getIVMTaskDefinition() {
-        return String.format("INSERT INTO `%s` %s", getName(), getMVQueryDefinedSql());
+        return formatInsertSql("INSERT INTO");
+    }
+
+    /**
+     * Build an INSERT SQL for this MV. Uses an explicit column list only when the schema
+     * has storage-filled columns (AUTO_INCREMENT) that the query doesn't produce. Otherwise
+     * uses positional form — matching pre-existing behavior for MVs with generated columns,
+     * which {@code InsertAnalyzer} rejects if listed explicitly.
+     */
+    private String formatInsertSql(String insertKeyword) {
+        String targetSpec = hasAutoIncrementColumn()
+                ? String.format("`%s` (%s)", getName(), queryProducedColumnList())
+                : String.format("`%s`", getName());
+        return String.format("%s %s %s", insertKeyword, targetSpec, getMVQueryDefinedSql());
+    }
+
+    /**
+     * Backtick-quoted schema columns in <strong>query projection order</strong>, excluding
+     * columns the storage engine fills in itself (AUTO_INCREMENT / generated). Sort-key
+     * reorder may permute schema order; the INSERT column list must still match the query's
+     * SELECT order so values line up correctly.
+     */
+    private String queryProducedColumnList() {
+        // getOrderedOutputColumns(true) returns query-output-order columns, already excluding
+        // generated (via baseSchemaWithoutGeneratedColumn) and AUTO_INCREMENT columns (which
+        // are marked NO_QUERY_OUTPUT in queryOutputIndices). Defensive !isAutoIncrement
+        // filter covers the identity-queryOutputIndices edge case.
+        return getOrderedOutputColumns(true).stream()
+                .filter(col -> !col.isAutoIncrement())
+                .map(col -> "`" + col.getName() + "`")
+                .collect(Collectors.joining(", "));
     }
 
     /**
@@ -1028,6 +1060,17 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     public void setEncodeRowIdVersion(int encodeRowIdVersion) {
         this.encodeRowIdVersion = encodeRowIdVersion;
+    }
+
+    /** Derived from the schema: {@code null} for non-IVM MVs, otherwise based on {@code __ROW_ID__}'s auto-increment flag. */
+    public RowIdStrategy getRowIdStrategy() {
+        Column rowIdCol = getColumn(IvmOpUtils.COLUMN_ROW_ID);
+        if (rowIdCol == null) {
+            return null;
+        }
+        return rowIdCol.isAutoIncrement()
+                ? RowIdStrategy.AUTO_INCREMENT
+                : RowIdStrategy.QUERY_COMPUTED;
     }
 
     /**
@@ -1795,9 +1838,18 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         sb.append("CREATE MATERIALIZED VIEW `").append(getName()).append("` (");
         List<String> colDef = Lists.newArrayList();
 
-        // NOTE: only output non-generated columns
-        // use ordered columns to keep the same order as the original create statement
-        List<Column> orderedColumns = getOrderedOutputColumns(true);
+        // NOTE: only output non-generated columns.
+        // Start with query-output order (preserves user's ORDER BY reorder effect), then
+        // append schema columns not produced by the query (e.g. AUTO_INCREMENT __ROW_ID__
+        // on non-aggregate IVM). Match the pre-existing behavior of showing hidden columns
+        // like __ROW_ID__ / __AGG_STATE__ in the DDL.
+        List<Column> orderedColumns = new ArrayList<>(getOrderedOutputColumns(true));
+        Set<String> alreadyIncluded = orderedColumns.stream()
+                .map(Column::getName)
+                .collect(Collectors.toSet());
+        getBaseSchemaWithoutGeneratedColumn().stream()
+                .filter(col -> !alreadyIncluded.contains(col.getName()))
+                .forEach(orderedColumns::add);
         for (Column column : orderedColumns) {
             StringBuilder colSb = new StringBuilder();
             // Since mv supports complex expressions as the output column, add `` to support to replay it.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -281,13 +281,37 @@ public class MaterializedViewAnalyzer {
         }
     }
 
+    /** {@code pair.second} for schema columns not produced by any query expression (storage-filled). */
+    private static final int NO_QUERY_OUTPUT = -1;
+
     @VisibleForTesting
     protected static List<Integer> getQueryOutputIndices(List<Pair<Column, Integer>> mvColumnPairs) {
         return Streams
                 .mapWithIndex(mvColumnPairs.stream(), (pair, idx) -> Pair.create(pair.second, (int) idx))
+                .filter(p -> p.first != NO_QUERY_OUTPUT)
                 .sorted(Comparator.comparingInt(x -> x.first))
                 .map(x -> x.second)
                 .collect(Collectors.toList());
+    }
+
+    private static Column createAutoIncrementRowIdColumn() {
+        Column col = new Column(IvmOpUtils.COLUMN_ROW_ID, IntegerType.BIGINT, false);
+        col.setIsKey(true);
+        col.setIsAllowNull(false);
+        col.setIsHidden(true);
+        col.setIsAutoIncrement(true);
+        return col;
+    }
+
+    /** Move/prepend {@code __ROW_ID__} to the head of the sort-keys list. */
+    private static List<String> prependRowIdToKeys(List<String> existing) {
+        List<String> result = Lists.newArrayList(IvmOpUtils.COLUMN_ROW_ID);
+        if (existing != null) {
+            existing.stream()
+                    .filter(k -> !IvmOpUtils.COLUMN_ROW_ID.equalsIgnoreCase(k))
+                    .forEach(result::add);
+        }
+        return result;
     }
 
     static class MaterializedViewAnalyzerVisitor implements AstVisitorExtendInterface<Void, ConnectContext> {
@@ -370,11 +394,9 @@ public class MaterializedViewAnalyzer {
                     Analyzer.analyze(queryStatement, context);
                     statement.setIvmViewDef(AstToSQLBuilder.buildSimple(queryStatement));
                     statement.setQueryStatement(queryStatement);
-                    // Use primary key as default keys type for IVM when the query itself
-                    // produces __ROW_ID__ (aggregate MVs encode group-by keys into __ROW_ID__).
-                    if (result.rowIdStrategy() == RowIdStrategy.QUERY_COMPUTED) {
-                        statement.setKeysType(KeysType.PRIMARY_KEYS);
-                    }
+                    // All incremental MVs are PK tables; the row-id strategy decides how __ROW_ID__ is sourced.
+                    statement.setKeysType(KeysType.PRIMARY_KEYS);
+                    statement.setRowIdStrategy(result.rowIdStrategy());
                     statement.setCurrentRefreshMode(result.currentRefreshMode());
                 } else {
                     // if not ivm, set query statement directly
@@ -411,8 +433,13 @@ public class MaterializedViewAnalyzer {
             // set the columns into createMaterializedViewStatement
             List<ColWithComment> colWithComments = statement.getColWithComments();
             List<String> keyCols = statement.getSortKeys();
+            if (statement.getRowIdStrategy() == RowIdStrategy.AUTO_INCREMENT) {
+                // AUTO_INCREMENT __ROW_ID__ is the PK; force it to be the leading sort key.
+                keyCols = prependRowIdToKeys(keyCols);
+                statement.setSortKeys(keyCols);
+            }
             List<Pair<Column, Integer>> mvColumnPairs = genMaterializedViewColumns(statement.getKeysType(),
-                    queryStatement, colWithComments, keyCols);
+                    statement.getRowIdStrategy(), queryStatement, colWithComments, keyCols);
             List<Column> mvColumns = mvColumnPairs.stream().map(pair -> pair.first).collect(Collectors.toList());
             statement.setMvColumnItems(mvColumns);
 
@@ -433,6 +460,9 @@ public class MaterializedViewAnalyzer {
             // change `queryStatement.getQueryRelation`'s outputs at the same time.
             List<Expr> outputExpressions = queryStatement.getQueryRelation().getOutputExpression();
             for (Pair<Column, Integer> pair : mvColumnPairs) {
+                if (pair.second == NO_QUERY_OUTPUT) {
+                    continue;   // AUTO_INCREMENT column: storage fills it, no query expr
+                }
                 Preconditions.checkState(pair.second < outputExpressions.size());
                 columnExprMap.put(pair.first, outputExpressions.get(pair.second));
             }
@@ -563,6 +593,7 @@ public class MaterializedViewAnalyzer {
          * from creating materialized view statement.
          */
         private List<Pair<Column, Integer>> genMaterializedViewColumns(KeysType keysType,
+                                                                       RowIdStrategy rowIdStrategy,
                                                                        QueryStatement queryStatement,
                                                                        List<ColWithComment> colWithComments,
                                                                        List<String> keyCols) {
@@ -609,6 +640,13 @@ public class MaterializedViewAnalyzer {
                 mvColumns.add(column);
             }
 
+            // Append the storage-filled __ROW_ID__. Final position is decided by the reorder step
+            // below (caller has already put __ROW_ID__ at the head of keyCols).
+            // QUERY_COMPUTED MVs already have __ROW_ID__ from the loop above (IVMAnalyzer adds it).
+            if (rowIdStrategy == RowIdStrategy.AUTO_INCREMENT) {
+                mvColumns.add(createAutoIncrementRowIdColumn());
+            }
+
             // set duplicate key, when sort key is set, it is dup key col.
             if (CollectionUtils.isEmpty(keyCols)) {
                 keyCols = chooseSortKeysByDefault(mvColumns);
@@ -622,11 +660,13 @@ public class MaterializedViewAnalyzer {
                 throw new SemanticException("The number of sort key should be less than the number of columns.");
             }
 
-            // Reorder the MV columns according to sort-key
+            // pair.second is the column's query-output position; appended AUTO_INCREMENT columns
+            // use NO_QUERY_OUTPUT since they don't come from the query.
             Map<String, Pair<Column, Integer>> columnMap = new HashMap<>();
             for (int i = 0; i < mvColumns.size(); i++) {
                 Column col = mvColumns.get(i);
-                if (columnMap.putIfAbsent(col.getName(), Pair.create(col, i)) != null) {
+                int queryOutputIdx = col.isAutoIncrement() ? NO_QUERY_OUTPUT : i;
+                if (columnMap.putIfAbsent(col.getName(), Pair.create(col, queryOutputIdx)) != null) {
                     throw new SemanticException("Duplicate column name '" + col.getName() + "'");
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionType;
+import com.starrocks.sql.analyzer.mv.RowIdStrategy;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.parser.NodePosition;
 
@@ -81,6 +82,9 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private MaterializedView.RefreshMode currentRefreshMode = MaterializedView.RefreshMode.PCT;
     // the encode row id version deduced by analyzer
     private int encodeRowIdVersion = 0;
+    // the __ROW_ID__ production strategy deduced by analyzer for incremental MVs;
+    // null when this is not an incremental MV
+    private RowIdStrategy rowIdStrategy = null;
 
     // Sink table information
     private List<Column> mvColumnItems = Lists.newArrayList();
@@ -376,6 +380,14 @@ public class CreateMaterializedViewStatement extends DdlStmt {
 
     public int getEncodeRowIdVersion() {
         return encodeRowIdVersion;
+    }
+
+    public void setRowIdStrategy(RowIdStrategy rowIdStrategy) {
+        this.rowIdStrategy = rowIdStrategy;
+    }
+
+    public RowIdStrategy getRowIdStrategy() {
+        return rowIdStrategy;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -33,6 +33,7 @@ import com.starrocks.scheduler.mv.hybrid.MVHybridBasedRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
@@ -886,6 +887,36 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     PlanTestBase.assertContains(planStr, "state_union");
                     // Verify MV scan still present
                     PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                }
+        );
+    }
+
+    /**
+     * End-to-end refresh of a non-aggregate incremental MV.
+     *
+     * <p>Non-aggregate incremental MVs are PK tables with an AUTO_INCREMENT
+     * {@code __ROW_ID__}. Refresh must run successfully through multiple runs
+     * (no INSERT positional-column mismatch from the AUTO_INCREMENT column) and
+     * the created MV must have {@link KeysType#PRIMARY_KEYS}.
+     */
+    @Test
+    public void testIVMWithScanNonAggregateIsPkTable() throws Exception {
+        doTestWith3Runs(
+                "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;",
+                plan -> {
+                    // First refresh: verify the MV is a PK table with AUTO_INCREMENT __ROW_ID__.
+                    MaterializedView mv = getMv("test_mv1");
+                    Assertions.assertEquals(KeysType.PRIMARY_KEYS, mv.getKeysType(),
+                            "non-aggregate incremental MV must be a PRIMARY_KEYS table");
+                    Assertions.assertNotNull(mv.getColumn("__ROW_ID__"),
+                            "__ROW_ID__ column must exist on the non-aggregate PK MV");
+                    Assertions.assertTrue(mv.getColumn("__ROW_ID__").isAutoIncrement(),
+                            "__ROW_ID__ must be AUTO_INCREMENT for a non-aggregate incremental MV");
+                },
+                plan -> {
+                    // Second refresh (delta[1,2]): refresh must still complete successfully.
+                    MaterializedView mv = getMv("test_mv1");
+                    Assertions.assertEquals(KeysType.PRIMARY_KEYS, mv.getKeysType());
                 }
         );
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -14,19 +14,25 @@
 
 package com.starrocks.sql.analyzer.mv;
 
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.scheduler.mv.ivm.MVIVMIcebergTestBase;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmOpUtils;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -106,6 +112,151 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
         assertTrue(result.isPresent(), "non-aggregate MV query must produce an IVM rewrite result");
         assertEquals(RowIdStrategy.AUTO_INCREMENT, result.get().rowIdStrategy(),
                 "non-aggregate MV over append-only Iceberg must yield AUTO_INCREMENT");
+    }
+
+    /**
+     * A non-aggregate incremental MV must be created as a PK table with an
+     * AUTO_INCREMENT {@code __ROW_ID__} column (strategy = AUTO_INCREMENT).
+     */
+    @Test
+    public void testNonAggregateIncrementalMvIsPrimaryKeyWithAutoIncrementRowId() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_nonagg_pk "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0`";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_nonagg_pk");
+
+            // All incremental MVs are PK tables.
+            assertEquals(KeysType.PRIMARY_KEYS, mv.getKeysType(),
+                    "non-aggregate incremental MV must be a PRIMARY_KEYS table");
+
+            // __ROW_ID__ column: BIGINT, AUTO_INCREMENT, hidden, key, not null
+            Column rowIdCol = mv.getColumn(IvmOpUtils.COLUMN_ROW_ID);
+            assertNotNull(rowIdCol, "__ROW_ID__ column must exist on non-agg incremental MV");
+            assertEquals(IntegerType.BIGINT, rowIdCol.getType(),
+                    "__ROW_ID__ must be BIGINT for AUTO_INCREMENT strategy");
+            assertTrue(rowIdCol.isAutoIncrement(), "__ROW_ID__ must be AUTO_INCREMENT");
+            assertTrue(rowIdCol.isKey(), "__ROW_ID__ must be a PK column");
+            assertFalse(rowIdCol.isAllowNull(), "__ROW_ID__ must be NOT NULL");
+
+            // Strategy persisted on MV
+            assertEquals(RowIdStrategy.AUTO_INCREMENT, mv.getRowIdStrategy(),
+                    "non-aggregate MV must persist AUTO_INCREMENT strategy");
+        });
+    }
+
+    /**
+     * An aggregate incremental MV must also be a PK table but with QUERY_COMPUTED
+     * strategy — {@code __ROW_ID__} comes from the query's encode(group_by_keys)
+     * expression and is NOT AUTO_INCREMENT.
+     */
+    @Test
+    public void testAggregateIncrementalMvStillUsesQueryComputedRowId() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_agg_pk "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, SUM(c1) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_agg_pk");
+
+            assertEquals(KeysType.PRIMARY_KEYS, mv.getKeysType(),
+                    "aggregate incremental MV must still be a PRIMARY_KEYS table");
+
+            Column rowIdCol = mv.getColumn(IvmOpUtils.COLUMN_ROW_ID);
+            assertNotNull(rowIdCol, "__ROW_ID__ must exist on aggregate incremental MV");
+            assertFalse(rowIdCol.isAutoIncrement(),
+                    "aggregate MV's __ROW_ID__ is QUERY_COMPUTED (encode), not AUTO_INCREMENT");
+
+            assertEquals(RowIdStrategy.QUERY_COMPUTED, mv.getRowIdStrategy(),
+                    "aggregate MV must persist QUERY_COMPUTED strategy");
+        });
+    }
+
+    /**
+     * Non-aggregate incremental MV (AUTO_INCREMENT): refresh SQL must use an explicit
+     * column list that omits {@code __ROW_ID__} so the storage engine auto-fills it.
+     */
+    @Test
+    public void testGetIVMTaskDefinitionOmitsAutoIncrementColumn() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_taskdef_nonagg "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0`";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_taskdef_nonagg");
+            String sql = mv.getIVMTaskDefinition();
+
+            assertTrue(sql.startsWith("INSERT INTO `mv_taskdef_nonagg` ("),
+                    "must use explicit column list form, got: " + sql);
+            assertFalse(sql.contains("`" + IvmOpUtils.COLUMN_ROW_ID + "`"),
+                    "AUTO_INCREMENT __ROW_ID__ must NOT be in the column list, got: " + sql);
+            assertTrue(sql.contains("`id`") && sql.contains("`data`") && sql.contains("`date`"),
+                    "visible columns must all be in the column list, got: " + sql);
+        });
+    }
+
+    /**
+     * Aggregate incremental MV (QUERY_COMPUTED): refresh SQL uses positional form since
+     * the schema has no AUTO_INCREMENT columns; the query itself produces {@code __ROW_ID__}
+     * via encode(group_by_keys).
+     */
+    @Test
+    public void testGetIVMTaskDefinitionForQueryComputedUsesPositionalForm() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_taskdef_agg "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, SUM(c1) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_taskdef_agg");
+            String sql = mv.getIVMTaskDefinition();
+
+            assertTrue(sql.startsWith("INSERT INTO `mv_taskdef_agg` "),
+                    "aggregate MV uses positional INSERT, got: " + sql);
+            assertFalse(sql.startsWith("INSERT INTO `mv_taskdef_agg` ("),
+                    "no explicit column list expected (no AUTO_INCREMENT columns), got: " + sql);
+            assertTrue(sql.contains(IvmOpUtils.COLUMN_ROW_ID),
+                    "__ROW_ID__ must appear in the SELECT alias (produced by encode), got: " + sql);
+        });
+    }
+
+    /**
+     * When user ORDER BY reorders the MV schema, the INSERT column list must still follow
+     * the query SELECT order (not the physical sort-key order). Otherwise refresh writes
+     * values into the wrong target columns (e.g. id's value into data's slot).
+     */
+    @Test
+    public void testGetIVMTaskDefinitionPreservesQueryOrderWhenReordered() throws Exception {
+        // Schema after PR-B + ORDER BY (data):
+        //   physical:          [__ROW_ID__ (PK), data (sort key), id, date]
+        //   query projection:  [id, data, date]
+        // Correct INSERT column list:  (id, data, date)  ← query SELECT order
+        // Buggy pre-fix would emit:    (data, id, date)  ← schema sort-key order
+        String ddl = "CREATE MATERIALIZED VIEW mv_reordered_nonagg "
+                + "ORDER BY (`data`) "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0`";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_reordered_nonagg");
+            String sql = mv.getIVMTaskDefinition();
+
+            assertTrue(sql.startsWith("INSERT INTO `mv_reordered_nonagg` ("),
+                    "must use explicit column list form, got: " + sql);
+            assertFalse(sql.contains("`" + IvmOpUtils.COLUMN_ROW_ID + "`"),
+                    "AUTO_INCREMENT __ROW_ID__ must NOT be in the column list, got: " + sql);
+
+            // All three user columns must appear; their relative order must match the
+            // SELECT list (id, then data, then date), not the physical schema order
+            // (which would put the sort key `data` first).
+            int idPos = sql.indexOf("`id`");
+            int dataPos = sql.indexOf("`data`");
+            int datePos = sql.indexOf("`date`");
+            assertTrue(idPos > 0 && dataPos > 0 && datePos > 0,
+                    "all three user columns must be in the list, got: " + sql);
+            assertTrue(idPos < dataPos && dataPos < datePos,
+                    "INSERT column list must be in SELECT order (id, data, date), got: " + sql);
+        });
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
@@ -199,6 +199,63 @@ public class IvmRewriterTest {
         Assertions.assertFalse(hasActionColumn, "__ACTION__ should be replaced by __op");
     }
 
+    /**
+     * Non-aggregate incremental MVs are PK tables, so
+     * {@code IvmRewriter.appendPkLoadOpColumn} runs for them too.
+     * Verify via the same mock-based plumbing: when the target MV has
+     * {@link KeysType#PRIMARY_KEYS}, the rewritten plan contains {@code __op}.
+     */
+    @Test
+    public void testNonAggregateIncrementalMvGetsOpColumn(@Mocked IcebergTable table,
+                                                           @Mocked MaterializedView targetMv,
+                                                           @Mocked InsertStmt insertStmt) {
+        mockIcebergTable(table);
+        new Expectations() {
+            {
+                insertStmt.getTargetTable();
+                result = targetMv;
+                minTimes = 0;
+
+                // Non-aggregate incremental MVs are also PRIMARY_KEYS.
+                targetMv.getKeysType();
+                result = KeysType.PRIMARY_KEYS;
+                minTimes = 0;
+            }
+        };
+
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        context.getSessionVariable().setEnableIVMRefresh(true);
+        context.setStatement(insertStmt);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
+        deriveLogicalProperty(root);
+
+        TaskContext taskContext = newTaskContext(context);
+        TaskScheduler scheduler = new TaskScheduler();
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+
+        IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
+
+        // Non-aggregate PK MV should have TopN → Project(__op) at the top, same as aggregate PK MV
+        OptExpression rewrittenChild = root.inputAt(0);
+        Assertions.assertTrue(rewrittenChild.getOp() instanceof LogicalTopNOperator,
+                "Non-aggregate PK MV should have TopN for DELETE-before-INSERT ordering");
+        OptExpression opProject = rewrittenChild.inputAt(0);
+        Assertions.assertTrue(opProject.getOp() instanceof LogicalProjectOperator);
+        LogicalProjectOperator opProjectOp = (LogicalProjectOperator) opProject.getOp();
+        // Should contain __op column
+        boolean hasOpColumn = opProjectOp.getColumnRefMap().keySet().stream()
+                .anyMatch(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()));
+        Assertions.assertTrue(hasOpColumn,
+                "Non-aggregate PK MV should have __op column (IvmRewriter.appendPkLoadOpColumn)");
+    }
+
     @Test
     public void testNoPkLoadOpColumnForDupKeysMv(@Mocked IcebergTable table,
                                                   @Mocked MaterializedView targetMv,


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
All Iceberg incremental MVs are now created with KeysType.PRIMARY_KEYS. Non-aggregate MVs (previously DUP_KEYS) get a hidden BIGINT AUTO_INCREMENT __ROW_ID__ column; aggregate MVs continue to use the query-computed encode(group_by_keys) as __ROW_ID__ (unchanged).

Changes:
- MaterializedViewAnalyzer unconditionally sets PRIMARY_KEYS for incremental; genMaterializedViewColumns injects __ROW_ID__ AUTO_INCREMENT column when the RowIdStrategy is AUTO_INCREMENT.
- MaterializedView.getIVMTaskDefinition emits an explicit INSERT column list that excludes AUTO_INCREMENT columns so storage fills them in. getTaskDefinition (full refresh) also uses the explicit-list form when the MV has AUTO_INCREMENT columns.
- MaterializedView.getRowIdStrategy() is derived from the schema: __ROW_ID__ isAutoIncrement -> AUTO_INCREMENT; otherwise QUERY_COMPUTED. No persisted field; single source of truth is the column schema itself.
- RowIdStrategy is carried on CreateMaterializedViewStatement as a transient field during MV creation (analyzer -> genMaterializedViewColumns).

Side effect: IvmRewriter.appendPkLoadOpColumn now runs for all incremental MVs (including non-aggregate), so every refresh plan carries a __op column. For append-only Iceberg sources, __op is always 0 (UPSERT), matching the existing aggregate-MV behavior.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
