### PR TITLE
[Refactor] Unify __ACTION__ and __op value domains

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaAggregateRule.java
@@ -178,11 +178,10 @@ public class IvmDeltaAggregateRule extends TransformationRule {
             projMap.put(origRef, stateUnion);
         }
 
-        // Add __ACTION__ column so appendPkLoadOpColumn can derive __op from it.
-        // For aggregate MVs, all output rows are UPSERTs (action = INSERT = 1).
+        // Aggregate MV outputs are all UPSERTs. __ACTION__ = 0 (= __op UPSERT).
         ColumnRefOperator actionColumn = delta.getActionColumn();
         if (actionColumn != null) {
-            projMap.put(actionColumn, ConstantOperator.createTinyInt((byte) 1));
+            projMap.put(actionColumn, ConstantOperator.createTinyInt((byte) 0));
         }
 
         OptExpression result = OptExpression.create(new LogicalProjectOperator(projMap), joinExpr);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaIcebergScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaIcebergScanRule.java
@@ -46,7 +46,7 @@ import java.util.Optional;
  * set by {@code MVIVMBasedRefreshProcessor.buildInsertPlan()} via {@code RelationTransformer}.
  * This rule reads that same data source as {@code TvrTableScanRule}.
  *
- * <p>For append-only Iceberg tables, the {@code __ACTION__} column is a constant {@code 1} (INSERT).
+ * <p>For append-only Iceberg tables, {@code __ACTION__} is a constant {@code 0} (INSERT = UPSERT).
  */
 public class IvmDeltaIcebergScanRule extends TransformationRule {
     public IvmDeltaIcebergScanRule() {
@@ -80,14 +80,14 @@ public class IvmDeltaIcebergScanRule extends TransformationRule {
                     new LogicalValuesOperator(outputColumns, Collections.emptyList())));
         }
 
-        // Build a project on top of the scan that adds __ACTION__ = 1 (INSERT, append-only)
+        // Build a project on top of the scan that adds __ACTION__ = 0 (append-only INSERT).
         ColumnRefOperator actionColumn = delta.getActionColumn();
         Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
         for (ColumnRefOperator col : scan.getOutputColumns()) {
             projectMap.put(col, col);
         }
         if (actionColumn != null) {
-            projectMap.put(actionColumn, ConstantOperator.createTinyInt((byte) 1));
+            projectMap.put(actionColumn, ConstantOperator.createTinyInt((byte) 0));
         }
 
         // Keep the scan with its tvrVersionRange intact — the physical layer (IcebergMetadata)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
@@ -15,7 +15,6 @@
 package com.starrocks.sql.optimizer.rule.ivm;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.JsonSyntaxException;
 import com.starrocks.catalog.Database;
@@ -27,7 +26,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -38,8 +36,6 @@ import com.starrocks.sql.optimizer.operator.SortPhase;
 import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
-import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -143,11 +139,8 @@ public class IvmRewriter {
 
         ColumnRefOperator loadOpColumn = rootTaskContext.getOptimizerContext().getColumnRefFactory()
                 .create(Load.LOAD_OP_COLUMN, IntegerType.TINYINT, false);
-        ScalarOperator isDeleteAction = new BinaryPredicateOperator(BinaryType.LT, actionColumn,
-                ConstantOperator.createTinyInt((byte) 0));
-        ScalarOperator loadOpExpr = new CaseWhenOperator(IntegerType.TINYINT, null,
-                ConstantOperator.createTinyInt((byte) 0),
-                Lists.newArrayList(isDeleteAction, ConstantOperator.createTinyInt((byte) 1)));
+        // __op shares __ACTION__'s domain (0 = UPSERT, 1 = DELETE) — direct alias.
+        ScalarOperator loadOpExpr = actionColumn;
 
         Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
         for (ColumnRefOperator outputColumn : rootOutputColumns) {
@@ -161,7 +154,11 @@ public class IvmRewriter {
         rootTaskContext.getRequiredColumns().union(loadOpColumn);
 
         OptExpression projectExpr = OptExpression.create(new LogicalProjectOperator(projectMap), root);
-        // DELETE must come first: __op=1 for DELETE, __op=0 for INSERT.
+        // TopN orders DELETEs before UPSERTs for same-PK batches. Skip it when __ACTION__
+        // is provably constant (e.g. append-only Iceberg) — there are no DELETEs to order.
+        if (isActionColumnConstant(root, actionColumn)) {
+            return projectExpr;
+        }
         List<Ordering> orderings = List.of(new Ordering(loadOpColumn, false, false));
         LogicalTopNOperator.Builder topNBuilder = LogicalTopNOperator.builder()
                 .withOperator(
@@ -171,6 +168,45 @@ public class IvmRewriter {
                 .setPerPipeline(true);
         LogicalTopNOperator topN = topNBuilder.build();
         return OptExpression.create(topN, projectExpr);
+    }
+
+    /**
+     * Walks down the plan tracing {@code target} through aliasing projections (including
+     * projections attached to non-Project operators like Filter). Returns true if the trace
+     * lands on a {@link ConstantOperator}; bails at multi-input operators (join/union/set op)
+     * or any non-constant, non-alias expression.
+     */
+    private static boolean isActionColumnConstant(OptExpression root, ColumnRefOperator actionColumn) {
+        OptExpression current = root;
+        ColumnRefOperator target = actionColumn;
+        for (int i = 0; current != null && i < 64; i++) {
+            Map<ColumnRefOperator, ScalarOperator> colMap = extractColumnRefMap(current.getOp());
+            if (colMap != null && colMap.containsKey(target)) {
+                ScalarOperator expr = colMap.get(target);
+                if (expr instanceof ConstantOperator) {
+                    return true;
+                }
+                if (!(expr instanceof ColumnRefOperator)) {
+                    return false;
+                }
+                target = (ColumnRefOperator) expr;
+            }
+            if (current.getInputs().size() != 1) {
+                return false;
+            }
+            current = current.inputAt(0);
+        }
+        return false;
+    }
+
+    private static Map<ColumnRefOperator, ScalarOperator> extractColumnRefMap(Operator op) {
+        if (op instanceof LogicalProjectOperator) {
+            return ((LogicalProjectOperator) op).getColumnRefMap();
+        }
+        if (op.getProjection() != null) {
+            return op.getProjection().getColumnRefMap();
+        }
+        return null;
     }
 
     static MaterializedView loadTargetMv(OptimizerContext optimizerContext) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmIcebergRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmIcebergRuleTest.java
@@ -75,15 +75,15 @@ public class IvmIcebergRuleTest {
 
         List<OptExpression> result = new IvmDeltaIcebergScanRule().transform(deltaExpr, context);
 
-        // Should produce: Project(id, data, __ACTION__=1) → IcebergScan
+        // Should produce: Project(id, data, __ACTION__=0) → IcebergScan
         Assertions.assertEquals(1, result.size());
         Assertions.assertTrue(result.get(0).getOp() instanceof LogicalProjectOperator);
         LogicalProjectOperator project = (LogicalProjectOperator) result.get(0).getOp();
-        // Project should contain __ACTION__ = 1 (constant)
+        // __ACTION__ = 0 (constant)
         Assertions.assertTrue(project.getColumnRefMap().containsKey(actionRef));
         ScalarOperator actionExpr = project.getColumnRefMap().get(actionRef);
         Assertions.assertTrue(actionExpr instanceof ConstantOperator);
-        Assertions.assertEquals((byte) 1, ((ConstantOperator) actionExpr).getTinyInt());
+        Assertions.assertEquals((byte) 0, ((ConstantOperator) actionExpr).getTinyInt());
         // Project should pass through original columns
         Assertions.assertTrue(project.getColumnRefMap().containsKey(idRef));
         Assertions.assertTrue(project.getColumnRefMap().containsKey(dataRef));
@@ -385,11 +385,11 @@ public class IvmIcebergRuleTest {
         Assertions.assertFalse(IvmRuleUtils.containsLogicalDelta(afterScan.get(0)));
         Assertions.assertFalse(IvmRuleUtils.containsLogicalVersion(afterScan.get(0)));
 
-        // Verify __ACTION__ = 1 (constant INSERT)
+        // __ACTION__ = 0 (constant)
         LogicalProjectOperator scanProject = (LogicalProjectOperator) afterScan.get(0).getOp();
         ScalarOperator actionValue = scanProject.getColumnRefMap().get(actionRef);
         Assertions.assertTrue(actionValue instanceof ConstantOperator);
-        Assertions.assertEquals((byte) 1, ((ConstantOperator) actionValue).getTinyInt());
+        Assertions.assertEquals((byte) 0, ((ConstantOperator) actionValue).getTinyInt());
     }
 
     // ==================== Helpers ====================

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
@@ -30,11 +30,14 @@ import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.ivm.common.IvmRuleUtils;
 import com.starrocks.sql.optimizer.task.TaskContext;
 import com.starrocks.sql.optimizer.task.TaskScheduler;
@@ -182,13 +185,11 @@ public class IvmRewriterTest {
 
         IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
 
-        // For PK MV, plan should have TopN → Project(__op) at the top
+        // Append-only Iceberg → constant __ACTION__ → TopN is skipped. Top is Project(__op).
         OptExpression rewrittenChild = root.inputAt(0);
-        Assertions.assertTrue(rewrittenChild.getOp() instanceof LogicalTopNOperator,
-                "PK MV should have TopN for DELETE-before-INSERT ordering");
-        OptExpression opProject = rewrittenChild.inputAt(0);
-        Assertions.assertTrue(opProject.getOp() instanceof LogicalProjectOperator);
-        LogicalProjectOperator opProjectOp = (LogicalProjectOperator) opProject.getOp();
+        Assertions.assertFalse(rewrittenChild.getOp() instanceof LogicalTopNOperator);
+        Assertions.assertTrue(rewrittenChild.getOp() instanceof LogicalProjectOperator);
+        LogicalProjectOperator opProjectOp = (LogicalProjectOperator) rewrittenChild.getOp();
         // Should contain __op column
         boolean hasOpColumn = opProjectOp.getColumnRefMap().keySet().stream()
                 .anyMatch(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()));
@@ -242,18 +243,158 @@ public class IvmRewriterTest {
 
         IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
 
-        // Non-aggregate PK MV should have TopN → Project(__op) at the top, same as aggregate PK MV
+        // Append-only Iceberg → constant __ACTION__ → TopN is skipped. Top is Project(__op).
         OptExpression rewrittenChild = root.inputAt(0);
-        Assertions.assertTrue(rewrittenChild.getOp() instanceof LogicalTopNOperator,
-                "Non-aggregate PK MV should have TopN for DELETE-before-INSERT ordering");
-        OptExpression opProject = rewrittenChild.inputAt(0);
-        Assertions.assertTrue(opProject.getOp() instanceof LogicalProjectOperator);
-        LogicalProjectOperator opProjectOp = (LogicalProjectOperator) opProject.getOp();
-        // Should contain __op column
+        Assertions.assertFalse(rewrittenChild.getOp() instanceof LogicalTopNOperator,
+                "No TopN expected for append-only Iceberg (constant __ACTION__)");
+        Assertions.assertTrue(rewrittenChild.getOp() instanceof LogicalProjectOperator);
+        LogicalProjectOperator opProjectOp = (LogicalProjectOperator) rewrittenChild.getOp();
         boolean hasOpColumn = opProjectOp.getColumnRefMap().keySet().stream()
                 .anyMatch(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()));
         Assertions.assertTrue(hasOpColumn,
                 "Non-aggregate PK MV should have __op column (IvmRewriter.appendPkLoadOpColumn)");
+    }
+
+    /** {@code __op} must be a direct alias of {@code __ACTION__} (not a CASE WHEN). */
+    @Test
+    public void testLoadOpColumnIsDirectAliasOfActionColumn(@Mocked IcebergTable table,
+                                                             @Mocked MaterializedView targetMv,
+                                                             @Mocked InsertStmt insertStmt) {
+        mockIcebergTable(table);
+        new Expectations() {
+            {
+                insertStmt.getTargetTable();
+                result = targetMv;
+                minTimes = 0;
+
+                targetMv.getKeysType();
+                result = KeysType.PRIMARY_KEYS;
+                minTimes = 0;
+            }
+        };
+
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        context.getSessionVariable().setEnableIVMRefresh(true);
+        context.setStatement(insertStmt);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
+        deriveLogicalProperty(root);
+        IvmRewriter.rewrite(root, newTaskContext(context), new TaskScheduler(), new ColumnRefSet());
+
+        OptExpression opProject = root.inputAt(0);
+        Assertions.assertTrue(opProject.getOp() instanceof LogicalProjectOperator);
+        LogicalProjectOperator opProjectOp = (LogicalProjectOperator) opProject.getOp();
+        ColumnRefOperator opCol = opProjectOp.getColumnRefMap().keySet().stream()
+                .filter(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("__op column must be produced"));
+        ScalarOperator opExpr = opProjectOp.getColumnRefMap().get(opCol);
+        Assertions.assertTrue(opExpr instanceof ColumnRefOperator,
+                "__op must be a direct column reference (not CASE WHEN), but was: " + opExpr);
+        Assertions.assertEquals(IvmRuleUtils.ACTION_COLUMN_NAME,
+                ((ColumnRefOperator) opExpr).getName(),
+                "__op must reference __ACTION__ directly");
+    }
+
+    /** TopN is skipped when {@code __ACTION__} is provably constant (no DELETEs to order). */
+    @Test
+    public void testTopNSkippedWhenActionConstant(@Mocked IcebergTable table,
+                                                   @Mocked MaterializedView targetMv,
+                                                   @Mocked InsertStmt insertStmt) {
+        mockIcebergTable(table);
+        new Expectations() {
+            {
+                insertStmt.getTargetTable();
+                result = targetMv;
+                minTimes = 0;
+
+                targetMv.getKeysType();
+                result = KeysType.PRIMARY_KEYS;
+                minTimes = 0;
+            }
+        };
+
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        context.getSessionVariable().setEnableIVMRefresh(true);
+        context.setStatement(insertStmt);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
+        deriveLogicalProperty(root);
+        IvmRewriter.rewrite(root, newTaskContext(context), new TaskScheduler(), new ColumnRefSet());
+
+        OptExpression top = root.inputAt(0);
+        Assertions.assertTrue(top.getOp() instanceof LogicalProjectOperator,
+                "top operator must be Project when __ACTION__ is constant; no TopN expected");
+        Assertions.assertFalse(top.getOp() instanceof LogicalTopNOperator);
+    }
+
+    /**
+     * Regression: when {@code __ACTION__} is forwarded through an aliasing projection
+     * (e.g., {@code IvmDeltaFilterRule} attaches {@code action → action}), the constant
+     * produced at the scan must still be detected — TopN is skipped.
+     */
+    @Test
+    public void testTopNSkippedAcrossAliasForwardingProjection(@Mocked IcebergTable table,
+                                                                @Mocked MaterializedView targetMv,
+                                                                @Mocked InsertStmt insertStmt) {
+        mockIcebergTable(table);
+        new Expectations() {
+            {
+                insertStmt.getTargetTable();
+                result = targetMv;
+                minTimes = 0;
+
+                targetMv.getKeysType();
+                result = KeysType.PRIMARY_KEYS;
+                minTimes = 0;
+            }
+        };
+
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        context.getSessionVariable().setEnableIVMRefresh(true);
+        context.setStatement(insertStmt);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        // Filter above scan → IvmDeltaFilterRule attaches a passthrough Projection carrying
+        // `actionColumn → actionColumn` on the Filter operator. Without alias-chain walking,
+        // isActionColumnConstant would miss the constant and keep the TopN.
+        OptExpression filter = OptExpression.create(
+                new LogicalFilterOperator(ConstantOperator.createBoolean(true)), scan);
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), filter);
+        deriveLogicalProperty(root);
+
+        IvmRewriter.rewrite(root, newTaskContext(context), new TaskScheduler(), new ColumnRefSet());
+
+        Assertions.assertFalse(containsTopN(root.inputAt(0)),
+                "TopN must be skipped when __ACTION__ is constant, even through alias forwarding");
+    }
+
+    private static boolean containsTopN(OptExpression expr) {
+        if (expr.getOp() instanceof LogicalTopNOperator) {
+            return true;
+        }
+        for (OptExpression child : expr.getInputs()) {
+            if (containsTopN(child)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Test


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:

1. Align __ACTION__ value domain with __op:
   - Before: __ACTION__ = +1 (INSERT), -1 (DELETE); __op = 0 (UPSERT), 1 (DELETE). IvmRewriter.appendPkLoadOpColumn emitted a CASE WHEN to bridge the two.
   - After: __ACTION__ uses the same 0/1 domain as __op. The expression simplifies to a direct column alias (__op := __ACTION__), removing the CASE WHEN.

2. Skip the DELETE-before-UPSERT TopN when __ACTION__ is a proven constant: TopN's purpose is to order same-PK DELETE rows before UPSERT rows so that batched writes commit correctly. For append-only Iceberg sources, __ACTION__ is a constant 0 — no DELETEs — and the sort is pure pipeline-breaker waste. A new isActionColumnConstant helper walks the plan's projection chain; when it proves constant, TopN is omitted. Any future non-constant __ACTION__ path (e.g. OLAP IVM or Iceberg delete files) automatically re-enables TopN.

Changes:
- IvmDeltaIcebergScanRule: __ACTION__ = 0 for append-only INSERT (was 1)
- IvmDeltaAggregateRule: __ACTION__ = 0 for aggregate UPSERT (was 1)
- IvmRewriter.appendPkLoadOpColumn: CASE WHEN -> identity; add TopN-skip guard
- IvmRewriter: new isActionColumnConstant helper; drop unused imports
- Tests: relax TopN-presence asserts (append-only skips TopN); add pinning tests for identity mapping and TopN-skip behavior; update IvmIcebergRuleTest's __ACTION__ constant checks from 1 to 0.

__ACTION__ is an internal optimizer-level column — never persisted, never exposed to users — so this change has no compatibility impact.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
