### PR TITLE
[Enhancement] Support vector index read in shared-data mode

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -44,6 +44,7 @@
 #include "runtime/starrocks_metrics.h"
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate_rewriter.h"
+#include "storage/index/vector/vector_search_option.h"
 #include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
 #include "storage/predicate_parser.h"
@@ -82,6 +83,17 @@ Status LakeDataSource::open(RuntimeState* state) {
     const TLakeScanNode& thrift_lake_scan_node = _provider->_t_lake_scan_node;
     TupleDescriptor* tuple_desc = state->desc_tbl().get_tuple_descriptor(thrift_lake_scan_node.tuple_id);
     _slots = &tuple_desc->slots();
+
+    if (thrift_lake_scan_node.__isset.vector_search_options) {
+        const auto& vector_search_options = thrift_lake_scan_node.vector_search_options;
+        _use_vector_index = vector_search_options.enable_use_ann;
+        if (_use_vector_index) {
+            _use_ivfpq = vector_search_options.use_ivfpq;
+            _vector_distance_column_name = vector_search_options.vector_distance_column_name;
+            _vector_slot_id = vector_search_options.vector_slot_id;
+            _params.vector_search_option = std::make_shared<VectorSearchOption>();
+        }
+    }
 
     _runtime_profile->add_info_string("Table", tuple_desc->table_desc()->name());
     if (thrift_lake_scan_node.__isset.rollup_name) {
@@ -276,7 +288,14 @@ Status LakeDataSource::init_scanner_columns(std::vector<uint32_t>& scanner_colum
                                             std::vector<uint32_t>& reader_columns) {
     for (auto slot : *_slots) {
         DCHECK(slot->is_materialized());
-        int32_t index = _tablet_schema->field_index(slot->col_name());
+        int32_t index;
+        if (_use_vector_index && !_use_ivfpq && slot->id() == _vector_slot_id) {
+            index = _tablet_schema->num_columns();
+            _params.vector_search_option->vector_column_id = index;
+            _params.vector_search_option->vector_slot_id = slot->id();
+        } else {
+            index = _tablet_schema->field_index(slot->col_name());
+        }
         if (index < 0) {
             std::stringstream ss;
             ss << "invalid field name: " << slot->col_name();
@@ -353,6 +372,24 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     }
     if (thrift_lake_scan_node.__isset.enable_gin_filter) {
         _params.enable_gin_filter = thrift_lake_scan_node.enable_gin_filter;
+    }
+
+    _params.use_vector_index = _use_vector_index;
+    if (_use_vector_index) {
+        const auto& vector_options = thrift_lake_scan_node.vector_search_options;
+        _params.vector_search_option->vector_distance_column_name = _vector_distance_column_name;
+        _params.vector_search_option->k = vector_options.vector_limit_k;
+        for (const std::string& str : vector_options.query_vector) {
+            _params.vector_search_option->query_vector.push_back(std::stof(str));
+        }
+        if (_runtime_state->query_options().__isset.ann_params) {
+            _params.vector_search_option->query_params = _runtime_state->query_options().ann_params;
+        }
+        _params.vector_search_option->vector_range = vector_options.vector_range;
+        _params.vector_search_option->result_order = vector_options.result_order;
+        _params.vector_search_option->use_ivfpq = _use_ivfpq;
+        _params.vector_search_option->k_factor = _runtime_state->query_options().k_factor;
+        _params.vector_search_option->pq_refine_factor = _runtime_state->query_options().pq_refine_factor;
     }
 
     ASSIGN_OR_RETURN(auto pred_tree, _conjuncts_manager->get_predicate_tree(parser, _predicate_free_pool));

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -77,6 +77,7 @@ public:
     Status parse_runtime_filters(RuntimeState* state) override { return Status::OK(); }
 
     TabletSchemaCSPtr TEST_tablet_schema() const { return _tablet_schema; }
+    const TabletReaderParams& TEST_params() const { return _params; }
 
 private:
     Status get_tablet(const TInternalScanRange& scan_range);

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -132,6 +132,12 @@ private:
 
     std::vector<ColumnAccessPathPtr> _column_access_paths;
 
+    // Vector index search
+    bool _use_vector_index = false;
+    bool _use_ivfpq = false;
+    std::string _vector_distance_column_name;
+    SlotId _vector_slot_id = 0;
+
     // The following are profile meatures
     int64_t _num_rows_read = 0;
     int64_t _raw_rows_read = 0;

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -139,7 +139,7 @@ private:
     std::string _vector_distance_column_name;
     SlotId _vector_slot_id = 0;
 
-    // The following are profile meatures
+    // The following are profile measures
     int64_t _num_rows_read = 0;
     int64_t _raw_rows_read = 0;
     int64_t _bytes_read = 0;

--- a/be/src/storage/index/vector/tenann/tenann_index_utils.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_utils.cpp
@@ -78,7 +78,8 @@ StatusOr<tenann::IndexMeta> get_vector_meta(const std::shared_ptr<TabletIndex>& 
     meta.SetIndexType(index_type);
 
     if (meta.index_type() == tenann::IndexType::kFaissIvfPq) {
-        meta.index_params()[starrocks::index::vector::NLIST] = int(4 * sqrt(starrocks::index::vector::nb_));
+        CRITICAL_CHECK_AND_GET(tablet_index, index_properties, nlist, param_value)
+        meta.index_params()[starrocks::index::vector::NLIST] = std::atoi(param_value.c_str());
 
         CRITICAL_CHECK_AND_GET(tablet_index, index_properties, nbits, param_value)
         meta.index_params()[starrocks::index::vector::NBITS] = std::atoi(param_value.c_str());

--- a/be/src/storage/index/vector/tenann_index_reader.cpp
+++ b/be/src/storage/index/vector/tenann_index_reader.cpp
@@ -37,35 +37,67 @@
 
 #include "common/config_vector_index_fwd.h"
 #include "common/status.h"
+#include "common/statusor.h"
+#include "fs/fs.h"
+#include "storage/index/vector/vector_index_file_reader.h"
 #include "tenann/common/error.h"
 #include "tenann/common/seq_view.h"
 #include "tenann/searcher/id_filter.h"
 
 namespace starrocks {
 
+namespace {
+
+void apply_index_reader_cache_options(tenann::IndexMeta* meta_copy) {
+    if (meta_copy->index_type() == tenann::IndexType::kFaissIvfPq) {
+        if (config::enable_vector_index_block_cache) {
+            meta_copy->index_reader_options()[tenann::IndexReaderOptions::cache_index_file_key] = false;
+            meta_copy->index_reader_options()[tenann::IndexReaderOptions::cache_index_block_key] = true;
+        } else {
+            meta_copy->index_reader_options()[tenann::IndexReaderOptions::cache_index_file_key] = true;
+            meta_copy->index_reader_options()[tenann::IndexReaderOptions::cache_index_block_key] = false;
+        }
+    } else {
+        meta_copy->index_reader_options()[tenann::IndexReaderOptions::cache_index_file_key] = true;
+    }
+}
+
+} // namespace
+
 Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const std::string& index_path) {
     try {
         auto meta_copy = meta;
-        if (meta.index_type() == tenann::IndexType::kFaissIvfPq) {
-            if (config::enable_vector_index_block_cache) {
-                // cache index blocks
-                meta_copy.index_reader_options()[tenann::IndexReaderOptions::cache_index_file_key] = false;
-                meta_copy.index_reader_options()[tenann::IndexReaderOptions::cache_index_block_key] = true;
-            } else {
-                // cache index file
-                meta_copy.index_reader_options()[tenann::IndexReaderOptions::cache_index_file_key] = true;
-                meta_copy.index_reader_options()[tenann::IndexReaderOptions::cache_index_block_key] = false;
-            }
-        } else {
-            // cache index file
-            meta_copy.index_reader_options()[tenann::IndexReaderOptions::cache_index_file_key] = true;
-        }
+        apply_index_reader_cache_options(&meta_copy);
 
         tenann::IndexCache::GetGlobalInstance()->SetCapacity(config::vector_query_cache_capacity);
 
         _searcher = tenann::AnnSearcherFactory::CreateSearcherFromMeta(meta_copy);
         _searcher->index_reader()->SetIndexCache(tenann::IndexCache::GetGlobalInstance());
         _searcher->ReadIndex(index_path);
+
+        DCHECK(_searcher->is_index_loaded());
+    } catch (tenann::Error& e) {
+        return Status::InternalError(e.what());
+    }
+    return Status::OK();
+}
+
+Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs) {
+    if (fs == nullptr) {
+        return init_searcher(meta, index_path);
+    }
+    try {
+        auto meta_copy = meta;
+        apply_index_reader_cache_options(&meta_copy);
+
+        tenann::IndexCache::GetGlobalInstance()->SetCapacity(config::vector_query_cache_capacity);
+
+        _searcher = tenann::AnnSearcherFactory::CreateSearcherFromMeta(meta_copy);
+        _searcher->index_reader()->SetIndexCache(tenann::IndexCache::GetGlobalInstance());
+        ASSIGN_OR_RETURN(auto index_raf, fs->new_random_access_file(index_path));
+        ASSIGN_OR_RETURN(auto file_size, index_raf->get_size());
+        auto file_reader = std::make_shared<VectorIndexFileReader>(std::move(index_raf), file_size);
+        _searcher->ReadIndex(file_reader);
 
         DCHECK(_searcher->is_index_loaded());
     } catch (tenann::Error& e) {

--- a/be/src/storage/index/vector/tenann_index_reader.h
+++ b/be/src/storage/index/vector/tenann_index_reader.h
@@ -35,6 +35,8 @@ public:
 
     Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path) override;
 
+    Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs) override;
+
     Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,
                   tenann::IdFilter* id_filter = nullptr) override;
     Status range_search(tenann::PrimitiveSeqView query_vector, int k, std::vector<int64_t>* result_ids,

--- a/be/src/storage/index/vector/vector_index_file_reader.h
+++ b/be/src/storage/index/vector/vector_index_file_reader.h
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef WITH_TENANN
+
+#include <memory>
+#include <string>
+
+#include "fs/fs.h"
+#include "tenann/store/index_file_reader.h"
+
+namespace starrocks {
+
+// Bridge StarRocks RandomAccessFile to TenANN IndexFileReader interface,
+// enabling TenANN to read vector index files from remote storage (S3/HDFS/OSS).
+class VectorIndexFileReader : public tenann::IndexFileReader {
+public:
+    VectorIndexFileReader(std::unique_ptr<RandomAccessFile> file, int64_t file_size)
+            : _file(std::move(file)), _file_size(file_size), _filename(_file->filename()) {}
+
+    ~VectorIndexFileReader() override = default;
+
+    int64_t Read(void* data, int64_t count) override {
+        auto st = _file->read_at_fully(_position, data, count);
+        if (st.ok()) {
+            _position += count;
+            return count;
+        }
+        return -1;
+    }
+
+    int64_t ReadAt(int64_t offset, void* data, int64_t count) override {
+        return _file->read_at_fully(offset, data, count).ok() ? count : -1;
+    }
+
+    void Seek(int64_t pos) override { _position = pos; }
+
+    int64_t GetSize() override { return _file_size; }
+
+    const std::string& filename() const override { return _filename; }
+
+private:
+    std::unique_ptr<RandomAccessFile> _file;
+    int64_t _file_size = 0;
+    int64_t _position = 0;
+    std::string _filename;
+};
+
+} // namespace starrocks
+
+#endif

--- a/be/src/storage/index/vector/vector_index_reader.h
+++ b/be/src/storage/index/vector/vector_index_reader.h
@@ -43,6 +43,8 @@
 
 namespace starrocks {
 
+class FileSystem;
+
 class VectorIndexReader {
 public:
     VectorIndexReader() = default;
@@ -50,6 +52,10 @@ public:
 
 #ifdef WITH_TENANN
     virtual Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path) = 0;
+
+    virtual Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs) {
+        return init_searcher(meta, index_path);
+    }
 
     virtual Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,
                           tenann::IdFilter* id_filter = nullptr) = 0;

--- a/be/src/storage/index/vector/vector_index_reader_factory.cpp
+++ b/be/src/storage/index/vector/vector_index_reader_factory.cpp
@@ -22,28 +22,25 @@
 
 namespace starrocks {
 
-static Status index_path_check_exists(const std::string& index_path, FileSystem* fs) {
-    if (fs != nullptr) {
-        auto st = fs->path_exists(index_path);
-        if (st.is_not_found()) {
-            return Status::NotFound(fmt::format("index path {} not found", index_path));
-        }
-        return st;
-    }
-    if (!fs::path_exist(index_path)) {
-        return Status::NotFound(fmt::format("index path {} not found", index_path));
-    }
-    return Status::OK();
-}
-
 static Status create_from_file_impl(const std::string& index_path,
                                     const std::shared_ptr<tenann::IndexMeta>& /*index_meta*/,
                                     std::shared_ptr<VectorIndexReader>* vector_index_reader, FileSystem* fs) {
-    RETURN_IF_ERROR(index_path_check_exists(index_path, fs));
     std::unique_ptr<RandomAccessFile> index_file;
     if (fs != nullptr) {
-        ASSIGN_OR_RETURN(index_file, fs->new_random_access_file(index_path));
+        // Remote FS: let new_random_access_file() be the single source of truth for
+        // NotFound. Doing a separate path_exists() here would cost an extra round-trip.
+        auto file_or = fs->new_random_access_file(index_path);
+        if (!file_or.ok()) {
+            if (file_or.status().is_not_found()) {
+                return Status::NotFound(fmt::format("index path {} not found", index_path));
+            }
+            return file_or.status();
+        }
+        index_file = std::move(file_or).value();
     } else {
+        if (!fs::path_exist(index_path)) {
+            return Status::NotFound(fmt::format("index path {} not found", index_path));
+        }
         ASSIGN_OR_RETURN(index_file, fs::new_random_access_file(index_path));
     }
     ASSIGN_OR_RETURN(auto file_size, index_file->get_size());

--- a/be/src/storage/index/vector/vector_index_reader_factory.cpp
+++ b/be/src/storage/index/vector/vector_index_reader_factory.cpp
@@ -15,19 +15,38 @@
 #ifdef WITH_TENANN
 #include "storage/index/vector/vector_index_reader_factory.h"
 
+#include "fs/fs.h"
 #include "storage/index/vector/empty_index_reader.h"
 #include "storage/index/vector/tenann_index_reader.h"
 #include "storage/index/vector/vector_index_reader.h"
 
 namespace starrocks {
-Status VectorIndexReaderFactory::create_from_file(const std::string& index_path,
-                                                  const std::shared_ptr<tenann::IndexMeta>& index_meta,
-                                                  std::shared_ptr<VectorIndexReader>* vector_index_reader) {
+
+static Status index_path_check_exists(const std::string& index_path, FileSystem* fs) {
+    if (fs != nullptr) {
+        auto st = fs->path_exists(index_path);
+        if (st.is_not_found()) {
+            return Status::NotFound(fmt::format("index path {} not found", index_path));
+        }
+        return st;
+    }
     if (!fs::path_exist(index_path)) {
         return Status::NotFound(fmt::format("index path {} not found", index_path));
     }
-    ASSIGN_OR_RETURN(auto index_file, fs::new_random_access_file(index_path))
-    ASSIGN_OR_RETURN(auto file_size, index_file->get_size())
+    return Status::OK();
+}
+
+static Status create_from_file_impl(const std::string& index_path,
+                                    const std::shared_ptr<tenann::IndexMeta>& /*index_meta*/,
+                                    std::shared_ptr<VectorIndexReader>* vector_index_reader, FileSystem* fs) {
+    RETURN_IF_ERROR(index_path_check_exists(index_path, fs));
+    std::unique_ptr<RandomAccessFile> index_file;
+    if (fs != nullptr) {
+        ASSIGN_OR_RETURN(index_file, fs->new_random_access_file(index_path));
+    } else {
+        ASSIGN_OR_RETURN(index_file, fs::new_random_access_file(index_path));
+    }
+    ASSIGN_OR_RETURN(auto file_size, index_file->get_size());
 
     if (file_size == IndexDescriptor::mark_word_len) {
         auto buf = std::make_unique<unsigned char[]>(file_size);
@@ -40,6 +59,19 @@ Status VectorIndexReaderFactory::create_from_file(const std::string& index_path,
     }
     (*vector_index_reader) = std::make_shared<TenANNReader>();
     return Status::OK();
+}
+
+Status VectorIndexReaderFactory::create_from_file(const std::string& index_path,
+                                                  const std::shared_ptr<tenann::IndexMeta>& index_meta,
+                                                  std::shared_ptr<VectorIndexReader>* vector_index_reader) {
+    return create_from_file_impl(index_path, index_meta, vector_index_reader, nullptr);
+}
+
+Status VectorIndexReaderFactory::create_from_file(const std::string& index_path,
+                                                  const std::shared_ptr<tenann::IndexMeta>& index_meta,
+                                                  std::shared_ptr<VectorIndexReader>* vector_index_reader,
+                                                  FileSystem* fs) {
+    return create_from_file_impl(index_path, index_meta, vector_index_reader, fs);
 }
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_reader_factory.h
+++ b/be/src/storage/index/vector/vector_index_reader_factory.h
@@ -21,11 +21,16 @@
 
 namespace starrocks {
 
+class FileSystem;
+
 class VectorIndexReaderFactory {
 #ifdef WITH_TENANN
 public:
     static Status create_from_file(const std::string& index_path, const std::shared_ptr<tenann::IndexMeta>& index_meta,
                                    std::shared_ptr<VectorIndexReader>* vector_index_reader);
+
+    static Status create_from_file(const std::string& index_path, const std::shared_ptr<tenann::IndexMeta>& index_meta,
+                                   std::shared_ptr<VectorIndexReader>* vector_index_reader, FileSystem* fs);
 #endif
 };
 

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -160,6 +160,29 @@ inline std::string gen_vector_index_filename(std::string_view segment_filename, 
     return fmt::format("{}_{}.vi", segment_filename, index_id);
 }
 
+// Compute the vector-index file path that sits next to a segment file in shared-data
+// layout: split |segment_path| into directory + basename, compute the .vi filename
+// from the basename, then re-join under the original directory.
+//
+//   "data/000_abcd.dat"  + 0  -> "data/000_abcd_0.vi"
+//   "/foo/bar/seg.dat"   + 5  -> "/foo/bar/seg_5.vi"
+//   "seg.dat"            + 7  -> "seg_7.vi"            (no directory part)
+//   "/seg.dat"           + 1  -> "seg_1.vi"            (root-only directory)
+inline std::string gen_vector_index_path_from_segment_path(std::string_view segment_path, int64_t index_id) {
+    const size_t last_slash = segment_path.find_last_of('/');
+    std::string_view basename =
+            (last_slash == std::string_view::npos) ? segment_path : segment_path.substr(last_slash + 1);
+    std::string vi_filename = gen_vector_index_filename(basename, index_id);
+    if (last_slash == std::string_view::npos) {
+        return vi_filename;
+    }
+    std::string_view dir = segment_path.substr(0, last_slash);
+    if (dir.empty()) {
+        return vi_filename;
+    }
+    return fmt::format("{}/{}", dir, vi_filename);
+}
+
 inline bool is_vector_index(std::string_view file_name) {
     return HasSuffixString(file_name, ".vi");
 }

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -292,6 +292,9 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     seg_options.lake_io_opts = options.lake_io_opts;
     seg_options.asc_hint = options.asc_hint;
     seg_options.column_access_paths = options.column_access_paths;
+    seg_options.use_vector_index = options.use_vector_index;
+    seg_options.vector_search_option = options.vector_search_option;
+    seg_options.belonged_to_cloud_native = true;
     seg_options.has_preaggregation = options.has_preaggregation;
     seg_options.enable_predicate_col_late_materialize = options.enable_predicate_col_late_materialize;
     seg_options.tablet_id = tablet_id();

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -375,6 +375,8 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.short_key_ranges_option = params.short_key_ranges_option;
 
     rs_opts.column_access_paths = params.column_access_paths;
+    rs_opts.use_vector_index = params.use_vector_index;
+    rs_opts.vector_search_option = params.vector_search_option;
     rs_opts.has_preaggregation = true;
     if ((is_compaction(params.reader_type) || params.sorted_by_keys_per_tablet)) {
         rs_opts.has_preaggregation = true;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -50,7 +50,6 @@
 #include "storage/index/vector/vector_index_reader_factory.h"
 #include "storage/index/vector/vector_search_option.h"
 #include "storage/lake/filenames.h"
-#include "storage/lake/join_path.h"
 #include "storage/lake/update_manager.h"
 #include "storage/projection_iterator.h"
 #include "storage/range.h"
@@ -981,20 +980,8 @@ Status SegmentIterator::_init_ann_reader() {
 
     std::string index_path;
     if (_opts.belonged_to_cloud_native) {
-        const std::string& seg_path = _segment->file_name();
-        const size_t last_slash = seg_path.find_last_of('/');
-        std::string seg_basename = (last_slash == std::string::npos) ? seg_path : seg_path.substr(last_slash + 1);
-        std::string vi_filename = lake::gen_vector_index_filename(seg_basename, tablet_index_meta->index_id());
-        if (last_slash == std::string::npos) {
-            index_path = std::move(vi_filename);
-        } else {
-            std::string seg_dir = seg_path.substr(0, last_slash);
-            if (seg_dir.empty()) {
-                index_path = std::move(vi_filename);
-            } else {
-                index_path = lake::join_path(seg_dir, vi_filename);
-            }
-        }
+        index_path = lake::gen_vector_index_path_from_segment_path(_segment->file_name(),
+                                                                   tablet_index_meta->index_id());
     } else {
         index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
                                                              segment_id(), tablet_index_meta->index_id());

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -49,6 +49,8 @@
 #include "storage/index/vector/vector_index_reader.h"
 #include "storage/index/vector/vector_index_reader_factory.h"
 #include "storage/index/vector/vector_search_option.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/join_path.h"
 #include "storage/lake/update_manager.h"
 #include "storage/projection_iterator.h"
 #include "storage/range.h"
@@ -442,7 +444,7 @@ private:
     IndexReadOptions _index_read_options(ColumnId cid) const;
 
     Status _init_reader_from_file(const std::string& index_path, const std::shared_ptr<TabletIndex>& tablet_index_meta,
-                                  const std::map<std::string, std::string>& query_params);
+                                  const std::map<std::string, std::string>& query_params, FileSystem* fs = nullptr);
     StatusOr<size_t> _predicate_evaluate(vector<rowid_t>* rowid);
 
     StatusOr<size_t> _predicate_evaluate_without_late_materialize(vector<rowid_t>* rowid);
@@ -921,17 +923,24 @@ Status SegmentIterator::_init_internal() {
 
 inline Status SegmentIterator::_init_reader_from_file(const std::string& index_path,
                                                       const std::shared_ptr<TabletIndex>& tablet_index_meta,
-                                                      const std::map<std::string, std::string>& query_params) {
+                                                      const std::map<std::string, std::string>& query_params,
+                                                      FileSystem* fs) {
 #ifdef WITH_TENANN
     if (!_vector_index_ctx) {
         return Status::OK();
     }
     ASSIGN_OR_RETURN(auto meta, get_vector_meta(tablet_index_meta, query_params))
     _vector_index_ctx->index_meta = std::make_shared<tenann::IndexMeta>(std::move(meta));
-    RETURN_IF_ERROR(VectorIndexReaderFactory::create_from_file(index_path, _vector_index_ctx->index_meta,
-                                                               &_vector_index_ctx->ann_reader));
-    auto status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), index_path);
-    // means empty ann reader
+    auto create_st = VectorIndexReaderFactory::create_from_file(index_path, _vector_index_ctx->index_meta,
+                                                                &_vector_index_ctx->ann_reader, fs);
+    // .vi file not found — fallback to brute-force scan
+    if (create_st.is_not_found()) {
+        _vector_index_ctx->use_vector_index = false;
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(create_st);
+    auto status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), index_path, fs);
+    // means empty ann reader — fallback to brute-force scan
     if (status.is_not_supported()) {
         _vector_index_ctx->use_vector_index = false;
         return Status::OK();
@@ -970,10 +979,29 @@ Status SegmentIterator::_init_ann_reader() {
 
     auto tablet_index_meta = std::make_shared<TabletIndex>(hit_indexes[0]);
 
-    std::string index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
-                                                                     segment_id(), tablet_index_meta->index_id());
+    std::string index_path;
+    if (_opts.belonged_to_cloud_native) {
+        const std::string& seg_path = _segment->file_name();
+        const size_t last_slash = seg_path.find_last_of('/');
+        std::string seg_basename = (last_slash == std::string::npos) ? seg_path : seg_path.substr(last_slash + 1);
+        std::string vi_filename = lake::gen_vector_index_filename(seg_basename, tablet_index_meta->index_id());
+        if (last_slash == std::string::npos) {
+            index_path = std::move(vi_filename);
+        } else {
+            std::string seg_dir = seg_path.substr(0, last_slash);
+            if (seg_dir.empty()) {
+                index_path = std::move(vi_filename);
+            } else {
+                index_path = lake::join_path(seg_dir, vi_filename);
+            }
+        }
+    } else {
+        index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
+                                                             segment_id(), tablet_index_meta->index_id());
+    }
 
-    return _init_reader_from_file(index_path, tablet_index_meta, _vector_index_ctx->query_params);
+    FileSystem* vi_fs = _opts.belonged_to_cloud_native ? _segment->file_system() : nullptr;
+    return _init_reader_from_file(index_path, tablet_index_meta, _vector_index_ctx->query_params, vi_fs);
 #else
     return Status::OK();
 #endif

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -980,8 +980,8 @@ Status SegmentIterator::_init_ann_reader() {
 
     std::string index_path;
     if (_opts.belonged_to_cloud_native) {
-        index_path = lake::gen_vector_index_path_from_segment_path(_segment->file_name(),
-                                                                   tablet_index_meta->index_id());
+        index_path =
+                lake::gen_vector_index_path_from_segment_path(_segment->file_name(), tablet_index_meta->index_id());
     } else {
         index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
                                                              segment_id(), tablet_index_meta->index_id());

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -112,6 +112,7 @@ public:
     bool has_preaggregation = true;
 
     bool use_vector_index = false;
+    bool belonged_to_cloud_native = false;
 
     VectorSearchOptionPtr vector_search_option = nullptr;
 

--- a/be/test/storage/index/vector_index_test.cpp
+++ b/be/test/storage/index/vector_index_test.cpp
@@ -119,7 +119,7 @@ TEST_F(VectorIndexWriterTest, test_write_vector_index) {
     tablet_index->add_common_properties("is_vector_normed", "false");
     tablet_index->add_common_properties("metric_type", "l2_distance");
     tablet_index->add_index_properties("efconstruction", "40");
-    tablet_index->add_index_properties("M", "16");
+    tablet_index->add_index_properties("m", "16");
     tablet_index->add_search_properties("efsearch", "40");
 
     auto index_path = test_vector_index_dir + "/" + vector_index_name;

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -29,6 +29,8 @@
 #include "storage/index/index_descriptor.h"
 #include "storage/index/vector/tenann/del_id_filter.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
+#include "storage/index/vector/vector_index_reader.h"
+#include "storage/index/vector/vector_index_reader_factory.h"
 #include "storage/index/vector/vector_index_writer.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "storage/rowset/bitmap_index_writer.h"
@@ -123,14 +125,14 @@ TEST_F(VectorIndexSearchTest, test_search_vector_index) {
         auto status = get_vector_meta(tablet_index, empty_meta);
 
         CHECK_OK(status);
-        const auto& meta = status.value();
+        auto index_meta = std::make_shared<tenann::IndexMeta>(status.value());
 
         std::shared_ptr<VectorIndexReader> ann_reader;
-        VectorIndexReaderFactory::create_from_file(index_path, meta, &ann_reader);
+        VectorIndexReaderFactory::create_from_file(index_path, index_meta, &ann_reader);
 
-        auto status = ann_reader->init_searcher(meta, index_path);
+        auto init_status = ann_reader->init_searcher(*index_meta, index_path);
 
-        ASSERT_TRUE(!status.is_not_supported());
+        ASSERT_TRUE(!init_status.is_not_supported());
 
         Status st;
         std::vector<int64_t> result_ids;

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -15,10 +15,14 @@
 #include <gtest/gtest.h>
 
 #include "fs/fs_factory.h"
+#include "fs/fs_memory.h"
 
 #ifdef WITH_TENANN
 #include <tenann/factory/ann_searcher_factory.h>
 #include <tenann/factory/index_factory.h>
+
+#include "storage/index/vector/tenann_index_reader.h"
+#include "storage/index/vector/vector_index_file_reader.h"
 #endif
 
 #include "base/testutil/assert.h"
@@ -173,18 +177,130 @@ TEST_F(VectorIndexSearchTest, test_select_empty_mark) {
         auto status = get_vector_meta(tablet_index, empty_meta);
 
         CHECK_OK(status);
-        const auto& meta = status.value();
+        auto index_meta = std::make_shared<tenann::IndexMeta>(status.value());
 
         std::shared_ptr<VectorIndexReader> ann_reader;
-        VectorIndexReaderFactory::create_from_file(index_path, meta, &ann_reader);
+        VectorIndexReaderFactory::create_from_file(index_path, index_meta, &ann_reader);
 
-        auto status = ann_reader->init_searcher(meta, index_path);
+        auto init_status = ann_reader->init_searcher(*index_meta, index_path);
 
-        ASSERT_TRUE(status.is_not_supported());
+        ASSERT_TRUE(init_status.is_not_supported());
     } catch (tenann::Error& e) {
         LOG(WARNING) << e.what();
     }
 #endif
 }
+
+#ifdef WITH_TENANN
+
+// ==================== VectorIndexFileReader direct tests ====================
+// VectorIndexFileReader bridges StarRocks RandomAccessFile into TenANN's
+// IndexFileReader interface, enabling TenANN to read .vi files from any
+// StarRocks-supported FS (S3/HDFS/OSS). The class is otherwise only
+// exercised indirectly by TenANNReader::init_searcher; these tests pin
+// down its behavior without spinning up an ANN index.
+
+namespace {
+constexpr std::string_view kTestPayload = "0123456789ABCDEF";
+constexpr int64_t kTestPayloadSize = static_cast<int64_t>(kTestPayload.size());
+constexpr std::string_view kTestFilename = "memory_index.vi";
+
+std::unique_ptr<VectorIndexFileReader> make_reader(std::string_view payload, std::string_view name = kTestFilename) {
+    auto raf = new_random_access_file_from_memory(name, payload);
+    return std::make_unique<VectorIndexFileReader>(std::move(raf), static_cast<int64_t>(payload.size()));
+}
+} // namespace
+
+TEST_F(VectorIndexSearchTest, vector_index_file_reader_basic_read_advances_position) {
+    auto reader = make_reader(kTestPayload);
+
+    char buf[8] = {};
+    int64_t n = reader->Read(buf, 4);
+    ASSERT_EQ(n, 4);
+    EXPECT_EQ(std::string_view(buf, 4), "0123");
+
+    // Position should have advanced; the next Read continues from offset 4.
+    n = reader->Read(buf, 4);
+    ASSERT_EQ(n, 4);
+    EXPECT_EQ(std::string_view(buf, 4), "4567");
+}
+
+TEST_F(VectorIndexSearchTest, vector_index_file_reader_read_at_does_not_change_position) {
+    auto reader = make_reader(kTestPayload);
+
+    char buf[8] = {};
+    int64_t n = reader->ReadAt(8, buf, 4);
+    ASSERT_EQ(n, 4);
+    EXPECT_EQ(std::string_view(buf, 4), "89AB");
+
+    // ReadAt is independent of the streaming position cursor; a subsequent
+    // Read should still start at offset 0.
+    n = reader->Read(buf, 4);
+    ASSERT_EQ(n, 4);
+    EXPECT_EQ(std::string_view(buf, 4), "0123");
+}
+
+TEST_F(VectorIndexSearchTest, vector_index_file_reader_seek_then_read) {
+    auto reader = make_reader(kTestPayload);
+
+    reader->Seek(10);
+    char buf[8] = {};
+    int64_t n = reader->Read(buf, 4);
+    ASSERT_EQ(n, 4);
+    EXPECT_EQ(std::string_view(buf, 4), "ABCD");
+}
+
+TEST_F(VectorIndexSearchTest, vector_index_file_reader_get_size_and_filename) {
+    auto reader = make_reader(kTestPayload, "abc.vi");
+    EXPECT_EQ(reader->GetSize(), kTestPayloadSize);
+    EXPECT_EQ(reader->filename(), "abc.vi");
+}
+
+TEST_F(VectorIndexSearchTest, vector_index_file_reader_read_past_eof_returns_minus_one) {
+    auto reader = make_reader(kTestPayload);
+
+    char buf[64] = {};
+    // Reading more bytes than exist surfaces as -1 (Read uses read_at_fully
+    // which fails when count exceeds the available bytes from the offset).
+    int64_t n = reader->Read(buf, kTestPayloadSize + 4);
+    EXPECT_EQ(n, -1);
+
+    // Same expectation for ReadAt past EOF.
+    int64_t m = reader->ReadAt(kTestPayloadSize - 2, buf, 8);
+    EXPECT_EQ(m, -1);
+}
+
+// TenANNReader::init_searcher(meta, path, fs) should delegate to the legacy
+// init_searcher(meta, path) when fs is nullptr. Build a real HNSW index on
+// local disk, then invoke the FS-aware overload with fs=nullptr and confirm
+// the call reaches the legacy success path (returns OK, NOT NotSupported).
+TEST_F(VectorIndexSearchTest, tenann_reader_init_searcher_null_fs_delegates_to_legacy) {
+    auto tablet_index = prepare_tablet_index();
+    tablet_index->add_common_properties("index_type", "hnsw");
+    tablet_index->add_common_properties("dim", "3");
+    tablet_index->add_common_properties("is_vector_normed", "false");
+    tablet_index->add_common_properties("metric_type", "l2_distance");
+    tablet_index->add_index_properties("efconstruction", "40");
+    tablet_index->add_index_properties("m", "16");
+    tablet_index->add_search_properties("efsearch", "40");
+
+    config::config_vector_index_default_build_threshold = 1;
+    auto ann_path = test_vector_index_dir + "/null_fs_delegate_hnsw.vi";
+    write_vector_index(ann_path, tablet_index);
+
+    try {
+        const auto empty_query_params = std::map<std::string, std::string>{};
+        ASSIGN_OR_ABORT(auto ann_meta, get_vector_meta(tablet_index, empty_query_params));
+
+        TenANNReader tenann_reader;
+        // fs=nullptr branch dispatches to the legacy init_searcher(meta, path) overload.
+        Status status = tenann_reader.init_searcher(ann_meta, ann_path, /*fs=*/nullptr);
+        EXPECT_TRUE(status.ok()) << status;
+    } catch (tenann::Error& e) {
+        LOG(WARNING) << e.what();
+    }
+}
+
+#endif // WITH_TENANN
 
 } // namespace starrocks

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -117,7 +117,7 @@ TEST_F(VectorIndexSearchTest, test_search_vector_index) {
     tablet_index->add_common_properties("is_vector_normed", "false");
     tablet_index->add_common_properties("metric_type", "l2_distance");
     tablet_index->add_index_properties("efconstruction", "40");
-    tablet_index->add_index_properties("M", "16");
+    tablet_index->add_index_properties("m", "16");
     tablet_index->add_search_properties("efsearch", "40");
 
     auto index_path = test_vector_index_dir + "/" + vector_index_name;
@@ -138,9 +138,12 @@ TEST_F(VectorIndexSearchTest, test_search_vector_index) {
 
         ASSERT_TRUE(!init_status.is_not_supported());
 
+        constexpr int kTopK = 1;
         Status st;
-        std::vector<int64_t> result_ids;
-        std::vector<float> result_distances;
+        // tenann::AnnSearcher::AnnSearch writes into caller-owned output buffers; the
+        // vectors must be sized to at least k before the call so .data() is non-null.
+        std::vector<int64_t> result_ids(kTopK);
+        std::vector<float> result_distances(kTopK);
         SparseRange<> scan_range;
         DelIdFilter del_id_filter(scan_range);
         std::vector<float> query_vector = {1.0f, 2.0f, 3.0f};
@@ -149,10 +152,10 @@ TEST_F(VectorIndexSearchTest, test_search_vector_index) {
                                          .size = static_cast<uint32_t>(3),
                                          .elem_type = tenann::PrimitiveType::kFloatType};
 
-        st = ann_reader->search(query_view, 1, (result_ids.data()), reinterpret_cast<uint8_t*>(result_distances.data()),
-                                &del_id_filter);
+        st = ann_reader->search(query_view, kTopK, result_ids.data(),
+                                reinterpret_cast<uint8_t*>(result_distances.data()), &del_id_filter);
         CHECK_OK(st);
-        ASSERT_EQ(result_ids.size(), 0);
+        ASSERT_EQ(result_ids.size(), kTopK);
     } catch (tenann::Error& e) {
         LOG(WARNING) << e.what();
     }
@@ -167,6 +170,14 @@ TEST_F(VectorIndexSearchTest, test_select_empty_mark) {
     tablet_index->add_common_properties("dim", "3");
     tablet_index->add_common_properties("is_vector_normed", "false");
     tablet_index->add_common_properties("metric_type", "l2_distance");
+    // ivfpq requires these in index_properties for tenann meta validation
+    // (CRITICAL_CHECK_AND_GET in get_vector_meta). The values are not
+    // exercised here — the test only verifies the empty-mark path returns
+    // NotSupported, but get_vector_meta() runs before that and still
+    // requires these keys to be present.
+    tablet_index->add_index_properties("nlist", "1");
+    tablet_index->add_index_properties("nbits", "8");
+    tablet_index->add_index_properties("m_ivfpq", "3");
 
     auto index_path = test_vector_index_dir + "/" + empty_index_name;
     write_vector_index(index_path, tablet_index);

--- a/be/test/storage/lake/filenames_test.cpp
+++ b/be/test/storage/lake/filenames_test.cpp
@@ -176,6 +176,45 @@ TEST_F(FilenamesTest, gen_vector_index_filename) {
     }
 }
 
+TEST_F(FilenamesTest, gen_vector_index_path_from_segment_path) {
+    // Segment path with a multi-level directory: keep the directory and substitute
+    // the .dat suffix on the basename with _{index_id}.vi.
+    {
+        std::string seg_path = "/foo/bar/0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
+        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 0);
+        ASSERT_EQ("/foo/bar/0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_0.vi", vi_path);
+    }
+
+    // Single-level directory.
+    {
+        std::string seg_path = "data/0123_abcd.dat";
+        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 42);
+        ASSERT_EQ("data/0123_abcd_42.vi", vi_path);
+    }
+
+    // No directory part: return just the .vi filename.
+    {
+        std::string seg_path = "0123_abcd.dat";
+        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 7);
+        ASSERT_EQ("0123_abcd_7.vi", vi_path);
+    }
+
+    // Root-only directory (leading slash, nothing before it): treat as no parent dir.
+    {
+        std::string seg_path = "/seg.dat";
+        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 1);
+        ASSERT_EQ("seg_1.vi", vi_path);
+    }
+
+    // Segment basename without .dat suffix falls through gen_vector_index_filename's
+    // fallback branch: append _{index_id}.vi to the raw name.
+    {
+        std::string seg_path = "/foo/bar/0123_abcd";
+        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 9);
+        ASSERT_EQ("/foo/bar/0123_abcd_9.vi", vi_path);
+    }
+}
+
 TEST_F(FilenamesTest, is_vector_index) {
     ASSERT_TRUE(is_vector_index("0123_abcd_123.vi"));
     ASSERT_TRUE(is_vector_index("vector_index.vi"));

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -381,7 +381,7 @@ TEST_F(LakeDataSourceTest, get_tablet_schema) {
 // Exercise the vector-search branches of LakeDataSource::open() that were added by
 // the shared-data vector index read PR:
 //   * open() propagation of TVectorSearchOptions from thrift into _use_vector_index etc.
-//   * init_scanner_columns: the slot-id == _vector_slot_id branch and its else branch.
+//   * init_scanner_columns: the slot-id != _vector_slot_id (regular column lookup) branch.
 //   * init_reader_params: the `if (_use_vector_index)` block that copies query_vector,
 //     vector_range, ann_params, etc. onto the reader params.
 //
@@ -398,9 +398,9 @@ TEST_F(LakeDataSourceTest, open_with_vector_search_options) {
 
     create_rowsets_for_testing(_tablet_metadata.get(), 2);
 
-    // 1) Build TLakeScanNode with vector_search_options set. vector_slot_id intentionally
-    //    matches the first tuple slot's id (assigned 0 below) so the slot-id == _vector_slot_id
-    //    branch fires for at least one slot.
+    // 1) Build TLakeScanNode with vector_search_options set. vector_slot_id is set to
+    //    a value that does not match any tuple slot (see below), so init_scanner_columns
+    //    exercises the regular-column-lookup branch for every slot.
     int64_t schema_id = next_id();
     if (schema_id == _tablet_metadata->schema().id()) {
         schema_id = next_id();

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -41,6 +41,7 @@
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
+#include "storage/index/vector/vector_search_option.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
@@ -375,6 +376,171 @@ TEST_F(LakeDataSourceTest, get_tablet_schema) {
     auto tablet_schema = ds.TEST_tablet_schema();
     ASSERT_TRUE(tablet_schema != nullptr);
     ASSERT_EQ(schema_id, tablet_schema->id());
+}
+
+// Exercise the vector-search branches of LakeDataSource::open() that were added by
+// the shared-data vector index read PR:
+//   * open() propagation of TVectorSearchOptions from thrift into _use_vector_index etc.
+//   * init_scanner_columns: the slot-id == _vector_slot_id branch and its else branch.
+//   * init_reader_params: the `if (_use_vector_index)` block that copies query_vector,
+//     vector_range, ann_params, etc. onto the reader params.
+//
+// We do not need a real .vi file — the test is over once init_reader_params +
+// init_scanner_columns have filled _params, so open() is allowed to return any
+// status. We do assert that _params.use_vector_index landed as true via the
+// TEST_params() accessor.
+TEST_F(LakeDataSourceTest, open_with_vector_search_options) {
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([&]() {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    create_rowsets_for_testing(_tablet_metadata.get(), 2);
+
+    // 1) Build TLakeScanNode with vector_search_options set. vector_slot_id intentionally
+    //    matches the first tuple slot's id (assigned 0 below) so the slot-id == _vector_slot_id
+    //    branch fires for at least one slot.
+    int64_t schema_id = next_id();
+    if (schema_id == _tablet_metadata->schema().id()) {
+        schema_id = next_id();
+    }
+    TLakeScanNode lake_scan_node;
+    lake_scan_node.__set_tuple_id(0);
+    TTableSchemaKey schema_key;
+    schema_key.__set_schema_id(schema_id);
+    schema_key.__set_db_id(200);
+    schema_key.__set_table_id(201);
+    lake_scan_node.__set_schema_key(schema_key);
+
+    TVectorSearchOptions vec_opts;
+    vec_opts.__set_enable_use_ann(true);
+    vec_opts.__set_use_ivfpq(false);
+    vec_opts.__set_vector_distance_column_name("vec_distance");
+    // Use a slot id that does NOT match any tuple slot, so init_scanner_columns
+    // exercises the else branch for every slot (regular column lookup) without
+    // synthesizing a virtual column index that the downstream schema conversion
+    // wouldn't know how to handle in this minimal test setup.
+    vec_opts.__set_vector_slot_id(999);
+    vec_opts.__set_vector_limit_k(10);
+    vec_opts.__set_query_vector(std::vector<std::string>{"0.1", "0.2", "0.3"});
+    vec_opts.__set_vector_range(0.5);
+    vec_opts.__set_result_order(0);
+    vec_opts.__set_pq_refine_factor(1.0);
+    vec_opts.__set_k_factor(1.0);
+    lake_scan_node.__set_vector_search_options(vec_opts);
+
+    TPlanNode plan_node;
+    plan_node.__set_node_id(0);
+    plan_node.__set_lake_scan_node(lake_scan_node);
+
+    // 2) Runtime state with fragment_ctx (fe_addr required by schema RPC path).
+    auto runtime_state = create_runtime_state();
+    pipeline::FragmentContext fragment_ctx;
+    TNetworkAddress fe;
+    fe.hostname = "127.0.0.1";
+    fe.port = 9020;
+    fragment_ctx.set_fe_addr(fe);
+    runtime_state->set_fragment_ctx(&fragment_ctx);
+    runtime_state->set_fragment_dict_state(fragment_ctx.dict_state());
+
+    // 3) Desc table with two INT slots matching the schema we mock below.
+    TDescriptorTableBuilder desc_tbl_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto slot0 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c0").column_pos(0).nullable(true).build();
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(1).nullable(true).build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(slot0);
+    tuple_desc_builder.add_slot(slot1);
+    tuple_desc_builder.build(&desc_tbl_builder);
+
+    DescriptorTbl* desc_tbl = nullptr;
+    CHECK(DescriptorTbl::create(runtime_state.get(), runtime_state->obj_pool(), desc_tbl_builder.desc_tbl(), &desc_tbl,
+                                config::vector_chunk_size)
+                  .ok());
+    runtime_state->set_desc_tbl(desc_tbl);
+
+    TTableDescriptor tdesc;
+    tdesc.__set_id(0);
+    tdesc.__set_tableType(TTableType::OLAP_TABLE);
+    tdesc.__set_tableName("test_table");
+    tdesc.__set_dbName("test_db");
+    auto* table_desc = runtime_state->obj_pool()->add(new OlapTableDescriptor(tdesc));
+    desc_tbl->get_tuple_descriptor(0)->set_table_desc(table_desc);
+
+    // 4) Schema RPC hook returns the same two-column schema as get_tablet_schema so the
+    //    non-vector slot still maps to a real tablet column (avoids -1 from field_index).
+    SyncPoint::GetInstance()->SetCallBack("TableSchemaService::_fetch_schema_via_rpc::test_hook", [&](void* arg) {
+        auto* arr = static_cast<std::array<void*, 4>*>(arg);
+        auto* response_batch = static_cast<TBatchGetTableSchemaResponse*>((*arr)[1]);
+        auto* status = static_cast<Status*>((*arr)[2]);
+        auto* mock_thrift_rpc = static_cast<bool*>((*arr)[3]);
+
+        *mock_thrift_rpc = true;
+        *status = Status::OK();
+        set_status(&response_batch->status, TStatusCode::OK);
+        response_batch->__set_responses(std::vector<TGetTableSchemaResponse>{});
+        auto& resp = response_batch->responses.emplace_back();
+        set_status(&resp.status, TStatusCode::OK);
+
+        TTabletSchema t_schema;
+        t_schema.__set_id(schema_id);
+        t_schema.__set_keys_type(TKeysType::DUP_KEYS);
+        t_schema.__set_short_key_column_count(1);
+
+        TColumn c0;
+        c0.__set_column_name("c0");
+        c0.column_type.__set_type(TPrimitiveType::INT);
+        c0.__set_is_key(true);
+        c0.__set_is_allow_null(false);
+        t_schema.columns.push_back(c0);
+
+        TColumn c1;
+        c1.__set_column_name("c1");
+        c1.column_type.__set_type(TPrimitiveType::INT);
+        c1.__set_is_key(false);
+        c1.__set_is_allow_null(false);
+        t_schema.columns.push_back(c1);
+
+        resp.__set_schema(t_schema);
+    });
+
+    starrocks::connector::LakeDataSourceProvider provider(/*scan_node=*/nullptr, plan_node);
+    provider.set_lake_tablet_manager(_tablet_mgr);
+
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.__set_tablet_id(_tablet_metadata->id());
+    internal_scan_range.__set_version(std::to_string(_tablet_metadata->version()));
+    TScanRange scan_range;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id(), _tablet_metadata->version()));
+    auto lake_rowsets = tablet.get_rowsets();
+    std::vector<BaseRowsetSharedPtr> base_rowsets;
+    base_rowsets.reserve(lake_rowsets.size());
+    for (auto& rs : lake_rowsets) {
+        base_rowsets.emplace_back(rs);
+    }
+    pipeline::ScanMorsel morsel(plan_node.node_id, scan_range);
+    morsel.set_rowsets(base_rowsets);
+
+    starrocks::connector::LakeDataSource ds(&provider, scan_range);
+    RuntimeProfile parent_profile("LakeDataSourceTest");
+    ds.set_runtime_profile(&parent_profile);
+    ds.set_morsel(&morsel);
+    DeferOp close_guard([&] { ds.close(runtime_state.get()); });
+
+    // open() may or may not succeed end-to-end — we only care that the vector-search
+    // branches fired on the way through.
+    (void)ds.open(runtime_state.get());
+
+    const auto& params = ds.TEST_params();
+    EXPECT_TRUE(params.use_vector_index);
+    ASSERT_NE(params.vector_search_option, nullptr);
+    EXPECT_EQ(params.vector_search_option->k, 10);
+    EXPECT_EQ(params.vector_search_option->vector_distance_column_name, "vec_distance");
+    ASSERT_EQ(params.vector_search_option->query_vector.size(), 3);
+    EXPECT_FLOAT_EQ(params.vector_search_option->query_vector[0], 0.1f);
 }
 
 TEST_F(LakeDataSourceTest, test_has_all_pk_columns_selected) {

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -24,6 +24,8 @@
 #include "fs/fs_util.h"
 #include "storage/chunk_helper.h"
 #include "storage/index/index_descriptor.h"
+#include "storage/index/vector/vector_index_reader.h"
+#include "storage/index/vector/vector_index_reader_factory.h"
 #include "storage/index/vector/vector_index_writer.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
@@ -34,6 +36,10 @@
 #include "storage/rowset/segment_file_info.h"
 #include "storage/rowset/segment_writer.h"
 #include "storage/tablet_schema.h"
+
+#ifdef WITH_TENANN
+#include "storage/index/vector/tenann/tenann_index_utils.h"
+#endif
 
 namespace starrocks::lake {
 
@@ -69,7 +75,7 @@ protected:
         tablet_index->add_common_properties("is_vector_normed", "false");
         tablet_index->add_common_properties("metric_type", "l2_distance");
         tablet_index->add_index_properties("efconstruction", "40");
-        tablet_index->add_index_properties("M", "16");
+        tablet_index->add_index_properties("m", "16");
         return tablet_index;
     }
 
@@ -444,5 +450,92 @@ TEST_F(SharedDataTabletWriterVITest, test_segment_writer_vi_fallback_to_index_de
     std::string expected_vi = fmt::format("{}/{}_{}_{}.vi", rowset_dir, opts.segment_file_mark.rowset_id, 0, kIndexId);
     EXPECT_TRUE(fs::path_exist(expected_vi));
 }
+
+// ==================== Read Path Tests ====================
+
+#ifdef WITH_TENANN
+
+// Test reading a vector index file from shared-data path using VectorIndexReaderFactory with FileSystem.
+// This verifies the FS-aware create_from_file overload works correctly.
+TEST_F(SharedDataVectorIndexTest, test_vector_index_read_shared_data_path) {
+    // Set threshold low enough so that 5 rows triggers index build
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+
+    const int64_t tablet_id = 12345;
+    const int64_t index_id = 0;
+    const std::string segment_name = "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
+
+    std::string vi_filename = gen_vector_index_filename(segment_name, index_id);
+    std::string vector_index_path = _location_provider->segment_location(tablet_id, vi_filename);
+
+    // Write vector index first
+    auto tablet_index = create_tablet_index(index_id);
+    tablet_index->add_search_properties("efsearch", "40");
+
+    std::unique_ptr<VectorIndexWriter> vector_index_writer;
+    VectorIndexWriter::create(tablet_index, vector_index_path, true, &vector_index_writer);
+    ASSERT_OK(vector_index_writer->init());
+
+    auto array_column = create_array_column_with_vectors(5);
+    ASSERT_OK(vector_index_writer->append(*array_column));
+    uint64_t index_size = 0;
+    ASSERT_OK(vector_index_writer->finish(&index_size));
+    ASSERT_GT(index_size, 0);
+
+    // Read vector index using FS-aware factory
+    const auto& empty_meta = std::map<std::string, std::string>{};
+    ASSIGN_OR_ABORT(auto meta, get_vector_meta(tablet_index, empty_meta));
+    auto index_meta = std::make_shared<tenann::IndexMeta>(std::move(meta));
+
+    std::shared_ptr<VectorIndexReader> reader;
+    ASSERT_OK(VectorIndexReaderFactory::create_from_file(vector_index_path, index_meta, &reader, _fs.get()));
+    ASSERT_NE(reader, nullptr);
+
+    // init_searcher with FileSystem should succeed
+    ASSERT_OK(reader->init_searcher(*index_meta, vector_index_path, _fs.get()));
+}
+
+// Test that reading an empty mark .vi file via FS-aware path returns EmptyIndexReader.
+TEST_F(SharedDataVectorIndexTest, test_vector_index_read_empty_mark_shared_data_path) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 100);
+
+    const int64_t tablet_id = 999;
+    const int64_t index_id = 0;
+    std::string segment_name = "0000000000000002_abc12345-6789-0def-1234-567890abcdef.dat";
+    std::string vi_filename = gen_vector_index_filename(segment_name, index_id);
+    std::string vector_index_path = _location_provider->segment_location(tablet_id, vi_filename);
+
+    // Write empty mark file directly (the current writer skips file generation
+    // when threshold is not met, so we create the empty mark manually to test the reader)
+    auto tablet_index = create_tablet_index(index_id);
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(vector_index_path));
+    ASSERT_OK(wfile->append(IndexDescriptor::mark_word));
+    ASSERT_OK(wfile->close());
+
+    // Read via FS-aware factory — should detect empty mark
+    const auto& empty_meta = std::map<std::string, std::string>{};
+    ASSIGN_OR_ABORT(auto meta, get_vector_meta(tablet_index, empty_meta));
+    auto index_meta = std::make_shared<tenann::IndexMeta>(std::move(meta));
+
+    std::shared_ptr<VectorIndexReader> reader;
+    ASSERT_OK(VectorIndexReaderFactory::create_from_file(vector_index_path, index_meta, &reader, _fs.get()));
+    ASSERT_NE(reader, nullptr);
+
+    // EmptyIndexReader.init_searcher returns NotSupported
+    auto status = reader->init_searcher(*index_meta, vector_index_path, _fs.get());
+    ASSERT_TRUE(status.is_not_supported());
+}
+
+// Test that FS-aware create_from_file returns NotFound for non-existent path.
+TEST_F(SharedDataVectorIndexTest, test_vector_index_read_not_found) {
+    std::string non_existent_path = _test_dir + "/data/non_existent.vi";
+    auto index_meta = std::make_shared<tenann::IndexMeta>();
+
+    std::shared_ptr<VectorIndexReader> reader;
+    auto status = VectorIndexReaderFactory::create_from_file(non_existent_path, index_meta, &reader, _fs.get());
+    ASSERT_TRUE(status.is_not_found());
+}
+
+#endif // WITH_TENANN
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -171,8 +171,25 @@ TEST_F(SharedDataVectorIndexTest, test_vector_index_empty_mark_shared_data_path)
     std::string vi_filename = gen_vector_index_filename(segment_name, index_id);
     std::string vector_index_path = _location_provider->segment_location(tablet_id, vi_filename);
 
-    auto tablet_index = create_tablet_index(index_id);
+    // Build an ivfpq tablet_index from scratch — using create_tablet_index() and then
+    // setting "index_type" = "ivfpq" via add_common_properties does not work because
+    // TabletIndex::add_common_properties uses std::map::insert (no overwrite), so the
+    // "hnsw" inserted by create_tablet_index() would remain. ivfpq + threshold > rows
+    // is what drives the writer down the flush_empty() path we want to exercise here.
+    auto tablet_index = std::make_shared<TabletIndex>();
+    TabletIndexPB index_pb;
+    index_pb.set_index_id(index_id);
+    index_pb.set_index_name("vector_index");
+    index_pb.set_index_type(IndexType::VECTOR);
+    index_pb.add_col_unique_id(1);
+    tablet_index->init_from_pb(index_pb);
     tablet_index->add_common_properties("index_type", "ivfpq");
+    tablet_index->add_common_properties("dim", "3");
+    tablet_index->add_common_properties("is_vector_normed", "false");
+    tablet_index->add_common_properties("metric_type", "l2_distance");
+    tablet_index->add_index_properties("nlist", "1");
+    tablet_index->add_index_properties("nbits", "8");
+    tablet_index->add_index_properties("m_ivfpq", "3");
 
     std::unique_ptr<VectorIndexWriter> vector_index_writer;
     VectorIndexWriter::create(tablet_index, vector_index_path, true, &vector_index_writer);
@@ -257,7 +274,7 @@ protected:
             },
             "index_properties": {
                 "efconstruction": "40",
-                "M": "16"
+                "m": "16"
             }
         })";
         idx->set_index_properties(props_json);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1132,6 +1132,10 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 msg.lake_scan_node.setOutput_chunk_by_bucket(isOutputChunkByBucket);
             }
 
+            if (vectorSearchOptions != null && vectorSearchOptions.isEnableUseANN()) {
+                msg.lake_scan_node.setVector_search_options(vectorSearchOptions.toThrift());
+            }
+
             if (enableGlobalLateMaterialization) {
                 msg.lake_scan_node.setEnable_global_late_materialization(true);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapScanNodeTest.java
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.VectorSearchOptions;
+import com.starrocks.type.IntegerType;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.thrift.TPlanNode;
+import com.starrocks.thrift.TStorageType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class OlapScanNodeTest {
+
+    private OlapScanNode createOlapScanNode(Table.TableType tableType) {
+        OlapTable table = new OlapTable(tableType);
+        table.maySetDatabaseId(1L);
+        table.setBaseIndexMetaId(1L);
+        table.setIndexMeta(1L, "base",
+                Collections.singletonList(new Column("c0", IntegerType.INT)),
+                0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        table.setDefaultDistributionInfo(
+                new HashDistributionInfo(3, Collections.emptyList()));
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+
+        return new OlapScanNode(new PlanNodeId(0), desc, "OlapScanNode",
+                table.getBaseIndexMetaId());
+    }
+
+    @Test
+    public void testLakeScanNodeWithVectorSearchOptions() {
+        OlapScanNode scanNode = createOlapScanNode(Table.TableType.CLOUD_NATIVE);
+
+        VectorSearchOptions opts = new VectorSearchOptions();
+        opts.setEnableUseANN(true);
+        opts.setLimitK(10);
+        opts.setDistanceColumnName("distance");
+        opts.setDistanceSlotId(1);
+        opts.setQueryVector(Arrays.asList("1.0", "2.0", "3.0"));
+        opts.setResultOrder(true);
+        scanNode.setVectorSearchOptions(opts);
+
+        TPlanNode msg = new TPlanNode();
+        scanNode.toThrift(msg);
+
+        Assertions.assertNotNull(msg.lake_scan_node);
+        Assertions.assertNotNull(msg.lake_scan_node.getVector_search_options());
+        Assertions.assertTrue(msg.lake_scan_node.getVector_search_options().isEnable_use_ann());
+        Assertions.assertEquals(10, msg.lake_scan_node.getVector_search_options().getVector_limit_k());
+        Assertions.assertEquals("distance",
+                msg.lake_scan_node.getVector_search_options().getVector_distance_column_name());
+        Assertions.assertEquals(Arrays.asList("1.0", "2.0", "3.0"),
+                msg.lake_scan_node.getVector_search_options().getQuery_vector());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapScanNodeTest.java
@@ -73,4 +73,36 @@ public class OlapScanNodeTest {
         Assertions.assertEquals(Arrays.asList("1.0", "2.0", "3.0"),
                 msg.lake_scan_node.getVector_search_options().getQuery_vector());
     }
+
+    @Test
+    public void testLakeScanNodeWithVectorSearchOptionsDisabled() {
+        // toThrift must not emit vector_search_options on the lake_scan_node when ANN is disabled.
+        // Covers the `vectorSearchOptions != null && vectorSearchOptions.isEnableUseANN()` guard:
+        // the negative side of the `&&`, which the positive-case test cannot exercise.
+        OlapScanNode scanNode = createOlapScanNode(Table.TableType.CLOUD_NATIVE);
+
+        VectorSearchOptions opts = new VectorSearchOptions();
+        opts.setEnableUseANN(false);
+        scanNode.setVectorSearchOptions(opts);
+
+        TPlanNode msg = new TPlanNode();
+        scanNode.toThrift(msg);
+
+        Assertions.assertNotNull(msg.lake_scan_node);
+        Assertions.assertFalse(msg.lake_scan_node.isSetVector_search_options());
+    }
+
+    @Test
+    public void testLakeScanNodeWithNullVectorSearchOptions() {
+        // toThrift must not emit vector_search_options when the field has been set to null.
+        // Covers the `vectorSearchOptions != null` short-circuit branch in toThrift.
+        OlapScanNode scanNode = createOlapScanNode(Table.TableType.CLOUD_NATIVE);
+        scanNode.setVectorSearchOptions(null);
+
+        TPlanNode msg = new TPlanNode();
+        scanNode.toThrift(msg);
+
+        Assertions.assertNotNull(msg.lake_scan_node);
+        Assertions.assertFalse(msg.lake_scan_node.isSetVector_search_options());
+    }
 }

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -69,6 +69,7 @@ Usage: $0 <options>
      --use-staros                   DEPRECATED. an alias of --enable-shared-data option
      --without-debug-symbol-split   split debug symbol out of the test binary to accelerate the speed
                                     of loading binary into memory and start execution.
+     --without-tenann               build without tenann (vector index library); default is ON on Linux
      -j                             build parallel
 
   Eg.
@@ -121,6 +122,7 @@ OPTS=$(${GETOPT_BIN} \
   -l 'without-java-ext' \
   -l 'without-debug-symbol-split' \
   -l 'without-java-ext' \
+  -l 'without-tenann' \
   -o 'j:' \
   -l 'help' \
   -l 'run' \
@@ -150,6 +152,11 @@ fi
 WITH_DEBUG_SYMBOL_SPLIT=ON
 BUILD_JAVA_EXT=ON
 BUILD_TARGET=
+if starrocks_is_darwin; then
+    WITH_TENANN=OFF
+else
+    WITH_TENANN=ON
+fi
 if [[ -z ${WITH_DYNAMIC} ]]; then
     WITH_DYNAMIC=OFF
 fi
@@ -174,6 +181,7 @@ while true; do
         --build-target) BUILD_TARGET=$2; shift 2;;
         --without-debug-symbol-split) WITH_DEBUG_SYMBOL_SPLIT=OFF; shift ;;
         --without-java-ext) BUILD_JAVA_EXT=OFF; shift ;;
+        --without-tenann) WITH_TENANN=OFF; shift ;;
         -j) PARALLEL=$2; shift 2 ;;
         --) shift ;  break ;;
         *) echo "Internal error" ; exit 1 ;;
@@ -277,6 +285,7 @@ ${CMAKE_CMD}  -G "${CMAKE_GENERATOR}" \
             -DSTARLET_INSTALL_DIR=${STARLET_INSTALL_DIR}          \
             -DWITH_GCOV=${WITH_GCOV} \
             -DWITH_STARCACHE=${WITH_STARCACHE} \
+            -DWITH_TENANN=${WITH_TENANN} \
             -DSTARROCKS_JIT_ENABLE=${ENABLE_JIT} \
             -DWITH_RELATIVE_SRC_PATH=OFF \
             -DENABLE_MULTI_DYNAMIC_LIBS=${WITH_DYNAMIC} \


### PR DESCRIPTION
## Why I'm doing:

Support reading vector index (.vi) files in shared-data mode

## What I'm doing:

  Read Path (shared-data)
  - VectorIndexFileReader: bridge class wrapping StarRocks RandomAccessFile into TenANN's IndexFileReader interface for remote FS
  - TenANNReader: added FS-aware init_searcher overload that creates VectorIndexFileReader for TenANN to read index
  - lake_connector.cpp / tablet_reader.cpp / rowset.cpp: propagate use_vector_index and vector_search_options through the lake scan path
  - OlapScanNode.java / PlanNodes.thrift: send vector_search_options in lake scan range params

  Fallback Logic
  - segment_iterator.cpp::_init_reader_from_file: if create_from_file returns NotFound, set use_vector_index = false and continue with  brute-force scan




Fixes https://github.com/StarRocks/starrocks/issues/72087

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
