### PR TITLE
fix: remove closed trigger to prevent duplicate backport conflict notifications

### DIFF
--- a/.github/workflows/ci-backport-checker.yml
+++ b/.github/workflows/ci-backport-checker.yml
@@ -7,7 +7,6 @@ on:
       - 'branch-[0-9].[0-9]'
       - 'branch-[0-9].[0-9].[0-9]'
     types:
-      - closed
       - labeled
 
 env:
@@ -26,14 +25,7 @@ jobs:
     if: >
       contains(github.event.pull_request.title, 'backport') &&
       startsWith(github.head_ref, 'mergify/bp') &&
-      (
-        (github.event.action == 'labeled' &&
-         (github.event.label.name == 'conflicts' || github.event.label.name == 'conflict')) ||
-        (github.event.action == 'closed' &&
-         github.event.pull_request.merged != true &&
-         (contains(github.event.pull_request.labels.*.name, 'conflicts') ||
-          contains(github.event.pull_request.labels.*.name, 'conflict')))
-      )
+      (github.event.label.name == 'conflicts' || github.event.label.name == 'conflict')
     env:
       STATUS: CONFLICT
 

--- a/.github/workflows/ci-backport-checker.yml
+++ b/.github/workflows/ci-backport-checker.yml
@@ -8,6 +8,7 @@ on:
       - 'branch-[0-9].[0-9].[0-9]'
     types:
       - closed
+      - labeled
 
 env:
   PR_ID: ${{ github.event.number }}
@@ -17,16 +18,22 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
   FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
 jobs:
   backport-close:
     runs-on: [self-hosted, normal]
     if: >
-      github.event.pull_request.merged != true &&
       contains(github.event.pull_request.title, 'backport') &&
-      (contains(github.event.pull_request.labels.*.name, 'conflicts') ||
-      contains(github.event.pull_request.labels.*.name, 'conflict')) &&
-      startsWith(github.head_ref, 'mergify/bp')
+      startsWith(github.head_ref, 'mergify/bp') &&
+      (
+        (github.event.action == 'labeled' &&
+         (github.event.label.name == 'conflicts' || github.event.label.name == 'conflict')) ||
+        (github.event.action == 'closed' &&
+         github.event.pull_request.merged != true &&
+         (contains(github.event.pull_request.labels.*.name, 'conflicts') ||
+          contains(github.event.pull_request.labels.*.name, 'conflict')))
+      )
     env:
       STATUS: CONFLICT
 


### PR DESCRIPTION
## What's Changed

Backport conflict Slack notifications were being sent twice per conflict.

**Root cause:** Mergify's flow is:
1. Label PR with `conflicts` → `labeled` event fires → notification sent ✓
2. Close the PR → `closed` event fires → PR still has `conflicts` label → notification sent again ✗

**Fix:** Remove the `closed` trigger type and the corresponding `closed` condition. The `labeled` event is sufficient and fires immediately when the conflict is detected.

## Behavior
- Before: 2 notifications per backport conflict
- After: 1 notification per backport conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)