### PR TITLE
[BugFix] Make allin1 entrypoint idempotent for priority_networks setup

### DIFF
--- a/docker/dockerfiles/allin1/entrypoint.sh
+++ b/docker/dockerfiles/allin1/entrypoint.sh
@@ -34,7 +34,7 @@ append_if_missing()
     local key=$1
     local value=$2
     local file=$3
-    grep -q "^${key}\s*=" "$file" && return
+    grep -Eq "^[[:space:]]*${key}[[:space:]]*=" "$file" && return
     # ensure the file ends with a newline before appending
     [ -s "$file" ] && [ -n "$(tail -c 1 "$file")" ] && echo >> "$file"
     echo "${key} = ${value}" >> "$file"

--- a/docker/dockerfiles/allin1/entrypoint.sh
+++ b/docker/dockerfiles/allin1/entrypoint.sh
@@ -29,10 +29,21 @@ update_feproxy_config()
     cat $SR_HOME/feproxy/feproxy.conf.template | sed -e "s|{{feproxyhome}}|$SR_HOME/feproxy|g" -e "s|{{fewebport}}|${fehttpport}|g" > $SR_HOME/feproxy/feproxy.conf
 }
 
+append_if_missing()
+{
+    local key=$1
+    local value=$2
+    local file=$3
+    grep -q "^${key}\s*=" "$file" && return
+    # ensure the file ends with a newline before appending
+    [ -s "$file" ] && [ -n "$(tail -c 1 "$file")" ] && echo >> "$file"
+    echo "${key} = ${value}" >> "$file"
+}
+
 setup_priority_networks()
 {
-    echo "priority_networks = 127.0.0.1/32" >> $SR_HOME/fe/conf/fe.conf
-    echo "priority_networks = 127.0.0.1/32" >> $SR_HOME/be/conf/be.conf
+    append_if_missing "priority_networks" "127.0.0.1/32" "$SR_HOME/fe/conf/fe.conf"
+    append_if_missing "priority_networks" "127.0.0.1/32" "$SR_HOME/be/conf/be.conf"
 }
 
 loginfo()


### PR DESCRIPTION
## Why I'm doing:

The `setup_priority_networks()` function in the allin1 Docker entrypoint unconditionally appends `priority_networks = 127.0.0.1/32` to both `fe.conf` and `be.conf` on every container start. Since the entrypoint runs each time the container starts (not just on first creation), restarting the container causes duplicate `priority_networks` entries to accumulate in the config files.

This is particularly problematic because:

1. **Missing trailing newline:** If a user edits `fe.conf` or `be.conf` and the file doesn't end with a newline, `echo >>` appends to the last existing line, producing corrupted entries like `streaming_load_max_mb=204800priority_networks = 127.0.0.1/32`. StarRocks can't parse this, and the container fails to start.

2. **Cascading corruption:** Once the first append lands on the same line as another property, subsequent restarts won't find `^priority_networks` at a line start, so the guard-less append keeps adding more broken entries.

3. **High visibility:** This image (`starrocks/allin1-ubuntu`) has [100K+ pulls on Docker Hub](https://hub.docker.com/r/starrocks/allin1-ubuntu) and is the one recommended in the [official quickstart docs](https://docs.starrocks.io/docs/quick_start/shared-nothing), so new users following the getting-started guide are likely to hit this on container restarts and attribute the failure to their Docker setup rather than the entrypoint script.

## What I'm doing:

Extract an `append_if_missing()` helper that:
- Skips the append if the key is already present (`grep -q`)
- Ensures the file ends with a newline before appending, preventing the missing-trailing-newline corruption
- Makes `setup_priority_networks()` fully idempotent across container restarts
- Respects user-provided `priority_networks` values in custom-mounted config files

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

---

## Reproduction steps (for PR description / issue reference)

```bash
docker pull starrocks/allin1-ubuntu
docker run -p 9030:9030 -p 8030:8030 -p 8040:8040 -itd --name quickstart starrocks/allin1-ubuntu

# Simulate a user editing the config without a trailing newline
docker exec quickstart bash -c 'printf "some_custom_property = 123" >> /data/deploy/starrocks/fe/conf/fe.conf'

# Restart the container
docker restart quickstart

# The config is now corrupted — priority_networks merged into the previous line
docker exec quickstart tail -3 /data/deploy/starrocks/fe/conf/fe.conf
# Output: some_custom_property = 123priority_networks = 127.0.0.1/32

# Even without the missing-newline scenario, plain restarts accumulate duplicates:
docker restart quickstart
docker restart quickstart
docker exec quickstart grep priority_networks /data/deploy/starrocks/fe/conf/fe.conf
# Output: multiple duplicate lines
```

After enough restarts (or one restart with a missing trailing newline), the config corruption prevents FE/BE from starting.

## Change summary

**File:** `docker/dockerfiles/allin1/entrypoint.sh`

**Before:**
```bash
setup_priority_networks()
{
    echo "priority_networks = 127.0.0.1/32" >> $SR_HOME/fe/conf/fe.conf
    echo "priority_networks = 127.0.0.1/32" >> $SR_HOME/be/conf/be.conf
}
```

**After:**
```bash
append_if_missing()
{
    local key=$1
    local value=$2
    local file=$3
    grep -q "^${key}" "$file" && return
    # ensure the file ends with a newline before appending
    [ -s "$file" ] && [ -n "$(tail -c 1 "$file")" ] && echo >> "$file"
    echo "${key} = ${value}" >> "$file"
}

setup_priority_networks()
{
    append_if_missing "priority_networks" "127.0.0.1/32" "$SR_HOME/fe/conf/fe.conf"
    append_if_missing "priority_networks" "127.0.0.1/32" "$SR_HOME/be/conf/be.conf"
}
```

## Branch

`fix/allin1-idempotent-priority-networks` (based on `main`)
