### PR TITLE
[BugFix] Avoid DB WRITE lock in TableRowCountAction REST endpoint

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableRowCountAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableRowCountAction.java
@@ -43,8 +43,8 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksHttpException;
+import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
-import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -96,25 +96,25 @@ public class TableRowCountAction extends RestBaseAction {
                 throw new StarRocksHttpException(HttpResponseStatus.NOT_FOUND,
                         "Database [" + dbName + "] " + "does not exists");
             }
-            Locker locker = new Locker();
-            locker.lockDatabase(db.getId(), LockType.WRITE);
-            try {
-                Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
-                if (table == null) {
-                    throw new StarRocksHttpException(HttpResponseStatus.NOT_FOUND,
-                            "Table [" + tableName + "] " + "does not exists");
-                }
-                // just only support OlapTable, ignore others such as ESTable
-                if (!(table instanceof OlapTable)) {
-                    // Forbidden
-                    throw new StarRocksHttpException(HttpResponseStatus.FORBIDDEN, "Table [" + tableName + "] "
-                            + "is not a OlapTable, only support OlapTable currently");
-                }
+            Table table = db.getTable(tableName);
+            if (table == null) {
+                throw new StarRocksHttpException(HttpResponseStatus.NOT_FOUND,
+                        "Table [" + tableName + "] " + "does not exists");
+            }
+            // just only support OlapTable, ignore others such as ESTable
+            if (!(table instanceof OlapTable)) {
+                // Forbidden
+                throw new StarRocksHttpException(HttpResponseStatus.FORBIDDEN, "Table [" + tableName + "] "
+                        + "is not a OlapTable, only support OlapTable currently");
+            }
+            // No revalidation under the lock (cf. lockTableAndCheckDbExist pattern):
+            // this endpoint is documented as approximate, and REST delivery already
+            // races with drop/rename. The lock is still needed to protect
+            // proximateRowCount's partition walk from concurrent mutation.
+            try (AutoCloseableLock ignore = new AutoCloseableLock(db.getId(), table.getId(), LockType.READ)) {
                 OlapTable olapTable = (OlapTable) table;
                 resultMap.put("status", 200);
                 resultMap.put("size", olapTable.proximateRowCount());
-            } finally {
-                locker.unLockDatabase(db.getId(), LockType.WRITE);
             }
         } catch (StarRocksHttpException e) {
             // status code  should conforms to HTTP semantic


### PR DESCRIPTION
The read-only `/api/{db}/{table}/_count` endpoint was acquiring a full DB WRITE lock just to compute olapTable.proximateRowCount(). Switch to the intensive-lock path (IS on DB + READ on the target table) via AutoCloseableLock. Null and type checks are hoisted out of the lock since getTable is a ConcurrentHashMap lookup and can fail fast without holding any lock.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
