### PR TITLE
[BugFix] Add __hash__ and __eq__ to ReflectedPartitionInfo

### DIFF
--- a/contrib/starrocks-python-client/starrocks/engine/interfaces.py
+++ b/contrib/starrocks-python-client/starrocks/engine/interfaces.py
@@ -260,9 +260,27 @@ class ReflectedPartitionInfo:
     partition_method: str  # includes the type and expressions
     pre_created_partitions: Optional[str] = None
 
+    def __post_init__(self) -> None:
+        # Normalize eagerly so that __hash__ and __eq__ see stable values
+        # and __str__ never needs to mutate fields.
+        if self.type:
+            self.type = self.type.upper()
+        if self.partition_method:
+            self.partition_method = self.partition_method.strip()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ReflectedPartitionInfo):
+            return NotImplemented
+        return (
+            self.type == other.type
+            and self.partition_method == other.partition_method
+            and self.pre_created_partitions == other.pre_created_partitions
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.type, self.partition_method, self.pre_created_partitions))
+
     def __str__(self) -> str:
-        self.type = self.type.upper() if self.type else self.type
-        self.partition_method = self.partition_method.strip() if self.partition_method else self.partition_method
         if self.pre_created_partitions:
             return f"{self.partition_method} {self.pre_created_partitions}"
         return f"{self.partition_method}"


### PR DESCRIPTION
Python dataclasses with eq=True (default) and frozen=False (default) set __hash__ to None, making instances unhashable. Add explicit __hash__ and __eq__ methods so ReflectedPartitionInfo can be used in sets and as dict keys.

## Why I'm doing:

`ReflectedPartitionInfo` 是一个使用 `@dataclasses.dataclass` 装饰的数据类。Python 规定，当 `eq=True`（默认）且 `frozen=False`（默认）时，`__hash__` 会被自动置为 `None`，导致该类的实例无法被哈希——无法放入 `set`，也无法作为 `dict` 的 key，在需要去重或缓存分区信息的场景下会抛出 `TypeError: unhashable type: 'ReflectedPartitionInfo'`。

**已发现于 SuperSet 创建 dataset 的场景。**

## What I'm doing:

Fixes #issue

为 `ReflectedPartitionInfo` 显式实现 `__eq__` 和 `__hash__` 方法，使其基于 `(type, partition_method, pre_created_partitions)` 三个字段进行相等性比较和哈希计算，从而让实例可哈希。

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
