### PR TITLE
[Feature] Support shared-data vector index and async build

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -38,10 +38,12 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.Utils;
+import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.persist.OriginStatementInfo;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.KeysType;
@@ -760,7 +762,10 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                 }
 
                 if (useAggregatePublish) {
-                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null, null);
+                    List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
+                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null,
+                            vectorIndexBuildInfos);
+                    VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -760,7 +760,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                 }
 
                 if (useAggregatePublish) {
-                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null);
+                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null, null);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -331,8 +331,8 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                     }
                 }
                 if (useAggregatePublish) {
-                    Utils.aggregatePublishVersion(tablets, Lists.newArrayList(txnInfo), commitVersion - 1, commitVersion, 
-                                null, null, computeResource, null);
+                    Utils.aggregatePublishVersion(tablets, Lists.newArrayList(txnInfo), commitVersion - 1, commitVersion,
+                                null, null, computeResource, null, null);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -34,9 +34,11 @@ import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.Utils;
+import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.mv.MVRepairHandler.PartitionRepairInfo;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.task.AgentBatchTask;
@@ -331,8 +333,10 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                     }
                 }
                 if (useAggregatePublish) {
+                    List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
                     Utils.aggregatePublishVersion(tablets, Lists.newArrayList(txnInfo), commitVersion - 1, commitVersion,
-                                null, null, computeResource, null, null);
+                                null, null, computeResource, null, vectorIndexBuildInfos);
+                    VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -874,7 +874,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                 }
 
                 if (isFileBundling) {
-                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null);
+                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null, null);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -49,10 +49,12 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.Utils;
+import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
@@ -874,7 +876,10 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                 }
 
                 if (isFileBundling) {
-                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null, null);
+                    List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
+                    Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null,
+                            vectorIndexBuildInfos);
+                    VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -32,9 +32,11 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.Utils;
+import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletReshardJobsItem;
@@ -515,8 +517,10 @@ public class MergeTabletJob extends TabletReshardJob {
             txnInfo.gtid = gtid;
 
             Map<Long, TabletRange> tabletRange = new HashMap<>();
+            List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
             Utils.publishVersion(tablets, txnInfo, commitVersion - 1, commitVersion, null, tabletRange,
-                    computeResource, null, useAggregatePublish);
+                    computeResource, null, useAggregatePublish, vectorIndexBuildInfos);
+            VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
 
             return tabletRange;
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -32,9 +32,11 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.Utils;
+import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletReshardJobsItem;
@@ -530,8 +532,10 @@ public class SplitTabletJob extends TabletReshardJob {
             txnInfo.gtid = gtid;
 
             Map<Long, TabletRange> tabletRange = new HashMap<>();
+            List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
             Utils.publishVersion(tablets, txnInfo, commitVersion - 1, commitVersion, null, tabletRange,
-                    computeResource, null, useAggregatePublish);
+                    computeResource, null, useAggregatePublish, vectorIndexBuildInfos);
+            VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
 
             return tabletRange;
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IndexParams.java
@@ -56,6 +56,8 @@ public class IndexParams {
                 true, "false", null);
         register(builder, IndexType.VECTOR, IndexParamType.COMMON, VectorIndexParams.CommonIndexParamKey.INDEX_BUILD_THRESHOLD,
                 false, false, null, null);
+        register(builder, IndexType.VECTOR, IndexParamType.COMMON, VectorIndexParams.CommonIndexParamKey.INDEX_BUILD_MODE,
+                false, false, null, null);
 
         // index
         register(builder, IndexType.VECTOR, IndexParamType.INDEX, VectorIndexParams.IndexParamsKey.M, false, true, "16", null);

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3353,6 +3353,9 @@ public class Config extends ConfigBase {
     public static String lake_background_warehouse = "default_warehouse";
 
     @ConfField(mutable = true)
+    public static String lake_vector_index_build_warehouse = "default_warehouse";
+
+    @ConfField(mutable = true)
     public static int lake_warehouse_max_compute_replica = 3;
 
     @ConfField(mutable = true, comment = "time interval to check whether warehouse is idle")

--- a/fe/fe-core/src/main/java/com/starrocks/common/VectorIndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/VectorIndexParams.java
@@ -70,7 +70,17 @@ public class VectorIndexParams {
         },
 
         // Threshold of row number to build index file
-        INDEX_BUILD_THRESHOLD
+        INDEX_BUILD_THRESHOLD,
+
+        // Index build mode: "sync" (default, build during write) or "async" (build asynchronously by scheduler)
+        INDEX_BUILD_MODE {
+            @Override
+            public void check(String value) {
+                if (!StringUtils.equalsIgnoreCase(value, "sync") && !StringUtils.equalsIgnoreCase(value, "async")) {
+                    throw new SemanticException("Value of `index_build_mode` must be `sync` or `async`");
+                }
+            }
+        }
     }
 
     public enum VectorIndexType {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -57,6 +57,9 @@ public class LakeTablet extends Tablet {
     @SerializedName(value = JSON_KEY_DATA_SIZE_UPDATE_TIME)
     private volatile long dataSizeUpdateTime = 0L;
 
+    @SerializedName(value = "vibv")
+    private volatile long vectorIndexBuiltVersion = 0L;
+
     private volatile long minVersion = 0L;
 
     public long rebuildPindexVersion = 0L;
@@ -197,6 +200,14 @@ public class LakeTablet extends Tablet {
 
         LakeTablet tablet = (LakeTablet) obj;
         return (id == tablet.id && dataSize == tablet.dataSize && rowCount == tablet.rowCount);
+    }
+
+    public long getVectorIndexBuiltVersion() {
+        return vectorIndexBuiltVersion;
+    }
+
+    public void setVectorIndexBuiltVersion(long v) {
+        this.vectorIndexBuiltVersion = Math.max(this.vectorIndexBuiltVersion, v);
     }
 
     public void setRebuildPindexVersion(long rebuildPindexVersion) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -19,15 +19,10 @@ import com.staros.proto.ShardInfo;
 import com.starrocks.alter.reshard.PublishTabletsInfo;
 import com.starrocks.alter.reshard.ReshardingTablet;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
-import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
-import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
-import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
-import com.starrocks.catalog.TabletInvertedIndex;
-import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.StarRocksException;
@@ -45,7 +40,6 @@ import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
@@ -162,7 +156,10 @@ public class Utils {
         List<Long> rebuildPindexTabletIds = new ArrayList<>();
         Map<ComputeNode, PublishTabletsInfo> nodeToPublishTabletsInfo = processTablets(tablets, computeResource,
                 warehouseManager, rebuildPindexTabletIds, baseVersion, newVersion);
-        
+
+        // Pre-compute once per batch so per-node requests can slice cheaply.
+        Map<Long, Long> batchBuiltVersions = buildTabletBuiltVersionsFromTablets(tablets);
+
         List<Future<PublishVersionResponse>> responseList = Lists.newArrayListWithCapacity(nodeToPublishTabletsInfo.size());
         List<ComputeNode> nodeList = Lists.newArrayListWithCapacity(nodeToPublishTabletsInfo.size());
         for (Map.Entry<ComputeNode, PublishTabletsInfo> entry : nodeToPublishTabletsInfo.entrySet()) {
@@ -178,7 +175,8 @@ public class Utils {
                 request.rebuildPindexTabletIds = rebuildPindexTabletIds;
             }
             request.reshardingTabletInfos = publishTabletInfo.getReshardingTablets();
-            request.tabletBuiltVersions = getTabletBuiltVersions(publishTabletInfo.getTabletIds());
+            request.tabletBuiltVersions = sliceTabletBuiltVersions(batchBuiltVersions,
+                    publishTabletInfo.getTabletIds());
 
             LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
             Future<PublishVersionResponse> future = lakeService.publishVersion(request);
@@ -312,6 +310,9 @@ public class Utils {
         Map<ComputeNode, PublishTabletsInfo> nodeToPublishTabletsInfo = processTablets(tablets, computeResource,
                 warehouseManager, rebuildPindexTabletIds, baseVersion, newVersion);
 
+        // Pre-compute once per batch so per-node requests can slice cheaply.
+        Map<Long, Long> batchBuiltVersions = buildTabletBuiltVersionsFromTablets(tablets);
+
         List<ComputeNodePB> computeNodes = new ArrayList<>();
         List<PublishVersionRequest> publishReqs = new ArrayList<>();
         for (Map.Entry<ComputeNode, PublishTabletsInfo> entry : nodeToPublishTabletsInfo.entrySet()) {
@@ -329,7 +330,8 @@ public class Utils {
             }
 
             singleReq.setReshardingTabletInfos(publishTabletInfo.getReshardingTablets());
-            singleReq.setTabletBuiltVersions(getTabletBuiltVersions(publishTabletInfo.getTabletIds()));
+            singleReq.setTabletBuiltVersions(sliceTabletBuiltVersions(batchBuiltVersions,
+                    publishTabletInfo.getTabletIds()));
 
             ComputeNodePB computeNodePB = new ComputeNodePB();
             computeNodePB.setHost(entry.getKey().getHost());
@@ -560,40 +562,36 @@ public class Utils {
         return Optional.of(node.getWarehouseId());
     }
 
-    private static Map<Long, Long> getTabletBuiltVersions(List<Long> tabletIds) {
-        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
-        if (invertedIndex == null) {
-            return null;
-        }
-        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+    // Build a per-batch map of tabletId -> vectorIndexBuiltVersion from the Tablet objects
+    // already in hand. Avoids a TabletInvertedIndex + db + table + partition + index
+    // traversal per tablet on the publish hot path.
+    private static Map<Long, Long> buildTabletBuiltVersionsFromTablets(List<Tablet> tablets) {
         Map<Long, Long> result = null;
-        for (Long tabletId : tabletIds) {
-            TabletMeta meta = invertedIndex.getTabletMeta(tabletId);
-            if (meta == null) {
-                continue;
-            }
-            Database db = metastore.getDb(meta.getDbId());
-            if (db == null) {
-                continue;
-            }
-            Table table = db.getTable(meta.getTableId());
-            if (!(table instanceof OlapTable)) {
-                continue;
-            }
-            PhysicalPartition partition = ((OlapTable) table).getPhysicalPartition(meta.getPhysicalPartitionId());
-            if (partition == null) {
-                continue;
-            }
-            MaterializedIndex index = partition.getIndex(meta.getIndexId());
-            if (index == null) {
-                continue;
-            }
-            Tablet tablet = index.getTablet(tabletId);
+        for (Tablet tablet : tablets) {
             if (!(tablet instanceof LakeTablet)) {
                 continue;
             }
             long bv = ((LakeTablet) tablet).getVectorIndexBuiltVersion();
             if (bv > 0) {
+                if (result == null) {
+                    result = new HashMap<>();
+                }
+                result.put(tablet.getId(), bv);
+            }
+        }
+        return result;
+    }
+
+    // Slice a batch-wide built-versions map for a single sub-request's tablet id set.
+    // Returns null when no entry matches so the request field stays unset.
+    private static Map<Long, Long> sliceTabletBuiltVersions(Map<Long, Long> all, List<Long> tabletIds) {
+        if (all == null || all.isEmpty()) {
+            return null;
+        }
+        Map<Long, Long> result = null;
+        for (Long tabletId : tabletIds) {
+            Long bv = all.get(tabletId);
+            if (bv != null) {
                 if (result == null) {
                     result = new HashMap<>();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -19,10 +19,15 @@ import com.staros.proto.ShardInfo;
 import com.starrocks.alter.reshard.PublishTabletsInfo;
 import com.starrocks.alter.reshard.ReshardingTablet;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.StarRocksException;
@@ -34,10 +39,12 @@ import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
 import com.starrocks.proto.TabletRangePB;
 import com.starrocks.proto.TxnInfoPB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
@@ -113,7 +120,7 @@ public class Utils {
                                       long newVersion, ComputeResource computeResource, boolean useAggregatePublish)
             throws NoAliveBackendException, RpcException {
         publishVersion(tablets, txnInfo, baseVersion, newVersion, null, computeResource,
-                null, useAggregatePublish);
+                null, useAggregatePublish, null);
     }
 
     public static void publishVersionBatch(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,
@@ -121,10 +128,11 @@ public class Utils {
                                            Map<Long, Double> compactionScores,
                                            Map<ComputeNode, List<Long>> nodeToTablets,
                                            ComputeResource computeResource,
-                                           Map<Long, Long> tabletRowNum)
+                                           Map<Long, Long> tabletRowNum,
+                                           List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         publishVersionBatch(tablets, txnInfos, baseVersion, newVersion, compactionScores, null, nodeToTablets,
-                computeResource, tabletRowNum);
+                computeResource, tabletRowNum, vectorIndexBuildInfos);
     }
 
     public static void publishVersionBatch(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,
@@ -133,7 +141,8 @@ public class Utils {
                                            Map<Long, TabletRange> tabletRanges,
                                            Map<ComputeNode, List<Long>> nodeToTablets,
                                            ComputeResource computeResource,
-                                           Map<Long, Long> tabletRowNum)
+                                           Map<Long, Long> tabletRowNum,
+                                           List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         if (!warehouseManager.isResourceAvailable(computeResource)) {
@@ -162,6 +171,7 @@ public class Utils {
                 request.rebuildPindexTabletIds = rebuildPindexTabletIds;
             }
             request.reshardingTabletInfos = publishTabletInfo.getReshardingTablets();
+            request.tabletBuiltVersions = getTabletBuiltVersions(publishTabletInfo.getTabletIds());
 
             LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
             Future<PublishVersionResponse> future = lakeService.publishVersion(request);
@@ -187,6 +197,10 @@ public class Utils {
                 if (baseVersion == 1 && tabletRowNum != null && response != null && response.tabletRowNums != null) {
                     tabletRowNum.putAll(response.tabletRowNums);
                 }
+                if (vectorIndexBuildInfos != null && response != null
+                        && response.vectorIndexBuildInfos != null) {
+                    vectorIndexBuildInfos.addAll(response.vectorIndexBuildInfos);
+                }
             } catch (Exception e) {
                 throw new RpcException(nodeList.get(i).getHost(), e.getMessage());
             }
@@ -203,24 +217,27 @@ public class Utils {
     public static void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
                                       long newVersion, Map<Long, Double> compactionScores,
                                       ComputeResource computeResource, Map<Long, Long> tabletRowNums,
-                                      boolean useAggregatePublish)
+                                      boolean useAggregatePublish,
+                                      List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         publishVersion(tablets, txnInfo, baseVersion, newVersion, compactionScores,
-                null, computeResource, tabletRowNums, useAggregatePublish);
+                null, computeResource, tabletRowNums, useAggregatePublish, vectorIndexBuildInfos);
     }
 
     public static void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
                                       long newVersion, Map<Long, Double> compactionScores,
                                       Map<Long, TabletRange> tabletRanges, ComputeResource computeResource,
-                                      Map<Long, Long> tabletRowNums, boolean useAggregatePublish)
+                                      Map<Long, Long> tabletRowNums, boolean useAggregatePublish,
+                                      List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         List<TxnInfoPB> txnInfos = Lists.newArrayList(txnInfo);
         if (!useAggregatePublish) {
             publishVersionBatch(tablets, txnInfos, baseVersion, newVersion,
-                    compactionScores, tabletRanges, null, computeResource, tabletRowNums);
+                    compactionScores, tabletRanges, null, computeResource, tabletRowNums,
+                    vectorIndexBuildInfos);
         } else {
-            aggregatePublishVersion(tablets, txnInfos, baseVersion, newVersion, compactionScores, 
-                    tabletRanges, null, computeResource, tabletRowNums);
+            aggregatePublishVersion(tablets, txnInfos, baseVersion, newVersion, compactionScores,
+                    tabletRanges, null, computeResource, tabletRowNums, vectorIndexBuildInfos);
         }
     }
 
@@ -305,7 +322,8 @@ public class Utils {
             }
 
             singleReq.setReshardingTabletInfos(publishTabletInfo.getReshardingTablets());
-    
+            singleReq.setTabletBuiltVersions(getTabletBuiltVersions(publishTabletInfo.getTabletIds()));
+
             ComputeNodePB computeNodePB = new ComputeNodePB();
             computeNodePB.setHost(entry.getKey().getHost());
             computeNodePB.setBrpcPort(entry.getKey().getBrpcPort());
@@ -340,17 +358,19 @@ public class Utils {
     public static void sendAggregatePublishVersionRequest(AggregatePublishVersionRequest request,
                                                           long baseVersion, ComputeResource computeResource,
                                                           Map<Long, Double> compactionScores,
-                                                          Map<Long, Long> tabletRowNum)
+                                                          Map<Long, Long> tabletRowNum,
+                                                          List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         sendAggregatePublishVersionRequest(request, baseVersion, computeResource, compactionScores, null,
-                tabletRowNum);
+                tabletRowNum, vectorIndexBuildInfos);
     }
 
     public static void sendAggregatePublishVersionRequest(AggregatePublishVersionRequest request,
                                                           long baseVersion, ComputeResource computeResource,
                                                           Map<Long, Double> compactionScores,
                                                           Map<Long, TabletRange> tabletRanges,
-                                                          Map<Long, Long> tabletRowNum)
+                                                          Map<Long, Long> tabletRowNum,
+                                                          List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         if (computeResource == null || !warehouseManager.isResourceAvailable(computeResource)) {
@@ -398,6 +418,10 @@ public class Utils {
             if (baseVersion == 1 && tabletRowNum != null && response != null && response.tabletRowNums != null) {
                 tabletRowNum.putAll(response.tabletRowNums);
             }
+            if (vectorIndexBuildInfos != null && response != null
+                    && response.vectorIndexBuildInfos != null) {
+                vectorIndexBuildInfos.addAll(response.vectorIndexBuildInfos);
+            }
         } catch (Exception e) {
             throw new RpcException(aggregatorNode.getHost(), e.getMessage());
         }
@@ -429,10 +453,11 @@ public class Utils {
                                                Map<Long, Double> compactionScores,
                                                Map<ComputeNode, List<Long>> nodeToTablets,
                                                ComputeResource computeResource,
-                                               Map<Long, Long> tabletRowNum)
+                                               Map<Long, Long> tabletRowNum,
+                                               List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         aggregatePublishVersion(tablets, txnInfos, baseVersion, newVersion, compactionScores,
-                null, nodeToTablets, computeResource, tabletRowNum);
+                null, nodeToTablets, computeResource, tabletRowNum, vectorIndexBuildInfos);
     }
 
     public static void aggregatePublishVersion(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,
@@ -441,14 +466,15 @@ public class Utils {
                                                Map<Long, TabletRange> tabletRanges,
                                                Map<ComputeNode, List<Long>> nodeToTablets,
                                                ComputeResource computeResource,
-                                               Map<Long, Long> tabletRowNum)
+                                               Map<Long, Long> tabletRowNum,
+                                               List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
         try {
             createSubRequestForAggregatePublish(tablets, txnInfos, baseVersion, newVersion,
                                                 nodeToTablets, computeResource, request);
             sendAggregatePublishVersionRequest(request, baseVersion, computeResource, compactionScores,
-                                               tabletRanges, tabletRowNum);
+                                               tabletRanges, tabletRowNum, vectorIndexBuildInfos);
         } catch (Exception e) {
             throw e;
         }
@@ -525,5 +551,48 @@ public class Utils {
         }
 
         return Optional.of(node.getWarehouseId());
+    }
+
+    private static Map<Long, Long> getTabletBuiltVersions(List<Long> tabletIds) {
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        if (invertedIndex == null) {
+            return null;
+        }
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Map<Long, Long> result = null;
+        for (Long tabletId : tabletIds) {
+            TabletMeta meta = invertedIndex.getTabletMeta(tabletId);
+            if (meta == null) {
+                continue;
+            }
+            Database db = metastore.getDb(meta.getDbId());
+            if (db == null) {
+                continue;
+            }
+            Table table = db.getTable(meta.getTableId());
+            if (!(table instanceof OlapTable)) {
+                continue;
+            }
+            PhysicalPartition partition = ((OlapTable) table).getPhysicalPartition(meta.getPhysicalPartitionId());
+            if (partition == null) {
+                continue;
+            }
+            MaterializedIndex index = partition.getIndex(meta.getIndexId());
+            if (index == null) {
+                continue;
+            }
+            Tablet tablet = index.getTablet(tabletId);
+            if (!(tablet instanceof LakeTablet)) {
+                continue;
+            }
+            long bv = ((LakeTablet) tablet).getVectorIndexBuiltVersion();
+            if (bv > 0) {
+                if (result == null) {
+                    result = new HashMap<>();
+                }
+                result.put(tabletId, bv);
+            }
+        }
+        return result;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -31,6 +31,7 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.ComputeNodePB;
 import com.starrocks.proto.PublishLogVersionBatchRequest;
@@ -119,8 +120,14 @@ public class Utils {
     public static void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
                                       long newVersion, ComputeResource computeResource, boolean useAggregatePublish)
             throws NoAliveBackendException, RpcException {
+        // Collect async vector index build infos reported by BE and enqueue them into the
+        // scheduler. Callers of this simplified overload (lake alter/rollup/schema-change
+        // paths) would otherwise drop those infos and the newly published versions would
+        // stay unbuilt until the next normal publish or leader recoveryScan.
+        List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
         publishVersion(tablets, txnInfo, baseVersion, newVersion, null, computeResource,
-                null, useAggregatePublish, null);
+                null, useAggregatePublish, vectorIndexBuildInfos);
+        VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
     }
 
     public static void publishVersionBatch(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
@@ -134,6 +134,12 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
     /**
      * One-time scan after becoming leader.
      * Finds all tablets in async vector index tables where builtVersion &lt; visibleVersion.
+     *
+     * TODO: this scan is currently synchronous and runs on the daemon thread. On large
+     * clusters (many DBs/tables/partitions) it can block checkRunningTasks /
+     * checkRunningTaskTimeout / scheduleFromPending for the duration of the scan and
+     * compete with DDL for catalog readlocks. Make it incremental (paged) and/or move
+     * it off the daemon thread so the scheduler stays responsive after a leader switch.
      */
     void recoveryScan() {
         int count = 0;
@@ -169,7 +175,10 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                                 builtVersion = ((LakeTablet) tablet).getVectorIndexBuiltVersion();
                             }
                             if (builtVersion < visibleVersion) {
-                                pendingTablets.put(tablet.getId(), visibleVersion);
+                                // Use merge(Math::max) so a concurrent onPublishComplete
+                                // enqueue with a newer target version is not overwritten
+                                // by recoveryScan's snapshot of visibleVersion.
+                                pendingTablets.merge(tablet.getId(), visibleVersion, Math::max);
                                 count++;
                             }
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
@@ -1,0 +1,423 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+package com.starrocks.lake.vector;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Index;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.proto.BuildVectorIndexResponse;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.IndexDef;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+
+/**
+ * Queue-driven scheduler for async vector index building in shared-data mode.
+ * <p>
+ * Normal operation: commit callbacks enqueue dirty tablets via {@link #addPendingTablet}.
+ * Leader switch: one-time recovery scan finds tablets where builtVersion &lt; visibleVersion.
+ * <p>
+ * builtVersion is stored on {@link LakeTablet} (with @SerializedName) and persisted via checkpoint.
+ * Publish path reads builtVersion directly from the tablet object.
+ */
+public class VectorIndexBuildScheduler extends FrontendDaemon {
+    private static final Logger LOG = LogManager.getLogger(VectorIndexBuildScheduler.class);
+
+    static final int MAX_CONCURRENT_TASKS = 64;
+    private static final long DEFAULT_INTERVAL_MS = 5000;
+    static final long BUILD_TIMEOUT_MS = 2 * 60 * 60 * 1000L; // 2 hours
+
+    // Pending queue: tabletId -> target visibleVersion
+    private final ConcurrentHashMap<Long, Long> pendingTablets = new ConcurrentHashMap<>();
+
+    // Running tasks: tabletId -> task
+    private final Map<Long, VectorIndexBuildTask> runningTasks = new ConcurrentHashMap<>();
+
+    // Preferred CN for re-enqueued tablets: tabletId -> last CN that was building it.
+    // On re-enqueue, scheduling prefers the same CN to avoid duplicate work
+    // (the CN already has partial .vi files + StarCache warm).
+    private final Map<Long, ComputeNode> preferredNodes = new ConcurrentHashMap<>();
+
+    // Cooldown for tablets whose CN reported "already in progress" (dedup rejection).
+    // Avoids tight retry loops — wait at least DEDUP_COOLDOWN_MS before re-dispatching.
+    private static final long DEDUP_COOLDOWN_MS = 5 * 60 * 1000L; // 5 minutes
+    private final Map<Long, Long> cooldownUntil = new ConcurrentHashMap<>();
+
+    private volatile boolean recoveryScanDone = false;
+
+    public VectorIndexBuildScheduler() {
+        super("vector-index-build-scheduler", DEFAULT_INTERVAL_MS);
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (!GlobalStateMgr.getCurrentState().isLeader()) {
+            recoveryScanDone = false;
+            return;
+        }
+
+        if (!recoveryScanDone) {
+            recoveryScan();
+            recoveryScanDone = true;
+        }
+
+        checkRunningTasks();
+        checkRunningTaskTimeout();
+        cleanupStaleEntries();
+        scheduleFromPending();
+    }
+
+    // ========== Public API ==========
+
+    /**
+     * Enqueue a tablet for async vector index building.
+     * Called from {@link com.starrocks.transaction.LakeTableTxnStateListener#preWriteCommitLog}.
+     */
+    public void addPendingTablet(long tabletId, long version) {
+        pendingTablets.merge(tabletId, version, Math::max);
+    }
+
+    /**
+     * Returns the builtVersion for a tablet, used by publish path.
+     * Reads directly from the LakeTablet object (checkpoint-persisted).
+     */
+    public Long getBuiltVersion(long tabletId) {
+        LakeTablet tablet = findLakeTablet(tabletId);
+        if (tablet != null) {
+            long bv = tablet.getVectorIndexBuiltVersion();
+            return bv > 0 ? bv : null;
+        }
+        return null;
+    }
+
+    /**
+     * Convenience entry point for publish callers: enqueue all build infos
+     * returned by BE in the publish response. No-op if scheduler is not initialized
+     * or input is empty.
+     */
+    public static void onPublishComplete(List<VectorIndexBuildInfoPB> infos) {
+        if (infos == null || infos.isEmpty()) {
+            return;
+        }
+        VectorIndexBuildScheduler scheduler = GlobalStateMgr.getCurrentState().getVectorIndexBuildScheduler();
+        if (scheduler == null) {
+            return;
+        }
+        for (VectorIndexBuildInfoPB info : infos) {
+            if (info.tabletId != null && info.version != null) {
+                scheduler.addPendingTablet(info.tabletId, info.version);
+            }
+        }
+    }
+
+    // ========== Recovery scan after leader switch ==========
+
+    /**
+     * One-time scan after becoming leader.
+     * Finds all tablets in async vector index tables where builtVersion &lt; visibleVersion.
+     */
+    void recoveryScan() {
+        int count = 0;
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        for (Long dbId : metastore.getDbIds()) {
+            Database db = metastore.getDb(dbId);
+            if (db == null) {
+                continue;
+            }
+
+            for (Table table : db.getTables()) {
+                if (!(table instanceof OlapTable)) {
+                    continue;
+                }
+                OlapTable olapTable = (OlapTable) table;
+                if (!olapTable.isCloudNativeTableOrMaterializedView()) {
+                    continue;
+                }
+                if (!hasAsyncVectorIndex(olapTable)) {
+                    continue;
+                }
+
+                for (PhysicalPartition partition : olapTable.getPhysicalPartitions()) {
+                    long visibleVersion = partition.getVisibleVersion();
+                    if (visibleVersion <= 1) {
+                        continue;
+                    }
+                    for (MaterializedIndex index :
+                            partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                        for (Tablet tablet : index.getTablets()) {
+                            long builtVersion = 0;
+                            if (tablet instanceof LakeTablet) {
+                                builtVersion = ((LakeTablet) tablet).getVectorIndexBuiltVersion();
+                            }
+                            if (builtVersion < visibleVersion) {
+                                pendingTablets.put(tablet.getId(), visibleVersion);
+                                count++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        LOG.info("Vector index build recovery scan: {} tablets enqueued", count);
+    }
+
+    // ========== Check running tasks ==========
+
+    void checkRunningTasks() {
+        Iterator<Map.Entry<Long, VectorIndexBuildTask>> it = runningTasks.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Long, VectorIndexBuildTask> entry = it.next();
+            VectorIndexBuildTask task = entry.getValue();
+            if (!task.isDone()) {
+                continue;
+            }
+
+            long tabletId = task.getTabletId();
+            long targetVersion = task.getVersion();
+
+            // Check dedup rejection (SERVICE_UNAVAILABLE) before getResponse()
+            // which throws for non-zero status codes.
+            if (task.isAlreadyBuilding()) {
+                // CN is still building this tablet. Re-enqueue with cooldown
+                // to avoid tight retry loop. Prefer same CN.
+                pendingTablets.merge(tabletId, targetVersion, Math::max);
+                preferredNodes.put(tabletId, task.getNode());
+                cooldownUntil.put(tabletId, System.currentTimeMillis() + DEDUP_COOLDOWN_MS);
+                LOG.info("Vector index build in progress on CN (dedup), "
+                        + "re-enqueued with {}s cooldown: tablet={}", DEDUP_COOLDOWN_MS / 1000, tabletId);
+                it.remove();
+                continue;
+            }
+
+            try {
+                BuildVectorIndexResponse response = task.getResponse();
+                long newBuiltVersion = response.newBuiltVersion != null ? response.newBuiltVersion : 0;
+
+                // Update builtVersion directly on the LakeTablet object
+                LakeTablet tablet = findLakeTablet(tabletId);
+                if (tablet != null) {
+                    tablet.setVectorIndexBuiltVersion(newBuiltVersion);
+                }
+
+                if (newBuiltVersion < targetVersion) {
+                    // Not all rowsets built yet (batch_limit), re-enqueue for next round
+                    pendingTablets.merge(tabletId, targetVersion, Math::max);
+                    LOG.info("Async vector index build partial: tablet={}, newBuiltVersion={}, "
+                                    + "targetVersion={}, re-enqueued",
+                            tabletId, newBuiltVersion, targetVersion);
+                } else {
+                    LOG.info("Async vector index build completed: tablet={}, newBuiltVersion={}",
+                            tabletId, newBuiltVersion);
+                    preferredNodes.remove(tabletId);
+                }
+            } catch (Exception e) {
+                // Real failure: re-enqueue, let scheduler freely pick any CN.
+                pendingTablets.merge(tabletId, targetVersion, Math::max);
+                LOG.warn("Vector index build failed, re-enqueued: tablet={}", tabletId, e);
+            }
+            it.remove();
+        }
+    }
+
+    void checkRunningTaskTimeout() {
+        long now = System.currentTimeMillis();
+        Iterator<Map.Entry<Long, VectorIndexBuildTask>> it = runningTasks.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Long, VectorIndexBuildTask> entry = it.next();
+            VectorIndexBuildTask task = entry.getValue();
+            if (!task.isDone() && now - task.getStartTimeMs() > BUILD_TIMEOUT_MS) {
+                LOG.warn("Vector index build timeout: tablet={}", task.getTabletId());
+                pendingTablets.merge(task.getTabletId(), task.getVersion(), Math::max);
+                preferredNodes.put(task.getTabletId(), task.getNode());
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Remove stale entries from preferredNodes and cooldownUntil for tablets
+     * that are no longer pending, running, or tracked anywhere.
+     */
+    void cleanupStaleEntries() {
+        long now = System.currentTimeMillis();
+        // Remove expired cooldowns
+        cooldownUntil.entrySet().removeIf(e -> now >= e.getValue());
+        // Remove preferredNodes for tablets not in pending or running
+        preferredNodes.keySet().removeIf(
+                tabletId -> !pendingTablets.containsKey(tabletId) && !runningTasks.containsKey(tabletId));
+    }
+
+    // ========== Schedule from pending queue ==========
+
+    void scheduleFromPending() {
+        Iterator<Map.Entry<Long, Long>> it = pendingTablets.entrySet().iterator();
+        while (it.hasNext()) {
+            if (runningTasks.size() >= MAX_CONCURRENT_TASKS) {
+                break;
+            }
+
+            Map.Entry<Long, Long> entry = it.next();
+            long tabletId = entry.getKey();
+            long version = entry.getValue();
+
+            if (runningTasks.containsKey(tabletId)) {
+                continue;
+            }
+
+            // Skip tablets in dedup cooldown (CN reported "already in progress")
+            Long cooldown = cooldownUntil.get(tabletId);
+            if (cooldown != null) {
+                if (System.currentTimeMillis() < cooldown) {
+                    continue;
+                }
+                cooldownUntil.remove(tabletId);
+            }
+
+            // Tablet dropped or metadata gone, discard orphan entry
+            LakeTablet tablet = findLakeTablet(tabletId);
+            if (tablet == null) {
+                it.remove();
+                continue;
+            }
+
+            // Fast check: already built, skip
+            if (tablet.getVectorIndexBuiltVersion() >= version) {
+                it.remove();
+                continue;
+            }
+
+            // Prefer the CN that was previously building this tablet (it has
+            // partial .vi files + warm StarCache). Fall back to any alive CN.
+            ComputeNode node = null;
+            ComputeNode preferred = preferredNodes.get(tabletId);
+            if (preferred != null && preferred.isAlive()) {
+                node = preferred;
+            }
+            if (node == null) {
+                node = pickComputeNode(tabletId);
+            }
+            if (node == null) {
+                continue;
+            }
+            preferredNodes.remove(tabletId);
+
+            long builtVersion = (tablet != null) ? tablet.getVectorIndexBuiltVersion() : 0;
+            VectorIndexBuildTask task = new VectorIndexBuildTask(node, tabletId, version, builtVersion);
+            try {
+                task.sendRequest();
+                runningTasks.put(tabletId, task);
+                it.remove();
+                LOG.info("Scheduled async vector index build: tablet={}, version={}, node={}",
+                        tabletId, version, node.getId());
+            } catch (Exception e) {
+                LOG.warn("Failed to send build vector index request: tablet={}", tabletId, e);
+            }
+        }
+    }
+
+    // ========== Helpers ==========
+
+    /**
+     * Find a LakeTablet object by tabletId via TabletInvertedIndex -> table -> partition -> index -> tablet.
+     */
+    @Nullable
+    private static LakeTablet findLakeTablet(long tabletId) {
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        if (invertedIndex == null) {
+            return null;
+        }
+        TabletMeta meta = invertedIndex.getTabletMeta(tabletId);
+        if (meta == null) {
+            return null;
+        }
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = metastore.getDb(meta.getDbId());
+        if (db == null) {
+            return null;
+        }
+        Table table = db.getTable(meta.getTableId());
+        if (!(table instanceof OlapTable)) {
+            return null;
+        }
+        PhysicalPartition partition = ((OlapTable) table).getPhysicalPartition(meta.getPhysicalPartitionId());
+        if (partition == null) {
+            return null;
+        }
+        MaterializedIndex index = partition.getIndex(meta.getIndexId());
+        if (index == null) {
+            return null;
+        }
+        Tablet tablet = index.getTablet(tabletId);
+        if (tablet instanceof LakeTablet) {
+            return (LakeTablet) tablet;
+        }
+        return null;
+    }
+
+    private ComputeNode pickComputeNode(long tabletId) {
+        try {
+            WarehouseManager whMgr = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            long tableId = getTableIdByTabletId(tabletId);
+            ComputeResource computeResource = whMgr.getVectorIndexBuildComputeResource(tableId);
+            return whMgr.getComputeNodeAssignedToTablet(computeResource, tabletId);
+        } catch (Exception e) {
+            LOG.warn("Failed to pick compute node for tablet {}", tabletId, e);
+            return null;
+        }
+    }
+
+    private static long getTableIdByTabletId(long tabletId) {
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        if (invertedIndex != null) {
+            TabletMeta meta = invertedIndex.getTabletMeta(tabletId);
+            if (meta != null) {
+                return meta.getTableId();
+            }
+        }
+        return -1;
+    }
+
+    static boolean hasAsyncVectorIndex(OlapTable table) {
+        if (table.getIndexes() == null) {
+            return false;
+        }
+        for (Index index : table.getIndexes()) {
+            if (index.getIndexType() == IndexDef.IndexType.VECTOR) {
+                Map<String, String> props = index.getProperties();
+                if (props != null && "async".equalsIgnoreCase(props.get("index_build_mode"))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // ========== Test helpers ==========
+
+    Map<Long, VectorIndexBuildTask> getRunningTasksForTest() {
+        return runningTasks;
+    }
+
+    ConcurrentHashMap<Long, Long> getPendingTabletsForTest() {
+        return pendingTablets;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
@@ -194,7 +194,7 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
             long tabletId = task.getTabletId();
             long targetVersion = task.getVersion();
 
-            // Check dedup rejection (SERVICE_UNAVAILABLE) before getResponse()
+            // Check dedup rejection (RESOURCE_BUSY) before getResponse()
             // which throws for non-zero status codes.
             if (task.isAlreadyBuilding()) {
                 // CN is still building this tablet. Re-enqueue with cooldown
@@ -219,8 +219,10 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                 }
 
                 if (newBuiltVersion < targetVersion) {
-                    // Not all rowsets built yet (batch_limit), re-enqueue for next round
+                    // Not all rowsets built yet (batch_limit), re-enqueue for next round.
+                    // Keep CN affinity so the next round reuses the same CN's cache warmup.
                     pendingTablets.merge(tabletId, targetVersion, Math::max);
+                    preferredNodes.put(tabletId, task.getNode());
                     LOG.info("Async vector index build partial: tablet={}, newBuiltVersion={}, "
                                     + "targetVersion={}, re-enqueued",
                             tabletId, newBuiltVersion, targetVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildTask.java
@@ -47,6 +47,9 @@ public class VectorIndexBuildTask {
 
     public BuildVectorIndexResponse getResponse() throws Exception {
         BuildVectorIndexResponse response = future.get();
+        if (response == null) {
+            throw new RuntimeException("Build vector index returned null response");
+        }
         if (response.status != null && response.status.statusCode != 0) {
             throw new RuntimeException("Build vector index failed: " + response.status.errorMsgs);
         }
@@ -64,7 +67,7 @@ public class VectorIndexBuildTask {
         }
         try {
             BuildVectorIndexResponse response = future.get();
-            return response.status != null
+            return response != null && response.status != null
                     && response.status.statusCode == TStatusCode.RESOURCE_BUSY.getValue();
         } catch (Exception e) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildTask.java
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+package com.starrocks.lake.vector;
+
+import com.starrocks.proto.BuildVectorIndexRequest;
+import com.starrocks.proto.BuildVectorIndexResponse;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TStatusCode;
+
+import java.util.concurrent.Future;
+
+/**
+ * Wraps an async RPC call to build vector index on a CN.
+ * FE passes the committedVersion so CN loads metadata at the correct version.
+ */
+public class VectorIndexBuildTask {
+    private final ComputeNode node;
+    private final long tabletId;
+    private final long version;
+    private final long builtVersion;
+    private final long startTimeMs;
+    private Future<BuildVectorIndexResponse> future;
+
+    public VectorIndexBuildTask(ComputeNode node, long tabletId, long version, long builtVersion) {
+        this.node = node;
+        this.tabletId = tabletId;
+        this.version = version;
+        this.builtVersion = builtVersion;
+        this.startTimeMs = System.currentTimeMillis();
+    }
+
+    public void sendRequest() throws RpcException {
+        BuildVectorIndexRequest request = new BuildVectorIndexRequest();
+        request.tabletId = tabletId;
+        request.version = version;
+        request.builtVersion = builtVersion;
+        LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
+        future = lakeService.buildVectorIndex(request);
+    }
+
+    public boolean isDone() {
+        return future != null && future.isDone();
+    }
+
+    public BuildVectorIndexResponse getResponse() throws Exception {
+        BuildVectorIndexResponse response = future.get();
+        if (response.status != null && response.status.statusCode != 0) {
+            throw new RuntimeException("Build vector index failed: " + response.status.errorMsgs);
+        }
+        return response;
+    }
+
+    /**
+     * Check if the last RPC was rejected because the CN is already building
+     * this tablet (tablet-level dedup). BE returns RESOURCE_BUSY (53) for
+     * this case.
+     */
+    public boolean isAlreadyBuilding() {
+        if (future == null || !future.isDone()) {
+            return false;
+        }
+        try {
+            BuildVectorIndexResponse response = future.get();
+            return response.status != null
+                    && response.status.statusCode == TStatusCode.RESOURCE_BUSY.getValue();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public long getTabletId() {
+        return tabletId;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public long getStartTimeMs() {
+        return startTimeMs;
+    }
+
+    public ComputeNode getNode() {
+        return node;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -22,6 +22,8 @@ import com.starrocks.proto.AbortTxnRequest;
 import com.starrocks.proto.AbortTxnResponse;
 import com.starrocks.proto.AggregateCompactRequest;
 import com.starrocks.proto.AggregatePublishVersionRequest;
+import com.starrocks.proto.BuildVectorIndexRequest;
+import com.starrocks.proto.BuildVectorIndexResponse;
 import com.starrocks.proto.CompactRequest;
 import com.starrocks.proto.CompactResponse;
 import com.starrocks.proto.DeleteDataRequest;
@@ -79,6 +81,7 @@ public interface LakeService {
     long TIMEOUT_VACUUM = MILLIS_PER_HOUR;
     long TIMEOUT_VACUUM_FULL = MILLIS_PER_HOUR * 24;
     long TIMEOUT_REPAIR_METADATA = MILLIS_PER_HOUR;
+    long TIMEOUT_BUILD_VECTOR_INDEX = MILLIS_PER_DAY;
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "publish_version", onceTalkTimeout = TIMEOUT_PUBLISH_VERSION)
     Future<PublishVersionResponse> publishVersion(PublishVersionRequest request);
@@ -146,5 +149,9 @@ public interface LakeService {
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "repair_tablet_metadata", onceTalkTimeout = TIMEOUT_REPAIR_METADATA)
     Future<RepairTabletMetadataResponse> repairTabletMetadata(RepairTabletMetadataRequest request);
+
+    @ProtobufRPC(serviceName = "LakeService", methodName = "build_vector_index",
+            onceTalkTimeout = TIMEOUT_BUILD_VECTOR_INDEX)
+    Future<BuildVectorIndexResponse> buildVectorIndex(BuildVectorIndexRequest request);
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
@@ -20,6 +20,8 @@ import com.starrocks.proto.AbortTxnRequest;
 import com.starrocks.proto.AbortTxnResponse;
 import com.starrocks.proto.AggregateCompactRequest;
 import com.starrocks.proto.AggregatePublishVersionRequest;
+import com.starrocks.proto.BuildVectorIndexRequest;
+import com.starrocks.proto.BuildVectorIndexResponse;
 import com.starrocks.proto.CompactRequest;
 import com.starrocks.proto.CompactResponse;
 import com.starrocks.proto.DeleteDataRequest;
@@ -200,5 +202,11 @@ public class LakeServiceWithMetrics implements LakeService {
     public Future<RepairTabletMetadataResponse> repairTabletMetadata(RepairTabletMetadataRequest request) {
         increaseMetrics();
         return lakeService.repairTabletMetadata(request);
+    }
+
+    @Override
+    public Future<BuildVectorIndexResponse> buildVectorIndex(BuildVectorIndexRequest request) {
+        increaseMetrics();
+        return lakeService.buildVectorIndex(request);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -817,6 +817,7 @@ public class GlobalStateMgr {
             this.storageVolumeMgr = new SharedDataStorageVolumeMgr();
             this.autovacuumDaemon = new AutovacuumDaemon();
             this.fullVacuumDaemon = new FullVacuumDaemon();
+            this.vectorIndexBuildScheduler = new VectorIndexBuildScheduler();
         } else {
             this.storageVolumeMgr = new SharedNothingStorageVolumeMgr();
         }
@@ -1614,7 +1615,6 @@ public class GlobalStateMgr {
             autovacuumDaemon.start();
             fullVacuumDaemon.start();
 
-            vectorIndexBuildScheduler = new VectorIndexBuildScheduler();
             vectorIndexBuildScheduler.start();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -144,6 +144,7 @@ import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.lake.vacuum.AutovacuumDaemon;
 import com.starrocks.lake.vacuum.FullVacuumDaemon;
+import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.leader.CheckpointController;
 import com.starrocks.leader.ReportHandler;
 import com.starrocks.leader.TabletCollector;
@@ -480,6 +481,9 @@ public class GlobalStateMgr {
     // For LakeTable
     private final CompactionMgr compactionMgr;
 
+    // For async vector index build
+    private VectorIndexBuildScheduler vectorIndexBuildScheduler;
+
     // For compaction forbidden policy
     private final CompactionControlScheduler compactionControlScheduler;
 
@@ -641,6 +645,10 @@ public class GlobalStateMgr {
 
     public CompactionMgr getCompactionMgr() {
         return compactionMgr;
+    }
+
+    public VectorIndexBuildScheduler getVectorIndexBuildScheduler() {
+        return vectorIndexBuildScheduler;
     }
 
     public CompactionControlScheduler getCompactionControlScheduler() {
@@ -1605,6 +1613,9 @@ public class GlobalStateMgr {
             starMgrMetaSyncer.start();
             autovacuumDaemon.start();
             fullVacuumDaemon.start();
+
+            vectorIndexBuildScheduler = new VectorIndexBuildScheduler();
+            vectorIndexBuildScheduler.start();
         }
 
         if (Config.enable_safe_mode) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -18,6 +18,7 @@ import com.google.api.client.util.Lists;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import com.staros.util.LockCloseable;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
@@ -401,7 +402,25 @@ public class WarehouseManager implements Writable {
     }
 
     public ComputeResource getVectorIndexBuildComputeResource(long tableId) {
-        return DEFAULT_RESOURCE;
+        // Route async vector index build work to the warehouse named by
+        // lake_vector_index_build_warehouse so users can isolate it from query
+        // workload. Fall back to the default resource if the configured
+        // warehouse is unset, missing, or unavailable — building on the
+        // default warehouse is always preferable to dropping the build.
+        String warehouseName = Config.lake_vector_index_build_warehouse;
+        if (warehouseName == null || warehouseName.isEmpty()
+                || warehouseName.equalsIgnoreCase(DEFAULT_WAREHOUSE_NAME)) {
+            return DEFAULT_RESOURCE;
+        }
+        Warehouse wh = getWarehouseAllowNull(warehouseName);
+        if (wh == null) {
+            return DEFAULT_RESOURCE;
+        }
+        try {
+            return acquireComputeResource(CRAcquireContext.of(wh.getId()));
+        } catch (Exception e) {
+            return DEFAULT_RESOURCE;
+        }
     }
 
     public Warehouse getBackgroundWarehouse() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -400,6 +400,10 @@ public class WarehouseManager implements Writable {
         return DEFAULT_RESOURCE;
     }
 
+    public ComputeResource getVectorIndexBuildComputeResource(long tableId) {
+        return DEFAULT_RESOURCE;
+    }
+
     public Warehouse getBackgroundWarehouse() {
         return getWarehouse(DEFAULT_WAREHOUSE_ID);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
@@ -244,9 +244,6 @@ public class IndexAnalyzer {
 
     // VectorIndexUtil methods
     public static void checkVectorIndexValid(Column column, Map<String, String> properties, KeysType keysType) {
-        if (RunMode.isSharedDataMode()) {
-            throw new SemanticException("The vector index does not support shared data mode");
-        }
         if (!Config.enable_experimental_vector) {
             throw new SemanticException(
                     "The vector index is disabled, enable it by setting FE config `enable_experimental_vector` to true");

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -54,10 +54,12 @@ import com.starrocks.lake.PartitionPublishVersionData;
 import com.starrocks.lake.TxnInfoHelper;
 import com.starrocks.lake.Utils;
 import com.starrocks.lake.compaction.Quantiles;
+import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.TxnInfoPB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
@@ -684,15 +686,17 @@ public class PublishVersionDaemon extends FrontendDaemon {
 
                 // used to delete txnLog when publish success
                 Map<ComputeNode, List<Long>> nodeToTablets = new HashMap<>();
+                List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
                 if (!useAggregatePublish) {
                     Utils.publishVersionBatch(publishTablets, txnInfos,
                             startVersion - 1, endVersion, compactionScores, nodeToTablets,
-                            computeResource, null);
+                            computeResource, null, vectorIndexBuildInfos);
                 } else {
-                    Utils.aggregatePublishVersion(publishTablets, txnInfos, startVersion - 1, endVersion, 
-                            compactionScores, nodeToTablets, computeResource, null);
+                    Utils.aggregatePublishVersion(publishTablets, txnInfos, startVersion - 1, endVersion,
+                            compactionScores, nodeToTablets, computeResource, null, vectorIndexBuildInfos);
                 }
 
+                VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 stateBatch.setCompactionScore(tableId, partitionId, quantiles);
                 stateBatch.putBeTablets(partitionId, nodeToTablets);
@@ -1075,9 +1079,11 @@ public class PublishVersionDaemon extends FrontendDaemon {
                 Map<Long, Double> compactionScores = new HashMap<>();
                 // Used to collect statistics when the partition is first imported
                 Map<Long, Long> tabletRowNums = new HashMap<>();
+                List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
                 Utils.publishVersion(normalTablets, txnInfo, baseVersion, txnVersion, compactionScores,
-                        computeResource, tabletRowNums, useAggregatePublish);
+                        computeResource, tabletRowNums, useAggregatePublish, vectorIndexBuildInfos);
 
+                VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 partitionCommitInfo.setCompactionScore(quantiles);
                 if (!tabletRowNums.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -298,7 +298,8 @@ public class LakeRollupJobTest {
             public static void sendAggregatePublishVersionRequest(AggregatePublishVersionRequest request,
                     long baseVersion, ComputeResource computeResource,
                     Map<Long, Double> compactionScores,
-                    Map<Long, Long> tabletRowNum)
+                    Map<Long, Long> tabletRowNum,
+                    java.util.List<com.starrocks.proto.VectorIndexBuildInfoPB> vectorIndexBuildInfos)
                     throws NoAliveBackendException, RpcException {
                 // Do nothing, just return successfully
             }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -39,6 +39,7 @@ import com.starrocks.proto.PublishVersionResponse;
 import com.starrocks.proto.ReshardingTabletInfoPB;
 import com.starrocks.proto.StatusPB;
 import com.starrocks.proto.TxnInfoPB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -433,7 +434,8 @@ public class MergeTabletJobTest {
                                        Map<Long, TabletRange> tabletRanges,
                                        ComputeResource computeResource,
                                        Map<Long, Long> tabletRowNums,
-                                       boolean useAggregatePublish) throws Exception {
+                                       boolean useAggregatePublish,
+                                       List<VectorIndexBuildInfoPB> vectorIndexBuildInfos) throws Exception {
                 throw new RuntimeException("mock");
             }
         };
@@ -465,7 +467,8 @@ public class MergeTabletJobTest {
                                        Map<Long, TabletRange> tabletRanges,
                                        ComputeResource computeResource,
                                        Map<Long, Long> tabletRowNums,
-                                       boolean useAggregatePublish) {
+                                       boolean useAggregatePublish,
+                                       List<VectorIndexBuildInfoPB> vectorIndexBuildInfos) {
                 actualResource.set(computeResource);
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -34,6 +34,7 @@ import com.starrocks.proto.ReshardingTabletInfoPB;
 import com.starrocks.proto.StatusPB;
 import com.starrocks.proto.TabletRangePB;
 import com.starrocks.proto.TxnInfoPB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -386,7 +387,8 @@ public class SplitTabletJobTest {
             public void publishVersion(List<Tablet> tablets, TxnInfoPB txnInfo,
                                        long baseVersion, long newVersion, Map<Long, Double> compactionScores,
                                        Map<Long, TabletRange> tabletRanges, ComputeResource computeResource,
-                                       Map<Long, Long> tabletRowNums, boolean useAggregatePublish) {
+                                       Map<Long, Long> tabletRowNums, boolean useAggregatePublish,
+                                       List<VectorIndexBuildInfoPB> vectorIndexBuildInfos) {
                 actualResource.set(computeResource);
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/common/VectorIndexParamsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/VectorIndexParamsTest.java
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+import com.starrocks.common.VectorIndexParams.CommonIndexParamKey;
+import com.starrocks.sql.analyzer.SemanticException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class VectorIndexParamsTest {
+
+    @Test
+    public void testIndexBuildModeAcceptsSyncAndAsync() {
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.INDEX_BUILD_MODE.check("sync"));
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.INDEX_BUILD_MODE.check("async"));
+    }
+
+    @Test
+    public void testIndexBuildModeIsCaseInsensitive() {
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.INDEX_BUILD_MODE.check("SYNC"));
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.INDEX_BUILD_MODE.check("Async"));
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.INDEX_BUILD_MODE.check("ASYNC"));
+    }
+
+    @Test
+    public void testIndexBuildModeRejectsInvalidValue() {
+        SemanticException ex = Assertions.assertThrows(SemanticException.class,
+                () -> CommonIndexParamKey.INDEX_BUILD_MODE.check("lazy"));
+        Assertions.assertTrue(ex.getMessage().contains("sync"));
+        Assertions.assertTrue(ex.getMessage().contains("async"));
+    }
+
+    @Test
+    public void testIndexBuildModeRejectsEmptyValue() {
+        Assertions.assertThrows(SemanticException.class,
+                () -> CommonIndexParamKey.INDEX_BUILD_MODE.check(""));
+    }
+
+    @Test
+    public void testIndexTypeAcceptsKnownTypes() {
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.INDEX_TYPE.check("HNSW"));
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.INDEX_TYPE.check("ivfpq"));
+    }
+
+    @Test
+    public void testIndexTypeRejectsUnknown() {
+        Assertions.assertThrows(SemanticException.class,
+                () -> CommonIndexParamKey.INDEX_TYPE.check("flat"));
+    }
+
+    @Test
+    public void testMetricTypeAcceptsKnown() {
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.METRIC_TYPE.check("cosine_similarity"));
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.METRIC_TYPE.check("L2_DISTANCE"));
+    }
+
+    @Test
+    public void testMetricTypeRejectsUnknown() {
+        Assertions.assertThrows(SemanticException.class,
+                () -> CommonIndexParamKey.METRIC_TYPE.check("manhattan"));
+    }
+
+    @Test
+    public void testDimRejectsNonInteger() {
+        Assertions.assertThrows(SemanticException.class,
+                () -> CommonIndexParamKey.DIM.check("abc"));
+    }
+
+    @Test
+    public void testDimRejectsZero() {
+        Assertions.assertThrows(SemanticException.class,
+                () -> CommonIndexParamKey.DIM.check("0"));
+    }
+
+    @Test
+    public void testIsVectorNormedAcceptsBooleanStrings() {
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.IS_VECTOR_NORMED.check("true"));
+        Assertions.assertDoesNotThrow(() -> CommonIndexParamKey.IS_VECTOR_NORMED.check("FALSE"));
+    }
+
+    @Test
+    public void testIsVectorNormedRejectsNonBoolean() {
+        Assertions.assertThrows(SemanticException.class,
+                () -> CommonIndexParamKey.IS_VECTOR_NORMED.check("yes"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/vector/VectorIndexBuildSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/vector/VectorIndexBuildSchedulerTest.java
@@ -1,0 +1,809 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+package com.starrocks.lake.vector;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Index;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.proto.BuildVectorIndexRequest;
+import com.starrocks.proto.BuildVectorIndexResponse;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.IndexDef;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class VectorIndexBuildSchedulerTest {
+
+    @Mocked
+    private GlobalStateMgr globalStateMgr;
+    @Mocked
+    private LocalMetastore localMetastore;
+    @Mocked
+    private WarehouseManager warehouseManager;
+
+    private VectorIndexBuildScheduler scheduler;
+
+    @BeforeEach
+    public void setUp() {
+        scheduler = new VectorIndexBuildScheduler();
+    }
+
+    // ========== Helper methods ==========
+
+    private Map<Long, VectorIndexBuildTask> getRunningTasks() {
+        return scheduler.getRunningTasksForTest();
+    }
+
+    private ConcurrentHashMap<Long, Long> getPendingTablets() {
+        return scheduler.getPendingTabletsForTest();
+    }
+
+    private LakeTable mockLakeTable(boolean asyncVectorIndex) {
+        LakeTable table = Mockito.mock(LakeTable.class);
+        Mockito.when(table.isCloudNativeTableOrMaterializedView()).thenReturn(true);
+        if (asyncVectorIndex) {
+            Index vectorIndex = Mockito.mock(Index.class);
+            Mockito.when(vectorIndex.getIndexType()).thenReturn(IndexDef.IndexType.VECTOR);
+            Map<String, String> props = new HashMap<>();
+            props.put("index_build_mode", "async");
+            Mockito.when(vectorIndex.getProperties()).thenReturn(props);
+            Mockito.when(table.getIndexes()).thenReturn(Lists.newArrayList(vectorIndex));
+        } else {
+            Mockito.when(table.getIndexes()).thenReturn(Collections.emptyList());
+        }
+        return table;
+    }
+
+    private Database mockDatabase(LakeTable... tables) {
+        Database db = Mockito.mock(Database.class);
+        Mockito.when(db.getTables()).thenReturn(Lists.newArrayList(tables));
+        return db;
+    }
+
+    private void setupRecoveryScanExpectations(Database db) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getLocalMetastore();
+                result = localMetastore;
+                localMetastore.getDbIds();
+                result = Lists.newArrayList(10001L);
+                localMetastore.getDb(10001L);
+                result = db;
+            }
+        };
+    }
+
+    private VectorIndexBuildTask createTaskWithFuture(long tabletId, long version,
+                                                       CompletableFuture<BuildVectorIndexResponse> future) {
+        ComputeNode node = Mockito.mock(ComputeNode.class);
+        VectorIndexBuildTask task = new VectorIndexBuildTask(node, tabletId, version, 0);
+        try {
+            java.lang.reflect.Field futureField = VectorIndexBuildTask.class.getDeclaredField("future");
+            futureField.setAccessible(true);
+            futureField.set(task, future);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return task;
+    }
+
+    private VectorIndexBuildTask createTaskWithStartTime(long tabletId, long version, long startTimeMs) {
+        ComputeNode node = Mockito.mock(ComputeNode.class);
+        VectorIndexBuildTask task = new VectorIndexBuildTask(node, tabletId, version, 0);
+        try {
+            java.lang.reflect.Field startField = VectorIndexBuildTask.class.getDeclaredField("startTimeMs");
+            startField.setAccessible(true);
+            startField.set(task, startTimeMs);
+            java.lang.reflect.Field futureField = VectorIndexBuildTask.class.getDeclaredField("future");
+            futureField.setAccessible(true);
+            futureField.set(task, new CompletableFuture<>());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return task;
+    }
+
+    private void setupFindLakeTabletExpectations(long tabletId, LakeTablet tablet,
+                                                  long dbId, long tableId, long partitionId, long indexId) {
+        TabletInvertedIndex invertedIndex = Mockito.mock(TabletInvertedIndex.class);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, null, true);
+        Mockito.when(invertedIndex.getTabletMeta(tabletId)).thenReturn(tabletMeta);
+
+        Database db = Mockito.mock(Database.class);
+        LakeTable table = Mockito.mock(LakeTable.class);
+        Mockito.when(db.getTable(tableId)).thenReturn(table);
+        PhysicalPartition partition = Mockito.mock(PhysicalPartition.class);
+        Mockito.when(table.getPhysicalPartition(partitionId)).thenReturn(partition);
+        MaterializedIndex matIndex = Mockito.mock(MaterializedIndex.class);
+        Mockito.when(partition.getIndex(indexId)).thenReturn(matIndex);
+        Mockito.when(matIndex.getTablet(tabletId)).thenReturn(tablet);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getTabletInvertedIndex();
+                result = invertedIndex;
+                minTimes = 0;
+                globalStateMgr.getLocalMetastore();
+                result = localMetastore;
+                minTimes = 0;
+                localMetastore.getDb(dbId);
+                result = db;
+                minTimes = 0;
+            }
+        };
+    }
+
+    // ========== addPendingTablet tests ==========
+
+    @Test
+    public void testAddPendingTablet() {
+        scheduler.addPendingTablet(1001L, 5L);
+        Assertions.assertEquals(5L, getPendingTablets().get(1001L));
+    }
+
+    @Test
+    public void testAddPendingTabletMergeMax() {
+        scheduler.addPendingTablet(1001L, 5L);
+        scheduler.addPendingTablet(1001L, 8L);
+        Assertions.assertEquals(8L, getPendingTablets().get(1001L));
+    }
+
+    @Test
+    public void testAddPendingTabletNoRegression() {
+        scheduler.addPendingTablet(1001L, 8L);
+        scheduler.addPendingTablet(1001L, 5L);
+        Assertions.assertEquals(8L, getPendingTablets().get(1001L));
+    }
+
+    // ========== Recovery scan tests ==========
+
+    @Test
+    public void testRecoveryScanFindsLaggingTablets() {
+        LakeTable table = mockLakeTable(true);
+        Database db = mockDatabase(table);
+
+        LakeTablet tablet1 = new LakeTablet(2001L);
+        tablet1.setVectorIndexBuiltVersion(3L);
+        LakeTablet tablet2 = new LakeTablet(2002L);
+
+        PhysicalPartition partition = Mockito.mock(PhysicalPartition.class);
+        Mockito.when(partition.getVisibleVersion()).thenReturn(5L);
+        MaterializedIndex matIndex = Mockito.mock(MaterializedIndex.class);
+        Mockito.when(matIndex.getTablets()).thenReturn(Lists.newArrayList(tablet1, tablet2));
+        Mockito.when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL))
+                .thenReturn(Lists.newArrayList(matIndex));
+        Mockito.when(table.getPhysicalPartitions()).thenReturn(Lists.newArrayList(partition));
+
+        setupRecoveryScanExpectations(db);
+        scheduler.recoveryScan();
+
+        ConcurrentHashMap<Long, Long> pending = getPendingTablets();
+        Assertions.assertEquals(5L, pending.get(2001L));
+        Assertions.assertEquals(5L, pending.get(2002L));
+    }
+
+    @Test
+    public void testRecoveryScanSkipsBuiltTablets() {
+        LakeTable table = mockLakeTable(true);
+        Database db = mockDatabase(table);
+
+        LakeTablet tablet = new LakeTablet(2001L);
+        tablet.setVectorIndexBuiltVersion(5L);
+
+        PhysicalPartition partition = Mockito.mock(PhysicalPartition.class);
+        Mockito.when(partition.getVisibleVersion()).thenReturn(5L);
+        MaterializedIndex matIndex = Mockito.mock(MaterializedIndex.class);
+        Mockito.when(matIndex.getTablets()).thenReturn(Lists.newArrayList(tablet));
+        Mockito.when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL))
+                .thenReturn(Lists.newArrayList(matIndex));
+        Mockito.when(table.getPhysicalPartitions()).thenReturn(Lists.newArrayList(partition));
+
+        setupRecoveryScanExpectations(db);
+        scheduler.recoveryScan();
+
+        Assertions.assertTrue(getPendingTablets().isEmpty());
+    }
+
+    @Test
+    public void testRecoveryScanSkipsNonAsyncTables() {
+        LakeTable table = mockLakeTable(false);
+        Database db = mockDatabase(table);
+
+        setupRecoveryScanExpectations(db);
+        scheduler.recoveryScan();
+
+        Assertions.assertTrue(getPendingTablets().isEmpty());
+    }
+
+    @Test
+    public void testRecoveryScanSkipsVersion1() {
+        LakeTable table = mockLakeTable(true);
+        Database db = mockDatabase(table);
+
+        PhysicalPartition partition = Mockito.mock(PhysicalPartition.class);
+        Mockito.when(partition.getVisibleVersion()).thenReturn(1L);
+        Mockito.when(table.getPhysicalPartitions()).thenReturn(Lists.newArrayList(partition));
+
+        setupRecoveryScanExpectations(db);
+        scheduler.recoveryScan();
+
+        Assertions.assertTrue(getPendingTablets().isEmpty());
+    }
+
+    // ========== checkRunningTasks tests ==========
+
+    @Test
+    public void testCheckRunningTasksSuccess() {
+        long tabletId = 3001L;
+        LakeTablet tablet = new LakeTablet(tabletId);
+
+        BuildVectorIndexResponse response = new BuildVectorIndexResponse();
+        response.newBuiltVersion = 7L;
+        CompletableFuture<BuildVectorIndexResponse> future = CompletableFuture.completedFuture(response);
+        VectorIndexBuildTask task = createTaskWithFuture(tabletId, 7L, future);
+        getRunningTasks().put(tabletId, task);
+
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        scheduler.checkRunningTasks();
+
+        Assertions.assertTrue(getRunningTasks().isEmpty());
+        Assertions.assertEquals(7L, tablet.getVectorIndexBuiltVersion());
+    }
+
+    @Test
+    public void testCheckRunningTasksFailure() {
+        long tabletId = 3001L;
+        CompletableFuture<BuildVectorIndexResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(new RuntimeException("RPC failed"));
+        VectorIndexBuildTask task = createTaskWithFuture(tabletId, 7L, future);
+        getRunningTasks().put(tabletId, task);
+
+        scheduler.checkRunningTasks();
+
+        Assertions.assertTrue(getRunningTasks().isEmpty());
+    }
+
+    @Test
+    public void testCheckRunningTasksSkipsInProgress() {
+        long tabletId = 3001L;
+        VectorIndexBuildTask task = createTaskWithStartTime(tabletId, 7L, System.currentTimeMillis());
+        getRunningTasks().put(tabletId, task);
+
+        scheduler.checkRunningTasks();
+
+        Assertions.assertEquals(1, getRunningTasks().size());
+    }
+
+    @Test
+    public void testCheckRunningTasksNullBuiltVersion() {
+        long tabletId = 3001L;
+        LakeTablet tablet = new LakeTablet(tabletId);
+
+        BuildVectorIndexResponse response = new BuildVectorIndexResponse();
+        response.newBuiltVersion = null;
+        CompletableFuture<BuildVectorIndexResponse> future = CompletableFuture.completedFuture(response);
+        VectorIndexBuildTask task = createTaskWithFuture(tabletId, 7L, future);
+        getRunningTasks().put(tabletId, task);
+
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        scheduler.checkRunningTasks();
+
+        Assertions.assertTrue(getRunningTasks().isEmpty());
+        Assertions.assertEquals(0L, tablet.getVectorIndexBuiltVersion());
+    }
+
+    // ========== checkRunningTaskTimeout tests ==========
+
+    @Test
+    public void testCheckRunningTaskTimeout() {
+        long tabletId = 3001L;
+        long oldStartTime = System.currentTimeMillis() - VectorIndexBuildScheduler.BUILD_TIMEOUT_MS - 1000;
+        VectorIndexBuildTask task = createTaskWithStartTime(tabletId, 7L, oldStartTime);
+        getRunningTasks().put(tabletId, task);
+
+        scheduler.checkRunningTaskTimeout();
+
+        Assertions.assertTrue(getRunningTasks().isEmpty());
+        Assertions.assertEquals(7L, getPendingTablets().get(tabletId));
+    }
+
+    @Test
+    public void testCheckRunningTaskTimeoutKeepsRecent() {
+        long tabletId = 3001L;
+        VectorIndexBuildTask task = createTaskWithStartTime(tabletId, 7L, System.currentTimeMillis());
+        getRunningTasks().put(tabletId, task);
+
+        scheduler.checkRunningTaskTimeout();
+
+        Assertions.assertEquals(1, getRunningTasks().size());
+        Assertions.assertTrue(getPendingTablets().isEmpty());
+    }
+
+    // ========== scheduleFromPending tests ==========
+
+    @Test
+    public void testScheduleFromPendingSkipsAlreadyBuilt() {
+        long tabletId = 3001L;
+        scheduler.addPendingTablet(tabletId, 5L);
+
+        LakeTablet tablet = new LakeTablet(tabletId);
+        tablet.setVectorIndexBuiltVersion(5L);
+
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        scheduler.scheduleFromPending();
+
+        Assertions.assertTrue(getPendingTablets().isEmpty());
+        Assertions.assertTrue(getRunningTasks().isEmpty());
+    }
+
+    @Test
+    public void testScheduleFromPendingSkipsAlreadyRunning() {
+        long tabletId = 3001L;
+        scheduler.addPendingTablet(tabletId, 5L);
+
+        VectorIndexBuildTask existing = createTaskWithStartTime(tabletId, 5L, System.currentTimeMillis());
+        getRunningTasks().put(tabletId, existing);
+
+        scheduler.scheduleFromPending();
+
+        Assertions.assertEquals(5L, getPendingTablets().get(tabletId));
+    }
+
+    // ========== hasAsyncVectorIndex tests ==========
+
+    @Test
+    public void testHasAsyncVectorIndexTrue() {
+        LakeTable table = mockLakeTable(true);
+        Assertions.assertTrue(VectorIndexBuildScheduler.hasAsyncVectorIndex(table));
+    }
+
+    @Test
+    public void testHasAsyncVectorIndexFalse() {
+        LakeTable table = mockLakeTable(false);
+        Assertions.assertFalse(VectorIndexBuildScheduler.hasAsyncVectorIndex(table));
+    }
+
+    @Test
+    public void testHasAsyncVectorIndexNullIndexes() {
+        LakeTable table = Mockito.mock(LakeTable.class);
+        Mockito.when(table.getIndexes()).thenReturn(null);
+        Assertions.assertFalse(VectorIndexBuildScheduler.hasAsyncVectorIndex(table));
+    }
+
+    // ========== LakeTablet builtVersion tests ==========
+
+    @Test
+    public void testLakeTabletBuiltVersionDefault() {
+        LakeTablet tablet = new LakeTablet(1001L);
+        Assertions.assertEquals(0L, tablet.getVectorIndexBuiltVersion());
+    }
+
+    @Test
+    public void testLakeTabletBuiltVersionSet() {
+        LakeTablet tablet = new LakeTablet(1001L);
+        tablet.setVectorIndexBuiltVersion(5L);
+        Assertions.assertEquals(5L, tablet.getVectorIndexBuiltVersion());
+    }
+
+    @Test
+    public void testLakeTabletBuiltVersionMaxSemantics() {
+        LakeTablet tablet = new LakeTablet(1001L);
+        tablet.setVectorIndexBuiltVersion(5L);
+        tablet.setVectorIndexBuiltVersion(3L);
+        Assertions.assertEquals(5L, tablet.getVectorIndexBuiltVersion());
+        tablet.setVectorIndexBuiltVersion(8L);
+        Assertions.assertEquals(8L, tablet.getVectorIndexBuiltVersion());
+    }
+
+    @Test
+    public void testLakeTabletBuiltVersionSerialization() {
+        LakeTablet tablet = new LakeTablet(1001L);
+        tablet.setVectorIndexBuiltVersion(7L);
+
+        com.google.gson.Gson gson = new com.google.gson.Gson();
+        String json = gson.toJson(tablet);
+        LakeTablet deserialized = gson.fromJson(json, LakeTablet.class);
+
+        Assertions.assertEquals(7L, deserialized.getVectorIndexBuiltVersion());
+    }
+
+    @Test
+    public void testLakeTabletBuiltVersionDeserializeOldFormat() {
+        String json = "{\"id\":1001,\"dataSize\":100,\"rowCount\":10}";
+        com.google.gson.Gson gson = new com.google.gson.Gson();
+        LakeTablet deserialized = gson.fromJson(json, LakeTablet.class);
+
+        Assertions.assertEquals(0L, deserialized.getVectorIndexBuiltVersion());
+    }
+
+    // ========== onPublishComplete tests ==========
+
+    private static VectorIndexBuildInfoPB infoOf(long tabletId, long version) {
+        VectorIndexBuildInfoPB info = new VectorIndexBuildInfoPB();
+        info.tabletId = tabletId;
+        info.version = version;
+        return info;
+    }
+
+    // GlobalStateMgr.getVectorIndexBuildScheduler() returns a Thread subclass which JMockit cannot
+    // auto-mock from an Expectations block. MockUp lets us override just that one method.
+    private void mockGetScheduler(VectorIndexBuildScheduler returnValue) {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public VectorIndexBuildScheduler getVectorIndexBuildScheduler() {
+                return returnValue;
+            }
+        };
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+            }
+        };
+    }
+
+    @Test
+    public void testOnPublishCompleteEnqueuesEachInfo() {
+        mockGetScheduler(scheduler);
+        List<VectorIndexBuildInfoPB> infos = new ArrayList<>();
+        infos.add(infoOf(4001L, 5L));
+        infos.add(infoOf(4002L, 7L));
+
+        VectorIndexBuildScheduler.onPublishComplete(infos);
+
+        Assertions.assertEquals(5L, getPendingTablets().get(4001L));
+        Assertions.assertEquals(7L, getPendingTablets().get(4002L));
+    }
+
+    @Test
+    public void testOnPublishCompleteSkipsNullAndEmpty() {
+        // No GlobalStateMgr expectation needed — early return on null/empty must not touch state.
+        VectorIndexBuildScheduler.onPublishComplete(null);
+        VectorIndexBuildScheduler.onPublishComplete(Collections.emptyList());
+        Assertions.assertTrue(getPendingTablets().isEmpty());
+    }
+
+    @Test
+    public void testOnPublishCompleteSkipsInfoWithNullFields() {
+        mockGetScheduler(scheduler);
+        VectorIndexBuildInfoPB missingTablet = new VectorIndexBuildInfoPB();
+        missingTablet.version = 1L;
+        VectorIndexBuildInfoPB missingVersion = new VectorIndexBuildInfoPB();
+        missingVersion.tabletId = 9L;
+
+        VectorIndexBuildScheduler.onPublishComplete(Lists.newArrayList(missingTablet, missingVersion));
+
+        Assertions.assertTrue(getPendingTablets().isEmpty());
+    }
+
+    @Test
+    public void testOnPublishCompleteHandlesNullScheduler() {
+        mockGetScheduler(null);
+        // Must silently no-op when scheduler is not initialized (FE startup race window).
+        Assertions.assertDoesNotThrow(
+                () -> VectorIndexBuildScheduler.onPublishComplete(Lists.newArrayList(infoOf(1L, 1L))));
+    }
+
+    // ========== getBuiltVersion tests ==========
+
+    @Test
+    public void testGetBuiltVersionReturnsValueWhenSet() {
+        long tabletId = 5001L;
+        LakeTablet tablet = new LakeTablet(tabletId);
+        tablet.setVectorIndexBuiltVersion(9L);
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        Assertions.assertEquals(9L, scheduler.getBuiltVersion(tabletId));
+    }
+
+    @Test
+    public void testGetBuiltVersionReturnsNullWhenZero() {
+        long tabletId = 5002L;
+        LakeTablet tablet = new LakeTablet(tabletId);
+        // builtVersion stays 0 — should map to null (publish path uses null as "no entry")
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        Assertions.assertNull(scheduler.getBuiltVersion(tabletId));
+    }
+
+    @Test
+    public void testGetBuiltVersionReturnsNullWhenTabletMissing() {
+        // No expectations: TabletInvertedIndex/metastore mocks return null,
+        // findLakeTablet returns null, getBuiltVersion returns null.
+        Assertions.assertNull(scheduler.getBuiltVersion(9999L));
+    }
+
+    // ========== cleanupStaleEntries tests ==========
+
+    @Test
+    public void testCleanupStaleEntriesRemovesExpiredCooldownAndOrphanPreferred() throws Exception {
+        // Stale cooldown (already expired) + preferred node not referenced anywhere — both must go.
+        Map<Long, Long> cooldownUntil = getMap("cooldownUntil");
+        Map<Long, ComputeNode> preferredNodes = getMap("preferredNodes");
+
+        cooldownUntil.put(6001L, System.currentTimeMillis() - 1000);
+        long futureTs = System.currentTimeMillis() + 60_000;
+        cooldownUntil.put(6002L, futureTs);
+
+        ComputeNode orphanNode = Mockito.mock(ComputeNode.class);
+        ComputeNode keepNode = Mockito.mock(ComputeNode.class);
+        preferredNodes.put(7001L, orphanNode);
+        preferredNodes.put(7002L, keepNode);
+        scheduler.addPendingTablet(7002L, 1L); // 7002 still pending → keep
+
+        scheduler.cleanupStaleEntries();
+
+        Assertions.assertFalse(cooldownUntil.containsKey(6001L), "expired cooldown removed");
+        Assertions.assertEquals(futureTs, cooldownUntil.get(6002L), "future cooldown kept");
+        Assertions.assertFalse(preferredNodes.containsKey(7001L), "orphan preferred removed");
+        Assertions.assertTrue(preferredNodes.containsKey(7002L), "preferred for pending tablet kept");
+    }
+
+    @SuppressWarnings("unchecked")
+    private <V> Map<Long, V> getMap(String fieldName) throws Exception {
+        java.lang.reflect.Field f = VectorIndexBuildScheduler.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        return (Map<Long, V>) f.get(scheduler);
+    }
+
+    // ========== scheduleFromPending — full-path / branch tests ==========
+
+    @Test
+    public void testScheduleFromPendingDispatchesTask(@Mocked BrpcProxy brpcProxy,
+                                                      @Mocked LakeService lakeService) throws Exception {
+        long tabletId = 8001L;
+        long version = 12L;
+        LakeTablet tablet = new LakeTablet(tabletId);
+        scheduler.addPendingTablet(tabletId, version);
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        ComputeNode node = Mockito.mock(ComputeNode.class);
+        Mockito.when(node.getId()).thenReturn(101L);
+        Mockito.when(node.getHost()).thenReturn("127.0.0.1");
+        Mockito.when(node.getBrpcPort()).thenReturn(8060);
+        ComputeResource resource = Mockito.mock(ComputeResource.class);
+        new Expectations() {
+            {
+                globalStateMgr.getWarehouseMgr();
+                result = warehouseManager;
+                minTimes = 0;
+                warehouseManager.getVectorIndexBuildComputeResource(anyLong);
+                result = resource;
+                warehouseManager.getComputeNodeAssignedToTablet(resource, tabletId);
+                result = node;
+                BrpcProxy.getLakeService("127.0.0.1", 8060);
+                result = lakeService;
+                lakeService.buildVectorIndex((BuildVectorIndexRequest) any);
+                result = new CompletableFuture<BuildVectorIndexResponse>(); // pending future, task remains running
+            }
+        };
+
+        scheduler.scheduleFromPending();
+
+        Assertions.assertTrue(getPendingTablets().isEmpty(), "tablet moved out of pending");
+        Assertions.assertTrue(getRunningTasks().containsKey(tabletId), "task added to runningTasks");
+    }
+
+    @Test
+    public void testScheduleFromPendingPrefersAliveNode(@Mocked BrpcProxy brpcProxy,
+                                                        @Mocked LakeService lakeService) throws Exception {
+        long tabletId = 8002L;
+        long version = 5L;
+        LakeTablet tablet = new LakeTablet(tabletId);
+        scheduler.addPendingTablet(tabletId, version);
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        ComputeNode preferred = Mockito.mock(ComputeNode.class);
+        Mockito.when(preferred.isAlive()).thenReturn(true);
+        Mockito.when(preferred.getId()).thenReturn(202L);
+        Mockito.when(preferred.getHost()).thenReturn("10.0.0.5");
+        Mockito.when(preferred.getBrpcPort()).thenReturn(8060);
+        getMap("preferredNodes").put(tabletId, preferred);
+
+        new Expectations() {
+            {
+                BrpcProxy.getLakeService("10.0.0.5", 8060);
+                result = lakeService;
+                lakeService.buildVectorIndex((BuildVectorIndexRequest) any);
+                result = new CompletableFuture<BuildVectorIndexResponse>();
+                // pickComputeNode must NOT be invoked — preferred node is alive.
+                warehouseManager.getComputeNodeAssignedToTablet((ComputeResource) any, anyLong);
+                times = 0;
+            }
+        };
+
+        scheduler.scheduleFromPending();
+
+        Assertions.assertTrue(getRunningTasks().containsKey(tabletId));
+        Assertions.assertFalse(getMap("preferredNodes").containsKey(tabletId), "preferred consumed");
+    }
+
+    @Test
+    public void testScheduleFromPendingSkipsTabletInActiveCooldown() throws Exception {
+        long tabletId = 8003L;
+        scheduler.addPendingTablet(tabletId, 5L);
+        long futureTs = System.currentTimeMillis() + 60_000;
+        getMap("cooldownUntil").put(tabletId, futureTs);
+
+        scheduler.scheduleFromPending();
+
+        Assertions.assertEquals(5L, getPendingTablets().get(tabletId), "still pending");
+        Assertions.assertTrue(getRunningTasks().isEmpty(), "no task dispatched");
+    }
+
+    @Test
+    public void testScheduleFromPendingClearsExpiredCooldownAndProceeds() throws Exception {
+        long tabletId = 8004L;
+        scheduler.addPendingTablet(tabletId, 5L);
+        getMap("cooldownUntil").put(tabletId, System.currentTimeMillis() - 1000);
+        // No findLakeTablet mock → tablet null → orphan-removed; this drives the "expired cooldown
+        // is cleared, then proceed with normal logic" path which currently sees tablet missing.
+
+        scheduler.scheduleFromPending();
+
+        Assertions.assertFalse(getPendingTablets().containsKey(tabletId), "orphan tablet removed");
+        Assertions.assertFalse(getMap("cooldownUntil").containsKey(tabletId), "expired cooldown cleared");
+    }
+
+    // ========== runAfterCatalogReady tests ==========
+
+    @Test
+    public void testRunAfterCatalogReadyOnFollowerResetsRecoveryFlag() throws Exception {
+        // Force the leader check to return false; daemon should bail out and reset recoveryScanDone.
+        java.lang.reflect.Field f = VectorIndexBuildScheduler.class.getDeclaredField("recoveryScanDone");
+        f.setAccessible(true);
+        f.setBoolean(scheduler, true);
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return false;
+            }
+        };
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+            }
+        };
+
+        java.lang.reflect.Method m =
+                VectorIndexBuildScheduler.class.getDeclaredMethod("runAfterCatalogReady");
+        m.setAccessible(true);
+        m.invoke(scheduler);
+
+        Assertions.assertFalse(f.getBoolean(scheduler), "recoveryScanDone reset on non-leader");
+    }
+
+    @Test
+    public void testRunAfterCatalogReadyOnLeaderRunsRecoveryThenSkips() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+            @Mock
+            public LocalMetastore getLocalMetastore() {
+                return localMetastore;
+            }
+        };
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                localMetastore.getDbIds();
+                result = Collections.emptyList();
+            }
+        };
+
+        java.lang.reflect.Method m =
+                VectorIndexBuildScheduler.class.getDeclaredMethod("runAfterCatalogReady");
+        m.setAccessible(true);
+
+        java.lang.reflect.Field f = VectorIndexBuildScheduler.class.getDeclaredField("recoveryScanDone");
+        f.setAccessible(true);
+
+        m.invoke(scheduler);
+        Assertions.assertTrue(f.getBoolean(scheduler), "recoveryScan ran on first leader tick");
+
+        // Second invocation must NOT re-scan; flag stays true.
+        m.invoke(scheduler);
+        Assertions.assertTrue(f.getBoolean(scheduler));
+    }
+
+    // ========== checkRunningTasks — partial-build branch ==========
+
+    @Test
+    public void testCheckRunningTasksPartialReEnqueues() {
+        long tabletId = 9101L;
+        LakeTablet tablet = new LakeTablet(tabletId);
+        tablet.setVectorIndexBuiltVersion(2L);
+
+        BuildVectorIndexResponse response = new BuildVectorIndexResponse();
+        response.newBuiltVersion = 5L; // partial — target was 10
+        CompletableFuture<BuildVectorIndexResponse> future = CompletableFuture.completedFuture(response);
+        VectorIndexBuildTask task = createTaskWithFuture(tabletId, 10L, future);
+        getRunningTasks().put(tabletId, task);
+
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        scheduler.checkRunningTasks();
+
+        Assertions.assertTrue(getRunningTasks().isEmpty(), "task removed");
+        Assertions.assertEquals(5L, tablet.getVectorIndexBuiltVersion(), "builtVersion updated to partial");
+        Assertions.assertEquals(10L, getPendingTablets().get(tabletId), "tablet re-enqueued for next round");
+    }
+
+    @Test
+    public void testCheckRunningTasksDedupRejection() {
+        long tabletId = 9102L;
+        BuildVectorIndexResponse response = new BuildVectorIndexResponse();
+        com.starrocks.proto.StatusPB status = new com.starrocks.proto.StatusPB();
+        status.statusCode = com.starrocks.thrift.TStatusCode.RESOURCE_BUSY.getValue();
+        status.errorMsgs = Lists.newArrayList("busy");
+        response.status = status;
+        CompletableFuture<BuildVectorIndexResponse> future = CompletableFuture.completedFuture(response);
+        VectorIndexBuildTask task = createTaskWithFuture(tabletId, 7L, future);
+        getRunningTasks().put(tabletId, task);
+
+        scheduler.checkRunningTasks();
+
+        Assertions.assertTrue(getRunningTasks().isEmpty(), "task removed");
+        Assertions.assertEquals(7L, getPendingTablets().get(tabletId), "tablet re-enqueued (cooldown)");
+    }
+
+    @Test
+    public void testScheduleFromPendingStopsAtMaxConcurrent() {
+        // Pre-fill runningTasks to MAX_CONCURRENT_TASKS so the loop breaks immediately.
+        for (int i = 0; i < VectorIndexBuildScheduler.MAX_CONCURRENT_TASKS; i++) {
+            ComputeNode node = Mockito.mock(ComputeNode.class);
+            getRunningTasks().put((long) (10_000 + i),
+                    createTaskWithStartTime(10_000 + i, 1L, System.currentTimeMillis()));
+        }
+        scheduler.addPendingTablet(9001L, 5L);
+
+        scheduler.scheduleFromPending();
+
+        // Pending tablet must NOT be promoted to running because we're at the cap.
+        Assertions.assertEquals(5L, getPendingTablets().get(9001L));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/vector/VectorIndexBuildTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/vector/VectorIndexBuildTaskTest.java
@@ -1,0 +1,141 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+package com.starrocks.lake.vector;
+
+import com.starrocks.proto.BuildVectorIndexRequest;
+import com.starrocks.proto.BuildVectorIndexResponse;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TStatusCode;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+public class VectorIndexBuildTaskTest {
+
+    private static ComputeNode mockNode() {
+        ComputeNode node = Mockito.mock(ComputeNode.class);
+        Mockito.when(node.getHost()).thenReturn("127.0.0.1");
+        Mockito.when(node.getBrpcPort()).thenReturn(8060);
+        return node;
+    }
+
+    private static void injectFuture(VectorIndexBuildTask task, Future<BuildVectorIndexResponse> future)
+            throws Exception {
+        Field f = VectorIndexBuildTask.class.getDeclaredField("future");
+        f.setAccessible(true);
+        f.set(task, future);
+    }
+
+    private static BuildVectorIndexResponse makeResponse(Integer statusCode) {
+        BuildVectorIndexResponse response = new BuildVectorIndexResponse();
+        if (statusCode != null) {
+            StatusPB status = new StatusPB();
+            status.statusCode = statusCode;
+            status.errorMsgs = Collections.singletonList("err");
+            response.status = status;
+        }
+        return response;
+    }
+
+    @Test
+    public void testConstructorAndGetters() {
+        ComputeNode node = mockNode();
+        long before = System.currentTimeMillis();
+        VectorIndexBuildTask task = new VectorIndexBuildTask(node, 1001L, 7L, 3L);
+        long after = System.currentTimeMillis();
+
+        Assertions.assertEquals(1001L, task.getTabletId());
+        Assertions.assertEquals(7L, task.getVersion());
+        Assertions.assertSame(node, task.getNode());
+        Assertions.assertTrue(task.getStartTimeMs() >= before && task.getStartTimeMs() <= after);
+    }
+
+    @Test
+    public void testIsDoneBeforeSend() {
+        VectorIndexBuildTask task = new VectorIndexBuildTask(mockNode(), 1L, 1L, 0L);
+        Assertions.assertFalse(task.isDone());
+        Assertions.assertFalse(task.isAlreadyBuilding());
+    }
+
+    @Test
+    public void testSendRequestDispatchesToLakeService(@Mocked BrpcProxy brpcProxy,
+                                                      @Mocked LakeService lakeService) throws Exception {
+        CompletableFuture<BuildVectorIndexResponse> future =
+                CompletableFuture.completedFuture(makeResponse(0));
+        new Expectations() {
+            {
+                BrpcProxy.getLakeService("127.0.0.1", 8060);
+                result = lakeService;
+                lakeService.buildVectorIndex((BuildVectorIndexRequest) any);
+                result = future;
+            }
+        };
+
+        VectorIndexBuildTask task = new VectorIndexBuildTask(mockNode(), 2002L, 9L, 4L);
+        task.sendRequest();
+
+        Assertions.assertTrue(task.isDone());
+        BuildVectorIndexResponse response = task.getResponse();
+        Assertions.assertEquals(0, response.status.statusCode);
+    }
+
+    @Test
+    public void testGetResponseThrowsOnNonZeroStatus() throws Exception {
+        VectorIndexBuildTask task = new VectorIndexBuildTask(mockNode(), 3L, 3L, 0L);
+        injectFuture(task, CompletableFuture.completedFuture(makeResponse(1)));
+
+        Assertions.assertTrue(task.isDone());
+        RuntimeException ex = Assertions.assertThrows(RuntimeException.class, task::getResponse);
+        Assertions.assertTrue(ex.getMessage().contains("Build vector index failed"));
+    }
+
+    @Test
+    public void testIsAlreadyBuildingDetectsResourceBusy() throws Exception {
+        VectorIndexBuildTask task = new VectorIndexBuildTask(mockNode(), 4L, 5L, 0L);
+        injectFuture(task,
+                CompletableFuture.completedFuture(makeResponse(TStatusCode.RESOURCE_BUSY.getValue())));
+
+        Assertions.assertTrue(task.isAlreadyBuilding());
+    }
+
+    @Test
+    public void testIsAlreadyBuildingFalseForOkAndOtherErrors() throws Exception {
+        VectorIndexBuildTask ok = new VectorIndexBuildTask(mockNode(), 5L, 5L, 0L);
+        injectFuture(ok, CompletableFuture.completedFuture(makeResponse(0)));
+        Assertions.assertFalse(ok.isAlreadyBuilding());
+
+        VectorIndexBuildTask other = new VectorIndexBuildTask(mockNode(), 6L, 5L, 0L);
+        injectFuture(other, CompletableFuture.completedFuture(makeResponse(1)));
+        Assertions.assertFalse(other.isAlreadyBuilding());
+    }
+
+    @Test
+    public void testIsAlreadyBuildingFalseWhenFutureThrows() throws Exception {
+        VectorIndexBuildTask task = new VectorIndexBuildTask(mockNode(), 7L, 5L, 0L);
+        CompletableFuture<BuildVectorIndexResponse> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("rpc blew up"));
+        injectFuture(task, failed);
+
+        // Future is done (completed exceptionally) but get() throws — should return false, not propagate.
+        Assertions.assertTrue(task.isDone());
+        Assertions.assertFalse(task.isAlreadyBuilding());
+    }
+
+    @Test
+    public void testIsAlreadyBuildingFalseWhenFutureNotDone() throws Exception {
+        VectorIndexBuildTask task = new VectorIndexBuildTask(mockNode(), 8L, 5L, 0L);
+        injectFuture(task, new CompletableFuture<>()); // never completes
+        Assertions.assertFalse(task.isDone());
+        Assertions.assertFalse(task.isAlreadyBuilding());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -1232,7 +1232,13 @@ public class PseudoBackend {
 
         @Override
         public Future<BuildVectorIndexResponse> buildVectorIndex(BuildVectorIndexRequest request) {
-            return CompletableFuture.completedFuture(null);
+            // Return a non-null OK response so VectorIndexBuildScheduler treats this as
+            // a successful build instead of looping/re-enqueuing on null and spamming logs.
+            BuildVectorIndexResponse response = new BuildVectorIndexResponse();
+            StatusPB pStatus = new StatusPB();
+            pStatus.statusCode = 0;
+            response.status = pStatus;
+            return CompletableFuture.completedFuture(response);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -31,6 +31,8 @@ import com.starrocks.proto.AbortTxnRequest;
 import com.starrocks.proto.AbortTxnResponse;
 import com.starrocks.proto.AggregateCompactRequest;
 import com.starrocks.proto.AggregatePublishVersionRequest;
+import com.starrocks.proto.BuildVectorIndexRequest;
+import com.starrocks.proto.BuildVectorIndexResponse;
 import com.starrocks.proto.CompactRequest;
 import com.starrocks.proto.CompactResponse;
 import com.starrocks.proto.DeleteDataRequest;
@@ -1225,6 +1227,11 @@ public class PseudoBackend {
 
         @Override
         public Future<RepairTabletMetadataResponse> repairTabletMetadata(RepairTabletMetadataRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<BuildVectorIndexResponse> buildVectorIndex(BuildVectorIndexRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
@@ -146,7 +146,7 @@ public class LakeAggregatePublishTest {
             warehouseMgrField.set(GlobalStateMgr.getCurrentState(), mockManager);
 
             Assertions.assertThrows(NoAliveBackendException.class, () -> Utils.aggregatePublishVersion(tablets, null, 1, 2, null,
-                        null, WarehouseManager.DEFAULT_RESOURCE, null));
+                        null, WarehouseManager.DEFAULT_RESOURCE, null, null));
 
             when(mockManager.getAliveComputeNodes(any())).thenReturn(null);
             LakeAggregator lakeAggregator = new LakeAggregator();

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -736,7 +736,13 @@ public class MockedBackend {
 
         @Override
         public Future<BuildVectorIndexResponse> buildVectorIndex(BuildVectorIndexRequest request) {
-            return CompletableFuture.completedFuture(null);
+            // Return a non-null OK response so VectorIndexBuildScheduler treats this as
+            // a successful build instead of looping/re-enqueuing on null and spamming logs.
+            BuildVectorIndexResponse response = new BuildVectorIndexResponse();
+            StatusPB pStatus = new StatusPB();
+            pStatus.statusCode = 0;
+            response.status = pStatus;
+            return CompletableFuture.completedFuture(response);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -26,6 +26,8 @@ import com.starrocks.proto.AbortTxnRequest;
 import com.starrocks.proto.AbortTxnResponse;
 import com.starrocks.proto.AggregateCompactRequest;
 import com.starrocks.proto.AggregatePublishVersionRequest;
+import com.starrocks.proto.BuildVectorIndexRequest;
+import com.starrocks.proto.BuildVectorIndexResponse;
 import com.starrocks.proto.CompactRequest;
 import com.starrocks.proto.CompactResponse;
 import com.starrocks.proto.DeleteDataRequest;
@@ -729,6 +731,11 @@ public class MockedBackend {
 
         @Override
         public Future<RepairTabletMetadataResponse> repairTabletMetadata(RepairTabletMetadataRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<BuildVectorIndexResponse> buildVectorIndex(BuildVectorIndexRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }


### PR DESCRIPTION
## Why I'm doing:

Synchronous vector index build blocks data ingestion — for large datasets, building .vi files inline during segment write significantly increases write latency. Async mode decouples index building from data loading to improve ingestion throughput.

## What I'm doing:

Part 2 of 2: FE scheduler and integration for async vector index build in shared-data mode.
Depends on #52458 (proto definitions are duplicated here for independent compilation; merge conflict on proto files expected and trivial to resolve).

- FE scheduler (`VectorIndexBuildScheduler`): queue-driven daemon that dispatches async vector index build tasks to CNs, with recovery scan after leader switch, timeout handling, and multi-round batch scheduling
- FE publish integration: `PublishVersionDaemon` passes `builtVersion` watermark to BE and collects `VectorIndexBuildInfoPB` from publish responses to enqueue new build tasks
- `LakeTablet.vectorIndexBuiltVersion`: checkpoint-persisted watermark tracking build progress per tablet
- `index_build_mode` index property: `sync` (default) or `async`
- Warehouse-aware CN routing: `lake_vector_index_build_warehouse` FE config (mutable via `ADMIN SET FRONTEND CONFIG`)
- RPC interface: `LakeService.buildVectorIndex` Java-side binding

Fixes https://github.com/StarRocks/starrocks/issues/72087


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

