### PR TITLE
[BugFix] Fixing the type of define expression for columns generated by UNNEST

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -576,13 +576,20 @@ class DecodeContext {
         @Override
         public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void ignore) {
             // string dict expression use origin string column
-            ScalarOperator res = stringRefToDefineExprMap.get(variable.getId());
-            if (res.isColumnRef() && variable.getId() == ((ColumnRefOperator) res).getId()) {
+            ScalarOperator define = stringRefToDefineExprMap.get(variable.getId());
+            if (define.isColumnRef() && variable.getId() == ((ColumnRefOperator) define).getId()) {
                 // mock to string column
                 return new ColumnRefOperator(variable.getId(), variable.getType(), variable.getName(),
                         variable.isNullable());
             }
-            return res.accept(this, null);
+            ScalarOperator result = define.accept(this, null);
+            if (result.isColumnRef() && result.getType().isArrayType() && variable.getType().isStringType()) {
+                // This is result of an unnest operator on an ARRAY<VARCHAR>, we replace the type with INT so that
+                // backend doesn't get confused when creating dictionaries.
+                ColumnRefOperator ref = result.cast();
+                return new ColumnRefOperator(ref.getId(), IntegerType.INT, ref.getName(), ref.isNullable());
+            }
+            return result;
         }
 
         @Override

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -603,3 +603,7 @@ select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_opti
 -- result:
 ["abc","bca"]
 -- !result
+with cte as (select st, IF(st = 'GS', null, lower(st)) r FROM s3, unnest(s3.a2) as T(st) order by a1) select * from cte order by st limit 1;
+-- result:
+AH	ah
+-- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -481,3 +481,5 @@ select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_opt
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=false)*/ cast(v3 as array<string>) from s4 limit 1;
 
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=true, low_cardinality_optimize_v2=true)*/ cast(v3 as array<string>) from s4 limit 1;
+
+with cte as (select st, IF(st = 'GS', null, lower(st)) r FROM s3, unnest(s3.a2) as T(st) order by a1) select * from cte order by st limit 1;


### PR DESCRIPTION
## Why I'm doing:
Currently GlobalDictExpressions generated for columns from UNNEST have and ARRAY type, which can cause crashes in the backend if it needs to generate a dictionary based on these columns.

## What I'm doing:
Setting the type correctly for Define expressions of columns generated by UNNEST. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
