### PR TITLE
[BugFix] Reject time-travel clauses in view and MV definitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -807,6 +807,25 @@ public class AnalyzerUtils {
         return tableRelations;
     }
 
+    public static void prohibitTimeTravelQuery(StatementBase statementBase, String operation) {
+        for (TableRelation tableRelation : collectTableRelations(statementBase)) {
+            if (tableRelation.getQueryPeriod() == null && Strings.isNullOrEmpty(tableRelation.getQueryPeriodString())) {
+                continue;
+            }
+
+            String tableName = tableRelation.getResolveTableName() != null
+                    ? tableRelation.getResolveTableName().toSql()
+                    : tableRelation.getName().toSql();
+            String queryPeriod = Strings.nullToEmpty(tableRelation.getQueryPeriodString()).trim();
+            if (queryPeriod.isEmpty()) {
+                throw new SemanticException("Do not support %s with time travel clause on table %s",
+                        operation, tableName);
+            }
+            throw new SemanticException("Do not support %s with time travel clause `%s` on table %s",
+                    operation, queryPeriod, tableName);
+        }
+    }
+
     public static List<ViewRelation> collectViewRelations(StatementBase statementBase) {
         List<ViewRelation> viewRelations = Lists.newArrayList();
         new AnalyzerUtils.ViewRelationsCollector(viewRelations).visit(statementBase);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -343,6 +343,7 @@ public class MaterializedViewAnalyzer {
             // analyze query statement, can check whether tables and columns exist in catalog
             Analyzer.analyze(queryStatement, context);
             AnalyzerUtils.checkNondeterministicFunction(queryStatement);
+            AnalyzerUtils.prohibitTimeTravelQuery(queryStatement, "create materialized view");
 
             boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(queryStatement);
             if (hasTemporaryTable) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -604,6 +604,16 @@ public class QueryAnalyzer {
             ((TableRelation) fromRelation).setPruneScanColumns(scanColumns);
         }
 
+        private boolean hasTemporalClause(TableRelation tableRelation) {
+            return tableRelation.getQueryPeriod() != null || tableRelation.getQueryPeriodString() != null;
+        }
+
+        private void checkNoTemporalClauseOnNonTableRelation(TableRelation tableRelation, String relationType) {
+            if (hasTemporalClause(tableRelation)) {
+                throw unsupportedException("Unsupported relation type for temporal clauses, relation type: " + relationType);
+            }
+        }
+
         private Relation resolveTableRef(Relation relation, Scope scope, Set<TableName> aliasSet) {
             if (relation instanceof JoinRelation) {
                 JoinRelation join = (JoinRelation) relation;
@@ -649,6 +659,8 @@ public class QueryAnalyzer {
                 if (tableName != null && Strings.isNullOrEmpty(tableName.getDb())) {
                     Optional<CTERelation> withQuery = scope.getCteQueries(tableName.getTbl());
                     if (withQuery.isPresent()) {
+                        checkNoTemporalClauseOnNonTableRelation(tableRelation, "CTE");
+
                         CTERelation withRelation = withQuery.get();
                         withRelation.addTableRef();
                         RelationFields withRelationFields = withQuery.get().getRelationFields();
@@ -703,6 +715,8 @@ public class QueryAnalyzer {
 
                 Relation r;
                 if (table instanceof View) {
+                    checkNoTemporalClauseOnNonTableRelation(tableRelation, table.getType().name());
+
                     View view = (View) table;
                     QueryStatement queryStatement = view.getQueryStatement();
                     ViewRelation viewRelation = new ViewRelation(tableName, view, queryStatement);
@@ -725,6 +739,8 @@ public class QueryAnalyzer {
 
                     r = viewRelation;
                 } else if (table instanceof ConnectorView) {
+                    checkNoTemporalClauseOnNonTableRelation(tableRelation, table.getType().name());
+
                     ConnectorView connectorView = (ConnectorView) table;
                     QueryStatement queryStatement = connectorView.getQueryStatement();
                     View view = new View(connectorView.getId(), connectorView.getName(), connectorView.getFullSchema(),
@@ -735,7 +751,7 @@ public class QueryAnalyzer {
 
                     r = viewRelation;
                 } else {
-                    if (tableRelation.getQueryPeriodString() != null && !table.isTemporal()) {
+                    if (hasTemporalClause(tableRelation) && !table.isTemporal()) {
                         throw unsupportedException("Unsupported table type for temporal clauses, table type: " +
                                 table.getType());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
@@ -74,6 +74,7 @@ public class ViewAnalyzer {
             }
 
             Analyzer.analyze(stmt.getQueryStatement(), context);
+            AnalyzerUtils.prohibitTimeTravelQuery(stmt.getQueryStatement(), "create view");
             boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(stmt.getQueryStatement());
             if (hasTemporaryTable) {
                 throw new SemanticException("View can't base on temporary table");
@@ -126,6 +127,7 @@ public class ViewAnalyzer {
             AlterViewClause alterViewClause = (AlterViewClause) alterClause;
 
             Analyzer.analyze(alterViewClause.getQueryStatement(), context);
+            AnalyzerUtils.prohibitTimeTravelQuery(alterViewClause.getQueryStatement(), "alter view");
             boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(((AlterViewClause) alterClause).getQueryStatement());
             if (hasTemporaryTable) {
                 throw new SemanticException("View can't base on temporary table");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -102,6 +102,21 @@ public class AnalyzeSingleTest {
     }
 
     @Test
+    public void testTimeTravelClauseOnViewRelation() throws Exception {
+        AnalyzeTestUtil.getStarRocksAssert()
+                .withView("create view test.view_time_travel_base as select v1, v2 from test.t0", () ->
+                        analyzeFail("select v1, v2 from test.view_time_travel_base for version as of 1",
+                                "Unsupported relation type for temporal clauses, relation type: VIEW"));
+    }
+
+    @Test
+    public void testTimeTravelClauseOnCteRelation() {
+        analyzeFail("with cte_time_travel_base as (select v1, v2 from test.t0) " +
+                        "select v1, v2 from cte_time_travel_base for version as of 1",
+                "Unsupported relation type for temporal clauses, relation type: CTE");
+    }
+
+    @Test
     public void testIdentifierStartWithDigit() {
         StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse("select * from a.11b", 0).get(0);
         Assertions.assertEquals("SELECT * FROM a.11b", AstToStringBuilder.toString(statementBase));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -243,6 +243,75 @@ public class MaterializedViewAnalyzerTest {
     }
 
     @Test
+    public void testCreateMaterializedViewWithTimeTravelClause() {
+        analyzeFail("create materialized view mv_time_travel\n" +
+                        "distributed by hash(id) buckets 3\n" +
+                        "refresh deferred manual\n" +
+                        "as select id, data, date from iceberg0.partitioned_db.t1 for version as of 1",
+                "Do not support create materialized view with time travel clause");
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithTimeTravelClauseInCte() {
+        analyzeFail("create materialized view mv_time_travel_in_cte\n" +
+                        "distributed by hash(id) buckets 3\n" +
+                        "refresh deferred manual\n" +
+                        "as with cte as (select id, data, date from iceberg0.partitioned_db.t1 for version as of 1)\n" +
+                        "select id, data, date from cte",
+                "Do not support create materialized view with time travel clause");
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithTimeTravelClauseOnView() throws Exception {
+        starRocksAssert.withView("create view test.base_view_mv_time_travel as select k1, k2 from test.tbl1", () ->
+                analyzeFail("create materialized view mv_time_travel_on_view\n" +
+                                "distributed by hash(k2) buckets 3\n" +
+                                "refresh deferred manual\n" +
+                                "as select k1, k2 from test.base_view_mv_time_travel for version as of 1",
+                        "Unsupported relation type for temporal clauses, relation type: VIEW"));
+    }
+
+    @Test
+    public void testCreateViewWithTimeTravelClause() {
+        analyzeFail("create view test.view_time_travel as " +
+                        "select id, data from iceberg0.partitioned_db.t1 for version as of 1",
+                "Do not support create view with time travel clause");
+    }
+
+    @Test
+    public void testCreateViewWithTimeTravelClauseInCte() {
+        analyzeFail("create view test.view_time_travel_in_cte as " +
+                        "with cte as (select id, data from iceberg0.partitioned_db.t1 for version as of 1)\n" +
+                        "select id, data from cte",
+                "Do not support create view with time travel clause");
+    }
+
+    @Test
+    public void testCreateViewWithTimeTravelClauseOnView() throws Exception {
+        starRocksAssert.withView("create view test.base_view_time_travel as select k1, k2 from test.tbl1", () ->
+                analyzeFail("create view test.view_time_travel_on_view as " +
+                                "select k1, k2 from test.base_view_time_travel for version as of 1",
+                        "Unsupported relation type for temporal clauses, relation type: VIEW"));
+    }
+
+    @Test
+    public void testAlterViewWithTimeTravelClause() throws Exception {
+        starRocksAssert.withView("create view test.view_alter_time_travel as select k1 from test.tbl1", () ->
+                analyzeFail("alter view test.view_alter_time_travel as " +
+                                "select id, data from iceberg0.partitioned_db.t1 for version as of 1",
+                        "Do not support alter view with time travel clause"));
+    }
+
+    @Test
+    public void testAlterViewWithTimeTravelClauseOnView() throws Exception {
+        starRocksAssert.withView("create view test.base_view_alter_time_travel as select k1, k2 from test.tbl1", () ->
+                starRocksAssert.withView("create view test.target_view_alter_time_travel as select k1, k2 from test.tbl1",
+                        () -> analyzeFail("alter view test.target_view_alter_time_travel as " +
+                                        "select k1, k2 from test.base_view_alter_time_travel for version as of 1",
+                                "Unsupported relation type for temporal clauses, relation type: VIEW")));
+    }
+
+    @Test
     public void testCreateMvWithNotExistResourceGroup() {
         String sql = "create materialized view mv\n" +
                 "PARTITION BY k1\n" +


### PR DESCRIPTION
## Why I'm doing:

`CREATE VIEW` and `CREATE MATERIALIZED VIEW` currently accept Iceberg time-travel clauses such as `FOR VERSION AS OF`, but the stored definition and refresh path do not preserve that semantics end to end. This can lead to wrong results for view execution and MV refresh. Until full support exists, these definitions should be rejected explicitly.

## What I'm doing:

- add a shared analyzer check to detect time-travel clauses on table relations and reject them with a semantic error
- apply the restriction to `CREATE VIEW`, `ALTER VIEW`, and `CREATE MATERIALIZED VIEW`
- add analyzer tests that cover all three DDL entry points
- validate the rejection behavior in the NovaRocks runtime environment

Fixes #71968

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
