### PR TITLE
[BugFix] Dedup ReshardingTablet in PublishTabletsInfo to avoid MERGE livelock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/IdenticalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/IdenticalTablet.java
@@ -56,6 +56,11 @@ public class IdenticalTablet implements ReshardingTablet {
         return oldTabletId;
     }
 
+    @Override
+    public long getFirstNewTabletId() {
+        return newTabletId;
+    }
+
     public long getOldTabletId() {
         return oldTabletId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergingTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergingTablet.java
@@ -57,6 +57,11 @@ public class MergingTablet implements ReshardingTablet {
     }
 
     @Override
+    public long getFirstNewTabletId() {
+        return newTabletId;
+    }
+
+    @Override
     public List<Long> getOldTabletIds() {
         return oldTabletIds;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/PublishTabletsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/PublishTabletsInfo.java
@@ -17,7 +17,9 @@ package com.starrocks.alter.reshard;
 import com.starrocks.proto.ReshardingTabletInfoPB;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /*
  * PublishTabletsInfo is for publish version
@@ -25,6 +27,15 @@ import java.util.List;
 public class PublishTabletsInfo {
     private final List<Long> tabletIds = new ArrayList<>();
     private final List<ReshardingTabletInfoPB> reshardingTablets = new ArrayList<>();
+
+    // A ReshardingTablet may be registered under every one of its old tablet
+    // ids (see MergeTabletJob.registerReshardingTablets). Iteration over
+    // partition tablets then calls addReshardingTablet multiple times for the
+    // same logical op. Dedupe by getIdentityKey() so each op is serialised
+    // into the wire request exactly once. Without this dedup, BE fan-outs
+    // parallel publish_resharding_tablet tasks that self-conflict on the
+    // per-reshard publish slot, leaving MERGE stuck in RUNNING.
+    private final Set<Long> addedReshardOpIds = new HashSet<>();
 
     public List<Long> getTabletIds() {
         return tabletIds;
@@ -39,7 +50,9 @@ public class PublishTabletsInfo {
     }
 
     public void addReshardingTablet(ReshardingTablet reshardingTablet) {
-        reshardingTablets.add(reshardingTablet.toProto());
+        if (addedReshardOpIds.add(reshardingTablet.getFirstNewTabletId())) {
+            reshardingTablets.add(reshardingTablet.toProto());
+        }
     }
 
     public List<Long> getOldTabletIds() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ReshardingTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ReshardingTablet.java
@@ -32,6 +32,14 @@ public interface ReshardingTablet {
 
     long getFirstOldTabletId();
 
+    /**
+     * Returns the first new tablet id produced by this reshard. New tablet
+     * ids are freshly allocated via GlobalStateMgr.getNextId() and never
+     * reused, so the returned value is globally unique and uniquely
+     * identifies this reshard op. Symmetric with {@link #getFirstOldTabletId()}.
+     */
+    long getFirstNewTabletId();
+
     List<Long> getOldTabletIds();
 
     List<Long> getNewTabletIds();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
@@ -62,6 +62,11 @@ public class SplittingTablet implements ReshardingTablet {
     }
 
     @Override
+    public long getFirstNewTabletId() {
+        return newTabletIds.get(0);
+    }
+
+    @Override
     public List<Long> getOldTabletIds() {
         return List.of(oldTabletId);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/PublishTabletsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/PublishTabletsInfoTest.java
@@ -37,4 +37,50 @@ public class PublishTabletsInfoTest {
         Assertions.assertFalse(publishTabletsInfo.getReshardingTablets().isEmpty());
         Assertions.assertFalse(publishTabletsInfo.getOldTabletIds().isEmpty());
     }
+
+    @Test
+    public void testAddReshardingTabletIsIdempotentByIdentityKey() {
+        // The same MergingTablet is registered under every one of its old tablet ids
+        // (see MergeTabletJob.registerReshardingTablets), so Utils.processTablets calls
+        // addReshardingTablet once per input. The dedup guard must keep the reshard op
+        // in the wire list exactly once regardless of how many times it is added.
+        PublishTabletsInfo info = new PublishTabletsInfo();
+
+        MergingTablet merge = new MergingTablet(List.of(31L, 32L, 33L, 34L), 100L);
+        info.addReshardingTablet(merge);
+        info.addReshardingTablet(merge);
+        info.addReshardingTablet(merge);
+        info.addReshardingTablet(merge);
+
+        Assertions.assertEquals(1, info.getReshardingTablets().size());
+        Assertions.assertEquals(100L, merge.getFirstNewTabletId());
+    }
+
+    @Test
+    public void testAddReshardingTabletDedupsLogicallyEqualButDistinctObjects() {
+        // Robustness goal: survive future changes that might produce multiple
+        // ReshardingTablet instances for the same logical op (e.g. image reload,
+        // replay, clone). Dedup is by content-derived identity key (first new tablet id),
+        // not by Java reference.
+        PublishTabletsInfo info = new PublishTabletsInfo();
+
+        info.addReshardingTablet(new MergingTablet(List.of(31L, 32L), 100L));
+        info.addReshardingTablet(new MergingTablet(List.of(31L, 32L), 100L));
+
+        Assertions.assertEquals(1, info.getReshardingTablets().size());
+    }
+
+    @Test
+    public void testAddReshardingTabletAcceptsDistinctReshardOps() {
+        // Different reshard ops have different new tablet ids (globally allocated
+        // via GlobalStateMgr.getNextId()), so they must not dedupe.
+        PublishTabletsInfo info = new PublishTabletsInfo();
+
+        info.addReshardingTablet(new MergingTablet(List.of(31L, 32L), 100L));
+        info.addReshardingTablet(new MergingTablet(List.of(41L, 42L), 200L));
+        info.addReshardingTablet(new SplittingTablet(50L, List.of(300L, 301L)));
+        info.addReshardingTablet(new IdenticalTablet(60L, 400L));
+
+        Assertions.assertEquals(4, info.getReshardingTablets().size());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

A MERGE reshard with N input tablets could hang in `JOB_STATE=RUNNING` indefinitely, with an FE-side runaway retry loop — one CN saw 20M+ `publish_version_executed_tasks` under a single stuck merge — and the partition bundle never reaching v+1 on OSS.

**Root cause** lives in the FE publish-request construction path:

1. A `ReshardingTablet` is registered under every one of its old tablet ids (`MergeTabletJob.registerReshardingTablets`).
2. `Utils.processTablets` iterates the partition's tablets to decide per-node routing, and invokes `PublishTabletsInfo.addReshardingTablet` once per input. For a MERGE with N inputs, the wire request ends up carrying **N copies of the same `ReshardingTabletInfoPB`**.
3. On the BE side, `LakeServiceImpl::publish_version` fans out one `CancellableRunnable` per `resharding_tablet_info`; all N tasks race to acquire the same per-reshard publish slot via `acquire_publish_tablet(old_tablet_ids[0])`. Exactly one CAS wins and does the merge; the other **N-1 return `Status::ResourceBusy`**.
4. The aggregate coordinator stamps the busy status onto the RPC response (`add_failed_tablets` + `response.status`), sets `has_failure=true`, and **skips `put_bundle_tablet_metadata`**.
5. The FE sees the RPC failure, sets `PublishState.FAILED`, and resubmits at the 10 ms scheduler tick. Every retry reproduces the same N-1 self-conflict — the loop is **deterministic, not flaky**.

Diagnosed from FE and BE logs on a live test cluster; see `/tmp/pk_reshard_test/ROOT_CAUSE_ANALYSIS.md` in the investigation artifacts.

## What I'm doing:

Fix at the source: make `PublishTabletsInfo.addReshardingTablet` idempotent by content-derived identity.

- Add `ReshardingTablet.getFirstNewTabletId()`, symmetric with the existing `getFirstOldTabletId()`. New tablet ids are freshly allocated via `GlobalStateMgr.getNextId()` and never reused, so the first new tablet id uniquely identifies a reshard op. Implemented in `MergingTablet`, `SplittingTablet`, `IdenticalTablet`.
- In `PublishTabletsInfo`, keep a `Set<Long> addedReshardOpIds` keyed by `getFirstNewTabletId()`; `addReshardingTablet` only appends to the wire list on first seen. This is robust to object-identity changes (e.g. replay from image, clones) as well as the existing reference-reuse pattern.
- Tests added in `PublishTabletsInfoTest`:
  - `testAddReshardingTabletIsIdempotentByIdentityKey` — same `MergingTablet` added 4 times → 1 entry in the wire list
  - `testAddReshardingTabletDedupsLogicallyEqualButDistinctObjects` — two distinct `MergingTablet` instances with same new id → deduped
  - `testAddReshardingTabletAcceptsDistinctReshardOps` — different reshard ops (different new ids) are not deduped

Fixes https://github.com/StarRocks/starrocks/issues/64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4