### PR TITLE
[Refactor] Drop meaningless "Base" prefix from MVRefreshProcessor family

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -34,8 +34,8 @@ import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.StmtExecutor;
-import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
+import com.starrocks.scheduler.mv.MVRefreshProcessor;
 import com.starrocks.scheduler.mv.MVRefreshProcessorFactory;
 import com.starrocks.scheduler.mv.MVTraceUtils;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
@@ -74,7 +74,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
     // used to store the mv task run context
     private MvTaskRunContext mvTaskRunContext;
     // used to store the mv refresh processor
-    private BaseMVRefreshProcessor mvRefreshProcessor;
+    private MVRefreshProcessor mvRefreshProcessor;
     // used to store the old transaction visible wait timeout to be restored after mv refresh task run
     private long oldTransactionVisibleWaitTimeout;
     // metrics entity for the mv
@@ -162,7 +162,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         // get exec plan
         mvTaskRunContext.getRefreshRuntimeState().reset();
         mvTaskRunContext.setIsExplain(true);
-        BaseMVRefreshProcessor.ProcessExecPlan processExecPlan =
+        MVRefreshProcessor.ProcessExecPlan processExecPlan =
                 mvRefreshProcessor.getProcessExecPlan(mvTaskRunContext);
         if (processExecPlan == null || processExecPlan.state() != Constants.TaskRunState.SUCCESS) {
             logger.info("No need to refresh mv: {}, because the materialized view is up to date.", mv.getName());
@@ -314,7 +314,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
                                                    MVRefreshExecutor executor) throws Exception {
         Stopwatch watch = Stopwatch.createStarted();
         mvTaskRunContext.getRefreshRuntimeState().reset();
-        final BaseMVRefreshProcessor.ProcessExecPlan processExecPlan = mvRefreshProcessor.getProcessExecPlan(taskRunContext);
+        final MVRefreshProcessor.ProcessExecPlan processExecPlan = mvRefreshProcessor.getProcessExecPlan(taskRunContext);
         if (processExecPlan.state() == Constants.TaskRunState.SKIPPED) {
             logger.info("MV {} refresh task skipped, no partitions to refresh", mv.getName());
             long elapsed = watch.elapsed(TimeUnit.MILLISECONDS);
@@ -372,7 +372,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         return this.mvTaskRunContext;
     }
 
-    public BaseMVRefreshProcessor getMVRefreshProcessor() {
+    public MVRefreshProcessor getMVRefreshProcessor() {
         return this.mvRefreshProcessor;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -93,7 +93,7 @@ import java.util.stream.Collectors;
 /**
  * Base class for materialized view refresh processor.
  */
-public abstract class BaseMVRefreshProcessor {
+public abstract class MVRefreshProcessor {
     // session.enable_spill
     protected static final String MV_SESSION_ENABLE_SPILL =
             PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX + SessionVariable.ENABLE_SPILL;
@@ -141,11 +141,11 @@ public abstract class BaseMVRefreshProcessor {
                                   InsertStmt insertStmt) {
     }
 
-    public BaseMVRefreshProcessor(Database db, MaterializedView mv,
-                                  MvTaskRunContext mvContext,
-                                  IMaterializedViewMetricsEntity mvEntity,
-                                  MaterializedView.RefreshMode refreshMode,
-                                  Class<?> clazz) {
+    public MVRefreshProcessor(Database db, MaterializedView mv,
+                              MvTaskRunContext mvContext,
+                              IMaterializedViewMetricsEntity mvEntity,
+                              MaterializedView.RefreshMode refreshMode,
+                              Class<?> clazz) {
         this.db = db;
         this.mv = mv;
         this.mvContext = mvContext;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessorFactory.java
@@ -19,32 +19,32 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
-import com.starrocks.scheduler.mv.hybrid.MVHybridBasedRefreshProcessor;
-import com.starrocks.scheduler.mv.ivm.MVIVMBasedRefreshProcessor;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.hybrid.MVHybridRefreshProcessor;
+import com.starrocks.scheduler.mv.ivm.MVIVMRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 
 import java.util.Map;
 
 public class MVRefreshProcessorFactory {
     public static final MVRefreshProcessorFactory INSTANCE = new MVRefreshProcessorFactory();
 
-    public BaseMVRefreshProcessor newProcessor(Database db, MaterializedView mv,
-                                               MvTaskRunContext mvContext,
-                                               IMaterializedViewMetricsEntity mvEntity) {
+    public MVRefreshProcessor newProcessor(Database db, MaterializedView mv,
+                                           MvTaskRunContext mvContext,
+                                           IMaterializedViewMetricsEntity mvEntity) {
         MaterializedView.RefreshMode refreshMode = mv.getCurrentRefreshMode();
         switch (refreshMode) {
             case INCREMENTAL:
-                return new MVIVMBasedRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
+                return new MVIVMRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
             case AUTO:
-                return new MVHybridBasedRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
+                return new MVHybridRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
             case FULL: {
                 // full refresh
                 Map<String, String> props = mvContext.getProperties();
                 props.put(TaskRun.FORCE, "true");
-                return new MVPCTBasedRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
+                return new MVPCTRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
             }
             default:
-                return new MVPCTBasedRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
+                return new MVPCTRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridRefreshProcessor.java
@@ -26,28 +26,28 @@ import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRunContext;
-import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
 import com.starrocks.scheduler.mv.MVRefreshParams;
-import com.starrocks.scheduler.mv.ivm.MVIVMBasedRefreshProcessor;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.MVRefreshProcessor;
+import com.starrocks.scheduler.mv.ivm.MVIVMRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 
 import java.util.Map;
 
-public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor {
-    private final MVPCTBasedRefreshProcessor pctProcessor;
-    private final MVIVMBasedRefreshProcessor ivmProcessor;
+public final class MVHybridRefreshProcessor extends MVRefreshProcessor {
+    private final MVPCTRefreshProcessor pctProcessor;
+    private final MVIVMRefreshProcessor ivmProcessor;
 
-    public MVHybridBasedRefreshProcessor(Database db,
-                                         MaterializedView mv,
-                                         MvTaskRunContext mvContext,
-                                         IMaterializedViewMetricsEntity mvEntity,
-                                         MaterializedView.RefreshMode refreshMode) {
-        super(db, mv, mvContext, mvEntity, refreshMode, MVHybridBasedRefreshProcessor.class);
-        this.ivmProcessor = new MVIVMBasedRefreshProcessor(db, mv, mvContext, mvEntity,
+    public MVHybridRefreshProcessor(Database db,
+                                    MaterializedView mv,
+                                    MvTaskRunContext mvContext,
+                                    IMaterializedViewMetricsEntity mvEntity,
+                                    MaterializedView.RefreshMode refreshMode) {
+        super(db, mv, mvContext, mvEntity, refreshMode, MVHybridRefreshProcessor.class);
+        this.ivmProcessor = new MVIVMRefreshProcessor(db, mv, mvContext, mvEntity,
                 MaterializedView.RefreshMode.INCREMENTAL);
-        this.pctProcessor = new MVPCTBasedRefreshProcessor(db, mv, mvContext, mvEntity,
+        this.pctProcessor = new MVPCTRefreshProcessor(db, mv, mvContext, mvEntity,
                 MaterializedView.RefreshMode.AUTO);
     }
 
@@ -125,7 +125,7 @@ public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor 
     }
 
     @VisibleForTesting
-    public BaseMVRefreshProcessor getCurrentProcessor() {
+    public MVRefreshProcessor getCurrentProcessor() {
         if (this.currentRefreshMode == MaterializedView.RefreshMode.AUTO) {
             return pctProcessor;
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -45,9 +45,9 @@ import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunBuilder;
 import com.starrocks.scheduler.TaskRunContext;
-import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
+import com.starrocks.scheduler.mv.MVRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.Analyzer;
@@ -79,18 +79,18 @@ import static com.starrocks.scheduler.TaskRun.MV_UNCOPYABLE_PROPERTIES;
  * - Build an incremental refresh plan based on the changed version ranges of base tables.
  * - Execute the refresh plan to update the materialized view.
  */
-public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
+public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
     // Per-call buffer: stores TVR deltas computed in getProcessExecPlan(), consumed in execProcessExecPlan().
     // NOT the editlog-persisted temp map (that is AsyncRefreshContext.tempBaseTableInfoTvrDeltaMap).
     private final Map<BaseTableInfo, TvrVersionRange> stagedTvrDeltaMap = Maps.newConcurrentMap();
     // whether the next task run is needed
     private boolean hasNextTaskRun = false;
 
-    public MVIVMBasedRefreshProcessor(Database db, MaterializedView mv,
-                                      MvTaskRunContext mvContext,
-                                      IMaterializedViewMetricsEntity mvEntity,
-                                      MaterializedView.RefreshMode refreshMode) {
-        super(db, mv, mvContext, mvEntity, refreshMode, MVIVMBasedRefreshProcessor.class);
+    public MVIVMRefreshProcessor(Database db, MaterializedView mv,
+                                 MvTaskRunContext mvContext,
+                                 IMaterializedViewMetricsEntity mvEntity,
+                                 MaterializedView.RefreshMode refreshMode) {
+        super(db, mv, mvContext, mvEntity, refreshMode, MVIVMRefreshProcessor.class);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
@@ -42,9 +42,9 @@ import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunBuilder;
 import com.starrocks.scheduler.TaskRunContext;
-import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
+import com.starrocks.scheduler.mv.MVRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.StatementPlanner;
@@ -72,7 +72,7 @@ import static com.starrocks.scheduler.TaskRun.MV_UNCOPYABLE_PROPERTIES;
  * based on partition changes in the base tables.
  * MVPCTBasedRefreshProcessor is not thread safe for concurrent runs of the same materialized view
  */
-public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
+public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
 
     // One-shot callback invoked after syncAndCheckPCTPartitions and before plan building. Used by
     // Hybrid fallback to freeze TVR so the pinned state is visible to the plan builder and differ.
@@ -101,11 +101,11 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
         return false;
     }
 
-    public MVPCTBasedRefreshProcessor(Database db, MaterializedView mv,
-                                      MvTaskRunContext mvContext,
-                                      IMaterializedViewMetricsEntity mvEntity,
-                                      MaterializedView.RefreshMode refreshMode) {
-        super(db, mv, mvContext, mvEntity, refreshMode, MVPCTBasedRefreshProcessor.class);
+    public MVPCTRefreshProcessor(Database db, MaterializedView mv,
+                                 MvTaskRunContext mvContext,
+                                 IMaterializedViewMetricsEntity mvEntity,
+                                 MaterializedView.RefreshMode refreshMode) {
+        super(db, mv, mvContext, mvEntity, refreshMode, MVPCTRefreshProcessor.class);
     }
 
     public void setAfterSyncHook(Runnable afterSyncHook) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
@@ -16,7 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.starrocks.clone.DynamicPartitionScheduler;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
@@ -576,7 +576,7 @@ public class DropPartitionWithExprListTest extends MVTestBase {
                                     MaterializedView mv = starRocksAssert.getMv("test", mvName);
                                     {
                                         // all partitions are expired, no need to create partitions for mv
-                                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                                         Assertions.assertEquals(0, mv.getVisiblePartitions().size());
                                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                                         ExecPlan execPlan = processor.getMvContext().getExecPlan();
@@ -591,7 +591,7 @@ public class DropPartitionWithExprListTest extends MVTestBase {
                                         addListPartition(tableName, "p6", "guangdong_p6",
                                                 now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), true);
 
-                                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                                         Assertions.assertTrue(processor != null);
                                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                                         Assertions.assertEquals(2, mv.getVisiblePartitions().size());
@@ -624,7 +624,7 @@ public class DropPartitionWithExprListTest extends MVTestBase {
                                     MaterializedView mv = starRocksAssert.getMv("test", mvName);
                                     {
                                         // all partitions are expired, no need to create partitions for mv
-                                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                                         Assertions.assertEquals(2, mv.getVisiblePartitions().size());
                                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                                         ExecPlan execPlan = processor.getMvContext().getExecPlan();
@@ -644,7 +644,7 @@ public class DropPartitionWithExprListTest extends MVTestBase {
 
                                     {
                                         // all partitions are expired, no need to create partitions for mv
-                                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                                         Assertions.assertEquals(0, mv.getVisiblePartitions().size());
                                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                                         ExecPlan execPlan = processor.getMvContext().getExecPlan();
@@ -659,7 +659,7 @@ public class DropPartitionWithExprListTest extends MVTestBase {
                                         addListPartition(tableName, "p6", "guangdong_p6",
                                                 now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), true);
 
-                                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                                         Assertions.assertTrue(processor != null);
                                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                                         Assertions.assertEquals(2, mv.getVisiblePartitions().size());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprRangeTest.java
@@ -16,7 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.clone.DynamicPartitionScheduler;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
@@ -258,7 +258,7 @@ public class DropPartitionWithExprRangeTest extends MVTestBase {
                                     MaterializedView mv = starRocksAssert.getMv("test", mvName);
                                     {
                                         // all partitions are expired, no need to create partitions for mv
-                                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                                         Assertions.assertEquals(0, mv.getVisiblePartitions().size());
                                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                                         ExecPlan execPlan = processor.getMvContext().getExecPlan();
@@ -276,7 +276,7 @@ public class DropPartitionWithExprRangeTest extends MVTestBase {
                                                 now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
                                                 now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
                                                 true);
-                                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                                         Assertions.assertTrue(processor != null);
                                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                                         Assertions.assertEquals(2, mv.getVisiblePartitions().size());
@@ -309,7 +309,7 @@ public class DropPartitionWithExprRangeTest extends MVTestBase {
                                     MaterializedView mv = starRocksAssert.getMv("test", mvName);
                                     {
                                         // all partitions are expired, no need to create partitions for mv
-                                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                                         Assertions.assertEquals(4, mv.getVisiblePartitions().size());
                                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                                         ExecPlan execPlan = processor.getMvContext().getExecPlan();
@@ -329,7 +329,7 @@ public class DropPartitionWithExprRangeTest extends MVTestBase {
 
                                     {
                                         // all partitions are expired, no need to create partitions for mv
-                                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                                         Assertions.assertEquals(0, mv.getVisiblePartitions().size());
                                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                                         ExecPlan execPlan = processor.getMvContext().getExecPlan();
@@ -347,7 +347,7 @@ public class DropPartitionWithExprRangeTest extends MVTestBase {
                                                 now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
                                                 now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
                                                 true);
-                                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                                         Assertions.assertTrue(processor != null);
                                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                                         Assertions.assertEquals(2, mv.getVisiblePartitions().size());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
@@ -24,7 +24,7 @@ import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunBuilder;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.expression.Expr;
@@ -259,7 +259,7 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                     TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
                     taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                     taskRun.executeTaskRun();
-                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                     Map<Table, Set<String>> baseTables = getRefTableRefreshedPartitions(processor);
                     Assertions.assertEquals(2, baseTables.size());
                     Assertions.assertEquals(Sets.newHashSet("p20220101"), baseTables.get(
@@ -302,7 +302,7 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                     // insert new data into tbl16's p20220202 partition
                     executeInsertSql("insert into tbl16 partition(p20220202) values('2022-02-02', 3, 10);");
                     taskRun.executeTaskRun();
-                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                     Assertions.assertEquals(Sets.newHashSet("p202202_202203"),
                             processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
                     Assertions.assertEquals("{tbl15=[p20220201, p20220202], tbl16=[p20220201, p20220202]}",
@@ -332,7 +332,7 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                     {
                         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                         taskRun.executeTaskRun();
-                        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         Map<Table, Set<String>> baseTables = getRefTableRefreshedPartitions(processor);
                         Assertions.assertEquals(2, baseTables.size());
                         Assertions.assertEquals(Sets.newHashSet("p20220101"),
@@ -349,7 +349,7 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                         executeInsertSql("insert into tbl16 partition(p20220202) values('2022-02-02', 3, 10);");
                         taskRun.executeTaskRun();
 
-                        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         // 1. updated partition of tbl16 is p20220202
                         // 2. date_trunc('month', p20220202) is '2022-02'
                         // 3. tbl15's associated partitions are p20220201 and p20220202
@@ -388,7 +388,7 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                         taskRun.executeTaskRun();
 
-                        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         Assertions.assertEquals(Sets.newHashSet("p2"),
                                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
                         ExecPlan execPlan = processor.getMvContext().getExecPlan();
@@ -401,7 +401,7 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                         executeInsertSql("insert into tbl2 partition(p2) values('2022-02-02', 3, 10);");
                         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                         taskRun.executeTaskRun();
-                        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         ExecPlan execPlan = processor.getMvContext().getExecPlan();
                         Assertions.assertTrue(execPlan != null);
                         assertPlanContains(execPlan, "partitions=5/5\n     rollup: tbl1",
@@ -453,7 +453,7 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                     executeInsertSql("insert into tbl15 partition(p20220202) values('2022-02-02', 3, 10);");
                     taskRun.executeTaskRun();
 
-                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                     Assertions.assertEquals(Sets.newHashSet("p202202_202203"),
                             processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
                     Assertions.assertEquals("{tbl15=[p20220201, p20220202]}",
@@ -491,7 +491,7 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                     executeInsertSql("insert into tbl2 partition(p1) values('2022-01-02', 3, 10);");
                     taskRun.executeTaskRun();
 
-                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                     Set<String> mvPartitionsToRefresh = processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh();
                     Assertions.assertTrue(mvPartitionsToRefresh.contains("p20220101_20220102"));
                     Map<String, Set<String>> refBasePartitionsToRefreshMap =
@@ -614,7 +614,7 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                         taskRun.executeTaskRun();
 
-                        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         Assertions.assertEquals(Sets.newHashSet("p1"),
                                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
                         Assertions.assertEquals("{tbl2=[p1], tbl1=[p1]}",

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVTaskRunProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVTaskRunProcessorTest.java
@@ -19,7 +19,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
@@ -230,8 +230,8 @@ public class MVTaskRunProcessorTest extends MVTestBase {
         taskRunContext.setProperties(testProperties);
         mvTaskRunProcessor.prepare(taskRunContext);
 
-        MVPCTBasedRefreshProcessor processor = 
-                (MVPCTBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        MVPCTRefreshProcessor processor =
+                (MVPCTRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
         Assertions.assertNotNull(processor);
 
         // Test getRetryTimes with different contexts

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -22,7 +22,7 @@ import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
@@ -174,7 +174,7 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
 
     private ExecPlan getExecPlan(TaskRun taskRun) {
         try {
-            MVPCTBasedRefreshProcessor processor = getProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             return execPlan;
@@ -185,7 +185,7 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
         }
     }
 
-    private MVPCTBasedRefreshProcessor getProcessor(TaskRun taskRun) {
+    private MVPCTRefreshProcessor getProcessor(TaskRun taskRun) {
         try {
             initAndExecuteTaskRun(taskRun);
             return getPartitionBasedRefreshProcessor(taskRun);
@@ -1093,7 +1093,7 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
                         TaskRun taskRun = TaskRunBuilder.newBuilder(task)
                                 .properties(props)
                                 .build();
-                        MVPCTBasedRefreshProcessor processor = getProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getProcessor(taskRun);
                         MvTaskRunContext mvTaskRunContext = processor.getMvContext();
                         Assertions.assertNull(mvTaskRunContext.getNextPartitionValues());
                         MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
@@ -1141,7 +1141,7 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
                         TaskRun taskRun = TaskRunBuilder.newBuilder(task)
                                 .properties(props)
                                 .build();
-                        MVPCTBasedRefreshProcessor processor = getProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getProcessor(taskRun);
                         MvTaskRunContext mvTaskRunContext = processor.getMvContext();
                         Assertions.assertNull(mvTaskRunContext.getNextPartitionValues());
                         MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
@@ -1186,7 +1186,7 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
                         TaskRun taskRun = TaskRunBuilder.newBuilder(task)
                                 .properties(props)
                                 .build();
-                        MVPCTBasedRefreshProcessor processor = getProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getProcessor(taskRun);
                         MvTaskRunContext mvTaskRunContext = processor.getMvContext();
                         Assertions.assertNull(mvTaskRunContext.getNextPartitionValues());
                         MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
@@ -1261,7 +1261,7 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
             executeInsertSql("INSERT INTO t1 VALUES \n" +
                     "    (\"2020-07-01\", \"beijing\",  1), (\"2020-07-01\", \"chengdu\",  2),\n" +
                     "    (\"2020-07-02\", \"beijing\",  3), (\"2020-07-02\", \"hangzhou\", 4);\n");
-            MVPCTBasedRefreshProcessor processor = getProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getProcessor(taskRun);
             MvTaskRunContext mvTaskRunContext = processor.getMvContext();
             Assertions.assertNull(mvTaskRunContext.getNextPartitionValues());
             MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
@@ -1353,7 +1353,7 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
                     String query = String.format("select * from %s ", tableName);
                     {
                         // all partitions are expired, no need to create partitions for mv
-                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                         Assertions.assertEquals(0, mv.getVisiblePartitions().size());
                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                         ExecPlan execPlan = processor.getMvContext().getExecPlan();
@@ -1455,7 +1455,7 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
                     String query = String.format("select * from %s ", tableName);
                     {
                         // all partitions are expired, no need to create partitions for mv
-                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                         Assertions.assertEquals(2, mv.getVisiblePartitions().size());
                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                         String plan = getFragmentPlan(query);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
@@ -15,7 +15,7 @@
 package com.starrocks.scheduler;
 
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -143,7 +143,7 @@ public class PCTRefreshRangePartitionOlapTest extends MVTestBase {
         ExecPlan execPlan = getMVRefreshExecPlan(taskRun, true);
         Assertions.assertNotNull(execPlan);
 
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         TaskRun nextTaskRun = processor.getNextTaskRun();
         String v = nextTaskRun.getProperties().get(TaskRun.FORCE);
         Assertions.assertEquals("true", v);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -26,7 +26,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.connector.hive.MockedHiveMetadata;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.common.SyncPartitionUtils;
@@ -201,7 +201,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -236,7 +236,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -284,7 +284,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -333,7 +333,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -381,7 +381,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -425,7 +425,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -480,7 +480,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -526,7 +526,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -572,7 +572,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -627,7 +627,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -683,7 +683,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -733,7 +733,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Assertions.assertEquals(2, materializedView.getPartition("p19980102").getDefaultPhysicalPartition()
                 .getVisibleVersion());
 
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
         String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -754,7 +754,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(mvProperties).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -776,7 +776,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(mvProperties).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -812,7 +812,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         // run 1
         {
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -835,7 +835,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.addPartition("partitioned_db", "part_tbl1", "par_date=2020-01-05");
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -855,7 +855,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.addPartition("partitioned_db", "part_tbl2", "par_date=2020-01-05");
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -877,7 +877,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.dropPartition("partitioned_db", "part_tbl1", "par_date=2020-01-05");
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -892,7 +892,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.dropPartition("partitioned_db", "part_tbl2", "par_date=2020-01-05");
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -929,7 +929,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         // run 1
         {
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -951,7 +951,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.addPartition("partitioned_db", "t1_par", "par_col=4/par_date=2020-01-05");
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -974,7 +974,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.addPartition("partitioned_db", "t2_par", "par_col=4/par_date=2020-01-05");
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -999,7 +999,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.dropPartition("partitioned_db", "t2_par", "par_col=3/par_date=2020-01-05");
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -1058,7 +1058,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -1077,7 +1077,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -1098,7 +1098,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -1255,7 +1255,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         // run 1
         {
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -1272,7 +1272,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.addPartition("partitioned_db", "t1_par",
                     "par_col=4/par_date=2020-01-05");
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -1289,7 +1289,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.dropPartition("partitioned_db", "t1_par",
                     "par_col=4/par_date=2020-01-05");
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             Assertions.assertTrue(execPlan == null);
@@ -1320,7 +1320,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         // run 1
         {
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -1334,7 +1334,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.addPartition("partitioned_db", "t1_par",
                     "par_col=4/par_date=2020-01-05");
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -1350,7 +1350,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             mockedHiveMetadata.dropPartition("partitioned_db", "t1_par",
                     "par_col=4/par_date=2020-01-05");
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             Assertions.assertTrue(execPlan == null);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -28,7 +28,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.common.QueryDebugOptions;
@@ -194,7 +194,7 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -272,7 +272,7 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -455,7 +455,7 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
             Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
             TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -26,7 +26,7 @@ import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
@@ -152,7 +152,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVTestBase {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         ExecPlan execPlan = processor.getMvContext().getExecPlan();
         Assertions.assertTrue(execPlan != null);
         String plan = execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL);
@@ -232,7 +232,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVTestBase {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         ExecPlan execPlan = processor.getMvContext().getExecPlan();
         Assertions.assertTrue(execPlan != null);
         String plan = execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL);
@@ -501,7 +501,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVTestBase {
                                 // the priority for next refresh batch is 70 which is specified in executeOption
                                 Assertions.assertEquals(70, status.getPriority());
 
-                                MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                                MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                                 MvTaskRunContext mvTaskRunContext = processor.getMvContext();
                                 Assertions.assertEquals(70, mvTaskRunContext.getExecuteOption().getPriority());
                                 Map<String, String> properties = mvTaskRunContext.getProperties();
@@ -548,7 +548,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVTestBase {
                     String query = String.format("select * from %s ", tableName);
                     {
                         // all partitions are expired, no need to create partitions for mv
-                        MVPCTBasedRefreshProcessor processor = refreshMV("test", mv);
+                        MVPCTRefreshProcessor processor = refreshMV("test", mv);
                         Assertions.assertEquals(0, mv.getVisiblePartitions().size());
                         Assertions.assertTrue(processor.getNextTaskRun() == null);
                         ExecPlan execPlan = processor.getMvContext().getExecPlan();
@@ -693,7 +693,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).setExecuteOption(executeOption).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MvTaskRunContext mvTaskRunContext = processor.getMvContext();
         Assertions.assertTrue(mvTaskRunContext.getExecPlan() != null);
         ExecPlan execPlan = mvTaskRunContext.getExecPlan();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -40,11 +40,11 @@ import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.ShowMaterializedViewStatus;
 import com.starrocks.qe.StmtExecutor;
-import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.MVRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshPartitioner;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshRangePartitioner;
 import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
 import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
@@ -306,7 +306,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -603,11 +603,11 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         List<TUniqueId> retryExecutorIds = new ArrayList<>();
         int originalRetryNum = connectContext.getSessionVariable().getQueryDebugOptions().getMaxRefreshMaterializedViewRetryNum();
         connectContext.getSessionVariable().getQueryDebugOptions().setMaxRefreshMaterializedViewRetryNum(2);
-        new MockUp<MVPCTBasedRefreshProcessor>() {
+        new MockUp<MVPCTRefreshProcessor>() {
             int runNum = 0;
             @Mock
             public Constants.TaskRunState execProcessExecPlan(TaskRunContext taskRunContext,
-                                                              BaseMVRefreshProcessor.ProcessExecPlan processExecPlan,
+                                                              MVRefreshProcessor.ProcessExecPlan processExecPlan,
                                                               MVRefreshExecutor executor) throws Exception {
                 if (runNum < 1) {
                     runNum++;
@@ -637,7 +637,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
     public void testBaseTablePartitionRename(TaskRun taskRun, MaterializedView mv) throws Exception {
         // mv need refresh with base table partition p1, p1 renamed with p10 after collect and before insert overwrite
-        new MockUp<BaseMVRefreshProcessor>() {
+        new MockUp<MVRefreshProcessor>() {
             @Mock
             public Map<Long, PCTTableSnapshotInfo> collectBaseTableSnapshotInfos() {
                 Map<Long, PCTTableSnapshotInfo> olapTables = Maps.newHashMap();
@@ -693,7 +693,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         // mv need refresh with base table partition p2, p2 replace with tp2 after collect and before insert overwrite
         OlapTable tbl1 =
                 ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), "tbl1"));
-        new MockUp<MVPCTBasedRefreshProcessor>() {
+        new MockUp<MVPCTRefreshProcessor>() {
             @Mock
             public Map<Long, BaseTableSnapshotInfo> collectBaseTableSnapshotInfos()
                     throws LockTimeoutException {
@@ -760,7 +760,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         // mv need refresh with base table partition p3, add partition p99 after collect and before insert overwrite
         OlapTable tbl1 =
                 ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), "tbl1"));
-        new MockUp<BaseMVRefreshProcessor>() {
+        new MockUp<MVRefreshProcessor>() {
             @Mock
             public Map<Long, PCTTableSnapshotInfo> collectBaseTableSnapshotInfos() {
                 Map<Long, PCTTableSnapshotInfo> olapTables = Maps.newHashMap();
@@ -868,7 +868,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         // mv need refresh with base table partition p4, drop partition p4 after collect and before insert overwrite
         OlapTable tbl1 =
                 ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(), "tbl1"));
-        new MockUp<BaseMVRefreshProcessor>() {
+        new MockUp<MVRefreshProcessor>() {
             @Mock
             public Map<Long, PCTTableSnapshotInfo> collectBaseTableSnapshotInfos() {
                 Map<Long, PCTTableSnapshotInfo> olapTables = Maps.newHashMap();
@@ -954,7 +954,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         Assertions.assertEquals(3, baseTableVisibleVersionMap.get(tbl1.getId()).get("p100").getVersion());
     }
 
-    private MVPCTBasedRefreshProcessor createProcessor(TaskRun taskRun, MaterializedView mv) throws Exception {
+    private MVPCTRefreshProcessor createProcessor(TaskRun taskRun, MaterializedView mv) throws Exception {
         TaskRunContext context = new TaskRunContext();
         context.setTaskRun(taskRun);
         context.setCtx(connectContext);
@@ -967,7 +967,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         MVTaskRunProcessor mvTaskRunProcessor = new MVTaskRunProcessor();
         mvTaskRunProcessor.prepare(mvContext);
 
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         return processor;
     }
 
@@ -1010,7 +1010,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
 
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
         PCellSortedSet mvToRefreshPartitionNames = getMVPCellWithNames(mv, mv.getPartitionNames());
         partitioner.filterPartitionByRefreshNumber(mvToRefreshPartitionNames,
@@ -1042,7 +1042,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
 
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
         partitioner.filterPartitionByRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()),
                 MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
@@ -1063,7 +1063,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
 
-        MVPCTBasedRefreshProcessor processor = createProcessor(taskRun, mv);
+        MVPCTRefreshProcessor processor = createProcessor(taskRun, mv);
         processor.getMvContext().setPartitionTopology(null);
         new MockUp<MVPCTRefreshRangePartitioner>() {
             @Mock
@@ -1072,7 +1072,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             }
         };
 
-        Method syncPartitions = BaseMVRefreshProcessor.class.getDeclaredMethod("syncPartitions");
+        Method syncPartitions = MVRefreshProcessor.class.getDeclaredMethod("syncPartitions");
         syncPartitions.setAccessible(true);
         InvocationTargetException exception = Assertions.assertThrows(InvocationTargetException.class,
                 () -> syncPartitions.invoke(processor));
@@ -1114,7 +1114,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
 
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
         partitioner.filterPartitionByRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()),
                 MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
@@ -1166,7 +1166,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         mv.getTableProperty().getProperties().put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER, "1");
         mv.getTableProperty().setPartitionRefreshNumber(1);
 
-        MVPCTBasedRefreshProcessor processor = createProcessor(taskRun, mv);
+        MVPCTRefreshProcessor processor = createProcessor(taskRun, mv);
         MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
         Set<String> allPartitions = new HashSet<>(mv.getPartitionNames());
 
@@ -1266,7 +1266,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         // by default, enable spill
         {
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             Assertions.assertTrue(execPlan.getConnectContext().getSessionVariable().isEnableSpill());
@@ -1280,7 +1280,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             // insert again.
             executeInsertSql(connectContext, insertSql);
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             MVTaskRunExtraMessage extraMessage = processor.getMVTaskRunExtraMessage();
@@ -1314,7 +1314,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
-        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
         Assertions.assertFalse(execPlan.getConnectContext().getSessionVariable().isEnableSpill());
@@ -1389,7 +1389,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         {
             // just refresh to avoid dirty data
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -1402,7 +1402,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -1415,7 +1415,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         {
             // just refresh to avoid dirty data
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
@@ -1459,7 +1459,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -1476,7 +1476,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -1522,7 +1522,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -1539,7 +1539,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -1585,7 +1585,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -1603,7 +1603,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             executeInsertSql(connectContext, insertSql);
 
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -1736,7 +1736,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                     {
                         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                         taskRun.executeTaskRun();
-                        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         MvTaskRunContext mvContext =
                                 processor.getMvContext();
                         Assertions.assertTrue(mvContext.hasNextBatchPartition());
@@ -1762,7 +1762,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                     {
                         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                         taskRun.executeTaskRun();
-                        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         MvTaskRunContext mvContext = processor.getMvContext();
                         Assertions.assertTrue(!mvContext.hasNextBatchPartition());
                         logSysInfo(processor.getMVTaskRunExtraMessage());
@@ -1851,7 +1851,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                     taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                                     taskRun.executeTaskRun();
 
-                                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                                     MvTaskRunContext mvContext = processor.getMvContext();
                                     Assertions.assertTrue(isEnd ? !mvContext.hasNextBatchPartition()
                                             : mvContext.hasNextBatchPartition());
@@ -1931,7 +1931,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                     {
                         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                         taskRun.executeTaskRun();
-                        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         MvTaskRunContext mvContext = processor.getMvContext();
                         Assertions.assertTrue(mvContext.hasNextBatchPartition());
                         logSysInfo(processor.getMVTaskRunExtraMessage());
@@ -1956,7 +1956,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                     {
                         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                         taskRun.executeTaskRun();
-                        MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                        MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                         MvTaskRunContext mvContext = processor.getMvContext();
                         Assertions.assertTrue(!mvContext.hasNextBatchPartition());
                         logSysInfo(processor.getMVTaskRunExtraMessage());
@@ -2036,7 +2036,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
                                     taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                                     taskRun.executeTaskRun();
-                                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                                     Map<Long, BaseTableSnapshotInfo> snapshotInfoMap = processor.getSnapshotBaseTables();
                                     Assertions.assertEquals(1, snapshotInfoMap.size());
                                     PCTTableSnapshotInfo tableSnapshotInfo =
@@ -2067,7 +2067,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
                                     taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                                     taskRun.executeTaskRun();
-                                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                                     Map<Long, BaseTableSnapshotInfo> snapshotInfoMap = processor.getSnapshotBaseTables();
                                     Assertions.assertEquals(1, snapshotInfoMap.size());
                                     PCTTableSnapshotInfo tableSnapshotInfo =
@@ -2137,7 +2137,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
                                     taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                                     taskRun.executeTaskRun();
-                                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                                     Map<Long, BaseTableSnapshotInfo> snapshotInfoMap = processor.getSnapshotBaseTables();
                                     Assertions.assertEquals(1, snapshotInfoMap.size());
                                     PCTTableSnapshotInfo tableSnapshotInfo =
@@ -2166,7 +2166,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
                                     taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                                     taskRun.executeTaskRun();
-                                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                                     Map<Long, BaseTableSnapshotInfo> snapshotInfoMap = processor.getSnapshotBaseTables();
                                     Assertions.assertEquals(1, snapshotInfoMap.size());
                                     PCTTableSnapshotInfo tableSnapshotInfo =
@@ -2535,7 +2535,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
                                     taskRunStatus.setProcessStartTime(System.currentTimeMillis());
 
-                                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                                     MvTaskRunContext mvContext = processor.getMvContext();
                                     Assertions.assertTrue(mvContext.hasNextBatchPartition());
                                     Assertions.assertEquals(Sets.newHashSet("p2"),
@@ -2573,7 +2573,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                     taskRun.executeTaskRun();
                                     taskRunStatus.setState(Constants.TaskRunState.SUCCESS);
 
-                                    MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                                    MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                                     MvTaskRunContext mvContext = processor.getMvContext();
                                     Assertions.assertTrue(!mvContext.hasNextBatchPartition());
                                     Assertions.assertEquals(Sets.newHashSet("p1"),
@@ -2674,7 +2674,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
                                 taskRunStatus.setProcessStartTime(System.currentTimeMillis());
 
-                                MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                                MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                                 MvTaskRunContext mvContext = processor.getMvContext();
                                 Assertions.assertTrue(mvContext.hasNextBatchPartition());
                                 Assertions.assertEquals(Sets.newHashSet("p1"),
@@ -2853,7 +2853,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 taskRun.executeTaskRun();
                                 FeConstants.runningUnitTest = true;
 
-                                MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                                MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                                 final MvTaskRunContext mvTaskRunContext = processor.getMvContext();
                                 final String postRun = mvTaskRunContext.getPostRun();
                                 Assertions.assertTrue(Strings.isNullOrEmpty(postRun));
@@ -2897,8 +2897,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                     MvTaskRunContext mvTaskRunContext = new MvTaskRunContext(taskRunContext);
                     MVTaskRunProcessor mvTaskRunProcessor = new MVTaskRunProcessor();
                     mvTaskRunProcessor.prepare(taskRunContext);
-                    MVPCTBasedRefreshProcessor processor =
-                            (MVPCTBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+                    MVPCTRefreshProcessor processor =
+                            (MVPCTRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
 
                     Set<String> result = processor.getPCTMVToRefreshedPartitions(false).getPartitionNames();
                     Assertions.assertTrue(result.isEmpty());
@@ -2940,8 +2940,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
                     MVTaskRunProcessor processor = new MVTaskRunProcessor();
                     processor.prepare(taskRunContext);
-                    MVPCTBasedRefreshProcessor mvRefreshProcessor =
-                            (MVPCTBasedRefreshProcessor) processor.getMVRefreshProcessor();
+                    MVPCTRefreshProcessor mvRefreshProcessor =
+                            (MVPCTRefreshProcessor) processor.getMVRefreshProcessor();
                     MvTaskRunContext mvTaskRunContext = new MvTaskRunContext(taskRunContext);
                     Set<String> result = mvRefreshProcessor.getPCTMVToRefreshedPartitions(false).getPartitionNames();
                     Assertions.assertFalse(result.isEmpty());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.util.UUIDUtil;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.DateLiteral;
 import com.starrocks.sql.common.DmlException;
@@ -156,7 +156,7 @@ public class PartitionBasedMvRefreshTest extends MVTestBase {
                             logSysInfo("start to execute task run:" + i);
                             Assertions.assertTrue(taskRun != null);
                             initAndExecuteTaskRun(taskRun);
-                            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                             MvTaskRunContext mvContext = processor.getMvContext();
                             ExecPlan execPlan = mvContext.getExecPlan();
                             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -231,7 +231,7 @@ public class PartitionBasedMvRefreshTest extends MVTestBase {
                             logSysInfo("start to execute task run:" + i);
                             Assertions.assertTrue(taskRun != null);
                             initAndExecuteTaskRun(taskRun);
-                            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                             MvTaskRunContext mvContext = processor.getMvContext();
                             ExecPlan execPlan = mvContext.getExecPlan();
                             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
@@ -283,7 +283,7 @@ public class PartitionBasedMvRefreshTest extends MVTestBase {
                                 String partitionEnd = executeOption.getTaskRunProperties().get(TaskRun.PARTITION_END);
                                 initAndExecuteTaskRun(taskRun, partitionStart, partitionEnd);
                             }
-                            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+                            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                             MvTaskRunContext mvContext = processor.getMvContext();
                             ExecPlan execPlan = mvContext.getExecPlan();
                             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -29,9 +29,9 @@ import com.starrocks.load.loadv2.IVMInsertLoadTxnCallback;
 import com.starrocks.scheduler.MVTaskRunProcessor;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
-import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
-import com.starrocks.scheduler.mv.hybrid.MVHybridBasedRefreshProcessor;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.MVRefreshProcessor;
+import com.starrocks.scheduler.mv.hybrid.MVHybridRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.ExecPlan;
@@ -471,10 +471,10 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         {
             advanceTableVersionTo(2);
             MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
-            Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-            MVHybridBasedRefreshProcessor hybridBasedRefreshProcessor =
-                    (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
-            Assertions.assertTrue(hybridBasedRefreshProcessor.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+            Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+            MVHybridRefreshProcessor hybridBasedRefreshProcessor =
+                    (MVHybridRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+            Assertions.assertTrue(hybridBasedRefreshProcessor.getCurrentProcessor() instanceof MVPCTRefreshProcessor);
         }
         // Once a checkpoint exists, append-only changes can switch AUTO back to IVM.
         {
@@ -486,10 +486,10 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                             TvrDeltaStats.EMPTY)
             ));
             MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(refreshedMv);
-            Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-            MVHybridBasedRefreshProcessor hybridBasedRefreshProcessor =
-                    (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
-            Assertions.assertTrue(hybridBasedRefreshProcessor.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor);
+            Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+            MVHybridRefreshProcessor hybridBasedRefreshProcessor =
+                    (MVHybridRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+            Assertions.assertTrue(hybridBasedRefreshProcessor.getCurrentProcessor() instanceof MVIVMRefreshProcessor);
         }
     }
 
@@ -502,10 +502,10 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         advanceTableVersionTo(2);
 
         MVTaskRunProcessor run1 = getMVTaskRunProcessor(mv);
-        Assertions.assertTrue(run1.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-        MVHybridBasedRefreshProcessor hybrid1 =
-                (MVHybridBasedRefreshProcessor) run1.getMVRefreshProcessor();
-        Assertions.assertTrue(hybrid1.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+        Assertions.assertTrue(run1.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+        MVHybridRefreshProcessor hybrid1 =
+                (MVHybridRefreshProcessor) run1.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid1.getCurrentProcessor() instanceof MVPCTRefreshProcessor);
 
         MaterializedView refreshedMv = getMv("test_mv1");
         TvrVersionRange checkpoint = refreshedMv.getRefreshScheme()
@@ -525,10 +525,10 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         ));
 
         MVTaskRunProcessor run2 = getMVTaskRunProcessor(refreshedMv);
-        Assertions.assertTrue(run2.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-        MVHybridBasedRefreshProcessor hybrid2 =
-                (MVHybridBasedRefreshProcessor) run2.getMVRefreshProcessor();
-        Assertions.assertTrue(hybrid2.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor);
+        Assertions.assertTrue(run2.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+        MVHybridRefreshProcessor hybrid2 =
+                (MVHybridRefreshProcessor) run2.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid2.getCurrentProcessor() instanceof MVIVMRefreshProcessor);
     }
 
     @Test
@@ -539,20 +539,20 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
 
         advanceTableVersionTo(2);
         MVTaskRunProcessor run1 = getMVTaskRunProcessor(mv);
-        Assertions.assertTrue(run1.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-        MVHybridBasedRefreshProcessor hybrid1 =
-                (MVHybridBasedRefreshProcessor) run1.getMVRefreshProcessor();
-        Assertions.assertTrue(hybrid1.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+        Assertions.assertTrue(run1.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+        MVHybridRefreshProcessor hybrid1 =
+                (MVHybridRefreshProcessor) run1.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid1.getCurrentProcessor() instanceof MVPCTRefreshProcessor);
 
         MaterializedView refreshedMv = getMv("test_mv1");
         advanceTableVersionTo(3);
         mockListTableDeltaTraitsThrows("Starting snapshot (exclusive) 2 is not a parent ancestor of end snapshot 3");
 
         MVTaskRunProcessor run2 = getMVTaskRunProcessor(refreshedMv);
-        Assertions.assertTrue(run2.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-        MVHybridBasedRefreshProcessor hybrid2 =
-                (MVHybridBasedRefreshProcessor) run2.getMVRefreshProcessor();
-        Assertions.assertTrue(hybrid2.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+        Assertions.assertTrue(run2.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+        MVHybridRefreshProcessor hybrid2 =
+                (MVHybridRefreshProcessor) run2.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid2.getCurrentProcessor() instanceof MVPCTRefreshProcessor);
     }
 
     @Test
@@ -565,13 +565,13 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         {
             advanceTableVersionTo(2);
             MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
-            Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVPCTBasedRefreshProcessor);
+            Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVPCTRefreshProcessor);
         }
         // if the base table has retractable changes, the refresh processor should be full refresh
         {
             mockListTableDeltaTraits();
             MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
-            Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVPCTBasedRefreshProcessor);
+            Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVPCTRefreshProcessor);
         }
     }
 
@@ -596,15 +596,15 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
 
         // Run 1: IVM fails (retractable changes) → fallback to PCT
         MVTaskRunProcessor run1 = getMVTaskRunProcessor(mv);
-        Assertions.assertTrue(run1.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-        MVHybridBasedRefreshProcessor hybrid1 =
-                (MVHybridBasedRefreshProcessor) run1.getMVRefreshProcessor();
+        Assertions.assertTrue(run1.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+        MVHybridRefreshProcessor hybrid1 =
+                (MVHybridRefreshProcessor) run1.getMVRefreshProcessor();
         // Verify fallback to PCT
-        Assertions.assertTrue(hybrid1.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+        Assertions.assertTrue(hybrid1.getCurrentProcessor() instanceof MVPCTRefreshProcessor);
 
         // Verify canGenerateNextTaskRun is NOT blocked (the core fix)
-        MVPCTBasedRefreshProcessor pctProcessor =
-                (MVPCTBasedRefreshProcessor) hybrid1.getCurrentProcessor();
+        MVPCTRefreshProcessor pctProcessor =
+                (MVPCTRefreshProcessor) hybrid1.getCurrentProcessor();
         Assertions.assertTrue(pctProcessor.getMvRefreshParams().isCanGenerateNextTaskRun(),
                 "IVM→PCT fallback should allow multi-batch splitting (canGenerateNextTaskRun=true)");
 
@@ -628,11 +628,11 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         ));
 
         MVTaskRunProcessor run2 = getMVTaskRunProcessor(refreshedMv);
-        Assertions.assertTrue(run2.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-        MVHybridBasedRefreshProcessor hybrid2 =
-                (MVHybridBasedRefreshProcessor) run2.getMVRefreshProcessor();
+        Assertions.assertTrue(run2.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+        MVHybridRefreshProcessor hybrid2 =
+                (MVHybridRefreshProcessor) run2.getMVRefreshProcessor();
         // Should switch back to IVM since delta[2,3] is append-only
-        Assertions.assertTrue(hybrid2.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor,
+        Assertions.assertTrue(hybrid2.getCurrentProcessor() instanceof MVIVMRefreshProcessor,
                 "After PCT fallback persists checkpoint, next IVM refresh should recover");
     }
 
@@ -659,15 +659,15 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         // First task_run: IVM fails (retractable changes) → fallback to PCT, batch 1
         TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
         MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
-        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-        MVHybridBasedRefreshProcessor hybrid =
-                (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+        MVHybridRefreshProcessor hybrid =
+                (MVHybridRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
         // Verify fallback to PCT
-        Assertions.assertTrue(hybrid.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+        Assertions.assertTrue(hybrid.getCurrentProcessor() instanceof MVPCTRefreshProcessor);
 
         // Verify canGenerateNextTaskRun is allowed
-        MVPCTBasedRefreshProcessor pctProcessor =
-                (MVPCTBasedRefreshProcessor) hybrid.getCurrentProcessor();
+        MVPCTRefreshProcessor pctProcessor =
+                (MVPCTRefreshProcessor) hybrid.getCurrentProcessor();
         Assertions.assertTrue(pctProcessor.getMvRefreshParams().isCanGenerateNextTaskRun(),
                 "IVM→PCT fallback should allow multi-batch splitting");
 
@@ -703,13 +703,13 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
             while (nextTaskRun != null) {
                 initAndExecuteTaskRun(nextTaskRun);
                 MVTaskRunProcessor nextProcessor = getMVTaskRunProcessor(nextTaskRun);
-                BaseMVRefreshProcessor refreshProcessor = nextProcessor.getMVRefreshProcessor();
-                if (refreshProcessor instanceof MVHybridBasedRefreshProcessor) {
-                    MVHybridBasedRefreshProcessor nextHybrid =
-                            (MVHybridBasedRefreshProcessor) refreshProcessor;
+                MVRefreshProcessor refreshProcessor = nextProcessor.getMVRefreshProcessor();
+                if (refreshProcessor instanceof MVHybridRefreshProcessor) {
+                    MVHybridRefreshProcessor nextHybrid =
+                            (MVHybridRefreshProcessor) refreshProcessor;
                     nextTaskRun = nextHybrid.getCurrentProcessor().getNextTaskRun();
-                } else if (refreshProcessor instanceof MVPCTBasedRefreshProcessor) {
-                    nextTaskRun = ((MVPCTBasedRefreshProcessor) refreshProcessor).getNextTaskRun();
+                } else if (refreshProcessor instanceof MVPCTRefreshProcessor) {
+                    nextTaskRun = ((MVPCTRefreshProcessor) refreshProcessor).getNextTaskRun();
                 } else {
                     nextTaskRun = null;
                 }
@@ -751,9 +751,9 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
 
         // Run: IVM fails → fallback to PCT (single batch, unpartitioned MV)
         MVTaskRunProcessor run1 = getMVTaskRunProcessor(mv);
-        MVHybridBasedRefreshProcessor hybrid =
-                (MVHybridBasedRefreshProcessor) run1.getMVRefreshProcessor();
-        Assertions.assertTrue(hybrid.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+        MVHybridRefreshProcessor hybrid =
+                (MVHybridRefreshProcessor) run1.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid.getCurrentProcessor() instanceof MVPCTRefreshProcessor);
 
         // After single-batch completes: TVR promoted, owner cleared
         MaterializedView refreshedMv = getMv("test_mv1");
@@ -791,7 +791,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
 
         advanceTableVersionTo(2);
         MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
-        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVIVMBasedRefreshProcessor);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVIVMRefreshProcessor);
 
         MvTaskRunContext mvContext = mvTaskRunProcessor.getMvTaskRunContext();
         MVTaskRunExtraMessage extraMessage = mvContext.getStatus().getMvTaskRunExtraMessage();
@@ -812,22 +812,22 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
         TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
         MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
-        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-        MVHybridBasedRefreshProcessor hybridProcessor =
-                (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
-        Assertions.assertTrue(hybridProcessor.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+        MVHybridRefreshProcessor hybridProcessor =
+                (MVHybridRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        Assertions.assertTrue(hybridProcessor.getCurrentProcessor() instanceof MVPCTRefreshProcessor);
 
         TaskRun nextTaskRun = hybridProcessor.getCurrentProcessor().getNextTaskRun();
         while (nextTaskRun != null) {
             initAndExecuteTaskRun(nextTaskRun);
             MVTaskRunProcessor nextProcessor = getMVTaskRunProcessor(nextTaskRun);
-            BaseMVRefreshProcessor refreshProcessor = nextProcessor.getMVRefreshProcessor();
-            if (refreshProcessor instanceof MVHybridBasedRefreshProcessor) {
-                MVHybridBasedRefreshProcessor nextHybrid =
-                        (MVHybridBasedRefreshProcessor) refreshProcessor;
+            MVRefreshProcessor refreshProcessor = nextProcessor.getMVRefreshProcessor();
+            if (refreshProcessor instanceof MVHybridRefreshProcessor) {
+                MVHybridRefreshProcessor nextHybrid =
+                        (MVHybridRefreshProcessor) refreshProcessor;
                 nextTaskRun = nextHybrid.getCurrentProcessor().getNextTaskRun();
-            } else if (refreshProcessor instanceof MVPCTBasedRefreshProcessor) {
-                nextTaskRun = ((MVPCTBasedRefreshProcessor) refreshProcessor).getNextTaskRun();
+            } else if (refreshProcessor instanceof MVPCTRefreshProcessor) {
+                nextTaskRun = ((MVPCTRefreshProcessor) refreshProcessor).getNextTaskRun();
             } else {
                 nextTaskRun = null;
             }
@@ -849,9 +849,9 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(refreshedMv.getDbId());
         taskRun = withMVRefreshTaskRun(db.getFullName(), refreshedMv);
         mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
-        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-        hybridProcessor = (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
-        Assertions.assertTrue(hybridProcessor.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
+        hybridProcessor = (MVHybridRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        Assertions.assertTrue(hybridProcessor.getCurrentProcessor() instanceof MVIVMRefreshProcessor);
 
         MvTaskRunContext mvContext = mvTaskRunProcessor.getMvTaskRunContext();
         MVTaskRunExtraMessage extraMessage = mvContext.getStatus().getMvTaskRunExtraMessage();
@@ -928,7 +928,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
         TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
         MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
-        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
 
         // First batch completed — inspect the runtime pinnedTvrMap hydrated by
         // setupPinnedContextIfNeeded after the afterSyncHook installed the owner.
@@ -961,11 +961,11 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
         TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
         MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
-        MVHybridBasedRefreshProcessor hybrid =
-                (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
-        Assertions.assertTrue(hybrid.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
-        MVPCTBasedRefreshProcessor pctProcessor =
-                (MVPCTBasedRefreshProcessor) hybrid.getCurrentProcessor();
+        MVHybridRefreshProcessor hybrid =
+                (MVHybridRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid.getCurrentProcessor() instanceof MVPCTRefreshProcessor);
+        MVPCTRefreshProcessor pctProcessor =
+                (MVPCTRefreshProcessor) hybrid.getCurrentProcessor();
 
         // First batch should have generated a next batch (partition_refresh_number=1 on 4 partitions).
         TaskRun nextTaskRun = pctProcessor.getNextTaskRun();
@@ -1015,10 +1015,10 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         // Job A: first batch installs owner=A_jobId and creates nextTaskRun for batch 2.
         TaskRun jobARun1 = withMVRefreshTaskRun(db.getFullName(), mv);
         MVTaskRunProcessor jobARun1Processor = getMVTaskRunProcessor(jobARun1);
-        MVHybridBasedRefreshProcessor jobAHybrid =
-                (MVHybridBasedRefreshProcessor) jobARun1Processor.getMVRefreshProcessor();
-        MVPCTBasedRefreshProcessor jobAPct =
-                (MVPCTBasedRefreshProcessor) jobAHybrid.getCurrentProcessor();
+        MVHybridRefreshProcessor jobAHybrid =
+                (MVHybridRefreshProcessor) jobARun1Processor.getMVRefreshProcessor();
+        MVPCTRefreshProcessor jobAPct =
+                (MVPCTRefreshProcessor) jobAHybrid.getCurrentProcessor();
         TaskRun jobABatch2 = jobAPct.getNextTaskRun();
         Assertions.assertNotNull(jobABatch2, "Job A should generate a batch 2");
         String jobAId = jobARun1Processor.getMvTaskRunContext().getStatus().getStartTaskRunId();
@@ -1079,10 +1079,10 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         // Batch 1: IVM fails -> Hybrid fallback to PCT -> afterSyncHook freezes at S2.
         TaskRun batch1 = withMVRefreshTaskRun(db.getFullName(), mv);
         MVTaskRunProcessor batch1Proc = getMVTaskRunProcessor(batch1);
-        MVHybridBasedRefreshProcessor hybrid =
-                (MVHybridBasedRefreshProcessor) batch1Proc.getMVRefreshProcessor();
-        MVPCTBasedRefreshProcessor pctProc =
-                (MVPCTBasedRefreshProcessor) hybrid.getCurrentProcessor();
+        MVHybridRefreshProcessor hybrid =
+                (MVHybridRefreshProcessor) batch1Proc.getMVRefreshProcessor();
+        MVPCTRefreshProcessor pctProc =
+                (MVPCTRefreshProcessor) hybrid.getCurrentProcessor();
         TaskRun batch2 = pctProc.getNextTaskRun();
         Assertions.assertNotNull(batch2, "Multi-batch fallback should generate batch 2");
 
@@ -1134,10 +1134,10 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         // refresh_mode=pct routes through MVPCTBasedRefreshProcessor directly, not Hybrid.
         // Therefore no afterSyncHook is installed, no owner is written, and isPinnedMode()
         // returns false on every batch of this job.
-        Assertions.assertTrue(batch1Proc.getMVRefreshProcessor() instanceof MVPCTBasedRefreshProcessor,
+        Assertions.assertTrue(batch1Proc.getMVRefreshProcessor() instanceof MVPCTRefreshProcessor,
                 "refresh_mode=pct must use MVPCTBasedRefreshProcessor directly (not Hybrid)");
-        MVPCTBasedRefreshProcessor pctProc =
-                (MVPCTBasedRefreshProcessor) batch1Proc.getMVRefreshProcessor();
+        MVPCTRefreshProcessor pctProc =
+                (MVPCTRefreshProcessor) batch1Proc.getMVRefreshProcessor();
 
         TaskRun batch2 = pctProc.getNextTaskRun();
         Assertions.assertNotNull(batch2,
@@ -1188,8 +1188,8 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
         TaskRun batch1 = withMVRefreshTaskRun(db.getFullName(), mv);
         MVTaskRunProcessor batch1Proc = getMVTaskRunProcessor(batch1);
-        MVPCTBasedRefreshProcessor pctProc =
-                (MVPCTBasedRefreshProcessor) batch1Proc.getMVRefreshProcessor();
+        MVPCTRefreshProcessor pctProc =
+                (MVPCTRefreshProcessor) batch1Proc.getMVRefreshProcessor();
         TaskRun batch2 = pctProc.getNextTaskRun();
         Assertions.assertNotNull(batch2, "Pure PCT multi-batch must generate a next batch");
         // Pure PCT never carries PINNED_REFRESH_JOB_ID, which is exactly what signals the
@@ -1266,7 +1266,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
         TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
         MVTaskRunProcessor processor = getMVTaskRunProcessor(taskRun);
-        Assertions.assertTrue(processor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        Assertions.assertTrue(processor.getMVRefreshProcessor() instanceof MVHybridRefreshProcessor);
 
         // After fallback batch 1, setupPinnedRangesIfNeeded should have written the snapshot id
         // into the task run's MVTaskRunExtraMessage. Pure PCT / non-pinned runs leave it empty.

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -52,7 +52,7 @@ import com.starrocks.scheduler.TaskRunBuilder;
 import com.starrocks.scheduler.TaskRunManager;
 import com.starrocks.scheduler.TaskRunProcessor;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
-import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -421,7 +421,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
         return getMVTaskRunProcessor(taskRun);
     }
 
-    protected MVPCTBasedRefreshProcessor refreshMV(String dbName, MaterializedView mv) throws Exception {
+    protected MVPCTRefreshProcessor refreshMV(String dbName, MaterializedView mv) throws Exception {
         TaskRun taskRun = withMVRefreshTaskRun(dbName, mv);
         return getPartitionBasedRefreshProcessor(taskRun);
     }
@@ -448,7 +448,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
                 QueryMaterializationContext.QueryCacheStats.class);
     }
 
-    protected Map<Table, Set<String>> getRefTableRefreshedPartitions(MVPCTBasedRefreshProcessor processor) {
+    protected Map<Table, Set<String>> getRefTableRefreshedPartitions(MVPCTRefreshProcessor processor) {
         PCellSortedSet set = PCellSortedSet.of(Set.of(PCellWithName.of("p20220101", new PCellNone())));
         Map<BaseTableSnapshotInfo, PCellSortedSet> baseTables = processor.getPCTRefTableRefreshPartitions(set);
         Assertions.assertEquals(2, baseTables.size());
@@ -673,7 +673,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
             Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
             TaskRun taskRun = TaskRunBuilder.newBuilder(task).setExecuteOption(executeOption).build();
             initAndExecuteTaskRun(taskRun);
-            MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
+            MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvTaskRunContext = processor.getMvContext();
             ExecPlan execPlan = mvTaskRunContext.getExecPlan();
             Assertions.assertTrue(execPlan != null);
@@ -688,10 +688,10 @@ public abstract class MVTestBase extends StarRocksTestBase {
         return (MVTaskRunProcessor) taskRun.getProcessor();
     }
 
-    public static MVPCTBasedRefreshProcessor getPartitionBasedRefreshProcessor(TaskRun taskRun) {
+    public static MVPCTRefreshProcessor getPartitionBasedRefreshProcessor(TaskRun taskRun) {
         Assertions.assertTrue(taskRun.getProcessor() instanceof MVTaskRunProcessor);
         MVTaskRunProcessor mvTaskRunProcessor = (MVTaskRunProcessor) taskRun.getProcessor();
-        return (MVPCTBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        return (MVPCTRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
     }
 
     protected void withMVQuery(String mvQuery,


### PR DESCRIPTION
## Why I'm doing:

The `Base` prefix on `BaseMVRefreshProcessor`, `MVHybridBasedRefreshProcessor`, `MVIVMBasedRefreshProcessor`, and `MVPCTBasedRefreshProcessor` carries no semantic meaning. None of these are actually "base" classes in the conventional sense — the shared abstract superclass is the only real base and it keeps serving that role unchanged. The prefix was just noise that made the names longer without communicating anything about the class's role.

## What I'm doing:

Pure rename refactor — no logic changes:

| Before | After |
|---|---|
| `BaseMVRefreshProcessor` | `MVRefreshProcessor` |
| `MVHybridBasedRefreshProcessor` | `MVHybridRefreshProcessor` |
| `MVIVMBasedRefreshProcessor` | `MVIVMRefreshProcessor` |
| `MVPCTBasedRefreshProcessor` | `MVPCTRefreshProcessor` |

All call sites, imports, factory references, and test classes updated to use the new names.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4