### PR TITLE
[BugFix] vararg Udaf's cache key should contains num_args

### DIFF
--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -135,9 +135,15 @@ Status init_udaf_context(int64_t id, const std::string& url, const std::string& 
     auto func_cache = UserFunctionCache::instance();
 
     if (use_cache) {
+        //assuming id is unique and num_args is small (less than 4096);
+        //user defined function is negative.
+        CHECK(num_args < 4096 && (-id) < (1L << 52));
+        // we adopt the cache key consisting of the function id and the number of arguments, since for non-group-by aggregation,
+        // AggBatchCallStub instance in cached JavaUDAFUniqueContext instance depends on the number of arguments.
+        int64_t cache_key = (-id) | (static_cast<int64_t>(num_args) << 52);
         ASSIGN_OR_RETURN(auto result,
                          func_cache->load_cacheable_java_udf(
-                                 id, url, checksum, TFunctionBinaryType::SRJAR,
+                                 cache_key, url, checksum, TFunctionBinaryType::SRJAR,
                                  [&symbol, num_args](const std::string& libpath) -> StatusOr<std::any> {
                                      ASSIGN_OR_RETURN(auto ctx, build_udaf_shared_context(libpath, symbol, num_args));
                                      return std::any(std::move(ctx));


### PR DESCRIPTION
## Why I'm doing:

The Pair [udaf fid,JavaUDAFSharedContext] is cached in memory for reuse, but JavaUDAFSharedContext instance owns AggBatchCallStub instance which depends on 
num_args() of FunctionContext, for the same udaf, num_args() may be different. so we use fid and num_args() to from a new cache key.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
