### PR TITLE
[Tool] Bump {fmt} version from 8.1.1 to 11.1.4 and adjust existing code to be compatible

### DIFF
--- a/be/src/connector/connector_chunk_sink.cpp
+++ b/be/src/connector/connector_chunk_sink.cpp
@@ -14,6 +14,8 @@
 
 #include "connector_chunk_sink.h"
 
+#include <fmt/ranges.h>
+
 #include "column/chunk.h"
 #include "common/status.h"
 #include "connector/sink_memory_manager.h"

--- a/be/src/exec/pipeline/nljoin/nljoin_context.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.cpp
@@ -14,6 +14,8 @@
 
 #include "exec/pipeline/nljoin/nljoin_context.h"
 
+#include <fmt/ranges.h>
+
 #include <algorithm>
 #include <memory>
 #include <numeric>

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -14,6 +14,8 @@
 
 #include "exec/pipeline/nljoin/nljoin_probe_operator.h"
 
+#include <fmt/ranges.h>
+
 #include "base/simd/simd.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/binlog_manager.h"
 
+#include <fmt/ranges.h>
+
 #include "fs/fs_factory.h"
 #include "storage/rowset/rowset.h"
 #include "storage/tablet.h"

--- a/be/src/storage/rowset/data_sample.cpp
+++ b/be/src/storage/rowset/data_sample.cpp
@@ -15,6 +15,7 @@
 #include "storage/rowset/data_sample.h"
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <random>
 #include <stdexcept>

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/rowset/json_column_iterator.h"
 
+#include <fmt/ranges.h>
+
 #include <memory>
 #include <utility>
 #include <vector>

--- a/be/src/storage/rowset/ordinal_page_index.cpp
+++ b/be/src/storage/rowset/ordinal_page_index.cpp
@@ -34,6 +34,8 @@
 
 #include "storage/rowset/ordinal_page_index.h"
 
+#include <fmt/ranges.h>
+
 #include <memory>
 
 #include "common/logging.h"

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -14,6 +14,8 @@
 
 #include "segment_iterator.h"
 
+#include <fmt/ranges.h>
+
 #include <algorithm>
 #include <memory>
 #include <unordered_map>

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -38,6 +38,8 @@
 #endif
 #endif
 
+#include <fmt/std.h>
+
 #include <thread>
 #include <tuple>
 

--- a/be/test/exec/sorting_test.cpp
+++ b/be/test/exec/sorting_test.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/sorting/sorting.h"
 
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include <memory>

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -283,10 +283,10 @@ CCTZ_SOURCE="cctz-2.3"
 CCTZ_MD5SUM="209348e50b24dbbdec6d961059c2fc92"
 
 # FMT
-FMT_DOWNLOAD="https://github.com/fmtlib/fmt/releases/download/8.1.1/fmt-8.1.1.zip"
-FMT_NAME="fmt-8.1.1.zip"
-FMT_SOURCE="fmt-8.1.1"
-FMT_MD5SUM="16dcd48ecc166f10162450bb28aabc87"
+FMT_DOWNLOAD="https://github.com/fmtlib/fmt/releases/download/11.1.4/fmt-11.1.4.zip"
+FMT_NAME="fmt-11.1.4.zip"
+FMT_SOURCE="fmt-11.1.4"
+FMT_MD5SUM="ad6a56b15cddf4aad2a234e7cfc9e8c9"
 
 # RYU
 RYU_DOWNLOAD="https://github.com/ulfjack/ryu/archive/aa31ca9361d21b1a00ee054aac49c87d07e74abc.zip"


### PR DESCRIPTION
## Why I'm doing:

In our fork, we require a more recent fmt version to work with another library dependency.

Most compatibility issues have been fixed here already: https://github.com/StarRocks/starrocks/pull/72022

## What I'm doing:

Upgrade `{fmt}` version from 8.1.1. to [11.1.4](https://github.com/fmtlib/fmt/releases/tag/11.1.4). 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
