### PR TITLE
[Refactor] Move query_spill_manager into SpillCore

### DIFF
--- a/be/AGENTS.md
+++ b/be/AGENTS.md
@@ -127,12 +127,12 @@ Minimal filesystem core on top of IOCore.
 - Remediation: Keep FSCore limited to IOCore plus core FS abstractions; move backend-specific behavior into FileSystem.
 
 ### SpillCore (`spillcore`)
-Core spill block and directory primitives without pipeline/query/runtime-service coupling.
+Core spill block, directory, and query-local spill primitives without pipeline/runtime-service coupling.
 - Targets: `SpillCore`
 - Allowed internal include prefixes: `exec/spill/`, `fs/`, `io/`, `common/`, `base/`, `gutil/`, `gen_cpp/`
 - Allowed target deps: `FSCore`, `IOCore`, `Common`, `Base`, `Gutil`, `StarRocksGen`
 - Core tests: `spill_core_test`
-- Remediation: Keep SpillCore limited to reusable spill block and directory infrastructure; move query bootstrap, pipeline ownership, and runtime-service integration upward.
+- Remediation: Keep SpillCore limited to reusable spill block, directory, and query-local spill infrastructure; move pipeline ownership and runtime-service integration upward.
 
 ### TypesCore (`typecore`)
 Core type system without runtime/storage/exec coupling.

--- a/be/AGENTS.md
+++ b/be/AGENTS.md
@@ -127,12 +127,12 @@ Minimal filesystem core on top of IOCore.
 - Remediation: Keep FSCore limited to IOCore plus core FS abstractions; move backend-specific behavior into FileSystem.
 
 ### SpillCore (`spillcore`)
-Core spill block, directory, and query-local spill primitives without pipeline/runtime-service coupling.
+Core spill block, directory, query-local spill, and spill memory-resource primitives without pipeline/runtime-service coupling.
 - Targets: `SpillCore`
 - Allowed internal include prefixes: `exec/spill/`, `fs/`, `io/`, `common/`, `base/`, `gutil/`, `gen_cpp/`
-- Allowed target deps: `FSCore`, `IOCore`, `Common`, `Base`, `Gutil`, `StarRocksGen`
+- Allowed target deps: `RuntimeCore`, `FSCore`, `IOCore`, `Common`, `Base`, `Gutil`, `StarRocksGen`
 - Core tests: `spill_core_test`
-- Remediation: Keep SpillCore limited to reusable spill block, directory, and query-local spill infrastructure; move pipeline ownership and runtime-service integration upward.
+- Remediation: Keep SpillCore limited to reusable spill block, directory, query-local spill, and spill memory-resource infrastructure; move pipeline ownership and runtime-service integration upward.
 
 ### TypesCore (`typecore`)
 Core type system without runtime/storage/exec coupling.

--- a/be/module_boundary_manifest.json
+++ b/be/module_boundary_manifest.json
@@ -118,7 +118,7 @@
     {
       "id": "spillcore",
       "doc_label": "SpillCore",
-      "summary": "Core spill block and directory primitives without pipeline/query/runtime-service coupling.",
+      "summary": "Core spill block, directory, and query-local spill primitives without pipeline/runtime-service coupling.",
       "owned_targets": ["SpillCore"],
       "owned_globs": [
         "be/src/exec/spill/block_manager.h",
@@ -132,6 +132,8 @@
         "be/src/exec/spill/file_block_manager.cpp",
         "be/src/exec/spill/hybird_block_manager.h",
         "be/src/exec/spill/hybird_block_manager.cpp",
+        "be/src/exec/spill/query_spill_manager.h",
+        "be/src/exec/spill/query_spill_manager.cpp",
         "be/src/exec/spill/block_reader.cpp",
         "be/src/exec/spill/global_spill_manager.h"
       ],
@@ -144,7 +146,7 @@
       "allowed_target_deps": ["FSCore", "IOCore", "Common", "Base", "Gutil", "StarRocksGen"],
       "allowed_test_targets": ["spill_core_test"],
       "allowed_test_link_deps": ["SpillCore", "FSCore", "IOCore", "Common", "Base", "Gutil", "StarRocksGen"],
-      "remediation": "Keep SpillCore limited to reusable spill block and directory infrastructure; move query bootstrap, pipeline ownership, and runtime-service integration upward."
+      "remediation": "Keep SpillCore limited to reusable spill block, directory, and query-local spill infrastructure; move pipeline ownership and runtime-service integration upward."
     },
     {
       "id": "typecore",

--- a/be/module_boundary_manifest.json
+++ b/be/module_boundary_manifest.json
@@ -118,7 +118,7 @@
     {
       "id": "spillcore",
       "doc_label": "SpillCore",
-      "summary": "Core spill block, directory, and query-local spill primitives without pipeline/runtime-service coupling.",
+      "summary": "Core spill block, directory, query-local spill, and spill memory-resource primitives without pipeline/runtime-service coupling.",
       "owned_targets": ["SpillCore"],
       "owned_globs": [
         "be/src/exec/spill/block_manager.h",
@@ -135,7 +135,10 @@
         "be/src/exec/spill/query_spill_manager.h",
         "be/src/exec/spill/query_spill_manager.cpp",
         "be/src/exec/spill/block_reader.cpp",
-        "be/src/exec/spill/global_spill_manager.h"
+        "be/src/exec/spill/global_spill_manager.h",
+        "be/src/exec/spill/operator_mem_resource_manager.h",
+        "be/src/exec/spill/operator_mem_resource_manager.cpp",
+        "be/src/exec/spill/partition.h"
       ],
       "allowed_include_prefixes": ["exec/spill/", "fs/", "io/", "common/", "base/", "gutil/", "gen_cpp/"],
       "forbidden_include_prefixes": ["exec/pipeline/", "exec/workgroup/", "exprs/", "runtime/", "storage/", "util/"],
@@ -143,10 +146,10 @@
         "runtime/exec_env.h",
         "exec/sort_exec_exprs.h"
       ],
-      "allowed_target_deps": ["FSCore", "IOCore", "Common", "Base", "Gutil", "StarRocksGen"],
+      "allowed_target_deps": ["RuntimeCore", "FSCore", "IOCore", "Common", "Base", "Gutil", "StarRocksGen"],
       "allowed_test_targets": ["spill_core_test"],
-      "allowed_test_link_deps": ["SpillCore", "FSCore", "IOCore", "Common", "Base", "Gutil", "StarRocksGen"],
-      "remediation": "Keep SpillCore limited to reusable spill block, directory, and query-local spill infrastructure; move pipeline ownership and runtime-service integration upward."
+      "allowed_test_link_deps": ["SpillCore", "RuntimeCore", "FSCore", "IOCore", "Common", "Base", "Gutil", "StarRocksGen"],
+      "remediation": "Keep SpillCore limited to reusable spill block, directory, query-local spill, and spill memory-resource infrastructure; move pipeline ownership and runtime-service integration upward."
     },
     {
       "id": "typecore",

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -41,13 +41,14 @@ set(SPILL_CORE_FILES
     spill/file_block_manager.cpp
     spill/hybird_block_manager.cpp
     spill/query_spill_manager.cpp
+    spill/operator_mem_resource_manager.cpp
 )
 
 ADD_BE_LIB(SpillCore
     ${SPILL_CORE_FILES}
 )
 
-target_link_libraries(SpillCore PUBLIC FSCore IOCore Common Base Gutil StarRocksGen)
+target_link_libraries(SpillCore PUBLIC RuntimeCore FSCore IOCore Common Base Gutil StarRocksGen)
 
 set(PIPELINE_PRIMITIVES_SRCS
     pipeline/operator.cpp
@@ -79,7 +80,6 @@ set(PIPELINE_RUNTIME_SRCS
     pipeline/runtime_filter_types.cpp
     workgroup/pipeline_executor_set.cpp
     workgroup/pipeline_executor_set_manager.cpp
-    spill/operator_mem_resource_manager.cpp
 )
 
 set(PIPELINE_ADAPTERS_SRCS

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SPILL_CORE_FILES
     spill/log_block_manager.cpp
     spill/file_block_manager.cpp
     spill/hybird_block_manager.cpp
+    spill/query_spill_manager.cpp
 )
 
 ADD_BE_LIB(SpillCore
@@ -79,7 +80,6 @@ set(PIPELINE_RUNTIME_SRCS
     workgroup/pipeline_executor_set.cpp
     workgroup/pipeline_executor_set_manager.cpp
     spill/operator_mem_resource_manager.cpp
-    spill/query_spill_manager.cpp
 )
 
 set(PIPELINE_ADAPTERS_SRCS

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -210,7 +210,8 @@ Status QueryContext::init_spill_manager(const TQueryOptions& query_options) {
         auto* services = runtime_services(_query_execution_services);
         auto* g_spill_manager =
                 services != nullptr ? services->global_spill_manager : ExecEnv::GetInstance()->global_spill_manager();
-        _spill_manager = std::make_unique<spill::QuerySpillManager>(_query_id, g_spill_manager);
+        auto* spill_dir_mgr = services != nullptr ? services->spill_dir_mgr : ExecEnv::GetInstance()->spill_dir_mgr();
+        _spill_manager = std::make_unique<spill::QuerySpillManager>(_query_id, g_spill_manager, spill_dir_mgr);
         st = _spill_manager->init_block_manager(query_options);
     });
     return st;

--- a/be/src/exec/spill/operator_mem_resource_manager.cpp
+++ b/be/src/exec/spill/operator_mem_resource_manager.cpp
@@ -14,6 +14,8 @@
 
 #include "exec/spill/operator_mem_resource_manager.h"
 
+#include <algorithm>
+
 #include "runtime/runtime_state.h"
 
 namespace starrocks::spill {

--- a/be/src/exec/spill/operator_mem_resource_manager.h
+++ b/be/src/exec/spill/operator_mem_resource_manager.h
@@ -15,7 +15,10 @@
 #pragma once
 
 #include "exec/spill/query_spill_manager.h"
-#include "runtime/runtime_state_fwd.h"
+
+namespace starrocks {
+class RuntimeState;
+} // namespace starrocks
 
 namespace starrocks::spill {
 enum MEM_RESOURCE {

--- a/be/src/exec/spill/query_spill_manager.cpp
+++ b/be/src/exec/spill/query_spill_manager.cpp
@@ -23,17 +23,20 @@
 #include "exec/spill/log_block_manager.h"
 #include "fs/fs_factory.h"
 #include "gen_cpp/InternalService_types.h"
-#include "runtime/exec_env.h"
 
 namespace starrocks::spill {
+
+Status QuerySpillManager::init_local_block_manager() {
+    _block_manager = std::make_unique<LogBlockManager>(_uid, _spill_dir_mgr);
+    return Status::OK();
+}
 
 Status QuerySpillManager::init_block_manager(const TQueryOptions& query_options) {
     const TSpillOptions& spill_options = query_options.spill_options;
     bool enable_spill_to_remote_storage =
             spill_options.__isset.enable_spill_to_remote_storage && spill_options.enable_spill_to_remote_storage;
     if (!enable_spill_to_remote_storage) {
-        _block_manager = std::make_unique<LogBlockManager>(_uid, ExecEnv::GetInstance()->spill_dir_mgr());
-        return Status::OK();
+        return init_local_block_manager();
     }
     DCHECK(spill_options.__isset.spill_to_remote_storage_options);
     const auto& options = spill_options.spill_to_remote_storage_options;
@@ -41,8 +44,7 @@ Status QuerySpillManager::init_block_manager(const TQueryOptions& query_options)
     if (!options.__isset.remote_storage_paths || !options.__isset.remote_storage_conf) {
         DCHECK(false) << "enable spill_to_remote_storage but remote_storage_paths or remote_storage_conf "
                          "is not set";
-        _block_manager = std::make_unique<LogBlockManager>(_uid, ExecEnv::GetInstance()->spill_dir_mgr());
-        return Status::OK();
+        return init_local_block_manager();
     }
     const auto& remote_storage_paths = options.remote_storage_paths;
     auto remote_storage_conf = std::make_shared<TCloudConfiguration>(options.remote_storage_conf);
@@ -65,7 +67,7 @@ Status QuerySpillManager::init_block_manager(const TQueryOptions& query_options)
     }
 
     // init block manager
-    auto local_block_manager = std::make_unique<LogBlockManager>(_uid, ExecEnv::GetInstance()->spill_dir_mgr());
+    auto local_block_manager = std::make_unique<LogBlockManager>(_uid, _spill_dir_mgr);
     auto remote_block_manager = std::make_unique<FileBlockManager>(_uid, _remote_dir_manager.get());
     _block_manager =
             std::make_unique<HyBirdBlockManager>(_uid, std::move(local_block_manager), std::move(remote_block_manager));

--- a/be/src/exec/spill/query_spill_manager.h
+++ b/be/src/exec/spill/query_spill_manager.h
@@ -27,8 +27,8 @@ class TQueryOptions;
 namespace starrocks::spill {
 class QuerySpillManager {
 public:
-    QuerySpillManager(const TUniqueId& uid, GlobalSpillManager* global_spill_manager)
-            : _uid(uid), _global_spill_manager(global_spill_manager) {}
+    QuerySpillManager(const TUniqueId& uid, GlobalSpillManager* global_spill_manager, DirManager* spill_dir_mgr)
+            : _uid(uid), _global_spill_manager(global_spill_manager), _spill_dir_mgr(spill_dir_mgr) {}
 
     Status init_block_manager(const TQueryOptions& query_options);
 
@@ -41,9 +41,12 @@ public:
     BlockManager* block_manager() const { return _block_manager.get(); }
 
 private:
+    Status init_local_block_manager();
+
     TUniqueId _uid;
     std::unique_ptr<BlockManager> _block_manager;
     std::unique_ptr<DirManager> _remote_dir_manager;
     GlobalSpillManager* _global_spill_manager = nullptr;
+    DirManager* _spill_dir_mgr = nullptr;
 };
 } // namespace starrocks::spill

--- a/be/src/types/CMakeLists.txt
+++ b/be/src/types/CMakeLists.txt
@@ -38,6 +38,11 @@ ADD_BE_LIB(TypesCore
     variant_value.cpp
 )
 
+target_link_libraries(TypesCore PRIVATE
+    simdjson
+    velocypack
+)
+
 ADD_BE_LIB(Types
     hll_sketch.cpp
     logical_type_size.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -77,7 +77,6 @@ set(EXEC_FILES
         ./exec/pipeline/exec_group_test.cpp
         ./exec/pipeline/glm_manager_tablet_adaptor_test.cpp
         ./exec/pipeline/scan/physical_split_morsel_queue_test.cpp
-        ./exec/query_spill_manager_test.cpp
         ./exec/query_cache/query_cache_test.cpp
         ./exec/query_cache/transform_operator.cpp
         ./exec/schema_columns_scanner_test.cpp

--- a/be/test/exec/query_spill_manager_test.cpp
+++ b/be/test/exec/query_spill_manager_test.cpp
@@ -31,10 +31,11 @@ protected:
     RuntimeState _dummy_state;
     TUniqueId dummy_query_id;
     GlobalSpillManager _global_mgr;
+    DirManager _dir_mgr;
 };
 
 TEST_F(QuerySpillManagerTest, test_inc) {
-    QuerySpillManager query_spill_manager_1(dummy_query_id, &_global_mgr);
+    QuerySpillManager query_spill_manager_1(dummy_query_id, &_global_mgr, &_dir_mgr);
 
     OperatorMemoryResourceManager op_mem_res_mgr;
     op_mem_res_mgr.prepare(&query_spill_manager_1, true, true, 128);
@@ -56,7 +57,7 @@ TEST_F(QuerySpillManagerTest, test_inc) {
 }
 
 TEST_F(QuerySpillManagerTest, test_low_memory_transition_is_idempotent) {
-    QuerySpillManager query_spill_manager(dummy_query_id, &_global_mgr);
+    QuerySpillManager query_spill_manager(dummy_query_id, &_global_mgr, &_dir_mgr);
     OperatorMemoryResourceManager op_mem_res_mgr;
     op_mem_res_mgr.prepare(&query_spill_manager, false, true, 64);
 

--- a/be/test/spill/CMakeLists.txt
+++ b/be/test/spill/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 set(SPILL_CORE_TEST_FILES
     ../base/cxa_throw_wrap.cpp
+    query_spill_manager_test.cpp
     spill_block_manager_test.cpp
 )
 

--- a/be/test/spill/CMakeLists.txt
+++ b/be/test/spill/CMakeLists.txt
@@ -14,12 +14,14 @@
 
 set(SPILL_CORE_TEST_FILES
     ../base/cxa_throw_wrap.cpp
+    operator_mem_resource_manager_test.cpp
     query_spill_manager_test.cpp
     spill_block_manager_test.cpp
 )
 
 set(SPILL_CORE_TEST_LINK_LIBS
     SpillCore
+    RuntimeCore
     FSCore
     IOCore
     Common

--- a/be/test/spill/operator_mem_resource_manager_test.cpp
+++ b/be/test/spill/operator_mem_resource_manager_test.cpp
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "exec/spill/query_spill_manager.h"
+#include "exec/spill/operator_mem_resource_manager.h"
+
+#include <algorithm>
 
 #include <gtest/gtest.h>
 
 #include "base/uid_util.h"
-#include "exec/spill/operator_mem_resource_manager.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::spill {
-class QuerySpillManagerTest : public ::testing::Test {
+class OperatorMemoryResourceManagerTest : public ::testing::Test {
 public:
     void SetUp() override { dummy_query_id = generate_uuid(); }
-
-    void TearDown() override {}
 
 protected:
     RuntimeState _dummy_state;
@@ -34,7 +33,7 @@ protected:
     DirManager _dir_mgr;
 };
 
-TEST_F(QuerySpillManagerTest, test_inc) {
+TEST_F(OperatorMemoryResourceManagerTest, test_inc) {
     QuerySpillManager query_spill_manager_1(dummy_query_id, &_global_mgr, &_dir_mgr);
 
     OperatorMemoryResourceManager op_mem_res_mgr;
@@ -56,7 +55,7 @@ TEST_F(QuerySpillManagerTest, test_inc) {
     EXPECT_EQ(_global_mgr.spill_expected_reserved_bytes(), 0);
 }
 
-TEST_F(QuerySpillManagerTest, test_low_memory_transition_is_idempotent) {
+TEST_F(OperatorMemoryResourceManagerTest, test_low_memory_transition_is_idempotent) {
     QuerySpillManager query_spill_manager(dummy_query_id, &_global_mgr, &_dir_mgr);
     OperatorMemoryResourceManager op_mem_res_mgr;
     op_mem_res_mgr.prepare(&query_spill_manager, false, true, 64);
@@ -67,7 +66,7 @@ TEST_F(QuerySpillManagerTest, test_low_memory_transition_is_idempotent) {
     EXPECT_FALSE(op_mem_res_mgr.enter_low_memory_mode());
 }
 
-TEST_F(QuerySpillManagerTest, test_compute_available_memory_bytes_matches_runtime_state) {
+TEST_F(OperatorMemoryResourceManagerTest, test_compute_available_memory_bytes_matches_runtime_state) {
     const size_t expected =
             std::min<size_t>(std::max<size_t>(_dummy_state.spill_mem_table_size() * _dummy_state.spill_mem_table_num(),
                                               _dummy_state.spill_operator_min_bytes()),

--- a/be/test/spill/operator_mem_resource_manager_test.cpp
+++ b/be/test/spill/operator_mem_resource_manager_test.cpp
@@ -14,9 +14,9 @@
 
 #include "exec/spill/operator_mem_resource_manager.h"
 
-#include <algorithm>
-
 #include <gtest/gtest.h>
+
+#include <algorithm>
 
 #include "base/uid_util.h"
 #include "runtime/runtime_state.h"

--- a/be/test/spill/query_spill_manager_test.cpp
+++ b/be/test/spill/query_spill_manager_test.cpp
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/spill/query_spill_manager.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "base/uid_util.h"
+#include "common/config_storage_fwd.h"
+#include "exec/spill/dir_manager.h"
+#include "fmt/format.h"
+#include "fs/fs_memory.h"
+#include "gen_cpp/InternalService_types.h"
+
+namespace starrocks::spill {
+
+class QuerySpillManagerCoreTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _query_id = generate_uuid();
+        _local_path = fmt::format("{}/query_spill_manager", config::storage_root_path);
+        _fs_handle = std::shared_ptr<FileSystem>(&_fs, [](FileSystem*) {});
+        ASSERT_OK(_fs.create_dir_recursive(_local_path));
+        _local_dir = std::make_shared<Dir>(_local_path, _fs_handle, 1024);
+        _dir_mgr = std::make_unique<DirManager>(std::vector<DirPtr>{_local_dir});
+    }
+
+protected:
+    MemoryFileSystem _fs;
+    std::shared_ptr<FileSystem> _fs_handle;
+    TUniqueId _query_id;
+    std::string _local_path;
+    DirPtr _local_dir;
+    std::unique_ptr<DirManager> _dir_mgr;
+    GlobalSpillManager _global_mgr;
+};
+
+TEST_F(QuerySpillManagerCoreTest, LocalSpillUsesInjectedDirManager) {
+    QuerySpillManager query_spill_manager(_query_id, &_global_mgr, _dir_mgr.get());
+    TQueryOptions query_options;
+    ASSERT_OK(query_spill_manager.init_block_manager(query_options));
+    ASSERT_NE(nullptr, query_spill_manager.block_manager());
+
+    AcquireBlockOptions block_options;
+    block_options.query_id = _query_id;
+    block_options.fragment_instance_id = _query_id;
+    block_options.plan_node_id = 1;
+    block_options.name = "local";
+    block_options.block_size = 16;
+    auto block_or = query_spill_manager.block_manager()->acquire_block(block_options);
+    ASSERT_TRUE(block_or.ok()) << block_or.status();
+    auto block = block_or.value();
+    EXPECT_EQ(fmt::format("LogBlock[container={}/{}/{}-{}]", _local_path, print_id(_query_id), print_id(_query_id),
+                          "local-1-0"),
+              block->debug_string());
+}
+
+TEST_F(QuerySpillManagerCoreTest, CountersForwardToGlobalSpillManager) {
+    QuerySpillManager query_spill_manager(_query_id, &_global_mgr, _dir_mgr.get());
+
+    query_spill_manager.increase_spillable_operators();
+    query_spill_manager.inc_reserve_bytes(128);
+    EXPECT_EQ(1, _global_mgr.spillable_operators());
+    EXPECT_EQ(128, _global_mgr.spill_expected_reserved_bytes());
+
+    query_spill_manager.dec_reserve_bytes(64);
+    query_spill_manager.decrease_spillable_operators();
+    EXPECT_EQ(0, _global_mgr.spillable_operators());
+    EXPECT_EQ(64, _global_mgr.spill_expected_reserved_bytes());
+}
+
+} // namespace starrocks::spill

--- a/build-support/exec_env_singleton_allowlist.txt
+++ b/build-support/exec_env_singleton_allowlist.txt
@@ -14,7 +14,6 @@ src/exec/pipeline/pipeline_driver_queue.cpp
 src/exec/pipeline/query_context.cpp
 src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
 src/exec/schema_scanner/schema_be_tablets_scanner.cpp
-src/exec/spill/query_spill_manager.cpp
 src/exec/workgroup/lock_free_work_group_scan_task_queue.cpp
 src/exec/workgroup/scan_task_queue.cpp
 src/exec/write_combined_txn_log.cpp


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
