### PR TITLE
[Enhancement] Cache UDAF for loading&initialize only once and re-use across queries

### DIFF
--- a/be/src/exec/aggregate/agg_profile.h
+++ b/be/src/exec/aggregate/agg_profile.h
@@ -37,6 +37,10 @@ struct AggStatistics {
 
         chunk_buffer_peak_memory = ADD_PEAK_COUNTER(runtime_profile, "ChunkBufferPeakMem", TUnit::BYTES);
         chunk_buffer_peak_size = ADD_PEAK_COUNTER(runtime_profile, "ChunkBufferPeakSize", TUnit::UNIT);
+
+        udaf_load_timer = ADD_TIMER(runtime_profile, "UdafLoadTime");
+        udaf_cache_hit_count = ADD_COUNTER(runtime_profile, "UdafCacheHitCount", TUnit::UNIT);
+        udaf_cache_populate_count = ADD_COUNTER(runtime_profile, "UdafCachePopulateCount", TUnit::UNIT);
     }
 
     // timer for build hash table and compute aggregate function
@@ -70,5 +74,9 @@ struct AggStatistics {
 
     RuntimeProfile::HighWaterMarkCounter* chunk_buffer_peak_memory{};
     RuntimeProfile::HighWaterMarkCounter* chunk_buffer_peak_size{};
+
+    RuntimeProfile::Counter* udaf_load_timer{};
+    RuntimeProfile::Counter* udaf_cache_hit_count{};
+    RuntimeProfile::Counter* udaf_cache_populate_count{};
 };
 } // namespace starrocks

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -158,7 +158,8 @@ bool AggrAutoContext::is_low_reduction(const size_t agg_count, const size_t chun
 }
 
 Status init_udaf_context(int64_t fid, const std::string& url, const std::string& checksum, const std::string& symbol,
-                         FunctionContext* context, const TCloudConfiguration& cloud_configuration);
+                         FunctionContext* context, const TCloudConfiguration& cloud_configuration,
+                         bool use_cache = false, bool* cache_hit_out = nullptr);
 
 int64_t Aggregator::get_two_level_threahold() {
     if (config::two_level_memory_threshold < 0) {
@@ -294,14 +295,31 @@ Status Aggregator::open(RuntimeState* state) {
                             [](const auto& ctx) { return ctx.binary_type == TFunctionBinaryType::SRJAR; });
 #ifndef __APPLE__
     if (_has_udaf) {
-        auto promise_st = call_function_in_pthread(state, [this]() {
+        auto& opts = state->query_options();
+        bool enable_cache = opts.__isset.enable_cache_udaf && opts.enable_cache_udaf;
+        auto promise_st = call_function_in_pthread(state, [this, enable_cache]() {
             std::vector<int> attached_udaf_idx;
             attached_udaf_idx.reserve(_agg_fn_ctxs.size());
             for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
                 if (_fns[i].binary_type == TFunctionBinaryType::SRJAR) {
                     const auto& fn = _fns[i];
-                    auto st = init_udaf_context(fn.fid, fn.hdfs_location, fn.checksum, fn.aggregate_fn.symbol,
-                                                _agg_fn_ctxs[i], fn.cloud_configuration);
+                    // use_cache only when isolation is explicitly shared and enable_cache_udaf is set
+                    bool use_cache = enable_cache && fn.__isset.isolated && !fn.isolated;
+                    bool cache_hit = false;
+                    Status st;
+                    {
+                        SCOPED_TIMER(_agg_stat->udaf_load_timer);
+                        st = init_udaf_context(fn.fid, fn.hdfs_location, fn.checksum, fn.aggregate_fn.symbol,
+                                               _agg_fn_ctxs[i], fn.cloud_configuration, use_cache,
+                                               use_cache ? &cache_hit : nullptr);
+                    }
+                    if (use_cache) {
+                        if (cache_hit) {
+                            COUNTER_UPDATE(_agg_stat->udaf_cache_hit_count, 1);
+                        } else {
+                            COUNTER_UPDATE(_agg_stat->udaf_cache_populate_count, 1);
+                        }
+                    }
                     if (!st.ok()) {
                         for (int idx : attached_udaf_idx) {
                             destroy_java_udaf_context(_agg_fn_ctxs[idx]);

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -57,7 +57,8 @@
 namespace starrocks {
 Status window_init_jvm_context(int64_t fid, const std::string& url, const std::string& checksum,
                                const std::string& symbol, FunctionContext* context,
-                               const TCloudConfiguration& cloud_configuration);
+                               const TCloudConfiguration& cloud_configuration, bool use_cache,
+                               bool* cache_hit_out = nullptr);
 
 Analytor::~Analytor() {
     if (_state != nullptr) {
@@ -337,6 +338,9 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
     _column_resize_timer = ADD_TIMER(_runtime_profile, "ColumnResizeTime");
     _partition_search_timer = ADD_TIMER(_runtime_profile, "PartitionSearchTime");
     _peer_group_search_timer = ADD_TIMER(_runtime_profile, "PeerGroupSearchTime");
+    _udaf_load_timer = ADD_TIMER(_runtime_profile, "UdafLoadTime");
+    _udaf_cache_hit_count = ADD_COUNTER(_runtime_profile, "UdafCacheHitCount", TUnit::UNIT);
+    _udaf_cache_populate_count = ADD_COUNTER(_runtime_profile, "UdafCachePopulateCount", TUnit::UNIT);
 
     DCHECK_EQ(_result_tuple_desc->slots().size(), _agg_functions.size());
 
@@ -398,8 +402,24 @@ Status Analytor::open(RuntimeState* state) {
 #ifndef __APPLE__
             if (_fns[i].binary_type == TFunctionBinaryType::SRJAR) {
                 const auto& fn = _fns[i];
-                auto st = window_init_jvm_context(fn.fid, fn.hdfs_location, fn.checksum, fn.aggregate_fn.symbol,
-                                                  _agg_fn_ctxs[i], fn.cloud_configuration);
+                auto& opts = _state->query_options();
+                bool use_cache =
+                        opts.__isset.enable_cache_udaf && opts.enable_cache_udaf && fn.__isset.isolated && !fn.isolated;
+                bool cache_hit = false;
+                Status st;
+                {
+                    SCOPED_TIMER(_udaf_load_timer);
+                    st = window_init_jvm_context(fn.fid, fn.hdfs_location, fn.checksum, fn.aggregate_fn.symbol,
+                                                 _agg_fn_ctxs[i], fn.cloud_configuration, use_cache,
+                                                 use_cache ? &cache_hit : nullptr);
+                }
+                if (use_cache) {
+                    if (cache_hit) {
+                        COUNTER_UPDATE(_udaf_cache_hit_count, 1);
+                    } else {
+                        COUNTER_UPDATE(_udaf_cache_populate_count, 1);
+                    }
+                }
                 RETURN_IF_ERROR(st);
                 attached_udaf_idx.emplace_back(i);
             }

--- a/be/src/exec/analytor.h
+++ b/be/src/exec/analytor.h
@@ -319,6 +319,9 @@ private:
     RuntimeProfile::Counter* _column_resize_timer = nullptr;
     RuntimeProfile::Counter* _partition_search_timer = nullptr;
     RuntimeProfile::Counter* _peer_group_search_timer = nullptr;
+    RuntimeProfile::Counter* _udaf_load_timer = nullptr;
+    RuntimeProfile::Counter* _udaf_cache_hit_count = nullptr;
+    RuntimeProfile::Counter* _udaf_cache_populate_count = nullptr;
 
     int64_t _num_rows_returned = 0;
     int64_t _limit; // -1: no limit

--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -14,6 +14,7 @@
 
 #include "exprs/agg/java_udaf_function.h"
 
+#include <any>
 #include <memory>
 
 #include "column/vectorized_fwd.h"
@@ -32,25 +33,21 @@ const AggregateFunction* getJavaUDAFFunction(bool input_nullable) {
     return &no_nullable_udaf_func;
 }
 
-Status init_udaf_context(int64_t id, const std::string& url, const std::string& checksum, const std::string& symbol,
-                         FunctionContext* context, const TCloudConfiguration& cloud_configuration) {
-    RETURN_IF_ERROR(detect_java_runtime());
-    std::string libpath;
-    std::string state = symbol + "$State";
-    auto func_cache = UserFunctionCache::instance();
-    RETURN_IF_ERROR(
-            func_cache->get_libpath(id, url, checksum, TFunctionBinaryType::SRJAR, &libpath, cloud_configuration));
-    auto udaf_ctx = std::make_unique<JavaUDAFContext>();
-    auto udf_classloader = std::make_unique<ClassLoader>(std::move(libpath));
+// Build a JavaUDAFSharedContext (class-level, shareable/cacheable).
+// This is the expensive part: class loading, method introspection, and stub class generation.
+// The UDAF object instance is NOT created here — it is per-aggregator (see build_udaf_unique_context).
+static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_udaf_shared_context(const std::string& libpath,
+                                                                                  const std::string& symbol,
+                                                                                  int num_args) {
+    std::string state_cls_name = symbol + "$State";
+
+    auto udaf_ctx = std::make_shared<JavaUDAFSharedContext>();
+    udaf_ctx->udf_classloader = std::make_unique<ClassLoader>(libpath);
     auto analyzer = std::make_unique<ClassAnalyzer>();
-    RETURN_IF_ERROR(udf_classloader->init());
+    RETURN_IF_ERROR(udaf_ctx->udf_classloader->init());
 
-    ASSIGN_OR_RETURN(udaf_ctx->udaf_class, udf_classloader->getClass(symbol));
-    ASSIGN_OR_RETURN(udaf_ctx->udaf_state_class, udf_classloader->getClass(state));
-    ASSIGN_OR_RETURN(udaf_ctx->handle, udaf_ctx->udaf_class.newInstance());
-
-    udaf_ctx->buffer_data.resize(DEFAULT_UDAF_BUFFER_SIZE);
-    udaf_ctx->buffer = std::make_unique<DirectByteBuffer>(udaf_ctx->buffer_data.data(), udaf_ctx->buffer_data.size());
+    ASSIGN_OR_RETURN(udaf_ctx->udaf_class, udaf_ctx->udf_classloader->getClass(symbol));
+    ASSIGN_OR_RETURN(udaf_ctx->udaf_state_class, udaf_ctx->udf_classloader->getClass(state_cls_name));
 
     auto add_method = [&](const std::string& name, jclass clazz, std::unique_ptr<JavaMethodDescriptor>* res) {
         std::string method_name = name;
@@ -68,41 +65,97 @@ Status init_udaf_context(int64_t id, const std::string& url, const std::string& 
 
     RETURN_IF_ERROR(add_method("create", udaf_ctx->udaf_class.clazz(), &udaf_ctx->create));
     RETURN_IF_ERROR(add_method("destroy", udaf_ctx->udaf_class.clazz(), &udaf_ctx->destory));
-
     RETURN_IF_ERROR(add_method("update", udaf_ctx->udaf_class.clazz(), &udaf_ctx->update));
-    const char* stub_clazz_name = AggBatchCallStub::stub_clazz_name;
-    const char* stub_method_name = AggBatchCallStub::batch_update_method_name;
-    jclass udaf_clazz = udaf_ctx->udaf_class.clazz();
-    jobject update_method = udaf_ctx->update->method.handle();
-    // Pass the actual number of input columns so that the stub generator can produce the correct
-    // signature for varargs UDAFs (N separate column arrays instead of one 2-D array).
-    // The Java side uses method.isVarArgs() to decide whether numActualVarArgs is relevant.
-    int num_actual_var_args = context->get_num_args();
-    ASSIGN_OR_RETURN(auto update_stub_clazz,
-                     udf_classloader->genCallStub(stub_clazz_name, udaf_clazz, update_method,
-                                                  ClassLoader::BATCH_SINGLE_UPDATE, num_actual_var_args));
-    ASSIGN_OR_RETURN(auto method, analyzer->get_method_object(update_stub_clazz.clazz(), stub_method_name));
-    udaf_ctx->update_batch_call_stub = std::make_unique<AggBatchCallStub>(
-            context, udaf_ctx->handle.handle(), std::move(update_stub_clazz), JavaGlobalRef(method));
-
     RETURN_IF_ERROR(add_method("merge", udaf_ctx->udaf_class.clazz(), &udaf_ctx->merge));
     RETURN_IF_ERROR(add_method("finalize", udaf_ctx->udaf_class.clazz(), &udaf_ctx->finalize));
     RETURN_IF_ERROR(add_method("serialize", udaf_ctx->udaf_class.clazz(), &udaf_ctx->serialize));
     RETURN_IF_ERROR(add_method("serializeLength", udaf_ctx->udaf_state_class.clazz(), &udaf_ctx->serialize_size));
 
+    // Generate and store the stub class/method — each unique context creates its own AggBatchCallStub from these
+    const char* stub_clazz_name = AggBatchCallStub::stub_clazz_name;
+    const char* stub_method_name = AggBatchCallStub::batch_update_method_name;
+    jclass udaf_clazz = udaf_ctx->udaf_class.clazz();
+    jobject update_method_obj = udaf_ctx->update->method.handle();
+    ASSIGN_OR_RETURN(udaf_ctx->update_stub_clazz,
+                     udaf_ctx->udf_classloader->genCallStub(stub_clazz_name, udaf_clazz, update_method_obj,
+                                                            ClassLoader::BATCH_SINGLE_UPDATE, num_args));
+    ASSIGN_OR_RETURN(udaf_ctx->update_stub_method,
+                     analyzer->get_method_object(udaf_ctx->update_stub_clazz.clazz(), stub_method_name));
+
+    // Look up FunctionStates method objects once — instance creation happens per aggregator
+    auto& state_clazz = JVMFunctionHelper::getInstance().function_state_clazz();
+    ASSIGN_OR_RETURN(udaf_ctx->states_get_method, analyzer->get_method_object(state_clazz.clazz(), "get"));
+    ASSIGN_OR_RETURN(udaf_ctx->states_batch_get_method, analyzer->get_method_object(state_clazz.clazz(), "batch_get"));
+    ASSIGN_OR_RETURN(udaf_ctx->states_add_method, analyzer->get_method_object(state_clazz.clazz(), "add"));
+    ASSIGN_OR_RETURN(udaf_ctx->states_remove_method, analyzer->get_method_object(state_clazz.clazz(), "remove"));
+    ASSIGN_OR_RETURN(udaf_ctx->states_clear_method, analyzer->get_method_object(state_clazz.clazz(), "clear"));
+
+    return udaf_ctx;
+}
+
+// Build a per-aggregator JavaUDAFUniqueContext on top of a (possibly cached) JavaUDAFSharedContext.
+static Status build_udaf_unique_context(std::shared_ptr<JavaUDAFSharedContext> udaf_ctx, FunctionContext* context) {
+    auto agg_ctx = std::make_unique<JavaUDAFUniqueContext>();
+    agg_ctx->ctx = std::move(udaf_ctx);
+
+    // Create a per-aggregator UDAF object instance
+    ASSIGN_OR_RETURN(agg_ctx->handle, agg_ctx->ctx->udaf_class.newInstance());
+
+    // Create a per-aggregator AggBatchCallStub with the shared stub class/method cloned as new global refs
+    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JVMClass stub_clazz(env->NewGlobalRef(agg_ctx->ctx->update_stub_clazz.clazz()));
+    jobject stub_method = env->NewGlobalRef(agg_ctx->ctx->update_stub_method.handle());
+    agg_ctx->update_batch_call_stub = std::make_unique<AggBatchCallStub>(
+            context, agg_ctx->handle.handle(), std::move(stub_clazz), JavaGlobalRef(stub_method));
+
+    agg_ctx->buffer_data.resize(DEFAULT_UDAF_BUFFER_SIZE);
+    agg_ctx->buffer = std::make_unique<DirectByteBuffer>(agg_ctx->buffer_data.data(), agg_ctx->buffer_data.size());
+
+    // Create a new FunctionStates instance for this aggregator.
+    // Method objects are cloned from the shared context (looked up only once at build time).
     auto& state_clazz = JVMFunctionHelper::getInstance().function_state_clazz();
     ASSIGN_OR_RETURN(auto instance, state_clazz.newInstance());
-    ASSIGN_OR_RETURN(auto get_func, analyzer->get_method_object(state_clazz.clazz(), "get"));
-    ASSIGN_OR_RETURN(auto batch_get_func, analyzer->get_method_object(state_clazz.clazz(), "batch_get"));
-    ASSIGN_OR_RETURN(auto add_func, analyzer->get_method_object(state_clazz.clazz(), "add"));
-    ASSIGN_OR_RETURN(auto remove_func, analyzer->get_method_object(state_clazz.clazz(), "remove"));
-    ASSIGN_OR_RETURN(auto clear_func, analyzer->get_method_object(state_clazz.clazz(), "clear"));
-    udaf_ctx->states = std::make_unique<UDAFStateList>(std::move(instance), get_func, batch_get_func, add_func,
-                                                       remove_func, clear_func);
-    udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle.handle(), context, udaf_ctx.get());
-    attach_java_udaf_context(context, std::move(udaf_ctx));
-
+    agg_ctx->states = std::make_unique<UDAFStateList>(
+            std::move(instance), JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_get_method.handle())),
+            JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_batch_get_method.handle())),
+            JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_add_method.handle())),
+            JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_remove_method.handle())),
+            JavaGlobalRef(env->NewGlobalRef(agg_ctx->ctx->states_clear_method.handle())));
+    agg_ctx->_func = std::make_unique<UDAFFunction>(agg_ctx->handle.handle(), context, agg_ctx.get());
+    attach_java_udaf_context(context, std::move(agg_ctx));
     return Status::OK();
+}
+
+Status init_udaf_context(int64_t id, const std::string& url, const std::string& checksum, const std::string& symbol,
+                         FunctionContext* context, const TCloudConfiguration& cloud_configuration, bool use_cache,
+                         bool* cache_hit_out) {
+    RETURN_IF_ERROR(detect_java_runtime());
+
+    int num_args = context->get_num_args();
+    auto func_cache = UserFunctionCache::instance();
+
+    if (use_cache) {
+        ASSIGN_OR_RETURN(auto result,
+                         func_cache->load_cacheable_java_udf(
+                                 id, url, checksum, TFunctionBinaryType::SRJAR,
+                                 [&symbol, num_args](const std::string& libpath) -> StatusOr<std::any> {
+                                     ASSIGN_OR_RETURN(auto ctx, build_udaf_shared_context(libpath, symbol, num_args));
+                                     return std::any(std::move(ctx));
+                                 },
+                                 cloud_configuration));
+        if (cache_hit_out != nullptr) {
+            *cache_hit_out = result.first;
+        }
+        auto shared_ctx = std::any_cast<std::shared_ptr<JavaUDAFSharedContext>>(result.second);
+        return build_udaf_unique_context(std::move(shared_ctx), context);
+    }
+
+    // Cache disabled: build without caching (download JAR via get_libpath first)
+    std::string libpath;
+    RETURN_IF_ERROR(
+            func_cache->get_libpath(id, url, checksum, TFunctionBinaryType::SRJAR, &libpath, cloud_configuration));
+    ASSIGN_OR_RETURN(auto shared_ctx, build_udaf_shared_context(libpath, symbol, num_args));
+    return build_udaf_unique_context(std::move(shared_ctx), context);
 }
 
 } // namespace starrocks

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -106,10 +106,10 @@ public:
         auto* udaf_ctx = get_java_udaf_context(ctx);
         DCHECK(udaf_ctx != nullptr);
         jvalue val = udaf_ctx->_func->finalize(this->data(state).handle);
-        auto st = append_jvalue(ctx->get_return_type(), udaf_ctx->finalize->method_desc[0].is_box, to, val);
+        auto st = append_jvalue(ctx->get_return_type(), udaf_ctx->ctx->finalize->method_desc[0].is_box, to, val);
         SET_FUNCTION_CONTEXT_ERR(st, ctx);
         RETURN_IF_UNLIKELY(!st.ok(), (void)0);
-        release_jvalue(udaf_ctx->finalize->method_desc[0].is_box, val);
+        release_jvalue(udaf_ctx->ctx->finalize->method_desc[0].is_box, val);
     }
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t batch_size,
@@ -119,7 +119,8 @@ public:
         auto* udf_ctxs = get_java_udaf_context(ctx);
         // 1 convert input as state
         // 1.1 create state list
-        auto rets = helper.batch_call(ctx, udf_ctxs->handle.handle(), udf_ctxs->create->method.handle(), batch_size);
+        auto rets =
+                helper.batch_call(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->create->method.handle(), batch_size);
         RETURN_IF_UNLIKELY_NULL(rets, (void)0);
         // 1.2 convert input as input array
         int num_cols = ctx->get_num_args();
@@ -143,11 +144,11 @@ public:
         RETURN_IF_UNLIKELY(!st.ok(), (void)0);
 
         // 2 batch call update
-        helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->update->method.handle(), args.data(),
+        helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->update->method.handle(), args.data(),
                                   args.size());
         // 3 get serialize size
         auto serialize_szs =
-                (jintArray)helper.int_batch_call(ctx, rets, udf_ctxs->serialize_size->method.handle(), batch_size);
+                (jintArray)helper.int_batch_call(ctx, rets, udf_ctxs->ctx->serialize_size->method.handle(), batch_size);
         RETURN_IF_UNLIKELY_NULL(serialize_szs, (void)0);
         LOCAL_REF_GUARD_ENV(env, serialize_szs);
 
@@ -164,7 +165,7 @@ public:
         RETURN_IF_UNLIKELY_NULL(buffer_array, (void)0);
         LOCAL_REF_GUARD_ENV(env, buffer_array);
         jobject state_and_buffer[2] = {rets, buffer_array};
-        helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->serialize->method.handle(),
+        helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->serialize->method.handle(),
                                   state_and_buffer, 2);
 
         // 5 ready
@@ -220,7 +221,7 @@ public:
             auto st = JavaDataTypeConverter::convert_to_boxed_array(ctx, columns, num_cols, batch_size, &args);
             SET_FUNCTION_CONTEXT_ERR(st, ctx);
             RETURN_IF_UNLIKELY(!st.ok(), (void)0);
-            helper.batch_update(ctx, udf_ctxs->handle.handle(), udf_ctxs->update->method.handle(), states_arr,
+            helper.batch_update(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->update->method.handle(), states_arr,
                                 args.data(), args.size());
         }
     }
@@ -241,7 +242,7 @@ public:
             auto st = JavaDataTypeConverter::convert_to_boxed_array(ctx, columns, num_cols, batch_size, &args);
             SET_FUNCTION_CONTEXT_ERR(st, ctx);
             RETURN_IF_UNLIKELY(!st.ok(), (void)0);
-            helper.batch_update_if_not_null(ctx, udf_ctxs->handle.handle(), udf_ctxs->update->method.handle(),
+            helper.batch_update_if_not_null(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->update->method.handle(),
                                             states_arr, args.data(), args.size());
         }
     }
@@ -314,7 +315,7 @@ public:
         };
         auto merger = [&](jobject state_array, jobject buffer_array) {
             jobject state_and_buffer[2] = {state_array, buffer_array};
-            helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->merge->method.handle(),
+            helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->merge->method.handle(),
                                       state_and_buffer, 2);
         };
         _merge_batch_process(ctx, std::move(provider), std::move(merger), column, 0, batch_size);
@@ -334,7 +335,7 @@ public:
         };
         auto merger = [&](jobject state_array, jobject buffer_array) {
             jobject state_and_buffer[] = {buffer_array};
-            helper.batch_update_if_not_null(ctx, udf_ctxs->handle.handle(), udf_ctxs->merge->method.handle(),
+            helper.batch_update_if_not_null(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->merge->method.handle(),
                                             state_array, state_and_buffer, 1);
         };
         _merge_batch_process(ctx, std::move(provider), std::move(merger), column, 0, batch_size);
@@ -354,7 +355,7 @@ public:
         };
         auto merger = [&](jobject state_array, jobject buffer_array) {
             jobject state_and_buffer[2] = {state_array, buffer_array};
-            helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->merge->method.handle(),
+            helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->merge->method.handle(),
                                       state_and_buffer, 2);
         };
         _merge_batch_process(ctx, std::move(provider), std::move(merger), column, start, size);
@@ -386,8 +387,8 @@ public:
         LOCAL_REF_GUARD_ENV(env, state_array);
 
         // step 2 serialize size
-        auto serialize_szs = (jintArray)helper.int_batch_call(ctx, state_array,
-                                                              udf_ctxs->serialize_size->method.handle(), batch_size);
+        auto serialize_szs = (jintArray)helper.int_batch_call(
+                ctx, state_array, udf_ctxs->ctx->serialize_size->method.handle(), batch_size);
         RETURN_IF_UNLIKELY_NULL(serialize_szs, (void)0);
         LOCAL_REF_GUARD_ENV(env, serialize_szs);
 
@@ -404,7 +405,7 @@ public:
         auto buffer_array = helper.create_object_array(udf_ctxs->buffer->handle(), batch_size);
         LOCAL_REF_GUARD_ENV(env, buffer_array);
         jobject state_and_buffer[2] = {state_array, buffer_array};
-        helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->serialize->method.handle(),
+        helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->serialize->method.handle(),
                                   state_and_buffer, 2);
 
         int offsets = 0;
@@ -443,12 +444,12 @@ public:
         // 2. batch call finalize
         CHECK(to->empty());
         // 3. get result from column
-        auto res = helper.batch_call(ctx, udf_ctxs->handle.handle(), udf_ctxs->finalize->method.handle(), &state_array,
-                                     1, batch_size);
+        auto res = helper.batch_call(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->finalize->method.handle(),
+                                     &state_array, 1, batch_size);
         RETURN_IF_UNLIKELY_NULL(res, (void)0);
         LOCAL_REF_GUARD_ENV(env, res);
 
-        LogicalType type = udf_ctxs->finalize->method_desc[0].type;
+        LogicalType type = udf_ctxs->ctx->finalize->method_desc[0].type;
         // For nullable inputs, our UDAF does not produce nullable results
         if (!to->is_nullable()) {
             MutableColumnPtr wrapper = const_cast<Column*>(to)->as_mutable_ptr();

--- a/be/src/exprs/agg/java_window_function.cpp
+++ b/be/src/exprs/agg/java_window_function.cpp
@@ -14,6 +14,7 @@
 
 #include "exprs/agg/java_window_function.h"
 
+#include <any>
 #include <vector>
 
 #include "runtime/user_function_cache.h"
@@ -25,23 +26,18 @@ const AggregateFunction* getJavaWindowFunction() {
     return &java_window_func;
 }
 
-Status window_init_jvm_context(int64_t fid, const std::string& url, const std::string& checksum,
-                               const std::string& symbol, FunctionContext* context,
-                               const TCloudConfiguration& cloud_configuration) {
-    RETURN_IF_ERROR(detect_java_runtime());
-    std::string libpath;
+// Build a JavaUDAFSharedContext for a window function (class-level, shareable/cacheable).
+static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_window_shared_context(const std::string& libpath,
+                                                                                    const std::string& symbol) {
     std::string state = symbol + "$State";
-    auto func_cache = UserFunctionCache::instance();
-    RETURN_IF_ERROR(
-            func_cache->get_libpath(fid, url, checksum, TFunctionBinaryType::SRJAR, &libpath, cloud_configuration));
-    auto udaf_ctx = std::make_unique<JavaUDAFContext>();
-    auto udf_classloader = std::make_unique<ClassLoader>(std::move(libpath));
-    auto analyzer = std::make_unique<ClassAnalyzer>();
-    RETURN_IF_ERROR(udf_classloader->init());
 
-    ASSIGN_OR_RETURN(udaf_ctx->udaf_class, udf_classloader->getClass(symbol));
-    ASSIGN_OR_RETURN(udaf_ctx->udaf_state_class, udf_classloader->getClass(state));
-    ASSIGN_OR_RETURN(udaf_ctx->handle, udaf_ctx->udaf_class.newInstance());
+    auto shared = std::make_shared<JavaUDAFSharedContext>();
+    shared->udf_classloader = std::make_unique<ClassLoader>(libpath);
+    auto analyzer = std::make_unique<ClassAnalyzer>();
+    RETURN_IF_ERROR(shared->udf_classloader->init());
+
+    ASSIGN_OR_RETURN(shared->udaf_class, shared->udf_classloader->getClass(symbol));
+    ASSIGN_OR_RETURN(shared->udaf_state_class, shared->udf_classloader->getClass(state));
 
     auto add_method = [&](const std::string& name, jclass clazz, std::unique_ptr<JavaMethodDescriptor>* res) {
         std::string method_name = name;
@@ -57,24 +53,72 @@ Status window_init_jvm_context(int64_t fid, const std::string& url, const std::s
         return Status::OK();
     };
 
-    RETURN_IF_ERROR(add_method("reset", udaf_ctx->udaf_class.clazz(), &udaf_ctx->reset));
-    RETURN_IF_ERROR(add_method("create", udaf_ctx->udaf_class.clazz(), &udaf_ctx->create));
-    RETURN_IF_ERROR(add_method("destroy", udaf_ctx->udaf_class.clazz(), &udaf_ctx->destory));
-    RETURN_IF_ERROR(add_method("finalize", udaf_ctx->udaf_class.clazz(), &udaf_ctx->finalize));
-    RETURN_IF_ERROR(add_method("windowUpdate", udaf_ctx->udaf_class.clazz(), &udaf_ctx->window_update));
+    RETURN_IF_ERROR(add_method("reset", shared->udaf_class.clazz(), &shared->reset));
+    RETURN_IF_ERROR(add_method("create", shared->udaf_class.clazz(), &shared->create));
+    RETURN_IF_ERROR(add_method("destroy", shared->udaf_class.clazz(), &shared->destory));
+    RETURN_IF_ERROR(add_method("finalize", shared->udaf_class.clazz(), &shared->finalize));
+    RETURN_IF_ERROR(add_method("windowUpdate", shared->udaf_class.clazz(), &shared->window_update));
 
+    // Look up FunctionStates method objects once — instance creation happens per aggregator
+    auto& state_clazz = JVMFunctionHelper::getInstance().function_state_clazz();
+    ASSIGN_OR_RETURN(shared->states_get_method, analyzer->get_method_object(state_clazz.clazz(), "get"));
+    ASSIGN_OR_RETURN(shared->states_batch_get_method, analyzer->get_method_object(state_clazz.clazz(), "batch_get"));
+    ASSIGN_OR_RETURN(shared->states_add_method, analyzer->get_method_object(state_clazz.clazz(), "add"));
+    ASSIGN_OR_RETURN(shared->states_remove_method, analyzer->get_method_object(state_clazz.clazz(), "remove"));
+    ASSIGN_OR_RETURN(shared->states_clear_method, analyzer->get_method_object(state_clazz.clazz(), "clear"));
+
+    return shared;
+}
+
+// Build a per-aggregator JavaUDAFUniqueContext for a window function on top of a shared context.
+static Status build_window_unique_context(std::shared_ptr<JavaUDAFSharedContext> shared, FunctionContext* context) {
+    auto udaf_ctx = std::make_unique<JavaUDAFUniqueContext>();
+    udaf_ctx->ctx = std::move(shared);
+
+    ASSIGN_OR_RETURN(udaf_ctx->handle, udaf_ctx->ctx->udaf_class.newInstance());
+
+    // Create a new FunctionStates instance; clone method refs from the shared context.
+    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
     auto& state_clazz = JVMFunctionHelper::getInstance().function_state_clazz();
     ASSIGN_OR_RETURN(auto instance, state_clazz.newInstance());
-    ASSIGN_OR_RETURN(auto get_func, analyzer->get_method_object(state_clazz.clazz(), "get"));
-    ASSIGN_OR_RETURN(auto batch_get_func, analyzer->get_method_object(state_clazz.clazz(), "batch_get"));
-    ASSIGN_OR_RETURN(auto add_func, analyzer->get_method_object(state_clazz.clazz(), "add"));
-    ASSIGN_OR_RETURN(auto remove_func, analyzer->get_method_object(state_clazz.clazz(), "remove"));
-    ASSIGN_OR_RETURN(auto clear_func, analyzer->get_method_object(state_clazz.clazz(), "clear"));
-    udaf_ctx->states = std::make_unique<UDAFStateList>(std::move(instance), get_func, batch_get_func, add_func,
-                                                       remove_func, clear_func);
+    udaf_ctx->states = std::make_unique<UDAFStateList>(
+            std::move(instance), JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_get_method.handle())),
+            JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_batch_get_method.handle())),
+            JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_add_method.handle())),
+            JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_remove_method.handle())),
+            JavaGlobalRef(env->NewGlobalRef(udaf_ctx->ctx->states_clear_method.handle())));
     udaf_ctx->_func = std::make_unique<UDAFFunction>(udaf_ctx->handle.handle(), context, udaf_ctx.get());
     attach_java_udaf_context(context, std::move(udaf_ctx));
-
     return Status::OK();
 }
+
+Status window_init_jvm_context(int64_t fid, const std::string& url, const std::string& checksum,
+                               const std::string& symbol, FunctionContext* context,
+                               const TCloudConfiguration& cloud_configuration, bool use_cache, bool* cache_hit_out) {
+    RETURN_IF_ERROR(detect_java_runtime());
+    auto func_cache = UserFunctionCache::instance();
+
+    if (use_cache) {
+        ASSIGN_OR_RETURN(auto result, func_cache->load_cacheable_java_udf(
+                                              fid, url, checksum, TFunctionBinaryType::SRJAR,
+                                              [&symbol](const std::string& libpath) -> StatusOr<std::any> {
+                                                  ASSIGN_OR_RETURN(auto ctx,
+                                                                   build_window_shared_context(libpath, symbol));
+                                                  return std::any(std::move(ctx));
+                                              },
+                                              cloud_configuration));
+        if (cache_hit_out != nullptr) {
+            *cache_hit_out = result.first;
+        }
+        auto shared = std::any_cast<std::shared_ptr<JavaUDAFSharedContext>>(result.second);
+        return build_window_unique_context(std::move(shared), context);
+    }
+
+    std::string libpath;
+    RETURN_IF_ERROR(
+            func_cache->get_libpath(fid, url, checksum, TFunctionBinaryType::SRJAR, &libpath, cloud_configuration));
+    ASSIGN_OR_RETURN(auto shared_ctx, build_window_shared_context(libpath, symbol));
+    return build_window_unique_context(std::move(shared_ctx), context);
+}
+
 } // namespace starrocks

--- a/be/src/exprs/java_function_call_expr.cpp
+++ b/be/src/exprs/java_function_call_expr.cpp
@@ -248,7 +248,7 @@ Status JavaFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
         auto function_cache = UserFunctionCache::instance();
         if (_fn.__isset.isolated && !_fn.isolated) {
             ASSIGN_OR_RETURN(auto desc, function_cache->load_cacheable_java_udf(func_cache_desc, get_func_desc));
-            _func_desc = std::any_cast<std::shared_ptr<JavaUDFContext>>(desc);
+            _func_desc = std::any_cast<std::shared_ptr<JavaUDFContext>>(desc.second);
         } else {
             std::string libpath;
             RETURN_IF_ERROR(function_cache->get_libpath(func_cache_desc, &libpath));

--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -149,13 +149,15 @@ Status UserFunctionCache::get_libpath(int64_t fid, const std::string& url, const
     return Status::OK();
 }
 
-StatusOr<std::any> UserFunctionCache::load_cacheable_java_udf(
+StatusOr<std::pair<bool, std::any>> UserFunctionCache::load_cacheable_java_udf(
         int64_t fid, const std::string& url, const std::string& checksum, FuncType function_type,
         const std::function<StatusOr<std::any>(const std::string& path)>& loader,
         const TCloudConfiguration& cloud_configuration) {
     UserFunctionCacheEntryPtr entry;
-    RETURN_IF_ERROR(_get_cache_entry(fid, url, checksum, function_type, &entry, loader, cloud_configuration));
-    return entry->cache_handle;
+    bool cache_hit = false;
+    RETURN_IF_ERROR(
+            _get_cache_entry(fid, url, checksum, function_type, &entry, loader, cloud_configuration, &cache_hit));
+    return std::make_pair(cache_hit, entry->cache_handle);
 }
 
 auto UserFunctionCache::_get_function_type(const std::string& url) -> FuncType {
@@ -221,7 +223,7 @@ Status UserFunctionCache::_load_cached_lib() {
 template <class Loader>
 Status UserFunctionCache::_get_cache_entry(int64_t fid, const std::string& url, const std::string& checksum,
                                            FuncType type, UserFunctionCacheEntryPtr* output_entry, Loader&& loader,
-                                           const TCloudConfiguration& cloud_configuration) {
+                                           const TCloudConfiguration& cloud_configuration, bool* cache_hit) {
     std::string suffix = ".unk";
     if (type == UDF_TYPE_JAVA) {
         suffix = JAVA_UDF_SUFFIX;
@@ -243,6 +245,11 @@ Status UserFunctionCache::_get_cache_entry(int64_t fid, const std::string& url, 
             _entry_map.emplace(fid, entry);
         }
     }
+
+    if (cache_hit != nullptr) {
+        *cache_hit = entry->is_loaded.load();
+    }
+
     auto st = _load_cache_entry(url, entry, loader, cloud_configuration);
     if (!st.ok()) {
         LOG(WARNING) << "fail to load cache entry, fid=" << fid;
@@ -308,7 +315,14 @@ Status UserFunctionCache::_load_cache_entry_internal(const std::string& url, Use
         return Status::NotSupported(fmt::format("unsupport udf type: {}, url: {}. url suffix must be '{}' or '{}'",
                                                 entry->function_type, url, JAVA_UDF_SUFFIX, PY_UDF_SUFFIX));
     }
-    entry->is_loaded.store(true);
+    // Only mark loaded when the loader populated a real cache handle.
+    // get_libpath uses a trivial loader that returns empty std::any{}; if we mark
+    // is_loaded=true there, a subsequent load_cacheable_java_udf for the same fid
+    // would skip building the shared context and return an empty handle, causing
+    // bad_any_cast at the call site.
+    if (entry->cache_handle.has_value()) {
+        entry->is_loaded.store(true);
+    }
     return Status::OK();
 }
 

--- a/be/src/runtime/user_function_cache.h
+++ b/be/src/runtime/user_function_cache.h
@@ -96,13 +96,15 @@ public:
     Status get_libpath(int64_t fid, const std::string& url, const std::string& checksum, FuncType function_type,
                        std::string* libpath, const TCloudConfiguration& cloud_configuration);
 
-    StatusOr<std::any> load_cacheable_java_udf(
+    // Returns {cache_hit, value}. cache_hit=false means the loader was called (cache miss/populate).
+    StatusOr<std::pair<bool, std::any>> load_cacheable_java_udf(
             const FunctionCacheDesc& desc, const std::function<StatusOr<std::any>(const std::string& entry)>& loader) {
         return load_cacheable_java_udf(desc.fid, desc.url, desc.checksum, desc.function_type, loader,
                                        desc.cloud_configuration);
     }
 
-    StatusOr<std::any> load_cacheable_java_udf(
+    // Returns {cache_hit, value}. cache_hit=false means the loader was called (cache miss/populate).
+    StatusOr<std::pair<bool, std::any>> load_cacheable_java_udf(
             int64_t fid, const std::string& url, const std::string& checksum, FuncType function_type,
             const std::function<StatusOr<std::any>(const std::string& entry)>& loader,
             const TCloudConfiguration& cloud_configuration);
@@ -115,7 +117,7 @@ private:
     template <class Loader>
     Status _get_cache_entry(int64_t fid, const std::string& url, const std::string& checksum, FuncType function_type,
                             UserFunctionCacheEntryPtr* output_entry, Loader&& loader,
-                            const TCloudConfiguration& cloud_configuration);
+                            const TCloudConfiguration& cloud_configuration, bool* cache_hit = nullptr);
     template <class Loader>
     Status _load_cache_entry(const std::string& url, UserFunctionCacheEntryPtr& entry, Loader&& loader,
                              const TCloudConfiguration& cloud_configuration);

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -108,14 +108,14 @@ static JNINativeMethod java_native_methods[] = {
 };
 #pragma GCC diagnostic pop
 
-JavaUDAFContext* get_java_udaf_context(FunctionContext* ctx) {
+JavaUDAFUniqueContext* get_java_udaf_context(FunctionContext* ctx) {
     if (ctx == nullptr) {
         return nullptr;
     }
-    return reinterpret_cast<JavaUDAFContext*>(ctx->get_function_state(FunctionContext::THREAD_LOCAL));
+    return reinterpret_cast<JavaUDAFUniqueContext*>(ctx->get_function_state(FunctionContext::THREAD_LOCAL));
 }
 
-void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFContext> udaf_ctx) {
+void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFUniqueContext> udaf_ctx) {
     DCHECK(ctx != nullptr);
     DCHECK(udaf_ctx != nullptr);
     auto* old_ctx = get_java_udaf_context(ctx);
@@ -1073,7 +1073,7 @@ JavaUDFContext::~JavaUDFContext() = default;
 
 int UDAFFunction::create() {
     auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
-    jmethodID create = _ctx->create->get_method_id();
+    jmethodID create = _ctx->ctx->create->get_method_id();
     auto obj = env->CallObjectMethod(_udaf_handle, create);
     LOCAL_REF_GUARD(obj);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
@@ -1084,7 +1084,7 @@ void UDAFFunction::destroy(int state) {
     auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
-    jmethodID destory = _ctx->destory->get_method_id();
+    jmethodID destory = _ctx->ctx->destory->get_method_id();
     // call destroy
     env->CallVoidMethod(_udaf_handle, destory, obj);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
@@ -1096,7 +1096,7 @@ jvalue UDAFFunction::finalize(int state) {
     JNIEnv* env = helper.getEnv();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
-    jmethodID finalize = _ctx->finalize->get_method_id();
+    jmethodID finalize = _ctx->ctx->finalize->get_method_id();
     jvalue res;
     res.l = env->CallObjectMethod(_udaf_handle, finalize, obj);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
@@ -1113,7 +1113,7 @@ void AggBatchCallStub::batch_update_single(int num_rows, jobject state, jobject*
     }
     auto* env = JVMFunctionHelper::getInstance().getEnv();
     env->CallStaticVoidMethodA(_stub_clazz.clazz(), env->FromReflectedMethod(_stub_method.handle()), jni_inputs);
-    CHECK_UDF_CALL_EXCEPTION(env, this->_ctx);
+    CHECK_UDF_CALL_EXCEPTION(env, _ctx);
 }
 
 StatusOr<jobject> BatchEvaluateStub::batch_evaluate(int num_rows, jobject* input, int cols) {
@@ -1156,7 +1156,7 @@ StatusOr<size_t> JavaListStub::size() {
 
 void UDAFFunction::update(jvalue* val) {
     auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
-    jmethodID update = _ctx->update->get_method_id();
+    jmethodID update = _ctx->ctx->update->get_method_id();
     env->CallVoidMethodA(_udaf_handle, update, val);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
 }
@@ -1165,7 +1165,7 @@ void UDAFFunction::merge(int state, jobject buffer) {
     auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
-    jmethodID merge = _ctx->merge->get_method_id();
+    jmethodID merge = _ctx->ctx->merge->get_method_id();
     env->CallVoidMethod(_udaf_handle, merge, obj, buffer);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
 }
@@ -1174,7 +1174,7 @@ void UDAFFunction::serialize(int state, jobject buffer) {
     auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
-    jmethodID serialize = _ctx->serialize->get_method_id();
+    jmethodID serialize = _ctx->ctx->serialize->get_method_id();
     env->CallVoidMethod(_udaf_handle, serialize, obj, buffer);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
 }
@@ -1183,7 +1183,7 @@ int UDAFFunction::serialize_size(int state) {
     auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
-    jmethodID serialize_size = _ctx->serialize_size->get_method_id();
+    jmethodID serialize_size = _ctx->ctx->serialize_size->get_method_id();
     int sz = env->CallIntMethod(obj, serialize_size);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
     return sz;
@@ -1193,7 +1193,7 @@ void UDAFFunction::reset(int state) {
     auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
-    jmethodID reset = _ctx->reset->get_method_id();
+    jmethodID reset = _ctx->ctx->reset->get_method_id();
     env->CallVoidMethod(_udaf_handle, reset, obj);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
 }
@@ -1204,7 +1204,7 @@ jobject UDAFFunction::window_update_batch(int state, int peer_group_start, int p
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
 
-    jmethodID window_update = _ctx->window_update->get_method_id();
+    jmethodID window_update = _ctx->ctx->window_update->get_method_id();
     jvalue jvalues[5 + col_sz];
     jvalues[0].l = obj;
     jvalues[1].j = peer_group_start;

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -383,7 +383,7 @@ public:
 
 private:
     FunctionContext* _ctx;
-    // UDAF object handle, owned by FunctionContext
+    // UDAF object handle, owned by JavaUDAFUniqueContext
     jobject _caller;
     JVMClass _stub_clazz;
     JavaGlobalRef _stub_method;
@@ -535,12 +535,48 @@ struct JavaUDFContext {
     std::unique_ptr<JavaMethodDescriptor> close;
 };
 
-// Function
-struct JavaUDAFContext;
+// Shareable, cacheable UDAF class-level context.
+// Contains class references and method descriptors — no per-aggregation state.
+// Cached via UserFunctionCache::load_cacheable_java_udf.
+struct JavaUDAFSharedContext {
+    std::unique_ptr<ClassLoader> udf_classloader;
+
+    JVMClass udaf_class = nullptr;
+    JVMClass udaf_state_class = nullptr;
+
+    std::unique_ptr<JavaMethodDescriptor> create;
+    std::unique_ptr<JavaMethodDescriptor> destory;
+    std::unique_ptr<JavaMethodDescriptor> update;
+    std::unique_ptr<JavaMethodDescriptor> merge;
+    std::unique_ptr<JavaMethodDescriptor> finalize;
+    std::unique_ptr<JavaMethodDescriptor> serialize;
+    std::unique_ptr<JavaMethodDescriptor> serialize_size;
+
+    // Window function methods (optional)
+    std::unique_ptr<JavaMethodDescriptor> reset;
+    std::unique_ptr<JavaMethodDescriptor> window_update;
+    std::unique_ptr<JavaMethodDescriptor> get_values;
+
+    // Generated stub class/method — used to create a per-aggregator AggBatchCallStub
+    JVMClass update_stub_clazz = nullptr;
+    JavaGlobalRef update_stub_method = nullptr;
+
+    // FunctionStates method objects — looked up once, cloned per aggregator instance
+    JavaGlobalRef states_get_method = nullptr;
+    JavaGlobalRef states_batch_get_method = nullptr;
+    JavaGlobalRef states_add_method = nullptr;
+    JavaGlobalRef states_remove_method = nullptr;
+    JavaGlobalRef states_clear_method = nullptr;
+};
+
+// Per-aggregator UDAF context stored as FunctionContext::THREAD_LOCAL.
+// Holds a reference to the shared class-level JavaUDAFSharedContext plus
+// mutable per-aggregation state.
+struct JavaUDAFUniqueContext;
 
 class UDAFFunction {
 public:
-    UDAFFunction(jobject udaf_handle, FunctionContext* function_ctx, JavaUDAFContext* ctx)
+    UDAFFunction(jobject udaf_handle, FunctionContext* function_ctx, JavaUDAFUniqueContext* ctx)
             : _udaf_handle(udaf_handle), _function_context(function_ctx), _ctx(ctx) {}
     // create a new state for UDAF
     int create();
@@ -569,37 +605,27 @@ private:
     // not owned udaf function handle
     jobject _udaf_handle;
     FunctionContext* _function_context;
-    JavaUDAFContext* _ctx;
+    JavaUDAFUniqueContext* _ctx;
 };
 
-struct JavaUDAFContext {
-    JVMClass udaf_class = nullptr;
-    JVMClass udaf_state_class = nullptr;
-    std::unique_ptr<JavaMethodDescriptor> create;
-    std::unique_ptr<JavaMethodDescriptor> destory;
-    std::unique_ptr<UDAFStateList> states;
-    std::unique_ptr<JavaMethodDescriptor> update;
-    std::unique_ptr<AggBatchCallStub> update_batch_call_stub;
-    std::unique_ptr<JavaMethodDescriptor> merge;
-    std::unique_ptr<JavaMethodDescriptor> finalize;
-    std::unique_ptr<JavaMethodDescriptor> serialize;
-    std::unique_ptr<JavaMethodDescriptor> serialize_size;
+struct JavaUDAFUniqueContext {
+    // Shared, possibly cached class-level context
+    std::shared_ptr<JavaUDAFSharedContext> ctx;
 
-    std::unique_ptr<JavaMethodDescriptor> reset;
-    std::unique_ptr<JavaMethodDescriptor> window_update;
-    std::unique_ptr<JavaMethodDescriptor> get_values;
-
-    std::unique_ptr<DirectByteBuffer> buffer;
-    // handle for UDAF object
+    // Per-aggregator UDAF object instance and its batch-update stub
     JavaGlobalRef handle = nullptr;
-    std::vector<uint8_t> buffer_data;
+    std::unique_ptr<AggBatchCallStub> update_batch_call_stub;
 
+    // Per-aggregator mutable state
+    std::unique_ptr<UDAFStateList> states;
     std::unique_ptr<UDAFFunction> _func;
+    std::unique_ptr<DirectByteBuffer> buffer;
+    std::vector<uint8_t> buffer_data;
 };
 
 // Java UDAF lifecycle management based on FunctionContext::THREAD_LOCAL state.
-JavaUDAFContext* get_java_udaf_context(FunctionContext* ctx);
-void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFContext> udaf_ctx);
+JavaUDAFUniqueContext* get_java_udaf_context(FunctionContext* ctx);
+void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFUniqueContext> udaf_ctx);
 void clear_java_udaf_states(FunctionContext* ctx);
 void destroy_java_udaf_context(FunctionContext* ctx);
 

--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -553,6 +553,14 @@ Used for MySQL client compatibility. No practical usage.
 * **Data Type**: boolean
 * **Introduced in**: v3.2.0
 
+### enable_cache_udaf
+
+* **Description**: When set to `true`, enables in-memory caching of the class-level Java UDAF initialization (class loading, method introspection, and batch-update stub generation). The cache is populated on first use and reused across all aggregator/analytor instances within the same BE process, eliminating the repeated per-instance initialization overhead that is otherwise proportional to pipeline DOP. Caching only applies to UDAFs and window functions that were created with `"isolation" = "shared"`. Functions created with `"isolation" = "private"` always go through the uncached path regardless of this setting. Default is `false`; enable after verifying that shared-isolation UDAFs are safe to share their class-level state across concurrent queries. The runtime profile exposes `UdafCacheHitCount`, `UdafCachePopulateCount`, and `UdafLoadTime` counters to observe cache behavior.
+* **Scope**: Session
+* **Default**: `false`
+* **Data Type**: boolean
+* **Introduced in**: v3.4.0
+
 ### enable_color_explain_output
 
 * **Scope**: Session

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -468,6 +468,14 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * **数据类型**: boolean
 * **引入版本**: v3.2.0
 
+### enable_cache_udaf
+
+* **描述**: 设置为 `true` 时，启用 Java UDAF 类级初始化的内存缓存（包括类加载、方法内省和批量更新 stub 类生成）。缓存在首次使用时填充，并在同一 BE 进程内的所有 aggregator/analytor 实例之间复用，从而消除原本与 pipeline DOP 成线性比例的重复每实例初始化开销。缓存仅适用于创建时指定 `"isolation" = "shared"` 的 UDAF 和窗口函数；使用 `"isolation" = "private"` 创建的函数无论此设置如何，始终走非缓存路径。默认为 `false`；在确认 shared 隔离模式的 UDAF 可安全跨并发查询共享类级状态后再启用。运行时 Profile 中提供 `UdafCacheHitCount`、`UdafCachePopulateCount` 和 `UdafLoadTime` 计数器用于观测缓存行为。
+* **范围**: Session
+* **默认值**: `false`
+* **数据类型**: boolean
+* **引入版本**: v3.4.0
+
 ### enable_color_explain_output
 
 * **范围**: Session

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -93,6 +93,9 @@ public class AggregateFunction extends Function {
     @SerializedName(value = "returnsNonNullOnEmpty")
     private boolean returnsNonNullOnEmpty;
 
+    @SerializedName(value = "isolated")
+    private boolean isolationType = true;
+
     public List<Boolean> getIsAscOrder() {
         return isAscOrder;
     }
@@ -118,6 +121,14 @@ public class AggregateFunction extends Function {
 
     public void setIsDistinct(boolean isDistinct) {
         this.isDistinct = isDistinct;
+    }
+
+    public void setIsolationType(boolean isolationType) {
+        this.isolationType = isolationType;
+    }
+
+    public boolean getIsolationType() {
+        return this.isolationType;
     }
 
     // only used for serialization
@@ -207,6 +218,7 @@ public class AggregateFunction extends Function {
         isAscOrder = other.isAscOrder;
         nullsFirst = other.nullsFirst;
         isDistinct = other.isDistinct;
+        isolationType = other.isolationType;
     }
 
     /**
@@ -224,6 +236,7 @@ public class AggregateFunction extends Function {
         newFn.setUserVisible(this.isUserVisible());
         newFn.setAggStateDesc(this.getAggStateDesc());
         newFn.setisAnalyticFn(this.isAnalyticFn());
+        newFn.setIsolationType(this.getIsolationType());
         return newFn;
     }
 
@@ -242,6 +255,7 @@ public class AggregateFunction extends Function {
         String objectFile;
         String symbolName;
         CloudConfiguration cloudConfiguration;
+        private boolean isolationType = true;
 
         private AggregateFunctionBuilder(TFunctionBinaryType binaryType) {
             this.binaryType = binaryType;
@@ -296,6 +310,11 @@ public class AggregateFunction extends Function {
             return this;
         }
 
+        public AggregateFunctionBuilder setIsolationType(boolean isolationType) {
+            this.isolationType = isolationType;
+            return this;
+        }
+
         public void setIntermediateType(Type intermediateType) {
             this.intermediateType = intermediateType;
         }
@@ -308,6 +327,7 @@ public class AggregateFunction extends Function {
             fn.symbolName = symbolName;
             fn.setLocation(new HdfsURI(objectFile));
             fn.setCloudConfiguration(cloudConfiguration);
+            fn.setIsolationType(isolationType);
             return fn;
         }
     }
@@ -372,7 +392,8 @@ public class AggregateFunction extends Function {
                 isAnalyticFn == agg.isAnalyticFn && isAggregateFn == agg.isAggregateFn &&
                 returnsNonNullOnEmpty == agg.returnsNonNullOnEmpty && Objects.equals(symbolName, agg.symbolName)
                 && isDistinct == agg.isDistinct && Objects.equals(nullsFirst, agg.getNullsFirst()) &&
-                Objects.equals(isAscOrder, agg.getIsAscOrder()) && super.equals(obj);
+                Objects.equals(isAscOrder, agg.getIsAscOrder()) && isolationType == agg.isolationType
+                && super.equals(obj);
     }
 
     @Override
@@ -392,6 +413,7 @@ public class AggregateFunction extends Function {
             aggFn.setNulls_first(nullsFirst);
         }
         aggFn.setIs_distinct(isDistinct);
+        fn.setIsolated(isolationType);
 
         aggFn.setSymbol(getSymbolName());
         fn.setAggregate_fn(aggFn);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -299,6 +299,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String INSERT_MAX_FILTER_RATIO = "insert_max_filter_ratio";
     public static final String INSERT_TIMEOUT = "insert_timeout";
     public static final String DYNAMIC_OVERWRITE = "dynamic_overwrite";
+    public static final String ENABLE_CACHE_UDAF = "enable_cache_udaf";
     public static final String ENABLE_SPILL = "enable_spill";
     public static final String ENABLE_SPILL_TO_REMOTE_STORAGE = "enable_spill_to_remote_storage";
     public static final String DISABLE_SPILL_TO_LOCAL_DISK = "disable_spill_to_local_disk";
@@ -1655,6 +1656,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = INSERT_TIMEOUT)
     private int insertTimeoutS = 14400;
+
+    @VariableMgr.VarAttr(name = ENABLE_CACHE_UDAF)
+    private boolean enableCacheUdaf = false;
 
     @VariableMgr.VarAttr(name = ENABLE_SPILL)
     private boolean enableSpill = false;
@@ -4084,6 +4088,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.insertTimeoutS = insertTimeoutS;
     }
 
+    public boolean isEnableCacheUdaf() {
+        return enableCacheUdaf;
+    }
+
+    public void setEnableCacheUdaf(boolean enableCacheUdaf) {
+        this.enableCacheUdaf = enableCacheUdaf;
+    }
+
     public boolean isEnableSpill() {
         return enableSpill;
     }
@@ -6236,6 +6248,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             tResult.setError_for_division_by_zero(true);
         }
 
+        tResult.setEnable_cache_udaf(enableCacheUdaf);
         tResult.setEnable_spill(enableSpill);
         if (enableSpill) {
             TSpillOptions spillOptions = new TSpillOptions();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -403,7 +403,8 @@ public class CreateFunctionAnalyzer {
                 hasVarArgs(argsDef.isVariadic()).intermediateType(intermediateType).objectFile(objectFile)
                 .isAnalyticFn(isAnalyticFn)
                 .symbolName(mainClass.getCanonicalName())
-                .cloudConfiguration(cloudConfiguration);
+                .cloudConfiguration(cloudConfiguration)
+                .setIsolationType(!"shared".equalsIgnoreCase(isolation));
         Function function = builder.build();
         function.setChecksum(checksum);
         return function;

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -389,6 +389,7 @@ struct TQueryOptions {
   214: optional string http_request_ip_allowlist = "";
   215: optional string http_request_host_allowlist_regexp = "";
   216: optional bool http_request_allow_private_in_allowlist = false;
+  217: optional bool enable_cache_udaf = false;
 }
 
 // A scan range plus the parameters needed to execute that scan.

--- a/test/sql/test_udf/R/test_udaf_cache
+++ b/test/sql/test_udf/R/test_udaf_cache
@@ -1,0 +1,260 @@
+-- name: test_udaf_cache @no_arrow_flight_sql @sequential
+set enable_profile=true;
+-- result:
+-- !result
+set enable_async_profile=false;
+-- result:
+-- !result
+update information_schema.be_configs set value=false where name="enable_pipeline_driver_parallel_prepare";
+-- result:
+-- !result
+CREATE AGGREGATE FUNCTION sumbigint_cache_shared(bigint)
+RETURNS bigint
+PROPERTIES (
+  "symbol" = "Sumbigint",
+  "type" = "StarrocksJar",
+  "file" = "${udf_url}/starrocks-jdbc%2FSumbigint.jar",
+  "isolation" = "shared"
+);
+-- result:
+-- !result
+CREATE AGGREGATE FUNCTION sumbigint_cache_private(bigint)
+RETURNS bigint
+PROPERTIES (
+  "symbol" = "Sumbigint",
+  "type" = "StarrocksJar",
+  "file" = "${udf_url}/starrocks-jdbc%2FSumbigint.jar",
+  "isolation" = "private"
+);
+-- result:
+-- !result
+CREATE AGGREGATE FUNCTION sumbigint_window(bigint)
+RETURNS bigint
+PROPERTIES (
+  "analytic" = "true",
+  "symbol" = "Windowbigint",
+  "type" = "StarrocksJar",
+  "file" = "${udf_url}/starrocks-jdbc%2FWindowbigint.jar",
+  "isolation" = "shared"
+);
+-- result:
+-- !result
+CREATE AGGREGATE FUNCTION sumbigint_window_private(bigint)
+RETURNS bigint
+PROPERTIES (
+  "analytic" = "true",
+  "symbol" = "Windowbigint",
+  "type" = "StarrocksJar",
+  "file" = "${udf_url}/starrocks-jdbc%2FWindowbigint.jar",
+  "isolation" = "private"
+);
+-- result:
+-- !result
+CREATE TABLE t_udaf_cache (c0 int, c1 bigint, c2 bigint) distributed by hash(c0) buckets 4 properties("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO t_udaf_cache SELECT generate_series % 100, generate_series, cast(rand()*100 as int)  FROM table(generate_series(1, 10000));
+-- result:
+-- !result
+set enable_cache_udaf=false;
+-- result:
+-- !result
+with cte as (
+    SELECT sumbigint_cache_shared(c1) sum0, sum(c1) sum1 FROM t_udaf_cache GROUP BY c0
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+-- result:
+1
+-- !result
+select assert_true(sumbigint_cache_shared(c1) = sum(c1)) from t_udaf_cache;
+-- result:
+1
+-- !result
+set enable_cache_udaf=true;
+-- result:
+-- !result
+with cte as (
+    SELECT sumbigint_cache_shared(c1) sum0, sum(c1) sum1 FROM t_udaf_cache GROUP BY c0
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+-- result:
+1
+-- !result
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true(populate_count > 0 and hit_count > 0), assert_true((select count(1) from t) > 0) from t;
+-- result:
+1	1
+-- !result
+with cte as (
+    SELECT sumbigint_cache_shared(c1) sum0, sum(c1) sum1 FROM t_udaf_cache GROUP BY c0
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+-- result:
+1
+-- !result
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true(hit_count > 0 and populate_count = 0), assert_true((select count(1) from t) > 0) from t;
+-- result:
+1	1
+-- !result
+select assert_true(sumbigint_cache_shared(c1) = sum(c1)) from t_udaf_cache;
+-- result:
+1
+-- !result
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true(hit_count > 0 and populate_count = 0), assert_true((select count(1) from t) > 0) from t;
+-- result:
+1	1
+-- !result
+with cte as (
+    SELECT sumbigint_cache_private(c1) sum0, sum(c1) sum1 FROM t_udaf_cache GROUP BY c0
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+-- result:
+1
+-- !result
+select assert_true(sumbigint_cache_private(c1) = sum(c1)) from t_udaf_cache;
+-- result:
+1
+-- !result
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true((hit_count is null or hit_count = 0) and (populate_count is null or populate_count = 0)) from t;
+-- result:
+1
+-- !result
+with cte as (
+    SELECT sumbigint_window(c1) OVER (PARTITION BY c2 ORDER BY c0) sum0, sum(c1) OVER (PARTITION BY c2 ORDER BY c0) sum1 FROM t_udaf_cache
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+-- result:
+1
+-- !result
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true(populate_count > 0 and hit_count > 0), assert_true((select count(1) from t) > 0) from t;
+-- result:
+1	1
+-- !result
+with cte as (
+    SELECT sumbigint_window(c1) OVER (PARTITION BY c2 ORDER BY c0) sum0, sum(c1) OVER (PARTITION BY c2 ORDER BY c0) sum1 FROM t_udaf_cache
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+-- result:
+1
+-- !result
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true(hit_count > 0 and populate_count = 0), assert_true((select count(1) from t) > 0) from t;
+-- result:
+1	1
+-- !result
+with cte as (
+    SELECT sumbigint_window_private(c1) OVER (ORDER BY c0) sum0, sum(c1) OVER (ORDER BY c0) sum1 FROM t_udaf_cache
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+-- result:
+1
+-- !result
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true((hit_count is null or hit_count = 0) and (populate_count is null or populate_count = 0)) from t;
+-- result:
+1
+-- !result
+set enable_cache_udaf=false;
+-- result:
+-- !result
+with cte as (
+    SELECT sumbigint_cache_shared(c1) sum0, sum(c1) sum1 FROM t_udaf_cache GROUP BY c0
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+-- result:
+1
+-- !result
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true((hit_count is null or hit_count = 0) and (populate_count is null or populate_count = 0)) from t;
+-- result:
+1
+-- !result
+DROP TABLE t_udaf_cache;
+-- result:
+-- !result
+DROP FUNCTION sumbigint_cache_shared(bigint);
+-- result:
+-- !result
+DROP FUNCTION sumbigint_cache_private(bigint);
+-- result:
+-- !result
+DROP FUNCTION sumbigint_window(bigint);
+-- result:
+-- !result
+DROP FUNCTION sumbigint_window_private(bigint);
+-- result:
+-- !result
+set enable_profile=false;
+-- result:
+-- !result
+set enable_cache_udaf=false;
+-- result:
+-- !result

--- a/test/sql/test_udf/T/test_udaf_cache
+++ b/test/sql/test_udf/T/test_udaf_cache
@@ -1,0 +1,239 @@
+-- name: test_udaf_cache @no_arrow_flight_sql @sequential
+
+set enable_profile=true;
+set enable_async_profile=false;
+
+update information_schema.be_configs set value=false where name="enable_pipeline_driver_parallel_prepare";
+
+-- Create a shared isolation UDAF for cache testing
+CREATE AGGREGATE FUNCTION sumbigint_cache_shared(bigint)
+RETURNS bigint
+PROPERTIES (
+  "symbol" = "Sumbigint",
+  "type" = "StarrocksJar",
+  "file" = "${udf_url}/starrocks-jdbc%2FSumbigint.jar",
+  "isolation" = "shared"
+);
+
+-- Create a private isolation UDAF for testing that cache is NOT used
+CREATE AGGREGATE FUNCTION sumbigint_cache_private(bigint)
+RETURNS bigint
+PROPERTIES (
+  "symbol" = "Sumbigint",
+  "type" = "StarrocksJar",
+  "file" = "${udf_url}/starrocks-jdbc%2FSumbigint.jar",
+  "isolation" = "private"
+);
+
+-- Create a shared isolation window function for cache testing
+CREATE AGGREGATE FUNCTION sumbigint_window(bigint)
+RETURNS bigint
+PROPERTIES (
+  "analytic" = "true",
+  "symbol" = "Windowbigint",
+  "type" = "StarrocksJar",
+  "file" = "${udf_url}/starrocks-jdbc%2FWindowbigint.jar",
+  "isolation" = "shared"
+);
+
+-- Create a private isolation window function for testing that cache is NOT used
+CREATE AGGREGATE FUNCTION sumbigint_window_private(bigint)
+RETURNS bigint
+PROPERTIES (
+  "analytic" = "true",
+  "symbol" = "Windowbigint",
+  "type" = "StarrocksJar",
+  "file" = "${udf_url}/starrocks-jdbc%2FWindowbigint.jar",
+  "isolation" = "private"
+);
+
+CREATE TABLE t_udaf_cache (c0 int, c1 bigint, c2 bigint) distributed by hash(c0) buckets 4 properties("replication_num"="1");
+
+-- 10000 rows: c0 = group key (0-99), c1 = value (1-10000)
+INSERT INTO t_udaf_cache SELECT generate_series % 100, generate_series, cast(rand()*100 as int)  FROM table(generate_series(1, 10000));
+
+-- ============================================================
+-- Test 1: enable_cache_udaf = false — correctness only, no cache
+-- ============================================================
+set enable_cache_udaf=false;
+
+-- group-by: every group must satisfy sumbigint == builtin sum
+with cte as (
+    SELECT sumbigint_cache_shared(c1) sum0, sum(c1) sum1 FROM t_udaf_cache GROUP BY c0
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+
+-- non-group-by: global sumbigint must equal global builtin sum
+select assert_true(sumbigint_cache_shared(c1) = sum(c1)) from t_udaf_cache;
+
+-- ============================================================
+-- Test 2: enable_cache_udaf = true, shared isolation
+-- First query populates cache; second and third hit cache
+-- ============================================================
+set enable_cache_udaf=true;
+
+-- first query: correctness + populates cache
+with cte as (
+    SELECT sumbigint_cache_shared(c1) sum0, sum(c1) sum1 FROM t_udaf_cache GROUP BY c0
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true(populate_count > 0 and hit_count > 0), assert_true((select count(1) from t) > 0) from t;
+
+-- second query: correctness + hits cache (group-by)
+with cte as (
+    SELECT sumbigint_cache_shared(c1) sum0, sum(c1) sum1 FROM t_udaf_cache GROUP BY c0
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true(hit_count > 0 and populate_count = 0), assert_true((select count(1) from t) > 0) from t;
+
+-- third query: correctness + hits cache (non-group-by)
+select assert_true(sumbigint_cache_shared(c1) = sum(c1)) from t_udaf_cache;
+
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true(hit_count > 0 and populate_count = 0), assert_true((select count(1) from t) > 0) from t;
+
+-- ============================================================
+-- Test 3: enable_cache_udaf = true, private isolation
+-- Cache must NOT be used; results must still be correct
+-- ============================================================
+
+-- group-by correctness
+with cte as (
+    SELECT sumbigint_cache_private(c1) sum0, sum(c1) sum1 FROM t_udaf_cache GROUP BY c0
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+
+-- non-group-by correctness
+select assert_true(sumbigint_cache_private(c1) = sum(c1)) from t_udaf_cache;
+
+-- no cache counters in profile (private isolation bypasses cache)
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true((hit_count is null or hit_count = 0) and (populate_count is null or populate_count = 0)) from t;
+
+-- ============================================================
+-- Test 4: Window function correctness + cache
+-- ============================================================
+
+-- first window query: correctness + populates cache
+with cte as (
+    SELECT sumbigint_window(c1) OVER (PARTITION BY c2 ORDER BY c0) sum0, sum(c1) OVER (PARTITION BY c2 ORDER BY c0) sum1 FROM t_udaf_cache
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true(populate_count > 0 and hit_count > 0), assert_true((select count(1) from t) > 0) from t;
+
+-- second window query: correctness + hits cache
+with cte as (
+    SELECT sumbigint_window(c1) OVER (PARTITION BY c2 ORDER BY c0) sum0, sum(c1) OVER (PARTITION BY c2 ORDER BY c0) sum1 FROM t_udaf_cache
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true(hit_count > 0 and populate_count = 0), assert_true((select count(1) from t) > 0) from t;
+
+-- ============================================================
+-- Test 5: Window function with private isolation
+-- Cache must NOT be used; results must still be correct
+-- ============================================================
+
+with cte as (
+    SELECT sumbigint_window_private(c1) OVER (ORDER BY c0) sum0, sum(c1) OVER (ORDER BY c0) sum1 FROM t_udaf_cache
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+
+-- no cache counters in profile
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true((hit_count is null or hit_count = 0) and (populate_count is null or populate_count = 0)) from t;
+
+-- ============================================================
+-- Test 6: Cache disabled after cache was populated — no cache activity
+-- ============================================================
+set enable_cache_udaf=false;
+
+with cte as (
+    SELECT sumbigint_cache_shared(c1) sum0, sum(c1) sum1 FROM t_udaf_cache GROUP BY c0
+)
+select assert_true(count(1) = sum(sum0 = sum1)) from cte;
+
+with t as (
+    SELECT
+        MAX(CASE WHEN line LIKE '%HitCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as hit_count,
+        MAX(CASE WHEN line LIKE '%PopulateCount%' THEN CAST(trim(split_part(line, ':', 2)) AS INT) END) as populate_count
+    FROM (
+        SELECT line FROM table(unnest(split(get_query_profile(last_query_id()), '\n'))) t(line)
+    ) v
+    WHERE v.line LIKE '%- UdafCacheHitCount%' OR v.line LIKE '%- UdafCachePopulateCount%'
+)
+select assert_true((hit_count is null or hit_count = 0) and (populate_count is null or populate_count = 0)) from t;
+
+-- ============================================================
+-- Cleanup
+-- ============================================================
+DROP TABLE t_udaf_cache;
+DROP FUNCTION sumbigint_cache_shared(bigint);
+DROP FUNCTION sumbigint_cache_private(bigint);
+DROP FUNCTION sumbigint_window(bigint);
+DROP FUNCTION sumbigint_window_private(bigint);
+
+set enable_profile=false;
+set enable_cache_udaf=false;


### PR DESCRIPTION
## Why I'm doing:

When `pipeline_dop > 1` (or `pipeline_dop = 0`, which auto-selects DOP based on CPU cores), the query pipeline spawns multiple aggregator/analytor driver instances. Each instance independently loads and initializes the Java UDAF — downloading the JAR, loading classes, resolving methods, and generating the batch-update stub — sequentially during driver preparation. This makes driver preparation time grow linearly with DOP, and becomes a significant bottleneck for high-DOP queries using Java UDAFs.

## What I'm doing:

Cache the expensive class-level UDAF initialization so it is performed only once (on first use) and reused across all aggregator/analytor instances within the same BE process.

**Core refactor:** Split `JavaUDAFContext` into two structs:

- **`JavaUDAFSharedContext`** — class-level, immutable: classloader, JVM class references, method descriptors, and the generated batch-update stub class. Built once and stored in `UserFunctionCache` keyed by function ID.
- **`JavaUDAFUniqueContext`** — per-aggregator, mutable: the UDAF object instance, `AggBatchCallStub`, `UDAFStateList`, and serialization buffer. Created cheaply from the shared context for each aggregator instance.

The same split is applied to window functions (`java_window_function.cpp`).

**Cache control:**
- A new session variable `enable_cache_udaf` (default `false`) gates the feature. Propagated to BE via `TQueryOptions.enable_cache_udaf` (field 217).
- Caching only applies when both `enable_cache_udaf = true` **and** the UDAF is created with `"isolation" = "shared"`. Functions with `"isolation" = "private"` always go through the original uncached path regardless of the session variable.

**Upgrade compatibility note:** In versions prior to this change, the `isolation` property on UDAF definitions was accepted syntactically but had no effect at runtime — all UDAFs were effectively private. After this upgrade, UDAFs created with `"isolation" = "shared"` will use the cache when `enable_cache_udaf = true`. Existing shared UDAFs must be **dropped and recreated** to pick up the `isolated = false` flag that is now serialized into the thrift `TFunction` and persisted in FE metadata.

**Bug fix:** `UserFunctionCache::_load_cache_entry_internal` previously set `is_loaded = true` even when the cache handle was empty (as is the case for the `get_libpath` code path). This would cause a subsequent `load_cacheable_java_udf` call for the same function ID to skip building the shared context and return an empty handle, resulting in `bad_any_cast` at the call site. Fixed by only setting `is_loaded` when `cache_handle.has_value()`.

**`load_cacheable_java_udf` API change:** Now returns `{cache_hit, value}` instead of just `value`, so callers can distinguish a cache miss (populate) from a hit.

**Observability:** Three new runtime profile counters on both `AggStatistics` (aggregation) and `Analytor` (window):
- `UdafLoadTime` — wall time spent in UDAF initialization (shared context build)
- `UdafCacheHitCount` — aggregator instances that reused a cached shared context
- `UdafCachePopulateCount` — aggregator instances that built and populated the cache

**FE changes:**
- `AggregateFunction` / `AggregateFunctionBuilder` gain an `isolationType` field; `CreateFunctionAnalyzer` maps `"isolation" = "shared"` → `isolated = false` on `TFunction`.
- `SessionVariable` gains `enable_cache_udaf` with getter/setter and thrift serialization.

**Performance Test**

use query in sql test
``` sql
-- no_cache
SELECT /*+SET_VAR(enable_cache_udaf=false)*/ sumbigint_cache_shared(c1) sum0, sumbigint_cache_shared(c1), sumbigint_cache_shared(c2) sum1 FROM t_udaf_cache; 

-- use_cache
SELECT /*+SET_VAR(enable_cache_udaf=true)*/ sumbigint_cache_shared(c1) sum0, sumbigint_cache_shared(c1), sumbigint_cache_shared(c2) sum1 FROM t_udaf_cache; 
```
concurrency=64

```
+===========+=============+=========================+
|           | e2e_latency | prepare-pipeline-driver |
+===========+=============+=========================+
| no_cache  | 0.150s      | 22.119ms                |
| use_cache | 0.069s      | 1.193ms                 |
+-----------+-------------+-------------------------+
```


concurrency=32
``` 
+===========+=============+=========================+
|           | e2e_latency | prepare-pipeline-driver |
+===========+=============+=========================+
| no_cache  | 0.069s      | 14.501ms                |
| use_cache | 0.037s      | 1.242ms                 |
+-----------+-------------+-------------------------+

```
concurrency=1  

```
+===========+=============+=========================+
|           | e2e_latency | prepare-pipeline-driver |
+===========+=============+=========================+
| no_cache  | 0.013s      | 3.737ms                 |
| use_cache | 0.008s      | <1.0ms                  |
+-----------+-------------+-------------------------+
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [x] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
