### PR TITLE
[Feature] Support Iceberg RowDelta composite sink on BE

### DIFF
--- a/be/src/connector/CMakeLists.txt
+++ b/be/src/connector/CMakeLists.txt
@@ -38,4 +38,5 @@ ADD_BE_LIB(Connector
         deletion_vector/deletion_vector.cpp
         deletion_vector/deletion_bitmap.cpp
         iceberg_delete_sink.cpp
+        iceberg_row_delta_sink.cpp
 )

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -240,6 +240,8 @@ public:
         __builtin_unreachable();
     }
 
+    virtual std::unique_ptr<ConnectorChunkSinkProvider> create_row_delta_sink_provider() const { return nullptr; }
+
     virtual ConnectorType connector_type() const = 0;
 };
 

--- a/be/src/connector/connector_chunk_sink.h
+++ b/be/src/connector/connector_chunk_sink.h
@@ -28,6 +28,7 @@
 namespace starrocks::connector {
 
 class AsyncFlushStreamPoller;
+class SinkMemoryManager;
 class SinkOperatorMemoryManager;
 
 using PartitionKey = std::pair<std::string, std::vector<int8_t>>;
@@ -43,15 +44,19 @@ public:
 
     void set_operator_mem_mgr(SinkOperatorMemoryManager* op_mem_mgr) { _op_mem_mgr = op_mem_mgr; }
 
+    // Expose the writer list so composite sinks can register it with the
+    // outer SinkOperatorMemoryManager for aggregated memory accounting.
+    std::vector<PartitionChunkWriterPtr>* writers() { return &_writers; }
+
     virtual ~ConnectorChunkSink() = default;
 
-    Status init();
+    virtual Status init();
 
     virtual Status add(const ChunkPtr& chunk);
 
     virtual Status finish();
 
-    void rollback();
+    virtual void rollback();
 
     virtual bool is_finished();
 
@@ -93,6 +98,11 @@ protected:
 
 struct ConnectorChunkSinkContext {
     virtual ~ConnectorChunkSinkContext() = default;
+
+    // Called by ConnectorSinkOperatorFactory after SinkMemoryManager is created.
+    // Composite sinks (e.g. IcebergRowDeltaSink) override this to receive the
+    // manager and create per-sub-sink child managers during initialization.
+    virtual void set_sink_mem_mgr(SinkMemoryManager* /*mgr*/) {}
 };
 
 class ConnectorChunkSinkProvider {

--- a/be/src/connector/iceberg_chunk_sink.cpp
+++ b/be/src/connector/iceberg_chunk_sink.cpp
@@ -95,7 +95,7 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergChunkSinkProvider::create_c
             ColumnEvaluator::clone(ctx->column_evaluators));
     auto location_provider = std::make_shared<connector::LocationProvider>(
             ctx->path, print_id(ctx->fragment_context->query_id()), runtime_state->be_number(), driver_id,
-            boost::to_lower_copy(ctx->format));
+            boost::to_lower_copy(ctx->format), ctx->writer_tag);
 
     std::vector<std::string>& partition_columns = ctx->partition_column_names;
     std::vector<std::string>& transform_exprs = ctx->transform_exprs;
@@ -118,7 +118,9 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergChunkSinkProvider::create_c
                         fs,
                         ctx->fragment_context,
                         query_execution_services->runtime->connector_sink_spill_executor,
-                        runtime_state->desc_tbl().get_tuple_descriptor(ctx->tuple_desc_id),
+                        ctx->override_tuple_desc != nullptr
+                                ? ctx->override_tuple_desc
+                                : runtime_state->desc_tbl().get_tuple_descriptor(ctx->tuple_desc_id),
                         column_evaluators,
                         ctx->sort_ordering});
         partition_chunk_writer_factory = std::make_unique<SpillPartitionChunkWriterFactory>(partition_chunk_writer_ctx);

--- a/be/src/connector/iceberg_chunk_sink.h
+++ b/be/src/connector/iceberg_chunk_sink.h
@@ -67,6 +67,15 @@ struct IcebergChunkSinkContext : public ConnectorChunkSinkContext {
     pipeline::FragmentContext* fragment_context = nullptr;
     int tuple_desc_id = -1;
     std::shared_ptr<SortOrdering> sort_ordering;
+
+    // Override tuple descriptor for the spill writer. When set (non-null), used instead of
+    // looking up tuple_desc_id from runtime_state->desc_tbl(). Needed by RowDelta data
+    // sub-sink whose data-only tuple is not registered in the global descriptor table.
+    TupleDescriptor* override_tuple_desc = nullptr;
+
+    // Optional tag inserted into file name prefix to distinguish writers.
+    // Empty by default (standalone INSERT). Set to "data" for RowDelta composite sinks.
+    std::string writer_tag;
 };
 
 class IcebergChunkSinkProvider : public ConnectorChunkSinkProvider {

--- a/be/src/connector/iceberg_connector.cpp
+++ b/be/src/connector/iceberg_connector.cpp
@@ -16,6 +16,7 @@
 
 #include "iceberg_chunk_sink.h"
 #include "iceberg_delete_sink.h"
+#include "iceberg_row_delta_sink.h"
 
 namespace starrocks::connector {
 
@@ -25,6 +26,10 @@ std::unique_ptr<ConnectorChunkSinkProvider> IcebergConnector::create_data_sink_p
 
 std::unique_ptr<ConnectorChunkSinkProvider> IcebergConnector::create_delete_sink_provider() const {
     return std::make_unique<connector::IcebergDeleteSinkProvider>();
+}
+
+std::unique_ptr<ConnectorChunkSinkProvider> IcebergConnector::create_row_delta_sink_provider() const {
+    return std::make_unique<IcebergRowDeltaSinkProvider>();
 }
 
 } // namespace starrocks::connector

--- a/be/src/connector/iceberg_connector.h
+++ b/be/src/connector/iceberg_connector.h
@@ -29,6 +29,7 @@ public:
 
     std::unique_ptr<ConnectorChunkSinkProvider> create_data_sink_provider() const override;
     std::unique_ptr<ConnectorChunkSinkProvider> create_delete_sink_provider() const override;
+    std::unique_ptr<ConnectorChunkSinkProvider> create_row_delta_sink_provider() const override;
 };
 
 } // namespace starrocks::connector

--- a/be/src/connector/iceberg_delete_sink.cpp
+++ b/be/src/connector/iceberg_delete_sink.cpp
@@ -118,14 +118,12 @@ Status IcebergDeleteSink::add(const ChunkPtr& chunk) {
     }
     SlotId file_path_slot_id = file_path_it->second.slot_ref.slot_id;
 
-    // Find pos column slot_id from the mapping
     auto pos_it = _column_slot_map.find("_pos");
     if (pos_it == _column_slot_map.end()) {
         return Status::InternalError("Could not find _pos column in column_slot_map");
     }
     SlotId pos_slot_id = pos_it->second.slot_ref.slot_id;
 
-    // Get file_path and pos columns using slot_id
     ColumnPtr file_path_column = chunk->get_column_by_slot_id(file_path_slot_id);
     ColumnPtr pos_column = chunk->get_column_by_slot_id(pos_slot_id);
     if (file_path_column == nullptr || pos_column == nullptr) {
@@ -257,7 +255,8 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergDeleteSinkProvider::create_
 
     // Create location provider for delete files
     auto location_provider = std::make_shared<connector::LocationProvider>(
-            ctx->path, print_id(ctx->fragment_context->query_id()), runtime_state->be_number(), driver_id, "parquet");
+            ctx->path, print_id(ctx->fragment_context->query_id()), runtime_state->be_number(), driver_id, "parquet",
+            ctx->writer_tag);
 
     std::vector<formats::FileColumnId> file_column_ids(column_names.size());
     // file_path column (index 0)

--- a/be/src/connector/iceberg_delete_sink.h
+++ b/be/src/connector/iceberg_delete_sink.h
@@ -65,6 +65,10 @@ struct IcebergDeleteSinkContext : public ConnectorChunkSinkContext {
 
     // Column name to slot reference mapping (stores slot_ref and type)
     std::unordered_map<std::string, TExprNode> column_slot_map;
+
+    // Optional tag inserted into file name prefix to distinguish writers.
+    // Empty by default (standalone DELETE). Set to "delete" for RowDelta composite sinks.
+    std::string writer_tag;
 };
 
 // IcebergDeleteSinkProvider creates IcebergDeleteSink for writing position delete files

--- a/be/src/connector/iceberg_row_delta_sink.cpp
+++ b/be/src/connector/iceberg_row_delta_sink.cpp
@@ -1,0 +1,165 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/iceberg_row_delta_sink.h"
+
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "exec/pipeline/fragment_context.h"
+
+namespace starrocks::connector {
+
+IcebergRowDeltaSink::IcebergRowDeltaSink(std::unique_ptr<ConnectorChunkSink> delete_sink,
+                                         std::unique_ptr<ConnectorChunkSink> data_sink, int32_t op_code_index,
+                                         SinkMemoryManager* sink_mem_mgr, RuntimeState* state)
+        : ConnectorChunkSink({}, {}, std::make_unique<NopPartitionChunkWriterFactory>(), state, true),
+          _delete_sink(std::move(delete_sink)),
+          _data_sink(std::move(data_sink)),
+          _op_code_index(op_code_index),
+          _sink_mem_mgr(sink_mem_mgr) {}
+
+Status IcebergRowDeltaSink::init() {
+    RETURN_IF_ERROR(ConnectorChunkSink::init());
+
+    _delete_sink->set_io_poller(_io_poller);
+    _data_sink->set_io_poller(_io_poller);
+
+    // Each sub-sink needs its own SinkOperatorMemoryManager because
+    // ConnectorChunkSink::init() binds the manager to the sink's _writers list.
+    if (_sink_mem_mgr != nullptr) {
+        _delete_sink->set_operator_mem_mgr(_sink_mem_mgr->create_child_manager());
+        _data_sink->set_operator_mem_mgr(_sink_mem_mgr->create_child_manager());
+    }
+
+    if (_profile != nullptr) {
+        _delete_sink->set_profile(_profile);
+        _data_sink->set_profile(_profile);
+    }
+
+    RETURN_IF_ERROR(_delete_sink->init());
+    RETURN_IF_ERROR(_data_sink->init());
+
+    // This composite sink owns no writers of its own (NopPartitionChunkWriterFactory),
+    // so the operator-level kill-victim / backpressure path would see an empty
+    // candidate list. Register sub-sink writer lists with the outer manager so
+    // memory pressure logic can flush real writers held by the sub-sinks.
+    if (_op_mem_mgr != nullptr) {
+        _op_mem_mgr->add_candidates(_delete_sink->writers());
+        _op_mem_mgr->add_candidates(_data_sink->writers());
+    }
+
+    return Status::OK();
+}
+
+void IcebergRowDeltaSink::callback_on_commit(const CommitResult& result) {
+    // Sub-sinks handle their own callbacks.
+}
+
+void IcebergRowDeltaSink::rollback() {
+    // The outer sink owns no writers; rollback actions are held by the sub-sinks.
+    // On cancel, propagate so uncommitted data / position-delete files get cleaned.
+    _delete_sink->rollback();
+    _data_sink->rollback();
+    ConnectorChunkSink::rollback();
+}
+
+// Filter the original chunk to keep only the specified rows, preserving all
+// columns and slot_ids. This ensures sub-sinks receive chunks that are
+// structurally identical to what the pipeline would produce for a standalone
+// DELETE or INSERT operation — same slot_ids, same column order, same types.
+static ChunkPtr filter_chunk_by_rows(const ChunkPtr& chunk, const std::vector<uint32_t>& row_indices) {
+    ChunkPtr filtered = chunk->clone_empty();
+    filtered->append_selective(*chunk, row_indices.data(), 0, row_indices.size());
+    return filtered;
+}
+
+Status IcebergRowDeltaSink::add(const ChunkPtr& chunk) {
+    int num_rows = chunk->num_rows();
+    if (num_rows == 0) {
+        return Status::OK();
+    }
+
+    auto op_code_column = chunk->get_column_by_index(_op_code_index);
+    const auto* op_codes = ColumnHelper::get_data_column(op_code_column.get());
+    const auto* op_code_data = down_cast<const FixedLengthColumn<int8_t>*>(op_codes)->get_data().data();
+
+    _delete_rows.clear();
+    _data_rows.clear();
+
+    for (int i = 0; i < num_rows; ++i) {
+        int8_t op = op_code_data[i];
+        switch (op) {
+        case OP_NO_OP:
+            break;
+        case OP_DELETE:
+            _delete_rows.push_back(i);
+            break;
+        case OP_UPDATE:
+            _delete_rows.push_back(i);
+            _data_rows.push_back(i);
+            break;
+        case OP_INSERT:
+            _data_rows.push_back(i);
+            break;
+        default:
+            return Status::InternalError(fmt::format("Unknown op_code: {}", op));
+        }
+    }
+
+    // Fast path: when all rows have the same op_code (common for pure UPDATE where
+    // every row is OP_UPDATE), pass the original chunk directly without copying.
+    bool all_to_delete = (_delete_rows.size() == num_rows);
+    bool all_to_data = (_data_rows.size() == num_rows);
+
+    if (!_delete_rows.empty()) {
+        RETURN_IF_ERROR(_delete_sink->add(all_to_delete ? chunk : filter_chunk_by_rows(chunk, _delete_rows)));
+    }
+
+    if (!_data_rows.empty()) {
+        RETURN_IF_ERROR(_data_sink->add(all_to_data ? chunk : filter_chunk_by_rows(chunk, _data_rows)));
+    }
+
+    return Status::OK();
+}
+
+Status IcebergRowDeltaSink::finish() {
+    RETURN_IF_ERROR(_delete_sink->finish());
+    RETURN_IF_ERROR(_data_sink->finish());
+    return Status::OK();
+}
+
+bool IcebergRowDeltaSink::is_finished() {
+    return _delete_sink->is_finished() && _data_sink->is_finished();
+}
+
+StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergRowDeltaSinkProvider::create_chunk_sink(
+        std::shared_ptr<ConnectorChunkSinkContext> context, int32_t driver_id) {
+    auto ctx = std::dynamic_pointer_cast<IcebergRowDeltaSinkContext>(context);
+    if (ctx == nullptr) {
+        return Status::InternalError("IcebergRowDeltaSinkProvider: context is not IcebergRowDeltaSinkContext");
+    }
+
+    auto runtime_state = ctx->data_sink_ctx->fragment_context->runtime_state();
+
+    IcebergDeleteSinkProvider delete_provider;
+    ASSIGN_OR_RETURN(auto delete_sink, delete_provider.create_chunk_sink(ctx->delete_sink_ctx, driver_id));
+
+    IcebergChunkSinkProvider data_provider;
+    ASSIGN_OR_RETURN(auto data_sink, data_provider.create_chunk_sink(ctx->data_sink_ctx, driver_id));
+
+    return std::make_unique<IcebergRowDeltaSink>(std::move(delete_sink), std::move(data_sink), ctx->op_code_index,
+                                                 ctx->sink_mem_mgr, runtime_state);
+}
+
+} // namespace starrocks::connector

--- a/be/src/connector/iceberg_row_delta_sink.h
+++ b/be/src/connector/iceberg_row_delta_sink.h
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "common/status.h"
+#include "connector/connector_chunk_sink.h"
+#include "connector/iceberg_chunk_sink.h"
+#include "connector/iceberg_delete_sink.h"
+#include "connector/sink_memory_manager.h"
+
+namespace starrocks::connector {
+
+// Context for IcebergRowDeltaSink
+// Composes delete-sink and data-sink contexts plus routing column indices.
+struct IcebergRowDeltaSinkContext : public ConnectorChunkSinkContext {
+    ~IcebergRowDeltaSinkContext() override = default;
+
+    // Sub-contexts for creating underlying sinks
+    std::shared_ptr<IcebergDeleteSinkContext> delete_sink_ctx;
+    std::shared_ptr<IcebergChunkSinkContext> data_sink_ctx;
+
+    // Index of the op_code column in the input chunk (last column)
+    int32_t op_code_index = -1;
+
+    // Query-level memory manager for creating child managers for sub-sinks.
+    // Set by ConnectorSinkOperatorFactory via set_sink_mem_mgr() after construction.
+    SinkMemoryManager* sink_mem_mgr = nullptr;
+
+    void set_sink_mem_mgr(SinkMemoryManager* mgr) override { sink_mem_mgr = mgr; }
+};
+
+// IcebergRowDeltaSinkProvider creates IcebergRowDeltaSink for Iceberg UPDATE operations.
+// It composes an IcebergDeleteSinkProvider and an IcebergChunkSinkProvider.
+class IcebergRowDeltaSinkProvider final : public ConnectorChunkSinkProvider {
+public:
+    ~IcebergRowDeltaSinkProvider() override = default;
+
+    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(std::shared_ptr<ConnectorChunkSinkContext> context,
+                                                                    int32_t driver_id) override;
+};
+
+// IcebergRowDeltaSink routes rows from an input chunk to a delete sink and a data sink
+// based on the op_code column. Used for Iceberg UPDATE which atomically deletes old rows
+// and inserts new rows (row-level delta / Merge-On-Read).
+//
+// Op codes:
+//   0 = no-op (skip)
+//   1 = delete only (position delete)
+//   2 = update (delete old row + insert new row)
+//   3 = insert only (new data row)
+class IcebergRowDeltaSink final : public ConnectorChunkSink {
+public:
+    // Op code constants
+    static constexpr int8_t OP_NO_OP = 0;
+    static constexpr int8_t OP_DELETE = 1;
+    static constexpr int8_t OP_UPDATE = 2;
+    static constexpr int8_t OP_INSERT = 3;
+
+    IcebergRowDeltaSink(std::unique_ptr<ConnectorChunkSink> delete_sink, std::unique_ptr<ConnectorChunkSink> data_sink,
+                        int32_t op_code_index, SinkMemoryManager* sink_mem_mgr, RuntimeState* state);
+
+    ~IcebergRowDeltaSink() override = default;
+
+    Status init() override;
+
+    void callback_on_commit(const CommitResult& result) override;
+
+    Status add(const ChunkPtr& chunk) override;
+
+    Status finish() override;
+
+    void rollback() override;
+
+    bool is_finished() override;
+
+private:
+    std::unique_ptr<ConnectorChunkSink> _delete_sink;
+    std::unique_ptr<ConnectorChunkSink> _data_sink;
+
+    int32_t _op_code_index;
+
+    SinkMemoryManager* _sink_mem_mgr = nullptr;
+
+    // Reused across add() calls to avoid per-chunk heap allocations
+    std::vector<uint32_t> _delete_rows;
+    std::vector<uint32_t> _data_rows;
+};
+
+// A no-op PartitionChunkWriterFactory used by IcebergRowDeltaSink's base class.
+// The RowDeltaSink delegates all actual writing to its sub-sinks, so this factory
+// is never used to create real writers.
+class NopPartitionChunkWriterFactory final : public PartitionChunkWriterFactory {
+public:
+    ~NopPartitionChunkWriterFactory() override = default;
+
+    Status init() override { return Status::OK(); }
+
+    PartitionChunkWriterPtr create(std::string partition,
+                                   std::vector<int8_t> partition_field_null_list) const override {
+        return nullptr;
+    }
+};
+
+} // namespace starrocks::connector

--- a/be/src/connector/sink_memory_manager.cpp
+++ b/be/src/connector/sink_memory_manager.cpp
@@ -21,30 +21,39 @@ namespace starrocks::connector {
 
 Status SinkOperatorMemoryManager::init(std::vector<PartitionChunkWriterPtr>* writers, AsyncFlushStreamPoller* io_poller,
                                        CommitFunc commit_func) {
-    _candidates = writers;
+    _candidate_lists.clear();
+    _candidate_lists.push_back(writers);
     _commit_func = std::move(commit_func);
     _io_poller = io_poller;
     return Status::OK();
 }
 
-bool SinkOperatorMemoryManager::kill_victim() {
-    if (_candidates->empty()) {
-        return false;
+void SinkOperatorMemoryManager::add_candidates(std::vector<PartitionChunkWriterPtr>* writers) {
+    if (writers == nullptr) {
+        return;
     }
+    _candidate_lists.push_back(writers);
+}
 
-    // Find a target file writer to flush.
+bool SinkOperatorMemoryManager::kill_victim() {
+    // Find a target file writer to flush across all registered candidate lists.
     // For buffered partition writer, choose the the writer with the largest file size.
     // For spillable partition writer, choose the the writer with the largest memory size that can be spilled.
     PartitionChunkWriterPtr victim = nullptr;
-    for (auto& writer : *_candidates) {
-        int64_t flushable_bytes = writer->get_flushable_bytes();
-        if (flushable_bytes == 0) {
+    for (auto* candidates : _candidate_lists) {
+        if (candidates == nullptr) {
             continue;
         }
-        if (victim && flushable_bytes < victim->get_flushable_bytes()) {
-            continue;
+        for (auto& writer : *candidates) {
+            int64_t flushable_bytes = writer->get_flushable_bytes();
+            if (flushable_bytes == 0) {
+                continue;
+            }
+            if (victim && flushable_bytes < victim->get_flushable_bytes()) {
+                continue;
+            }
+            victim = writer;
         }
-        victim = writer;
     }
     if (victim == nullptr) {
         return false;
@@ -67,8 +76,13 @@ int64_t SinkOperatorMemoryManager::update_releasable_memory() {
 
 int64_t SinkOperatorMemoryManager::update_writer_occupied_memory() {
     int64_t writer_occupied_memory = 0;
-    for (auto& writer : *_candidates) {
-        writer_occupied_memory += writer->get_flushable_bytes();
+    for (auto* candidates : _candidate_lists) {
+        if (candidates == nullptr) {
+            continue;
+        }
+        for (auto& writer : *candidates) {
+            writer_occupied_memory += writer->get_flushable_bytes();
+        }
     }
     _writer_occupied_memory.store(writer_occupied_memory);
     return _writer_occupied_memory;

--- a/be/src/connector/sink_memory_manager.h
+++ b/be/src/connector/sink_memory_manager.h
@@ -30,6 +30,11 @@ public:
     Status init(std::vector<PartitionChunkWriterPtr>* writers, AsyncFlushStreamPoller* io_poller,
                 CommitFunc commit_func);
 
+    // Register an additional writer list. Used by composite sinks
+    // (e.g. IcebergRowDeltaSink) so memory pressure logic can see writers
+    // owned by their sub-sinks.
+    void add_candidates(std::vector<PartitionChunkWriterPtr>* writers);
+
     // return true if a victim is found and killed, otherwise return false
     bool kill_victim();
 
@@ -44,7 +49,8 @@ public:
     int64_t writer_occupied_memory() { return _writer_occupied_memory.load(); }
 
 private:
-    std::vector<PartitionChunkWriterPtr>* _candidates = nullptr; // reference, owned by sink operator
+    // One or more references to writer lists owned by sink operator(s).
+    std::vector<std::vector<PartitionChunkWriterPtr>*> _candidate_lists;
     CommitFunc _commit_func;
     AsyncFlushStreamPoller* _io_poller;
     std::atomic_int64_t _releasable_memory{0};

--- a/be/src/connector/utils.h
+++ b/be/src/connector/utils.h
@@ -100,10 +100,13 @@ StatusOr<std::string> build_canonical_file_suffix(const std::string& format, TCo
 class LocationProvider {
 public:
     // file_name_prefix = {query_id}_{be_number}_{driver_id}
+    // or {query_id}_{be_number}_{writer_tag}_{driver_id} when writer_tag is non-empty
     LocationProvider(const std::string& base_path, const std::string& query_id, int be_number, int driver_id,
-                     std::string file_suffix)
+                     std::string file_suffix, std::string writer_tag = "")
             : _base_path(PathUtils::remove_trailing_slash(base_path)),
-              _file_name_prefix(fmt::format("{}_{}_{}", query_id, be_number, driver_id)),
+              _file_name_prefix(writer_tag.empty()
+                                        ? fmt::format("{}_{}_{}", query_id, be_number, driver_id)
+                                        : fmt::format("{}_{}_{}_{}", query_id, be_number, writer_tag, driver_id)),
               _file_name_suffix(std::move(file_suffix)) {}
 
     // location = base_path/partition/{query_id}_{be_number}_{driver_id}_index.file_suffix

--- a/be/src/exec/data_sinks/data_sink_factory.cpp
+++ b/be/src/exec/data_sinks/data_sink_factory.cpp
@@ -152,8 +152,8 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
     }
 #ifndef __APPLE__
     case TDataSinkType::ICEBERG_TABLE_SINK:
-    case TDataSinkType::ICEBERG_DELETE_SINK: 
-    case TDataSinkType::ICEBERG_ROW_DELTA_SINK: {                                       
+    case TDataSinkType::ICEBERG_DELETE_SINK:
+    case TDataSinkType::ICEBERG_ROW_DELTA_SINK: {
         if (!thrift_sink.__isset.iceberg_table_sink) {
             return Status::InternalError("Missing iceberg table sink");
         }

--- a/be/src/exec/data_sinks/data_sink_factory.cpp
+++ b/be/src/exec/data_sinks/data_sink_factory.cpp
@@ -152,7 +152,8 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
     }
 #ifndef __APPLE__
     case TDataSinkType::ICEBERG_TABLE_SINK:
-    case TDataSinkType::ICEBERG_DELETE_SINK: {
+    case TDataSinkType::ICEBERG_DELETE_SINK: 
+    case TDataSinkType::ICEBERG_ROW_DELTA_SINK: {                                       
         if (!thrift_sink.__isset.iceberg_table_sink) {
             return Status::InternalError("Missing iceberg table sink");
         }
@@ -161,7 +162,8 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
     }
 #else
     case TDataSinkType::ICEBERG_TABLE_SINK:
-    case TDataSinkType::ICEBERG_DELETE_SINK: {
+    case TDataSinkType::ICEBERG_DELETE_SINK:
+    case TDataSinkType::ICEBERG_ROW_DELTA_SINK: {
         return Status::NotSupported("Iceberg table sink is disabled on macOS");
     }
 #endif

--- a/be/src/exec/data_sinks/iceberg_table_sink.cpp
+++ b/be/src/exec/data_sinks/iceberg_table_sink.cpp
@@ -16,13 +16,16 @@
 
 #include <unordered_map>
 
+#include "common/config.h"
 #include "common/runtime_profile.h"
+#include "connector/iceberg_row_delta_sink.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exprs/expr.h"
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
+#include "runtime/descriptor_helper.h"
 #include "runtime/descriptors_ext.h"
 #include "runtime/runtime_state.h"
 #include "runtime/service_contexts.h"
@@ -65,7 +68,8 @@ Status append_iceberg_sink_column(const SlotDescriptor* slot,
     } else if (col_name == HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER) {
         field_id.field_id = HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID;
     } else {
-        return Status::InternalError("Iceberg sink field ids do not match output expressions");
+        return Status::InternalError(
+                fmt::format("Iceberg sink field ids do not match output expressions, col_name={}", col_name));
     }
 
     parquet_field_ids->push_back(field_id);
@@ -118,15 +122,15 @@ Status IcebergTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operat
     auto* iceberg_table_desc = down_cast<IcebergTableDescriptor*>(table_desc);
     auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
 
-    // Determine if this is a delete sink (delete files) or regular sink (data files)
-    bool is_delete_sink = (thrift_sink.type == TDataSinkType::ICEBERG_DELETE_SINK);
-
     std::unique_ptr<connector::ConnectorChunkSinkProvider> sink_provider;
     std::shared_ptr<connector::ConnectorChunkSinkContext> sink_ctx;
     std::vector<TExpr> partition_expr;
     std::vector<std::string> transform_exprs = iceberg_table_desc->get_transform_exprs();
 
-    if (is_delete_sink) {
+    if (thrift_sink.type == TDataSinkType::ICEBERG_ROW_DELTA_SINK) {
+        RETURN_IF_ERROR(create_row_delta_sink_context(thrift_sink, runtime_state, context, iceberg_table_desc,
+                                                      sink_provider, sink_ctx, partition_expr));
+    } else if (thrift_sink.type == TDataSinkType::ICEBERG_DELETE_SINK) {
         RETURN_IF_ERROR(create_delete_sink_context(thrift_sink, runtime_state, context, iceberg_table_desc,
                                                    sink_provider, sink_ctx, partition_expr));
     } else {
@@ -200,7 +204,9 @@ Status IcebergTableSink::create_delete_sink_context(
     // Configure partition columns if table is partitioned
     delete_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
 
-    // Build column name to slot reference map for partition column updates
+    // Build column name → slot reference map.
+    // Used by IcebergDeleteSink::add() to locate _file/_pos columns by slot_id,
+    // and by update_partition_expr_slot_refs_by_map() to bind partition expressions.
     TupleDescriptor* tuple_desc = runtime_state->desc_tbl().get_tuple_descriptor(t_iceberg_sink.tuple_id);
     if (tuple_desc == nullptr) {
         return Status::InternalError(
@@ -358,6 +364,192 @@ Status IcebergTableSink::create_data_sink_context(const TDataSink& thrift_sink, 
         }
         data_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
     }
+
+    return Status::OK();
+}
+
+Status IcebergTableSink::create_row_delta_sink_context(
+        const TDataSink& thrift_sink, RuntimeState* runtime_state, pipeline::PipelineBuilderContext* context,
+        IcebergTableDescriptor* iceberg_table_desc,
+        std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
+        std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx, std::vector<TExpr>& partition_expr) const {
+    auto* fragment_ctx = context->fragment_context();
+    auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
+
+    // Resolve tuple descriptor
+    TupleDescriptor* tuple_desc = runtime_state->desc_tbl().get_tuple_descriptor(t_iceberg_sink.tuple_id);
+    if (tuple_desc == nullptr) {
+        return Status::InternalError(
+                fmt::format("Failed to find tuple descriptor with id {}", t_iceberg_sink.tuple_id));
+    }
+
+    const auto& slots = tuple_desc->slots();
+    const auto& output_exprs = this->get_output_expr();
+    if (slots.size() != output_exprs.size()) {
+        return Status::InternalError(fmt::format("Mismatched slot and output expression counts: {} vs {}", slots.size(),
+                                                 output_exprs.size()));
+    }
+
+    // Determine column layout indices:
+    //   [_file, _pos, data_col1, ..., data_colN, op_code]
+    // No partition prefix — partition columns are part of data_cols (full table schema).
+    const size_t total_slots = slots.size();
+    const int32_t data_column_start = 2; // after _file and _pos
+    const int32_t op_code_index = static_cast<int32_t>(total_slots - 1);
+    const int32_t data_column_count = op_code_index - data_column_start;
+
+    if (data_column_count < 0 || data_column_start > op_code_index) {
+        return Status::InternalError(
+                fmt::format("Invalid row delta column layout: total_slots={}, data_column_start={}", total_slots,
+                            data_column_start));
+    }
+
+    // --- Create delete sub-context ---
+    auto delete_sink_ctx = std::make_shared<connector::IcebergDeleteSinkContext>();
+    delete_sink_ctx->writer_tag = "delete";
+    delete_sink_ctx->path = t_iceberg_sink.data_location;
+    delete_sink_ctx->cloud_configuration = t_iceberg_sink.cloud_configuration;
+    delete_sink_ctx->compression_type = t_iceberg_sink.compression_type;
+    if (t_iceberg_sink.__isset.target_max_file_size) {
+        delete_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
+    }
+    delete_sink_ctx->tuple_desc_id = t_iceberg_sink.tuple_id;
+    auto* query_execution_services = runtime_state->query_execution_services();
+    delete_sink_ctx->executor = query_execution_services->execution->pipeline_sink_io_pool;
+    delete_sink_ctx->fragment_context = fragment_ctx;
+
+    // Delete output_exprs: columns from 0 to data_column_start-1 (_file, _pos, partition cols)
+    std::vector<TExpr> delete_output_exprs(output_exprs.begin(), output_exprs.begin() + data_column_start);
+    delete_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(delete_output_exprs, runtime_state);
+    delete_sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
+    delete_sink_ctx->output_exprs = delete_output_exprs;
+
+    // Configure partition columns for delete context
+    delete_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
+
+    // Build column name → slot reference map from all columns (except op_code).
+    // IcebergDeleteSink::add() uses this to locate _file/_pos by slot_id,
+    // and update_partition_expr_slot_refs_by_map() uses it to bind partition exprs.
+    // Since we pass the full original chunk to sub-sinks (not sub-chunks),
+    // all slot_ids are available at runtime.
+    for (int32_t i = 0; i < op_code_index; ++i) {
+        const auto* slot = slots[i];
+        const auto& expr = output_exprs[i];
+        for (const auto& node : expr.nodes) {
+            if (node.node_type == TExprNodeType::SLOT_REF && node.__isset.slot_ref) {
+                delete_sink_ctx->column_slot_map[std::string(slot->col_name())] = node;
+                break;
+            }
+        }
+    }
+
+    // --- Create data sub-context ---
+    auto data_sink_ctx = std::make_shared<connector::IcebergChunkSinkContext>();
+    data_sink_ctx->writer_tag = "data";
+    data_sink_ctx->path = t_iceberg_sink.__isset.data_location && !t_iceberg_sink.data_location.empty()
+                                  ? t_iceberg_sink.data_location
+                                  : t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
+    data_sink_ctx->cloud_conf = t_iceberg_sink.cloud_configuration;
+    data_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
+    data_sink_ctx->executor = query_execution_services->execution->pipeline_sink_io_pool;
+    data_sink_ctx->format = t_iceberg_sink.file_format;
+    data_sink_ctx->compression_type = t_iceberg_sink.compression_type;
+    if (t_iceberg_sink.__isset.target_max_file_size) {
+        data_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
+    }
+
+    // Data output_exprs: columns from data_column_start to op_code_index-1
+    std::vector<TExpr> data_output_exprs(output_exprs.begin() + data_column_start,
+                                         output_exprs.begin() + op_code_index);
+    data_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(data_output_exprs, runtime_state);
+
+    size_t num_data_evaluators = data_sink_ctx->column_evaluators.size();
+
+    // Build sink schema from data columns
+    auto field_ids_by_name = build_top_level_field_id_map(iceberg_table_desc->get_iceberg_schema()->fields);
+    data_sink_ctx->column_names.clear();
+    data_sink_ctx->parquet_field_ids.clear();
+    data_sink_ctx->column_names.reserve(num_data_evaluators);
+    data_sink_ctx->parquet_field_ids.reserve(num_data_evaluators);
+    for (size_t i = 0; i < num_data_evaluators; ++i) {
+        RETURN_IF_ERROR(append_iceberg_sink_column(slots[data_column_start + i], field_ids_by_name,
+                                                   &data_sink_ctx->column_names, &data_sink_ctx->parquet_field_ids));
+    }
+
+    if (data_sink_ctx->column_names.size() != num_data_evaluators ||
+        data_sink_ctx->parquet_field_ids.size() != num_data_evaluators) {
+        return Status::InternalError("Iceberg row delta sink schema metadata does not match output expressions");
+    }
+
+    data_sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
+    data_sink_ctx->fragment_context = fragment_ctx;
+
+    // Create a data-only tuple descriptor for the data sub-sink.
+    // The full row-delta tuple includes _file, _pos, data_cols, op_code, but the data
+    // writer only has evaluators for data_cols. SpillPartitionChunkWriter sizes merged
+    // chunks from tuple_desc->slots().size(), so the full tuple causes out-of-bounds.
+    {
+        TSlotDescriptorBuilder slot_builder;
+        TTupleDescriptorBuilder tuple_builder;
+        for (size_t i = 0; i < num_data_evaluators; ++i) {
+            const auto* slot = slots[data_column_start + i];
+            tuple_builder.add_slot(slot_builder.type(slot->type().type)
+                                           .nullable(slot->is_nullable())
+                                           .is_materialized(true)
+                                           .column_name(std::string(slot->col_name()))
+                                           .build());
+        }
+        TDescriptorTableBuilder desc_tbl_builder;
+        tuple_builder.build(&desc_tbl_builder);
+        TDescriptorTable t_desc_tbl = desc_tbl_builder.desc_tbl();
+        DescriptorTbl* data_desc_tbl = nullptr;
+        RETURN_IF_ERROR(DescriptorTbl::create(runtime_state, runtime_state->obj_pool(), t_desc_tbl, &data_desc_tbl,
+                                              config::vector_chunk_size));
+        data_sink_ctx->override_tuple_desc = data_desc_tbl->get_tuple_descriptor(0);
+        DCHECK(data_sink_ctx->override_tuple_desc != nullptr);
+    }
+    data_sink_ctx->tuple_desc_id = t_iceberg_sink.tuple_id;
+
+    // Sort ordering for data files
+    auto& sort_order = iceberg_table_desc->sort_order();
+    if (!sort_order.sort_key_idxes.empty()) {
+        data_sink_ctx->sort_ordering = std::make_shared<connector::SortOrdering>();
+        data_sink_ctx->sort_ordering->sort_key_idxes.assign(sort_order.sort_key_idxes.begin(),
+                                                            sort_order.sort_key_idxes.end());
+        data_sink_ctx->sort_ordering->sort_descs.descs.reserve(sort_order.sort_key_idxes.size());
+        for (size_t idx = 0; idx < sort_order.sort_key_idxes.size(); ++idx) {
+            bool is_asc = idx < sort_order.is_ascs.size() ? sort_order.is_ascs[idx] : true;
+            bool is_null_first = false;
+            if (idx < sort_order.is_null_firsts.size()) {
+                is_null_first = sort_order.is_null_firsts[idx];
+            } else if (is_asc) {
+                is_null_first = true;
+            }
+            data_sink_ctx->sort_ordering->sort_descs.descs.emplace_back(is_asc, is_null_first);
+        }
+    }
+
+    // --- Set up partition expressions for both contexts ---
+    if (!iceberg_table_desc->is_unpartitioned_table()) {
+        partition_expr = iceberg_table_desc->get_partition_exprs();
+        const auto& partition_source_column_names = iceberg_table_desc->partition_source_column_names();
+
+        // Update partition expressions using column slot map (same approach as delete sink)
+        RETURN_IF_ERROR(update_partition_expr_slot_refs_by_map(partition_expr, delete_sink_ctx->column_slot_map,
+                                                               partition_source_column_names));
+        delete_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
+        data_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
+    }
+
+    // --- Assemble IcebergRowDeltaSinkContext ---
+    auto row_delta_ctx = std::make_shared<connector::IcebergRowDeltaSinkContext>();
+    row_delta_ctx->delete_sink_ctx = delete_sink_ctx;
+    row_delta_ctx->data_sink_ctx = data_sink_ctx;
+    row_delta_ctx->op_code_index = op_code_index;
+
+    sink_ctx = row_delta_ctx;
+    auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::ICEBERG);
+    sink_provider = connector->create_row_delta_sink_provider();
 
     return Status::OK();
 }

--- a/be/src/exec/data_sinks/iceberg_table_sink.cpp
+++ b/be/src/exec/data_sinks/iceberg_table_sink.cpp
@@ -418,11 +418,15 @@ Status IcebergTableSink::create_row_delta_sink_context(
     delete_sink_ctx->executor = query_execution_services->execution->pipeline_sink_io_pool;
     delete_sink_ctx->fragment_context = fragment_ctx;
 
-    // Delete output_exprs: columns from 0 to data_column_start-1 (_file, _pos, partition cols)
-    std::vector<TExpr> delete_output_exprs(output_exprs.begin(), output_exprs.begin() + data_column_start);
-    delete_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(delete_output_exprs, runtime_state);
+    // Pass the full output_exprs list (one per tuple slot) so
+    // IcebergDeleteSinkProvider::create_chunk_sink()'s strict
+    // `tuple_desc->slots().size() == ctx->output_exprs.size()` DCHECK holds in
+    // debug builds. The delete sub-sink only consumes evaluators [0]=_file and
+    // [1]=_pos at runtime; trailing data-column / op_code evaluators are held
+    // but not used.
+    delete_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(output_exprs, runtime_state);
     delete_sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
-    delete_sink_ctx->output_exprs = delete_output_exprs;
+    delete_sink_ctx->output_exprs = output_exprs;
 
     // Configure partition columns for delete context
     delete_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();

--- a/be/src/exec/data_sinks/iceberg_table_sink.h
+++ b/be/src/exec/data_sinks/iceberg_table_sink.h
@@ -16,6 +16,7 @@
 
 #include "connector/iceberg_chunk_sink.h"
 #include "connector/iceberg_delete_sink.h"
+#include "connector/iceberg_row_delta_sink.h"
 #include "exec/data_sink.h"
 #include "exec/pipeline/sink/connector_sink_operator.h"
 
@@ -68,6 +69,13 @@ private:
                                     std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
                                     std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
                                     std::vector<TExpr>& partition_expr) const;
+
+    Status create_row_delta_sink_context(const TDataSink& thrift_sink, RuntimeState* runtime_state,
+                                         pipeline::PipelineBuilderContext* context,
+                                         IcebergTableDescriptor* iceberg_table_desc,
+                                         std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
+                                         std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
+                                         std::vector<TExpr>& partition_expr) const;
 
     ObjectPool* _pool;
     const std::vector<TExpr>& _t_output_expr;

--- a/be/src/exec/pipeline/sink/connector_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/connector_sink_operator.cpp
@@ -140,6 +140,9 @@ ConnectorSinkOperatorFactory::ConnectorSinkOperatorFactory(
     MemTracker* query_pool_tracker = GlobalEnv::GetInstance()->query_pool_mem_tracker();
     MemTracker* query_tracker = _fragment_context->runtime_state()->query_mem_tracker_ptr().get();
     _sink_mem_mgr = std::make_shared<connector::SinkMemoryManager>(query_pool_tracker, query_tracker);
+
+    // Pass SinkMemoryManager to RowDelta context so sub-sinks can get their own child managers
+    _sink_context->set_sink_mem_mgr(_sink_mem_mgr.get());
 }
 
 OperatorPtr ConnectorSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -31,6 +31,7 @@ set(EXEC_FILES
         ./connector_sink/async_flush_output_stream_test.cpp
         ./connector_sink/iceberg_table_sink_test.cpp
         ./connector_sink/iceberg_delete_sink_test.cpp
+        ./connector_sink/iceberg_row_delta_sink_test.cpp
         ./connector_sink/sink_memory_manager_test.cpp
         ./fs/azure/azblob_uri_test.cpp
         ./fs/azure/fs_azblob_test.cpp

--- a/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
@@ -324,8 +324,8 @@ TEST_F(IcebergRowDeltaSinkTest, init_wires_sub_sink_mem_managers) {
 TEST_F(IcebergRowDeltaSinkTest, add_fast_path_all_delete_skips_copy) {
     auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
 
-    auto chunk = build_chunk({"file1.parquet", "file1.parquet", "file2.parquet"}, {0, 1, 2},
-                             {"val0", "val1", "val2"}, {1, 1, 1});  // all OP_DELETE
+    auto chunk = build_chunk({"file1.parquet", "file1.parquet", "file2.parquet"}, {0, 1, 2}, {"val0", "val1", "val2"},
+                             {1, 1, 1}); // all OP_DELETE
 
     ASSERT_OK(sink->add(chunk));
 
@@ -338,7 +338,7 @@ TEST_F(IcebergRowDeltaSinkTest, add_fast_path_all_delete_skips_copy) {
 TEST_F(IcebergRowDeltaSinkTest, add_fast_path_all_insert_skips_copy) {
     auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
 
-    auto chunk = build_chunk({"", "", ""}, {0, 0, 0}, {"val0", "val1", "val2"}, {3, 3, 3});  // all OP_INSERT
+    auto chunk = build_chunk({"", "", ""}, {0, 0, 0}, {"val0", "val1", "val2"}, {3, 3, 3}); // all OP_INSERT
 
     ASSERT_OK(sink->add(chunk));
 

--- a/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
@@ -58,12 +58,21 @@ public:
 
     void rollback() override { ++rollback_count; }
 
+    Status finish() override {
+        ++finish_count;
+        return Status::OK();
+    }
+
+    bool is_finished() override { return finished; }
+
     // Expose protected _op_mem_mgr so tests can assert init() wired it.
     SinkOperatorMemoryManager* get_op_mem_mgr() const { return _op_mem_mgr; }
 
     std::vector<ChunkPtr> received_chunks;
     int total_rows = 0;
     int rollback_count = 0;
+    int finish_count = 0;
+    bool finished = false;
 };
 
 class IcebergRowDeltaSinkTest : public ::testing::Test {
@@ -345,6 +354,42 @@ TEST_F(IcebergRowDeltaSinkTest, add_fast_path_all_insert_skips_copy) {
     ASSERT_EQ(data_mock->received_chunks.size(), 1u);
     EXPECT_EQ(data_mock->received_chunks[0].get(), chunk.get());
     EXPECT_TRUE(delete_mock->received_chunks.empty());
+}
+
+// Test 9: finish() forwards to both sub-sinks.
+TEST_F(IcebergRowDeltaSinkTest, finish_forwards_to_both_sub_sinks) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    EXPECT_EQ(delete_mock->finish_count, 0);
+    EXPECT_EQ(data_mock->finish_count, 0);
+
+    ASSERT_OK(sink->finish());
+
+    EXPECT_EQ(delete_mock->finish_count, 1);
+    EXPECT_EQ(data_mock->finish_count, 1);
+}
+
+// Test 10: is_finished() is true only when both sub-sinks report finished.
+TEST_F(IcebergRowDeltaSinkTest, is_finished_requires_both_sub_sinks) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    EXPECT_FALSE(sink->is_finished());
+
+    delete_mock->finished = true;
+    EXPECT_FALSE(sink->is_finished()); // data sub-sink not yet finished
+
+    data_mock->finished = true;
+    EXPECT_TRUE(sink->is_finished());
+}
+
+// Test 11: callback_on_commit() is a no-op on the composite sink — sub-sinks
+// handle their own commit callbacks.
+TEST_F(IcebergRowDeltaSinkTest, callback_on_commit_is_noop) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    CommitResult result;
+    sink->callback_on_commit(result); // must not crash; no observable side effect
+    SUCCEED();
 }
 
 } // namespace starrocks::connector

--- a/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
@@ -44,14 +44,26 @@ public:
 
     void callback_on_commit(const CommitResult& result) override {}
 
+    // Skip the base class setup (profile / writer factory / op_mem_mgr wiring) that a
+    // mock doesn't need. The outer IcebergRowDeltaSink's init() still drives real
+    // assignments against `_op_mem_mgr` before invoking this, which is what the init()
+    // test inspects via get_op_mem_mgr().
+    Status init() override { return Status::OK(); }
+
     Status add(const ChunkPtr& chunk) override {
         received_chunks.push_back(chunk);
         total_rows += chunk->num_rows();
         return Status::OK();
     }
 
+    void rollback() override { ++rollback_count; }
+
+    // Expose protected _op_mem_mgr so tests can assert init() wired it.
+    SinkOperatorMemoryManager* get_op_mem_mgr() const { return _op_mem_mgr; }
+
     std::vector<ChunkPtr> received_chunks;
     int total_rows = 0;
+    int rollback_count = 0;
 };
 
 class IcebergRowDeltaSinkTest : public ::testing::Test {
@@ -261,6 +273,78 @@ TEST_F(IcebergRowDeltaSinkTest, unknown_op_code) {
     auto status = sink->add(chunk);
     EXPECT_FALSE(status.ok());
     EXPECT_THAT(std::string(status.message()), testing::HasSubstr("Unknown op_code"));
+}
+
+// Test 6: Verify rollback() fans out to both sub-sinks so cancelled queries
+// do not leak uncommitted position-delete or data files.
+TEST_F(IcebergRowDeltaSinkTest, rollback_forwards_to_both_sub_sinks) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    EXPECT_EQ(delete_mock->rollback_count, 0);
+    EXPECT_EQ(data_mock->rollback_count, 0);
+
+    sink->rollback();
+
+    EXPECT_EQ(delete_mock->rollback_count, 1);
+    EXPECT_EQ(data_mock->rollback_count, 1);
+}
+
+// Test 7: Verify init() creates a child SinkOperatorMemoryManager for each sub-sink
+// when a SinkMemoryManager is supplied, so memory pressure logic can see both
+// sub-sinks' writer lists (OOM-safety wiring described in the commit).
+TEST_F(IcebergRowDeltaSinkTest, init_wires_sub_sink_mem_managers) {
+    auto query_pool_tracker =
+            std::make_unique<MemTracker>(MemTrackerType::QUERY_POOL, -1, "IcebergRowDeltaSinkTest_pool");
+    auto query_tracker = std::make_unique<MemTracker>(MemTrackerType::QUERY, -1, "IcebergRowDeltaSinkTest_query");
+    SinkMemoryManager mgr(query_pool_tracker.get(), query_tracker.get());
+
+    auto delete_sink = std::make_unique<MockChunkSink>(_runtime_state.get());
+    auto data_sink = std::make_unique<MockChunkSink>(_runtime_state.get());
+    auto* delete_ptr = delete_sink.get();
+    auto* data_ptr = data_sink.get();
+
+    IcebergRowDeltaSink sink(std::move(delete_sink), std::move(data_sink), /*op_code_index=*/3, &mgr,
+                             _runtime_state.get());
+    // Provide an outer SinkOperatorMemoryManager so the base init() path doesn't
+    // dereference a null pointer and so the add_candidates() branch is exercised.
+    sink.set_operator_mem_mgr(mgr.create_child_manager());
+
+    ASSERT_OK(sink.init());
+
+    // Each sub-sink should now have its own child manager, distinct from each other
+    // and from nullptr. This confirms lines 40–43 of iceberg_row_delta_sink.cpp ran.
+    EXPECT_NE(delete_ptr->get_op_mem_mgr(), nullptr);
+    EXPECT_NE(data_ptr->get_op_mem_mgr(), nullptr);
+    EXPECT_NE(delete_ptr->get_op_mem_mgr(), data_ptr->get_op_mem_mgr());
+}
+
+// Test 8: When every row in a chunk routes to the same sub-sink (pure DELETE or
+// pure INSERT), add() should forward the original ChunkPtr without copying.
+// This covers the `all_to_delete` / `all_to_data` fast path in add().
+TEST_F(IcebergRowDeltaSinkTest, add_fast_path_all_delete_skips_copy) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    auto chunk = build_chunk({"file1.parquet", "file1.parquet", "file2.parquet"}, {0, 1, 2},
+                             {"val0", "val1", "val2"}, {1, 1, 1});  // all OP_DELETE
+
+    ASSERT_OK(sink->add(chunk));
+
+    ASSERT_EQ(delete_mock->received_chunks.size(), 1u);
+    // Zero-copy: the delete sink received the exact same shared_ptr.
+    EXPECT_EQ(delete_mock->received_chunks[0].get(), chunk.get());
+    EXPECT_TRUE(data_mock->received_chunks.empty());
+}
+
+TEST_F(IcebergRowDeltaSinkTest, add_fast_path_all_insert_skips_copy) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    auto chunk = build_chunk({"", "", ""}, {0, 0, 0}, {"val0", "val1", "val2"}, {3, 3, 3});  // all OP_INSERT
+
+    ASSERT_OK(sink->add(chunk));
+
+    ASSERT_EQ(data_mock->received_chunks.size(), 1u);
+    EXPECT_EQ(data_mock->received_chunks[0].get(), chunk.get());
+    EXPECT_TRUE(delete_mock->received_chunks.empty());
 }
 
 } // namespace starrocks::connector

--- a/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
@@ -1,0 +1,266 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/iceberg_row_delta_sink.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "column/binary_column.h"
+#include "column/chunk.h"
+#include "column/fixed_length_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config_exec_fwd.h"
+#include "common/status.h"
+#include "exec/pipeline/fragment_context.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/descriptors.h"
+#include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::connector {
+
+// A mock ConnectorChunkSink that records chunks passed to add().
+class MockChunkSink : public ConnectorChunkSink {
+public:
+    explicit MockChunkSink(RuntimeState* state)
+            : ConnectorChunkSink({}, {}, std::make_unique<NopPartitionChunkWriterFactory>(), state, true) {}
+
+    void callback_on_commit(const CommitResult& result) override {}
+
+    Status add(const ChunkPtr& chunk) override {
+        received_chunks.push_back(chunk);
+        total_rows += chunk->num_rows();
+        return Status::OK();
+    }
+
+    std::vector<ChunkPtr> received_chunks;
+    int total_rows = 0;
+};
+
+class IcebergRowDeltaSinkTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _pool = std::make_unique<ObjectPool>();
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        TUniqueId fragment_id;
+        fragment_id.hi = 0;
+        fragment_id.lo = 0;
+        _runtime_state =
+                std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, ExecEnv::GetInstance());
+        auto* exec_env = ExecEnv::GetInstance();
+        _runtime_state->set_exec_env(exec_env);
+        _runtime_state->set_query_execution_services(&exec_env->query_execution_services());
+        // Initialize mem trackers for the runtime state
+        _runtime_state->init_instance_mem_tracker();
+
+        // Create and set up a basic descriptor table for the runtime state
+        // Need to ensure tuple with ID 0 exists since context->tuple_desc_id is set to 0
+        TDescriptorTableBuilder desc_tbl_builder;
+        // Create a tuple
+        TSlotDescriptorBuilder slot_builder;
+        TTupleDescriptorBuilder tuple_builder;
+        tuple_builder.add_slot(slot_builder.type(TYPE_VARCHAR).column_name("file_path").is_materialized(true).build());
+        tuple_builder.add_slot(slot_builder.type(TYPE_BIGINT).column_name("pos").is_materialized(true).build());
+        tuple_builder.build(&desc_tbl_builder);
+        TDescriptorTable t_desc_tbl = desc_tbl_builder.desc_tbl();
+        DescriptorTbl* desc_tbl = nullptr;
+        ASSERT_TRUE(DescriptorTbl::create(_runtime_state.get(), _pool.get(), t_desc_tbl, &desc_tbl,
+                                          config::vector_chunk_size)
+                            .ok());
+        _runtime_state->set_desc_tbl(desc_tbl);
+
+        _fragment_context = std::make_shared<pipeline::FragmentContext>();
+        _fragment_context->set_runtime_state(std::move(_runtime_state));
+        // Get the runtime state back from fragment context after moving
+        _runtime_state = _fragment_context->runtime_state_ptr();
+        _fragment_context->set_fragment_instance_id(fragment_id);
+        _mem_tracker = std::make_unique<MemTracker>(MemTrackerType::QUERY_POOL, -1, "IcebergRowDeltaSinkTest");
+    }
+
+    // Build a chunk with the layout: [_file(VARCHAR), _pos(BIGINT), data_col(VARCHAR), op_code(TINYINT)]
+    // Each row gets its own op_code from the provided vector.
+    ChunkPtr build_chunk(const std::vector<std::string>& files, const std::vector<int64_t>& positions,
+                         const std::vector<std::string>& data_values, const std::vector<int8_t>& op_codes) {
+        auto chunk = std::make_shared<Chunk>();
+
+        // _file column (slot 0)
+        auto file_col = BinaryColumn::create();
+        for (const auto& f : files) {
+            file_col->append(f);
+        }
+        chunk->append_column(file_col, 0);
+
+        // _pos column (slot 1)
+        auto pos_col = FixedLengthColumn<int64_t>::create();
+        for (auto p : positions) {
+            pos_col->append(p);
+        }
+        chunk->append_column(pos_col, 1);
+
+        // data column (slot 2)
+        auto data_col = BinaryColumn::create();
+        for (const auto& v : data_values) {
+            data_col->append(v);
+        }
+        chunk->append_column(data_col, 2);
+
+        // op_code column (slot 3)
+        auto op_col = FixedLengthColumn<int8_t>::create();
+        for (auto op : op_codes) {
+            op_col->append(op);
+        }
+        chunk->append_column(op_col, 3);
+
+        return chunk;
+    }
+
+    // Create the IcebergRowDeltaSink with mock sub-sinks.
+    // Returns the sink and raw pointers to the mock sinks for verification.
+    struct SinkWithMocks {
+        std::unique_ptr<IcebergRowDeltaSink> sink;
+        MockChunkSink* delete_sink;
+        MockChunkSink* data_sink;
+    };
+
+    SinkWithMocks create_row_delta_sink_with_mocks(int32_t op_code_index = 3) {
+        auto delete_sink = std::make_unique<MockChunkSink>(_runtime_state.get());
+        auto data_sink = std::make_unique<MockChunkSink>(_runtime_state.get());
+        auto* delete_ptr = delete_sink.get();
+        auto* data_ptr = data_sink.get();
+
+        auto row_delta_sink = std::make_unique<IcebergRowDeltaSink>(std::move(delete_sink), std::move(data_sink),
+                                                                    op_code_index, nullptr, _runtime_state.get());
+
+        return {std::move(row_delta_sink), delete_ptr, data_ptr};
+    }
+
+    std::unique_ptr<ObjectPool> _pool;
+    std::shared_ptr<RuntimeState> _runtime_state;
+    std::shared_ptr<pipeline::FragmentContext> _fragment_context;
+    std::unique_ptr<MemTracker> _mem_tracker;
+};
+
+// Test 1: Verify that IcebergRowDeltaSink can be constructed with mock sub-sinks
+TEST_F(IcebergRowDeltaSinkTest, create_row_delta_sink) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    ASSERT_NE(sink, nullptr);
+
+    // Verify the sink is of the correct type
+    auto* row_delta_sink = dynamic_cast<IcebergRowDeltaSink*>(sink.get());
+    ASSERT_NE(row_delta_sink, nullptr);
+
+    // Verify that a provider rejects a wrong context type
+    auto provider = std::make_unique<IcebergRowDeltaSinkProvider>();
+    auto bad_ctx = std::make_shared<IcebergDeleteSinkContext>();
+    bad_ctx->fragment_context = _fragment_context.get();
+    auto result = provider->create_chunk_sink(bad_ctx, 0);
+    ASSERT_FALSE(result.ok());
+    EXPECT_THAT(std::string(result.status().message()),
+                testing::HasSubstr("context is not IcebergRowDeltaSinkContext"));
+}
+
+// Test 2: Verify op_code routing sends rows to correct sub-sinks
+TEST_F(IcebergRowDeltaSinkTest, op_code_routing) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    // Build a chunk with 4 rows, one per op_code: NO_OP(0), DELETE(1), UPDATE(2), INSERT(3)
+    auto chunk = build_chunk({"file1.parquet", "file1.parquet", "file2.parquet", ""}, {0, 1, 2, 0},
+                             {"val0", "val1", "val2", "val3"}, {0, 1, 2, 3});
+
+    ASSERT_OK(sink->add(chunk));
+
+    // DELETE(1) and UPDATE(2) go to delete sink => 2 rows
+    EXPECT_EQ(delete_mock->total_rows, 2);
+    // UPDATE(2) and INSERT(3) go to data sink => 2 rows
+    EXPECT_EQ(data_mock->total_rows, 2);
+
+    // Verify delete chunk content: rows 1 and 2 (DELETE and UPDATE).
+    // filter_chunk_by_rows preserves all columns and slot_ids, so sub-sinks receive
+    // the full 4-column chunk (_file, _pos, data, op_code) filtered to matching rows.
+    ASSERT_EQ(delete_mock->received_chunks.size(), 1);
+    auto& del_chunk = delete_mock->received_chunks[0];
+    EXPECT_EQ(del_chunk->num_rows(), 2);
+    EXPECT_EQ(del_chunk->num_columns(), 4);
+
+    // Check _file values in delete chunk
+    auto* del_file_col = down_cast<const BinaryColumn*>(del_chunk->get_column_by_index(0).get());
+    EXPECT_EQ(del_file_col->get_slice(0).to_string(), "file1.parquet");
+    EXPECT_EQ(del_file_col->get_slice(1).to_string(), "file2.parquet");
+
+    // Check _pos values in delete chunk
+    auto* del_pos_col = down_cast<const FixedLengthColumn<int64_t>*>(del_chunk->get_column_by_index(1).get());
+    EXPECT_EQ(del_pos_col->get_data()[0], 1);
+    EXPECT_EQ(del_pos_col->get_data()[1], 2);
+
+    // Verify data chunk content: rows 2 and 3 (UPDATE and INSERT).
+    // Same structural preservation as the delete sink — all 4 columns retained.
+    ASSERT_EQ(data_mock->received_chunks.size(), 1);
+    auto& dat_chunk = data_mock->received_chunks[0];
+    EXPECT_EQ(dat_chunk->num_rows(), 2);
+    EXPECT_EQ(dat_chunk->num_columns(), 4);
+
+    // Check data values at column index 2 (the data column in the original chunk layout)
+    auto* dat_col = down_cast<const BinaryColumn*>(dat_chunk->get_column_by_index(2).get());
+    EXPECT_EQ(dat_col->get_slice(0).to_string(), "val2");
+    EXPECT_EQ(dat_col->get_slice(1).to_string(), "val3");
+}
+
+// Test 3: Verify add() with an empty chunk returns OK without invoking sub-sinks
+TEST_F(IcebergRowDeltaSinkTest, add_empty_chunk) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    auto chunk = std::make_shared<Chunk>();
+    ASSERT_OK(sink->add(chunk));
+
+    EXPECT_EQ(delete_mock->total_rows, 0);
+    EXPECT_EQ(data_mock->total_rows, 0);
+    EXPECT_TRUE(delete_mock->received_chunks.empty());
+    EXPECT_TRUE(data_mock->received_chunks.empty());
+}
+
+// Test 4: Verify all NO_OP rows produce zero rows to both sub-sinks
+TEST_F(IcebergRowDeltaSinkTest, all_no_op) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    auto chunk = build_chunk({"file1.parquet", "file2.parquet", "file3.parquet"}, {0, 1, 2}, {"val0", "val1", "val2"},
+                             {0, 0, 0});
+
+    ASSERT_OK(sink->add(chunk));
+
+    EXPECT_EQ(delete_mock->total_rows, 0);
+    EXPECT_EQ(data_mock->total_rows, 0);
+    EXPECT_TRUE(delete_mock->received_chunks.empty());
+    EXPECT_TRUE(data_mock->received_chunks.empty());
+}
+
+// Test 5: Verify that an unknown op_code returns an error status
+TEST_F(IcebergRowDeltaSinkTest, unknown_op_code) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks();
+
+    auto chunk = build_chunk({"file1.parquet"}, {0}, {"val0"}, {99});
+
+    auto status = sink->add(chunk);
+    EXPECT_FALSE(status.ok());
+    EXPECT_THAT(std::string(status.message()), testing::HasSubstr("Unknown op_code"));
+}
+
+} // namespace starrocks::connector

--- a/be/test/connector_sink/iceberg_table_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_table_sink_test.cpp
@@ -22,6 +22,7 @@
 
 #include "base/testutil/assert.h"
 #include "common/config_exec_fwd.h"
+#include "connector/iceberg_row_delta_sink.h"
 #include "exec/pipeline/empty_set_operator.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/pipeline.h"
@@ -593,6 +594,200 @@ TEST_F(IcebergTableSinkTest, row_lineage_field_ids_ignore_non_written_hidden_col
     EXPECT_EQ(sink_ctx->parquet_field_ids[0].field_id, 1);
     EXPECT_EQ(sink_ctx->parquet_field_ids[1].field_id, 2147483540);
     EXPECT_EQ(sink_ctx->parquet_field_ids[2].field_id, 2147483539);
+}
+
+namespace {
+// Build a minimal SLOT_REF TExpr referring to slot_id in tuple 0.
+// from_exprs() / column_slot_map population only inspect node_type and slot_ref,
+// so this is enough to exercise create_row_delta_sink_context without setting
+// up full type descriptors.
+TExpr make_slot_ref_expr(int slot_id) {
+    TExpr expr;
+    TExprNode node;
+    node.node_type = TExprNodeType::SLOT_REF;
+    node.__set_slot_ref(TSlotRef());
+    node.slot_ref.slot_id = slot_id;
+    node.slot_ref.tuple_id = 0;
+    expr.nodes.push_back(node);
+    return expr;
+}
+} // namespace
+
+// Drives create_row_delta_sink_context() end-to-end via decompose_to_pipeline,
+// then exercises IcebergRowDeltaSinkProvider::create_chunk_sink() on the
+// resulting context. Covers:
+//   - the row-delta dispatch branch in decompose_to_pipeline
+//   - IcebergConnector::create_row_delta_sink_provider()
+//   - the bulk of create_row_delta_sink_context() (delete sub-context, data
+//     sub-context, override_tuple_desc, op_code_index, and the unpartitioned
+//     branch)
+//   - IcebergRowDeltaSinkProvider::create_chunk_sink() success path, which in
+//     turn drives IcebergDeleteSinkProvider and IcebergChunkSinkProvider
+TEST_F(IcebergTableSinkTest, decompose_to_pipeline_row_delta) {
+    // Tuple layout for a row-delta write: [_file, _pos, c1, op_code]
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto file_slot = slot_desc_builder.type(LogicalType::TYPE_VARCHAR)
+                             .column_name("_file")
+                             .column_pos(0)
+                             .nullable(false)
+                             .build();
+    auto pos_slot = slot_desc_builder.type(LogicalType::TYPE_BIGINT)
+                            .column_name("_pos")
+                            .column_pos(1)
+                            .nullable(false)
+                            .build();
+    auto c1_slot = slot_desc_builder.type(LogicalType::TYPE_INT)
+                           .column_name("c1")
+                           .column_pos(2)
+                           .nullable(true)
+                           .build();
+    auto op_slot = slot_desc_builder.type(LogicalType::TYPE_TINYINT)
+                           .column_name("op_code")
+                           .column_pos(3)
+                           .nullable(false)
+                           .build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(file_slot);
+    tuple_desc_builder.add_slot(pos_slot);
+    tuple_desc_builder.add_slot(c1_slot);
+    tuple_desc_builder.add_slot(op_slot);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    // Iceberg schema must include the data column ("c1") so
+    // build_top_level_field_id_map() can resolve its parquet_field_id.
+    TIcebergTable t_iceberg_table;
+    TColumn t_column;
+    t_column.__set_column_name("c1");
+    t_iceberg_table.__set_columns({t_column});
+
+    TIcebergSchemaField c1_field;
+    c1_field.__set_field_id(1);
+    c1_field.__set_name("c1");
+    TIcebergSchema iceberg_schema;
+    iceberg_schema.__set_fields({c1_field});
+    t_iceberg_table.__set_iceberg_schema(iceberg_schema);
+
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1);
+
+    TDataSink data_sink;
+    data_sink.__set_type(TDataSinkType::ICEBERG_ROW_DELTA_SINK);
+    TIcebergTableSink iceberg_table_sink;
+    iceberg_table_sink.__set_location("/path/to/table");
+    iceberg_table_sink.__set_data_location("/path/to/table/data");
+    iceberg_table_sink.__set_tuple_id(0);
+    iceberg_table_sink.__set_target_max_file_size(128LL * 1024 * 1024);
+    data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+    std::vector<TExpr> exprs = {make_slot_ref_expr(0), make_slot_ref_expr(1), make_slot_ref_expr(2),
+                                make_slot_ref_expr(3)};
+
+    IcebergTableSink sink(&_pool, exprs);
+    pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(11, 11)};
+
+    EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
+
+    pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
+    pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
+    auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
+    ASSERT_NE(connector_sink_factory, nullptr);
+
+    auto* row_delta_ctx =
+            dynamic_cast<connector::IcebergRowDeltaSinkContext*>(connector_sink_factory->_sink_context.get());
+    ASSERT_NE(row_delta_ctx, nullptr);
+    ASSERT_NE(row_delta_ctx->delete_sink_ctx, nullptr);
+    ASSERT_NE(row_delta_ctx->data_sink_ctx, nullptr);
+    EXPECT_EQ(row_delta_ctx->op_code_index, 3);
+
+    // delete sub-context: tagged "delete", carries the full output_exprs (one
+    // per slot) so IcebergDeleteSinkProvider's strict 1:1 DCHECK holds, and
+    // its column_slot_map covers every non-op_code slot (here _file, _pos, c1).
+    EXPECT_EQ(row_delta_ctx->delete_sink_ctx->writer_tag, "delete");
+    EXPECT_EQ(row_delta_ctx->delete_sink_ctx->output_exprs.size(), 4);
+    EXPECT_EQ(row_delta_ctx->delete_sink_ctx->column_slot_map.size(), 3);
+    EXPECT_TRUE(row_delta_ctx->delete_sink_ctx->column_slot_map.count("_file") == 1);
+    EXPECT_TRUE(row_delta_ctx->delete_sink_ctx->column_slot_map.count("_pos") == 1);
+
+    // data sub-context: tagged "data", path resolves to data_location when set,
+    // and override_tuple_desc has only data columns (op_code excluded).
+    EXPECT_EQ(row_delta_ctx->data_sink_ctx->writer_tag, "data");
+    EXPECT_EQ(row_delta_ctx->data_sink_ctx->path, "/path/to/table/data");
+    ASSERT_NE(row_delta_ctx->data_sink_ctx->override_tuple_desc, nullptr);
+    EXPECT_EQ(row_delta_ctx->data_sink_ctx->override_tuple_desc->slots().size(), 1);
+    EXPECT_EQ(row_delta_ctx->data_sink_ctx->column_names.size(), 1);
+    EXPECT_EQ(row_delta_ctx->data_sink_ctx->column_names[0], "c1");
+    EXPECT_EQ(row_delta_ctx->data_sink_ctx->parquet_field_ids[0].field_id, 1);
+
+    // Now drive IcebergRowDeltaSinkProvider::create_chunk_sink() success path.
+    connector::IcebergRowDeltaSinkProvider provider;
+    auto sink_or = provider.create_chunk_sink(connector_sink_factory->_sink_context, /*driver_id=*/0);
+    ASSERT_OK(sink_or.status());
+    auto created_sink = std::move(sink_or).value();
+    ASSERT_NE(created_sink, nullptr);
+    EXPECT_NE(dynamic_cast<connector::IcebergRowDeltaSink*>(created_sink.get()), nullptr);
+}
+
+// Tuple too short to be a row-delta layout. With only [_file, _pos]
+// the layout invariant `data_column_count >= 0` fails and the function
+// returns InternalError without touching downstream sub-context setup.
+TEST_F(IcebergTableSinkTest, row_delta_invalid_column_layout) {
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto file_slot = slot_desc_builder.type(LogicalType::TYPE_VARCHAR)
+                             .column_name("_file")
+                             .column_pos(0)
+                             .nullable(false)
+                             .build();
+    auto pos_slot = slot_desc_builder.type(LogicalType::TYPE_BIGINT)
+                            .column_name("_pos")
+                            .column_pos(1)
+                            .nullable(false)
+                            .build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(file_slot);
+    tuple_desc_builder.add_slot(pos_slot);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    TIcebergTable t_iceberg_table;
+    TIcebergSchema iceberg_schema;
+    t_iceberg_table.__set_iceberg_schema(iceberg_schema);
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1);
+
+    TDataSink data_sink;
+    data_sink.__set_type(TDataSinkType::ICEBERG_ROW_DELTA_SINK);
+    TIcebergTableSink iceberg_table_sink;
+    iceberg_table_sink.__set_location("/path/to/table");
+    iceberg_table_sink.__set_tuple_id(0);
+    data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+    std::vector<TExpr> exprs = {make_slot_ref_expr(0), make_slot_ref_expr(1)};
+
+    IcebergTableSink sink(&_pool, exprs);
+    pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(12, 12)};
+
+    auto status = sink.decompose_to_pipeline(prev_operators, data_sink, context.get());
+    EXPECT_FALSE(status.ok());
+    EXPECT_THAT(std::string(status.message()), testing::HasSubstr("Invalid row delta column layout"));
 }
 
 } // namespace starrocks

--- a/be/test/connector_sink/iceberg_table_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_table_sink_test.cpp
@@ -632,16 +632,9 @@ TEST_F(IcebergTableSinkTest, decompose_to_pipeline_row_delta) {
                              .column_pos(0)
                              .nullable(false)
                              .build();
-    auto pos_slot = slot_desc_builder.type(LogicalType::TYPE_BIGINT)
-                            .column_name("_pos")
-                            .column_pos(1)
-                            .nullable(false)
-                            .build();
-    auto c1_slot = slot_desc_builder.type(LogicalType::TYPE_INT)
-                           .column_name("c1")
-                           .column_pos(2)
-                           .nullable(true)
-                           .build();
+    auto pos_slot =
+            slot_desc_builder.type(LogicalType::TYPE_BIGINT).column_name("_pos").column_pos(1).nullable(false).build();
+    auto c1_slot = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(2).nullable(true).build();
     auto op_slot = slot_desc_builder.type(LogicalType::TYPE_TINYINT)
                            .column_name("op_code")
                            .column_pos(3)
@@ -748,11 +741,8 @@ TEST_F(IcebergTableSinkTest, row_delta_invalid_column_layout) {
                              .column_pos(0)
                              .nullable(false)
                              .build();
-    auto pos_slot = slot_desc_builder.type(LogicalType::TYPE_BIGINT)
-                            .column_name("_pos")
-                            .column_pos(1)
-                            .nullable(false)
-                            .build();
+    auto pos_slot =
+            slot_desc_builder.type(LogicalType::TYPE_BIGINT).column_name("_pos").column_pos(1).nullable(false).build();
     TTupleDescriptorBuilder tuple_desc_builder;
     tuple_desc_builder.add_slot(file_slot);
     tuple_desc_builder.add_slot(pos_slot);

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -255,6 +255,11 @@ struct TSchemaTableSink {
     2: optional Descriptors.TNodesInfo nodes_info
 }
 
+enum TIcebergWriteMode {
+    APPEND,
+    ROW_DELTA
+}
+
 struct TIcebergTableSink {
     // table location
     1: optional string location
@@ -266,8 +271,8 @@ struct TIcebergTableSink {
     7: optional i64 target_max_file_size
     8: optional i32 tuple_id
     9: optional string data_location
-    // write mode: "ROW_DELTA" for UPDATE/MERGE (mixed delete + data files)
-    10: optional string write_mode
+    // write mode: ROW_DELTA for UPDATE / MERGE (mixed delete + data files)
+    10: optional TIcebergWriteMode write_mode
 }
 
 struct THiveTableSink {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -60,7 +60,8 @@ enum TDataSinkType {
     MULTI_OLAP_TABLE_SINK,
     SPLIT_DATA_STREAM_SINK,
     NOOP_SINK,
-    ICEBERG_DELETE_SINK
+    ICEBERG_DELETE_SINK,
+    ICEBERG_ROW_DELTA_SINK
 }
 
 enum TResultSinkType {
@@ -265,6 +266,8 @@ struct TIcebergTableSink {
     7: optional i64 target_max_file_size
     8: optional i32 tuple_id
     9: optional string data_location
+    // write mode: "ROW_DELTA" for UPDATE/MERGE (mixed delete + data files)
+    10: optional string write_mode
 }
 
 struct THiveTableSink {


### PR DESCRIPTION
## Why I'm doing:

Groundwork for Iceberg UPDATE / MERGE on the BE. A RowDelta write atomically produces both Position Delete files (for removed rows) and Data files (for new rows) in a single commit. The existing BE only has `IcebergChunkSink` (pure append) and `IcebergDeleteSink` (position deletes); neither can drive a combined delete+insert within one sink operator.

## What I'm doing:

Add `IcebergRowDeltaSink`, a composite sink that fans rows into per-`op_code` sub-sinks and atomically produces both Position Delete files and Data files, and wire it end-to-end on the BE.

**Thrift**
- Add `op_code` enum (`NO_OP=0, DELETE=1, UPDATE=2, INSERT=3`) and `TIcebergRowDeltaSink` message so FE can describe a RowDelta write and BE can dispatch it.

**Sink framework extensions (backward-compatible)**
- `SinkOperatorMemoryManager` now accepts multiple candidate writer lists, so composite sinks can expose sub-sink writers to the outer kill-victim / backpressure path.
- `ConnectorChunkSink::init()` and `rollback()` are now virtual; a new `ConnectorChunkSinkContext::set_sink_mem_mgr()` hook lets composite sinks attach sub-sink memory managers at construction time.
- `LocationProvider` gains a `writer_tag` for semantic file-name separation between delete and data sub-sinks.

**Iceberg RowDelta sink**
- `IcebergRowDeltaSink` filters chunks by `op_code` and forwards them to `IcebergDeleteSink` (position deletes) and `IcebergChunkSink` (new data files), preserving slot_ids so `ColumnExprEvaluator` works unchanged.
- Registers both sub-sinks' `_writers` with the outer `SinkOperatorMemoryManager` to prevent OOM under large RowDelta workloads.
- Overrides `rollback()` to forward to both sub-sinks so cancelled queries do not leak uncommitted files.
- `IcebergConnector` / `data_sink` / `connector_sink_operator` / `runtime/iceberg_table_sink` are wired to construct and drive the new sink when the Thrift message carries `TIcebergRowDeltaSink`.

**Tests**
- `iceberg_row_delta_sink_test` covers: op_code routing (honoring `filter_chunk_by_rows`'s preserve-all-columns semantics), empty / all-NO_OP chunks, unknown op_code rejection, provider context-type validation, rollback fan-out to both sub-sinks, init memory-manager wiring, and the `add()` zero-copy fast path when every row shares one op_code.

Fixes: https://github.com/StarRocks/starrocks/issues/72046
StarrocksTest: https://github.com/StarRocks/StarRocksTest/pull/11258

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: adds a new Thrift-driven composite sink path gated by `TIcebergRowDeltaSink`; existing Iceberg INSERT / DELETE flows are unchanged. FE wiring follows in a separate PR.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4