### PR TITLE
[BugFix] Fix PipelineTimerTask stuck in waitUtilFinished

### DIFF
--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -430,9 +430,9 @@ void FragmentContext::destroy_pass_through_chunk_buffer() {
 
 Status FragmentContext::set_pipeline_timer(PipelineTimer* timer) {
     _pipeline_timer = timer;
-    _timeout_task = new CheckFragmentTimeout(this);
+    _timeout_task = std::make_shared<CheckFragmentTimeout>(this);
     timespec tm = butil::seconds_from_now(runtime_state()->query_ctx()->get_query_expire_seconds());
-    RETURN_IF_ERROR(_pipeline_timer->schedule(_timeout_task, tm));
+    RETURN_IF_ERROR(_pipeline_timer->schedule(_timeout_task.get(), tm));
     return Status::OK();
 }
 
@@ -442,14 +442,14 @@ void FragmentContext::clear_pipeline_timer() {
             for (auto& [ignore, task] : _rf_timeout_tasks) {
                 if (task) {
                     task->unschedule(_pipeline_timer);
-                    SAFE_DELETE(task);
+                    task.reset();
                 }
             }
             _rf_timeout_tasks.clear();
         }
         if (_timeout_task) {
             _timeout_task->unschedule(_pipeline_timer);
-            SAFE_DELETE(_timeout_task);
+            _timeout_task.reset();
         }
     }
 }
@@ -583,21 +583,22 @@ void FragmentContext::init_event_scheduler() {
 void FragmentContext::add_timer_observer(PipelineObserver* observer, uint64_t timeout) {
     RFScanWaitTimeout* task;
     if (auto iter = _rf_timeout_tasks.find(timeout); iter != _rf_timeout_tasks.end()) {
-        task = down_cast<RFScanWaitTimeout*>(iter->second);
+        task = down_cast<RFScanWaitTimeout*>(iter->second.get());
     } else {
-        task = new RFScanWaitTimeout();
-        _rf_timeout_tasks.emplace(timeout, task);
+        auto timeoutTask = std::make_shared<RFScanWaitTimeout>();
+        task = timeoutTask.get();
+        _rf_timeout_tasks.emplace(timeout, timeoutTask);
     }
     task->add_observer(_runtime_state.get(), observer);
 }
 
 Status FragmentContext::submit_all_timer() {
     timespec tm = butil::microseconds_to_timespec(butil::gettimeofday_us());
-    for (auto [delta_ns, task] : _rf_timeout_tasks) {
+    for (const auto& [delta_ns, task] : _rf_timeout_tasks) {
         timespec abstime = tm;
         abstime.tv_nsec += delta_ns;
         butil::timespec_normalize(&abstime);
-        RETURN_IF_ERROR(_pipeline_timer->schedule(task, abstime));
+        RETURN_IF_ERROR(_pipeline_timer->schedule(task.get(), abstime));
     }
     return Status::OK();
 }

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -216,9 +216,9 @@ private:
 
     std::unique_ptr<EventScheduler> _event_scheduler;
     PipelineTimer* _pipeline_timer = nullptr;
-    PipelineTimerTask* _timeout_task = nullptr;
-    PipelineTimerTask* _report_state_task = nullptr;
-    std::unordered_map<uint64_t, PipelineTimerTask*> _rf_timeout_tasks;
+    std::shared_ptr<PipelineTimerTask> _timeout_task = nullptr;
+    std::shared_ptr<PipelineTimerTask> _report_state_task = nullptr;
+    std::unordered_map<uint64_t, std::shared_ptr<PipelineTimerTask>> _rf_timeout_tasks;
 
     RuntimeFilterHub _runtime_filter_hub;
 

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/pipeline/pipeline_driver.h"
 
+#include <memory>
 #include <random>
 #include <sstream>
 
@@ -795,7 +796,7 @@ void PipelineDriver::_update_global_rf_timer() {
     if (!_runtime_state->enable_event_scheduler()) {
         return;
     }
-    auto timer = std::make_unique<RFScanWaitTimeout>(true);
+    auto timer = std::make_shared<RFScanWaitTimeout>(true);
     timer->add_observer(_runtime_state, &_observer);
     _global_rf_timer = std::move(timer);
     timespec abstime = butil::nanoseconds_from_now(_global_rf_wait_timeout_ns);

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 
 #include "base/phmap/phmap.h"
 #include "column/vectorized_fwd.h"
@@ -630,7 +631,7 @@ protected:
 
     std::atomic<bool> _is_operator_cancelled{false};
 
-    std::unique_ptr<PipelineTimerTask> _global_rf_timer;
+    std::shared_ptr<PipelineTimerTask> _global_rf_timer;
 
     std::atomic<bool> _local_prepare_is_done{false};
 

--- a/be/src/exec/pipeline/schedule/pipeline_timer.cpp
+++ b/be/src/exec/pipeline/schedule/pipeline_timer.cpp
@@ -25,18 +25,7 @@
 namespace starrocks::pipeline {
 
 void PipelineTimerTask::waitUtilFinished() {
-    if (_finished.load(std::memory_order_acquire)) {
-        return;
-    }
-    // seq_cst is required: it pairs with the seq_cst load of _has_consumer in
-    // doRun() so that if doRun observes no consumer (and thus skips notify),
-    // this thread is guaranteed to observe _finished == true in the while-loop
-    // below and return without sleeping.
-    _has_consumer.store(true, std::memory_order_seq_cst);
-    std::unique_lock lock(_mutex);
-    while (!_finished) {
-        _cv.wait(lock);
-    }
+    _latch.wait();
 }
 
 void PipelineTimerTask::unschedule(PipelineTimer* timer) {

--- a/be/src/exec/pipeline/schedule/pipeline_timer.h
+++ b/be/src/exec/pipeline/schedule/pipeline_timer.h
@@ -14,10 +14,9 @@
 
 #pragma once
 
-#include <atomic>
-#include <condition_variable>
 #include <cstdint>
-#include <mutex>
+#include <latch>
+#include <memory>
 
 #include "common/status.h"
 
@@ -42,38 +41,32 @@ private:
     TaskId _tid{};
 };
 
-class PipelineTimerTask {
+class PipelineTimerTask : public std::enable_shared_from_this<PipelineTimerTask> {
 public:
     virtual ~PipelineTimerTask() = default;
 
     void doRun() {
+        auto self = shared_from_this();
         Run();
-        _finished.store(true, std::memory_order_seq_cst);
-        // seq_cst pairs with the seq_cst store of _has_consumer in waitUtilFinished
-        // to guarantee that at least one of the two threads observes the other's
-        // write (Dekker-style), so no wakeup can be lost.
-        if (_has_consumer.load(std::memory_order_seq_cst)) {
-            _cv.notify_one();
-        }
+        _latch.count_down();
     }
 
-    // only call when unschedule == 1
-    void waitUtilFinished();
     void unschedule(PipelineTimer* timer);
 
     void set_tid(TaskId tid) { _tid = tid; }
     TaskId tid() const { return _tid; }
+
+private:
+    // only call when unschedule == 1
+    void waitUtilFinished();
 
 protected:
     // implement interface
     virtual void Run() = 0;
 
 protected:
-    std::atomic<bool> _finished{};
-    std::atomic<bool> _has_consumer{};
+    std::latch _latch{1};
     TaskId _tid{};
-    std::mutex _mutex;
-    std::condition_variable _cv;
 };
 
 class PipelineTimer {

--- a/be/src/exec/pipeline/wait_operator.cpp
+++ b/be/src/exec/pipeline/wait_operator.cpp
@@ -30,7 +30,7 @@ Status WaitSourceOperator::prepare(RuntimeState* state) {
     _wait_context->observable->attach_source_observer(state, observer());
     if (state->enable_event_scheduler()) {
         auto fragment_ctx = state->fragment_ctx();
-        auto timer = std::make_unique<RFScanWaitTimeout>();
+        auto timer = std::make_shared<RFScanWaitTimeout>();
         timer->add_observer(state, observer());
         _wait_timer_task = std::move(timer);
         timespec abstime = butil::microseconds_to_timespec(butil::gettimeofday_us());
@@ -79,7 +79,7 @@ Status WaitSinkOperator::prepare(RuntimeState* state) {
         // driver when the block timeout elapses, so that need_input() gets re-evaluated and the
         // driver resumes rather than hanging until query timeout.
         auto fragment_ctx = state->fragment_ctx();
-        auto timer = std::make_unique<RFScanWaitTimeout>();
+        auto timer = std::make_shared<RFScanWaitTimeout>();
         timer->add_observer(state, observer());
         _wait_timer_task = std::move(timer);
         timespec abstime = butil::microseconds_to_timespec(butil::gettimeofday_us());

--- a/be/src/exec/pipeline/wait_operator.h
+++ b/be/src/exec/pipeline/wait_operator.h
@@ -84,7 +84,7 @@ private:
     WaitContext* _wait_context = nullptr;
     int64_t _wait_time_ns = 0;
     EnumDebugAction _action = EnumDebugAction::WAIT;
-    std::unique_ptr<PipelineTimerTask> _wait_timer_task;
+    std::shared_ptr<PipelineTimerTask> _wait_timer_task;
 };
 
 class WaitSinkOperator final : public Operator {
@@ -124,7 +124,7 @@ private:
     int64_t _wait_time_ns = 0;
     EnumDebugAction _action = EnumDebugAction::WAIT;
     mutable bool _reached_timeout = false;
-    std::unique_ptr<PipelineTimerTask> _wait_timer_task;
+    std::shared_ptr<PipelineTimerTask> _wait_timer_task;
 };
 
 class WaitContextFactory {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -57,6 +57,7 @@ set(EXEC_FILES
         ./exec/workgroup/work_group_manager_test.cpp
         ./exec/workgroup/mem_tracker_manager_test.cpp
         ./exec/pipeline/schedule/observer_test.cpp
+        ./exec/pipeline/schedule/pipeline_timer_test.cpp
         ./exec/pipeline/pipeline_control_flow_test.cpp
         ./exec/pipeline/pipeline_driver_queue_test.cpp
         ./exec/pipeline/multi_level_concurrent_queue_test.cpp

--- a/be/test/exec/pipeline/schedule/observer_test.cpp
+++ b/be/test/exec/pipeline/schedule/observer_test.cpp
@@ -118,24 +118,24 @@ TEST(TimerThreadTest, test) {
             int32_t& changed;
             std::counting_semaphore<>& s;
         };
-        Timer noop(changed, s);
+        auto noop = std::make_shared<Timer>(changed, s);
         //
         timespec abstime = butil::microseconds_to_timespec(butil::gettimeofday_us());
         timespec s1 = abstime;
         s1.tv_sec -= 10;
         // schedule a expired task
-        ASSERT_OK(timer.schedule(&noop, s1));
+        ASSERT_OK(timer.schedule(noop.get(), s1));
         s.acquire();
-        noop.unschedule(&timer);
+        noop->unschedule(&timer);
         ASSERT_TRUE(changed);
 
         timespec s2 = abstime;
         s2.tv_sec += 3600;
         // schedule a task
         changed = false;
-        ASSERT_OK(timer.schedule(&noop, s2));
+        ASSERT_OK(timer.schedule(noop.get(), s2));
         sleep(1);
-        noop.unschedule(&timer);
+        noop->unschedule(&timer);
         ASSERT_FALSE(changed);
     }
     {
@@ -151,16 +151,16 @@ TEST(TimerThreadTest, test) {
             int32_t& changed;
             std::counting_semaphore<>& s;
         };
-        SleepTimer noop(changed, s);
+        auto noop = std::make_shared<SleepTimer>(changed, s);
         //
         timespec abstime = butil::microseconds_to_timespec(butil::gettimeofday_us());
         timespec s1 = abstime;
         s1.tv_sec -= 10;
         // schedule a expired task
-        ASSERT_OK(timer.schedule(&noop, s1));
+        ASSERT_OK(timer.schedule(noop.get(), s1));
         s.acquire();
         // will wait util timer finished
-        noop.unschedule(&timer);
+        noop->unschedule(&timer);
         ASSERT_TRUE(changed);
     }
 }

--- a/be/test/exec/pipeline/schedule/pipeline_timer_test.cpp
+++ b/be/test/exec/pipeline/schedule/pipeline_timer_test.cpp
@@ -1,0 +1,285 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/schedule/pipeline_timer.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <semaphore>
+#include <thread>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "butil/time.h"
+#include "gtest/gtest.h"
+#include "util/brpc_stub_cache.h"
+
+namespace starrocks::pipeline {
+
+namespace {
+
+constexpr int TIMER_TASK_REMOVED = 0;
+
+timespec past_abstime() {
+    timespec ts = butil::microseconds_to_timespec(butil::gettimeofday_us());
+    ts.tv_sec -= 10;
+    return ts;
+}
+
+timespec future_abstime(int seconds) {
+    return butil::seconds_from_now(seconds);
+}
+
+// Minimal PipelineTimerTask that records Run() invocations and lets the test
+// choreograph when Run() returns. Unlike the lambda tasks in observer_test, this
+// exposes enough hooks for testing the _finished / _has_consumer protocol.
+class ProbeTask final : public PipelineTimerTask {
+public:
+    void Run() override {
+        run_enter.release();
+        ran.store(true, std::memory_order_release);
+        if (block_until_released) {
+            run_gate.acquire();
+        }
+    }
+
+    std::atomic<bool> ran{false};
+    bool block_until_released{false};
+    std::counting_semaphore<> run_enter{0};
+    std::counting_semaphore<> run_gate{0};
+};
+
+class LightProbe final : public LightTimerTask {
+public:
+    void Run() override { ran.store(true, std::memory_order_release); }
+    std::atomic<bool> ran{false};
+};
+
+} // namespace
+
+PipelineTimer timer;
+
+std::once_flag timer_init_flag;
+
+class PipelineTimerTaskTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        std::call_once(timer_init_flag, []() { ASSERT_OK(timer.start()); });
+    }
+};
+
+// Scheduled task with past abstime must run, and unschedule after completion
+// must return promptly without wedging in waitUtilFinished.
+TEST_F(PipelineTimerTaskTest, runs_when_due_and_unschedule_after_done_does_not_block) {
+    auto task = std::make_shared<ProbeTask>();
+    ASSERT_OK(timer.schedule(task.get(), past_abstime()));
+    task->run_enter.acquire();
+    // Give doRun a moment to finish its post-Run bookkeeping.
+    while (!task->ran.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    // task.unschedule drives waitUtilFinished only when rc == 1 (running).
+    // Either way, the call must not deadlock.
+    auto start = std::chrono::steady_clock::now();
+    task->unschedule(&timer);
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    EXPECT_LT(elapsed, std::chrono::seconds(5));
+    EXPECT_TRUE(task->ran.load(std::memory_order_acquire));
+}
+
+// Unscheduling a not-yet-due task must remove it cleanly (rc == 0) without waiting.
+TEST_F(PipelineTimerTaskTest, unschedule_pending_task_removes_without_wait) {
+    auto task = std::make_shared<ProbeTask>();
+    ASSERT_OK(timer.schedule(task.get(), future_abstime(3600)));
+
+    int rc = timer.unschedule(task.get());
+    EXPECT_EQ(rc, TIMER_TASK_REMOVED);
+
+    // Give bthread a beat; Run should never be invoked.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_FALSE(task->ran.load(std::memory_order_acquire));
+}
+
+// When Run is in progress, unschedule reports TIMER_TASK_RUNNING and
+// PipelineTimerTask::unschedule blocks inside waitUtilFinished until Run returns.
+TEST_F(PipelineTimerTaskTest, wait_util_finished_blocks_until_run_returns) {
+    auto task = std::make_shared<ProbeTask>();
+    task->block_until_released = true;
+
+    ASSERT_OK(timer.schedule(task.get(), past_abstime()));
+    // Wait until Run has started on the timer thread.
+    task->run_enter.acquire();
+
+    // bthread has consumed the task from its heap -> unschedule must say "running".
+    int rc = timer.unschedule(task.get());
+    EXPECT_EQ(rc, TIMER_TASK_RUNNING);
+
+    // Let another thread call waitUtilFinished; unblock Run a bit later and verify
+    // the waiter returns.
+    std::atomic<bool> waiter_returned{false};
+    std::thread waiter([&] {
+        task->waitUtilFinished();
+        waiter_returned.store(true, std::memory_order_release);
+    });
+
+    // Confirm the waiter is actually blocked, i.e., Run hasn't returned yet.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_FALSE(waiter_returned.load(std::memory_order_acquire));
+
+    // Release Run; the waiter must observe _finished and return.
+    task->run_gate.release();
+    waiter.join();
+    EXPECT_TRUE(waiter_returned.load(std::memory_order_acquire));
+    EXPECT_TRUE(task->ran.load(std::memory_order_acquire));
+}
+
+// waitUtilFinished must be a no-op once the task has already finished.
+TEST_F(PipelineTimerTaskTest, wait_util_finished_returns_immediately_when_already_done) {
+    auto task = std::make_shared<ProbeTask>();
+    ASSERT_OK(timer.schedule(task.get(), past_abstime()));
+    task->run_enter.acquire();
+
+    // Drain post-Run state by asking unschedule to synchronize.
+    task->unschedule(&timer);
+
+    auto start = std::chrono::steady_clock::now();
+    task->waitUtilFinished();
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    EXPECT_LT(elapsed, std::chrono::milliseconds(50));
+}
+
+// Dekker / lost-wakeup stress. Each iteration creates a fresh task, schedules it
+// with a past abstime and immediately calls PipelineTimerTask::unschedule. This
+// races the waiter's store of _has_consumer against doRun()'s _finished store +
+// _has_consumer load. A regression on the memory ordering (or on mutex + CV
+// coordination) will manifest as a permanent hang here; the watchdog bounds
+// the failure mode to a test timeout instead of a CI stall.
+TEST_F(PipelineTimerTaskTest, dekker_synchronization_stress) {
+    constexpr int kIterations = 2000;
+    constexpr auto kWatchdog = std::chrono::seconds(30);
+
+    std::atomic<int> completed{0};
+    std::atomic<bool> done{false};
+
+    std::thread watchdog([&] {
+        auto deadline = std::chrono::steady_clock::now() + kWatchdog;
+        while (!done.load(std::memory_order_acquire)) {
+            if (std::chrono::steady_clock::now() > deadline) {
+                ADD_FAILURE() << "waitUtilFinished hang detected at iteration "
+                              << completed.load(std::memory_order_acquire);
+                std::_Exit(1);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    });
+
+    for (int i = 0; i < kIterations; ++i) {
+        auto task = std::make_shared<ProbeTask>();
+        ASSERT_OK(timer.schedule(task.get(), past_abstime()));
+        // unschedule drives the race: may see TIMER_TASK_REMOVED (we got there
+        // first), TIMER_TASK_RUNNING (bthread already popped it) or -1 (finished
+        // before we looked). Only the "running" case exercises waitUtilFinished,
+        // but all three must terminate quickly.
+        task->unschedule(&timer);
+        completed.store(i + 1, std::memory_order_release);
+    }
+
+    done.store(true, std::memory_order_release);
+    watchdog.join();
+    EXPECT_EQ(completed.load(std::memory_order_acquire), kIterations);
+}
+
+TEST_F(PipelineTimerTaskTest, batched_tasks_all_unblock_eventually) {
+    constexpr int kTasks = 16;
+    std::vector<std::shared_ptr<ProbeTask>> tasks;
+    tasks.reserve(kTasks);
+    for (int i = 0; i < kTasks; ++i) {
+        tasks.emplace_back(std::make_shared<ProbeTask>());
+    }
+
+    // The first task holds up the TimerThread so that the head-of-batch waiter
+    // has to go through waitUtilFinished. This mirrors the production scenario
+    // where a fragment finalize thread is stuck waiting for CheckFragmentTimeout
+    // to return.
+    tasks[0]->block_until_released = true;
+
+    timespec when = past_abstime();
+    for (auto& t : tasks) {
+        ASSERT_OK(timer.schedule(t.get(), when));
+    }
+
+    // Wait for the first task to actually start running.
+    tasks[0]->run_enter.acquire();
+
+    // Fire off one waiter per task. Each one mimics clear_pipeline_timer.
+    std::vector<std::thread> waiters;
+    std::atomic<int> finished{0};
+    waiters.reserve(kTasks);
+    for (auto& t : tasks) {
+        waiters.emplace_back([&, raw = t.get()] {
+            raw->unschedule(&timer);
+            finished.fetch_add(1, std::memory_order_acq_rel);
+        });
+    }
+
+    // All tail waiters should return quickly (bthread cancels them); only the
+    // head waiter should still be blocked on waitUtilFinished.
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (finished.load(std::memory_order_acquire) < kTasks - 1) {
+        ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+                << "tail waiters did not return while head-of-batch Run was still blocked";
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    // Head waiter must still be pending at this point.
+    EXPECT_LT(finished.load(std::memory_order_acquire), kTasks);
+
+    // Release the head; its waiter must now drain via the notify path.
+    tasks[0]->run_gate.release();
+
+    for (auto& w : waiters) {
+        w.join();
+    }
+    EXPECT_EQ(finished.load(std::memory_order_acquire), kTasks);
+    EXPECT_TRUE(tasks[0]->ran.load(std::memory_order_acquire));
+}
+
+// LightTimerTask goes through a separate schedule/unschedule pair and lacks the
+// _finished / _has_consumer protocol. Cover it to prevent regressions in the
+// other overload of PipelineTimer.
+TEST_F(PipelineTimerTaskTest, light_timer_task_runs_and_unschedules) {
+    {
+        LightProbe expired;
+        ASSERT_OK(timer.schedule(&expired, past_abstime()));
+        for (int i = 0; i < 100 && !expired.ran.load(std::memory_order_acquire); ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        EXPECT_TRUE(expired.ran.load(std::memory_order_acquire));
+    }
+    {
+        LightProbe pending;
+        ASSERT_OK(timer.schedule(&pending, future_abstime(3600)));
+        int rc = timer.unschedule(&pending);
+        EXPECT_EQ(rc, TIMER_TASK_REMOVED);
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        EXPECT_FALSE(pending.ran.load(std::memory_order_acquire));
+    }
+}
+
+} // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing:

```
#include <condition_variable>
#include <iostream>
#include <thread>
#include <atomic>

    std::atomic<bool> _finished{};
    std::atomic<bool> _has_consumer{};
    std::mutex _mutex;
    std::condition_variable _cv;

void waitUtilFinished() {
    _has_consumer.store(true, std::memory_order_seq_cst);
    std::unique_lock lock(_mutex);
    while (!_finished) {
        std::this_thread::sleep_for(std::chrono::milliseconds(100));
        _cv.wait(lock);
    }
}

void doRun() {
    std::this_thread::sleep_for(std::chrono::milliseconds(10));
    _finished.store(true, std::memory_order_seq_cst);
    if (_has_consumer.load(std::memory_order_seq_cst)) {
        _cv.notify_one();
    }
}


int main() {
    std::thread t1(doRun);
    std::thread t2(waitUtilFinished);

    t1.join();
    t2.join();
}
```

## What I'm doing:

Fixes #71939

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
