### PR TITLE
[Enhancement] Auto-repair corrupted PK tablets via error-state scheduling

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -118,7 +118,16 @@ Status Tablet::_init_once_action() {
     if (keys_type() == PRIMARY_KEYS) {
         _updates = std::make_unique<TabletUpdates>(*this);
         Status st = _updates->init();
-        LOG_IF(WARNING, !st.ok()) << "Fail to init updates: " << st;
+        if (!st.ok()) {
+            if (st.is_corruption()) {
+                LOG(ERROR) << "Tablet " << tablet_id() << " init failed with corruption: " << st
+                           << ", setting to error state for FE-driven repair";
+                _updates->set_error(std::string(st.message()));
+                return Status::OK();
+            }
+            LOG(WARNING) << "Tablet " << tablet_id() << " fail to init updates: " << st;
+            return st;
+        }
         return st;
     }
     for (const auto& rs_meta : _tablet_meta->all_rs_metas()) {

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -621,6 +621,85 @@ TEST_F(TabletUpdatesTest, test_rowset_file_existence) {
     ASSERT_FALSE(_tablet->updates()->rowset_check_file_existence());
 }
 
+TEST_F(TabletUpdatesTest, test_pk_tablet_init_corruption_sets_error_state) {
+    srand(GetCurrentTimeMicros());
+    auto tablet_id = rand();
+    auto schema_hash = rand();
+    _tablet = create_tablet(tablet_id, schema_hash);
+
+    // Write some data so the tablet has at least one rowset whose metadata we can corrupt.
+    std::vector<int64_t> keys = {0, 1, 2, 3, 4};
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys)).ok());
+    ASSERT_EQ(2, _tablet->updates()->max_version());
+
+    auto data_dir = _tablet->data_dir();
+    std::string meta_str;
+    ASSERT_TRUE(_tablet->tablet_meta()->serialize(&meta_str).ok());
+
+    // Pick the rowset that the apply version references and delete its metadata from
+    // the local kv store. This is the meta-level corruption that TabletUpdates::init
+    // cannot auto-purge (the apply version's own rowset is missing), so init returns
+    // Status::Corruption and we exercise the corruption branch in Tablet::_init_once_action.
+    std::vector<RowsetSharedPtr> applied_rowsets;
+    EditVersion full_edit_version;
+    ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(2, &applied_rowsets, &full_edit_version).ok());
+    ASSERT_FALSE(applied_rowsets.empty());
+    RowsetSharedPtr applied_rowset = applied_rowsets.back();
+    uint32_t rowset_seg_id = applied_rowset->rowset_meta()->get_rowset_seg_id();
+    uint32_t num_segments = static_cast<uint32_t>(applied_rowset->num_segments());
+    ASSERT_TRUE(TabletMetaManager::rowset_delete(data_dir, tablet_id, rowset_seg_id, num_segments).ok());
+
+    // Drop the in-memory tablet so reload re-reads everything from disk.
+    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(tablet_id);
+    _tablet.reset();
+
+    // Reload. Init must not propagate a hard failure; the corruption branch in
+    // Tablet::_init_once_action sets the tablet to error state and returns OK so the
+    // tablet is still loaded and reportable to FE for repair.
+    auto st = StorageEngine::instance()->tablet_manager()->load_tablet_from_meta(data_dir, tablet_id, schema_hash,
+                                                                                 meta_str, true);
+    ASSERT_TRUE(st.ok()) << st;
+
+    auto reloaded = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    ASSERT_NE(nullptr, reloaded);
+    ASSERT_NE(nullptr, reloaded->updates());
+    ASSERT_TRUE(reloaded->updates()->is_error());
+    _tablet = reloaded;
+}
+
+// Covers the non-corruption branch in Tablet::_init_once_action: when TabletUpdates::init
+// returns a non-corruption error (here, the tablet meta has no updates_pb because we
+// already released it), _init_once_action must propagate the error rather than silently
+// flipping the tablet to error state.
+TEST_F(TabletUpdatesTest, test_pk_tablet_init_non_corruption_error_propagates) {
+    srand(GetCurrentTimeMicros());
+    auto tablet_id = rand();
+    auto schema_hash = rand();
+    _tablet = create_tablet(tablet_id, schema_hash);
+
+    auto data_dir = _tablet->data_dir();
+    std::string meta_str;
+    ASSERT_TRUE(_tablet->tablet_meta()->serialize(&meta_str).ok());
+
+    // Build a fresh TabletMeta from the serialized bytes, then release the updates_pb
+    // out of it. After this, when Tablet::_init_once_action runs, TabletUpdates::init
+    // will see a null updates_pb and return Status::InternalError - the non-corruption
+    // path under test.
+    auto fresh_meta = std::make_shared<TabletMeta>();
+    ASSERT_TRUE(fresh_meta->deserialize(meta_str).ok());
+    std::unique_ptr<TabletUpdatesPB> released(fresh_meta->release_updates(nullptr));
+    ASSERT_NE(nullptr, released);
+
+    auto fresh_tablet = Tablet::create_tablet_from_meta(fresh_meta, data_dir);
+    ASSERT_NE(nullptr, fresh_tablet);
+
+    auto init_st = fresh_tablet->init();
+    ASSERT_FALSE(init_st.ok());
+    ASSERT_FALSE(init_st.is_corruption());
+    // The original tablet (still in the manager) is unaffected - we only mutated a
+    // freshly-deserialized copy of its meta.
+}
+
 TEST_F(TabletUpdatesTest, writeread_with_delete_with_sort_key) {
     _tablet = create_tablet_with_sort_key(rand(), rand(), {1});
     // write

--- a/docs/en/administration/management/FE_parameters/stats_storage.md
+++ b/docs/en/administration/management/FE_parameters/stats_storage.md
@@ -399,6 +399,15 @@ This topic introduces the following types of FE configurations:
 - Description: The maximum duration the scheduler allows for a BE node to remain inactive. After the time threshold is reached, tablets on that BE node will be migrated to other active BE nodes.
 - Introduced in: v2.5.7
 
+### `tablet_sched_delete_error_state_replica_permits_per_second`
+
+- Default: 10.0
+- Type: Double
+- Unit: Permits per second
+- Is mutable: Yes
+- Description: The maximum number of error-state replicas the tablet scheduler is allowed to delete per second. Deletions exceeding this rate are skipped and retried in later scheduling rounds. Changes take effect on the next scheduling round without a restart.
+- Introduced in: v3.5.18, v4.0.11, v4.1.2
+
 ### `tablet_sched_disable_balance`
 
 - Default: false

--- a/docs/ja/administration/management/FE_parameters/stats_storage.md
+++ b/docs/ja/administration/management/FE_parameters/stats_storage.md
@@ -399,6 +399,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：スケジューラが BE ノードを非アクティブのままにする最大期間。この時間しきい値に達すると、その BE ノード上のタブレットは他のアクティブな BE ノードに移行されます。
 - 導入時期：v2.5.7
 
+### `tablet_sched_delete_error_state_replica_permits_per_second`
+
+- デフォルト：10.0
+- タイプ：Double
+- 単位：Permits per second
+- 変更可能：Yes
+- 説明：タブレットスケジューラが 1 秒あたりに削除できる error-state レプリカの最大数。このレートを超える削除はスキップされ、以降のスケジューリングラウンドで再試行されます。変更は再起動なしで次のスケジューリングラウンドから反映されます。
+- 導入時期：v3.5.18、v4.0.11、v4.1.2
+
 ### `tablet_sched_disable_balance`
 
 - デフォルト：false

--- a/docs/zh/administration/management/FE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/FE_parameters/stats_storage.md
@@ -399,6 +399,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 调度器允许 BE 节点保持非活动状态的最大持续时间。达到时间阈值后，该 BE 节点上的 tablet 将迁移到其他活动 BE 节点。
 - 引入版本: v2.5.7
 
+### `tablet_sched_delete_error_state_replica_permits_per_second`
+
+- 默认值: 10.0
+- 类型: Double
+- 单位: 每秒许可数
+- 是否可变: Yes
+- 描述: tablet 调度器每秒最多删除 error-state 副本的数量。超过该速率的删除会被跳过，留到后续调度轮次重试。修改后无需重启，在下一轮调度时生效。
+- 引入版本: v3.5.18、v4.0.11、v4.1.2
+
 ### `tablet_sched_disable_balance`
 
 - 默认值: false

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -252,7 +252,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         SystemInfoService infoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
         try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
             for (Replica replica : replicas) {
-                if (replica.isBad()) {
+                if (replica.isBad() || replica.isErrorState()) {
                     continue;
                 }
 
@@ -271,7 +271,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         Multimap<Replica, Long> map = LinkedHashMultimap.create();
         try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
             for (Replica replica : replicas) {
-                if (replica.isBad()) {
+                if (replica.isBad() || replica.isErrorState()) {
                     continue;
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -887,6 +887,7 @@ public class TabletChecker extends FrontendDaemon {
         return replica.getState() == Replica.ReplicaState.CLONE
                 || replica.getState() == Replica.ReplicaState.DECOMMISSION
                 || replica.isBad()
+                || replica.isErrorState()
                 || !replicaHostSet.add(backend.getHost());
     }
 
@@ -1318,11 +1319,11 @@ public class TabletChecker extends FrontendDaemon {
                 continue;
             }
 
-            if (replica.isBad()) {
-                LOG.debug("colocate tablet {} has bad replica, need to drop-then-repair, " +
+            if (replica.isBad() || replica.isErrorState()) {
+                LOG.debug("colocate tablet {} has bad or error-state replica, need to drop-then-repair, " +
                                 "current backend set: {}, visible version: {}", localTablet.getId(), backendsSet,
                         visibleVersion);
-                // we use `TabletScheduler#handleColocateRedundant()` to drop bad replica forcefully.
+                // we use `TabletScheduler#handleColocateRedundant()` to drop such replicas forcefully.
                 return TabletHealthStatus.COLOCATE_REDUNDANT;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -574,7 +574,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
     public List<Replica> getHealthyReplicas(boolean includeDecommissioned) {
         List<Replica> candidates = Lists.newArrayList();
         for (Replica replica : tablet.getImmutableReplicas()) {
-            if (replica.isBad() || replica.getState() == ReplicaState.RECOVER ||
+            if (replica.isBad() || replica.isErrorState() || replica.getState() == ReplicaState.RECOVER ||
                     (!includeDecommissioned && replica.getState() == ReplicaState.DECOMMISSION)) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.RateLimiter;
 import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.catalog.CatalogRecycleBin;
 import com.starrocks.catalog.ColocateTableIndex.GroupId;
@@ -181,6 +182,10 @@ public class TabletScheduler extends LeaderDaemon {
     private final Rebalancer rebalancer;
 
     private final AtomicBoolean forceCleanSchedQ = new AtomicBoolean(false);
+
+    // Throttle for error-state replica deletion.
+    private final RateLimiter errorReplicaDeleteRateLimiter =
+            RateLimiter.create(Config.tablet_sched_delete_error_state_replica_permits_per_second);
 
     // result of adding a tablet to pendingTablets
     public enum AddResult {
@@ -452,6 +457,8 @@ public class TabletScheduler extends LeaderDaemon {
      */
     @Override
     protected void runAfterLeaseValid() {
+        refreshErrorReplicaDeleteRateLimiter();
+
         if (!updateWorkingSlots()) {
             return;
         }
@@ -505,6 +512,16 @@ public class TabletScheduler extends LeaderDaemon {
         lastSlotAdjustTime = 0;
         currentSlotPerPathConfig = 0;
         forceCleanSchedQ.set(false);
+    }
+
+    // Re-sync the error-replica delete RateLimiter with Config if the value has changed,
+    // allowing mutable Config updates to take effect at the start of each check loop.
+    private void refreshErrorReplicaDeleteRateLimiter() {
+        double configured = Config.tablet_sched_delete_error_state_replica_permits_per_second;
+        if (configured > 0 && configured != errorReplicaDeleteRateLimiter.getRate()) {
+            errorReplicaDeleteRateLimiter.setRate(configured);
+            LOG.info("error-state replica delete rate limiter updated to {} permits/sec", configured);
+        }
     }
 
     private void updateClusterLoadStatisticsAndPriority() {
@@ -1010,7 +1027,7 @@ public class TabletScheduler extends LeaderDaemon {
         int unavailableCnt = 0;
         for (Replica replica : replicas) {
             if (GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(replica.getBackendId()) == null ||
-                    replica.isBad()) {
+                    replica.isBad() || replica.isErrorState()) {
                 unavailableCnt++;
             }
         }
@@ -1125,6 +1142,7 @@ public class TabletScheduler extends LeaderDaemon {
             checkMetaExist(tabletCtx);
             if (deleteBackendDropped(tabletCtx, force)
                     || deleteBadReplica(tabletCtx, force)
+                    || deleteErrorStateReplica(tabletCtx, force)
                     || deleteBackendUnavailable(tabletCtx, force)
                     || deleteCloneOrDecommissionReplica(tabletCtx, force)
                     || deleteLocationMismatchReplica(tabletCtx, force)
@@ -1161,6 +1179,53 @@ public class TabletScheduler extends LeaderDaemon {
                 deleteReplicaInternal(tabletCtx, replica, "replica is bad", force);
                 return true;
             }
+        }
+        return false;
+    }
+
+    private boolean deleteErrorStateReplica(TabletSchedCtx tabletCtx, boolean force) throws SchedException {
+        List<Replica> replicas = tabletCtx.getReplicas();
+        for (Replica replica : replicas) {
+            if (replica.isErrorState()) {
+                // Only drop an error-state replica when at least one other replica is still healthy
+                // and loadable. Dropping the last usable replica would turn a recoverable error-state
+                // tablet into data loss with no source to clone from.
+                if (!hasAnotherHealthyReplica(replicas, replica)) {
+                    LOG.info("skip deleting error-state replica {} of tablet {}: no other healthy replica remains",
+                            replica.getId(), tabletCtx.getTabletId());
+                    return false;
+                }
+                if (!errorReplicaDeleteRateLimiter.tryAcquire()) {
+                    LOG.info("skip deleting error-state replica {} of tablet {} due to throttling",
+                            replica.getId(), tabletCtx.getTabletId());
+                    return false;
+                }
+                deleteReplicaInternal(tabletCtx, replica, "replica is in error state", force);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Returns true if `replicas` contains at least one replica other than `exclude` that is
+    // not bad, not in error state, on an alive backend, and in a loadable state.
+    private static boolean hasAnotherHealthyReplica(List<Replica> replicas, Replica exclude) {
+        SystemInfoService infoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        for (Replica replica : replicas) {
+            if (replica == exclude) {
+                continue;
+            }
+            if (replica.isBad() || replica.isErrorState()) {
+                continue;
+            }
+            if (!replica.getState().canLoad()) {
+                continue;
+            }
+            Backend be = infoService.getBackend(replica.getBackendId());
+            if (be == null || !be.isAlive()) {
+                continue;
+            }
+            return true;
         }
         return false;
     }
@@ -1367,18 +1432,35 @@ public class TabletScheduler extends LeaderDaemon {
             List<Replica> replicas = tabletCtx.getReplicas();
             for (Replica replica : replicas) {
                 boolean forceDropBad = false;
+                String reason = "colocate redundant";
                 if (backendSet.contains(replica.getBackendId())) {
                     if (replica.isBad() && replicas.size() > 1) {
                         forceDropBad = true;
-                        LOG.info("colocate tablet {}, replica {} is bad," +
-                                        "will forcefully drop it, current backend set: {}",
+                        reason = "colocate redundant bad replica";
+                        LOG.info("colocate tablet {}, replica {} is bad, will forcefully drop it," +
+                                        " current backend set: {}",
+                                tabletCtx.getTabletId(), replica.getBackendId(), backendSet);
+                    } else if (replica.isErrorState() && hasAnotherHealthyReplica(replicas, replica)) {
+                        // Only drop an error-state replica when another healthy replica remains,
+                        // otherwise we would turn a recoverable tablet into data loss.
+                        // Throttle through the same rate limiter as the generic path so a colocate
+                        // repair wave cannot bypass tablet_sched_delete_error_state_replica_permits_per_second.
+                        if (!errorReplicaDeleteRateLimiter.tryAcquire()) {
+                            LOG.info("skip deleting error-state replica {} of colocate tablet {} due to throttling",
+                                    replica.getId(), tabletCtx.getTabletId());
+                            continue;
+                        }
+                        forceDropBad = true;
+                        reason = "colocate redundant error-state replica";
+                        LOG.info("colocate tablet {}, replica {} is in error state, will forcefully drop it," +
+                                        " current backend set: {}",
                                 tabletCtx.getTabletId(), replica.getBackendId(), backendSet);
                     } else {
                         continue;
                     }
                 }
 
-                deleteReplicaInternal(tabletCtx, replica, "colocate redundant", forceDropBad);
+                deleteReplicaInternal(tabletCtx, replica, reason, forceDropBad);
                 throw new SchedException(Status.FINISHED, "colocate redundant replica is deleted");
             }
             throw new SchedException(Status.UNRECOVERABLE, "unable to delete any colocate redundant replicas. replicas: " +

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1867,6 +1867,18 @@ public class Config extends ConfigBase {
     public static boolean tablet_sched_always_force_decommission_replica = false;
 
     /**
+     * Rate limit (permits per second) for deleting error-state replicas in the tablet scheduler.
+     * A Guava RateLimiter with this rate guards deleteErrorStateReplica(); if tryAcquire() fails,
+     * the deletion is skipped in the current scheduling round. The RateLimiter is re-synced to
+     * this value at the start of each tablet scheduler check loop, so config changes take effect
+     * on the next loop without requiring a restart.
+     * Default: 10 deletions per second.
+     */
+    @ConfField(mutable = true,
+            comment = "Rate limit (permits/sec) for deleting error-state replicas in the tablet scheduler")
+    public static double tablet_sched_delete_error_state_replica_permits_per_second = 10.0;
+
+    /**
      * For certain deployment, like k8s pods + pvc, the replica is not lost even the
      * corresponding backend is detected as dead, because the replica data is persisted
      * on a pvc which is backed by a remote storage service, such as AWS EBS. And later,

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
@@ -290,4 +290,44 @@ public class LocalTabletTest {
         Multimap<Replica, Long> map2 = tablet.getNormalReplicaBackendPathMap(infoService, true);
         Assertions.assertTrue(map2.size() == 3);
     }
+
+    @Test
+    public void testNormalReplicaSelectorsFilterErrorState() {
+        List<Replica> replicas = Lists.newArrayList(new Replica(10001, 20001, ReplicaState.NORMAL, 10, -1),
+                new Replica(10002, 20002, ReplicaState.NORMAL, 10, -1),
+                new Replica(10003, 20003, ReplicaState.NORMAL, 10, -1));
+        LocalTablet tablet = new LocalTablet(10004, replicas);
+
+        new MockUp<SimpleScheduler>() {
+            @Mock
+            public boolean isInBlocklist(long id) {
+                return false;
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public boolean checkBackendAlive(long id) {
+                return true;
+            }
+        };
+
+        // Baseline: all three replicas included.
+        Assertions.assertEquals(3, tablet.getNormalReplicaBackendIds().size());
+        Assertions.assertEquals(3, tablet.getNormalReplicaBackendPathMap(infoService, false).size());
+
+        // Marking a replica error-state should exclude it from both write-path selectors,
+        // matching the behavior of the query-path selectors and preventing writes to a
+        // replica that BE will reject once its TabletUpdates enters error state.
+        replicas.get(0).setIsErrorState(true);
+        List<Long> beIds = tablet.getNormalReplicaBackendIds();
+        Assertions.assertEquals(2, beIds.size());
+        Assertions.assertFalse(beIds.contains(20001L));
+
+        Multimap<Replica, Long> map = tablet.getNormalReplicaBackendPathMap(infoService, false);
+        Assertions.assertEquals(2, map.size());
+        for (Map.Entry<Replica, Long> entry : map.entries()) {
+            Assertions.assertNotEquals(20001L, (long) entry.getKey().getBackendId());
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletCheckerTest.java
@@ -16,6 +16,10 @@ package com.starrocks.clone;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.LocalTablet.TabletHealthStatus;
+import com.starrocks.catalog.Replica;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import org.junit.jupiter.api.Assertions;
@@ -23,10 +27,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 public class TabletCheckerTest {
@@ -128,6 +136,61 @@ public class TabletCheckerTest {
         requiredLocation.put("*", "");
         Assertions.assertTrue(TabletChecker.shouldEnsureReplicaHA(3, requiredLocation, systemInfoService));
         requiredLocation.clear();
+    }
+
+    @Test
+    public void testIsReplicaStateAbnormal() throws Exception {
+        Method method = TabletChecker.class.getDeclaredMethod(
+                "isReplicaStateAbnormal", Replica.class, Backend.class, Set.class);
+        method.setAccessible(true);
+
+        Backend backend = Mockito.mock(Backend.class);
+        Mockito.when(backend.getHost()).thenReturn("host1");
+
+        // Normal replica is not abnormal
+        Replica normalReplica = new Replica(1L, 10001L, 0, Replica.ReplicaState.NORMAL);
+        Set<String> hosts = new HashSet<>();
+        Assertions.assertFalse((Boolean) method.invoke(null, normalReplica, backend, hosts));
+
+        // Error-state replica is abnormal
+        Replica errorReplica = new Replica(2L, 10002L, 0, Replica.ReplicaState.NORMAL);
+        errorReplica.setIsErrorState(true);
+        hosts = new HashSet<>();
+        Assertions.assertTrue((Boolean) method.invoke(null, errorReplica, backend, hosts));
+
+        // Bad replica is abnormal
+        Replica badReplica = new Replica(3L, 10003L, 0, Replica.ReplicaState.NORMAL);
+        badReplica.setBad(true);
+        hosts = new HashSet<>();
+        Assertions.assertTrue((Boolean) method.invoke(null, badReplica, backend, hosts));
+
+        // CLONE state replica is abnormal
+        Replica cloneReplica = new Replica(4L, 10004L, 0, Replica.ReplicaState.CLONE);
+        hosts = new HashSet<>();
+        Assertions.assertTrue((Boolean) method.invoke(null, cloneReplica, backend, hosts));
+
+        // DECOMMISSION state replica is abnormal
+        Replica decommissionReplica = new Replica(5L, 10005L, 0, Replica.ReplicaState.DECOMMISSION);
+        hosts = new HashSet<>();
+        Assertions.assertTrue((Boolean) method.invoke(null, decommissionReplica, backend, hosts));
+    }
+
+    @Test
+    public void testColocateTabletHealthStatusDetectsErrorStateReplica() {
+        long visibleVersion = 10L;
+        // Replica on backend 20001 is in error state; the error-state check must run before
+        // the disk-decommission check so we do not depend on SystemInfoService being populated.
+        Replica errorReplica = new Replica(10001L, 20001L, Replica.ReplicaState.NORMAL, visibleVersion, -1);
+        errorReplica.setIsErrorState(true);
+        Replica healthyReplica1 = new Replica(10002L, 20002L, Replica.ReplicaState.NORMAL, visibleVersion, -1);
+        Replica healthyReplica2 = new Replica(10003L, 20003L, Replica.ReplicaState.NORMAL, visibleVersion, -1);
+
+        LocalTablet tablet = new LocalTablet(10004L,
+                new ArrayList<>(Arrays.asList(errorReplica, healthyReplica1, healthyReplica2)));
+        Set<Long> backendsSet = Sets.newHashSet(20001L, 20002L, 20003L);
+
+        Assertions.assertEquals(TabletHealthStatus.COLOCATE_REDUNDANT,
+                TabletChecker.getColocateTabletHealthStatus(tablet, visibleVersion, 3, backendsSet));
     }
 
     private static SystemInfoService systemInfoService;

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -348,6 +348,36 @@ public class TabletSchedCtxTest {
     }
 
     @Test
+    public void testGetHealthyReplicasExcludesErrorState() {
+        Replica healthyReplica = new Replica(70010L, be1.getId(), 0, Replica.ReplicaState.NORMAL);
+        healthyReplica.setPathHash(2001L);
+        healthyReplica.updateVersionInfo(100L, 100L, 0L);
+
+        Replica errorReplica = new Replica(70011L, be2.getId(), 0, Replica.ReplicaState.NORMAL);
+        errorReplica.setPathHash(2002L);
+        errorReplica.updateVersionInfo(100L, 100L, 0L);
+        errorReplica.setIsErrorState(true);
+
+        LocalTablet tablet = new LocalTablet(30002L, Lists.newArrayList(healthyReplica, errorReplica));
+
+        TabletSchedCtx ctx = new TabletSchedCtx(Type.REPAIR, DB_ID, TB_ID, PART_ID, INDEX_ID,
+                30002L, System.currentTimeMillis(),
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+        ctx.setTablet(tablet);
+        ctx.setStorageMedium(TStorageMedium.HDD);
+        ctx.setVersionInfo(100L, 100L, 0L, 0L);
+
+        List<Replica> healthy = ctx.getHealthyReplicas(false);
+        Assertions.assertEquals(1, healthy.size());
+        Assertions.assertEquals(healthyReplica.getId(), healthy.get(0).getId());
+
+        // Also verify error-state replicas are excluded even when includeDecommissioned is true
+        List<Replica> healthyWithDecomm = ctx.getHealthyReplicas(true);
+        Assertions.assertEquals(1, healthyWithDecomm.size());
+        Assertions.assertEquals(healthyReplica.getId(), healthyWithDecomm.get(0).getId());
+    }
+
+    @Test
     public void testChooseSrcReplica() {
         Replica replicaNormalIncomplete = new Replica(70001L, be1.getId(), 0, Replica.ReplicaState.NORMAL);
         replicaNormalIncomplete.setPathHash(2001L);

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -17,6 +17,7 @@ package com.starrocks.clone;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.RateLimiter;
 import com.starrocks.catalog.CatalogRecycleBin;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
@@ -50,6 +51,8 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AgentTaskExecutor;
 import com.starrocks.task.CloneTask;
 import com.starrocks.task.CreateReplicaTask;
 import com.starrocks.thrift.TBackend;
@@ -73,6 +76,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -84,6 +88,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.Set;
 
 import static com.starrocks.sql.ast.KeysType.DUP_KEYS;
 
@@ -765,6 +770,347 @@ public class TabletSchedulerTest {
                 ((java.util.concurrent.atomic.AtomicBoolean) Deencapsulation.getField(scheduler, "forceCleanSchedQ"))
                         .get(),
                 "forceCleanSchedQ must reset to false");
+    }
+
+    // Combined coverage for the error-state replica handling in the generic redundant-replica path:
+    //   * deleteErrorStateReplica drops one error-state replica and bumps the rate limiter,
+    //   * the rate limiter then throttles the next would-be drop,
+    //   * the safety guard preserves an error-state replica when no healthy peer remains (RF=1).
+    @Test
+    public void testDeleteErrorStateReplica() throws Exception {
+        long beId1 = 10001L;
+        long beId2 = 10002L;
+        long dbIdMulti = 20001L;
+        long tblIdMulti = 20002L;
+        long partIdMulti = 20003L;
+        long physPartIdMulti = 20003L;
+        long indexIdMulti = 20004L;
+
+        long dbIdSingle = 21001L;
+        long tblIdSingle = 21002L;
+        long partIdSingle = 21003L;
+        long physPartIdSingle = 21003L;
+        long indexIdSingle = 21004L;
+        long singleTabletId = 21005L;
+
+        // Use a low rate so the second deletion in the multi-replica scenario is throttled.
+        double savedRate = Config.tablet_sched_delete_error_state_replica_permits_per_second;
+        Config.tablet_sched_delete_error_state_replica_permits_per_second = 0.1;
+
+        // Shared backends - registered so deleteBackendDropped()/Unavailable() don't fire.
+        Backend be1 = new Backend(beId1, "192.168.0.1", 9030);
+        be1.setAlive(true);
+        systemInfoService.addBackend(be1);
+        Backend be2 = new Backend(beId2, "192.168.0.2", 9030);
+        be2.setAlive(true);
+        systemInfoService.addBackend(be2);
+
+        // Multi-replica fixture (two error-state tablets sharing the same index).
+        MaterializedIndex indexMulti = new MaterializedIndex(indexIdMulti);
+        Replica normalA = new Replica(30001L, beId1, 0, Replica.ReplicaState.NORMAL);
+        Replica errorA = new Replica(30002L, beId2, 0, Replica.ReplicaState.NORMAL);
+        errorA.setIsErrorState(true);
+        LocalTablet tabletA = new LocalTablet(20005L, Lists.newArrayList(normalA, errorA));
+        indexMulti.addTablet(tabletA, new TabletMeta(dbIdMulti, tblIdMulti, physPartIdMulti, indexIdMulti, TStorageMedium.HDD));
+
+        Replica normalB = new Replica(30003L, beId1, 0, Replica.ReplicaState.NORMAL);
+        Replica errorB = new Replica(30004L, beId2, 0, Replica.ReplicaState.NORMAL);
+        errorB.setIsErrorState(true);
+        LocalTablet tabletB = new LocalTablet(20006L, Lists.newArrayList(normalB, errorB));
+        indexMulti.addTablet(tabletB, new TabletMeta(dbIdMulti, tblIdMulti, physPartIdMulti, indexIdMulti, TStorageMedium.HDD));
+
+        PhysicalPartition partMulti = new PhysicalPartition(physPartIdMulti, partIdMulti, indexMulti);
+        Database dbMulti = new Database(dbIdMulti, "db_multi");
+        OlapTable tableMulti = new OlapTable(tblIdMulti, "table_multi", null, null, null, null);
+
+        // RF=1 fixture - safety guard scenario.
+        MaterializedIndex indexSingle = new MaterializedIndex(indexIdSingle);
+        Replica errorSolo = new Replica(31001L, beId1, 0, Replica.ReplicaState.NORMAL);
+        errorSolo.setIsErrorState(true);
+        LocalTablet tabletSolo = new LocalTablet(singleTabletId, Lists.newArrayList(errorSolo));
+        indexSingle.addTablet(tabletSolo,
+                new TabletMeta(dbIdSingle, tblIdSingle, physPartIdSingle, indexIdSingle, TStorageMedium.HDD));
+        PhysicalPartition partSingle = new PhysicalPartition(physPartIdSingle, partIdSingle, indexSingle);
+        Database dbSingle = new Database(dbIdSingle, "db_single");
+        OlapTable tableSingle = new OlapTable(tblIdSingle, "table_single", null, null, null, null);
+
+        // One mock setup serves both fixtures - minTimes=0 means unused entries are harmless.
+        new Expectations() {
+            {
+                globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(dbIdMulti);
+                minTimes = 0;
+                result = dbMulti;
+                globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(dbMulti, tblIdMulti);
+                minTimes = 0;
+                result = tableMulti;
+                globalStateMgr.getLocalMetastore().getPhysicalPartitionIncludeRecycleBin(tableMulti, physPartIdMulti);
+                minTimes = 0;
+                result = partMulti;
+
+                globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(dbIdSingle);
+                minTimes = 0;
+                result = dbSingle;
+                globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(dbSingle, tblIdSingle);
+                minTimes = 0;
+                result = tableSingle;
+                globalStateMgr.getLocalMetastore().getPhysicalPartitionIncludeRecycleBin(tableSingle, physPartIdSingle);
+                minTimes = 0;
+                result = partSingle;
+            }
+        };
+        new MockUp<AgentTaskExecutor>() {
+            @Mock
+            public void submit(AgentBatchTask task) {
+                // no-op for test
+            }
+        };
+
+        try {
+            TabletScheduler scheduler = new TabletScheduler(new TabletSchedulerStat());
+
+            // Scenario A: first error-state tablet -> success (consumes the only token).
+            TabletSchedCtx ctxA = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR, dbIdMulti, tblIdMulti, partIdMulti,
+                    indexIdMulti, tabletA.getId(), System.currentTimeMillis());
+            ctxA.setTablet(tabletA);
+            SchedException exA = Assertions.assertThrows(SchedException.class,
+                    () -> scheduler.handleTabletByTypeAndStatus(
+                            LocalTablet.TabletHealthStatus.FORCE_REDUNDANT, ctxA, new AgentBatchTask()));
+            Assertions.assertEquals(SchedException.Status.FINISHED, exA.getStatus());
+            Assertions.assertTrue(exA.getMessage().contains("redundant replica is deleted"));
+
+            // Scenario B: second error-state tablet -> throttled, no other deleter matches,
+            // so handleRedundantReplica falls through to UNRECOVERABLE.
+            TabletSchedCtx ctxB = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR, dbIdMulti, tblIdMulti, partIdMulti,
+                    indexIdMulti, tabletB.getId(), System.currentTimeMillis());
+            ctxB.setTablet(tabletB);
+            SchedException exB = Assertions.assertThrows(SchedException.class,
+                    () -> scheduler.handleTabletByTypeAndStatus(
+                            LocalTablet.TabletHealthStatus.FORCE_REDUNDANT, ctxB, new AgentBatchTask()));
+            Assertions.assertEquals(SchedException.Status.UNRECOVERABLE, exB.getStatus());
+            Assertions.assertTrue(exB.getMessage().contains("unable to delete any redundant replicas"));
+
+            // Scenario C: RF=1 -> safety guard fires before the rate limiter, the error-state
+            // replica is preserved, and handleRedundantReplica falls through to UNRECOVERABLE.
+            TabletSchedCtx ctxC = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR, dbIdSingle, tblIdSingle, partIdSingle,
+                    indexIdSingle, singleTabletId, System.currentTimeMillis());
+            ctxC.setTablet(tabletSolo);
+            SchedException exC = Assertions.assertThrows(SchedException.class,
+                    () -> scheduler.handleTabletByTypeAndStatus(
+                            LocalTablet.TabletHealthStatus.FORCE_REDUNDANT, ctxC, new AgentBatchTask()));
+            Assertions.assertEquals(SchedException.Status.UNRECOVERABLE, exC.getStatus());
+            Assertions.assertTrue(exC.getMessage().contains("unable to delete any redundant replicas"));
+            Assertions.assertTrue(errorSolo.isErrorState(), "error-state replica should still be present");
+        } finally {
+            Config.tablet_sched_delete_error_state_replica_permits_per_second = savedRate;
+        }
+    }
+
+    // Combined coverage for handleColocateRedundant: the bad-replica branch always drops,
+    // the error-state-replica branch drops once and is then throttled by the same rate
+    // limiter as the generic redundant path so colocate cannot bypass the throttle.
+    @Test
+    public void testHandleColocateRedundantDropsAbnormalReplicas() throws Exception {
+        long beId1 = 12001L;
+        long beId2 = 12002L;
+        long dbId = 22001L;
+        long tblId = 22002L;
+        long partitionId = 22003L;
+        long physicalPartitionId = 22003L;
+        long indexId = 22004L;
+
+        // Low rate so the second error-state colocate drop in this test is throttled.
+        double savedRate = Config.tablet_sched_delete_error_state_replica_permits_per_second;
+        Config.tablet_sched_delete_error_state_replica_permits_per_second = 0.1;
+
+        Backend be1 = new Backend(beId1, "10.2.0.1", 9030);
+        be1.setAlive(true);
+        systemInfoService.addBackend(be1);
+        Backend be2 = new Backend(beId2, "10.2.0.2", 9030);
+        be2.setAlive(true);
+        systemInfoService.addBackend(be2);
+
+        // Three tablets share the same index/partition/db. Order in each replicas list
+        // matters: handleColocateRedundant acts on the first matching replica.
+        MaterializedIndex index = new MaterializedIndex(indexId);
+
+        Replica badReplica = new Replica(32001L, beId1, 0, Replica.ReplicaState.NORMAL);
+        badReplica.setBad(true);
+        Replica healthyForBad = new Replica(32002L, beId2, 0, Replica.ReplicaState.NORMAL);
+        LocalTablet tabletBad = new LocalTablet(22005L, Lists.newArrayList(badReplica, healthyForBad));
+        index.addTablet(tabletBad, new TabletMeta(dbId, tblId, physicalPartitionId, indexId, TStorageMedium.HDD));
+
+        Replica errorReplicaA = new Replica(33001L, beId1, 0, Replica.ReplicaState.NORMAL);
+        errorReplicaA.setIsErrorState(true);
+        Replica healthyForErrA = new Replica(33002L, beId2, 0, Replica.ReplicaState.NORMAL);
+        LocalTablet tabletErrA = new LocalTablet(22006L, Lists.newArrayList(errorReplicaA, healthyForErrA));
+        index.addTablet(tabletErrA, new TabletMeta(dbId, tblId, physicalPartitionId, indexId, TStorageMedium.HDD));
+
+        Replica errorReplicaB = new Replica(33003L, beId1, 0, Replica.ReplicaState.NORMAL);
+        errorReplicaB.setIsErrorState(true);
+        Replica healthyForErrB = new Replica(33004L, beId2, 0, Replica.ReplicaState.NORMAL);
+        LocalTablet tabletErrB = new LocalTablet(22007L, Lists.newArrayList(errorReplicaB, healthyForErrB));
+        index.addTablet(tabletErrB, new TabletMeta(dbId, tblId, physicalPartitionId, indexId, TStorageMedium.HDD));
+
+        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, partitionId, index);
+        Database db = new Database(dbId, "db_colocate");
+        OlapTable table = new OlapTable(tblId, "table_colocate", null, null, null, null);
+
+        new Expectations() {
+            {
+                globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(dbId);
+                minTimes = 0;
+                result = db;
+                globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, tblId);
+                minTimes = 0;
+                result = table;
+                globalStateMgr.getLocalMetastore().getPhysicalPartitionIncludeRecycleBin(table, physicalPartitionId);
+                minTimes = 0;
+                result = physicalPartition;
+            }
+        };
+        new MockUp<AgentTaskExecutor>() {
+            @Mock
+            public void submit(AgentBatchTask task) {
+                // no-op for test
+            }
+        };
+
+        try {
+            TabletScheduler scheduler = new TabletScheduler(new TabletSchedulerStat());
+            Set<Long> backendSet = Sets.newHashSet(beId1, beId2);
+
+            // Scenario A: bad-replica branch drops unconditionally (no rate limiter on bad path).
+            TabletSchedCtx ctxBad = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR, dbId, tblId, partitionId, indexId,
+                    tabletBad.getId(), System.currentTimeMillis());
+            ctxBad.setTablet(tabletBad);
+            ctxBad.setColocateGroupBackendIds(backendSet);
+            SchedException exBad = Assertions.assertThrows(SchedException.class,
+                    () -> scheduler.handleTabletByTypeAndStatus(
+                            LocalTablet.TabletHealthStatus.COLOCATE_REDUNDANT, ctxBad, new AgentBatchTask()));
+            Assertions.assertEquals(SchedException.Status.FINISHED, exBad.getStatus());
+            Assertions.assertTrue(exBad.getMessage().contains("colocate redundant replica is deleted"));
+
+            // Scenario B: error-state branch drops once and consumes the only available token.
+            TabletSchedCtx ctxErrA = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR, dbId, tblId, partitionId, indexId,
+                    tabletErrA.getId(), System.currentTimeMillis());
+            ctxErrA.setTablet(tabletErrA);
+            ctxErrA.setColocateGroupBackendIds(backendSet);
+            SchedException exErrA = Assertions.assertThrows(SchedException.class,
+                    () -> scheduler.handleTabletByTypeAndStatus(
+                            LocalTablet.TabletHealthStatus.COLOCATE_REDUNDANT, ctxErrA, new AgentBatchTask()));
+            Assertions.assertEquals(SchedException.Status.FINISHED, exErrA.getStatus());
+            Assertions.assertTrue(exErrA.getMessage().contains("colocate redundant replica is deleted"));
+
+            // Scenario C: a second error-state colocate tablet is throttled, so the loop falls
+            // through to UNRECOVERABLE and the error-state replica is preserved for the next round.
+            TabletSchedCtx ctxErrB = new TabletSchedCtx(TabletSchedCtx.Type.REPAIR, dbId, tblId, partitionId, indexId,
+                    tabletErrB.getId(), System.currentTimeMillis());
+            ctxErrB.setTablet(tabletErrB);
+            ctxErrB.setColocateGroupBackendIds(backendSet);
+            SchedException exErrB = Assertions.assertThrows(SchedException.class,
+                    () -> scheduler.handleTabletByTypeAndStatus(
+                            LocalTablet.TabletHealthStatus.COLOCATE_REDUNDANT, ctxErrB, new AgentBatchTask()));
+            Assertions.assertEquals(SchedException.Status.UNRECOVERABLE, exErrB.getStatus());
+            Assertions.assertTrue(exErrB.getMessage().contains("unable to delete any colocate redundant replicas"));
+            Assertions.assertTrue(errorReplicaB.isErrorState(),
+                    "throttled error-state colocate replica should still be present");
+        } finally {
+            Config.tablet_sched_delete_error_state_replica_permits_per_second = savedRate;
+        }
+    }
+
+    // Reflection-based coverage for the small private helpers introduced by this feature.
+    // Bundled together because they share no heavy fixture and do not need the full
+    // db/table/partition mock chain.
+    @Test
+    public void testTabletSchedulerErrorStateHelpers() throws Exception {
+        long aliveBe = 30000L;
+        long deadBe = 30001L;
+        long missingBe = 30002L; // intentionally not registered with systemInfoService
+        Backend alive = new Backend(aliveBe, "10.1.0.1", 9030);
+        alive.setAlive(true);
+        systemInfoService.addBackend(alive);
+        Backend dead = new Backend(deadBe, "10.1.0.2", 9030);
+        dead.setAlive(false);
+        systemInfoService.addBackend(dead);
+
+        // ---- refreshErrorReplicaDeleteRateLimiter ----
+        double savedRate = Config.tablet_sched_delete_error_state_replica_permits_per_second;
+        try {
+            Config.tablet_sched_delete_error_state_replica_permits_per_second = 5.0;
+            TabletScheduler scheduler = new TabletScheduler(new TabletSchedulerStat());
+
+            Field rlField = TabletScheduler.class.getDeclaredField("errorReplicaDeleteRateLimiter");
+            rlField.setAccessible(true);
+            RateLimiter limiter = (RateLimiter) rlField.get(scheduler);
+            Assertions.assertEquals(5.0, limiter.getRate(), 1e-9);
+
+            Method refresh = TabletScheduler.class.getDeclaredMethod("refreshErrorReplicaDeleteRateLimiter");
+            refresh.setAccessible(true);
+
+            // Same config -> no-op (false branch of the if predicate).
+            refresh.invoke(scheduler);
+            Assertions.assertEquals(5.0, limiter.getRate(), 1e-9);
+
+            // Changed config -> setRate + LOG.info path.
+            Config.tablet_sched_delete_error_state_replica_permits_per_second = 25.0;
+            refresh.invoke(scheduler);
+            Assertions.assertEquals(25.0, limiter.getRate(), 1e-9);
+
+            // Zero or negative -> ignored (the >0 guard).
+            Config.tablet_sched_delete_error_state_replica_permits_per_second = 0.0;
+            refresh.invoke(scheduler);
+            Assertions.assertEquals(25.0, limiter.getRate(), 1e-9);
+
+            // ---- isDataLost ----
+            Method isDataLost = TabletScheduler.class.getDeclaredMethod("isDataLost", List.class);
+            isDataLost.setAccessible(true);
+
+            Replica healthy = new Replica(60000L, aliveBe, 0, Replica.ReplicaState.NORMAL);
+            Assertions.assertFalse((Boolean) isDataLost.invoke(scheduler, Lists.newArrayList(healthy)));
+
+            Replica bad = new Replica(60001L, aliveBe, 0, Replica.ReplicaState.NORMAL);
+            bad.setBad(true);
+            Assertions.assertTrue((Boolean) isDataLost.invoke(scheduler, Lists.newArrayList(bad)));
+
+            Replica errored = new Replica(60002L, aliveBe, 0, Replica.ReplicaState.NORMAL);
+            errored.setIsErrorState(true);
+            Assertions.assertTrue((Boolean) isDataLost.invoke(scheduler, Lists.newArrayList(errored)));
+
+            // Mixed: only some lost -> not data-lost.
+            Assertions.assertFalse((Boolean) isDataLost.invoke(scheduler, Lists.newArrayList(healthy, errored)));
+
+            // ---- hasAnotherHealthyReplica ----
+            Method hasAnother = TabletScheduler.class.getDeclaredMethod(
+                    "hasAnotherHealthyReplica", List.class, Replica.class);
+            hasAnother.setAccessible(true);
+
+            Replica exclude = new Replica(50000L, aliveBe, 0, Replica.ReplicaState.NORMAL);
+
+            // Each peer flavor below should be skipped, leaving no other healthy peer.
+            Replica peerBad = new Replica(50001L, aliveBe, 0, Replica.ReplicaState.NORMAL);
+            peerBad.setBad(true);
+            Assertions.assertFalse((Boolean) hasAnother.invoke(null, Lists.newArrayList(exclude, peerBad), exclude));
+
+            Replica peerErr = new Replica(50002L, aliveBe, 0, Replica.ReplicaState.NORMAL);
+            peerErr.setIsErrorState(true);
+            Assertions.assertFalse((Boolean) hasAnother.invoke(null, Lists.newArrayList(exclude, peerErr), exclude));
+
+            Replica peerClone = new Replica(50003L, aliveBe, 0, Replica.ReplicaState.CLONE);
+            Assertions.assertFalse((Boolean) hasAnother.invoke(null, Lists.newArrayList(exclude, peerClone), exclude));
+
+            Replica peerDeadBe = new Replica(50004L, deadBe, 0, Replica.ReplicaState.NORMAL);
+            Assertions.assertFalse((Boolean) hasAnother.invoke(null, Lists.newArrayList(exclude, peerDeadBe), exclude));
+
+            Replica peerMissingBe = new Replica(50005L, missingBe, 0, Replica.ReplicaState.NORMAL);
+            Assertions.assertFalse((Boolean) hasAnother.invoke(null, Lists.newArrayList(exclude, peerMissingBe), exclude));
+
+            // Healthy peer present -> true.
+            Replica peerOk = new Replica(50006L, aliveBe, 0, Replica.ReplicaState.NORMAL);
+            Assertions.assertTrue((Boolean) hasAnother.invoke(null, Lists.newArrayList(exclude, peerOk), exclude));
+        } finally {
+            Config.tablet_sched_delete_error_state_replica_permits_per_second = savedRate;
+        }
     }
 
     @Test

--- a/handbook/architecture/index.md
+++ b/handbook/architecture/index.md
@@ -7,3 +7,4 @@ Use this section when you need the repo map or the current internal harness boun
 - [Repo Topology](repo-topology.md): top-level map, subsystem entrypoints, and where to look first.
 - [BE Boundary Harness](be-boundary-harness.md): phase-1 module-boundary guardrails and the files that enforce them.
 - [Schema Compatibility Harness](schema-compatibility-harness.md): diff-aware guardrails for thrift and protobuf evolution in `gensrc/`.
+- [PK Tablet Auto-Repair](pk-tablet-auto-repair.md): design and workflow for auto-recovering primary-key tablets whose replica hit init-time corruption.

--- a/handbook/architecture/pk-tablet-auto-repair.md
+++ b/handbook/architecture/pk-tablet-auto-repair.md
@@ -1,0 +1,339 @@
+# Auto-Repair of Corrupted Primary-Key Tablets
+
+- Status: landed
+- Scope: BE tablet init, FE replica state, cluster scheduler
+
+## Purpose
+
+Describe the design and end-to-end workflow for automatic recovery of
+primary-key (PK) tablets whose local replica data is unusable (for example,
+missing segment files or corrupted rowset metadata discovered during init).
+The goal is to keep the cluster online and self-healing when a single BE
+replica is corrupted, instead of stalling the tablet or crashing the BE.
+
+This document describes **what** each actor does and **why**; it does not
+reference specific code paths.
+
+## Background: the problem
+
+A PK tablet opens (initializes) when the BE starts, when a tablet is cloned
+in, or when the tablet is first loaded from meta. Before this change, if
+that init step hit a corruption (for example, a rowset referenced a segment
+file that no longer existed on disk), the failure was surfaced as an error
+from the load path. The tablet stayed in a half-loaded state, any write to
+that tablet kept failing, and in some deployments the process would even
+hard-fail. Operators had to manually identify the bad replica, drop it from
+the FE metadata, and wait for the scheduler to clone a fresh copy.
+
+The cluster already tracks a per-replica flag called the **error state** and
+the BE already knew how to declare that state at runtime when a write
+operation discovered corruption. What was missing:
+
+1. A graceful path for **init-time** corruption so the BE does not stall or
+   crash and so the FE can still see the tablet.
+2. Treating error-state replicas as "abnormal" everywhere the FE picks
+   replicas (not just on the query path).
+3. A scheduler action that **drops** an error-state replica so a clean
+   replica can be cloned in its place, subject to safety checks and rate
+   limiting.
+
+## High-level picture
+
+```
+    +------------------+              +------------------+
+    |     BE node      |   reports    |        FE        |
+    | (holds a PK      |  tablet      | (TabletChecker + |
+    |  tablet replica) |  error       |  TabletScheduler)|
+    +------------------+ -----------> +------------------+
+            ^                                   |
+            | clone task                        | "drop then clone"
+            |                                   v
+            |                           +-----------------+
+            +---------------------------| repair decision |
+                                        +-----------------+
+```
+
+An error-state replica is no longer hidden or terminal. It is a signal that
+FE can act on with a controlled, rate-limited drop-then-clone flow.
+
+## BE-side design change
+
+### Tablet init states (before / after)
+
+```
+ before (init-time corruption)                after (init-time corruption)
+ -----------------------------                ----------------------------
+
+         init                                         init
+          |                                            |
+          v                                            v
+    [corruption]                                 [corruption]
+          |                                            |
+          v                                            v
+  + - - - - - - - -+                         + - - - - - - - - - - - +
+  | error returned |                         | tablet enters ERROR   |
+  | tablet stalls  |                         | state inside BE,      |
+  | or BE may FATAL|                         | init reports OK so    |
+  + - - - - - - - -+                         | the tablet is loaded  |
+                                             | and reportable to FE  |
+                                             + - - - - - - - - - - - +
+```
+
+The BE behavior change is narrowly scoped to PK tablets and to the specific
+**corruption** flavor of init failure. Any other init failure (permission
+error, truly missing meta, etc.) still bubbles up unchanged. Writes to a
+replica in the ERROR state are refused by the BE; the FE-side repair flow is
+what eventually removes the replica from the tablet.
+
+Key invariants:
+
+- ERROR state is set **once** during init on a corruption signal.
+- A replica in ERROR state is visible to the FE's report protocol.
+- A replica in ERROR state refuses writes at the BE boundary; reads that
+  would need its data fall back to healthy replicas via the FE query path.
+
+### What the BE reports
+
+The existing heartbeat / tablet-report channel now carries the ERROR flag
+for a PK replica that entered ERROR during init. FE already knew how to
+mark the corresponding `Replica` metadata as "in error state"; no wire
+format change was needed.
+
+## FE-side design change
+
+The FE change has three parts:
+
+1. **Classification** - treat error-state replicas as abnormal everywhere
+   they matter.
+2. **Scheduling** - add an explicit "drop the error-state replica" action
+   to the repair scheduler, for both the general and the colocate paths.
+3. **Safety** - do not drop if it would destroy the last usable copy, and
+   rate-limit drops cluster-wide.
+
+### Classification changes
+
+Before this change, several FE helpers that pick replicas only filtered out
+the pre-existing `isBad()` flag. The query path had already been extended
+to also filter out error-state replicas, but the write-path, the colocate
+health checker, and the empty-tablet-recovery predicate still treated an
+error-state replica as "healthy enough." That asymmetry caused writes to
+be routed to replicas the BE would then reject.
+
+After the change, the following paths all treat `isErrorState` identically
+to `isBad`:
+
+```
+   scope                                   before         after
+   ----------------------------------      ---------      --------
+   query replica selection                 excluded       excluded
+   write / load replica selection          INCLUDED       excluded
+   generic replica health check            abnormal       abnormal
+   colocate replica health check           healthy        abnormal
+   "data is totally lost" predicate        not lost       lost
+```
+
+The net effect: once BE marks a replica as error-state, FE stops routing
+work to it, the checker flags the tablet as needing repair, and the
+scheduler picks it up.
+
+### Scheduling changes
+
+The tablet scheduler's redundant-replica handler already had a checklist of
+reasons to drop a replica (bad, backend down, wrong location, stale
+version, etc.). A new reason is added near the top of that list:
+
+```
+  handleRedundantReplica (decision order):
+
+     1. backend of replica was dropped            (existing)
+     2. replica is marked BAD                     (existing)
+     3. replica is in ERROR state                 (new)
+     4. backend of replica is unavailable         (existing)
+     5. replica is CLONE or DECOMMISSION          (existing)
+     6. location mismatch                         (existing)
+     7. failed / lower version                    (existing)
+     ...
+```
+
+A symmetric change is made on the **colocate** redundant-replica path so
+colocate tables are not a second-class citizen for this feature.
+
+### Safety guard
+
+Dropping the only usable copy of a tablet converts a recoverable situation
+into data loss. Therefore the scheduler enforces:
+
+```
+  drop error-state replica
+    requires: at least one OTHER replica is
+              - not bad
+              - not in error state
+              - on an alive backend
+              - in a state that can serve loads
+```
+
+If that condition is not met, the drop is skipped for this round and the
+error-state replica is **preserved** so the operator or a follow-up round
+still has something to clone from (or to manually repair).
+
+### Rate limiting
+
+Error-state deletions pass through a cluster-local token bucket
+(Guava `RateLimiter`) so a cluster-wide incident cannot trigger a rapid
+cascade of drops. When a token is not available, the drop is skipped and
+the scheduler moves on to other repair work this round; the replica stays
+error-state and is retried on a future round.
+
+The rate is a mutable config. The scheduler re-syncs the bucket's rate at
+the start of every check loop, so operators can tune the rate at runtime
+without restarting FE.
+
+## End-to-end workflow
+
+### Sequence (happy path: single corrupted replica, 3-replica tablet)
+
+```
+  BE (holder)    BE (other)    FE (report)    FE (checker)    FE (scheduler)
+      |               |             |               |                |
+      | init finds    |             |               |                |
+      | corruption    |             |               |                |
+      |-- set ERROR ->|             |               |                |
+      |     state     |             |               |                |
+      |               |             |               |                |
+      |---- tablet report with ERROR flag --------->|                |
+      |                             |-- mark replica isErrorState    |
+      |                             |               |                |
+      |                             |               |-- classify as  |
+      |                             |               |   abnormal ->  |
+      |                             |               |   needs repair |
+      |                             |               |-------- enqueue|
+      |                             |               |                |
+      |                             |               |     handleRedundantReplica:
+      |                             |               |      * other healthy replicas? yes
+      |                             |               |      * rate limiter token? yes
+      |                             |               |      * DROP the error-state replica
+      |                             |               |                |
+      |<--- delete replica task ------------------------------------ |
+      | drop data                   |               |                |
+      |                             |               |                |
+      |                             |               |     next round: checker
+      |                             |               |     sees REPLICA_MISSING,
+      |                             |               |     scheduler issues clone
+      |                             |               |                |
+      |                  <----- clone task from healthy replica -----|
+      |                  | copy data                |                |
+      |                  |                          |                |
+      v                  v                          v                v
+  (empty /        (source for         (replica count       (healthy state)
+   recycled)        clone)              restored)
+```
+
+### Replica state transitions (FE view)
+
+```
+                 +-----------+     BE reports error      +----------------+
+        init --> |  NORMAL   |-------------------------->|  ERROR_STATE   |
+                 +-----------+                           +----------------+
+                     |   ^                                      |
+                     |   | clone completes                      |
+                     |   |                                      | scheduler drops
+                     |   +--------- [REPLICA_MISSING ---+       | (safety guard +
+                     |              then re-created]    |       |  rate limited)
+                     |                                  |       v
+                     |                                  |  +-----------+
+                     +----- other pre-existing paths ---+  | (removed) |
+                        (bad, decommission, location, ...)  +-----------+
+```
+
+Key points:
+
+- ERROR_STATE is not a dead end: it is a transient state that funnels into
+  the existing drop-then-clone repair pipeline.
+- A single tablet can cycle through ERROR_STATE multiple times (e.g., on
+  repeated disk faults); each cycle is rate-limited.
+
+### Scheduler decision flow (drop-then-clone, simplified)
+
+```
+             tablet flagged unhealthy by checker
+                          |
+                          v
+              +-----------------------+
+              | handleRedundantReplica|
+              +-----------------------+
+                          |
+                    for each reason:
+                   backend dropped? bad? ERROR STATE? ...
+                          |
+                  matches "ERROR STATE"?
+                          |
+                          v
+                +-------------------+
+                | safety guard:     |
+                | is there ANOTHER  |
+                | healthy replica?  |
+                +-------------------+
+                   |              |
+                 yes             no
+                   |              |
+                   v              v
+          +----------------+   +--------+
+          | rate limiter   |   | SKIP,  |
+          | token avail?   |   | keep   |
+          +----------------+   | replica|
+            |         |        +--------+
+          yes         no
+            |          \--> SKIP this round, retry later
+            v
+     DROP error-state replica
+            |
+            v
+     ...next round: REPLICA_MISSING -> clone task to fresh BE
+```
+
+## Configuration and observability
+
+### Operator knobs
+
+- `tablet_sched_delete_error_state_replica_permits_per_second`
+  mutable. Number of error-state replica drops allowed per second across
+  the whole scheduler. Changes take effect on the next scheduler round; no
+  restart needed. Default is tuned for typical clusters; lower it during an
+  incident to slow the repair pipeline, raise it to accelerate recovery.
+
+### What operators should see
+
+- **BE logs**: a PK tablet entering error state during init logs a clear
+  "corruption -> ERROR state for FE-driven repair" line with the tablet id.
+  The BE then stays up and serves other tablets normally.
+- **FE logs**: replicas reported as error-state are logged when the
+  scheduler decides to skip (throttled or safety-guard) or when it drops
+  them. Both skip paths log the replica and tablet id so incidents are
+  traceable across rounds.
+- **SHOW TABLETS / replica listing**: the error-state flag is already
+  surfaced on the replica row, so operators can spot an affected replica
+  before (and during) the repair cycle.
+
+## Non-goals / explicit limits
+
+- **Not a general corruption detector.** Only the specific init-time
+  corruption path on PK tablets has been re-classified. Other failure
+  types still fail loudly.
+- **Not a write-side fix.** A BE that discovers corruption during a write
+  still raises an error to the writer; this change is about graceful load
+  + FE-driven repair, not silent write-time recovery.
+- **Not a substitute for meta repair.** If the meta itself is gone (for
+  example, a missing tablet record), this flow does not help.
+- **RF=1 tablets cannot be auto-repaired.** The safety guard keeps the
+  error-state replica in place (rather than destroying the last copy),
+  which matches the pre-existing behavior for bad replicas.
+
+## Rollout and compatibility
+
+- No protocol or metadata format change. The error-state flag already
+  existed on FE and BE before this change.
+- Safe to roll in mixed versions: a BE without the change continues to
+  behave as before; the FE-side classification changes still work because
+  they key off a flag that pre-dated this work.
+- Safe to disable by setting the rate-limit config to a very small number;
+  the feature is effectively throttled off without a restart.


### PR DESCRIPTION
Allow the cluster to recover automatically when a primary-key tablet's replica fails init with a corruption error (for example, a missing segment file). Previously this stalled the tablet or could crash the BE and forced manual operator intervention.

BE
* Treat init-time corruption of a PK tablet as non-fatal: mark TabletUpdates as error-state and return OK so the tablet loads and is reportable to FE. Other init failures still propagate as before.

FE classification
* Exclude error-state replicas from write/load replica selection and from the "data lost" empty-tablet fallback, matching the query path.
* Flag error-state replicas as abnormal in the colocate health check.

FE scheduler
* Add a redundant-replica deletion step that drops error-state replicas.
* Safety guard: skip the drop when no other healthy, alive, loadable replica remains, so RF=1 or all-bad cases are preserved instead of being destroyed.
* Throttle drops with a Guava RateLimiter driven by the new mutable config tablet_sched_delete_error_state_replica_permits_per_second (default 10/sec); the limiter re-syncs at the start of each scheduler round, so changes take effect without a restart.
* Extend handleColocateRedundant with the same error-state branch and safety guard so colocate tablets share the recovery path.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4