### PR TITLE
[UT] Add IVM SQL tester cases for Iceberg DELETE and expire_snapshots

### DIFF
--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_delete
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_delete
@@ -1,0 +1,405 @@
+-- name: test_ivm_with_iceberg_delete
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+create table t2 (
+  id int,
+  val string
+);
+-- result:
+-- !result
+insert into t1 values
+  ('a', 1, '2023-12-01'), ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'), ('b', 4, '2023-12-02'),
+  ('c', 5, '2023-12-03'), ('c', 6, '2023-12-03'),
+  ('d', 7, '2023-12-04'), ('d', 8, '2023-12-04');
+-- result:
+-- !result
+insert into t2 values (1,'x'), (2,'y'), (3,'z'), (5,'p'), (7,'q');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "auto")
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+-- result:
+mv-397534
+-- !result
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt;
+-- result:
+a	1	2023-12-01
+a	2	2023-12-01
+b	3	2023-12-02
+b	4	2023-12-02
+c	5	2023-12-03
+c	6	2023-12-03
+d	7	2023-12-04
+d	8	2023-12-04
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 9, '2023-12-05');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt;
+-- result:
+a	1	2023-12-01
+a	2	2023-12-01
+b	3	2023-12-02
+b	4	2023-12-02
+c	5	2023-12-03
+c	6	2023-12-03
+d	7	2023-12-04
+d	8	2023-12-04
+e	9	2023-12-05
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 2;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt;
+-- result:
+a	1	2023-12-01
+b	3	2023-12-02
+b	4	2023-12-02
+c	5	2023-12-03
+c	6	2023-12-03
+d	7	2023-12-04
+d	8	2023-12-04
+e	9	2023-12-05
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('f', 10, '2023-12-06');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt;
+-- result:
+a	1	2023-12-01
+b	3	2023-12-02
+b	4	2023-12-02
+c	5	2023-12-03
+c	6	2023-12-03
+d	7	2023-12-04
+d	8	2023-12-04
+e	9	2023-12-05
+f	10	2023-12-06
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "auto")
+AS SELECT dt, sum(col_int) AS sum_col_int, count(col_int) AS cnt
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   WHERE col_int > 3
+   GROUP BY dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+-- result:
+mv-397616
+-- !result
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	11	2
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('g', 10, '2023-12-07');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	11	2
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+2023-12-07	10	1
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	11	2
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+2023-12-07	10	1
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 5;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	6	1
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+2023-12-07	10	1
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('h', 11, '2023-12-08');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	6	1
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+2023-12-07	10	1
+2023-12-08	11	1
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "auto")
+AS SELECT t1.dt, t1.col_str, t2.val
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 t1
+   JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 t2 ON t1.col_int = t2.id;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+-- result:
+mv-397732
+-- !result
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT dt, col_str, val FROM test_mv1 ORDER BY dt, col_str, val;
+-- result:
+2023-12-02	b	z
+2023-12-04	d	q
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('i', 3, '2023-12-09');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT dt, col_str, val FROM test_mv1 ORDER BY dt, col_str, val;
+-- result:
+2023-12-02	b	z
+2023-12-04	d	q
+2023-12-09	i	z
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int IN (3, 7);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT dt, col_str, val FROM test_mv1 ORDER BY dt, col_str, val;
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('j', 2, '2023-12-10');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT dt, col_str, val FROM test_mv1 ORDER BY dt, col_str, val;
+-- result:
+2023-12-10	j	y
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "auto")
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+-- result:
+mv-397877
+-- !result
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt = '2023-12-04';
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT count(*) FROM test_mv1 WHERE dt = '2023-12-04';
+-- result:
+0
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-05' ORDER BY col_str, col_int, dt;
+-- result:
+b	4	2023-12-02
+c	6	2023-12-03
+e	9	2023-12-05
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('new_d', 99, '2023-12-04');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt = '2023-12-04' ORDER BY col_str, col_int;
+-- result:
+new_d	99	2023-12-04
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('new_e', 100, '2023-12-11');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt IN ('2023-12-04', '2023-12-11') ORDER BY col_str, col_int, dt;
+-- result:
+new_d	99	2023-12-04
+new_e	100	2023-12-11
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "incremental")
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+-- result:
+mv-398032
+-- !result
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 2;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT ERROR_MESSAGE LIKE '%not append-only%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_expire_snapshots
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_expire_snapshots
@@ -1,0 +1,326 @@
+-- name: test_ivm_with_iceberg_expire_snapshots
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt)
+properties ('history.expire.max-snapshot-age-ms' = '1');
+-- result:
+-- !result
+insert into t1 values
+  ('a', 1, '2023-12-01'), ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'), ('b', 4, '2023-12-02'),
+  ('c', 5, '2023-12-03'), ('c', 6, '2023-12-03'),
+  ('d', 7, '2023-12-04'), ('d', 8, '2023-12-04');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "auto")
+AS SELECT dt, sum(col_int) AS sum_col_int, count(col_int) AS cnt
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   WHERE col_int > 3
+   GROUP BY dt;
+-- result:
+-- !result
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+-- result:
+mv-401869
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	11	2
+2023-12-04	15	2
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 9, '2023-12-05');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	11	2
+2023-12-04	15	2
+2023-12-05	9	1
+-- !result
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(retain_last = 1);
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('f', 10, '2023-12-06');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	11	2
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('g', 11, '2023-12-07');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('h', 12, '2023-12-08');
+-- result:
+-- !result
+shell: sleep 2
+-- result:
+0
+
+-- !result
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(retain_last = 1);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	11	2
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+2023-12-07	11	1
+2023-12-08	12	1
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('k', 13, '2023-12-11');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	11	2
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+2023-12-07	11	1
+2023-12-08	12	1
+2023-12-11	13	1
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 6;
+-- result:
+-- !result
+[UC]EXPIRE_CUTOFF=SELECT cast(max(committed_at) as string) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1$snapshots;
+-- result:
+2026-04-24 00:14:05.646000
+-- !result
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(older_than = '${EXPIRE_CUTOFF}');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	5	1
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+2023-12-07	11	1
+2023-12-08	12	1
+2023-12-11	13	1
+-- !result
+SELECT dt, sum(col_int) AS sum_col_int, count(*) AS cnt
+  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+  WHERE col_int > 3
+  GROUP BY dt ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	5	1
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+2023-12-07	11	1
+2023-12-08	12	1
+2023-12-11	13	1
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('l', 14, '2023-12-12');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+[UC]ANCHOR_TS=SELECT cast(max(committed_at) as string) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1$snapshots;
+-- result:
+2026-04-24 00:14:06.639000
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('m', 15, '2023-12-13');
+-- result:
+-- !result
+[UC]BEFORE_ANCHOR=SELECT cast(date_sub('${ANCHOR_TS}', interval 1 hour) as string);
+-- result:
+2026-04-23 23:14:06.639000
+-- !result
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(older_than = '${BEFORE_ANCHOR}');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	5	1
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+2023-12-07	11	1
+2023-12-08	12	1
+2023-12-11	13	1
+2023-12-12	14	1
+2023-12-13	15	1
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('n', 16, '2023-12-14');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('o', 17, '2023-12-15');
+-- result:
+-- !result
+shell: sleep 2
+-- result:
+0
+
+-- !result
+[UC]NOW_TS=SELECT cast(now() as string);
+-- result:
+2026-04-24 00:14:12
+-- !result
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(older_than = '${NOW_TS}', retain_last = 1);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+PCT
+-- !result
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- result:
+2023-12-02	4	1
+2023-12-03	5	1
+2023-12-04	15	2
+2023-12-05	9	1
+2023-12-06	10	1
+2023-12-07	11	1
+2023-12-08	12	1
+2023-12-11	13	1
+2023-12-12	14	1
+2023-12-13	15	1
+2023-12-14	16	1
+2023-12-15	17	1
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv2 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "incremental")
+AS SELECT dt, sum(col_int) AS sum_col_int, count(col_int) AS cnt
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   WHERE col_int > 3
+   GROUP BY dt;
+-- result:
+-- !result
+[UC]TASK_NAME2=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv2';
+-- result:
+mv-402031
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('p', 18, '2023-12-16');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('q', 19, '2023-12-17');
+-- result:
+-- !result
+shell: sleep 2
+-- result:
+0
+
+-- !result
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(retain_last = 1);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT ERROR_MESSAGE REGEXP '(not append-only|not a parent ancestor)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+DROP MATERIALIZED VIEW test_mv2;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_delete
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_delete
@@ -1,0 +1,232 @@
+-- name: test_ivm_with_iceberg_delete
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+
+create table t2 (
+  id int,
+  val string
+);
+
+insert into t1 values
+  ('a', 1, '2023-12-01'), ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'), ('b', 4, '2023-12-02'),
+  ('c', 5, '2023-12-03'), ('c', 6, '2023-12-03'),
+  ('d', 7, '2023-12-04'), ('d', 8, '2023-12-04');
+
+insert into t2 values (1,'x'), (2,'y'), (3,'z'), (5,'p'), (7,'q');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+set enable_materialized_view_rewrite = false;
+
+-- ==============================================================
+-- Part A: refresh_mode = "auto" — IVM -> PCT fallback -> IVM recovery
+-- ==============================================================
+
+-- --- MV shape (1): SELECT * — row-level DELETE ---
+-- Expected refreshMode sequence: PCT, INCREMENTAL, PCT, INCREMENTAL
+-- Note: First refresh after MV creation is PCT (no prior anchor snapshot,
+-- full-build establishes the baseline). Subsequent append-only refreshes
+-- are INCREMENTAL; DELETE triggers PCT fallback; next append recovers.
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "auto")
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt;
+
+-- Second INSERT: still append-only, should remain IVM
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 9, '2023-12-05');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt;
+
+-- Row-level DELETE: non-append-only delta -> expect PCT fallback
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 2;
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt;
+
+-- Subsequent INSERT: append-only -> IVM should recover
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('f', 10, '2023-12-06');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_str, col_int, dt;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+-- --- MV shape (2): aggregation — DELETE outside then inside MV WHERE ---
+-- Expected refreshMode sequence: PCT, INCREMENTAL, PCT, PCT, INCREMENTAL
+-- Note: count(col_int) is used instead of count(*) because IVM requires
+-- aggregate functions with combine semantics; count(*) has no combine
+-- implementation (would fail with "No matching function: count_combine()").
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "auto")
+AS SELECT dt, sum(col_int) AS sum_col_int, count(col_int) AS cnt
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   WHERE col_int > 3
+   GROUP BY dt;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+-- Second INSERT: append-only -> still IVM
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('g', 10, '2023-12-07');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+-- DELETE OUTSIDE MV WHERE: col_int = 1 rows are not in MV (filter: col_int > 3).
+-- Expected: PCT fallback (non-append-only delta), MV aggregated rows unchanged.
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 1;
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+-- DELETE INSIDE MV WHERE: col_int = 5 is inside filter.
+-- Expected: PCT fallback + MV aggregation reflects deletion.
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 5;
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+-- Subsequent INSERT: recover to IVM
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('h', 11, '2023-12-08');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+-- --- MV shape (3): JOIN — cross-partition DELETE ---
+-- Expected refreshMode sequence: PCT, INCREMENTAL, PCT, INCREMENTAL
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "auto")
+AS SELECT t1.dt, t1.col_str, t2.val
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 t1
+   JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 t2 ON t1.col_int = t2.id;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, col_str, val FROM test_mv1 ORDER BY dt, col_str, val;
+
+-- Second INSERT: append-only -> still IVM
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('i', 3, '2023-12-09');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, col_str, val FROM test_mv1 ORDER BY dt, col_str, val;
+
+-- Cross-partition DELETE: col_int IN (3, 7) hits 2023-12-02, 2023-12-04, 2023-12-09
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int IN (3, 7);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, col_str, val FROM test_mv1 ORDER BY dt, col_str, val;
+
+-- Subsequent INSERT: recover to IVM
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('j', 2, '2023-12-10');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, col_str, val FROM test_mv1 ORDER BY dt, col_str, val;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+-- ==============================================================
+-- Part A extra: partition-level DELETE (metadata delete optimization)
+-- Expected refreshMode sequence: PCT, PCT, PCT, INCREMENTAL
+--
+-- Partition-level DELETE triggers Iceberg metadata-delete; the PCT
+-- refresh that follows produces only partition drops (no INSERT),
+-- so MVPCTBasedRefreshProcessor returns SKIPPED before
+-- updateVersionMeta runs and TVR is NOT committed. Step 3's INSERT
+-- therefore still sees the stale anchor and must fall back to PCT
+-- again (but this PCT has INSERT work, so TVR finally commits).
+-- Step 4 verifies that after TVR catches up, a subsequent append
+-- recovers to INCREMENTAL, i.e., the delayed-by-one-refresh effect
+-- self-heals.
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "auto")
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+
+-- Partition-level DELETE: removes dt=2023-12-04 entirely (metadata delete path)
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt = '2023-12-04';
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT count(*) FROM test_mv1 WHERE dt = '2023-12-04';
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt <= '2023-12-05' ORDER BY col_str, col_int, dt;
+
+-- Step 3: Insert new rows into the dropped partition.
+-- Expected PCT (still): TVR anchor is stale (not committed in Step 2's
+-- SKIPPED path), so the range spans the drop snapshot and IVM rejects
+-- as non-append-only. This PCT has real INSERT work and will commit TVR.
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('new_d', 99, '2023-12-04');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt = '2023-12-04' ORDER BY col_str, col_int;
+
+-- Step 4: Another append after Step 3's PCT committed TVR.
+-- Expected INCREMENTAL — verifies the "delayed by one refresh" bug
+-- self-heals once a PCT with INSERT work succeeds.
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('new_e', 100, '2023-12-11');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT col_str, col_int, dt FROM test_mv1 WHERE dt IN ('2023-12-04', '2023-12-11') ORDER BY col_str, col_int, dt;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+-- ==============================================================
+-- Part B: refresh_mode = "incremental" — expect refresh FAILED on DELETE
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "incremental")
+AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 2;
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- Refresh must FAIL because incremental mode does not allow non-append-only delta
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%not append-only%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+-- ==============================================================
+-- Cleanup
+-- ==============================================================
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_expire_snapshots
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_expire_snapshots
@@ -1,0 +1,189 @@
+-- name: test_ivm_with_iceberg_expire_snapshots
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+
+-- Set history.expire.max-snapshot-age-ms = 1 (default is 5 days) so
+-- expire_snapshots can actually expire freshly created snapshots in
+-- this test. Without this override, all snapshots are younger than
+-- the default 5-day safety window and retain_last / older_than have
+-- no observable effect on MV anchor expiry.
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt)
+properties ('history.expire.max-snapshot-age-ms' = '1');
+
+insert into t1 values
+  ('a', 1, '2023-12-01'), ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'), ('b', 4, '2023-12-02'),
+  ('c', 5, '2023-12-03'), ('c', 6, '2023-12-03'),
+  ('d', 7, '2023-12-04'), ('d', 8, '2023-12-04');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+set enable_materialized_view_rewrite = false;
+
+-- ==============================================================
+-- Part A: refresh_mode = "auto" — snapshot lifecycle scenarios
+-- Single aggregation MV reused across A1..A4.
+-- Note: count(col_int) is used instead of count(*) because IVM
+-- requires aggregate functions with combine semantics; count(*) would
+-- fail MV creation with "No matching function: count_combine()".
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "auto")
+AS SELECT dt, sum(col_int) AS sum_col_int, count(col_int) AS cnt
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   WHERE col_int > 3
+   GROUP BY dt;
+
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+
+-- --- A1: expire keeps the MV's anchor -> IVM chain unbroken ---
+-- Expected refreshMode sequence: PCT, INCREMENTAL, INCREMENTAL
+-- Note: First refresh is PCT (new MV baseline build); second is IVM
+-- (append-only); third runs after expire_snapshots but anchor is the
+-- latest snapshot so IVM chain is unbroken.
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+-- Second batch + refresh (append-only, still IVM)
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 9, '2023-12-05');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+-- Expire all but latest snapshot; MV anchor IS the latest -> still valid
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(retain_last = 1);
+
+-- Next append: anchor preserved -> stays IVM
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('f', 10, '2023-12-06');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+-- --- A2: expire MV's anchor -> PCT fallback + IVM recovery ---
+-- Expected refreshMode sequence: PCT, INCREMENTAL
+-- Create multiple snapshots beyond the MV's current anchor
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('g', 11, '2023-12-07');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('h', 12, '2023-12-08');
+
+-- Sleep so all snapshots age past history.expire.max-snapshot-age-ms=1
+shell: sleep 2
+-- retain_last=1 now keeps only the very latest snapshot; MV anchor is gone
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(retain_last = 1);
+
+-- Refresh must fall back to PCT
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+-- Next append: IVM should recover (anchor is now the post-PCT snapshot)
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('k', 13, '2023-12-11');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+-- --- A3: DELETE + expire + refresh — position delete lifecycle ---
+-- Expected refreshMode: PCT
+-- MV and base-table-direct aggregation must match after delete+expire.
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 6;
+-- Expire older than latest snapshot's commit time (keeps the post-delete snapshot only).
+-- Using t1$snapshots metadata table to obtain the latest committed_at as a string.
+[UC]EXPIRE_CUTOFF=SELECT cast(max(committed_at) as string) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1$snapshots;
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(older_than = '${EXPIRE_CUTOFF}');
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+-- Cross-check MV vs direct aggregation on base table
+SELECT dt, sum(col_int) AS sum_col_int, count(*) AS cnt
+  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+  WHERE col_int > 3
+  GROUP BY dt ORDER BY dt;
+
+-- --- A4: older_than parameter variants ---
+-- Expected refreshMode sequence: INCREMENTAL, INCREMENTAL, PCT
+-- Return to clean IVM state after A3
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('l', 14, '2023-12-12');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+
+-- Capture MV's current anchor timestamp (committed_at of latest snapshot)
+[UC]ANCHOR_TS=SELECT cast(max(committed_at) as string) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1$snapshots;
+
+-- 4a: expire older_than = (anchor_ts - 1 hour) -> no-op, anchor preserved
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('m', 15, '2023-12-13');
+[UC]BEFORE_ANCHOR=SELECT cast(date_sub('${ANCHOR_TS}', interval 1 hour) as string);
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(older_than = '${BEFORE_ANCHOR}');
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+-- 4b: produce newer snapshots, then expire older_than = now() -> anchor gone, PCT
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('n', 16, '2023-12-14');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('o', 17, '2023-12-15');
+-- Sleep so snapshots age past property threshold AND NOW_TS is strictly newer
+shell: sleep 2
+[UC]NOW_TS=SELECT cast(now() as string);
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(older_than = '${NOW_TS}', retain_last = 1);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT dt, sum_col_int, cnt FROM test_mv1 ORDER BY dt;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+-- ==============================================================
+-- Part B: refresh_mode = "incremental" — expect FAILED when anchor expires
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_mv2 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "incremental")
+AS SELECT dt, sum(col_int) AS sum_col_int, count(col_int) AS cnt
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   WHERE col_int > 3
+   GROUP BY dt;
+
+[UC]TASK_NAME2=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv2';
+
+-- Initial refresh succeeds as IVM
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+
+-- Produce newer snapshots, then expire the anchor
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('p', 18, '2023-12-16');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('q', 19, '2023-12-17');
+-- Sleep so snapshots age past history.expire.max-snapshot-age-ms=1
+shell: sleep 2
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(retain_last = 1);
+
+-- Refresh must FAIL (incremental cannot handle expired anchor).
+-- The Iceberg connector surfaces this as "Starting snapshot ... is
+-- not a parent ancestor of end snapshot ..." because the MV's TVR
+-- anchor is no longer part of the current snapshot chain after
+-- expire_snapshots removed it.
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE REGEXP '(not append-only|not a parent ancestor)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+
+DROP MATERIALIZED VIEW test_mv2;
+
+-- ==============================================================
+-- Cleanup
+-- ==============================================================
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Two new SQL integration tests under test/sql/test_materialized_view_ivm/ verifying IVM (Incremental View Maintenance) behavior when the Iceberg base table undergoes DELETE or expire_snapshots maintenance.

test_ivm_with_iceberg_delete (refresh_mode=auto and incremental):
- MV (1) SELECT *: row-level DELETE triggers PCT fallback; next append recovers to INCREMENTAL
- MV (2) aggregation: DELETE outside MV WHERE leaves MV unchanged but still triggers PCT fallback; inside-WHERE DELETE reflects removal; recovery works
- MV (3) JOIN: cross-partition DELETE with same fallback/recovery
- Partition-level DELETE (metadata-delete path): data correctly dropped and re-added; documents observed PCT-delay-by-one-refresh effect that self-heals on the next refresh that performs INSERT work
- refresh_mode=incremental: DELETE produces STATE=FAILED with ERROR_MESSAGE matching "not append-only"

test_ivm_with_iceberg_expire_snapshots (refresh_mode=auto and incremental):
- A1: expire_snapshots(retain_last=1) when MV anchor is latest -> IVM chain unbroken
- A2: expire anchor after additional snapshots -> PCT fallback, then IVM recovery on next append
- A3: DELETE + expire combined -> MV data matches direct aggregation against base table
- A4: older_than variants (before-anchor is no-op; =now() with retain_last expires anchor)
- refresh_mode=incremental: expired anchor produces STATE=FAILED with ERROR_MESSAGE matching "not a parent ancestor"

Observability uses inline SQL against
information_schema.task_runs.EXTRA_MESSAGE JSON ($.refreshMode) to assert whether each refresh used INCREMENTAL or PCT path.

Tables override history.expire.max-snapshot-age-ms=1 and a short `shell: sleep 2` is placed before expire calls that depend on real snapshot expiration, to work around Iceberg's default 5-day safety window that would otherwise make expire_snapshots a no-op in fast test runs.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
