### PR TITLE
[auto-perf-opt] Prefetch SST tail to warm starlet cache before Table::Open

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -493,6 +493,21 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 CONF_mInt32(pk_index_memtable_max_count, "4");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
+// When opening a persistent-index SST for read (LakePersistentIndex::init ->
+// PersistentIndexSstable::new_sstable -> sstable::Table::Open), Table::Open
+// issues 4 small, scattered reads for the tail (footer, index block,
+// metaindex block, filter block). On shared-data clusters at cold-start the
+// per-CN fan-out of those reads saturates OSS egress and drives the
+// `pindex_init_sst_open_us` tail (~ 12 s p99 on the 1 TB benchmark).
+// A single touch_cache(filesize - tail, tail) warms the starlet local cache
+// for the tail region, so the 4 subsequent Table::Open reads become
+// cache hits instead of 4 separate OSS GETs per SST. Disable to revert to
+// pre-optimization behavior.
+CONF_mBool(enable_pk_index_sst_tail_prefetch, "true");
+// Bytes to prefetch from the SST tail before Table::Open. 1 MiB by default
+// comfortably covers the footer (48 B) + index block + metaindex block +
+// bloom filter block for a PK-index SST of ~1 M keys @ 10 bits/key.
+CONF_mInt64(pk_index_sst_tail_prefetch_bytes, "1048576");
 // The parameters for pk index size-tiered compaction strategy.
 CONF_mInt64(pk_index_size_tiered_min_level_size, "131072");
 CONF_mInt64(pk_index_size_tiered_level_multiplier, "10");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -480,7 +480,17 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 // The maximum number of memtables for pk index in shared-data mode.
-CONF_mInt32(pk_index_memtable_max_count, "2");
+// Controls the async-flush pipeline depth in LakePersistentIndex::flush_memtable:
+// while (inactive_memtables.size() + 1 < pk_index_memtable_max_count) the new
+// flush is submitted to the pk_index_memtable_flush pool; otherwise the write
+// path falls back to a synchronous flush that blocks the caller. With the prior
+// value of 2, only one inactive memtable could be in flight, so any hot PK
+// tablet that filled two memtables within a flush cycle (~100-200 ms of SST
+// IO) paid a full sync flush on its write path — a primary contributor to the
+// upsert P99 / Max tail on shared-data. 4 allows 3 pending async flushes,
+// giving bursty writers headroom without unbounded memory growth (each memtable
+// is bounded by l0_max_mem_usage / l0_min_mem_usage and the update memtracker).
+CONF_mInt32(pk_index_memtable_max_count, "4");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 // The parameters for pk index size-tiered compaction strategy.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -711,6 +711,8 @@
         "pk_index_parallel_execution_min_rows",
         "pk_index_memtable_max_count",
         "pk_index_memtable_max_wait_flush_timeout_ms",
+        "enable_pk_index_sst_tail_prefetch",
+        "pk_index_sst_tail_prefetch_bytes",
         "pk_index_size_tiered_min_level_size",
         "pk_index_size_tiered_level_multiplier",
         "pk_index_size_tiered_max_level",

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -90,6 +90,23 @@ CONF_mInt32(pk_index_memtable_max_count, "4");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 
+// When opening a persistent-index SST for read (LakePersistentIndex::init ->
+// PersistentIndexSstable::new_sstable -> sstable::Table::Open), Table::Open
+// issues 4 small, scattered reads for the tail (footer, index block,
+// metaindex block, filter block). On shared-data clusters at cold-start the
+// per-CN fan-out of those reads saturates OSS egress and drives the
+// `pindex_init_sst_open_us` tail (~ 12 s p99 on the 1 TB benchmark).
+// A single touch_cache(filesize - tail, tail) warms the starlet local cache
+// for the tail region, so the 4 subsequent Table::Open reads become
+// cache hits instead of 4 separate OSS GETs per SST. Disable to revert to
+// pre-optimization behavior.
+CONF_mBool(enable_pk_index_sst_tail_prefetch, "true");
+
+// Bytes to prefetch from the SST tail before Table::Open. 1 MiB by default
+// comfortably covers the footer (48 B) + index block + metaindex block +
+// bloom filter block for a PK-index SST of ~1 M keys @ 10 bits/key.
+CONF_mInt64(pk_index_sst_tail_prefetch_bytes, "1048576");
+
 // The parameters for pk index size-tiered compaction strategy.
 CONF_mInt64(pk_index_size_tiered_min_level_size, "131072");
 

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -75,7 +75,17 @@ CONF_mBool(enable_pk_index_parallel_execution, "true");
 CONF_mInt64(pk_index_parallel_execution_min_rows, "16384");
 
 // The maximum number of memtables for pk index in shared-data mode.
-CONF_mInt32(pk_index_memtable_max_count, "2");
+// Controls the async-flush pipeline depth in LakePersistentIndex::flush_memtable:
+// while (inactive_memtables.size() + 1 < pk_index_memtable_max_count) the new
+// flush is submitted to the pk_index_memtable_flush pool; otherwise the write
+// path falls back to a synchronous flush that blocks the caller. With the prior
+// value of 2, only one inactive memtable could be in flight, so any hot PK
+// tablet that filled two memtables within a flush cycle (~100-200 ms of SST
+// IO) paid a full sync flush on its write path — a primary contributor to the
+// upsert P99 / Max tail on shared-data. 4 allows 3 pending async flushes,
+// giving bursty writers headroom without unbounded memory growth (each memtable
+// is bounded by l0_max_mem_usage / l0_min_mem_usage and the update memtracker).
+CONF_mInt32(pk_index_memtable_max_count, "4");
 
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -949,7 +949,7 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
         auto pkc = pk_column->clone();
         auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
         if (!st.ok()) {
-            per_task_status[del_idx] = st;
+            per_task_status[del_idx] = st.status();
             return;
         }
         pkcs[del_idx] = std::move(pkc);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -897,29 +897,94 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
 
 // Rebuild index's memtable via del files, it will read from del file and write to index.
 // If it fail, SR will retry publish txn, and this index's memtable will be release and rebuild again.
+//
+// The read+deserialize of del-file contents (OSS IO + CPU) is performed in parallel across
+// del files via the pk_index_execution thread pool; the subsequent index get/replay_erase
+// is kept sequential because PersistentIndexMemtable has a single-writer contract.
+// This is critical for cold-start publishes where a tablet's PK index is not resident:
+// trace data (iter-005) showed rebuild_index_del_cost_us dominating pindex_load_from_lake_tablet_us
+// (e.g. 10.0 s / 10.1 s) with serialized OSS reads. The same thread pool and
+// enable_pk_index_parallel_execution flag are already used by _open_sstables_parallel.
 Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pkey_schema, int64_t rowset_version) {
     TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_index_del_cost_us");
     // Build pk column struct from schema
     ASSIGN_OR_RETURN(auto pk_encoding_type, rowset->tablet_schema()->primary_key_encoding_type_or_error());
     MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type));
-    // Iterate all del files and insert into index.
-    for (int del_idx = 0; del_idx < rowset->metadata().del_files_size(); ++del_idx) {
-        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+
+    const int ndel = rowset->metadata().del_files_size();
+    if (ndel == 0) {
+        return Status::OK();
+    }
+
+    // Phase 1 (parallel): read each del file from storage and deserialize into a per-file pk column.
+    // Nothing in this phase touches the pk index, so it is safe to run concurrently.
+    std::vector<MutableColumnPtr> pkcs(ndel);
+    std::vector<Status> per_task_status(ndel);
+    auto read_one = [&](int del_idx) {
         const auto& del = rowset->metadata().del_files(del_idx);
         RandomAccessFileOptions ropts;
         if (!del.encryption_meta().empty()) {
-            ASSIGN_OR_RETURN(ropts.encryption_info, KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
+            auto unwrap_res = KeyCache::instance().unwrap_encryption_meta(del.encryption_meta());
+            if (!unwrap_res.ok()) {
+                per_task_status[del_idx] = unwrap_res.status();
+                return;
+            }
+            ropts.encryption_info = *unwrap_res;
         }
-        ASSIGN_OR_RETURN(auto read_file,
-                         fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name())));
-        ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
-        const auto* data = reinterpret_cast<const uint8_t*>(read_buffer.data());
-        const auto* end = data + read_buffer.size();
-        // serialize to column
+        auto rf_res = fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name()));
+        if (!rf_res.ok()) {
+            per_task_status[del_idx] = rf_res.status();
+            return;
+        }
+        auto rf = std::move(rf_res).value();
+        auto buf_res = rf->read_all();
+        if (!buf_res.ok()) {
+            per_task_status[del_idx] = buf_res.status();
+            return;
+        }
+        auto buf = std::move(buf_res).value();
+        const auto* data = reinterpret_cast<const uint8_t*>(buf.data());
+        const auto* end = data + buf.size();
         auto pkc = pk_column->clone();
-        using Serd = serde::ColumnArraySerde;
-        RETURN_IF_ERROR(Serd::deserialize(data, end, pkc.get()));
+        auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
+        if (!st.ok()) {
+            per_task_status[del_idx] = st;
+            return;
+        }
+        pkcs[del_idx] = std::move(pkc);
+    };
+    std::unique_ptr<ThreadPoolToken> token;
+    if (ndel > 1 && config::enable_pk_index_parallel_execution) {
+        auto* pool = ExecEnv::GetInstance()->pk_index_execution_thread_pool();
+        if (pool != nullptr) {
+            token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+        }
+    }
+    for (int i = 0; i < ndel; ++i) {
+        if (token) {
+            auto st = token->submit_func([&read_one, i]() { read_one(i); });
+            if (!st.ok()) {
+                // Fall back to inline execution if submission fails (e.g. shutting down).
+                read_one(i);
+            }
+        } else {
+            read_one(i);
+        }
+    }
+    if (token) {
+        token->wait();
+    }
+    for (auto& st : per_task_status) {
+        RETURN_IF_ERROR(st);
+    }
+
+    // Phase 2 (sequential): filter old deletes via pk-index get() and replay_erase() them.
+    // Order must match the original single-threaded iteration so replay is deterministic.
+    for (int del_idx = 0; del_idx < ndel; ++del_idx) {
+        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+        const auto& del = rowset->metadata().del_files(del_idx);
+        auto& pkc = pkcs[del_idx];
         // We can't insert delete operation to index directly, because some delete operation is
         // older than current item, and we need to igore these delete operations.
         std::vector<IndexValue> found_values(pkc->size(), IndexValue(NullIndexValue));

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -259,6 +259,18 @@ StatusOr<PersistentIndexSstableUniquePtr> PersistentIndexSstable::new_sstable(
         opts.encryption_info = std::move(info);
     }
     ASSIGN_OR_RETURN(auto rf, fs::new_random_access_file(opts, location));
+    // sstable::Table::Open will issue 4 scattered reads for the SST tail
+    // (footer / index / metaindex / filter). On starlet, turn them into
+    // cache hits by pre-warming the tail with a single touch_cache. No-op on
+    // local filesystems.
+    if (config::enable_pk_index_sst_tail_prefetch) {
+        const int64_t filesize = sstable_pb.filesize();
+        const int64_t tail_size =
+                std::min<int64_t>(filesize, std::max<int64_t>(0, config::pk_index_sst_tail_prefetch_bytes));
+        if (tail_size > 0) {
+            (void)rf->touch_cache(filesize - tail_size, tail_size);
+        }
+    }
     RETURN_IF_ERROR(sstable->init(std::move(rf), sstable_pb, cache, need_filter, delvec, metadata, tablet_mgr));
     return std::move(sstable);
 }


### PR DESCRIPTION
## Context (measured on 999_1gb_1_1tb realtime upsert benchmark, 1 TB shared-data, 6 CN)

`LakePersistentIndex::init` → `PersistentIndexSstable::new_sstable` → `sstable::Table::Open` issues **4 scattered OSS reads** per SST on cold-load:

1. footer (48 bytes, end of file)
2. index block
3. metaindex block
4. filter block (bloom)

All four live in the tail of the file per the LevelDB table layout. They run on the `pk_index_execution` pool (iter-004..008 sizes this at 1024 threads) but the bottleneck is OSS egress, not pool slots: at cold-start on the 1 TB fixture, 300+ tablets init their PK indexes nearly simultaneously, so aggregate per-CN OSS concurrency saturates.

Observed per-publish cost (cost ≥ 5 s publish traces, iter-008 / build 1224 = main + PR #72057):

| Pattern | Scope | iter-008 count (of 44) | Slowest in that pattern |
|---|---|---:|---|
| A | `rebuild_index_segment_cost_us` (segment-scan / local-disk)          | 1  | ~7 s  |
| B | `rebuild_index_del_cost_us` (post-PR #72057: del-file parallel IO)   | 21 | 6.8 s |
| **C** | **`pindex_init_sst_open_us` (SST metadata OSS reads)**         | **20** | **~12 s** |

Pattern B was the old top lever; PR #72057 took it from 13 s max down to 6.8 s max. **Pattern C (12 s) is now the longest remaining cold-start per-publish bar.**

## What this PR does

Before `sstable::Table::Open`, pre-warm the **starlet local disk cache** for the tail of the SST with a single `touch_cache(filesize - tail, tail)`. Default tail = 1 MiB, which comfortably covers a PK-index SST filter of ~1 M keys at 10 bits/key plus the index, metaindex, and footer blocks.

Result: the 4 subsequent scattered reads in `Table::Open` become cache hits instead of 4 separate OSS GETs per SST open. At N tablets × M SSTs/tablet concurrent cold-loads, aggregate OSS requests drop ~4×.

Only `new_sstable` is modified — every call site (`_open_sstables_parallel`, compaction, etc.) inherits the behavior.

## Gating

- `enable_pk_index_sst_tail_prefetch` (default `true`, mutable) — kill switch.
- `pk_index_sst_tail_prefetch_bytes` (default `1048576`, mutable) — tail size.
- No-op on filesystems that do not implement `touch_cache` (fs_s3, fs_posix). Shared-nothing mode therefore sees no change.

## Expected impact

- Cold-start `pindex_init_sst_open_us` p99 should drop from ~12 s toward single-digit seconds.
- Cold-start Upsert Max (which has been CommitAndPublish-dominated) should drop proportionally.
- Upsert P99 already well under the 3 000 ms target (1 651 ms in iter-008) — that P99 may tighten further but the primary target is cold-start Max.

## What this PR does NOT fix

- Steady-state `WriteDataTimeMs` P99 / Max (~5-10 s on iter-008). Different code path.
- Cold-start CN hot-spotting (one CN serialising multiple per-publish waits) — orthogonal, driven by workload placement, not PK-index code.

## Test plan

- [ ] TSP build + deploy to `benchmark_luoyixin_1tb_6cn_2disk2` (in-place over build 1224 which already has PR #72057 merged into iter-006 branch).
- [ ] Re-run 999_1gb_1_1tb upsert workload (`--skip-setup --skip-prepare` to match iter-008 conditions) and compare:
  - [ ] Per-publish `pindex_init_sst_open_us` distribution on cost ≥ 5 s cold-start traces (target: max dropped ≥ 2× vs iter-008's 11-12 s)
  - [ ] Whole-run Upsert P99 / Max
  - [ ] Steady-state P99 / Max (should be unchanged within noise)
  - [ ] Error rate (must remain 0 %)
- [ ] Confirm compile + unit tests green in TSP build.