### PR TITLE
[BugFix] Allow millisecond and microsecond in date_trunc for DATETIME

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -96,10 +96,11 @@ public class FunctionAnalyzer {
 
             if (functionCallExpr.getChild(1).getType().isDatetime()) {
 
-                if (!Lists.newArrayList("year", "quarter", "month", "week", "day", "hour", "minute", "second")
-                        .contains(lowerParam)) {
+                if (!Lists.newArrayList("year", "quarter", "month", "week", "day", "hour", "minute", "second",
+                        "millisecond", "microsecond").contains(lowerParam)) {
                     throw new SemanticException("date_trunc function can't support argument other than " +
-                            "year|quarter|month|week|day|hour|minute|second", functionCallExpr.getChild(0).getPos());
+                            "year|quarter|month|week|day|hour|minute|second|millisecond|microsecond",
+                            functionCallExpr.getChild(0).getPos());
                 }
             } else if (functionCallExpr.getChild(1).getType().isDate()) {
                 if (!Lists.newArrayList("year", "quarter", "month", "week", "day")

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
@@ -78,9 +78,11 @@ public class AnalyzeFunctionTest {
         analyzeSuccess("select date_trunc(\"hour\", th) from tall");
         analyzeSuccess("select date_trunc(\"minute\", th) from tall");
         analyzeSuccess("select date_trunc(\"second\", th) from tall");
+        analyzeSuccess("select date_trunc(\"millisecond\", th) from tall");
+        analyzeSuccess("select date_trunc(\"microsecond\", th) from tall");
 
         analyzeFail("select date_trunc(\"foo\", th) from tall",
-                "date_trunc function can't support argument other than year|quarter|month|week|day|hour|minute|second");
+                "year|quarter|month|week|day|hour|minute|second|millisecond|microsecond");
 
         analyzeFail("select date_trunc(ta, th) from tall",
                 "date_trunc requires first parameter must be a string constant");


### PR DESCRIPTION
## Why I'm doing:

  `date_trunc('millisecond', ...)` and `date_trunc('microsecond', ...)` on DATETIME columns
  were throwing a FE semantic error despite the BE (`datetime_trunc_prepare`) already supporting
  both units. Users had no way to truncate DATETIME values to sub-second precision via `date_trunc`.

  ## What I'm doing:

  Adds `millisecond` and `microsecond` to the FE analyzer allowlist for `date_trunc` on DATETIME
  columns. No BE changes needed — support was already present in `datetime_trunc_prepare`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
