### PR TITLE
[BugFix] Preserve time-travel clauses in AST to SQL output

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -394,6 +394,11 @@ public class AST2SQLVisitor extends AST2StringVisitor {
         StringBuilder sqlBuilder = new StringBuilder();
         sqlBuilder.append(node.getName().toSql());
 
+        if (StringUtils.isNotEmpty(node.getQueryPeriodString())) {
+            sqlBuilder.append(" ");
+            sqlBuilder.append(StringUtils.trim(node.getQueryPeriodString()));
+        }
+
         if (node.getPartitionNames() != null) {
             List<String> partitionNames = node.getPartitionNames().getPartitionNames();
             if (partitionNames != null && !partitionNames.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
@@ -198,4 +198,26 @@ public class AstToSQLBuilderTest {
                 "WHERE `cte02`.`priority` IS NOT NULL";
         Assertions.assertEquals(expected, toPrettySQL(stmt));
     }
+
+    @Test
+    public void testTimeTravelRoundTrip() {
+        {
+            String sql = "SELECT * FROM t0 FOR VERSION AS OF 1";
+            StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+            String serializedSql = AstToSQLBuilder.toSQL(stmt);
+            Assertions.assertEquals("SELECT *\nFROM `t0` FOR VERSION AS OF 1", serializedSql);
+            Assertions.assertEquals("SELECT *\nFROM `t0` FOR VERSION AS OF 1", AstToSQLBuilder.buildSimple(stmt));
+            Assertions.assertDoesNotThrow(() -> SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT));
+        }
+
+        {
+            String sql = "SELECT * FROM t0 FOR SYSTEM_TIME AS OF '2016-10-09 08:07:06'";
+            StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+            String serializedSql = AstToSQLBuilder.toSQL(stmt);
+            Assertions.assertEquals("SELECT *\nFROM `t0` FOR SYSTEM_TIME AS OF '2016-10-09 08:07:06'", serializedSql);
+            Assertions.assertEquals("SELECT *\nFROM `t0` FOR SYSTEM_TIME AS OF '2016-10-09 08:07:06'",
+                    AstToSQLBuilder.buildSimple(stmt));
+            Assertions.assertDoesNotThrow(() -> SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT));
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

AST-to-SQL serialization currently drops time-travel clauses stored in `TableRelation.queryPeriodString`, so SQL that contains `FOR VERSION AS OF` or `FOR SYSTEM_TIME AS OF` cannot round-trip through `AstToSQLBuilder`. Any later path that reparses the serialized SQL loses that time-travel semantics.

## What I'm doing:

- serialize `queryPeriodString` in `AST2SQLVisitor.visitTable()` right after the table name
- trim the parser-added trailing whitespace so the generated SQL stays stable
- add regression tests for both `AstToSQLBuilder.toSQL()` and `AstToSQLBuilder.buildSimple()` with version-based and system-time-based time travel

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
