### PR TITLE
[BugFix] Remove redundant DB READ lock in getTableNamesViewWithLock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -409,14 +409,19 @@ public class Database extends MetaObject implements Writable {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Returns an unmodifiable view of the table names in this database.
+     *
+     * <p>NOTE: despite the "WithLock" suffix, this method acquires <b>no</b>
+     * database lock. The name is retained for API compatibility with
+     * existing callers. {@code nameToTable} is a {@link ConcurrentHashMap},
+     * and its {@code keySet()} is already a thread-safe weakly-consistent
+     * view, so no locking is required to read it safely. Callers that need
+     * a stable snapshot must copy the returned set themselves (e.g.
+     * {@code new HashSet<>(db.getTableNamesViewWithLock())}).
+     */
     public Set<String> getTableNamesViewWithLock() {
-        Locker locker = new Locker();
-        locker.lockDatabase(id, LockType.READ);
-        try {
-            return Collections.unmodifiableSet(this.nameToTable.keySet());
-        } finally {
-            locker.unLockDatabase(id, LockType.READ);
-        }
+        return Collections.unmodifiableSet(this.nameToTable.keySet());
     }
 
     /**


### PR DESCRIPTION
nameToTable is a ConcurrentHashMap, so its keySet() already returns a thread-safe weakly-consistent view. The enclosing DB READ lock did not snapshot the returned set (it stayed a live view after unlock), so the lock added only contention, not correctness. All production callers either copy the result immediately (LocalMetastore.dropDb, LocalMetastore.recoverDatabase) or iterate inside an outer lock (FrontendServiceImpl.describeWithoutDbAndTable), so dropping this inner lock is observably equivalent.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
