### PR TITLE
[BugFix] Be crash while query information_schema.warehouse_queries

### DIFF
--- a/be/src/exec/schema_scanner/schema_warehouse_metrics.cpp
+++ b/be/src/exec/schema_scanner/schema_warehouse_metrics.cpp
@@ -25,7 +25,7 @@ namespace starrocks {
 
 SchemaScanner::ColumnDesc WarehouseMetricsScanner::_s_columns[] = {
         //   name,       type,          size,     is_null
-        {"WAREHOUSE_ID", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
+        {"WAREHOUSE_ID", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
         {"WAREHOUSE_NAME", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"QUEUE_PENDING_LENGTH", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"QUEUE_RUNNING_LENGTH", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
@@ -86,7 +86,17 @@ Status WarehouseMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
 Status WarehouseMetricsScanner::fill_chunk(ChunkPtr* chunk) {
     auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
     const TGetWarehouseMetricsResponeItem& item = _response.metrics[_idx++];
-    DatumArray datum_array{Slice(item.warehouse_id),
+    // Parse WAREHOUSE_ID from thrift string to int64. Thrift carries it as a
+    // string for backward compatibility with older clients, but the system
+    // table schema is BIGINT, so convert here.
+    int64_t warehouse_id = 0;
+    try {
+        warehouse_id = std::stoll(item.warehouse_id);
+    } catch (const std::exception& e) {
+        return Status::InternalError(
+                fmt::format("invalid warehouse_id '{}' in warehouse_metrics: {}", item.warehouse_id, e.what()));
+    }
+    DatumArray datum_array{warehouse_id,
                            Slice(item.warehouse_name),
                            Slice(item.queue_pending_length),
                            Slice(item.queue_running_length),

--- a/be/src/exec/schema_scanner/schema_warehouse_metrics.cpp
+++ b/be/src/exec/schema_scanner/schema_warehouse_metrics.cpp
@@ -86,9 +86,7 @@ Status WarehouseMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
 Status WarehouseMetricsScanner::fill_chunk(ChunkPtr* chunk) {
     auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
     const TGetWarehouseMetricsResponeItem& item = _response.metrics[_idx++];
-    // Parse WAREHOUSE_ID from thrift string to int64. Thrift carries it as a
-    // string for backward compatibility with older clients, but the system
-    // table schema is BIGINT, so convert here.
+    // Parse WAREHOUSE_ID from thrift string to int64.
     int64_t warehouse_id = 0;
     try {
         warehouse_id = std::stoll(item.warehouse_id);

--- a/be/src/exec/schema_scanner/schema_warehouse_queries.cpp
+++ b/be/src/exec/schema_scanner/schema_warehouse_queries.cpp
@@ -25,7 +25,7 @@ namespace starrocks {
 
 SchemaScanner::ColumnDesc WarehouseQueriesScanner::_s_columns[] = {
         //   name,       type,          size,     is_null
-        {"WAREHOUSE_ID", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
+        {"WAREHOUSE_ID", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
         {"WAREHOUSE_NAME", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"QUERY_ID", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"STATE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
@@ -86,7 +86,17 @@ Status WarehouseQueriesScanner::get_next(ChunkPtr* chunk, bool* eos) {
 Status WarehouseQueriesScanner::fill_chunk(ChunkPtr* chunk) {
     auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
     const TGetWarehouseQueriesResponseItem& item = _response.queries[_idx++];
-    DatumArray datum_array{Slice(item.warehouse_id),
+    // Parse WAREHOUSE_ID from thrift string to int64. Thrift carries it as a
+    // string for backward compatibility with older clients, but the system
+    // table schema is BIGINT, so convert here.
+    int64_t warehouse_id = 0;
+    try {
+        warehouse_id = std::stoll(item.warehouse_id);
+    } catch (const std::exception& e) {
+        return Status::InternalError(
+                fmt::format("invalid warehouse_id '{}' in warehouse_queries: {}", item.warehouse_id, e.what()));
+    }
+    DatumArray datum_array{warehouse_id,
                            Slice(item.warehouse_name),
                            Slice(item.query_id),
                            Slice(item.state),

--- a/be/src/exec/schema_scanner/schema_warehouse_queries.cpp
+++ b/be/src/exec/schema_scanner/schema_warehouse_queries.cpp
@@ -86,9 +86,7 @@ Status WarehouseQueriesScanner::get_next(ChunkPtr* chunk, bool* eos) {
 Status WarehouseQueriesScanner::fill_chunk(ChunkPtr* chunk) {
     auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
     const TGetWarehouseQueriesResponseItem& item = _response.queries[_idx++];
-    // Parse WAREHOUSE_ID from thrift string to int64. Thrift carries it as a
-    // string for backward compatibility with older clients, but the system
-    // table schema is BIGINT, so convert here.
+    // Parse WAREHOUSE_ID from thrift string to int64.
     int64_t warehouse_id = 0;
     try {
         warehouse_id = std::stoll(item.warehouse_id);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetrics.java
@@ -99,7 +99,7 @@ public class WarehouseMetrics {
 
     public List<ScalarOperator> toConstantOperators() {
         List<ScalarOperator> result = Lists.newArrayList();
-        result.add(ConstantOperator.createVarchar(String.valueOf(warehouseId)));
+        result.add(ConstantOperator.createBigint(warehouseId));
         result.add(ConstantOperator.createVarchar(warehouseName));
         result.add(ConstantOperator.createVarchar(String.valueOf(queuePendingLength)));
         result.add(ConstantOperator.createVarchar(String.valueOf(queueRunningLength)));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryMetrics.java
@@ -94,13 +94,13 @@ public class WarehouseQueryMetrics {
 
     public List<ScalarOperator> toConstantOperators() {
         List<ScalarOperator> result = Lists.newArrayList();
-        result.add(ConstantOperator.createVarchar(String.valueOf(warehouseId)));
+        result.add(ConstantOperator.createBigint(warehouseId));
         result.add(ConstantOperator.createVarchar(warehouseName));
         result.add(ConstantOperator.createVarchar(DebugUtil.printId(queryId)));
         result.add(ConstantOperator.createVarchar(state.name()));
         result.add(ConstantOperator.createVarchar(String.valueOf(estCostsSlots)));
         result.add(ConstantOperator.createVarchar(String.valueOf(allocateSlots)));
-        result.add(ConstantOperator.createDouble(queuedWaitSeconds));
+        result.add(ConstantOperator.createVarchar(String.valueOf(queuedWaitSeconds)));
         result.add(ConstantOperator.createVarchar(query));
         if (extraMessage.isPresent()) {
             LogicalSlot.ExtraMessage extra = extraMessage.get();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricsTest.java
@@ -65,10 +65,6 @@ public class WarehouseMetricsTest {
         assertThat(thrift.getMax_slots()).isEqualTo("1");
     }
 
-    // Regression: see issues/2026-04-21-bug1-warehouse-queries-crash.md
-    // Same schema-mismatch hazard as WarehouseQueryMetrics: if toConstantOperators()
-    // produces a column whose type differs from the system table schema, BE
-    // UnionConstSourceOperator SIGABRTs on append. This test pins the alignment.
     @Test
     public void testToConstantOperatorsTypesMatchSchema() {
         WarehouseMetrics metrics = new WarehouseMetrics(42L, "wh", 1, 1, 1, 1, 1, 1, 1, 1, 1,

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseMetricsTest.java
@@ -17,9 +17,14 @@
 
 package com.starrocks.qe.scheduler.warehouse;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.system.information.WarehouseMetricsSystemTable;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.thrift.TGetWarehouseMetricsResponeItem;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,5 +63,28 @@ public class WarehouseMetricsTest {
         assertThat(thrift.getSum_required_slots()).isEqualTo("1");
         assertThat(thrift.getRemain_slots()).isEqualTo("1");
         assertThat(thrift.getMax_slots()).isEqualTo("1");
+    }
+
+    // Regression: see issues/2026-04-21-bug1-warehouse-queries-crash.md
+    // Same schema-mismatch hazard as WarehouseQueryMetrics: if toConstantOperators()
+    // produces a column whose type differs from the system table schema, BE
+    // UnionConstSourceOperator SIGABRTs on append. This test pins the alignment.
+    @Test
+    public void testToConstantOperatorsTypesMatchSchema() {
+        WarehouseMetrics metrics = new WarehouseMetrics(42L, "wh", 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                Optional.empty());
+        List<ScalarOperator> ops = metrics.toConstantOperators();
+        List<Column> schema = new WarehouseMetricsSystemTable().getFullSchema();
+        assertThat(ops).hasSize(schema.size());
+        for (int i = 0; i < schema.size(); i++) {
+            Column col = schema.get(i);
+            ScalarOperator op = ops.get(i);
+            assertThat(op).isInstanceOf(ConstantOperator.class);
+            assertThat(op.getType().getPrimitiveType())
+                    .as("column %s at index %d", col.getName(), i)
+                    .isEqualTo(col.getType().getPrimitiveType());
+        }
+        assertThat(((ConstantOperator) ops.get(0)).getBigint()).isEqualTo(42L);
+        assertThat(((ConstantOperator) ops.get(1)).getVarchar()).isEqualTo("wh");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryMetricsTest.java
@@ -17,11 +17,17 @@
 
 package com.starrocks.qe.scheduler.warehouse;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.system.information.WarehouseQueriesSystemTable;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.thrift.TGetWarehouseQueriesResponseItem;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class WarehouseQueryMetricsTest {
     @Test
@@ -52,5 +58,31 @@ public class WarehouseQueryMetricsTest {
         assertThat(thrift.getAllocate_slots()).isEqualTo("1");
         assertThat(thrift.getQueued_wait_seconds()).isEqualTo("1.0");
         assertThat(thrift.getQuery()).isEqualTo("select 1");
+    }
+
+    // Regression: see issues/2026-04-21-bug1-warehouse-queries-crash.md
+    // toConstantOperators() feeds rows into BE UnionConstSourceOperator, which expects
+    // each ConstantOperator's type to match the system table column's declared type.
+    // When they diverge (e.g. schema=BIGINT but op=VARCHAR), BE crashes with SIGABRT in
+    // down_cast<FixedLengthColumnBase<long>>. This test pins the type alignment.
+    @Test
+    public void testToConstantOperatorsTypesMatchSchema() {
+        WarehouseQueryMetrics metrics = new WarehouseQueryMetrics(42L, "wh",
+                null, LogicalSlot.State.ALLOCATED, 1, 1, 1.5,
+                "select 1", null);
+        List<ScalarOperator> ops = metrics.toConstantOperators();
+        List<Column> schema = new WarehouseQueriesSystemTable().getFullSchema();
+        assertThat(ops).hasSize(schema.size());
+        for (int i = 0; i < schema.size(); i++) {
+            Column col = schema.get(i);
+            ScalarOperator op = ops.get(i);
+            assertThat(op).isInstanceOf(ConstantOperator.class);
+            assertThat(op.getType().getPrimitiveType())
+                    .as("column %s at index %d", col.getName(), i)
+                    .isEqualTo(col.getType().getPrimitiveType());
+        }
+        // Spot-check key column values round-trip through the correct type
+        assertThat(((ConstantOperator) ops.get(0)).getBigint()).isEqualTo(42L);
+        assertThat(((ConstantOperator) ops.get(1)).getVarchar()).isEqualTo("wh");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryMetricsTest.java
@@ -26,6 +26,7 @@ import com.starrocks.thrift.TGetWarehouseQueriesResponseItem;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,16 +61,11 @@ public class WarehouseQueryMetricsTest {
         assertThat(thrift.getQuery()).isEqualTo("select 1");
     }
 
-    // Regression: see issues/2026-04-21-bug1-warehouse-queries-crash.md
-    // toConstantOperators() feeds rows into BE UnionConstSourceOperator, which expects
-    // each ConstantOperator's type to match the system table column's declared type.
-    // When they diverge (e.g. schema=BIGINT but op=VARCHAR), BE crashes with SIGABRT in
-    // down_cast<FixedLengthColumnBase<long>>. This test pins the type alignment.
     @Test
     public void testToConstantOperatorsTypesMatchSchema() {
         WarehouseQueryMetrics metrics = new WarehouseQueryMetrics(42L, "wh",
                 null, LogicalSlot.State.ALLOCATED, 1, 1, 1.5,
-                "select 1", null);
+                "select 1", Optional.empty());
         List<ScalarOperator> ops = metrics.toConstantOperators();
         List<Column> schema = new WarehouseQueriesSystemTable().getFullSchema();
         assertThat(ops).hasSize(schema.size());

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -637,19 +637,19 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
         // supported
         starRocksAssert.query("select count(1) from information_schema.warehouse_metrics")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select * from information_schema.warehouse_metrics")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select WAREHOUSE_NAME, REMAIN_SLOTS from information_schema.warehouse_metrics")
                 .explainContains("constant exprs: \n" +
                         "         'default_warehouse' | '0'");
         starRocksAssert.query("select count(1) from information_schema.warehouse_metrics where warehouse_id = '0'")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select * from information_schema.warehouse_metrics where WAREHOUSE_ID = '0'")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select WAREHOUSE_NAME, REMAIN_SLOTS from information_schema.warehouse_metrics " +
                         "where WAREHOUSE_ID = 0")
                 .explainContains("constant exprs: \n" +
@@ -657,10 +657,10 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
         starRocksAssert.query("select count(1) from information_schema.warehouse_metrics where WAREHOUSE_NAME = " +
                         "'default_warehouse'")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select * from information_schema.warehouse_metrics where WAREHOUSE_NAME= 'default_warehouse'")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select WAREHOUSE_NAME, REMAIN_SLOTS from information_schema.warehouse_metrics " +
                         "where WAREHOUSE_NAME = 'default_warehouse'")
                 .explainContains("constant exprs: \n" +
@@ -698,19 +698,19 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
         // supported
         starRocksAssert.query("select count(1) from information_schema.warehouse_queries")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select * from information_schema.warehouse_queries")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select WAREHOUSE_NAME, EST_COSTS_SLOTS from information_schema.warehouse_queries")
                 .explainContains("     constant exprs: \n" +
                         "         'default_warehouse' | '1'");
         starRocksAssert.query("select count(1) from information_schema.warehouse_queries where warehouse_id = '0'")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select * from information_schema.warehouse_queries where WAREHOUSE_ID = '0'")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select WAREHOUSE_NAME, EST_COSTS_SLOTS from information_schema.warehouse_queries " +
                         "where WAREHOUSE_ID = 0")
                 .explainContains("     constant exprs: \n" +
@@ -718,10 +718,10 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
         starRocksAssert.query("select count(1) from information_schema.warehouse_queries where WAREHOUSE_NAME = " +
                         "'default_warehouse'")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select * from information_schema.warehouse_queries where WAREHOUSE_NAME= 'default_warehouse'")
                 .explainContains("     constant exprs: \n" +
-                        "         '0'");
+                        "         0");
         starRocksAssert.query("select WAREHOUSE_NAME, EST_COSTS_SLOTS from information_schema.warehouse_queries " +
                         "where WAREHOUSE_NAME = 'default_warehouse'")
                 .explainContains("     constant exprs: \n" +

--- a/test/sql/test_information_schema/R/test_warehouse_metrics
+++ b/test/sql/test_information_schema/R/test_warehouse_metrics
@@ -23,6 +23,19 @@ EXTRA_MESSAGE	varchar(2048)	YES	false	None
 SELECT * FROM information_schema.warehouse_metrics;
 -- result:
 -- !result
+SET enable_evaluate_schema_scan_rule=false;
+-- result:
+-- !result
+SELECT * FROM information_schema.warehouse_metrics;
+-- result:
+-- !result
+SELECT COUNT(*) FROM information_schema.warehouse_metrics;
+-- result:
+0
+-- !result
+SET enable_evaluate_schema_scan_rule=true;
+-- result:
+-- !result
 DROP DATABASE db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_information_schema/R/test_warehouse_queries
+++ b/test/sql/test_information_schema/R/test_warehouse_queries
@@ -23,6 +23,19 @@ EXTRA_MESSAGE	varchar(2048)	YES	false	None
 SELECT * FROM information_schema.warehouse_queries;
 -- result:
 -- !result
+SET enable_evaluate_schema_scan_rule=false;
+-- result:
+-- !result
+SELECT * FROM information_schema.warehouse_queries;
+-- result:
+-- !result
+SELECT COUNT(*) FROM information_schema.warehouse_queries;
+-- result:
+0
+-- !result
+SET enable_evaluate_schema_scan_rule=true;
+-- result:
+-- !result
 DROP DATABASE db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_information_schema/T/test_warehouse_metrics
+++ b/test/sql/test_information_schema/T/test_warehouse_metrics
@@ -2,5 +2,12 @@
 CREATE DATABASE db_${uuid0};
 USE db_${uuid0};
 desc information_schema.warehouse_metrics;
+-- FE-eval path (default): ConstantOperator types must match schema (WAREHOUSE_ID=BIGINT)
 SELECT * FROM information_schema.warehouse_metrics;
+-- BE-scan path: exercises schema check in schema_chunk_source.cpp; pre-fix this reported
+-- "schema not match. input is VARCHAR(16) and output is BIGINT".
+SET enable_evaluate_schema_scan_rule=false;
+SELECT * FROM information_schema.warehouse_metrics;
+SELECT COUNT(*) FROM information_schema.warehouse_metrics;
+SET enable_evaluate_schema_scan_rule=true;
 DROP DATABASE db_${uuid0};

--- a/test/sql/test_information_schema/T/test_warehouse_queries
+++ b/test/sql/test_information_schema/T/test_warehouse_queries
@@ -2,5 +2,12 @@
 CREATE DATABASE db_${uuid0};
 USE db_${uuid0};
 desc information_schema.warehouse_queries;
+-- FE-eval path (default): ConstantOperator types must match schema (WAREHOUSE_ID=BIGINT)
 SELECT * FROM information_schema.warehouse_queries;
+-- BE-scan path: exercises schema check in schema_chunk_source.cpp; pre-fix this reported
+-- "schema not match. input is VARCHAR(16) and output is BIGINT".
+SET enable_evaluate_schema_scan_rule=false;
+SELECT * FROM information_schema.warehouse_queries;
+SELECT COUNT(*) FROM information_schema.warehouse_queries;
+SET enable_evaluate_schema_scan_rule=true;
 DROP DATABASE db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
**Table**
  `information_schema.warehouse_queries` and `information_schema.warehouse_metrics`

**FE Side**
`WAREHOUSE_ID BIGINT` on the FE side

**BE Side**
`WAREHOUSE_ID VARCHAR` on the BE side

**Problem**
Query these system tables triggered a type-mismatch assertion and crashed the BE(Debug compiled) with SIGABRT.
```
be/src/gutil/casts.h:100: To down_cast(From&) [with                                                                       
    To = const starrocks::FixedLengthColumnBase<long int>&;
    From = const starrocks::Column]:                                                                                                      
    Assertion `dynamic_cast<ToAsPointer>(&f) != NULL' failed.        
  *** Aborted at ... ***                                                                                                                  
  *** SIGABRT received by PID ...; stack trace: ***                  
      @  google::FailureSignalHandler(int, siginfo_t*, void*)
      @  raise
      @  abort
      @  __assert_fail
      @  down_cast<FixedLengthColumnBase<long> const&>(Column const&)
      @  FixedLengthColumnBase<long>::append(Column const&, ulong, ulong)
      @  NullableColumn::append(Column const&, ulong, ulong)
      @  ColumnHelper::copy_and_unfold_const_column(TypeDescriptor, bool, ..., int)
      @  ColumnHelper::move_column(TypeDescriptor, bool, ..., int)
      @  pipeline::UnionConstSourceOperator::pull_chunk(RuntimeState*)
      @  pipeline::PipelineDriver::process(...)
      @  pipeline::GlobalDriverExecutor::_worker_thread()
```

## What I'm doing:

**Thrift RPC**
Keep using varchar `WAREHOUSE_ID`

**FE & BE Side**
Declare `WAREHOUSE_ID` as `TYPE_BIGINT` for   `information_schema.warehouse_queries` and `information_schema.warehouse_metrics`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
