### PR TITLE
[Enhancement] Batch tablet-location lookup in OlapTableSink.createLocation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -877,6 +877,20 @@ public class OlapTableSink extends DataSink {
         }
     }
 
+    // Pick the first alive node id from a pre-fetched candidate list.
+    // Returns -1 when the list is null/empty or no candidate is alive; callers fall back to a per-tablet lookup.
+    private static long pickAliveComputeNodeId(List<Long> candidates, SystemInfoService infoService) {
+        if (candidates == null || candidates.isEmpty()) {
+            return -1L;
+        }
+        for (Long id : candidates) {
+            if (id != null && (infoService.checkBackendAlive(id) || infoService.checkComputeNodeAlive(id))) {
+                return id;
+            }
+        }
+        return -1L;
+    }
+
     public static TOlapTableLocationParam createLocation(OlapTable table, TOlapTablePartitionParam partitionParam,
                                                          boolean enableReplicatedStorage,
                                                          TransactionState txnState) throws StarRocksException {
@@ -896,6 +910,32 @@ public class OlapTableSink extends DataSink {
             return locationParam;
         }
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        // Batch retrieve all tablets' location info in shared-data mode so we make one StarOS RPC per statement
+        // instead of N (one per tablet) while holding db-IS + table-READ in the planner critical section.
+        // Matches the pattern in OlapScanNode.getScanRangeLocations / MetaScanNode.computeRangeLocations.
+        Map<Long, List<Long>> prefetchedTabletLocations = Collections.emptyMap();
+        if (table.isCloudNativeTableOrMaterializedView()) {
+            List<Long> allTabletIds = new ArrayList<>();
+            for (TOlapTablePartition tPhysicalPartition : partitionParam.getPartitions()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(tPhysicalPartition.getId());
+                List<MaterializedIndex> indexes = (txnState != null)
+                        ? txnState.getPartitionLoadedIndexes(table.getId(), physicalPartition)
+                        : physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL);
+                for (MaterializedIndex index : indexes) {
+                    for (Tablet tablet : index.getTablets()) {
+                        allTabletIds.add(tablet.getId());
+                    }
+                }
+            }
+            if (!allTabletIds.isEmpty()) {
+                // partial results are ok and can be handled by the per-tablet fallback below.
+                Map<Long, List<Long>> locations =
+                        warehouseManager.getAllComputeNodeIdsAssignToTablets(computeResource, allTabletIds);
+                if (locations != null) {
+                    prefetchedTabletLocations = locations;
+                }
+            }
+        }
         for (TOlapTablePartition tPhysicalPartition : partitionParam.getPartitions()) {
             PhysicalPartition physicalPartition = table.getPhysicalPartition(tPhysicalPartition.getId());
             int quorum = table.getPartitionInfo().getQuorumNum(physicalPartition.getParentId(), table.writeQuorum());
@@ -910,8 +950,14 @@ public class OlapTableSink extends DataSink {
                 for (int idx = 0; idx < index.getTablets().size(); ++idx) {
                     Tablet tablet = index.getTablets().get(idx);
                     if (table.isCloudNativeTableOrMaterializedView()) {
-                        long computeNodeId =
-                                warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId()).getId();
+                        long computeNodeId = pickAliveComputeNodeId(
+                                prefetchedTabletLocations.get(tablet.getId()), infoService);
+                        if (computeNodeId == -1L) {
+                            // Batch missed this tablet or had no alive candidate. Fall back to the per-tablet
+                            // lookup, which preserves the ERR_NO_NODES_IN_WAREHOUSE semantics on failure.
+                            computeNodeId = warehouseManager
+                                    .getComputeNodeAssignedToTablet(computeResource, tablet.getId()).getId();
+                        }
                         locationParam.addToTablets(new TTabletLocation(tablet.getId(), Lists.newArrayList(computeNodeId)));
                     } else {
                         // we should ensure the replica backend is alive

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ScanNodeComputeScanRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ScanNodeComputeScanRangeTest.java
@@ -29,6 +29,8 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TOlapTablePartition;
+import com.starrocks.thrift.TOlapTablePartitionParam;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -122,6 +124,40 @@ public class ScanNodeComputeScanRangeTest {
         ComputeResource computeResource =
                 GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource();
         Assertions.assertDoesNotThrow(() -> metaScanNode.computeRangeLocations(computeResource));
+        Assertions.assertEquals(1, invokeCounter.get());
+    }
+
+    @Test
+    public void testOlapTableSinkCreateLocationBatchesStarClientCalls() {
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", "t1");
+        Assertions.assertNotNull(table);
+        Assertions.assertInstanceOf(OlapTable.class, table);
+        OlapTable olapTable = (OlapTable) table;
+        Assertions.assertEquals(1L, olapTable.getAllPartitionIds().size());
+        long partitionId = olapTable.getAllPartitionIds().get(0);
+        Partition partition = olapTable.getPartition(partitionId);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+
+        TOlapTablePartitionParam partitionParam = new TOlapTablePartitionParam();
+        TOlapTablePartition tPartition = new TOlapTablePartition();
+        tPartition.setId(physicalPartition.getId());
+        partitionParam.addToPartitions(tPartition);
+
+        AtomicInteger invokeCounter = new AtomicInteger(0);
+        new MockUp<StarClient>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(Invocation invocation, String serviceId, List<Long> shardIds,
+                                                long workerGroupId) throws StarClientException {
+                invokeCounter.incrementAndGet();
+                return invocation.proceed(serviceId, shardIds, workerGroupId);
+            }
+        };
+
+        ComputeResource computeResource =
+                GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource();
+        Assertions.assertDoesNotThrow(() ->
+                OlapTableSink.createLocation(olapTable, partitionParam, false, computeResource, null));
+        // 10 tablets share a single batched StarClient.getShardInfo call.
         Assertions.assertEquals(1, invokeCounter.get());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedWarehouseManager.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedWarehouseManager.java
@@ -123,6 +123,18 @@ public class MockedWarehouseManager extends WarehouseManager {
         return computeNodeIdSetAssignedToTablet;
     }
 
+    @Override
+    public Map<Long, List<Long>> getAllComputeNodeIdsAssignToTablets(ComputeResource computeResource,
+                                                                     List<Long> tabletIds) {
+        Map<Long, List<Long>> result = new HashMap<>();
+        if (tabletIds != null) {
+            for (Long tabletId : tabletIds) {
+                result.put(tabletId, new ArrayList<>(computeNodeIdSetAssignedToTablet));
+            }
+        }
+        return result;
+    }
+
     public void setComputeNodeIdsAssignToTablet(Set<Long> computeNodeIds) {
         computeNodeIdSetAssignedToTablet.addAll(computeNodeIds);
     }


### PR DESCRIPTION
In shared-data mode, OlapTableSink.createLocation resolved compute-node placement per tablet via WarehouseManager.getComputeNodeAssignedToTablet, which ultimately issued one StarOS StarClient.getShardInfo RPC per tablet while holding db-IS + table-READ in the planner critical section. A slow ShardSchedulerV2.scheduleAddToGroup inside any single call could stall the lock for minutes and fan out to every concurrent DML/DDL on the db.

Apply the same batched lookup that #67325 introduced for OlapScanNode and MetaScanNode: pre-fetch Map<tabletId, List<nodeId>> via one WarehouseManager.getAllComputeNodeIdsAssignToTablets call before the partition loop, pick the first alive candidate per tablet, and fall back to the per-tablet call only when the batch misses a tablet or has no alive candidate (preserves the ERR_NO_NODES_IN_WAREHOUSE semantics and the partial-results fallback pattern used in the scan paths).

Also add getAllComputeNodeIdsAssignToTablets to MockedWarehouseManager so existing sink tests exercise the new path through the mock.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
