### PR TITLE
[Refactor] Extract shared PCT partitioner flow

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mv/refresh/pct/MVPCTRefreshPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/refresh/pct/MVPCTRefreshPlanner.java
@@ -1,0 +1,155 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.mv.refresh.pct;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshPartitioner;
+import com.starrocks.scheduler.mv.pct.PCTPartitionTopology;
+import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.common.SyncPartitionUtils;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared refresh-control flow for partitioned PCT refresh.
+ *
+ * <p>Shape-specific algorithms still live on {@link MVPCTRefreshPartitioner}'s subclasses via
+ * abstract hooks. This helper only owns the common orchestration path.
+ */
+public final class MVPCTRefreshPlanner {
+    private final MVPCTRefreshPartitioner partitioner;
+
+    public MVPCTRefreshPlanner(MVPCTRefreshPartitioner partitioner) {
+        this.partitioner = partitioner;
+    }
+
+    /**
+     * Compute the materialized view partitions to refresh for the current task run.
+     *
+     * <p>This method first resolves the refresh candidate set under the MV read lock, including
+     * potential-partition expansion. If {@code skipBatchFilter} is false, it then applies
+     * property-based and batch-size filtering outside the lock so the lock scope stays aligned
+     * with the original detect-only path.
+     *
+     * @param snapshotBaseTables snapshot base tables captured for this refresh attempt
+     * @param skipBatchFilter whether to skip the batch-filter stage and return the full candidate set
+     * @return partitions selected for this refresh, or the full candidate set when batch filtering is skipped
+     */
+    public PCellSortedSet getMVToRefreshedPartitions(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
+                                                     boolean skipBatchFilter)
+            throws AnalysisException, LockTimeoutException {
+        PCellSortedSet mvToRefreshedPartitions;
+        Locker locker = new Locker();
+        if (!locker.tryLockTableWithIntensiveDbLock(partitioner.getDb().getId(), partitioner.getMv().getId(),
+                LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
+            partitioner.getLogger().warn("failed to lock database: {} in detectMVPartitionsToRefresh",
+                    partitioner.getDb().getFullName());
+            throw new LockTimeoutException(String.format("Materialized view %s.%s refresh failed: "
+                            + "failed to acquire read lock on database %s within %d ms "
+                            + "when detecting partitions to refresh",
+                    partitioner.getDb().getFullName(), partitioner.getMv().getName(),
+                    partitioner.getDb().getFullName(), Config.mv_refresh_try_lock_timeout_ms));
+        }
+        try {
+            if (partitioner.getMvRefreshParams().isForce()) {
+                mvToRefreshedPartitions = partitioner.getMVPartitionsToRefreshWithForce();
+            } else {
+                mvToRefreshedPartitions = partitioner.getMVPartitionsToRefreshWithCheck(snapshotBaseTables);
+            }
+            if (mvToRefreshedPartitions == null || mvToRefreshedPartitions.isEmpty()) {
+                partitioner.getLogger().info("no partitions to refresh for materialized view");
+                return mvToRefreshedPartitions;
+            }
+
+            Map<Table, PCellSortedSet> baseChangedPartitionNames =
+                    partitioner.getBasePartitionNamesByMVPartitionNames(mvToRefreshedPartitions);
+            if (baseChangedPartitionNames.isEmpty()) {
+                partitioner.getLogger().info(
+                        "Cannot get associated base table change partitions from mv's refresh partitions {}",
+                        mvToRefreshedPartitions);
+                return mvToRefreshedPartitions;
+            }
+
+            Map<Table, PCellSortedSet> baseChangedPCellsSortedSet =
+                    partitioner.toBaseTableWithSortedSet(baseChangedPartitionNames);
+            if (partitioner.isCalcPotentialRefreshPartition(baseChangedPCellsSortedSet, mvToRefreshedPartitions)) {
+                partitioner.getLogger().info("Start calcPotentialRefreshPartition, needRefreshMvPartitionNames: {},"
+                                + " baseChangedPartitionNames: {}",
+                        mvToRefreshedPartitions, baseChangedPCellsSortedSet);
+                PCTPartitionTopology partitionTopology = partitioner.getMvContext().getPartitionTopology();
+                PCellSortedSet potentialPartitions = PCellSortedSet.of();
+                SyncPartitionUtils.calcPotentialRefreshPartition(mvToRefreshedPartitions,
+                        baseChangedPartitionNames,
+                        partitionTopology.getRefBaseTableMVIntersectedPartitions(),
+                        partitionTopology.getMvRefBaseTableIntersectedPartitions(),
+                        potentialPartitions);
+                partitioner.addMVToRefreshPotentialPartitions(potentialPartitions);
+                mvToRefreshedPartitions.addAll(partitioner.getMVToRefreshPotentialPartitions());
+                partitioner.getLogger().info("Finish calcPotentialRefreshPartition, needRefreshMvPartitionNames: {},"
+                                + " baseChangedPartitionNames: {}",
+                        mvToRefreshedPartitions, baseChangedPartitionNames);
+            }
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(partitioner.getDb().getId(), partitioner.getMv().getId(), LockType.READ);
+        }
+        if (!skipBatchFilter) {
+            filterMVToRefreshPartitions(mvToRefreshedPartitions);
+
+            int partitionRefreshNumber = partitioner.getMv().getTableProperty().getPartitionRefreshNumber();
+            partitioner.getLogger().info("filter partitions to refresh partitionRefreshNumber={}, "
+                            + "partitionsToRefresh:{}, mvPotentialPartitionNames:{}, next start:{}, "
+                            + "next end:{}, next list values:{}",
+                    partitionRefreshNumber, mvToRefreshedPartitions, partitioner.getMVToRefreshPotentialPartitions(),
+                    partitioner.getMvContext().getNextPartitionStart(), partitioner.getMvContext().getNextPartitionEnd(),
+                    partitioner.getMvContext().getNextPartitionValues());
+        }
+        return mvToRefreshedPartitions;
+    }
+
+    private void filterMVToRefreshPartitions(PCellSortedSet mvToRefreshedPartitions) {
+        if (mvToRefreshedPartitions == null || mvToRefreshedPartitions.isEmpty()) {
+            return;
+        }
+
+        partitioner.filterMVToRefreshPartitionsByProperty(mvToRefreshedPartitions);
+        partitioner.getLogger().info("after filter with auto_refresh_partition_number, partitionsToRefresh: {}",
+                mvToRefreshedPartitions);
+        if (mvToRefreshedPartitions.isEmpty() || mvToRefreshedPartitions.size() <= 1) {
+            return;
+        }
+        if (!partitioner.getMvRefreshParams().isCanGenerateNextTaskRun() || !partitioner.isGenerateNextTaskRun()) {
+            return;
+        }
+        boolean hasUnsupportedTableTypeForAdaptiveRefresh = partitioner.getMv().getBaseTableTypes().stream()
+                .anyMatch(type -> !MVPCTRefreshPartitioner.isAdaptiveRefreshSupported(type));
+        if (hasUnsupportedTableTypeForAdaptiveRefresh) {
+            partitioner.filterPartitionByRefreshNumber(
+                    mvToRefreshedPartitions, MaterializedView.PartitionRefreshStrategy.STRICT);
+        } else {
+            partitioner.filterPartitionByRefreshNumber(
+                    mvToRefreshedPartitions, partitioner.getMv().getPartitionRefreshStrategy());
+        }
+        partitioner.getLogger().info("after filterPartitionByAdaptive, partitionsToRefresh: {}",
+                mvToRefreshedPartitions);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/refresh/pct/MVPCTRefreshSynchronizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/refresh/pct/MVPCTRefreshSynchronizer.java
@@ -1,0 +1,255 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.mv.refresh.pct;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.concurrent.lock.LockParams;
+import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.scheduler.mv.MVRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
+import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
+import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
+import com.starrocks.sql.common.DmlException;
+import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared PCT/IVM refresh preparation flow extracted from {@link MVRefreshProcessor}.
+ */
+public final class MVPCTRefreshSynchronizer {
+    private final MVRefreshProcessor processor;
+
+    public MVPCTRefreshSynchronizer(MVRefreshProcessor processor) {
+        this.processor = processor;
+    }
+
+    /**
+     * Sync and check the partitions of the materialized view and its base tables.
+     */
+    public void syncAndCheckPCTPartitions() throws Exception {
+        Map<BaseTableSnapshotInfo, PCellSortedSet> baseTableCandidatePartitions = Maps.newHashMap();
+        if (processor.isExternalTablePreciseRefreshEnabled()) {
+            try (Timer ignored = Tracers.watchScope("MVRefreshComputeCandidatePartitions")) {
+                if (!syncPartitions()) {
+                    throw new DmlException(String.format("materialized view %s.%s refresh task failed: "
+                                    + "pre-sync partition failed during external table candidate partition computation",
+                            processor.getDb().getFullName(), processor.getMv().getName()));
+                }
+                PCellSortedSet mvCandidatePartition = getPCTMVToRefreshedPartitions(true, false);
+                PCTRefreshScope candidateScope = processor.buildPCTRefreshScope(mvCandidatePartition);
+                baseTableCandidatePartitions = candidateScope.getRefTableRefreshPartitions();
+            } catch (Exception e) {
+                processor.getLogger().warn("failed to compute candidate partitions in sync partitions",
+                        DebugUtil.getRootStackTrace(e));
+                if (e.getMessage() == null || !e.getMessage().contains("not exist")) {
+                    throw e;
+                }
+            }
+        }
+
+        try (Timer ignored = Tracers.watchScope("MVRefreshSyncAndCheckPartitions")) {
+            if (!syncAndCheckPCTPartitions(baseTableCandidatePartitions)) {
+                throw new DmlException(String.format("materialized view %s.%s refresh task failed: "
+                                + "sync and check partition failed, base table partition may have changed "
+                                + "too frequently or exceeded max retry times(%d)",
+                        processor.getDb().getFullName(), processor.getMv().getName(),
+                        Config.max_mv_check_base_table_change_retry_times));
+            }
+        }
+    }
+
+    /**
+     * Compute PCT partition metadata for the current refresh.
+     */
+    public void updatePCTToRefreshMetas(boolean skipBatchFilter) throws Exception {
+        PCellSortedSet mvPartitionsToRefresh = getPCTMVToRefreshedPartitions(false, skipBatchFilter);
+        PCTRefreshScope refreshScope = processor.buildPCTRefreshScope(mvPartitionsToRefresh);
+        processor.applyPCTRefreshScope(refreshScope);
+        processor.updatePCTBaseTableSnapshotInfos(refreshScope.getRefTableRefreshPartitions());
+        processor.updatePCTMVToRefreshInfoIntoTaskRun(refreshScope.getMvPartitionsToRefresh(),
+                refreshScope.getRefTablePartitionNames());
+        processor.getLogger().info("mvToRefreshedPartitions:{}, refTableRefreshPartitions:{}",
+                refreshScope.getMvPartitionsToRefresh(), refreshScope.getRefTableRefreshPartitions());
+    }
+
+    public PCellSortedSet getPCTMVToRefreshedPartitions(boolean tentative,
+                                                        boolean skipBatchFilter)
+            throws AnalysisException, LockTimeoutException {
+        processor.getMvRefreshParams().setIsTentative(tentative);
+        final PCellSortedSet mvToRefreshedPartitions = processor.getMvPctRefreshPlanner()
+                .getMVToRefreshedPartitions(processor.getSnapshotBaseTables(), skipBatchFilter);
+        if (!tentative) {
+            processor.updateCurrentRefreshParamsIntoTaskRun();
+        }
+        return mvToRefreshedPartitions;
+    }
+
+    public Map<BaseTableSnapshotInfo, PCellSortedSet> getPCTRefTableRefreshPartitions(PCellSortedSet mvToRefreshedPartitions) {
+        return processor.buildPCTRefreshScope(mvToRefreshedPartitions).getRefTableRefreshPartitions();
+    }
+
+    boolean syncPartitions() throws AnalysisException, LockTimeoutException {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        processor.setSnapshotBaseTables(processor.collectBaseTableSnapshotInfos());
+
+        if (!processor.getMvContext().isExplain() && processor.getMvRefreshParams().isNonTentativeForce()) {
+            PCellSortedSet toRefreshPartitions = processor.getMvPctRefreshPartitioner().getMVPartitionsToRefreshByParams();
+            if (toRefreshPartitions != null && !toRefreshPartitions.isEmpty()) {
+                processor.getLogger().info("force refresh, drop partitions: [{}]",
+                        Joiner.on(",").join(toRefreshPartitions.getPartitionNames()));
+
+                Database db = processor.getDb();
+                MaterializedView mv = processor.getMv();
+                Locker locker = new Locker();
+                if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.WRITE,
+                        Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
+                    processor.getLogger().warn("failed to lock database: {} in syncPartitions for force refresh",
+                            db.getFullName());
+                    throw new DmlException("Force refresh of materialized view %s.%s failed: "
+                                    + "failed to acquire write lock on database %s within %d ms",
+                            db.getFullName(), mv.getName(), db.getFullName(),
+                            Config.mv_refresh_try_lock_timeout_ms);
+                }
+                try {
+                    if (!mv.isPartitionedTable() || processor.getMvRefreshParams().isCompleteRefresh()) {
+                        mv.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
+                    } else {
+                        mv.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMapByMVPartitions(
+                                toRefreshPartitions.getPartitionNames());
+                    }
+                } catch (Exception e) {
+                    processor.getLogger().warn("failed to clear version map {} for force refresh",
+                            Joiner.on(",").join(toRefreshPartitions.getPartitionNames()),
+                            DebugUtil.getRootStackTrace(e));
+                    throw new AnalysisException("failed to clear version map for force refresh: " + e.getMessage());
+                } finally {
+                    locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.WRITE);
+                }
+            }
+        }
+
+        boolean result = processor.getMvPctRefreshPartitioner().syncAddOrDropPartitions();
+        if (result && processor.getMv().isPartitionedTable() && processor.getMvContext().getPartitionTopology() == null) {
+            throw new DmlException("Materialized view %s.%s refresh failed: partition topology was not published "
+                            + "after sync partitions succeeded",
+                    processor.getDb().getFullName(), processor.getMv().getName());
+        }
+        processor.getLogger().info("finish sync partitions, cost(ms): {}", stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        return result;
+    }
+
+    private boolean syncAndCheckPCTPartitions(Map<BaseTableSnapshotInfo, PCellSortedSet> baseTableCandidatePartitions)
+            throws AnalysisException, LockTimeoutException {
+        int retryNum = 0;
+        boolean checked = false;
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        while (!checked && retryNum++ < Config.max_mv_check_base_table_change_retry_times) {
+            processor.increaseRefreshRetryMetaCount(1L);
+            try (Timer ignored = Tracers.watchScope("MVRefreshExternalTable")) {
+                if (!processor.isPinnedMode()) {
+                    processor.refreshExternalTable(baseTableCandidatePartitions);
+                } else {
+                    processor.getLogger().info("Skip refreshExternalTable in pinned PCT mode");
+                }
+            }
+
+            if (shouldSyncPartitionsAfterExternalRefresh(retryNum)) {
+                try (Timer ignored = Tracers.watchScope("MVRefreshSyncPartitions")) {
+                    if (!syncPartitions()) {
+                        processor.getLogger().warn("Sync partitions failed.");
+                        return false;
+                    }
+                }
+            }
+
+            try (Timer ignored = Tracers.watchScope("MVRefreshCheckBaseTableChange")) {
+                if (checkPCTBaseTablePartitionChange()) {
+                    processor.getLogger().info("materialized view base partition has changed. "
+                            + "retry to sync partitions, retryNum:{}", retryNum);
+                    Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+                    continue;
+                }
+            }
+            checked = true;
+        }
+        Tracers.record("MVRefreshSyncPartitionsRetryTimes", String.valueOf(retryNum));
+        processor.getLogger().info("sync and check mv partition changing after {} times: {}, costs: {} ms",
+                retryNum, checked, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        return checked;
+    }
+
+    private boolean shouldSyncPartitionsAfterExternalRefresh(int retryNum) {
+        if (!processor.isExternalTablePreciseRefreshEnabled() || retryNum > 1) {
+            return true;
+        }
+
+        for (BaseTableInfo baseTableInfo : processor.getMv().getBaseTableInfos()) {
+            Optional<Table> optTable = MvUtils.getTable(baseTableInfo);
+            if (optTable.isEmpty()) {
+                continue;
+            }
+            Table table = optTable.get();
+            if (isRefreshableExternalBaseTable(table) && !supportsPreciseExternalTableRefresh(table)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean checkPCTBaseTablePartitionChange() throws LockTimeoutException {
+        Locker locker = new Locker();
+        LockParams lockParams = processor.collectDatabases();
+        if (!locker.tryLockTableWithIntensiveDbLock(lockParams,
+                LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
+            processor.getLogger().warn("failed to lock database: {} in checkBaseTablePartitionChange", lockParams);
+            throw new LockTimeoutException("Failed to lock database: " + lockParams
+                    + " in checkBaseTablePartitionChange");
+        }
+        try {
+            return processor.getSnapshotBaseTables().values().stream()
+                    .anyMatch(snapshotInfo -> ((PCTTableSnapshotInfo) snapshotInfo).hasBaseTableChanged(processor.getMv()));
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(lockParams, LockType.READ);
+        }
+    }
+
+    private boolean isRefreshableExternalBaseTable(Table table) {
+        return !(table.isNativeTableOrMaterializedView() || table.isView()
+                || MaterializedViewAnalyzer.isExternalTableFromResource(table));
+    }
+
+    private boolean supportsPreciseExternalTableRefresh(Table table) {
+        return table.isHiveTable() || table.isHudiTable();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -20,7 +20,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -35,8 +34,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.Pair;
-import com.starrocks.common.profile.Timer;
-import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.DebugUtil;
@@ -47,6 +44,8 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.metric.IMaterializedViewMetricsEntity;
+import com.starrocks.mv.refresh.pct.MVPCTRefreshPlanner;
+import com.starrocks.mv.refresh.pct.MVPCTRefreshSynchronizer;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.scheduler.Constants;
@@ -112,7 +111,9 @@ public abstract class MVRefreshProcessor {
     protected final Logger logger;
     // Collect all bases tables of the mv to be updated meta after mv refresh success.
     // format :     table id -> <base table info, snapshot table>
-    protected final MVPCTRefreshPartitioner mvRefreshPartitioner;
+    protected final MVPCTRefreshPartitioner mvPctRefreshPartitioner;
+    protected final MVPCTRefreshPlanner mvPctRefreshPlanner;
+    protected final MVPCTRefreshSynchronizer mvPctRefreshSynchronizer;
     protected final MVRefreshParams mvRefreshParams;
     protected final PCTRefreshScopeCalculator pctRefreshScopeCalculator;
     // current refresh mode, can be changed in the refresh's runtime for `auto` mode
@@ -154,7 +155,9 @@ public abstract class MVRefreshProcessor {
         this.logger = MVTraceUtils.getLogger(mv, clazz);
         this.mvRefreshParams = new MVRefreshParams(mv, mvContext.getProperties());
         // prepare mv refresh partitioner
-        this.mvRefreshPartitioner = buildMvRefreshPartitioner(mv, mvContext, mvRefreshParams);
+        this.mvPctRefreshPartitioner = buildMvRefreshPartitioner(mv, mvContext, mvRefreshParams);
+        this.mvPctRefreshPlanner = new MVPCTRefreshPlanner(mvPctRefreshPartitioner);
+        this.mvPctRefreshSynchronizer = new MVPCTRefreshSynchronizer(this);
         this.currentRefreshMode = refreshMode;
         this.pctRefreshScopeCalculator = new PCTRefreshScopeCalculator();
         this.isEnableExternalTablePreciseRefresh = isEnableExternalTablePreciseRefresh();
@@ -217,6 +220,38 @@ public abstract class MVRefreshProcessor {
         return mvRefreshParams;
     }
 
+    public Database getDb() {
+        return db;
+    }
+
+    public MaterializedView getMv() {
+        return mv;
+    }
+
+    public IMaterializedViewMetricsEntity getMvEntity() {
+        return mvEntity;
+    }
+
+    public Logger getLogger() {
+        return logger;
+    }
+
+    public MVPCTRefreshPartitioner getMvPctRefreshPartitioner() {
+        return mvPctRefreshPartitioner;
+    }
+
+    public MVPCTRefreshPlanner getMvPctRefreshPlanner() {
+        return mvPctRefreshPlanner;
+    }
+
+    public Map<Long, BaseTableSnapshotInfo> getSnapshotBaseTables() {
+        return snapshotBaseTables;
+    }
+
+    public boolean isExternalTablePreciseRefreshEnabled() {
+        return isEnableExternalTablePreciseRefresh;
+    }
+
     /**
      * Get the retry times for the mv refresh processor.
      *
@@ -255,7 +290,7 @@ public abstract class MVRefreshProcessor {
         return nextTaskRun;
     }
 
-    protected void setSnapshotBaseTables(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
+    public void setSnapshotBaseTables(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
         refreshRuntimeState.replaceSnapshotBaseTables(snapshotBaseTables);
     }
 
@@ -266,7 +301,7 @@ public abstract class MVRefreshProcessor {
 
     // True when this task run owns the persistent pinning record — the fallback first batch right
     // after afterSyncHook installs us, and every subsequent batch of the same job.
-    protected boolean isPinnedMode() {
+    public boolean isPinnedMode() {
         String owner = mv.getRefreshScheme().getAsyncRefreshContext().getTempTvrOwnerStartTaskRunId();
         return owner != null && owner.equals(getStartTaskRunId());
     }
@@ -428,147 +463,6 @@ public abstract class MVRefreshProcessor {
         return table.isHiveTable() || table.isHudiTable();
     }
 
-    private boolean shouldSyncPartitionsAfterExternalRefresh(int retryNum) {
-        if (!isEnableExternalTablePreciseRefresh || retryNum > 1) {
-            return true;
-        }
-
-        for (BaseTableInfo baseTableInfo : mv.getBaseTableInfos()) {
-            final Optional<Table> optTable = MvUtils.getTable(baseTableInfo);
-            if (optTable.isEmpty()) {
-                continue;
-            }
-            final Table table = optTable.get();
-            // Iceberg/Paimon/Delta/JDBC/ODPS still refresh table-level metadata. If we skip syncPartitions here,
-            // later PCT phases may keep using snapshotBaseTables collected before refreshExternalTable().
-            if (isRefreshableExternalBaseTable(table) && !supportsPreciseExternalTableRefresh(table)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Sync and check the partitions of the materialized view and its base tables.
-     * @param taskRunContext the task run context which contains the task run information
-     * @throws Exception if any error occurs during the sync and check
-     */
-    protected void syncAndCheckPCTPartitions(TaskRunContext taskRunContext) throws Exception {
-        // The candidate partition info is used to refresh the external table
-        Map<BaseTableSnapshotInfo, PCellSortedSet> baseTableCandidatePartitions = Maps.newHashMap();
-        if (isEnableExternalTablePreciseRefresh) {
-            try (Timer ignored = Tracers.watchScope("MVRefreshComputeCandidatePartitions")) {
-                if (!syncPartitions()) {
-                    throw new DmlException(String.format("materialized view %s.%s refresh task failed: " +
-                                    "pre-sync partition failed during external table candidate partition computation",
-                            db.getFullName(), mv.getName()));
-                }
-                PCellSortedSet mvCandidatePartition = getPCTMVToRefreshedPartitions(true);
-                PCTRefreshScope candidateScope = buildPCTRefreshScope(mvCandidatePartition);
-                baseTableCandidatePartitions = candidateScope.getRefTableRefreshPartitions();
-            } catch (Exception e) {
-                logger.warn("failed to compute candidate partitions in sync partitions",
-                        DebugUtil.getRootStackTrace(e));
-                // Since at here we sync partitions before the refreshExternalTable, the situation may happen that
-                // the base-table not exists before refreshExternalTable, so we just need to swallow this exception
-                if (e.getMessage() == null || !e.getMessage().contains("not exist")) {
-                    throw e;
-                }
-            }
-        }
-
-        // Refresh the partition information of these base-table partitions, and create mv partitions if needed
-        try (Timer ignored = Tracers.watchScope("MVRefreshSyncAndCheckPartitions")) {
-            if (!syncAndCheckPCTPartitions(baseTableCandidatePartitions)) {
-                throw new DmlException(String.format("materialized view %s.%s refresh task failed: " +
-                                "sync and check partition failed, base table partition may have changed " +
-                                "too frequently or exceeded max retry times(%d)",
-                        db.getFullName(), mv.getName(), Config.max_mv_check_base_table_change_retry_times));
-            }
-        }
-    }
-
-    /**
-     * Sync base table's partition infos to be used later.
-     */
-    protected boolean syncPartitions() throws AnalysisException, LockTimeoutException {
-        final Stopwatch stopwatch = Stopwatch.createStarted();
-        // collect base table snapshot infos
-        setSnapshotBaseTables(collectBaseTableSnapshotInfos());
-
-        if (!mvContext.isExplain() && mvRefreshParams.isNonTentativeForce()) {
-            // drop existing partitions for force refresh
-            PCellSortedSet toRefreshPartitions = mvRefreshPartitioner.getMVPartitionsToRefreshByParams();
-            if (toRefreshPartitions != null && !toRefreshPartitions.isEmpty()) {
-                logger.info("force refresh, drop partitions: [{}]",
-                        Joiner.on(",").join(toRefreshPartitions.getPartitionNames()));
-
-                // first lock and drop partitions from a visible map
-                Locker locker = new Locker();
-                if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.WRITE,
-                        Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
-                    logger.warn("failed to lock database: {} in syncPartitions for force refresh", db.getFullName());
-                    throw new DmlException("Force refresh of materialized view %s.%s failed: " +
-                                    "failed to acquire write lock on database %s within %d ms",
-                            db.getFullName(), mv.getName(), db.getFullName(), Config.mv_refresh_try_lock_timeout_ms);
-                }
-                try {
-                    // for non-partitioned MVs, or for complete refresh of partitioned MVs, just clear the visible
-                    // version map directly since all partitions will be refreshed.
-                    if (!mv.isPartitionedTable() || mvRefreshParams.isCompleteRefresh()) {
-                        mv.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
-                    } else {
-                        mv.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMapByMVPartitions(
-                                toRefreshPartitions.getPartitionNames());
-                    }
-                } catch (Exception e) {
-                    logger.warn("failed to clear version map {} for force refresh",
-                            Joiner.on(",").join(toRefreshPartitions.getPartitionNames()),
-                            DebugUtil.getRootStackTrace(e));
-                    throw new AnalysisException("failed to clear version map for force refresh: " + e.getMessage());
-                } finally {
-                    locker.unLockTableWithIntensiveDbLock(db.getId(), this.mv.getId(), LockType.WRITE);
-                }
-            }
-        }
-        // do sync partitions (add or drop partitions) for materialized view
-        boolean result = mvRefreshPartitioner.syncAddOrDropPartitions();
-        if (result && mv.isPartitionedTable() && mvContext.getPartitionTopology() == null) {
-            throw new DmlException("Materialized view %s.%s refresh failed: partition topology was not published " +
-                            "after sync partitions succeeded",
-                    db.getFullName(), mv.getName());
-        }
-        logger.info("finish sync partitions, cost(ms): {}", stopwatch.elapsed(TimeUnit.MILLISECONDS));
-        return result;
-    }
-
-    /**
-     * Compute PCT partition metadata for the current refresh.
-     *
-     * @param skipBatchFilter if true, skip batch filtering (partition_refresh_number, adaptive, refreshPartitionLimit)
-     *                        and record all detected changed partitions. This is used by IVM where all changed
-     *                        partitions are refreshed via TVR delta regardless of partition_refresh_number.
-     *                        if false, apply batch filtering as in normal PCT execution.
-     */
-    protected void updatePCTToRefreshMetas(TaskRunContext taskRunContext,
-                                           boolean skipBatchFilter) throws Exception {
-        PCellSortedSet mvPartitionsToRefresh = getPCTMVToRefreshedPartitions(false, skipBatchFilter);
-        PCTRefreshScope refreshScope = buildPCTRefreshScope(mvPartitionsToRefresh);
-        mvContext.setRefreshScope(refreshScope);
-        this.pctMVToRefreshedPartitions = refreshScope.getMvPartitionsToRefresh();
-        this.pctRefTableRefreshPartitions = refreshScope.getRefTableRefreshPartitions();
-        this.pctRefTablePartitionNames = refreshScope.getRefTablePartitionNames();
-        this.updatePCTBaseTableSnapshotInfos(pctRefTableRefreshPartitions);
-        // add a message into information_schema
-        this.updatePCTMVToRefreshInfoIntoTaskRun(pctMVToRefreshedPartitions, pctRefTablePartitionNames);
-        logger.info("mvToRefreshedPartitions:{}, refTableRefreshPartitions:{}",
-                pctMVToRefreshedPartitions, pctRefTableRefreshPartitions);
-    }
-
-    protected void updatePCTToRefreshMetas(TaskRunContext taskRunContext) throws Exception {
-        updatePCTToRefreshMetas(taskRunContext, false);
-    }
-
     /**
      * Build an AST for insert stmt
      *
@@ -645,7 +539,35 @@ public abstract class MVRefreshProcessor {
         return this.mvContext.getStatus().getMvTaskRunExtraMessage();
     }
 
-    protected void refreshExternalTable(Map<BaseTableSnapshotInfo, PCellSortedSet> baseTableCandidatePartitions) {
+    public void updateCurrentRefreshParamsIntoTaskRun() {
+        updateTaskRunStatus(status -> {
+            status.getMvTaskRunExtraMessage().setForceRefresh(mvRefreshParams.isForce());
+            status.getMvTaskRunExtraMessage().setPartitionStart(mvRefreshParams.getRangeStart());
+            status.getMvTaskRunExtraMessage().setPartitionEnd(mvRefreshParams.getRangeEnd());
+        });
+    }
+
+    public void applyPCTRefreshScope(PCTRefreshScope refreshScope) {
+        mvContext.setRefreshScope(refreshScope);
+        pctMVToRefreshedPartitions = refreshScope.getMvPartitionsToRefresh();
+        pctRefTableRefreshPartitions = refreshScope.getRefTableRefreshPartitions();
+        pctRefTablePartitionNames = refreshScope.getRefTablePartitionNames();
+    }
+
+    public PCTRefreshScope buildPCTRefreshScope(PCellSortedSet mvPartitionsToRefresh) {
+        return pctRefreshScopeCalculator.buildScope(
+                mvContext.getPartitionTopology(),
+                snapshotBaseTables,
+                mvPartitionsToRefresh,
+                mvRefreshParams.isCompleteRefresh(),
+                !mvPctRefreshPartitioner.getMVToRefreshPotentialPartitions().isEmpty());
+    }
+
+    public void increaseRefreshRetryMetaCount(long delta) {
+        mvEntity.increaseRefreshRetryMetaCount(delta);
+    }
+
+    public void refreshExternalTable(Map<BaseTableSnapshotInfo, PCellSortedSet> baseTableCandidatePartitions) {
         final List<Pair<Table, BaseTableInfo>> toRepairTables = new ArrayList<>();
         // use it if refresh external table fails
         final ConnectContext connectContext = mvContext.getCtx();
@@ -739,7 +661,7 @@ public abstract class MVRefreshProcessor {
      * @return: the deduplicated databases of the materialized view's base tables,
      * throw exception if the database does not exist.
      */
-    protected LockParams collectDatabases() {
+    public LockParams collectDatabases() {
         final LockParams lockParams = new LockParams();
         final ConnectContext connectContext = mvContext.getCtx();
         for (BaseTableInfo baseTableInfo : mv.getBaseTableInfos()) {
@@ -825,137 +747,8 @@ public abstract class MVRefreshProcessor {
         return tables;
     }
 
-    /**
-     * @param tentative if true, this is a tentative computation for candidate estimation
-     *                  (isForce() returns true to get all partitions, task run status is not updated).
-     *                  if false, this is the final computation for metadata recording.
-     * @param skipBatchFilter if true, skip batch filtering (partition_refresh_number, adaptive, refreshPartitionLimit).
-     *                        This is used by IVM where all changed partitions are refreshed via TVR delta,
-     *                        so PCT metadata should reflect all of them.
-     */
-    @VisibleForTesting
-    public PCellSortedSet getPCTMVToRefreshedPartitions(boolean tentative,
-                                                        boolean skipBatchFilter)
-            throws AnalysisException, LockTimeoutException {
-        mvRefreshParams.setIsTentative(tentative);
-        final PCellSortedSet mvToRefreshedPartitions;
-        if (skipBatchFilter) {
-            mvToRefreshedPartitions = mvRefreshPartitioner.detectMVPartitionsToRefresh(snapshotBaseTables);
-        } else {
-            mvToRefreshedPartitions = mvRefreshPartitioner.getMVToRefreshedPartitions(snapshotBaseTables);
-        }
-        // update mv extra message
-        if (!tentative) {
-            updateTaskRunStatus(status -> {
-                MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
-                extraMessage.setForceRefresh(mvRefreshParams.isForce());
-                extraMessage.setPartitionStart(mvRefreshParams.getRangeStart());
-                extraMessage.setPartitionEnd(mvRefreshParams.getRangeEnd());
-            });
-        }
-        return mvToRefreshedPartitions;
-    }
-
-    @VisibleForTesting
-    public PCellSortedSet getPCTMVToRefreshedPartitions(boolean tentative)
-            throws AnalysisException, LockTimeoutException {
-        return getPCTMVToRefreshedPartitions(tentative, false);
-    }
-
-    /**
-     * return to-refreshed base table's table name and partition names mapping
-     */
-    @VisibleForTesting
-    public Map<BaseTableSnapshotInfo, PCellSortedSet> getPCTRefTableRefreshPartitions(PCellSortedSet mvToRefreshedPartitions) {
-        return buildPCTRefreshScope(mvToRefreshedPartitions).getRefTableRefreshPartitions();
-    }
-
-    private PCTRefreshScope buildPCTRefreshScope(PCellSortedSet mvPartitionsToRefresh) {
-        return pctRefreshScopeCalculator.buildScope(
-                mvContext.getPartitionTopology(),
-                snapshotBaseTables,
-                mvPartitionsToRefresh,
-                mvRefreshParams.isCompleteRefresh(),
-                !mvRefreshPartitioner.getMVToRefreshPotentialPartitions().isEmpty());
-    }
-
-    /**
-     * Sync partitions of base tables and check whether they are changing anymore
-     */
-    protected boolean syncAndCheckPCTPartitions(Map<BaseTableSnapshotInfo, PCellSortedSet> baseTableCandidatePartitions)
-            throws AnalysisException, LockTimeoutException {
-        // collect partition infos of ref base tables
-        int retryNum = 0;
-        boolean checked = false;
-        Stopwatch stopwatch = Stopwatch.createStarted();
-        while (!checked && retryNum++ < Config.max_mv_check_base_table_change_retry_times) {
-            mvEntity.increaseRefreshRetryMetaCount(1L);
-            try (Timer ignored = Tracers.watchScope("MVRefreshExternalTable")) {
-                // Skip in pinned mode — subsequent batches reuse the cached metadata the pinning
-                // owner already collected, keeping a consistent job-wide view across base tables.
-                if (!isPinnedMode()) {
-                    refreshExternalTable(baseTableCandidatePartitions);
-                } else {
-                    logger.info("Skip refreshExternalTable in pinned PCT mode");
-                }
-            }
-
-            if (shouldSyncPartitionsAfterExternalRefresh(retryNum)) {
-                try (Timer ignored = Tracers.watchScope("MVRefreshSyncPartitions")) {
-                    // sync partitions between mv and base tables out of lock
-                    // do it outside lock because it is a time-cost operation
-                    if (!syncPartitions()) {
-                        logger.warn("Sync partitions failed.");
-                        return false;
-                    }
-                }
-            }
-
-            try (Timer ignored = Tracers.watchScope("MVRefreshCheckBaseTableChange")) {
-                // check whether there are partition changes for base tables, eg: partition rename
-                // retry to sync partitions if any base table changed the partition infos
-                if (checkPCTBaseTablePartitionChange()) {
-                    logger.info("materialized view base partition has changed. " +
-                            "retry to sync partitions, retryNum:{}", retryNum);
-                    // sleep 100ms
-                    Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-                    continue;
-                }
-            }
-            checked = true;
-        }
-        Tracers.record("MVRefreshSyncPartitionsRetryTimes", String.valueOf(retryNum));
-        logger.info("sync and check mv partition changing after {} times: {}, costs: {} ms",
-                retryNum, checked, stopwatch.elapsed(TimeUnit.MILLISECONDS));
-        return checked;
-    }
-
-    /**
-     * Check whether the base table's partition has changed or not. Wait to refresh until all mv's base tables
-     * don't change again.
-     *
-     * @return: true if the base table's partition has changed, otherwise false.
-     */
-    private boolean checkPCTBaseTablePartitionChange() throws LockTimeoutException {
-        LockParams lockParams = collectDatabases();
-        Locker locker = new Locker();
-        if (!locker.tryLockTableWithIntensiveDbLock(lockParams,
-                LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
-            logger.warn("failed to lock database: {} in checkBaseTablePartitionChange", lockParams);
-            throw new LockTimeoutException("Failed to lock database: " + lockParams
-                    + " in checkBaseTablePartitionChange");
-        }
-        // check snapshotBaseTables and current tables in catalog
-        try {
-            return snapshotBaseTables.values().stream()
-                    .anyMatch(snapshotInfo -> ((PCTTableSnapshotInfo) snapshotInfo).hasBaseTableChanged(mv));
-        } finally {
-            locker.unLockTableWithIntensiveDbLock(lockParams, LockType.READ);
-        }
-    }
-
-    protected void updatePCTMVToRefreshInfoIntoTaskRun(PCellSortedSet finalMvToRefreshedPartitions,
-                                                       PCellSetMapping finalRefTablePartitionNames) {
+    public void updatePCTMVToRefreshInfoIntoTaskRun(PCellSortedSet finalMvToRefreshedPartitions,
+                                                    PCellSetMapping finalRefTablePartitionNames) {
         updateTaskRunStatus(status -> {
             MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
             extraMessage.setMvPartitionsToRefresh(finalMvToRefreshedPartitions.getPartitionNames());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -101,7 +101,7 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         // Reset per-call buffer to prevent accumulation across retries within the same task run
         // (processor instance is reused by retryProcessTaskRun).
         this.stagedTvrDeltaMap.clear();
-        syncAndCheckPCTPartitions(taskRunContext);
+        mvPctRefreshSynchronizer.syncAndCheckPCTPartitions();
 
         // collect change snapshots
         try (Timer ignored = Tracers.watchScope("MVRefreshCheckChangedVersionRanges")) {
@@ -139,7 +139,7 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
             try {
                 // IVM refreshes all changed partitions via TVR delta (not limited by partition_refresh_number),
                 // so pass skipBatchFilter=true to record complete PCT metadata without truncation.
-                updatePCTToRefreshMetas(taskRunContext, /* skipBatchFilter */ true);
+                mvPctRefreshSynchronizer.updatePCTToRefreshMetas(/* skipBatchFilter */ true);
             } catch (Exception e) {
                 // if the check failed, we should not throw exception here
                 // because this check only affects pct-based refresh rather than ivm-based mv refresh.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
@@ -50,7 +50,6 @@ import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
-import com.starrocks.sql.common.SyncPartitionUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -225,40 +224,6 @@ public abstract class MVPCTRefreshPartitioner {
     }
 
     /**
-     * Calculate the associated potential partitions to refresh according to the partitions to refresh.
-     * NOTE: This must be called after filterMVToRefreshPartitions, otherwise it may lose some potential to-refresh mv partitions
-     * which will cause filtered insert load.
-     * @param result: partitions to refresh for materialized view which will be changed in this method.
-     */
-    public void calcPotentialMVRefreshPartitions(PCellSortedSet result) {
-        // check non-ref base tables or force refresh
-        Map<Table, PCellSortedSet> baseChangedPartitionNames = getBasePartitionNamesByMVPartitionNames(result);
-        if (baseChangedPartitionNames.isEmpty()) {
-            logger.info("Cannot get associated base table change partitions from mv's refresh partitions {}",
-                    result);
-            return;
-        }
-
-        // use base table's changed partitions instead of to-refresh partitions to decide
-        Map<Table, PCellSortedSet> baseChangedPCellsSortedSet = toBaseTableWithSortedSet(baseChangedPartitionNames);
-        if (isCalcPotentialRefreshPartition(baseChangedPCellsSortedSet, result)) {
-            // because the relation of partitions between materialized view and base partition table is n : m,
-            // should calculate the candidate partitions recursively.
-            logger.info("Start calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
-                    " baseChangedPartitionNames: {}", result, baseChangedPCellsSortedSet);
-            PCTPartitionTopology partitionTopology = mvContext.getPartitionTopology();
-            SyncPartitionUtils.calcPotentialRefreshPartition(result,
-                    baseChangedPartitionNames,
-                    partitionTopology.getRefBaseTableMVIntersectedPartitions(),
-                    partitionTopology.getMvRefBaseTableIntersectedPartitions(),
-                    mvToRefreshPotentialPartitions);
-            result.addAll(mvToRefreshPotentialPartitions);
-            logger.info("Finish calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
-                    " baseChangedPartitionNames: {}", result, baseChangedPartitionNames);
-        }
-    }
-
-    /**
      * Filter mv to refresh partitions by some properties, like auto_partition_refresh_number.
      * @param mvToRefreshedPartitions: partitions to refresh for materialized view
      */
@@ -271,103 +236,8 @@ public abstract class MVPCTRefreshPartitioner {
         return PCellSortedSet.of(mvToRefreshPotentialPartitions);
     }
 
-    /**
-     * @return the partitions to refresh for materialized view
-     */
-    private PCellSortedSet getMVPartitionsToRefresh(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables)
-            throws AnalysisException {
-        if (mvRefreshParams.isForce()) {
-            // Force refresh
-            return getMVPartitionsToRefreshWithForce();
-        } else {
-            return getMVPartitionsToRefreshWithCheck(snapshotBaseTables);
-        }
-    }
-
-    /**
-     * Detect all MV partitions that need refresh, including partition change detection and
-     * potential partition calculation, but without any batch filtering (no partition_refresh_number,
-     * no adaptive truncation, no refreshPartitionLimit).
-     *
-     * <p>This is used by IVM to record complete PCT metadata that reflects all actually refreshed partitions.
-     */
-    public PCellSortedSet detectMVPartitionsToRefresh(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables)
-            throws AnalysisException, LockTimeoutException {
-        PCellSortedSet mvToRefreshedPartitions = null;
-        Locker locker = new Locker();
-        if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(),
-                LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
-            logger.warn("failed to lock database: {} in detectMVPartitionsToRefresh", db.getFullName());
-            throw new LockTimeoutException(String.format("Materialized view %s.%s refresh failed: " +
-                    "failed to acquire read lock on database %s within %d ms " +
-                    "when detecting partitions to refresh",
-                    db.getFullName(), mv.getName(), db.getFullName(), Config.mv_refresh_try_lock_timeout_ms));
-        }
-        try {
-            mvToRefreshedPartitions = getMVPartitionsToRefresh(snapshotBaseTables);
-            if (mvToRefreshedPartitions == null || mvToRefreshedPartitions.isEmpty()) {
-                logger.info("no partitions to refresh for materialized view");
-                return mvToRefreshedPartitions;
-            }
-            calcPotentialMVRefreshPartitions(mvToRefreshedPartitions);
-        } finally {
-            locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.READ);
-        }
-        return mvToRefreshedPartitions;
-    }
-
-    /**
-     * Compute the partitions to be refreshed in this task, according to [start, end), ttl, and other context info.
-     * This applies batch filtering (partition_refresh_number, adaptive, refreshPartitionLimit) on top of
-     * {@link #detectMVPartitionsToRefresh} results.
-     * If it's tentative, only return the result rather than modify any state.
-     * If it's not, it would modify the context state, like `NEXT_PARTITION_START`.
-     */
-    public PCellSortedSet getMVToRefreshedPartitions(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables)
-            throws AnalysisException, LockTimeoutException {
-        PCellSortedSet mvToRefreshedPartitions = detectMVPartitionsToRefresh(snapshotBaseTables);
-        if (mvToRefreshedPartitions == null || mvToRefreshedPartitions.isEmpty()) {
-            return mvToRefreshedPartitions;
-        }
-
-        // filter partitions to avoid refreshing too many partitions
-        filterMVToRefreshPartitions(mvToRefreshedPartitions);
-
-        int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
-        logger.info("filter partitions to refresh partitionRefreshNumber={}, partitionsToRefresh:{}, " +
-                        "mvPotentialPartitionNames:{}, next start:{}, next end:{}, next list values:{}",
-                partitionRefreshNumber, mvToRefreshedPartitions, mvToRefreshPotentialPartitions,
-                mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), mvContext.getNextPartitionValues());
-        return mvToRefreshedPartitions;
-    }
-
-    private void filterMVToRefreshPartitions(PCellSortedSet mvToRefreshedPartitions) {
-        if (mvToRefreshedPartitions == null || mvToRefreshedPartitions.isEmpty()) {
-            return;
-        }
-
-        // first filter partitions by user's config(eg: auto_refresh_partition_number)
-        filterMVToRefreshPartitionsByProperty(mvToRefreshedPartitions);
-        logger.info("after filter with auto_refresh_partition_number, partitionsToRefresh: {}",
-                mvToRefreshedPartitions);
-        if (mvToRefreshedPartitions.isEmpty() || mvToRefreshedPartitions.size() <= 1) {
-            return;
-        }
-        // if cannot generate next task run, return directly
-        if (!mvRefreshParams.isCanGenerateNextTaskRun() || !isGenerateNextTaskRun()) {
-            return;
-        }
-        // filter partitions by partition refresh strategy
-        boolean hasUnsupportedTableType = mv.getBaseTableTypes().stream()
-                .anyMatch(type -> !SUPPORTED_TABLE_TYPES_FOR_ADAPTIVE_MV_REFRESH.contains(type));
-        if (hasUnsupportedTableType) {
-            filterPartitionByRefreshNumber(mvToRefreshedPartitions, MaterializedView.PartitionRefreshStrategy.STRICT);
-        } else {
-            MaterializedView.PartitionRefreshStrategy partitionRefreshStrategy = mv.getPartitionRefreshStrategy();
-            filterPartitionByRefreshNumber(mvToRefreshedPartitions, partitionRefreshStrategy);
-        }
-        logger.info("after filterPartitionByAdaptive, partitionsToRefresh: {}",
-                mvToRefreshedPartitions);
+    public void addMVToRefreshPotentialPartitions(PCellSortedSet potentialPartitions) {
+        mvToRefreshPotentialPartitions.addAll(potentialPartitions);
     }
 
     /**
@@ -490,6 +360,30 @@ public abstract class MVPCTRefreshPartitioner {
         // An external table is not supported to refresh by partition.
         return ConnectorPartitionTraits.isSupportPCTRefresh(baseTable.getType()) &&
                 !MaterializedViewAnalyzer.isExternalTableFromResource(baseTable);
+    }
+
+    public static boolean isAdaptiveRefreshSupported(Table.TableType tableType) {
+        return SUPPORTED_TABLE_TYPES_FOR_ADAPTIVE_MV_REFRESH.contains(tableType);
+    }
+
+    public Logger getLogger() {
+        return logger;
+    }
+
+    public MvTaskRunContext getMvContext() {
+        return mvContext;
+    }
+
+    public Database getDb() {
+        return db;
+    }
+
+    public MaterializedView getMv() {
+        return mv;
+    }
+
+    public MVRefreshParams getMvRefreshParams() {
+        return mvRefreshParams;
     }
 
     /**
@@ -661,7 +555,7 @@ public abstract class MVPCTRefreshPartitioner {
      * @param toRefreshPartitions : the need to refresh materialized view partition names
      * @return : the corresponding ref base table partition names to the materialized view partition names
      */
-    protected Map<Table, PCellSortedSet> getBasePartitionNamesByMVPartitionNames(PCellSortedSet toRefreshPartitions) {
+    public Map<Table, PCellSortedSet> getBasePartitionNamesByMVPartitionNames(PCellSortedSet toRefreshPartitions) {
         Map<Table, PCellSortedSet> result = new HashMap<>();
         PCTPartitionTopology partitionTopology = mvContext.getPartitionTopology();
         Map<String, Map<Table, PCellSortedSet>> mvRefBaseTablePartitionMaps =
@@ -747,7 +641,7 @@ public abstract class MVPCTRefreshPartitioner {
         }
     }
 
-    protected Map<Table, PCellSortedSet> toBaseTableWithSortedSet(Map<Table, PCellSortedSet> baseToPartitionNames) {
+    public Map<Table, PCellSortedSet> toBaseTableWithSortedSet(Map<Table, PCellSortedSet> baseToPartitionNames) {
         Map<Table, PCellSortedSet> result = new HashMap<>();
         PCTPartitionTopology partitionTopology = mvContext.getPartitionTopology();
         Map<Table, BaseToMVPartitionMapping> refBaseTableRangePartitionMap =

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
@@ -134,7 +134,7 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
         }
 
         // sync and check partitions of base tables
-        syncAndCheckPCTPartitions(taskRunContext);
+        mvPctRefreshSynchronizer.syncAndCheckPCTPartitions();
 
         // Clear-before-run: if the hook throws, the field is still nulled out on retry.
         final Runnable hook = this.afterSyncHook;
@@ -147,7 +147,7 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
 
         // check to refresh partitions of mv and base tables
         try (Timer ignored = Tracers.watchScope("MVRefreshCheckMVToRefreshPartitions")) {
-            updatePCTToRefreshMetas(taskRunContext);
+            mvPctRefreshSynchronizer.updatePCTToRefreshMetas(false);
             PCTRefreshScope refreshScope = mvContext.getRefreshScope();
             if (refreshScope == null || refreshScope.isEmpty()) {
                 return new ProcessExecPlan(Constants.TaskRunState.SKIPPED, null, null);
@@ -219,7 +219,7 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
                     db.getFullName(), mv.getName(), Config.mv_refresh_try_lock_timeout_ms));
         }
 
-        PCTPredicateBuilder predicateBuilder = new PCTPredicateBuilder(mvRefreshPartitioner);
+        PCTPredicateBuilder predicateBuilder = new PCTPredicateBuilder(mvPctRefreshPartitioner);
         MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(db, mv, mvContext, predicateBuilder);
         try {
             // Analyze and prepare a partition & Rebuild insert statement by
@@ -361,8 +361,8 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
         return new PCTTableSnapshotInfo(baseTableInfo, table);
     }
 
-    public MVPCTRefreshPartitioner getMvRefreshPartitioner() {
-        return mvRefreshPartitioner;
+    public MVPCTRefreshPartitioner getMvPctRefreshPartitioner() {
+        return mvPctRefreshPartitioner;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -34,6 +34,7 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
+import com.starrocks.mv.refresh.pct.MVPCTRefreshSynchronizer;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.QeProcessorImpl;
@@ -1011,7 +1012,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         initAndExecuteTaskRun(taskRun);
 
         MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
-        MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
+        MVPCTRefreshPartitioner partitioner = processor.getMvPctRefreshPartitioner();
         PCellSortedSet mvToRefreshPartitionNames = getMVPCellWithNames(mv, mv.getPartitionNames());
         partitioner.filterPartitionByRefreshNumber(mvToRefreshPartitionNames,
                 MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
@@ -1043,7 +1044,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         initAndExecuteTaskRun(taskRun);
 
         MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
-        MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
+        MVPCTRefreshPartitioner partitioner = processor.getMvPctRefreshPartitioner();
         partitioner.filterPartitionByRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()),
                 MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -1072,10 +1073,10 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             }
         };
 
-        Method syncPartitions = MVRefreshProcessor.class.getDeclaredMethod("syncPartitions");
+        Method syncPartitions = MVPCTRefreshSynchronizer.class.getDeclaredMethod("syncPartitions");
         syncPartitions.setAccessible(true);
         InvocationTargetException exception = Assertions.assertThrows(InvocationTargetException.class,
-                () -> syncPartitions.invoke(processor));
+                () -> syncPartitions.invoke(new MVPCTRefreshSynchronizer(processor)));
         Assertions.assertInstanceOf(DmlException.class, exception.getCause());
         Assertions.assertTrue(exception.getCause().getMessage().contains("partition topology was not published"));
     }
@@ -1115,7 +1116,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         initAndExecuteTaskRun(taskRun);
 
         MVPCTRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
-        MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
+        MVPCTRefreshPartitioner partitioner = processor.getMvPctRefreshPartitioner();
         partitioner.filterPartitionByRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()),
                 MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -1167,7 +1168,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         mv.getTableProperty().setPartitionRefreshNumber(1);
 
         MVPCTRefreshProcessor processor = createProcessor(taskRun, mv);
-        MVPCTRefreshPartitioner partitioner = processor.getMvRefreshPartitioner();
+        MVPCTRefreshPartitioner partitioner = processor.getMvPctRefreshPartitioner();
         Set<String> allPartitions = new HashSet<>(mv.getPartitionNames());
 
         // ascending refresh
@@ -2900,7 +2901,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                     MVPCTRefreshProcessor processor =
                             (MVPCTRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
 
-                    Set<String> result = processor.getPCTMVToRefreshedPartitions(false).getPartitionNames();
+                    Set<String> result = new MVPCTRefreshSynchronizer(processor)
+                            .getPCTMVToRefreshedPartitions(false, false).getPartitionNames();
                     Assertions.assertTrue(result.isEmpty());
                 });
     }
@@ -2943,7 +2945,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                     MVPCTRefreshProcessor mvRefreshProcessor =
                             (MVPCTRefreshProcessor) processor.getMVRefreshProcessor();
                     MvTaskRunContext mvTaskRunContext = new MvTaskRunContext(taskRunContext);
-                    Set<String> result = mvRefreshProcessor.getPCTMVToRefreshedPartitions(false).getPartitionNames();
+                    Set<String> result = new MVPCTRefreshSynchronizer(mvRefreshProcessor)
+                            .getPCTMVToRefreshedPartitions(false, false).getPartitionNames();
                     Assertions.assertFalse(result.isEmpty());
                     Set<String> expect = ImmutableSet.of("p0", "p1", "p2", "p3", "p4");
                     Assertions.assertEquals(expect, result);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -35,6 +35,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.mv.refresh.pct.MVPCTRefreshSynchronizer;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
@@ -450,7 +451,8 @@ public abstract class MVTestBase extends StarRocksTestBase {
 
     protected Map<Table, Set<String>> getRefTableRefreshedPartitions(MVPCTRefreshProcessor processor) {
         PCellSortedSet set = PCellSortedSet.of(Set.of(PCellWithName.of("p20220101", new PCellNone())));
-        Map<BaseTableSnapshotInfo, PCellSortedSet> baseTables = processor.getPCTRefTableRefreshPartitions(set);
+        Map<BaseTableSnapshotInfo, PCellSortedSet> baseTables =
+                new MVPCTRefreshSynchronizer(processor).getPCTRefTableRefreshPartitions(set);
         Assertions.assertEquals(2, baseTables.size());
         return baseTables.entrySet()
                 .stream()


### PR DESCRIPTION
## Why I'm doing:

Reduce coupling in the PCT refresh path by moving shared planning and synchronization control flow out of `MVPCTRefreshPartitioner` and `MVRefreshProcessor`, while keeping the existing range/list/non partitioner implementations unchanged.

## What I'm doing:

- extract shared PCT refresh planning logic into `MVPCTRefreshPlanner`
- extract shared PCT refresh synchronization and metadata preparation logic into `MVPCTRefreshSynchronizer`
- remove direct forwarding methods from `MVRefreshProcessor` and `MVPCTRefreshPartitioner`, and update processors/tests to call the new collaborators directly

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
