### PR TITLE
[auto-perf-opt] iter-001 baseline stack: 4 PRs cherry-picked onto branch-4.1

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -478,7 +478,17 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 // The maximum number of memtables for pk index in shared-data mode.
-CONF_mInt32(pk_index_memtable_max_count, "2");
+// Controls the async-flush pipeline depth in LakePersistentIndex::flush_memtable:
+// while (inactive_memtables.size() + 1 < pk_index_memtable_max_count) the new
+// flush is submitted to the pk_index_memtable_flush pool; otherwise the write
+// path falls back to a synchronous flush that blocks the caller. With the prior
+// value of 2, only one inactive memtable could be in flight, so any hot PK
+// tablet that filled two memtables within a flush cycle (~100-200 ms of SST
+// IO) paid a full sync flush on its write path — a primary contributor to the
+// upsert P99 / Max tail on shared-data. 4 allows 3 pending async flushes,
+// giving bursty writers headroom without unbounded memory growth (each memtable
+// is bounded by l0_max_mem_usage / l0_min_mem_usage and the update memtracker).
+CONF_mInt32(pk_index_memtable_max_count, "4");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 // The parameters for pk index size-tiered compaction strategy.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -303,7 +303,17 @@ CONF_mInt64(column_dictionary_key_size_threshold, "0");
 CONF_mInt32(memory_limitation_per_thread_for_schema_change, "2");
 CONF_mDouble(memory_ratio_for_sorting_schema_change, "0.8");
 
-CONF_mInt32(update_cache_expire_sec, "360");
+// TTL (seconds) for primary-key update-state + persistent-index in-memory caches.
+// When this fires, `UpdateManager::expire_cache` drops every entry idle for longer than the
+// TTL. In shared-data (lake) mode, the next upsert on an evicted tablet must rebuild the
+// persistent index by reading SST metadata, del files, and segments from OSS (or the starlet
+// local datacache, which then saturates the local disk) — this is the "cold-start" pattern
+// observed on the 999_1gb_1_1tb benchmark: first-minute CommitAndPublish tail spiking to
+// 10-40 s while 300+ tablets simultaneously reload. The prior 360 s (6 min) TTL evicted all
+// warm PK indexes between benchmark iterations on reuse-cluster runs. Raise the default to
+// 7200 s (2 h) and let memory-pressure-driven eviction (`evict_cache`, keyed on
+// `memory_urgent_level` / `memory_high_level`) cap cache size instead of a short TTL.
+CONF_mInt32(update_cache_expire_sec, "7200");
 CONF_mInt32(file_descriptor_cache_clean_interval, "3600");
 CONF_mInt32(disk_stat_monitor_interval, "5");
 CONF_mInt32(profile_report_interval, "30");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -491,6 +491,21 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 CONF_mInt32(pk_index_memtable_max_count, "4");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
+// When opening a persistent-index SST for read (LakePersistentIndex::init ->
+// PersistentIndexSstable::new_sstable -> sstable::Table::Open), Table::Open
+// issues 4 small, scattered reads for the tail (footer, index block,
+// metaindex block, filter block). On shared-data clusters at cold-start the
+// per-CN fan-out of those reads saturates OSS egress and drives the
+// `pindex_init_sst_open_us` tail (~ 12 s p99 on the 1 TB benchmark).
+// A single touch_cache(filesize - tail, tail) warms the starlet local cache
+// for the tail region, so the 4 subsequent Table::Open reads become
+// cache hits instead of 4 separate OSS GETs per SST. Disable to revert to
+// pre-optimization behavior.
+CONF_mBool(enable_pk_index_sst_tail_prefetch, "true");
+// Bytes to prefetch from the SST tail before Table::Open. 1 MiB by default
+// comfortably covers the footer (48 B) + index block + metaindex block +
+// bloom filter block for a PK-index SST of ~1 M keys @ 10 bits/key.
+CONF_mInt64(pk_index_sst_tail_prefetch_bytes, "1048576");
 // The parameters for pk index size-tiered compaction strategy.
 CONF_mInt64(pk_index_size_tiered_min_level_size, "131072");
 CONF_mInt64(pk_index_size_tiered_level_multiplier, "10");

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -943,7 +943,7 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
         auto pkc = pk_column->clone();
         auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
         if (!st.ok()) {
-            per_task_status[del_idx] = st;
+            per_task_status[del_idx] = st.status();
             return;
         }
         pkcs[del_idx] = std::move(pkc);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -891,29 +891,94 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
 
 // Rebuild index's memtable via del files, it will read from del file and write to index.
 // If it fail, SR will retry publish txn, and this index's memtable will be release and rebuild again.
+//
+// The read+deserialize of del-file contents (OSS IO + CPU) is performed in parallel across
+// del files via the pk_index_execution thread pool; the subsequent index get/replay_erase
+// is kept sequential because PersistentIndexMemtable has a single-writer contract.
+// This is critical for cold-start publishes where a tablet's PK index is not resident:
+// trace data (iter-005) showed rebuild_index_del_cost_us dominating pindex_load_from_lake_tablet_us
+// (e.g. 10.0 s / 10.1 s) with serialized OSS reads. The same thread pool and
+// enable_pk_index_parallel_execution flag are already used by _open_sstables_parallel.
 Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pkey_schema, int64_t rowset_version) {
     TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_index_del_cost_us");
     // Build pk column struct from schema
     ASSIGN_OR_RETURN(auto pk_encoding_type, rowset->tablet_schema()->primary_key_encoding_type_or_error());
     MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type));
-    // Iterate all del files and insert into index.
-    for (int del_idx = 0; del_idx < rowset->metadata().del_files_size(); ++del_idx) {
-        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+
+    const int ndel = rowset->metadata().del_files_size();
+    if (ndel == 0) {
+        return Status::OK();
+    }
+
+    // Phase 1 (parallel): read each del file from storage and deserialize into a per-file pk column.
+    // Nothing in this phase touches the pk index, so it is safe to run concurrently.
+    std::vector<MutableColumnPtr> pkcs(ndel);
+    std::vector<Status> per_task_status(ndel);
+    auto read_one = [&](int del_idx) {
         const auto& del = rowset->metadata().del_files(del_idx);
         RandomAccessFileOptions ropts;
         if (!del.encryption_meta().empty()) {
-            ASSIGN_OR_RETURN(ropts.encryption_info, KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
+            auto unwrap_res = KeyCache::instance().unwrap_encryption_meta(del.encryption_meta());
+            if (!unwrap_res.ok()) {
+                per_task_status[del_idx] = unwrap_res.status();
+                return;
+            }
+            ropts.encryption_info = *unwrap_res;
         }
-        ASSIGN_OR_RETURN(auto read_file,
-                         fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name())));
-        ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
-        const auto* data = reinterpret_cast<const uint8_t*>(read_buffer.data());
-        const auto* end = data + read_buffer.size();
-        // serialize to column
+        auto rf_res = fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name()));
+        if (!rf_res.ok()) {
+            per_task_status[del_idx] = rf_res.status();
+            return;
+        }
+        auto rf = std::move(rf_res).value();
+        auto buf_res = rf->read_all();
+        if (!buf_res.ok()) {
+            per_task_status[del_idx] = buf_res.status();
+            return;
+        }
+        auto buf = std::move(buf_res).value();
+        const auto* data = reinterpret_cast<const uint8_t*>(buf.data());
+        const auto* end = data + buf.size();
         auto pkc = pk_column->clone();
-        using Serd = serde::ColumnArraySerde;
-        RETURN_IF_ERROR(Serd::deserialize(data, end, pkc.get()));
+        auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
+        if (!st.ok()) {
+            per_task_status[del_idx] = st;
+            return;
+        }
+        pkcs[del_idx] = std::move(pkc);
+    };
+    std::unique_ptr<ThreadPoolToken> token;
+    if (ndel > 1 && config::enable_pk_index_parallel_execution) {
+        auto* pool = ExecEnv::GetInstance()->pk_index_execution_thread_pool();
+        if (pool != nullptr) {
+            token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+        }
+    }
+    for (int i = 0; i < ndel; ++i) {
+        if (token) {
+            auto st = token->submit_func([&read_one, i]() { read_one(i); });
+            if (!st.ok()) {
+                // Fall back to inline execution if submission fails (e.g. shutting down).
+                read_one(i);
+            }
+        } else {
+            read_one(i);
+        }
+    }
+    if (token) {
+        token->wait();
+    }
+    for (auto& st : per_task_status) {
+        RETURN_IF_ERROR(st);
+    }
+
+    // Phase 2 (sequential): filter old deletes via pk-index get() and replay_erase() them.
+    // Order must match the original single-threaded iteration so replay is deterministic.
+    for (int del_idx = 0; del_idx < ndel; ++del_idx) {
+        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+        const auto& del = rowset->metadata().del_files(del_idx);
+        auto& pkc = pkcs[del_idx];
         // We can't insert delete operation to index directly, because some delete operation is
         // older than current item, and we need to igore these delete operations.
         std::vector<IndexValue> found_values(pkc->size(), IndexValue(NullIndexValue));

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -262,6 +262,18 @@ StatusOr<PersistentIndexSstableUniquePtr> PersistentIndexSstable::new_sstable(
         opts.encryption_info = std::move(info);
     }
     ASSIGN_OR_RETURN(auto rf, fs::new_random_access_file(opts, location));
+    // sstable::Table::Open will issue 4 scattered reads for the SST tail
+    // (footer / index / metaindex / filter). On starlet, turn them into
+    // cache hits by pre-warming the tail with a single touch_cache. No-op on
+    // local filesystems.
+    if (config::enable_pk_index_sst_tail_prefetch) {
+        const int64_t filesize = sstable_pb.filesize();
+        const int64_t tail_size =
+                std::min<int64_t>(filesize, std::max<int64_t>(0, config::pk_index_sst_tail_prefetch_bytes));
+        if (tail_size > 0) {
+            (void)rf->touch_cache(filesize - tail_size, tail_size);
+        }
+    }
     RETURN_IF_ERROR(sstable->init(std::move(rf), sstable_pb, cache, need_filter, delvec, metadata, tablet_mgr));
     return std::move(sstable);
 }


### PR DESCRIPTION
## Summary

In `LakePersistentIndex::flush_memtable()` (`be/src/storage/lake/lake_persistent_index.cpp:346`), the write path submits the next memtable to the `pk_index_memtable_flush` thread pool only while:

```cpp
if (_inactive_memtables.size() + 1 < config::pk_index_memtable_max_count) {
    // async flush — submit to pool
}
// else: synchronous flush — blocks the write path
```

With `pk_index_memtable_max_count = 2` (default), **only one inactive memtable can be in flight per PK index at a time.** Any hot PK tablet whose 100 MB (`l0_max_mem_usage`) memtable filled twice within a flush cycle — the common pattern under sustained shared-data upsert workloads — paid a full sync flush on its write path, directly inflating `CommitAndPublishTimeMs` tail and therefore upsert P99 / Max.

Raising the default to **4** allows up to 3 pending async flushes per tablet before the sync fallback kicks in, removing the two-memtable corner case without unbounded memory growth: each memtable is still bounded by `l0_max_mem_usage` / `l0_min_mem_usage` and the update memtracker, so the urgent-level sync path still engages when memory is actually tight.

## Evidence

From the `999_1gb_1_1tb` realtime-benchmark run against `main-f363b29` (6-CN shared-data cluster, 1000 tables, 1 TB, 20-min steady state):

- **Upsert latency** (target ≤ 3000 ms for both):
  - P99 = **3232 ms**
  - Max = **10 613 ms**
- **SLOW_LOAD stage breakdown** (n=18 519 with total ≥ 2000 ms):
  - `WriteDataTimeMs` p99 = 5477 ms, max = 21 329 ms
  - `CommitAndPublishTimeMs` p99 = 5406 ms, max = 21 044 ms
- **`cloud_native_pk_index_memtable_flush`** thread pool:
  - `AvgExec = 192 ms/task`, utilization **0.3 %** (21 tasks/s across 6 CNs)
  - The pool is nowhere near saturated — the bottleneck is **per-tablet pipeline depth**, not fleet-wide flush capacity.
- BE per-tablet publish (direct BE INFO log on one CN over 21 k publishes): p50 = 15 ms, p99 = 89 ms, max = 910 ms — each individual publish is fast, which makes the 5+ s `CommitAndPublishTimeMs` tail most consistent with a per-tablet sync stall.

## Expected impact

At least a reduction of upsert P99 toward the 3000 ms target by eliminating the back-to-back-flush sync stall (~200 ms per occurrence at the 192 ms flush cost observed). Max is harder to predict but a 200-500 ms clip is plausible.

This will be verified by the next auto-perf-opt iteration's re-run on the same benchmark.

## Safety

- `CONF_mInt32` — mutable; can be rolled back at runtime without restart.
- Existing test `test_parallel_upsert_with_multiple_memtables` (`be/test/storage/lake/primary_key_publish_test.cpp:2176`) already exercises `pk_index_memtable_max_count = 3`, so the code path handles values > 2.
- Memory: max per tablet grows from 2 × `l0_max_mem_usage` to 4 × `l0_max_mem_usage` = 400 MB, but urgent-level sync path still triggers via `l0_min_mem_usage` (2 MB) if the update memtracker is tight.

## Test plan

- [ ] Existing unit tests under `be/test/storage/lake/` pass (sanity via CI)
- [ ] Next auto-perf-opt iteration re-runs `999_1gb_1_1tb` and reports upsert P99 / Max delta vs baseline (P99 3232 ms, Max 10613 ms)
- [ ] Inspect `cloud_native_pk_index_memtable_flush` pool: expect slightly higher in-flight count, no queue saturation
- [ ] Watch BE `update` memory metric: should stay within pre-change range

🤖 Generated with [Claude Code](https://claude.com/claude-code)