### PR TITLE
[Enhancement] Parallelize lake _do_update_with_condition for no-SST path

### DIFF
--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -191,18 +191,20 @@ static bool has_partial_update(const RowsetUpdateStateParams& params) {
 //
 // Lazy load is ENABLED when:
 // 1. Normal transaction (no txn_meta) - safe to defer loading as no special merge logic needed
-// 2. Condition update with SST ingestion but no partial updates - parallel path can handle lazy load
+// 2. Condition update without partial updates - both the SST-backed parallel path and the
+//    non-SST chunk-parallel path iterate the PK column chunk by chunk, so neither needs the
+//    full segment materialized upfront.
 //
 // Lazy load is DISABLED when:
 // 1. Partial updates are involved - WHY: partial update handler needs immediate access to standalone
-//    PK columns to merge with existing data, can't wait for lazy loading
-// 2. Condition update without SST files - WHY: serial condition merge path requires full PK column
-//    upfront for old value lookups
+//    PK columns to merge with existing data, can't wait for lazy loading.
 //
 // PERFORMANCE: Enabling lazy load reduces peak memory by ~50% for large primary key columns (>100MB)
+// and, for the non-SST condition-merge path, lets _do_update_with_condition produce multiple
+// per-segment chunks so its compare phase actually scales on lake_partial_update_thread_pool.
 static bool should_enable_lazy_load(const RowsetUpdateStateParams& params) {
-    return !params.op_write.has_txn_meta() || (!params.op_write.txn_meta().merge_condition().empty() &&
-                                               !has_partial_update(params) && params.op_write.ssts_size() > 0);
+    return !params.op_write.has_txn_meta() ||
+           (!params.op_write.txn_meta().merge_condition().empty() && !has_partial_update(params));
 }
 
 Status RowsetUpdateState::load_segment(uint32_t segment_id, const RowsetUpdateStateParams& params, int64_t base_version,

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -407,9 +407,12 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                     builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
                 }
             } else {
+                // NON-SST CONDITION MERGE PATH:
+                // When SST files are absent, new-row condition values are read from the freshly
+                // ingested segment file on demand. Compare work is parallelized per chunk; the
+                // final index.upsert is applied serially after the barrier.
                 RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
-                                                          state.upserts(local_id)->standalone_pk_column(), index,
-                                                          &new_deletes));
+                                                          state.upserts(local_id), index, &new_deletes));
             }
             if (state.auto_increment_deletes(local_id) != nullptr) {
                 RETURN_IF_ERROR(index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes,
@@ -1119,9 +1122,126 @@ Status UpdateManager::_do_update_with_condition_parallel(const RowsetUpdateState
     return upsert->status();
 }
 
+namespace {
+
+// Per-chunk output of the parallel compare phase for _do_update_with_condition (non-SST path).
+//
+// The compare phase runs concurrently per chunk; its results are consumed serially
+// afterwards because PrimaryIndex::upsert is not thread-safe. pk_column is retained
+// so the serial merge can upsert winners without re-encoding the chunk.
+struct ChunkCondMergeResult {
+    MutableColumnPtr pk_column;
+    // Absolute row offset of this chunk within the segment (== SegmentPKIterator::current().second).
+    size_t chunk_offset = 0;
+    // Half-open intervals [begin, end) in chunk-local coordinates identifying new rows
+    // that won their condition comparison and must be upserted into the index.
+    // Any replaced old rowids are collected by index.upsert into new_deletes.
+    std::vector<std::pair<uint32_t, uint32_t>> winner_ranges;
+    // Chunk-local indices of new rows that LOST their condition comparison
+    // (old row wins); these must be deleted from the current segment.
+    std::vector<uint32_t> new_loser_local_ids;
+};
+
+} // namespace
+
+// Compare phase for one chunk in the non-SST parallel condition merge.
+// Mirrors _process_single_chunk_update_with_condition but writes into a per-chunk
+// result instead of mutating the shared index, so it is safe to run concurrently
+// and the caller can apply index.upsert serially.
+static Status process_single_chunk_update_with_condition_no_sst(
+        UpdateManager* mgr, const RowsetUpdateStateParams& params, uint32_t rowset_id, int32_t upsert_idx,
+        SegmentPKIterator* segment_pk_iterator, const std::pair<ChunkPtr, size_t>& current,
+        const TabletColumn& tablet_column, const std::vector<uint32_t>& read_column_ids, LakePrimaryIndex& index,
+        ChunkCondMergeResult* result) {
+    TRACE_COUNTER_INCREMENT("process_condition_update_count", 1);
+    ASSIGN_OR_RETURN(result->pk_column, segment_pk_iterator->encoded_pk_column(current.first.get()));
+    const auto chunk_size = result->pk_column->size();
+    if (chunk_size == 0) {
+        return Status::OK();
+    }
+    std::vector<uint64_t> old_rowids(chunk_size);
+    RETURN_IF_ERROR(index.get(*result->pk_column, &old_rowids));
+    // Fast path: no PKs in this chunk collide with the index → every new row wins.
+    bool non_old_value = std::all_of(old_rowids.begin(), old_rowids.end(), [](int64_t id) { return -1 == id; });
+    if (non_old_value) {
+        result->winner_ranges.emplace_back(0u, static_cast<uint32_t>(chunk_size));
+        return Status::OK();
+    }
+
+    std::map<uint32_t, std::vector<uint32_t>> old_rowids_by_rssid;
+    size_t num_default = 0;
+    std::vector<uint32_t> idxes;
+    RowsetUpdateState::plan_read_by_rssid(old_rowids, &num_default, &old_rowids_by_rssid, &idxes);
+    MutableColumns old_columns(1);
+    auto old_unordered_column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
+    old_columns[0] = old_unordered_column->clone_empty();
+    RETURN_IF_ERROR(
+            mgr->get_column_values(params, read_column_ids, num_default > 0, old_rowids_by_rssid, &old_columns));
+    auto old_column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
+    old_column->append_selective(*old_columns[0], idxes.data(), 0, idxes.size());
+
+    // Read new-row condition values from the freshly-ingested segment; rowid in this segment
+    // equals chunk_offset + local_idx.
+    std::map<uint32_t, std::vector<uint32_t>> new_rowids_by_rssid;
+    std::vector<uint32_t> rowids;
+    rowids.reserve(chunk_size);
+    for (size_t j = 0; j < chunk_size; ++j) {
+        rowids.push_back(static_cast<uint32_t>(j + current.second));
+    }
+    new_rowids_by_rssid[rowset_id + upsert_idx] = std::move(rowids);
+    // only support condition update on single column
+    MutableColumns new_columns(1);
+    auto new_column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
+    new_columns[0] = new_column->clone_empty();
+    RETURN_IF_ERROR(mgr->get_column_values(params, read_column_ids, false, new_rowids_by_rssid, &new_columns));
+
+    // Walk the chunk building contiguous "new wins" ranges, splitting on losers.
+    uint32_t run_begin = 0;
+    uint32_t run_step = 0;
+    for (size_t j = 0; j < old_column->size(); ++j) {
+        if (num_default > 0 && idxes[j] == 0) {
+            // plan_read_by_rssid uses idx 0 as sentinel for "no old row"; new row wins by default.
+            run_step++;
+        } else {
+            int r = old_column->compare_at(j, j, *new_columns[0].get(), -1);
+            if (r > 0) {
+                // Old wins: close the current winner run (if any) and mark this new row as loser.
+                if (run_step > 0) {
+                    result->winner_ranges.emplace_back(run_begin, run_begin + run_step);
+                }
+                result->new_loser_local_ids.push_back(static_cast<uint32_t>(j));
+                run_begin = static_cast<uint32_t>(j + 1);
+                run_step = 0;
+            } else {
+                // New wins (old <= new): extend the current run.
+                run_step++;
+            }
+        }
+    }
+    if (run_step > 0) {
+        result->winner_ranges.emplace_back(run_begin, run_begin + run_step);
+    }
+    return Status::OK();
+}
+
+// Performs condition-based merge update for the non-SST path using chunk-level parallelism.
+//
+// ALGORITHM:
+//   1. Iterate segment chunks serially; submit each chunk's compare work to the
+//      pk_index_execution thread pool (if parallelism is enabled).
+//   2. Each compare task: index.get() → read old/new condition columns → compute
+//      winner ranges and loser indices into a per-chunk result. No index writes.
+//   3. Barrier (token->wait()).
+//   4. Serial merge: for each chunk in order, index.upsert() the winner ranges and
+//      append new-loser rowids to new_deletes. The old rowids displaced by winners
+//      are collected by index.upsert via its DeletesMap out-param.
+//
+// WHY the upsert is serial: PrimaryIndex::upsert is documented [not thread-safe]; in
+// this path there is no later SST ingest, so winners must be inserted into the index
+// here, which forces the write phase to be serial.
 Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& params, uint32_t rowset_id,
                                                 int32_t upsert_idx, int32_t condition_column,
-                                                const MutableColumnPtr& upsert, PrimaryIndex& index,
+                                                const SegmentPKIteratorPtr& upsert, LakePrimaryIndex& index,
                                                 DeletesMap* new_deletes) {
     RETURN_ERROR_IF_FALSE(condition_column >= 0);
     TRACE_COUNTER_SCOPE_LATENCY_US("do_update_with_condition_latency_us");
@@ -1129,66 +1249,71 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
     std::vector<uint32_t> read_column_ids;
     read_column_ids.push_back(condition_column);
 
-    std::vector<uint64_t> old_rowids(upsert->size());
-    RETURN_IF_ERROR(index.get(*upsert, &old_rowids));
-    bool non_old_value = std::all_of(old_rowids.begin(), old_rowids.end(), [](int id) { return -1 == id; });
-    if (!non_old_value) {
-        std::map<uint32_t, std::vector<uint32_t>> old_rowids_by_rssid;
-        size_t num_default = 0;
-        vector<uint32_t> idxes;
-        RowsetUpdateState::plan_read_by_rssid(old_rowids, &num_default, &old_rowids_by_rssid, &idxes);
-        MutableColumns old_columns(1);
-        auto old_unordered_column =
-                ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
-        old_columns[0] = old_unordered_column->clone_empty();
-        RETURN_IF_ERROR(get_column_values(params, read_column_ids, num_default > 0, old_rowids_by_rssid, &old_columns));
-        auto old_column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
-        old_column->append_selective(*old_columns[0], idxes.data(), 0, idxes.size());
-
-        std::map<uint32_t, std::vector<uint32_t>> new_rowids_by_rssid;
-        std::vector<uint32_t> rowids;
-        rowids.reserve(upsert->size());
-        for (int j = 0; j < upsert->size(); ++j) {
-            rowids.push_back(j);
-        }
-        new_rowids_by_rssid[rowset_id + upsert_idx] = rowids;
-        // only support condition update on single column
-        MutableColumns new_columns(1);
-        auto new_column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
-        new_columns[0] = new_column->clone_empty();
-        RETURN_IF_ERROR(get_column_values(params, read_column_ids, false, new_rowids_by_rssid, &new_columns));
-
-        int idx_begin = 0;
-        int upsert_idx_step = 0;
-        for (int j = 0; j < old_column->size(); ++j) {
-            if (num_default > 0 && idxes[j] == 0) {
-                // plan_read_by_rssid will return idx with 0 if we have default value
-                upsert_idx_step++;
-            } else {
-                int r = old_column->compare_at(j, j, *new_columns[0].get(), -1);
-                if (r > 0) {
-                    RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upsert, idx_begin,
-                                                 idx_begin + upsert_idx_step, new_deletes));
-
-                    idx_begin = j + 1;
-                    upsert_idx_step = 0;
-
-                    // Update delete vector of current segment which is being applied
-                    (*new_deletes)[rowset_id + upsert_idx].push_back(j);
-                } else {
-                    upsert_idx_step++;
-                }
-            }
-        }
-
-        if (idx_begin < old_column->size()) {
-            RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upsert, idx_begin, idx_begin + upsert_idx_step,
-                                         new_deletes));
-        }
-    } else {
-        RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upsert, new_deletes));
+    std::unique_ptr<ThreadPoolToken> token;
+    if (config::enable_pk_index_parallel_execution) {
+        token = ExecEnv::GetInstance()->lake_partial_update_thread_pool()->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
     }
 
+    std::mutex mutex;
+    Status status = Status::OK();
+    // Per-chunk results accumulated in iteration order; consumed after the compare barrier.
+    std::vector<std::unique_ptr<ChunkCondMergeResult>> chunk_results;
+
+    for (; !upsert->done(); upsert->next()) {
+        auto current = upsert->current();
+        chunk_results.emplace_back(std::make_unique<ChunkCondMergeResult>());
+        auto* result = chunk_results.back().get();
+        result->chunk_offset = current.second;
+
+        auto compare_func = [&, result, current]() {
+            auto st = process_single_chunk_update_with_condition_no_sst(this, params, rowset_id, upsert_idx,
+                                                                        upsert.get(), current, tablet_column,
+                                                                        read_column_ids, index, result);
+            if (!st.ok()) {
+                std::lock_guard<std::mutex> lock(mutex);
+                status.update(st);
+            }
+        };
+
+        if (token) {
+            auto submit_st = token->submit_func(compare_func);
+            if (!submit_st.ok()) {
+                std::lock_guard<std::mutex> lock(mutex);
+                status.update(submit_st);
+            }
+        } else {
+            compare_func();
+            RETURN_IF_ERROR(status);
+        }
+    }
+
+    if (token) {
+        TRACE_COUNTER_SCOPE_LATENCY_US("parallel_condition_update_wait_us");
+        token->wait();
+    }
+    RETURN_IF_ERROR(status);
+    RETURN_IF_ERROR(upsert->status());
+
+    // Serial merge: apply index.upsert to each chunk's winner ranges and record new-losers.
+    // rowid_start=chunk_offset ensures the index records rowids that match the segment file layout.
+    const uint32_t rssid = rowset_id + upsert_idx;
+    for (const auto& result : chunk_results) {
+        if (result->pk_column == nullptr) {
+            continue;
+        }
+        for (const auto& range : result->winner_ranges) {
+            RETURN_IF_ERROR(index.upsert(rssid, static_cast<uint32_t>(result->chunk_offset), *result->pk_column,
+                                         range.first, range.second, new_deletes));
+        }
+        if (!result->new_loser_local_ids.empty()) {
+            auto& seg_deletes = (*new_deletes)[rssid];
+            seg_deletes.reserve(seg_deletes.size() + result->new_loser_local_ids.size());
+            for (uint32_t local : result->new_loser_local_ids) {
+                seg_deletes.push_back(static_cast<uint32_t>(result->chunk_offset) + local);
+            }
+        }
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -235,9 +235,17 @@ private:
     Status _do_update(uint32_t rowset_id, int32_t upsert_idx, const SegmentPKIteratorPtr& upsert,
                       LakePrimaryIndex& index, DeletesMap* new_deletes, bool read_only, bool is_cloud_native_index);
 
+    // Performs condition-based merge update using parallel chunk-level execution for segments
+    // WITHOUT pre-materialized SST files. Unlike the SST-backed sibling, new-row condition values
+    // are read from the freshly-ingested segment file on demand, and winning new rows are upserted
+    // into the primary index in-place here (there is no later SST ingest).
+    //
+    // PARALLELISM: compare/read phase runs per-chunk on the lake_partial_update_thread_pool;
+    // index.upsert is applied serially after the barrier because PrimaryIndex::upsert is not
+    // thread-safe.
     Status _do_update_with_condition(const RowsetUpdateStateParams& params, uint32_t rowset_id, int32_t upsert_idx,
-                                     int32_t condition_column, const MutableColumnPtr& upsert, PrimaryIndex& index,
-                                     DeletesMap* new_deletes);
+                                     int32_t condition_column, const SegmentPKIteratorPtr& upsert,
+                                     LakePrimaryIndex& index, DeletesMap* new_deletes);
 
     int32_t _get_condition_column(const TxnLogPB_OpWrite& op_write, const TabletSchema& tablet_schema);
 

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -420,6 +420,202 @@ TEST_P(ConditionUpdateTest, test_condition_update_parallel) {
     }
 }
 
+// Exercises the non-SST condition-merge path with parallel execution enabled
+// (the branch refactored by _do_update_with_condition to use chunk-level parallelism
+// plus a serial index.upsert phase). SSTs are intentionally not produced here:
+// ignore_merge_condition_inside_same_transaction is left at its default (false) and
+// write_buffer_size is left large, so the publish path enters _do_update_with_condition.
+//
+// Scenario mirrors test_condition_update but the compare phase runs on the
+// pk_index_execution_thread_pool; results must be identical to the serial path.
+TEST_P(ConditionUpdateTest, test_condition_update_no_sst_parallel) {
+    ConfigResetGuard<bool> guard(&config::enable_pk_index_parallel_execution, true);
+
+    auto chunk0 = generate_data(kChunkSize, 0, 3, 4);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+
+    // Four condition updates with c1 as the merge column (max wins):
+    //   (c1=4,c2=5): 4 > 3, new wins -> (4,5)
+    //   (c1=3,c2=6): 3 < 4, old wins -> (4,5)
+    //   (c1=4,c2=6): 4 >= 4, new wins on tie -> (4,6)
+    //   (c1=5,c2=6): 5 > 4, new wins -> (5,6)
+    Chunk chunks[4];
+    chunks[0] = generate_data(kChunkSize, 0, 4, 5);
+    chunks[1] = generate_data(kChunkSize, 0, 3, 6);
+    chunks[2] = generate_data(kChunkSize, 0, 4, 6);
+    chunks[3] = generate_data(kChunkSize, 0, 5, 6);
+    std::pair<int, int> result[4] = {{4, 5}, {4, 5}, {4, 6}, {5, 6}};
+    for (int i = 0; i < 4; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_merge_condition("c1")
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+        ASSERT_EQ(kChunkSize, check(version, [&](int c0, int c1, int c2) {
+                      return (c0 * result[i].first == c1) && (c0 * result[i].second == c2);
+                  }));
+    }
+}
+
+// Covers the non-SST parallel path across multiple segments within a single txn.
+// write_buffer_size=1 forces each write() to flush into its own segment so the publish
+// loop calls _do_update_with_condition repeatedly; each call submits its chunk's
+// compare task to the shared pool, and the final index.upsert is applied per segment
+// after the barrier.
+TEST_P(ConditionUpdateTest, test_condition_update_no_sst_parallel_multi_segment) {
+    ConfigResetGuard<bool> guard(&config::enable_pk_index_parallel_execution, true);
+
+    auto chunk0 = generate_data(kChunkSize, 0, 3, 4);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    auto chunk1 = generate_data(kChunkSize, 0, 4, 5);
+    auto chunk2 = generate_data(kChunkSize, 0, 3, 6);
+    // Force one segment per write.
+    ConfigResetGuard<int64_t> guard_buf(&config::write_buffer_size, 1);
+    for (int i = 0; i < 2; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_merge_condition("c1")
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(i == 0 ? chunk1 : chunk2, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    // After both condition updates, c1=4,c2=5 must win over the (c1=3,c2=6) follow-up.
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 4 == c1) && (c0 * 5 == c2); }));
+}
+
+// Covers the "all new rows win / no collisions" fast path in the non-SST parallel merge:
+// every primary key in the condition-update chunk is brand new (disjoint from baseline keys),
+// so index.get() returns -1 for every row and the per-chunk task skips the condition-column
+// reads. Serial merge then upserts the whole chunk as a single winner range.
+TEST_P(ConditionUpdateTest, test_condition_update_no_sst_parallel_all_new_keys) {
+    ConfigResetGuard<bool> guard(&config::enable_pk_index_parallel_execution, true);
+
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // Baseline keys: shift=0, so c0 in [0, kChunkSize).
+    auto baseline = generate_data(kChunkSize, 0, 3, 4);
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(baseline, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Condition update on disjoint keys (shift=1 → c0 in [kChunkSize, 2*kChunkSize)).
+    auto disjoint = generate_data(kChunkSize, 1, 7, 8);
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_merge_condition("c1")
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(disjoint, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Both key ranges coexist: baseline rows keep (3,4) and new rows carry (7,8).
+    ASSERT_EQ(2 * kChunkSize, check(version, [](int c0, int c1, int c2) {
+                  if (c0 < kChunkSize) {
+                      return (c0 * 3 == c1) && (c0 * 4 == c2);
+                  }
+                  return (c0 * 7 == c1) && (c0 * 8 == c2);
+              }));
+}
+
 INSTANTIATE_TEST_SUITE_P(ConditionUpdateTest, ConditionUpdateTest, ::testing::Values(PrimaryKeyParam{true}));
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

The lake condition-update publish path has three branches (`be/src/storage/lake/update_manager.cpp:340-369`):

| Branch | Parallel? |
|---|---|
| `_do_update` (no condition) | ✅ chunk-level via `LakePrimaryIndex::parallel_upsert/get` |
| `_do_update_with_condition_parallel` (condition + SSTs) | ✅ chunk-level compare |
| `_do_update_with_condition` (condition, no SSTs) | ❌ serial for the whole segment |

The third branch was the only remaining serial path. For large tablets doing conditional updates without SST spill, the compare phase (`index.get` + reading old/new condition columns + row-by-row `compare_at`) was a single-threaded bottleneck, while the other two paths already scaled to multiple cores on the `pk_index_execution_thread_pool`.

## What I'm doing:

Refactor `_do_update_with_condition` to use chunk-level parallelism while keeping the final index-write serial:

1. Change the signature to take `SegmentPKIteratorPtr` (chunked iterator, same as the parallel sibling) instead of a flat `MutableColumnPtr` and to use `LakePrimaryIndex&` for consistency.
2. Iterate chunks; submit each chunk's compare work (encode PK → `index.get` → read old/new condition columns → compute winner ranges / new-loser indices) to `pk_index_execution_thread_pool` when `config::enable_pk_index_parallel_execution` is on. Results land in a per-chunk `ChunkCondMergeResult`.
3. Barrier (`token->wait()`), then serially apply `index.upsert(rssid, chunk_offset, pk_column, begin, end, new_deletes)` to each chunk's winner ranges and append new-loser rowids.

The index write is kept serial because `PrimaryIndex::upsert` is documented `[not thread-safe]` and, unlike the SST-backed sibling, this path has no later `ingest_sst` to consolidate writes. The parallelism win comes from the compare/read phase, which is the dominant cost on large segments (I/O-bound condition column reads).

Semantics are preserved exactly: old-row deletes from replaced keys still come from `index.upsert`'s `DeletesMap` out-param, and new-losers are pushed into `new_deletes` with absolute rowids (`chunk_offset + local_idx`).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4