### PR TITLE
[Refactor] Do not rely on implicit conversions in {fmt} calls 

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -251,7 +251,7 @@ void SinkBuffer::cancel_one_sinker(RuntimeState* const state) {
         VLOG_OPERATOR << fmt::format(
                 "fragment_instance_id {}, _is_finishing {}, _num_remaining_eos {}, "
                 "_num_sending_rpc {}, chunk is full {}",
-                print_id(_fragment_ctx->fragment_instance_id()), _is_finishing, _num_remaining_eos, _num_sending_rpc,
+                print_id(_fragment_ctx->fragment_instance_id()), _is_finishing.load(), _num_remaining_eos.load(), _num_sending_rpc.load(),
                 is_full());
     }
 }

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -251,8 +251,8 @@ void SinkBuffer::cancel_one_sinker(RuntimeState* const state) {
         VLOG_OPERATOR << fmt::format(
                 "fragment_instance_id {}, _is_finishing {}, _num_remaining_eos {}, "
                 "_num_sending_rpc {}, chunk is full {}",
-                print_id(_fragment_ctx->fragment_instance_id()), _is_finishing.load(), _num_remaining_eos.load(), _num_sending_rpc.load(),
-                is_full());
+                print_id(_fragment_ctx->fragment_instance_id()), _is_finishing.load(), _num_remaining_eos.load(),
+                _num_sending_rpc.load(), is_full());
     }
 }
 

--- a/be/src/exec/pipeline/fetch_processor.cpp
+++ b/be/src/exec/pipeline/fetch_processor.cpp
@@ -227,7 +227,7 @@ StatusOr<FetchTaskPtr> FetchProcessor::_create_fetch_task(TupleId request_tuple_
         return std::make_shared<FetchTask>(std::move(task_ctx));
     }
     default:
-        return Status::InternalError(fmt::format("Unknown row position type: {}", row_position_type));
+        return Status::InternalError(fmt::format("Unknown row position type: {}", static_cast<uint8_t>(row_position_type)));
     }
 }
 

--- a/be/src/exec/pipeline/fetch_processor.cpp
+++ b/be/src/exec/pipeline/fetch_processor.cpp
@@ -227,7 +227,8 @@ StatusOr<FetchTaskPtr> FetchProcessor::_create_fetch_task(TupleId request_tuple_
         return std::make_shared<FetchTask>(std::move(task_ctx));
     }
     default:
-        return Status::InternalError(fmt::format("Unknown row position type: {}", static_cast<uint8_t>(row_position_type)));
+        return Status::InternalError(
+                fmt::format("Unknown row position type: {}", static_cast<uint8_t>(row_position_type)));
     }
 }
 

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -87,7 +87,7 @@ void NLJoinProbeOperator::_advance_join_stage(JoinStage stage) const {
     DCHECK_LE(_join_stage, stage) << "current=" << _join_stage << ", advance to " << stage;
     if (_join_stage != stage) {
         _join_stage = stage;
-        VLOG(3) << fmt::format("operator {} enter join_stage {}", _driver_sequence, stage);
+        VLOG(3) << fmt::format("operator {} enter join_stage {}", _driver_sequence, static_cast<int>(stage));
     }
 }
 

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -432,7 +432,7 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         }
         default:
             DCHECK(false) << "unsupport UDF TYPE" << type_desc.type;
-            return Status::NotSupported(fmt::format("unsupport UDF TYPE:{}", type_desc.type));
+            return Status::NotSupported(fmt::format("unsupport UDF TYPE:{}", static_cast<int>(type_desc.type)));
         }
     }
     return Status::OK();

--- a/be/src/udf/udf_call_stub.cpp
+++ b/be/src/udf/udf_call_stub.cpp
@@ -84,7 +84,7 @@ StatusOr<ColumnPtr> AbstractArrowFuncCallStub::_convert_arrow_to_native(const ar
                                                 field_type.nullable(), true);
     if (UNLIKELY(converter == nullptr)) {
         return Status::NotSupported(fmt::format("unsupported arrow type {} to starrocks type {}",
-                                                field_type.type()->ToString(), _func_ctx->get_return_type().type));
+                                                field_type.type()->ToString(), static_cast<int>(_func_ctx->get_return_type().type)));
     }
     // UDF return result is always nullable
     auto native_column = FunctionHelper::create_column(_func_ctx->get_return_type(), true);

--- a/be/src/udf/udf_call_stub.cpp
+++ b/be/src/udf/udf_call_stub.cpp
@@ -84,7 +84,8 @@ StatusOr<ColumnPtr> AbstractArrowFuncCallStub::_convert_arrow_to_native(const ar
                                                 field_type.nullable(), true);
     if (UNLIKELY(converter == nullptr)) {
         return Status::NotSupported(fmt::format("unsupported arrow type {} to starrocks type {}",
-                                                field_type.type()->ToString(), static_cast<int>(_func_ctx->get_return_type().type)));
+                                                field_type.type()->ToString(),
+                                                static_cast<int>(_func_ctx->get_return_type().type)));
     }
     // UDF return result is always nullable
     auto native_column = FunctionHelper::create_column(_func_ctx->get_return_type(), true);

--- a/be/src/util/compression/stream_compressor.cpp
+++ b/be/src/util/compression/stream_compressor.cpp
@@ -396,7 +396,7 @@ StatusOr<std::unique_ptr<StreamCompressor>> StreamCompressor::create_compressor(
         compressor = std::make_unique<ZstdStreamCompressor>();
         break;
     default:
-        return Status::InternalError(fmt::format("Unknown compress type: {}", type));
+        return Status::InternalError(fmt::format("Unknown compress type: {}", static_cast<int>(type)));
     }
 
     RETURN_IF_ERROR(compressor->init());

--- a/be/src/util/compression/stream_decompressor.cpp
+++ b/be/src/util/compression/stream_decompressor.cpp
@@ -1152,7 +1152,7 @@ StatusOr<std::unique_ptr<StreamDecompressor>> StreamDecompressor::create_decompr
         decompressor = std::make_unique<LzoStreamDecompressor>();
         break;
     default:
-        return Status::InternalError(fmt::format("Unknown compress type: {}", type));
+        return Status::InternalError(fmt::format("Unknown compress type: {}", static_cast<int>(type)));
     }
 
     RETURN_IF_ERROR(decompressor->init());


### PR DESCRIPTION
## Why I'm doing:

Fix code that does not compile with more recent `{fmt}` versions anymore (in preparation to a planned `{fmt}` version upgrade). Future versions of fmt do not allow for many implicit conversions anymore.

## What I'm doing:

Change implicit conversions in fmt calls to explicit ones:

- Instead of relying on implicit `enum` to `int` conversions, `static_cast` the enum values to `int`
- Instead of relying on implicit `std::atomic<T>` to `T` conversions, explicitly call `.load()` on the atomic

See also this PR doing something similar: https://github.com/StarRocks/starrocks/pull/25806

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
