### PR TITLE
[BugFix] Clone duplicate column refs in CTE consumer projection (solution 2)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
@@ -647,7 +647,7 @@ public class Explain {
             PhysicalCTEConsumeOperator consume = (PhysicalCTEConsumeOperator) optExpression.getOp();
             StringBuilder sb = new StringBuilder("- CTEConsume[" + consume.getCteId() + "]\n");
 
-            for (Map.Entry<ColumnRefOperator, ColumnRefOperator> kv : consume.getCteOutputColumnRefMap().entrySet()) {
+            for (Map.Entry<ColumnRefOperator, ScalarOperator> kv : consume.getCteOutputColumnRefMap().entrySet()) {
                 String expression = EXPR_PRINTER.print(kv.getKey()) + " := " + EXPR_PRINTER.print(kv.getValue());
                 buildOperatorProperty(sb, expression, context.step);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEConsumeOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEConsumeOperator.java
@@ -98,6 +98,7 @@ public class PhysicalCTEConsumeOperator extends PhysicalOperator {
                 "cteId='" + cteId + '\'' +
                 ", limit=" + limit +
                 ", predicate=" + predicate +
+                ", outputColumns='" + getCteOutputColumnRefMap() + '\'' +
                 '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEConsumeOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEConsumeOperator.java
@@ -33,9 +33,13 @@ import java.util.Objects;
 public class PhysicalCTEConsumeOperator extends PhysicalOperator {
     private final int cteId;
 
-    private final Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap;
+    // Value type is ScalarOperator (not ColumnRefOperator) so that CloneDuplicateColRefRule
+    // can wrap duplicated producer column refs in a CloneOperator in place. At construction
+    // time the values are always ColumnRefOperator; CloneOperator values are only introduced
+    // by CloneDuplicateColRefRule near the end of optimization.
+    private final Map<ColumnRefOperator, ScalarOperator> cteOutputColumnRefMap;
 
-    public PhysicalCTEConsumeOperator(int cteId, Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap,
+    public PhysicalCTEConsumeOperator(int cteId, Map<ColumnRefOperator, ScalarOperator> cteOutputColumnRefMap,
                                       long limit, ScalarOperator predicate, Projection projection) {
         super(OperatorType.PHYSICAL_CTE_CONSUME);
         this.cteId = cteId;
@@ -49,14 +53,14 @@ public class PhysicalCTEConsumeOperator extends PhysicalOperator {
         return cteId;
     }
 
-    public Map<ColumnRefOperator, ColumnRefOperator> getCteOutputColumnRefMap() {
+    public Map<ColumnRefOperator, ScalarOperator> getCteOutputColumnRefMap() {
         return cteOutputColumnRefMap;
     }
 
     @Override
     public RowOutputInfo deriveRowOutputInfo(List<OptExpression> inputs) {
         List<ColumnOutputInfo> entryList = Lists.newArrayList();
-        for (Map.Entry<ColumnRefOperator, ColumnRefOperator> entry : cteOutputColumnRefMap.entrySet()) {
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : cteOutputColumnRefMap.entrySet()) {
             entryList.add(new ColumnOutputInfo(entry.getKey(), entry.getValue()));
         }
         return new RowOutputInfo(entryList);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/CTEConsumerReuseImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/CTEConsumerReuseImplementationRule.java
@@ -16,15 +16,19 @@
 package com.starrocks.sql.optimizer.rule.implementation;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
+import java.util.Map;
 
 public class CTEConsumerReuseImplementationRule extends ImplementationRule {
     public CTEConsumerReuseImplementationRule() {
@@ -35,8 +39,12 @@ public class CTEConsumerReuseImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         // delete children of cte consume
         LogicalCTEConsumeOperator logical = (LogicalCTEConsumeOperator) input.getOp();
+        // Widen the value type to ScalarOperator so CloneDuplicateColRefRule can later
+        // substitute duplicated producer refs with CloneOperator in place.
+        Map<ColumnRefOperator, ScalarOperator> cteOutputColumnRefMap =
+                Maps.newHashMap(logical.getCteOutputColumnRefMap());
         PhysicalCTEConsumeOperator consume =
-                new PhysicalCTEConsumeOperator(logical.getCteId(), logical.getCteOutputColumnRefMap(),
+                new PhysicalCTEConsumeOperator(logical.getCteId(), cteOutputColumnRefMap,
                         logical.getLimit(), logical.getPredicate(), logical.getProjection());
         return Lists.newArrayList(OptExpression.create(consume));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/CloneDuplicateColRefRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/CloneDuplicateColRefRule.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CloneOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -73,10 +74,19 @@ public class CloneDuplicateColRefRule implements TreeRewriteRule {
                 PhysicalProjectOperator projectOp = optExpression.getOp().cast();
                 substColumnRefOperatorWithCloneOperator(projectOp.getColumnRefMap());
                 substColumnRefOperatorWithCloneOperator(projectOp.getCommonSubOperatorMap());
-            } else if (optExpression.getOp().getProjection() != null) {
-                Projection projection = optExpression.getOp().getProjection();
-                substColumnRefOperatorWithCloneOperator(projection.getColumnRefMap());
-                substColumnRefOperatorWithCloneOperator(projection.getCommonSubOperatorMap());
+            } else {
+                // PhysicalCTEConsumeOperator's cteOutputColumnRefMap is materialized into a
+                // ProjectNode in PlanFragmentBuilder, so it has the same shared-column hazard
+                // as a regular projection and must also be processed here.
+                if (optExpression.getOp() instanceof PhysicalCTEConsumeOperator) {
+                    PhysicalCTEConsumeOperator consume = optExpression.getOp().cast();
+                    substColumnRefOperatorWithCloneOperator(consume.getCteOutputColumnRefMap());
+                }
+                if (optExpression.getOp().getProjection() != null) {
+                    Projection projection = optExpression.getOp().getProjection();
+                    substColumnRefOperatorWithCloneOperator(projection.getColumnRefMap());
+                    substColumnRefOperatorWithCloneOperator(projection.getCommonSubOperatorMap());
+                }
             }
             optExpression.getInputs().forEach(input -> this.visit(input, context));
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/CloneDuplicateColRefRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/CloneDuplicateColRefRule.java
@@ -24,10 +24,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.task.TaskContext;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 // ProjectOperator or Projection of Operator may have several ColumnRefs remapped to the same ColumnRef, for an example:
 // 1.ColumnRef(1)->ColumnRef(1);
@@ -52,11 +49,6 @@ public class CloneDuplicateColRefRule implements TreeRewriteRule {
             if (colRefMap == null || colRefMap.isEmpty()) {
                 return;
             }
-
-            List<Map.Entry<ColumnRefOperator, ScalarOperator>> entries =
-                    colRefMap.entrySet().stream()
-                            .sorted(Comparator.comparing(entry -> entry.getKey().getId()))
-                            .collect(Collectors.toList());
 
             Map<ScalarOperator, Integer> duplicateColRefs = Maps.newHashMap();
             colRefMap.forEach((k, v) -> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1940,7 +1940,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     }
 
     private Void computeCTEConsume(Operator node, ExpressionContext context, int cteId,
-                                   Map<ColumnRefOperator, ColumnRefOperator> columnRefMap) {
+                                   Map<ColumnRefOperator, ? extends ScalarOperator> columnRefMap) {
 
         if (!context.getChildrenStatistics().isEmpty() && context.getChildStatistics(0) != null) {
             //  use the statistics of children first
@@ -1965,7 +1965,9 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         Statistics produceStatistics = produceStatisticsOp.get();
         Statistics.Builder builder = Statistics.builder();
         for (ColumnRefOperator ref : columnRefMap.keySet()) {
-            ColumnRefOperator produceRef = columnRefMap.get(ref);
+            // Statistics are computed before CloneDuplicateColRefRule runs, so values are
+            // always ColumnRefOperator here even for the physical CTE consume operator.
+            ColumnRefOperator produceRef = (ColumnRefOperator) columnRefMap.get(ref);
             ColumnStatistic statistic = produceStatistics.getColumnStatistic(produceRef);
             builder.addColumnStatistic(ref, statistic);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -196,6 +196,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CloneOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
@@ -3563,8 +3564,12 @@ public class PlanFragmentBuilder {
             ExchangeNode exchangeNode = new ExchangeNode(context.getNextNodeId(),
                     cteFragment.getPlanRoot(), DistributionSpec.DistributionType.SHUFFLE);
             this.currentExecGroup.add(exchangeNode, true);
+            // Values may be wrapped in CloneOperator by CloneDuplicateColRefRule when
+            // multiple consumer columns alias the same producer column; unwrap to recover
+            // the underlying producer ColumnRef so the exchange receives each column once.
             exchangeNode.setReceiveColumns(consume.getCteOutputColumnRefMap().values().stream()
-                    .map(ColumnRefOperator::getId).distinct().collect(Collectors.toList()));
+                    .map(v -> v instanceof CloneOperator ? v.getChild(0) : v)
+                    .map(v -> ((ColumnRefOperator) v).getId()).distinct().collect(Collectors.toList()));
             exchangeNode.setDataPartition(cteFragment.getDataPartition());
             exchangeNode.forceCollectExecStats();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
 
 public class CTEPlanTest extends PlanTestBase {
     private static class TestStorage extends EmptyStatisticStorage {
@@ -1332,5 +1334,35 @@ public class CTEPlanTest extends PlanTestBase {
         Assertions.assertEquals(1, StringUtils.countMatches(plan, "TABLE: t0"));
         // x1 with NOT MATERIALIZED: inlined even though it has random(), t1 scanned twice
         Assertions.assertEquals(2, StringUtils.countMatches(plan, "TABLE: t1"));
+    }
+
+    @Test
+    public void testCTEConsumeDuplicateColRefNeedsCloneBasic() throws Exception {
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+
+        String sql = "WITH base AS (" +
+                "  SELECT v1, v2, CAST(v1 AS BIGINT) AS v1_dup FROM t0" +
+                ") [materialized] " +
+                "SELECT v1, v2, v1_dup FROM base WHERE v1 > 0 " +
+                "UNION ALL " +
+                "SELECT v1, v2, v1_dup FROM base WHERE v1 < 0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "MultiCastDataSinks");
+        assertContains(plan, "clone(");
+    }
+
+    @Test
+    public void testCTEConsumeDuplicateColRefNeedsCloneMultiplePredicates() throws Exception {
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+
+        String sql = "WITH base AS (" +
+                "  SELECT v1, v2, CAST(v1 AS BIGINT) AS v1_dup FROM t0" +
+                ") [materialized] " +
+                "SELECT v1, v2, v1_dup FROM base WHERE v1 > 10 or v1_dup < -10  " +
+                "UNION ALL " +
+                "SELECT v1, v2, v1_dup FROM base WHERE v1 < 5 and v1_dup > -5";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "MultiCastDataSinks");
+        assertContains(plan, "clone(");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

On `branch-3.5-cc`, in DEBUG mode , this query crashes BE:
```sql
WITH base AS (
  SELECT v1, v2, CAST(v1 AS BIGINT) AS v1_dup FROM t0
) [materialized]
SELECT v1, v2, v1_dup FROM base WHERE v1 > 10 OR v1_dup < -10
UNION ALL
SELECT v1, v2, v1_dup FROM base WHERE v1 < 5 AND v1_dup > -5;
```

## What I'm doing:


Clone duplicate column refs in CTE consumer projection

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5
  - [ ] 3.4

