### PR TITLE
[BugFix] Clone duplicate column refs in CTE consumer projection (solution 1)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEConsumeOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEConsumeOperator.java
@@ -98,6 +98,7 @@ public class PhysicalCTEConsumeOperator extends PhysicalOperator {
                 "cteId='" + cteId + '\'' +
                 ", limit=" + limit +
                 ", predicate=" + predicate +
+                ", outputColumns='" + getCteOutputColumnRefMap() + '\'' +
                 '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/CloneDuplicateColRefRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/CloneDuplicateColRefRule.java
@@ -24,10 +24,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.task.TaskContext;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 // ProjectOperator or Projection of Operator may have several ColumnRefs remapped to the same ColumnRef, for an example:
 // 1.ColumnRef(1)->ColumnRef(1);
@@ -47,29 +44,29 @@ public class CloneDuplicateColRefRule implements TreeRewriteRule {
         return root;
     }
 
-    private static class Visitor extends OptExpressionVisitor<Void, Void> {
-        void substColumnRefOperatorWithCloneOperator(Map<ColumnRefOperator, ScalarOperator> colRefMap) {
-            if (colRefMap == null || colRefMap.isEmpty()) {
-                return;
-            }
-
-            Map<ScalarOperator, Integer> duplicateColRefs = Maps.newHashMap();
-            colRefMap.forEach((k, v) -> {
-                if (!v.isColumnRef()) {
-                    return;
-                }
-                duplicateColRefs.put(v, duplicateColRefs.getOrDefault(v, 0) + 1);
-            });
-
-            for (ColumnRefOperator key : colRefMap.keySet()) {
-                ScalarOperator value = colRefMap.get(key);
-                if (value.isColumnRef() && duplicateColRefs.get(value) > 1 && !key.equals(value)) {
-                    duplicateColRefs.put(value, duplicateColRefs.get(value) - 1);
-                    colRefMap.put(key, new CloneOperator(value));
-                }
-            }
+    public static void substColumnRefOperatorWithCloneOperator(Map<ColumnRefOperator, ScalarOperator> colRefMap) {
+        if (colRefMap == null || colRefMap.isEmpty()) {
+            return;
         }
 
+        Map<ScalarOperator, Integer> duplicateColRefs = Maps.newHashMap();
+        colRefMap.forEach((k, v) -> {
+            if (!v.isColumnRef()) {
+                return;
+            }
+            duplicateColRefs.put(v, duplicateColRefs.getOrDefault(v, 0) + 1);
+        });
+
+        for (ColumnRefOperator key : colRefMap.keySet()) {
+            ScalarOperator value = colRefMap.get(key);
+            if (value.isColumnRef() && duplicateColRefs.get(value) > 1 && !key.equals(value)) {
+                duplicateColRefs.put(value, duplicateColRefs.get(value) - 1);
+                colRefMap.put(key, new CloneOperator(value));
+            }
+        }
+    }
+
+    private static class Visitor extends OptExpressionVisitor<Void, Void> {
         @Override
         public Void visit(OptExpression optExpression, Void context) {
             if (optExpression.getOp() instanceof PhysicalProjectOperator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/CloneDuplicateColRefRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/CloneDuplicateColRefRule.java
@@ -53,11 +53,6 @@ public class CloneDuplicateColRefRule implements TreeRewriteRule {
                 return;
             }
 
-            List<Map.Entry<ColumnRefOperator, ScalarOperator>> entries =
-                    colRefMap.entrySet().stream()
-                            .sorted(Comparator.comparing(entry -> entry.getKey().getId()))
-                            .collect(Collectors.toList());
-
             Map<ScalarOperator, Integer> duplicateColRefs = Maps.newHashMap();
             colRefMap.forEach((k, v) -> {
                 if (!v.isColumnRef()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -203,6 +203,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamAggOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamJoinOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamScanOperator;
+import com.starrocks.sql.optimizer.rule.tree.CloneDuplicateColRefRule;
 import com.starrocks.sql.optimizer.rule.tree.prunesubfield.SubfieldAccessPathNormalizer;
 import com.starrocks.sql.optimizer.rule.tree.prunesubfield.SubfieldExpressionCollector;
 import com.starrocks.sql.optimizer.statistics.Statistics;
@@ -959,7 +960,7 @@ public class PlanFragmentBuilder {
 
             tupleDescriptor.computeMemLayout();
 
-            // set unused output columns 
+            // set unused output columns
             setUnUsedOutputColumns(node, scanNode, predicates, referenceTable);
 
             // set isPreAggregation
@@ -3575,6 +3576,13 @@ public class PlanFragmentBuilder {
 
             Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
             projectMap.putAll(consume.getCteOutputColumnRefMap());
+            // cteOutputColumnRefMap can map several consumer columns to the same producer
+            // column (e.g. after a no-op CAST is folded away).  Without this substitution the
+            // ProjectNode below would emit a chunk with shared Column pointers, which downstream
+            // operators (e.g. SelectNode's filter) are not generally safe to mutate.
+            // CloneDuplicateColRefRule cannot fix this because cteOutputColumnRefMap's value type
+            // is ColumnRefOperator, not ScalarOperator, so a CloneOperator cannot live in it.
+            CloneDuplicateColRefRule.substColumnRefOperatorWithCloneOperator(projectMap);
             consumeFragment = buildProjectNode(optExpression, new Projection(projectMap), consumeFragment, context);
             consumeFragment.setQueryGlobalDicts(cteFragment.getQueryGlobalDicts());
             consumeFragment.setQueryGlobalDictExprs(cteFragment.getQueryGlobalDictExprs());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
 
 public class CTEPlanTest extends PlanTestBase {
     private static class TestStorage extends EmptyStatisticStorage {
@@ -1332,5 +1334,35 @@ public class CTEPlanTest extends PlanTestBase {
         Assertions.assertEquals(1, StringUtils.countMatches(plan, "TABLE: t0"));
         // x1 with NOT MATERIALIZED: inlined even though it has random(), t1 scanned twice
         Assertions.assertEquals(2, StringUtils.countMatches(plan, "TABLE: t1"));
+    }
+
+    @Test
+    public void testCTEConsumeDuplicateColRefNeedsCloneBasic() throws Exception {
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+
+        String sql = "WITH base AS (" +
+                "  SELECT v1, v2, CAST(v1 AS BIGINT) AS v1_dup FROM t0" +
+                ") [materialized] " +
+                "SELECT v1, v2, v1_dup FROM base WHERE v1 > 0 " +
+                "UNION ALL " +
+                "SELECT v1, v2, v1_dup FROM base WHERE v1 < 0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "MultiCastDataSinks");
+        assertContains(plan, "clone(");
+    }
+
+    @Test
+    public void testCTEConsumeDuplicateColRefNeedsCloneMultiplePredicates() throws Exception {
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+
+        String sql = "WITH base AS (" +
+                "  SELECT v1, v2, CAST(v1 AS BIGINT) AS v1_dup FROM t0" +
+                ") [materialized] " +
+                "SELECT v1, v2, v1_dup FROM base WHERE v1 > 10 or v1_dup < -10  " +
+                "UNION ALL " +
+                "SELECT v1, v2, v1_dup FROM base WHERE v1 < 5 and v1_dup > -5";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "MultiCastDataSinks");
+        assertContains(plan, "clone(");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

On `branch-3.5-cc`, in DEBUG mode , this query crashes BE:
```sql
WITH base AS (
  SELECT v1, v2, CAST(v1 AS BIGINT) AS v1_dup FROM t0
) [materialized]
SELECT v1, v2, v1_dup FROM base WHERE v1 > 10 OR v1_dup < -10
UNION ALL
SELECT v1, v2, v1_dup FROM base WHERE v1 < 5 AND v1_dup > -5;
```


## What I'm doing:

Clone duplicate column refs in CTE consumer projection

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5
  - [ ] 3.4

