### PR TITLE
[BugFix] Avoid static-destruction race in master_info singleton

### DIFF
--- a/be/src/common/system/master_info.cpp
+++ b/be/src/common/system/master_info.cpp
@@ -17,8 +17,12 @@
 namespace starrocks {
 
 static butil::DoublyBufferedData<TMasterInfo>* get_or_create_data() {
-    static butil::DoublyBufferedData<TMasterInfo> obj;
-    return &obj;
+    // Intentionally leaked: background threads (e.g. ReportOlapTableTaskWorkerPool)
+    // may still call get_master_info() during process shutdown. If this singleton
+    // were destroyed at exit, its internal TLS key would be invalidated to -1 and
+    // subsequent reads would fire the `Invalid id=-1` CHECK in butil.
+    static auto* obj = new butil::DoublyBufferedData<TMasterInfo>();
+    return obj;
 }
 
 static bool update(TMasterInfo& bg, const TMasterInfo& new_value) {


### PR DESCRIPTION

## Why I'm doing:

```
ed_data.h:291] Check failed: false Invalid id=-1F20260420 14:43:07.596873 140418381571648 doubly_buffered_data.h:291] Check failed: false Invalid id=-1F202604
20 14:43:07.612863 140418373121600 doubly_buffered_data.h:291] Check failed: false Invalid id=-1F20260420 14:43:07.736879 140414100624960 doubly_buffered_data
.h:291] Check failed: false Invalid id=-1
    @     0x7fbb93cc39fc pthread_kill
    @     0x7fbb93c6f476 raise
    @     0x7fbb93c557f3 abort
    @         0x32b9b89b starrocks::failure_function()
    @         0x3a7a7bdd google::LogMessage::Fail()
    @         0x3a7a8cc4 google::LogMessageFatal::~LogMessageFatal()
    @         0x3610ec03 butil::DoublyBufferedData<starrocks::TMasterInfo, butil::Void, false>::WrapperTLSGroup::get_or_create_tls_data(int)
    @         0x3610dfe9 butil::DoublyBufferedData<starrocks::TMasterInfo, butil::Void, false>::Read(butil::DoublyBufferedData<starrocks::TMasterInfo, butil::Void, false>::ScopedPtr*)
    @         0x3610d015 starrocks::get_master_info(butil::DoublyBufferedData<starrocks::TMasterInfo, butil::Void, false>::ScopedPtr*)
    @         0x3610d3e4 starrocks::get_master_address()
F20260420 14:43:07.548894 140418496800320 doubly_buffered_data.h:291] Check failed: false Invalid id=-1F20260420 14:43:07.565010 140418390021696 doubly_buffered_data.h:291] Check failed: false Invalid id=-1F20260420 14:43:07.596873 140418381571648 doubly_buffered_data.h:291] Check failed: false Invalid id=-1F20260420 14:43:07.612863 140418373121600 doubly_buffered_data.h:291] Check failed: false Invalid id=-1F20260420 14:43:07.736879 140414100624960 doubly_buffered_data.h:291] Check failed: false Invalid id=-1F20260420 14:43:08.376705 140418479900224 doubly_buffered_data.h:291] Check failed: false Invalid id=-1
    @         0x1f8c9a8d starrocks::ReportOlapTableTaskWorkerPool::_worker_thread_callback(void*)
    @         0x1f90d418 void* std::__invoke_impl<void*, void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>(std::__invoke_other, void* (*&&)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*&&)
    @         0x1f90d23e std::__invoke_result<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>::type std::__invoke<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>(void* (*&&)(void*), starrocks::TaskWo@
    @         0x1f90d11b void* std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>)
    @         0x1f90ce82 std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> >::operator()()
    @         0x1f90cb9e std::thread::_State_impl<std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> > >::_M_run()
    @         0x3da0bdb4 execute_native_thread_routine
    @         0x1f69b616 asan_thread_start(void*)
    @     0x7fbb93cc1ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7fbb93d538d0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1268cf)
WARNING: Logging before InitGoogleLogging() is written to STDERR
```

The `TMasterInfo` DoublyBufferedData singleton was defined as a function-local static, so it was destroyed at process exit. Background threads such as `ReportOlapTableTaskWorkerPool::_worker_thread_callback` keep calling `get_master_address()` during shutdown, and reads after destruction hit the butil `CHECK(id >= 0) << "Invalid id=-1"` assertion because the internal TLS key has already been invalidated.


## What I'm doing:

Leak the singleton via a `static auto* = new` to keep it alive for the entire process lifetime, eliminating the destruction-order race.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
