### PR TITLE
[Enhancement] Protect IVM rewrite fallback from plan mutation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
@@ -45,6 +45,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.ivm.common.IvmRuleUtils;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.task.TaskContext;
 import com.starrocks.sql.optimizer.task.TaskScheduler;
 import com.starrocks.type.IntegerType;
@@ -91,32 +92,68 @@ public class IvmRewriter {
             return;
         }
 
-        OptExpression originalPlan = tree.getInputs().get(0);
+        OptExpression originalPlan = tree.inputAt(0);
+        ColumnRefSet requiredColumnsBefore = requiredColumns.clone();
+        ColumnRefSet taskRequiredColumnsBefore = rootTaskContext.getRequiredColumns().clone();
+        String originalPlanDigest = IvmRuleUtils.structureDigest(originalPlan);
+        boolean committed = false;
+        Throwable failure = null;
 
-        // Phase 1: Wrap with LogicalDeltaOperator and apply delta/version rules iteratively
-        ColumnRefOperator actionColumn = optimizerContext.getColumnRefFactory()
-                .create(IvmRuleUtils.ACTION_COLUMN_NAME, IvmRuleUtils.ACTION_COLUMN_TYPE, false);
-        tree.setChild(0, OptExpression.create(
-                new LogicalDeltaOperator(true, actionColumn), originalPlan));
-        deriveLogicalProperty(tree);
-        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.IVM_DELTA_REWRITE_RULES);
-
-        // Phase 2: Convergence check — if any markers remain, fall back to original plan
-        if (IvmRuleUtils.containsLogicalDelta(tree.getInputs().get(0))
-                || IvmRuleUtils.containsLogicalVersion(tree.getInputs().get(0))) {
-            tree.setChild(0, originalPlan);
+        try {
+            // Phase 1: Rewrite a cloned trial plan so fallback cannot corrupt the original plan.
+            ColumnRefOperator actionColumn = optimizerContext.getColumnRefFactory()
+                    .create(IvmRuleUtils.ACTION_COLUMN_NAME, IvmRuleUtils.ACTION_COLUMN_TYPE, false);
+            OptExpression trialPlan = MvUtils.cloneExpression(originalPlan);
+            tree.setChild(0, OptExpression.create(
+                    new LogicalDeltaOperator(true, actionColumn), trialPlan));
             deriveLogicalProperty(tree);
+            scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.IVM_DELTA_REWRITE_RULES);
+
+            // Phase 2: Convergence check — if any markers remain, fall back to original plan.
+            if (IvmRuleUtils.containsLogicalDelta(tree.inputAt(0))
+                    || IvmRuleUtils.containsLogicalVersion(tree.inputAt(0))) {
+                return;
+            }
+
+            // Phase 3: For PK target MVs, append __op column for UPSERT/DELETE semantics.
+            OptExpression rewrittenRoot = tree.inputAt(0);
+            deriveLogicalProperty(rewrittenRoot);
+            if (isPrimaryKeyTargetMv(optimizerContext)) {
+                rewrittenRoot = appendPkLoadOpColumn(rewrittenRoot, rootTaskContext, requiredColumns, actionColumn);
+            }
+            tree.setChild(0, rewrittenRoot);
+            deriveLogicalProperty(tree);
+            committed = true;
+        } catch (RuntimeException | Error t) {
+            failure = t;
+            throw t;
+        } finally {
+            if (!committed) {
+                tree.setChild(0, originalPlan);
+                restoreColumnRefSet(requiredColumns, requiredColumnsBefore);
+                restoreColumnRefSet(rootTaskContext.getRequiredColumns(), taskRequiredColumnsBefore);
+                deriveLogicalProperty(tree);
+            }
+            checkOriginalPlanNotMutated(originalPlanDigest, originalPlan, failure);
+        }
+    }
+
+    private static void restoreColumnRefSet(ColumnRefSet target, ColumnRefSet source) {
+        target.clear();
+        target.union(source);
+    }
+
+    private static void checkOriginalPlanNotMutated(String digestBefore, OptExpression originalPlan, Throwable failure) {
+        String digestAfter = IvmRuleUtils.structureDigest(originalPlan);
+        if (digestBefore.equals(digestAfter)) {
             return;
         }
-
-        // Phase 3: For PK target MVs, append __op column for UPSERT/DELETE semantics
-        OptExpression rewrittenRoot = tree.getInputs().get(0);
-        deriveLogicalProperty(rewrittenRoot);
-        if (isPrimaryKeyTargetMv(optimizerContext)) {
-            rewrittenRoot = appendPkLoadOpColumn(rewrittenRoot, rootTaskContext, requiredColumns, actionColumn);
+        IllegalStateException leak = new IllegalStateException("IVM rewrite leaked mutation into originalPlan");
+        if (failure != null) {
+            failure.addSuppressed(leak);
+        } else {
+            throw leak;
         }
-        tree.setChild(0, rewrittenRoot);
-        deriveLogicalProperty(tree);
     }
 
     private static boolean isPrimaryKeyTargetMv(OptimizerContext optimizerContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmRuleUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmRuleUtils.java
@@ -19,6 +19,8 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
 
+import java.util.Arrays;
+
 public class IvmRuleUtils {
     public static final String ACTION_COLUMN_NAME = "__ACTION__";
     public static final Type ACTION_COLUMN_TYPE = IntegerType.TINYINT;
@@ -48,5 +50,29 @@ public class IvmRuleUtils {
             }
         }
         return false;
+    }
+
+    public static String structureDigest(OptExpression root) {
+        StringBuilder sb = new StringBuilder();
+        buildStructureDigest(root, sb);
+        return sb.toString();
+    }
+
+    private static void buildStructureDigest(OptExpression node, StringBuilder sb) {
+        sb.append(node.getOp().getOpType())
+                .append('[')
+                .append(node.getOp())
+                .append(']');
+        if (node.getLogicalProperty() != null) {
+            int[] outputColumnIds = node.getOutputColumns().getColumnIds();
+            Arrays.sort(outputColumnIds);
+            sb.append("out=").append(Arrays.toString(outputColumnIds));
+        }
+        sb.append('(');
+        for (OptExpression child : node.getInputs()) {
+            buildStructureDigest(child, sb);
+            sb.append(',');
+        }
+        sb.append(')');
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
@@ -71,6 +71,7 @@ public class IvmRewriterTest {
         // Wrap in LogicalTreeAnchorOperator (required by RewriteTreeTask)
         OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
         deriveLogicalProperty(root);
+        String originalPlanDigest = IvmRuleUtils.structureDigest(scan);
 
         TaskContext taskContext = newTaskContext(context);
         TaskScheduler scheduler = new TaskScheduler();
@@ -81,6 +82,7 @@ public class IvmRewriterTest {
         // Plan should be unchanged — no Delta operator injected
         Assertions.assertFalse(IvmRuleUtils.containsLogicalDelta(root));
         Assertions.assertSame(scan, root.inputAt(0));
+        Assertions.assertEquals(originalPlanDigest, IvmRuleUtils.structureDigest(scan));
     }
 
     // ==================== Convergence: success ====================
@@ -100,6 +102,7 @@ public class IvmRewriterTest {
         // Wrap: root → scan (simulating INSERT target → query)
         OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
         deriveLogicalProperty(root);
+        String originalPlanDigest = IvmRuleUtils.structureDigest(scan);
 
         TaskContext taskContext = newTaskContext(context);
         TaskScheduler scheduler = new TaskScheduler();
@@ -112,6 +115,7 @@ public class IvmRewriterTest {
         Assertions.assertFalse(IvmRuleUtils.containsLogicalVersion(root));
         // Root child should no longer be the original scan (plan was rewritten)
         Assertions.assertNotSame(scan, root.inputAt(0));
+        Assertions.assertEquals(originalPlanDigest, IvmRuleUtils.structureDigest(scan));
     }
 
     // ==================== Convergence: failure → fallback ====================
@@ -132,16 +136,63 @@ public class IvmRewriterTest {
         OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
         deriveLogicalProperty(root);
         OptExpression originalChild = root.inputAt(0);
+        String originalPlanDigest = IvmRuleUtils.structureDigest(originalChild);
 
         TaskContext taskContext = newTaskContext(context);
         TaskScheduler scheduler = new TaskScheduler();
         ColumnRefSet requiredColumns = new ColumnRefSet();
+        ColumnRefSet requiredColumnsBefore = requiredColumns.clone();
+        ColumnRefSet taskRequiredColumnsBefore = taskContext.getRequiredColumns().clone();
 
         IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
 
         // Convergence failed → original plan restored
         Assertions.assertFalse(IvmRuleUtils.containsLogicalDelta(root));
         Assertions.assertSame(originalChild, root.inputAt(0));
+        Assertions.assertEquals(originalPlanDigest, IvmRuleUtils.structureDigest(originalChild));
+        Assertions.assertEquals(requiredColumnsBefore, requiredColumns);
+        Assertions.assertEquals(taskRequiredColumnsBefore, taskContext.getRequiredColumns());
+    }
+
+    @Test
+    public void testRewriteRestoresOriginalPlanWhenRewriteThrows(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        context.getSessionVariable().setEnableIVMRefresh(true);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
+        deriveLogicalProperty(root);
+        OptExpression originalChild = root.inputAt(0);
+        String originalPlanDigest = IvmRuleUtils.structureDigest(originalChild);
+
+        TaskContext taskContext = newTaskContext(context);
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+        requiredColumns.union(idRef);
+        taskContext.getRequiredColumns().union(dataRef);
+        ColumnRefSet requiredColumnsBefore = requiredColumns.clone();
+        ColumnRefSet taskRequiredColumnsBefore = taskContext.getRequiredColumns().clone();
+        TaskScheduler throwingScheduler = new TaskScheduler() {
+            @Override
+            public void rewriteIterative(OptExpression rewriteTree, TaskContext rewriteTaskContext,
+                                         com.starrocks.sql.optimizer.rule.Rule rule) {
+                throw new RuntimeException("injected IVM rewrite failure");
+            }
+        };
+
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                () -> IvmRewriter.rewrite(root, taskContext, throwingScheduler, requiredColumns));
+        Assertions.assertEquals("injected IVM rewrite failure", exception.getMessage());
+
+        Assertions.assertSame(originalChild, root.inputAt(0));
+        Assertions.assertEquals(originalPlanDigest, IvmRuleUtils.structureDigest(originalChild));
+        Assertions.assertEquals(requiredColumnsBefore, requiredColumns);
+        Assertions.assertEquals(taskRequiredColumnsBefore, taskContext.getRequiredColumns());
     }
 
     // ==================== appendPkLoadOpColumn ====================


### PR DESCRIPTION
## Why I'm doing:
IVM rewrite currently wraps and rewrites the original query plan directly. When rewrite fails to converge or throws during rule execution, the root may be restored, but parts of the original plan can already have been mutated through shared OptExpression / Operator references. This can leave the fallback path with a partially modified plan instead of the true pre-IVM plan.

## What I'm doing:
Run IVM rewrite on a cloned trialPlan instead of the original plan, and commit the rewritten result only after all IVM markers are eliminated. If rewrite does not converge or throws, restore the original plan and required column sets in finally. Also add a lightweight structure digest guard to detect unexpected mutation leakage into the original plan, plus unit coverage for successful rewrite, non-converged fallback, and exception fallback paths.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
