### PR TITLE
[Enhancement] Support vector index write in shared-data mode

### DIFF
--- a/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
@@ -172,7 +172,8 @@ void TenAnnIndexBuilderProxy::close() const {
     }
     // TenANN's IndexBuilder::Close() does NOT call IndexFileWriter::Close().
     // For S3, objects are only visible after close(), so we must explicitly
-    // close the file writer to finalize the upload.
+    // close the file writer to finalize the upload. VectorIndexFileWriter::Close()
+    // is idempotent, so the destructor path can safely re-enter.
     if (_file_writer) {
         _file_writer->Close();
     }

--- a/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
@@ -62,6 +62,11 @@ Status TenAnnIndexBuilderProxy::init() {
         // build and write index
         _index_builder = tenann::IndexFactory::CreateBuilderFromMeta(meta_copy);
         _index_builder->index_writer()->SetIndexCache(tenann::IndexCache::GetGlobalInstance());
+        // Use tenann file writer for remote FS (S3/HDFS) in shared-data mode
+        if (_file_writer != nullptr) {
+            _index_builder->index_writer()->SetFileWriter(
+                    std::shared_ptr<tenann::IndexFileWriter>(_file_writer, [](tenann::IndexFileWriter*) {}));
+        }
         if (_is_element_nullable) {
             _index_builder->EnableCustomRowId();
         }
@@ -164,6 +169,12 @@ Status TenAnnIndexBuilderProxy::flush() {
 void TenAnnIndexBuilderProxy::close() const {
     if (_index_builder && !_index_builder->is_closed()) {
         _index_builder->Close();
+    }
+    // TenANN's IndexBuilder::Close() does NOT call IndexFileWriter::Close().
+    // For S3, objects are only visible after close(), so we must explicitly
+    // close the file writer to finalize the upload.
+    if (_file_writer) {
+        _file_writer->Close();
     }
 }
 

--- a/be/src/storage/index/vector/tenann/tenann_index_builder.h
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.h
@@ -31,7 +31,14 @@ public:
     TenAnnIndexBuilderProxy(std::shared_ptr<TabletIndex> tablet_index, std::string segment_index_path,
                             bool is_element_nullable)
             : VectorIndexBuilder(std::move(tablet_index), std::move(segment_index_path)),
-              _is_element_nullable(is_element_nullable) {}
+              _is_element_nullable(is_element_nullable),
+              _file_writer(nullptr) {}
+
+    TenAnnIndexBuilderProxy(std::shared_ptr<TabletIndex> tablet_index, std::string segment_index_path,
+                            bool is_element_nullable, class tenann::IndexFileWriter* file_writer)
+            : VectorIndexBuilder(std::move(tablet_index), std::move(segment_index_path)),
+              _is_element_nullable(is_element_nullable),
+              _file_writer(file_writer) {}
 
     // proxy should not clean index builder resource
     ~TenAnnIndexBuilderProxy() override { close(); };
@@ -42,7 +49,7 @@ public:
 
     Status flush() override;
 
-    void close() const;
+    void close() const override;
 
 private:
     OnceFlag _init_once;
@@ -54,6 +61,7 @@ private:
     bool _is_input_normalized = false;
 
     const bool _is_element_nullable;
+    tenann::IndexFileWriter* _file_writer = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_builder.h
+++ b/be/src/storage/index/vector/vector_index_builder.h
@@ -34,6 +34,11 @@ public:
     // flush data into disk
     virtual Status flush() = 0;
 
+    // close the index builder and finalize the underlying file.
+    // Must be called after flush() and before reading the index file,
+    // because remote FS (S3) objects are only visible after close().
+    virtual void close() const {};
+
     // we should make sure the independence of TenAnn index, include data and metadata, to make [[IndexScanNode]] simple
     // enough in the future other than to read the meta both in StarRocks and TenAnn.
     // Furthermore, TenAnn index within tablet level should decouple with segment, therefore we should do the empty mark

--- a/be/src/storage/index/vector/vector_index_builder_factory.cpp
+++ b/be/src/storage/index/vector/vector_index_builder_factory.cpp
@@ -23,12 +23,12 @@ namespace starrocks {
 StatusOr<std::unique_ptr<VectorIndexBuilder>> VectorIndexBuilderFactory::create_index_builder(
         const std::shared_ptr<TabletIndex>& tablet_index, const std::string& segment_index_path,
         const IndexBuilderType index_builder_type, const bool is_element_nullable,
-        [[maybe_unused]] void* file_writer) {
+        [[maybe_unused]] VectorIndexFileWriter* file_writer) {
     switch (index_builder_type) {
     case TEN_ANN:
 #ifdef WITH_TENANN
         return std::make_unique<TenAnnIndexBuilderProxy>(tablet_index, segment_index_path, is_element_nullable,
-                                                         static_cast<VectorIndexFileWriter*>(file_writer));
+                                                         file_writer);
 #else
         return std::make_unique<EmptyVectorIndexBuilder>(tablet_index, segment_index_path);
 #endif

--- a/be/src/storage/index/vector/vector_index_builder_factory.cpp
+++ b/be/src/storage/index/vector/vector_index_builder_factory.cpp
@@ -16,16 +16,19 @@
 
 #include "column/array_column.h"
 #include "storage/index/vector/tenann/tenann_index_builder.h"
+#include "storage/index/vector/vector_index_file_writer.h"
 
 namespace starrocks {
 // =============== IndexBuilderFactory =============
 StatusOr<std::unique_ptr<VectorIndexBuilder>> VectorIndexBuilderFactory::create_index_builder(
         const std::shared_ptr<TabletIndex>& tablet_index, const std::string& segment_index_path,
-        const IndexBuilderType index_builder_type, const bool is_element_nullable) {
+        const IndexBuilderType index_builder_type, const bool is_element_nullable,
+        [[maybe_unused]] void* file_writer) {
     switch (index_builder_type) {
     case TEN_ANN:
 #ifdef WITH_TENANN
-        return std::make_unique<TenAnnIndexBuilderProxy>(tablet_index, segment_index_path, is_element_nullable);
+        return std::make_unique<TenAnnIndexBuilderProxy>(tablet_index, segment_index_path, is_element_nullable,
+                                                         static_cast<VectorIndexFileWriter*>(file_writer));
 #else
         return std::make_unique<EmptyVectorIndexBuilder>(tablet_index, segment_index_path);
 #endif

--- a/be/src/storage/index/vector/vector_index_builder_factory.h
+++ b/be/src/storage/index/vector/vector_index_builder_factory.h
@@ -25,9 +25,12 @@ namespace starrocks {
 
 class VectorIndexBuilderFactory {
 public:
+    // file_writer: optional, for remote FS (S3/HDFS) in shared-data mode. Pass VectorIndexFileWriter* when
+    // WITH_TENANN, else nullptr.
     static StatusOr<std::unique_ptr<VectorIndexBuilder>> create_index_builder(
             const std::shared_ptr<TabletIndex>& tablet_index, const std::string& segment_index_path,
-            const IndexBuilderType index_builder_type, const bool is_element_nullable);
+            const IndexBuilderType index_builder_type, const bool is_element_nullable,
+            [[maybe_unused]] void* file_writer = nullptr);
 
     static StatusOr<IndexBuilderType> get_index_builder_type_from_config(
             const std::shared_ptr<TabletIndex>& _tablet_index) {

--- a/be/src/storage/index/vector/vector_index_builder_factory.h
+++ b/be/src/storage/index/vector/vector_index_builder_factory.h
@@ -23,14 +23,16 @@
 
 namespace starrocks {
 
+class VectorIndexFileWriter;
+
 class VectorIndexBuilderFactory {
 public:
-    // file_writer: optional, for remote FS (S3/HDFS) in shared-data mode. Pass VectorIndexFileWriter* when
-    // WITH_TENANN, else nullptr.
+    // file_writer: optional, for remote FS (S3/HDFS) in shared-data mode. In non-TenANN
+    // builds VectorIndexFileWriter is a stub and the argument is ignored.
     static StatusOr<std::unique_ptr<VectorIndexBuilder>> create_index_builder(
             const std::shared_ptr<TabletIndex>& tablet_index, const std::string& segment_index_path,
             const IndexBuilderType index_builder_type, const bool is_element_nullable,
-            [[maybe_unused]] void* file_writer = nullptr);
+            [[maybe_unused]] VectorIndexFileWriter* file_writer = nullptr);
 
     static StatusOr<IndexBuilderType> get_index_builder_type_from_config(
             const std::shared_ptr<TabletIndex>& _tablet_index) {

--- a/be/src/storage/index/vector/vector_index_file_writer.h
+++ b/be/src/storage/index/vector/vector_index_file_writer.h
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef WITH_TENANN
+
+#include <memory>
+#include <string>
+
+#include "base/string/slice.h"
+#include "fs/fs.h"
+#include "tenann/store/index_file_writer.h"
+
+namespace starrocks {
+
+// Bridge StarRocks WritableFile to TenANN IndexFileWriter interface,
+// enabling TenANN to write vector index files to remote storage (S3/HDFS/OSS).
+class VectorIndexFileWriter : public tenann::IndexFileWriter {
+public:
+    explicit VectorIndexFileWriter(std::unique_ptr<WritableFile> file)
+            : _file(std::move(file)), _filename(_file->filename()) {}
+
+    ~VectorIndexFileWriter() override = default;
+
+    int64_t Write(const void* data, int64_t count) override {
+        auto st = _file->append(Slice(static_cast<const char*>(data), count));
+        return st.ok() ? count : -1;
+    }
+
+    void Flush() override { (void)_file->flush(WritableFile::FLUSH_SYNC); }
+
+    void Close() override { (void)_file->close(); }
+
+    const std::string& filename() const override { return _filename; }
+
+private:
+    std::unique_ptr<WritableFile> _file;
+    std::string _filename;
+};
+
+} // namespace starrocks
+
+#else // !WITH_TENANN
+
+namespace starrocks {
+// Stub for non-TenANN builds so that unique_ptr<VectorIndexFileWriter> compiles.
+class VectorIndexFileWriter {};
+} // namespace starrocks
+
+#endif

--- a/be/src/storage/index/vector/vector_index_file_writer.h
+++ b/be/src/storage/index/vector/vector_index_file_writer.h
@@ -20,6 +20,8 @@
 #include <string>
 
 #include "base/string/slice.h"
+#include "common/logging.h"
+#include "common/status.h"
 #include "fs/fs.h"
 #include "tenann/store/index_file_writer.h"
 
@@ -27,6 +29,11 @@ namespace starrocks {
 
 // Bridge StarRocks WritableFile to TenANN IndexFileWriter interface,
 // enabling TenANN to write vector index files to remote storage (S3/HDFS/OSS).
+//
+// TenANN's IndexFileWriter interface returns void for Flush/Close, so we retain the
+// first error internally and surface it via status(). For object storage (S3), a
+// silent Close() failure would leave the uploaded object missing or incomplete, so
+// callers must check status() after Close() and fail the write if it is not OK.
 class VectorIndexFileWriter : public tenann::IndexFileWriter {
 public:
     explicit VectorIndexFileWriter(std::unique_ptr<WritableFile> file)
@@ -35,19 +42,47 @@ public:
     ~VectorIndexFileWriter() override = default;
 
     int64_t Write(const void* data, int64_t count) override {
+        if (!_status.ok()) {
+            return -1;
+        }
         auto st = _file->append(Slice(static_cast<const char*>(data), count));
-        return st.ok() ? count : -1;
+        if (!st.ok()) {
+            _record_error(st);
+            return -1;
+        }
+        return count;
     }
 
-    void Flush() override { (void)_file->flush(WritableFile::FLUSH_SYNC); }
+    void Flush() override { _record_error(_file->flush(WritableFile::FLUSH_SYNC)); }
 
-    void Close() override { (void)_file->close(); }
+    // Idempotent: tenann's IndexBuilder::Close() and our own explicit close from
+    // VectorIndexWriter::finish() can both route here, and WritableFile::close() on
+    // an already-closed file (EBADF on posix, repeated CompleteMultipartUpload on S3)
+    // would otherwise fabricate a spurious error in _status.
+    void Close() override {
+        if (_closed) {
+            return;
+        }
+        _closed = true;
+        _record_error(_file->close());
+    }
 
     const std::string& filename() const override { return _filename; }
 
+    const Status& status() const { return _status; }
+
 private:
+    void _record_error(const Status& st) {
+        if (!st.ok() && _status.ok()) {
+            LOG(WARNING) << "VectorIndexFileWriter failure on " << _filename << ": " << st;
+            _status = st;
+        }
+    }
+
     std::unique_ptr<WritableFile> _file;
     std::string _filename;
+    Status _status;
+    bool _closed = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_writer.cpp
+++ b/be/src/storage/index/vector/vector_index_writer.cpp
@@ -99,6 +99,14 @@ Status VectorIndexWriter::finish(uint64_t* index_size) {
             // Close the builder to finalize the underlying file.
             // S3 objects are only visible/readable after close().
             _index_builder->close();
+#ifdef WITH_TENANN
+            // Surface any error from the bridged WritableFile: tenann's IndexFileWriter
+            // interface is void, so failures during flush/close would otherwise be dropped
+            // silently and leave an incomplete/missing object on remote storage.
+            if (_file_writer_holder != nullptr) {
+                RETURN_IF_ERROR(_file_writer_holder->status());
+            }
+#endif
         } else {
             // flush with empty mark
             RETURN_IF_ERROR(VectorIndexBuilder::flush_empty(_vector_index_file_path));

--- a/be/src/storage/index/vector/vector_index_writer.cpp
+++ b/be/src/storage/index/vector/vector_index_writer.cpp
@@ -18,6 +18,8 @@
 #include "common/runtime_profile.h"
 #include "fs/fs_util.h"
 #include "runtime/starrocks_metrics.h"
+#include "storage/index/index_descriptor.h"
+#include "storage/index/vector/vector_index_file_writer.h"
 
 namespace starrocks {
 
@@ -30,6 +32,8 @@ VectorIndexWriter::VectorIndexWriter(std::shared_ptr<TabletIndex> tablet_index, 
     // Element of array column must be nullable.
     DCHECK(_is_element_nullable);
 }
+
+VectorIndexWriter::~VectorIndexWriter() = default;
 
 void VectorIndexWriter::create(const std::shared_ptr<TabletIndex>& tablet_index,
                                const std::string& vector_index_file_path, bool is_element_nullable,
@@ -92,6 +96,9 @@ Status VectorIndexWriter::finish(uint64_t* index_size) {
         if (_index_builder.get() != nullptr) {
             // flush with index
             RETURN_IF_ERROR(_index_builder->flush());
+            // Close the builder to finalize the underlying file.
+            // S3 objects are only visible/readable after close().
+            _index_builder->close();
         } else {
             // flush with empty mark
             RETURN_IF_ERROR(VectorIndexBuilder::flush_empty(_vector_index_file_path));
@@ -117,9 +124,21 @@ uint64_t VectorIndexWriter::estimate_buffer_size() const {
 Status VectorIndexWriter::_prepare_index_builder() {
     ASSIGN_OR_RETURN(auto index_builder_type,
                      VectorIndexBuilderFactory::get_index_builder_type_from_config(_tablet_index))
+#ifdef WITH_TENANN
+    // Create VectorIndexFileWriter to support remote FS (S3/HDFS) in shared-data mode.
+    // TenANN doesn't understand staros:// scheme, so we create a WritableFile through
+    // StarRocks FS and bridge it to tenann via VectorIndexFileWriter.
+    ASSIGN_OR_RETURN(auto wfile, fs::new_writable_file(_vector_index_file_path));
+    auto file_writer = std::make_unique<VectorIndexFileWriter>(std::move(wfile));
+    ASSIGN_OR_RETURN(_index_builder, VectorIndexBuilderFactory::create_index_builder(
+                                             _tablet_index, _vector_index_file_path, index_builder_type,
+                                             _is_element_nullable, file_writer.get()));
+    _file_writer_holder = std::move(file_writer);
+#else
     ASSIGN_OR_RETURN(_index_builder,
                      VectorIndexBuilderFactory::create_index_builder(_tablet_index, _vector_index_file_path,
                                                                      index_builder_type, _is_element_nullable));
+#endif
     RETURN_IF_ERROR(_index_builder->init());
 
     if (_buffer_column != nullptr) {

--- a/be/src/storage/index/vector/vector_index_writer.h
+++ b/be/src/storage/index/vector/vector_index_writer.h
@@ -29,6 +29,7 @@
 namespace starrocks {
 
 class ArrayColumn;
+class VectorIndexFileWriter;
 
 class VectorIndexWriter {
 public:
@@ -37,6 +38,8 @@ public:
 
     VectorIndexWriter(std::shared_ptr<TabletIndex> tablet_index, std::string vector_index_file_path,
                       bool is_element_nullable);
+
+    ~VectorIndexWriter();
 
     Status init();
 
@@ -53,6 +56,11 @@ public:
 private:
     std::shared_ptr<TabletIndex> _tablet_index;
     std::string _vector_index_file_path;
+    // Declared before _index_builder: TenAnnIndexBuilderProxy stores a raw pointer to this
+    // VectorIndexFileWriter. Members are destroyed in reverse declaration order, so the
+    // proxy's destructor (which calls close() -> _file_writer->Close()) must run BEFORE
+    // _file_writer_holder is freed, otherwise we get a use-after-free on teardown.
+    std::unique_ptr<VectorIndexFileWriter> _file_writer_holder;
     std::unique_ptr<VectorIndexBuilder> _index_builder;
 
     uint32_t _start_vector_index_build_threshold;

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -151,6 +151,19 @@ inline std::string gen_segment_filename(int64_t txn_id) {
     return fmt::format("{:016x}_{}.dat", txn_id, generate_uuid_string());
 }
 
+// Generate vector index filename from segment filename.
+// e.g. "0123_abcd.dat" + index_id 123 -> "0123_abcd_123.vi"
+inline std::string gen_vector_index_filename(std::string_view segment_filename, int64_t index_id) {
+    if (segment_filename.ends_with(".dat")) {
+        return fmt::format("{}_{}.vi", segment_filename.substr(0, segment_filename.size() - 4), index_id);
+    }
+    return fmt::format("{}_{}.vi", segment_filename, index_id);
+}
+
+inline bool is_vector_index(std::string_view file_name) {
+    return HasSuffixString(file_name, ".vi");
+}
+
 // Helper function to extract uuid from filename, which is used in shared-data cross cluster migration
 inline std::string extract_uuid_from(std::string_view file_name) {
     if (file_name.empty()) {

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -16,6 +16,8 @@
 
 #include <fmt/format.h>
 
+#include <unordered_map>
+
 #include "column/chunk.h"
 #include "common/config_compaction_fwd.h"
 #include "common/config_rowset_fwd.h"
@@ -38,21 +40,25 @@ namespace {
 // For each column with a vector index, resolve a full segment-level path for the
 // upcoming .vi file and stash it in |opts.vector_index_file_paths|. The SegmentWriter
 // picks these up to direct tenann's writer at object storage.
-void fill_vector_index_file_paths(const TabletSchemaCSPtr& schema, int64_t tablet_id, std::string_view segment_name,
-                                  TabletManager* tablet_mgr, LocationProvider* location_provider, FileSystem* fs,
-                                  SegmentWriterOptions& opts) {
+//
+// Errors from schema lookups are surfaced; silently skipping them would leave the
+// map empty and make SegmentWriter fall back to the IndexDescriptor-based path,
+// which in shared-data mode is not reachable via the location provider.
+Status fill_vector_index_file_paths(const TabletSchemaCSPtr& schema, int64_t tablet_id, std::string_view segment_name,
+                                    TabletManager* tablet_mgr, LocationProvider* location_provider, FileSystem* fs,
+                                    SegmentWriterOptions& opts) {
     for (uint32_t i = 0; i < schema->num_columns(); ++i) {
         const auto& column = schema->column(i);
         if (!schema->has_index(column.unique_id(), IndexType::VECTOR)) {
             continue;
         }
         std::unordered_map<IndexType, TabletIndex> tablet_index;
-        if (!schema->get_indexes_for_column(column.unique_id(), &tablet_index).ok()) {
-            continue;
-        }
+        RETURN_IF_ERROR(schema->get_indexes_for_column(column.unique_id(), &tablet_index));
         auto it = tablet_index.find(IndexType::VECTOR);
         if (it == tablet_index.end()) {
-            continue;
+            return Status::InternalError(
+                    fmt::format("schema reports VECTOR index on column uid={} but get_indexes_for_column returned none",
+                                column.unique_id()));
         }
         int64_t index_id = it->second.index_id();
         std::string vi_name = gen_vector_index_filename(segment_name, index_id);
@@ -64,6 +70,7 @@ void fill_vector_index_file_paths(const TabletSchemaCSPtr& schema, int64_t table
         }
         opts.vector_index_file_paths[index_id] = std::move(full_path);
     }
+    return Status::OK();
 }
 } // namespace
 
@@ -211,7 +218,8 @@ Status HorizontalGeneralTabletWriter::reset_segment_writer(bool eos) {
     } else {
         ASSIGN_OR_RETURN(of, create_file_fn());
     }
-    fill_vector_index_file_paths(_schema, _tablet_id, name, _tablet_mgr, _location_provider.get(), _fs.get(), opts);
+    RETURN_IF_ERROR(fill_vector_index_file_paths(_schema, _tablet_id, name, _tablet_mgr, _location_provider.get(),
+                                                 _fs.get(), opts));
     auto w = std::make_unique<SegmentWriter>(std::move(of), _seg_id++, _schema, opts);
     RETURN_IF_ERROR(w->init());
     _seg_writer = std::move(w);
@@ -236,9 +244,14 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
         segment_file_info.sort_key_min = _seg_writer->get_sort_key_min();
         segment_file_info.sort_key_max = _seg_writer->get_sort_key_max();
         segment_file_info.num_rows = _seg_writer->num_rows();
-        // Record which vector indexes actually generated .vi files
-        for (const auto& [index_id, _] : _seg_writer->vector_index_file_paths()) {
-            segment_file_info.vector_index_ids.push_back(index_id);
+        // Record the vector index IDs configured for this segment. For non-empty segments
+        // VectorIndexWriter::finish() always produces a .vi file (real index or empty-mark)
+        // for every configured VI column; a zero-row segment short-circuits and produces
+        // no .vi file, so we must not advertise non-existent files downstream.
+        if (segment_file_info.num_rows > 0) {
+            for (const auto& [index_id, _] : _seg_writer->vector_index_file_paths()) {
+                segment_file_info.vector_index_ids.push_back(index_id);
+            }
         }
         _data_size += segment_size;
         collect_writer_stats(_stats, _seg_writer.get());
@@ -381,9 +394,13 @@ Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
         segment_file_info.sort_key_min = segment_writer->get_sort_key_min();
         segment_file_info.sort_key_max = segment_writer->get_sort_key_max();
         segment_file_info.num_rows = segment_writer->num_rows();
-        // Record which vector indexes actually generated .vi files
-        for (const auto& [index_id, _] : segment_writer->vector_index_file_paths()) {
-            segment_file_info.vector_index_ids.push_back(index_id);
+        // Record the vector index IDs configured for this segment. See the matching
+        // comment in HorizontalGeneralTabletWriter: a zero-row segment writes no .vi
+        // file, so we must not advertise non-existent files downstream.
+        if (segment_file_info.num_rows > 0) {
+            for (const auto& [index_id, _] : segment_writer->vector_index_file_paths()) {
+                segment_file_info.vector_index_ids.push_back(index_id);
+            }
         }
         _data_size += segment_size;
         collect_writer_stats(_stats, segment_writer.get());
@@ -462,7 +479,8 @@ StatusOr<std::shared_ptr<SegmentWriter>> VerticalGeneralTabletWriter::create_seg
         ASSIGN_OR_RETURN(of, fs::new_writable_file(wopts, _tablet_mgr->segment_location(_tablet_id, name)));
     }
 
-    fill_vector_index_file_paths(_schema, _tablet_id, name, _tablet_mgr, _location_provider.get(), _fs.get(), opts);
+    RETURN_IF_ERROR(fill_vector_index_file_paths(_schema, _tablet_id, name, _tablet_mgr, _location_provider.get(),
+                                                 _fs.get(), opts));
 
     auto w = std::make_shared<SegmentWriter>(std::move(of), _seg_id++, _schema, opts);
     RETURN_IF_ERROR(w->init(column_indexes, is_key));

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -19,6 +19,7 @@
 #include "column/chunk.h"
 #include "common/config_compaction_fwd.h"
 #include "common/config_rowset_fwd.h"
+#include "common/config_vector_index_fwd.h"
 #include "common/thread/threadpool.h"
 #include "fs/bundle_file.h"
 #include "fs/fs_util.h"
@@ -26,11 +27,45 @@
 #include "runtime/current_thread.h"
 #include "serde/column_array_serde.h"
 #include "storage/lake/filenames.h"
+#include "storage/lake/location_provider.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/vacuum.h"
 #include "storage/rowset/segment_writer.h"
 
 namespace starrocks::lake {
+
+namespace {
+// For each column with a vector index, resolve a full segment-level path for the
+// upcoming .vi file and stash it in |opts.vector_index_file_paths|. The SegmentWriter
+// picks these up to direct tenann's writer at object storage.
+void fill_vector_index_file_paths(const TabletSchemaCSPtr& schema, int64_t tablet_id, std::string_view segment_name,
+                                  TabletManager* tablet_mgr, LocationProvider* location_provider, FileSystem* fs,
+                                  SegmentWriterOptions& opts) {
+    for (uint32_t i = 0; i < schema->num_columns(); ++i) {
+        const auto& column = schema->column(i);
+        if (!schema->has_index(column.unique_id(), IndexType::VECTOR)) {
+            continue;
+        }
+        std::unordered_map<IndexType, TabletIndex> tablet_index;
+        if (!schema->get_indexes_for_column(column.unique_id(), &tablet_index).ok()) {
+            continue;
+        }
+        auto it = tablet_index.find(IndexType::VECTOR);
+        if (it == tablet_index.end()) {
+            continue;
+        }
+        int64_t index_id = it->second.index_id();
+        std::string vi_name = gen_vector_index_filename(segment_name, index_id);
+        std::string full_path;
+        if (location_provider && fs) {
+            full_path = location_provider->segment_location(tablet_id, vi_name);
+        } else {
+            full_path = tablet_mgr->segment_location(tablet_id, vi_name);
+        }
+        opts.vector_index_file_paths[index_id] = std::move(full_path);
+    }
+}
+} // namespace
 
 void collect_writer_stats(OlapWriterStatistics& writer_stats, SegmentWriter* segment_writer) {
     if (segment_writer == nullptr) {
@@ -176,6 +211,7 @@ Status HorizontalGeneralTabletWriter::reset_segment_writer(bool eos) {
     } else {
         ASSIGN_OR_RETURN(of, create_file_fn());
     }
+    fill_vector_index_file_paths(_schema, _tablet_id, name, _tablet_mgr, _location_provider.get(), _fs.get(), opts);
     auto w = std::make_unique<SegmentWriter>(std::move(of), _seg_id++, _schema, opts);
     RETURN_IF_ERROR(w->init());
     _seg_writer = std::move(w);
@@ -200,6 +236,10 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
         segment_file_info.sort_key_min = _seg_writer->get_sort_key_min();
         segment_file_info.sort_key_max = _seg_writer->get_sort_key_max();
         segment_file_info.num_rows = _seg_writer->num_rows();
+        // Record which vector indexes actually generated .vi files
+        for (const auto& [index_id, _] : _seg_writer->vector_index_file_paths()) {
+            segment_file_info.vector_index_ids.push_back(index_id);
+        }
         _data_size += segment_size;
         collect_writer_stats(_stats, _seg_writer.get());
         _stats.segment_count++;
@@ -341,6 +381,10 @@ Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
         segment_file_info.sort_key_min = segment_writer->get_sort_key_min();
         segment_file_info.sort_key_max = segment_writer->get_sort_key_max();
         segment_file_info.num_rows = segment_writer->num_rows();
+        // Record which vector indexes actually generated .vi files
+        for (const auto& [index_id, _] : segment_writer->vector_index_file_paths()) {
+            segment_file_info.vector_index_ids.push_back(index_id);
+        }
         _data_size += segment_size;
         collect_writer_stats(_stats, segment_writer.get());
         _stats.segment_count++;
@@ -417,6 +461,9 @@ StatusOr<std::shared_ptr<SegmentWriter>> VerticalGeneralTabletWriter::create_seg
     } else {
         ASSIGN_OR_RETURN(of, fs::new_writable_file(wopts, _tablet_mgr->segment_location(_tablet_id, name)));
     }
+
+    fill_vector_index_file_paths(_schema, _tablet_id, name, _tablet_mgr, _location_provider.get(), _fs.get(), opts);
+
     auto w = std::make_shared<SegmentWriter>(std::move(of), _seg_id++, _schema, opts);
     RETURN_IF_ERROR(w->init(column_indexes, is_key));
     return w;

--- a/be/src/storage/rowset/segment_file_info.h
+++ b/be/src/storage/rowset/segment_file_info.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "fs/fs.h"
 #include "storage/variant_tuple.h"
 
@@ -23,7 +25,8 @@ struct SegmentFileInfo : public FileInfo {
     VariantTuple sort_key_min;
     VariantTuple sort_key_max;
     int64_t num_rows = 0;
-    std::vector<int64_t> vector_index_ids; // IDs of vector indexes that actually generated .vi files
+    // IDs of vector indexes configured for this segment (one .vi file per id).
+    std::vector<int64_t> vector_index_ids;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_file_info.h
+++ b/be/src/storage/rowset/segment_file_info.h
@@ -23,6 +23,7 @@ struct SegmentFileInfo : public FileInfo {
     VariantTuple sort_key_min;
     VariantTuple sort_key_max;
     int64_t num_rows = 0;
+    std::vector<int64_t> vector_index_ids; // IDs of vector indexes that actually generated .vi files
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -193,11 +193,20 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
                                                                    _opts.segment_file_mark.rowset_id, _segment_id,
                                                                    opts.tablet_index.at(GIN).index_id()));
         } else if (opts.need_vector_index) {
-            opts.standalone_index_file_paths.emplace(
-                    IndexType::VECTOR,
-                    IndexDescriptor::vector_index_file_path(_opts.segment_file_mark.rowset_path_prefix,
-                                                            _opts.segment_file_mark.rowset_id, _segment_id,
-                                                            opts.tablet_index.at(IndexType::VECTOR).index_id()));
+            int64_t index_id = opts.tablet_index.at(IndexType::VECTOR).index_id();
+            // Shared-data mode: tablet writer pre-populates vector_index_file_paths with
+            // location-provider-resolved paths. Shared-nothing mode: the map is empty and
+            // we fall back to the IndexDescriptor-based path.
+            auto it = _opts.vector_index_file_paths.find(index_id);
+            if (it != _opts.vector_index_file_paths.end()) {
+                opts.standalone_index_file_paths.emplace(IndexType::VECTOR, it->second);
+            } else {
+                opts.standalone_index_file_paths.emplace(
+                        IndexType::VECTOR,
+                        IndexDescriptor::vector_index_file_path(_opts.segment_file_mark.rowset_path_prefix,
+                                                                _opts.segment_file_mark.rowset_id, _segment_id,
+                                                                index_id));
+            }
         }
 
         if (column.type() == LogicalType::TYPE_ARRAY) {
@@ -339,6 +348,13 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
         uint64_t standalone_index_size = 0;
         RETURN_IF_ERROR(column_writer->write_vector_index(&standalone_index_size));
         *index_size += _wfile->size() - index_offset + standalone_index_size;
+
+        // Track vector index storage type for footer.
+        if (standalone_index_size > 0) {
+            _footer.set_vector_index_storage_type(VECTOR_INDEX_STORAGE_STANDALONE);
+        } else {
+            _footer.set_vector_index_storage_type(VECTOR_INDEX_STORAGE_NONE);
+        }
 
         // check global dict valid
         _check_column_global_dict_valid(column_writer.get(), column_index);

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -202,10 +202,9 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
                 opts.standalone_index_file_paths.emplace(IndexType::VECTOR, it->second);
             } else {
                 opts.standalone_index_file_paths.emplace(
-                        IndexType::VECTOR,
-                        IndexDescriptor::vector_index_file_path(_opts.segment_file_mark.rowset_path_prefix,
-                                                                _opts.segment_file_mark.rowset_id, _segment_id,
-                                                                index_id));
+                        IndexType::VECTOR, IndexDescriptor::vector_index_file_path(
+                                                   _opts.segment_file_mark.rowset_path_prefix,
+                                                   _opts.segment_file_mark.rowset_id, _segment_id, index_id));
             }
         }
 
@@ -349,11 +348,11 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
         RETURN_IF_ERROR(column_writer->write_vector_index(&standalone_index_size));
         *index_size += _wfile->size() - index_offset + standalone_index_size;
 
-        // Track vector index storage type for footer.
+        // The footer's vector_index_storage_type is a segment-level flag: any column that
+        // produced a standalone .vi file makes the whole segment STANDALONE. Only upgrade
+        // to STANDALONE here; never reset back to NONE for subsequent non-vector columns.
         if (standalone_index_size > 0) {
             _footer.set_vector_index_storage_type(VECTOR_INDEX_STORAGE_STANDALONE);
-        } else {
-            _footer.set_vector_index_storage_type(VECTOR_INDEX_STORAGE_NONE);
         }
 
         // check global dict valid

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -37,6 +37,7 @@
 #include <storage/flat_json_config.h>
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -81,6 +82,11 @@ struct SegmentWriterOptions {
     GlobalDictByNameMaps* global_dicts = nullptr;
     std::vector<int32_t> referenced_column_ids;
     SegmentFileMark segment_file_mark;
+    // Full paths (including location scheme) for vector index files, keyed by index_id.
+    // Populated by the tablet writer for shared-data mode where the location provider
+    // resolves object-storage paths; in shared-nothing mode this map is empty and the
+    // segment writer falls back to IndexDescriptor-based path construction.
+    std::map<int64_t, std::string> vector_index_file_paths;
     std::string encryption_meta;
     bool is_compaction = false;
     std::shared_ptr<FlatJsonConfig> flat_json_config = nullptr;
@@ -162,6 +168,8 @@ public:
     const VariantTuple& get_sort_key_min() { return _sort_key_min; }
 
     const VariantTuple& get_sort_key_max() { return _sort_key_max; }
+
+    const std::map<int64_t, std::string>& vector_index_file_paths() const { return _opts.vector_index_file_paths; }
 
 private:
     Status _write_short_key_index();

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -437,6 +437,7 @@ SET(DW_TEST_FILES
     ./storage/lake/delta_writer_test.cpp
     ./storage/lake/filenames_test.cpp
     ./storage/lake/lake_data_source_test.cpp
+    ./storage/lake/shared_data_vector_index_test.cpp
     ./storage/lake/lake_delvec_loader_test.cpp
     ./storage/lake/lake_meta_reader_test.cpp
     ./storage/lake/lake_persistent_index_test.cpp

--- a/be/test/storage/lake/filenames_test.cpp
+++ b/be/test/storage/lake/filenames_test.cpp
@@ -152,4 +152,37 @@ TEST_F(FilenamesTest, gen_segment_filename_from) {
         ASSERT_TRUE(new_file_name.empty());
     }
 }
+
+TEST_F(FilenamesTest, gen_vector_index_filename) {
+    // Standard segment filename with .dat extension: strip the extension and append _{index_id}.vi
+    {
+        std::string segment_filename = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
+        std::string vi_filename = gen_vector_index_filename(segment_filename, 123);
+        ASSERT_EQ("0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_123.vi", vi_filename);
+    }
+
+    // Different index_id
+    {
+        std::string segment_filename = "0123_abcd.dat";
+        std::string vi_filename = gen_vector_index_filename(segment_filename, 456);
+        ASSERT_EQ("0123_abcd_456.vi", vi_filename);
+    }
+
+    // Segment filename without .dat: append _{index_id}.vi to the raw name (fallback branch).
+    {
+        std::string segment_filename = "0123_abcd";
+        std::string vi_filename = gen_vector_index_filename(segment_filename, 789);
+        ASSERT_EQ("0123_abcd_789.vi", vi_filename);
+    }
+}
+
+TEST_F(FilenamesTest, is_vector_index) {
+    ASSERT_TRUE(is_vector_index("0123_abcd_123.vi"));
+    ASSERT_TRUE(is_vector_index("vector_index.vi"));
+    ASSERT_TRUE(is_vector_index("a.vi"));
+    ASSERT_FALSE(is_vector_index("0123_abcd.dat"));
+    ASSERT_FALSE(is_vector_index("file.ivt"));
+    ASSERT_FALSE(is_vector_index(""));
+    ASSERT_FALSE(is_vector_index("file.vi.bak")); // .vi is substring, but suffix is .bak
+}
 } // namespace starrocks::lake

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -1,0 +1,178 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "column/array_column.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+#include "common/config_vector_index_fwd.h"
+#include "fs/fs_factory.h"
+#include "fs/fs_util.h"
+#include "storage/index/index_descriptor.h"
+#include "storage/index/vector/vector_index_writer.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/test_util.h"
+
+namespace starrocks::lake {
+
+// Unit tests for vector index support on shared-data write path.
+// Shared-data mode uses LocationProvider + FileSystem to write segments and vector index files
+// to remote storage (S3/HDFS). These tests verify VectorIndexWriter and path generation work
+// correctly with the path layout used by LocationProvider::segment_location().
+class SharedDataVectorIndexTest : public ::testing::Test {
+public:
+    SharedDataVectorIndexTest() = default;
+
+protected:
+    void SetUp() override {
+        srand(GetCurrentTimeMicros());
+        _test_dir = "shared_data_vector_index_test_" + std::to_string(GetCurrentTimeMicros());
+        CHECK_OK(fs::remove_all(_test_dir));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kSegmentDirectoryName)));
+        ASSIGN_OR_ABORT(_fs, FileSystemFactory::CreateSharedFromString(_test_dir));
+        _location_provider = std::make_shared<FixedLocationProvider>(_test_dir);
+    }
+
+    void TearDown() override { (void)fs::remove_all(_test_dir); }
+
+    std::shared_ptr<TabletIndex> create_tablet_index(int64_t index_id = 0, int32_t col_unique_id = 1) {
+        std::shared_ptr<TabletIndex> tablet_index = std::make_shared<TabletIndex>();
+        TabletIndexPB index_pb;
+        index_pb.set_index_id(index_id);
+        index_pb.set_index_name("vector_index");
+        index_pb.set_index_type(IndexType::VECTOR);
+        index_pb.add_col_unique_id(col_unique_id);
+        tablet_index->init_from_pb(index_pb);
+        tablet_index->add_common_properties("index_type", "hnsw");
+        tablet_index->add_common_properties("dim", "3");
+        tablet_index->add_common_properties("is_vector_normed", "false");
+        tablet_index->add_common_properties("metric_type", "l2_distance");
+        tablet_index->add_index_properties("efconstruction", "40");
+        tablet_index->add_index_properties("M", "16");
+        return tablet_index;
+    }
+
+    ColumnPtr create_array_column_with_vectors(size_t num_rows) {
+        auto element = FixedLengthColumn<float>::create();
+        auto null_column = NullColumn::create();
+        auto offsets = UInt32Column::create();
+        offsets->append(0);
+
+        for (size_t i = 0; i < num_rows; ++i) {
+            element->append(static_cast<float>(i) + 1.1f);
+            element->append(static_cast<float>(i) + 2.2f);
+            element->append(static_cast<float>(i) + 3.3f);
+            null_column->append(0);
+            null_column->append(0);
+            null_column->append(0);
+            offsets->append((i + 1) * 3);
+        }
+
+        auto nullable_column = NullableColumn::create(std::move(element), std::move(null_column));
+        return ArrayColumn::create(std::move(nullable_column), std::move(offsets));
+    }
+
+    std::string _test_dir;
+    std::shared_ptr<FileSystem> _fs;
+    std::shared_ptr<LocationProvider> _location_provider;
+};
+
+// Test VectorIndexWriter writing to a path that follows shared-data layout.
+// The path is generated using LocationProvider::segment_location(tablet_id, vi_filename),
+// which is the same path format used by fill_vector_index_file_paths in general_tablet_writer.
+TEST_F(SharedDataVectorIndexTest, test_vector_index_write_shared_data_path) {
+    // Set threshold low enough so that 5 rows triggers index build
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+
+    const int64_t tablet_id = 12345;
+    const int64_t index_id = 0;
+    const std::string segment_name = "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
+
+    std::string vi_filename = gen_vector_index_filename(segment_name, index_id);
+    std::string vector_index_path = _location_provider->segment_location(tablet_id, vi_filename);
+
+    auto tablet_index = create_tablet_index(index_id);
+    std::unique_ptr<VectorIndexWriter> vector_index_writer;
+    VectorIndexWriter::create(tablet_index, vector_index_path, true, &vector_index_writer);
+    ASSERT_OK(vector_index_writer->init());
+
+    auto array_column = create_array_column_with_vectors(5);
+    ASSERT_OK(vector_index_writer->append(*array_column));
+    ASSERT_EQ(vector_index_writer->size(), 5);
+
+    uint64_t index_size = 0;
+    ASSERT_OK(vector_index_writer->finish(&index_size));
+    ASSERT_GT(index_size, 0);
+
+    // Verify the vector index file exists at the shared-data path
+    ASSERT_OK(_fs->path_exists(vector_index_path));
+
+#ifndef WITH_TENANN
+    // Without tenann, vector index writes empty mark
+    ASSIGN_OR_ABORT(auto index_file, _fs->new_random_access_file(vector_index_path));
+    ASSIGN_OR_ABORT(auto data, index_file->read_all());
+    ASSERT_EQ(data, IndexDescriptor::mark_word);
+#endif
+}
+
+// Test that gen_vector_index_filename produces correct filename for shared-data segment names.
+TEST_F(SharedDataVectorIndexTest, test_vector_index_filename_for_shared_data_segment) {
+    std::string segment_name = "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
+    std::string vi_name = gen_vector_index_filename(segment_name, 0);
+    ASSERT_EQ(vi_name, "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_0.vi");
+
+    vi_name = gen_vector_index_filename(segment_name, 123);
+    ASSERT_EQ(vi_name, "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_123.vi");
+
+    // Verify full path from LocationProvider matches expected layout
+    const int64_t tablet_id = 1;
+    std::string full_path = _location_provider->segment_location(tablet_id, vi_name);
+    std::string expected = _test_dir + "/data/0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_123.vi";
+    ASSERT_EQ(full_path, expected);
+}
+
+// Test VectorIndexWriter skips file generation when build threshold is not met (shared-data path).
+TEST_F(SharedDataVectorIndexTest, test_vector_index_empty_mark_shared_data_path) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 100);
+
+    const int64_t tablet_id = 999;
+    const int64_t index_id = 0;
+    std::string segment_name = "0000000000000002_abc12345-6789-0def-1234-567890abcdef.dat";
+    std::string vi_filename = gen_vector_index_filename(segment_name, index_id);
+    std::string vector_index_path = _location_provider->segment_location(tablet_id, vi_filename);
+
+    auto tablet_index = create_tablet_index(index_id);
+    tablet_index->add_common_properties("index_type", "ivfpq");
+
+    std::unique_ptr<VectorIndexWriter> vector_index_writer;
+    VectorIndexWriter::create(tablet_index, vector_index_path, true, &vector_index_writer);
+    ASSERT_OK(vector_index_writer->init());
+
+    auto array_column = create_array_column_with_vectors(3);
+    ASSERT_OK(vector_index_writer->append(*array_column));
+
+    uint64_t index_size = 0;
+    ASSERT_OK(vector_index_writer->finish(&index_size));
+
+    // With threshold 100 and only 3 rows, threshold is not met,
+    // so no index file is generated and index_size remains 0
+    ASSERT_EQ(index_size, 0);
+    ASSERT_TRUE(_fs->path_exists(vector_index_path).is_not_found());
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -16,17 +16,24 @@
 
 #include "base/testutil/assert.h"
 #include "column/array_column.h"
+#include "column/chunk.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
 #include "common/config_vector_index_fwd.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
+#include "storage/chunk_helper.h"
 #include "storage/index/index_descriptor.h"
 #include "storage/index/vector/vector_index_writer.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/general_tablet_writer.h"
 #include "storage/lake/join_path.h"
+#include "storage/lake/tablet_manager.h"
 #include "storage/lake/test_util.h"
+#include "storage/rowset/segment_file_info.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/tablet_schema.h"
 
 namespace starrocks::lake {
 
@@ -178,6 +185,265 @@ TEST_F(SharedDataVectorIndexTest, test_vector_index_empty_mark_shared_data_path)
     ASSIGN_OR_ABORT(auto index_file, _fs->new_random_access_file(vector_index_path));
     ASSIGN_OR_ABORT(auto data, index_file->read_all());
     ASSERT_EQ(data, IndexDescriptor::mark_word);
+}
+
+// =============== Tablet-writer-level tests ================
+//
+// Drive HorizontalGeneralTabletWriter and VerticalGeneralTabletWriter end-to-end with a
+// vector-indexed schema to exercise the shared-data write path:
+//   * general_tablet_writer.cpp::fill_vector_index_file_paths (both location-provider
+//     and tablet-manager fallbacks)
+//   * SegmentFileInfo::vector_index_ids propagation for both writer flavors
+//   * segment_writer.cpp VECTOR init branch that picks up pre-populated paths, and the
+//     per-segment STANDALONE footer flag
+//
+// Uses TestBase for _tablet_mgr/_lp plumbing so segments land under a real test dir.
+class SharedDataTabletWriterVITest : public TestBase {
+public:
+    SharedDataTabletWriterVITest()
+            : TestBase("shared_data_tablet_writer_vi_test_" + std::to_string(GetCurrentTimeMicros())) {
+        clear_and_init_test_dir();
+    }
+
+protected:
+    static constexpr int64_t kTabletId = 20001;
+    static constexpr int64_t kIndexId = 77;
+    static constexpr int32_t kKeyColUniqueId = 1;
+    static constexpr int32_t kVectorColUniqueId = 2;
+
+    TabletSchemaPB create_vi_schema_pb() {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(DUP_KEYS);
+        schema_pb.set_num_short_key_columns(1);
+
+        auto* c0 = schema_pb.add_column();
+        c0->set_unique_id(kKeyColUniqueId);
+        c0->set_name("pk");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+
+        // Vector index requires a non-nullable outer array column
+        // (DCHECK in ArrayColumnWriter::append).
+        auto* c1 = schema_pb.add_column();
+        c1->set_unique_id(kVectorColUniqueId);
+        c1->set_name("vec");
+        c1->set_type("ARRAY");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        auto* child = c1->add_children_columns();
+        child->set_unique_id(3);
+        child->set_name("element");
+        child->set_type("FLOAT");
+        child->set_is_nullable(true);
+
+        auto* idx = schema_pb.add_table_indices();
+        idx->set_index_id(kIndexId);
+        idx->set_index_name("vec_idx");
+        idx->set_index_type(IndexType::VECTOR);
+        idx->add_col_unique_id(kVectorColUniqueId);
+        std::string props_json = R"({
+            "common_properties": {
+                "index_type": "hnsw",
+                "dim": "3",
+                "is_vector_normed": "false",
+                "metric_type": "l2_distance"
+            },
+            "index_properties": {
+                "efconstruction": "40",
+                "M": "16"
+            }
+        })";
+        idx->set_index_properties(props_json);
+        return schema_pb;
+    }
+
+    ChunkUniquePtr build_chunk(const TabletSchemaCSPtr& tablet_schema, int num_rows) {
+        auto schema = ChunkHelper::convert_schema(tablet_schema);
+        auto chunk = ChunkHelper::new_chunk(schema, num_rows);
+        for (int i = 0; i < num_rows; ++i) {
+            chunk->get_column_raw_ptr_by_index(0)->append_datum(Datum(static_cast<int32_t>(i)));
+            DatumArray arr;
+            arr.emplace_back(static_cast<float>(i) + 0.1f);
+            arr.emplace_back(static_cast<float>(i) + 0.2f);
+            arr.emplace_back(static_cast<float>(i) + 0.3f);
+            chunk->get_column_raw_ptr_by_index(1)->append_datum(Datum(arr));
+        }
+        return chunk;
+    }
+};
+
+// HorizontalGeneralTabletWriter without set_location_provider/set_fs: fill_vector_index_file_paths
+// must fall back to tablet_mgr->segment_location for the .vi path. Verifies that the written
+// SegmentFileInfo records vector_index_ids and that a .vi artifact lands next to the segment.
+TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_vi_via_tablet_mgr) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+
+    auto schema_pb = create_vi_schema_pb();
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    int64_t txn_id = 2001;
+    auto writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr.get(), kTabletId, tablet_schema, txn_id,
+                                                                  /*is_compaction=*/false);
+    ASSERT_OK(writer->open());
+
+    auto chunk = build_chunk(tablet_schema, 5);
+    ASSERT_OK(writer->write(*chunk));
+    ASSERT_OK(writer->finish());
+
+    ASSERT_EQ(writer->segments().size(), 1);
+    const auto& seg = writer->segments().front();
+    EXPECT_EQ(seg.num_rows, 5);
+    ASSERT_EQ(seg.vector_index_ids.size(), 1);
+    EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
+
+    std::string seg_path = _tablet_mgr->segment_location(kTabletId, seg.path);
+    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    EXPECT_TRUE(fs::path_exist(seg_path));
+    EXPECT_TRUE(fs::path_exist(vi_path));
+
+    writer->close();
+}
+
+// HorizontalGeneralTabletWriter with set_location_provider/set_fs: fill_vector_index_file_paths
+// must resolve .vi paths through LocationProvider (the shared-data S3/HDFS branch). Uses the same
+// underlying local path so we can still assert file existence.
+TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_vi_via_location_provider) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+
+    auto schema_pb = create_vi_schema_pb();
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    int64_t txn_id = 2002;
+    auto writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr.get(), kTabletId, tablet_schema, txn_id,
+                                                                  /*is_compaction=*/false);
+    writer->set_location_provider(_lp);
+    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(_test_dir));
+    writer->set_fs(fs);
+    ASSERT_OK(writer->open());
+
+    auto chunk = build_chunk(tablet_schema, 3);
+    ASSERT_OK(writer->write(*chunk));
+    ASSERT_OK(writer->finish());
+
+    ASSERT_EQ(writer->segments().size(), 1);
+    const auto& seg = writer->segments().front();
+    EXPECT_EQ(seg.num_rows, 3);
+    ASSERT_EQ(seg.vector_index_ids.size(), 1);
+    EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
+
+    std::string vi_path = _lp->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    EXPECT_TRUE(fs::path_exist(vi_path));
+
+    writer->close();
+}
+
+// VerticalGeneralTabletWriter writes key columns first, then value columns. Covers the
+// matching vector_index_ids propagation + fill_vector_index_file_paths in VerticalGeneralTabletWriter
+// and the segment_writer VECTOR init branch under vertical mode.
+TEST_F(SharedDataTabletWriterVITest, test_vertical_writer_vi) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+
+    auto schema_pb = create_vi_schema_pb();
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    int64_t txn_id = 2003;
+    auto writer = std::make_unique<VerticalGeneralTabletWriter>(_tablet_mgr.get(), kTabletId, tablet_schema, txn_id,
+                                                                /*max_rows_per_segment=*/INT32_MAX,
+                                                                /*is_compaction=*/false);
+    ASSERT_OK(writer->open());
+
+    // VerticalGeneralTabletWriter::write_columns expects a chunk whose columns match
+    // the provided column_indexes. Build per-column chunks rather than passing the
+    // full multi-column chunk.
+    constexpr int kRows = 4;
+    auto key_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema, {0}));
+    auto vec_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema, {1}));
+
+    auto key_col = Int32Column::create();
+    for (int i = 0; i < kRows; ++i) {
+        key_col->append(i);
+    }
+    Chunk key_chunk({std::move(key_col)}, key_schema);
+
+    auto element_col = FixedLengthColumn<float>::create();
+    auto element_null = NullColumn::create();
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    for (int i = 0; i < kRows; ++i) {
+        element_col->append(static_cast<float>(i) + 0.1f);
+        element_col->append(static_cast<float>(i) + 0.2f);
+        element_col->append(static_cast<float>(i) + 0.3f);
+        element_null->append(0);
+        element_null->append(0);
+        element_null->append(0);
+        offsets->append((i + 1) * 3);
+    }
+    auto nullable_elements = NullableColumn::create(std::move(element_col), std::move(element_null));
+    auto vec_col = ArrayColumn::create(std::move(nullable_elements), std::move(offsets));
+    Chunk vec_chunk({std::move(vec_col)}, vec_schema);
+
+    ASSERT_OK(writer->write_columns(key_chunk, /*column_indexes=*/{0}, /*is_key=*/true));
+    ASSERT_OK(writer->flush_columns());
+    ASSERT_OK(writer->write_columns(vec_chunk, /*column_indexes=*/{1}, /*is_key=*/false));
+    ASSERT_OK(writer->flush_columns());
+    ASSERT_OK(writer->finish());
+
+    ASSERT_EQ(writer->segments().size(), 1);
+    const auto& seg = writer->segments().front();
+    EXPECT_EQ(seg.num_rows, kRows);
+    ASSERT_EQ(seg.vector_index_ids.size(), 1);
+    EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
+
+    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    EXPECT_TRUE(fs::path_exist(vi_path));
+
+    writer->close();
+}
+
+// Exercise the segment_writer.cpp fallback branch that resolves the vector index path
+// via IndexDescriptor when vector_index_file_paths is empty. This is the path a caller
+// that hasn't been migrated to pre-populate the map would take (shared-nothing style).
+// Without this coverage, the else-branch sits as dead code even though it's still
+// load-bearing for callers that don't go through general_tablet_writer/rowset_writer.
+TEST_F(SharedDataTabletWriterVITest, test_segment_writer_vi_fallback_to_index_descriptor) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+
+    auto schema_pb = create_vi_schema_pb();
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    std::string rowset_dir = _test_dir + "/rowset_fallback";
+    ASSERT_TRUE(fs::create_directories(rowset_dir).ok());
+    std::string seg_path = rowset_dir + "/segment_0.dat";
+
+    SegmentWriterOptions opts;
+    // Intentionally leave opts.vector_index_file_paths empty to hit the else-branch.
+    opts.segment_file_mark.rowset_path_prefix = rowset_dir;
+    opts.segment_file_mark.rowset_id = "1";
+
+    ASSIGN_OR_ABORT(auto wfile, fs::new_writable_file(seg_path));
+    auto writer = std::make_unique<SegmentWriter>(std::move(wfile), /*segment_id=*/0, tablet_schema, opts);
+    ASSERT_OK(writer->init());
+
+    constexpr int kRows = 3;
+    auto schema = ChunkHelper::convert_schema(tablet_schema);
+    auto chunk = ChunkHelper::new_chunk(schema, kRows);
+    for (int i = 0; i < kRows; ++i) {
+        chunk->get_column_raw_ptr_by_index(0)->append_datum(Datum(static_cast<int32_t>(i)));
+        DatumArray arr;
+        arr.emplace_back(static_cast<float>(i) + 0.1f);
+        arr.emplace_back(static_cast<float>(i) + 0.2f);
+        arr.emplace_back(static_cast<float>(i) + 0.3f);
+        chunk->get_column_raw_ptr_by_index(1)->append_datum(Datum(arr));
+    }
+    ASSERT_OK(writer->append_chunk(*chunk));
+
+    uint64_t seg_size = 0, idx_size = 0, footer_pos = 0;
+    ASSERT_OK(writer->finalize(&seg_size, &idx_size, &footer_pos));
+
+    std::string expected_vi =
+            fmt::format("{}/{}_{}_{}.vi", rowset_dir, opts.segment_file_mark.rowset_id, 0, kIndexId);
+    EXPECT_TRUE(fs::path_exist(expected_vi));
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -441,8 +441,7 @@ TEST_F(SharedDataTabletWriterVITest, test_segment_writer_vi_fallback_to_index_de
     uint64_t seg_size = 0, idx_size = 0, footer_pos = 0;
     ASSERT_OK(writer->finalize(&seg_size, &idx_size, &footer_pos));
 
-    std::string expected_vi =
-            fmt::format("{}/{}_{}_{}.vi", rowset_dir, opts.segment_file_mark.rowset_id, 0, kIndexId);
+    std::string expected_vi = fmt::format("{}/{}_{}_{}.vi", rowset_dir, opts.segment_file_mark.rowset_id, 0, kIndexId);
     EXPECT_TRUE(fs::path_exist(expected_vi));
 }
 

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -40,7 +40,6 @@ public:
 
 protected:
     void SetUp() override {
-        srand(GetCurrentTimeMicros());
         _test_dir = "shared_data_vector_index_test_" + std::to_string(GetCurrentTimeMicros());
         CHECK_OK(fs::remove_all(_test_dir));
         CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kSegmentDirectoryName)));
@@ -142,11 +141,14 @@ TEST_F(SharedDataVectorIndexTest, test_vector_index_filename_for_shared_data_seg
     // Verify full path from LocationProvider matches expected layout
     const int64_t tablet_id = 1;
     std::string full_path = _location_provider->segment_location(tablet_id, vi_name);
-    std::string expected = _test_dir + "/data/0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_123.vi";
+    std::string expected = lake::join_path(lake::join_path(_test_dir, lake::kSegmentDirectoryName), vi_name);
     ASSERT_EQ(full_path, expected);
 }
 
-// Test VectorIndexWriter skips file generation when build threshold is not met (shared-data path).
+// Test VectorIndexWriter writes an empty-mark file when the build threshold is not met
+// (shared-data path). finish() goes through VectorIndexBuilder::flush_empty(), which
+// writes IndexDescriptor::mark_word so the reader can distinguish "threshold not met"
+// from a missing segment.
 TEST_F(SharedDataVectorIndexTest, test_vector_index_empty_mark_shared_data_path) {
     ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 100);
 
@@ -169,10 +171,13 @@ TEST_F(SharedDataVectorIndexTest, test_vector_index_empty_mark_shared_data_path)
     uint64_t index_size = 0;
     ASSERT_OK(vector_index_writer->finish(&index_size));
 
-    // With threshold 100 and only 3 rows, threshold is not met,
-    // so no index file is generated and index_size remains 0
-    ASSERT_EQ(index_size, 0);
-    ASSERT_TRUE(_fs->path_exists(vector_index_path).is_not_found());
+    // Threshold not met -> flush_empty() writes IndexDescriptor::mark_word.
+    ASSERT_OK(_fs->path_exists(vector_index_path));
+    ASSERT_EQ(index_size, IndexDescriptor::mark_word.size());
+
+    ASSIGN_OR_ABORT(auto index_file, _fs->new_random_access_file(vector_index_path));
+    ASSIGN_OR_ABORT(auto data, index_file->read_all());
+    ASSERT_EQ(data, IndexDescriptor::mark_word);
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION

## Why I'm doing:

Vector index (ANN) previously only supported shared-nothing mode. In shared-data (cloud-native) mode, creating a vector index was explicitly blocked with "The vector index does not support shared data mode". This PR enables vector index file generation during segment writes in shared-data mode, where index files need to be written to remote storage  via StarRocks' FS layer.

## What I'm doing:
  BE Write Path

  - Vector index file path generation: Add gen_vector_index_filename() and is_vector_index() in lake/filenames.h to derive .vi filenames from segment filenames (e.g., segment_123.dat → segment_123_{index_id}.vi).
  - Lake tablet writer integration: Add fill_vector_index_file_paths() helper in general_tablet_writer.cpp that resolves full remote paths via LocationProvider::segment_location() for both horizontal and vertical writers.
  - Path plumbing: Add vector_index_file_paths (index_id → full path) and vector_index_build_threshold to SegmentWriterOptions and ColumnWriterOptions, propagated from lake writer → segment writer → column writer → VectorIndexWriter.
  - Shared-nothing path refactor: Move vector index file path resolution from inline construction in segment_writer.cpp to
  pre-populated vector_index_file_paths map (filled by rowset_writer.cpp for shared-nothing, general_tablet_writer.cpp for shared-data).

  TenANN Remote FS Bridge

  - Add VectorIndexFileWriter bridging StarRocks WritableFile to TenANN IndexFileWriter interface, enabling TenANN to write vector index files to remote storage.

 Fixes https://github.com/StarRocks/starrocks/issues/72087

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

