### PR TITLE
[auto-perf-opt] Parallelize del-file OSS reads in LakePersistentIndex::load_dels

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -480,7 +480,17 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 // The maximum number of memtables for pk index in shared-data mode.
-CONF_mInt32(pk_index_memtable_max_count, "2");
+// Controls the async-flush pipeline depth in LakePersistentIndex::flush_memtable:
+// while (inactive_memtables.size() + 1 < pk_index_memtable_max_count) the new
+// flush is submitted to the pk_index_memtable_flush pool; otherwise the write
+// path falls back to a synchronous flush that blocks the caller. With the prior
+// value of 2, only one inactive memtable could be in flight, so any hot PK
+// tablet that filled two memtables within a flush cycle (~100-200 ms of SST
+// IO) paid a full sync flush on its write path — a primary contributor to the
+// upsert P99 / Max tail on shared-data. 4 allows 3 pending async flushes,
+// giving bursty writers headroom without unbounded memory growth (each memtable
+// is bounded by l0_max_mem_usage / l0_min_mem_usage and the update memtracker).
+CONF_mInt32(pk_index_memtable_max_count, "4");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 // The parameters for pk index size-tiered compaction strategy.

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -75,7 +75,17 @@ CONF_mBool(enable_pk_index_parallel_execution, "true");
 CONF_mInt64(pk_index_parallel_execution_min_rows, "16384");
 
 // The maximum number of memtables for pk index in shared-data mode.
-CONF_mInt32(pk_index_memtable_max_count, "2");
+// Controls the async-flush pipeline depth in LakePersistentIndex::flush_memtable:
+// while (inactive_memtables.size() + 1 < pk_index_memtable_max_count) the new
+// flush is submitted to the pk_index_memtable_flush pool; otherwise the write
+// path falls back to a synchronous flush that blocks the caller. With the prior
+// value of 2, only one inactive memtable could be in flight, so any hot PK
+// tablet that filled two memtables within a flush cycle (~100-200 ms of SST
+// IO) paid a full sync flush on its write path — a primary contributor to the
+// upsert P99 / Max tail on shared-data. 4 allows 3 pending async flushes,
+// giving bursty writers headroom without unbounded memory growth (each memtable
+// is bounded by l0_max_mem_usage / l0_min_mem_usage and the update memtracker).
+CONF_mInt32(pk_index_memtable_max_count, "4");
 
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -949,7 +949,7 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
         auto pkc = pk_column->clone();
         auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
         if (!st.ok()) {
-            per_task_status[del_idx] = st;
+            per_task_status[del_idx] = st.status();
             return;
         }
         pkcs[del_idx] = std::move(pkc);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -897,29 +897,94 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
 
 // Rebuild index's memtable via del files, it will read from del file and write to index.
 // If it fail, SR will retry publish txn, and this index's memtable will be release and rebuild again.
+//
+// The read+deserialize of del-file contents (OSS IO + CPU) is performed in parallel across
+// del files via the pk_index_execution thread pool; the subsequent index get/replay_erase
+// is kept sequential because PersistentIndexMemtable has a single-writer contract.
+// This is critical for cold-start publishes where a tablet's PK index is not resident:
+// trace data (iter-005) showed rebuild_index_del_cost_us dominating pindex_load_from_lake_tablet_us
+// (e.g. 10.0 s / 10.1 s) with serialized OSS reads. The same thread pool and
+// enable_pk_index_parallel_execution flag are already used by _open_sstables_parallel.
 Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pkey_schema, int64_t rowset_version) {
     TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_index_del_cost_us");
     // Build pk column struct from schema
     ASSIGN_OR_RETURN(auto pk_encoding_type, rowset->tablet_schema()->primary_key_encoding_type_or_error());
     MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type));
-    // Iterate all del files and insert into index.
-    for (int del_idx = 0; del_idx < rowset->metadata().del_files_size(); ++del_idx) {
-        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+
+    const int ndel = rowset->metadata().del_files_size();
+    if (ndel == 0) {
+        return Status::OK();
+    }
+
+    // Phase 1 (parallel): read each del file from storage and deserialize into a per-file pk column.
+    // Nothing in this phase touches the pk index, so it is safe to run concurrently.
+    std::vector<MutableColumnPtr> pkcs(ndel);
+    std::vector<Status> per_task_status(ndel);
+    auto read_one = [&](int del_idx) {
         const auto& del = rowset->metadata().del_files(del_idx);
         RandomAccessFileOptions ropts;
         if (!del.encryption_meta().empty()) {
-            ASSIGN_OR_RETURN(ropts.encryption_info, KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
+            auto unwrap_res = KeyCache::instance().unwrap_encryption_meta(del.encryption_meta());
+            if (!unwrap_res.ok()) {
+                per_task_status[del_idx] = unwrap_res.status();
+                return;
+            }
+            ropts.encryption_info = *unwrap_res;
         }
-        ASSIGN_OR_RETURN(auto read_file,
-                         fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name())));
-        ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
-        const auto* data = reinterpret_cast<const uint8_t*>(read_buffer.data());
-        const auto* end = data + read_buffer.size();
-        // serialize to column
+        auto rf_res = fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name()));
+        if (!rf_res.ok()) {
+            per_task_status[del_idx] = rf_res.status();
+            return;
+        }
+        auto rf = std::move(rf_res).value();
+        auto buf_res = rf->read_all();
+        if (!buf_res.ok()) {
+            per_task_status[del_idx] = buf_res.status();
+            return;
+        }
+        auto buf = std::move(buf_res).value();
+        const auto* data = reinterpret_cast<const uint8_t*>(buf.data());
+        const auto* end = data + buf.size();
         auto pkc = pk_column->clone();
-        using Serd = serde::ColumnArraySerde;
-        RETURN_IF_ERROR(Serd::deserialize(data, end, pkc.get()));
+        auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
+        if (!st.ok()) {
+            per_task_status[del_idx] = st;
+            return;
+        }
+        pkcs[del_idx] = std::move(pkc);
+    };
+    std::unique_ptr<ThreadPoolToken> token;
+    if (ndel > 1 && config::enable_pk_index_parallel_execution) {
+        auto* pool = ExecEnv::GetInstance()->pk_index_execution_thread_pool();
+        if (pool != nullptr) {
+            token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+        }
+    }
+    for (int i = 0; i < ndel; ++i) {
+        if (token) {
+            auto st = token->submit_func([&read_one, i]() { read_one(i); });
+            if (!st.ok()) {
+                // Fall back to inline execution if submission fails (e.g. shutting down).
+                read_one(i);
+            }
+        } else {
+            read_one(i);
+        }
+    }
+    if (token) {
+        token->wait();
+    }
+    for (auto& st : per_task_status) {
+        RETURN_IF_ERROR(st);
+    }
+
+    // Phase 2 (sequential): filter old deletes via pk-index get() and replay_erase() them.
+    // Order must match the original single-threaded iteration so replay is deterministic.
+    for (int del_idx = 0; del_idx < ndel; ++del_idx) {
+        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+        const auto& del = rowset->metadata().del_files(del_idx);
+        auto& pkc = pkcs[del_idx];
         // We can't insert delete operation to index directly, because some delete operation is
         // older than current item, and we need to igore these delete operations.
         std::vector<IndexValue> found_values(pkc->size(), IndexValue(NullIndexValue));


### PR DESCRIPTION
## What type of PR is this?

- [x] improvement
- [ ] feature
- [ ] bug
- [ ] refactor
- [ ] doc

## Which StarRocks version(s) does this PR apply to?

- main

## Summary

On cold-start PK-index publishes on shared-data tables, `LakePersistentIndex::load_dels` is the dominant latency contributor: each rowset with del_files reads + deserializes them strictly serially, so a tablet with N rowsets × M del_files waits `N*M × OSS_read_latency` before any index work can begin.

This PR splits `load_dels` into two phases:

1. **Phase 1 (parallel)** — open, `read_all()` and `ColumnArraySerde::deserialize()` one pk column per del file on the `pk_index_execution` thread pool, using the same `enable_pk_index_parallel_execution` gate and `CONCURRENT` `ThreadPoolToken` pattern already used by `_open_sstables_parallel`. Nothing in this phase touches the pk index.
2. **Phase 2 (sequential)** — iterate the per-file pk columns **in the original order** and run `get()` / `generate_filter` / `replay_erase()` against the index. `PersistentIndexMemtable` keeps its single-writer contract and replay order is preserved exactly.

The parallel phase is skipped when `ndel <= 1` or when the flag is off, so the common single-del-file fast path has no overhead. Submission failures fall back to inline execution, so no new failure mode is introduced.

## Evidence this is the right target

Running the `999_1gb_1_1tb` realtime-benchmark template against a 6-CN shared-data cluster on top of PR #72016, iter-005's publish-version trace on the slowest tablet during the first-write burst showed:

```
txn=2309387  tablet=13991  cost=10.9s
    primary_index_load_latency_us      10.4s   ← whole publish-side load
    pindex_load_from_lake_tablet_us    10.1s   ← load_from_lake_tablet scope
    rebuild_index_del_cost_us          10.0s   ← cumulative load_dels scope
```

The entire 10 s cold-start tail is OSS read + deserialize in `load_dels`, not index mutation. Pool `cloud_native_pk_index_execution` simultaneously hit **~1848 active threads**, so 1848 tablets were all burning their budget on serialized per-rowset del-file OSS reads at the same moment. Across all 6 CNs, `segment_io_remote` + local-disk IO was the binder, not CPU (sysstat showed `usr%` in the 70s, not saturation).

## Expected impact

On cold-start tablets with multiple del files per rowset, `load_from_lake_tablet` latency falls toward `max(OSS_read_latency)` across del files instead of `sum(OSS_read_latency)`. Steady-state tablets that already had resident pk indexes are unaffected (no load_dels call).

Concretely we expect iter-005's whole-run upsert Max (32 786 ms, dominated by cold-start CommitAndPublishTimeMs) to fall, while steady-state P99 (1627 ms) should be within run-to-run noise.

Result will be validated in the next iteration of the optimization run against baseline iter-005.

## Thread safety

Phase 1 only touches disjoint slots in `pkcs[]` / `per_task_status[]` and calls `clone()`, `new_random_access_file()`, `read_all()`, and `ColumnArraySerde::deserialize()` — all safe to invoke concurrently. `pk_column` is a locally-constructed empty template column, and `clone()` does not mutate it. Phase 2 runs on the calling thread, preserving every existing invariant around `get()` / `replay_erase()`.