### PR TITLE
[BugFix] Fix compilation error in branch-4.1 backport of #68434

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -654,8 +654,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
             // Mark this partition as coming from table deletion (also forces directory removal)
             recyclePartitionInfo.setFromTableDeletion(true);
 
-            // Add via helper to keep recycle-bin indexes (physicalPartitionIdToPartitionId) consistent
-            putPartitionToRecycleBin(recyclePartitionInfo);
+            idToPartition.put(partitionId, recyclePartitionInfo);
             // Use the table's recycle time to maintain consistency with ClusterSnapshot safety checks
             idToRecycleTime.put(partitionId, partitionRecycleTime);
             partitionIds.add(partitionId);


### PR DESCRIPTION
## Why I'm doing this

The backport PR #72079 has a CI compilation failure:

```
ERROR /root/starrocks/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java:[658,13] cannot find symbol
  symbol:   method putPartitionToRecycleBin(com.starrocks.catalog.RecyclePartitionInfo)
```

`putPartitionToRecycleBin` was introduced by PR #71425 which only landed in `main`, not `branch-4.1`. The backport of #68434 accidentally referenced this helper.

## What I'm doing

Replace the call to `putPartitionToRecycleBin(recyclePartitionInfo)` with the equivalent direct call `idToPartition.put(partitionId, recyclePartitionInfo)` that works in branch-4.1.

## Type

- [x] BugFix