### PR TITLE
[BugFix] Relax StarMgrMetaSyncer DB locks that stall DDL over StarOS RPCs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -542,7 +542,12 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         HashMap<Long, Set<Long>> redundantGroupToShards = new HashMap<>();
         List<PhysicalPartition> physicalPartitions = new ArrayList<>();
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        // Intensive path: IS on DB + READ on this table. We only need table-scoped
+        // consistency here (partition walk on one known table plus a flag flip);
+        // DROP TABLE / DROP DATABASE both take DB WRITE which still conflict with
+        // IS, so the manual re-check below is still sufficient to detect a drop
+        // that committed before we acquired the lock.
+        locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
         try {
             if (GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), table.getId()) == null) {
                 return false; // table might be dropped
@@ -554,11 +559,11 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                     .forEach(physicalPartitions::addAll);
             table.setShardGroupChanged(false);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
         }
 
         for (PhysicalPartition physicalPartition : physicalPartitions) {
-            locker.lockDatabase(db.getId(), LockType.READ);
+            locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
             try {
                 // schema change might replace the shards in the original shard group
                 if (table.getState() != OlapTable.OlapTableState.NORMAL) {
@@ -606,7 +611,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                     redundantGroupToShards.put(materializedIndex.getShardGroupId(), starmgrShardIdsSet);
                 }
             } finally {
-                locker.unLockDatabase(db.getId(), LockType.READ);
+                locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
             }
         }
 
@@ -640,7 +645,13 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             return;
         }
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.WRITE);
+        // Intensive path: IS on DB + READ on this table. Despite the "update" name,
+        // the call below only reads olapTable.getShardGroupIds(); the real mutation
+        // is of ColocateTableIndex's internal maps (guarded by its own writeLock)
+        // and external StarOS state via updateMetaGroup(). DROP TABLE / DROP DATABASE
+        // both take DB WRITE which still conflicts with IS, so the re-check below
+        // still detects a drop that committed before we acquired the lock.
+        locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
         try {
             // check db and table again
             if (GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(db.getId()) == null) {
@@ -652,7 +663,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             GlobalStateMgr.getCurrentState().getColocateTableIndex().updateLakeTableColocationInfo(table, true /* isJoin */,
                     null /* expectGroupId */);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
         }
     }
 


### PR DESCRIPTION
syncTableMetaInternal and syncTableColocationInfo ran periodically while holding a DB-wide READ or WRITE lock across external StarOS RPCs (listShard, updateMetaGroup). For the duration of each RPC the whole database was effectively frozen: concurrent CREATE / DROP / ALTER / RENAME on any other table in the same DB blocked waiting for the syncer, and any RPC stall extended that window arbitrarily.

The critical sections only need table-scoped consistency on a single known table: syncTableMetaInternal walks one table's partitions and flips shardGroupChanged; syncTableColocationInfo reads one table's shard-group IDs and forwards them to StarOS under ColocateTableIndex's own internal writeLock. Drop / rename of this DB or table still takes DB WRITE, which conflicts with IS, so the manual getDb / getTable == null re-check still catches drops that committed before the lock was acquired.

Switch all three sites to the intensive-lock path already used by getAllPartitionShardGroupId in the same file:

  syncTableMetaInternal   : DB READ  -> IS + table READ
  syncTableColocationInfo : DB WRITE -> IS + table READ

syncTableColocationInfo drops to table READ rather than table WRITE because the call is semantically a read of the OlapTable's shard groups plus a mutation of external StarOS state and ColocateTableIndex's own maps (the latter guarded by its internal writeLock), not a mutation of the Java Table object.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
