### PR TITLE
[Enhancement] Optimize CatalogRecycleBin adjusted recycle timestamp lookup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -333,15 +333,8 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
         return GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isDeletionSafeToExecute(originalRecycleTime);
     }
 
-    private synchronized long getAdjustedRecycleTimestamp(long id) {
-        Map<Long, RecycleTableInfo> idToRecycleTableInfo =  Maps.newHashMap();
-        for (Map<Long, RecycleTableInfo> tableEntry : idToTableInfo.rowMap().values()) {
-            for (Map.Entry<Long, RecycleTableInfo> entry : tableEntry.entrySet()) {
-                idToRecycleTableInfo.put(entry.getKey(), entry.getValue());
-            }
-        }
-
-        RecycleTableInfo tableInfo = idToRecycleTableInfo.get(id);
+    private synchronized long getAdjustedRecycleTimestamp(long dbId, long id) {
+        RecycleTableInfo tableInfo = idToTableInfo.row(dbId).get(id);
         if (tableInfo != null && !tableInfo.isRecoverable()) {
             return 0;
         }
@@ -368,8 +361,8 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
      * if we can erase this instance, we should check if anyone enable erase later.
      * Only used by main loop.
      */
-    private synchronized boolean timeExpired(long id, long currentTimeMs) {
-        long latencyMs = currentTimeMs - getAdjustedRecycleTimestamp(id);
+    private synchronized boolean timeExpired(long dbId, long id, long currentTimeMs) {
+        long latencyMs = currentTimeMs - getAdjustedRecycleTimestamp(dbId, id);
         long expireMs = max(Config.catalog_trash_expire_second * 1000L, Config.catalog_recycle_bin_erase_min_latency_ms);
         // customize expireMs for partition that need to be retained for a configurable period
         if (idToPartition.containsKey(id)) {
@@ -397,7 +390,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
             return false;
         }
 
-        if (timeExpired(databaseInfo.getDb().getId(), currentTimeMs)) {
+        if (timeExpired(databaseInfo.getDb().getId(), databaseInfo.getDb().getId(), currentTimeMs)) {
             return true;
         }
 
@@ -414,7 +407,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
             return false;
         }
 
-        if (timeExpired(tableInfo.getTable().getId(), currentTimeMs)) {
+        if (timeExpired(tableInfo.getDbId(), tableInfo.getTable().getId(), currentTimeMs)) {
             return true;
         }
 
@@ -436,7 +429,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
             return false;
         }
 
-        if (timeExpired(partitionInfo.getPartition().getId(), currentTimeMs)) {
+        if (timeExpired(partitionInfo.getDbId(), partitionInfo.getPartition().getId(), currentTimeMs)) {
             return true;
         }
 
@@ -458,13 +451,13 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
     /**
      * make sure there are still some time before the subject is erased
      */
-    public synchronized boolean ensureEraseLater(long id, long currentTimeMs) {
+    public synchronized boolean ensureEraseLater(long dbId, long id, long currentTimeMs) {
         // 1. not in idToRecycleTime, maybe already erased, sorry it's too late!
         if (!idToRecycleTime.containsKey(id)) {
             return false;
         }
         // 2. will expire after quite a long time, don't worry
-        long latency = currentTimeMs - getAdjustedRecycleTimestamp(id);
+        long latency = currentTimeMs - getAdjustedRecycleTimestamp(dbId, id);
         if (latency < (Config.catalog_trash_expire_second - LATE_RECYCLE_INTERVAL_SECONDS) * 1000L) {
             return true;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -587,19 +587,19 @@ public class TabletScheduler extends LeaderDaemon {
     protected boolean checkIfTabletExpired(TabletSchedCtx ctx, CatalogRecycleBin recycleBin, long currentTimeMs) {
         // check if about to erase
         long dbId = ctx.getDbId();
-        if (recycleBin.getDatabase(dbId) != null && !recycleBin.ensureEraseLater(dbId, currentTimeMs)) {
+        if (recycleBin.getDatabase(dbId) != null && !recycleBin.ensureEraseLater(dbId, dbId, currentTimeMs)) {
             LOG.warn("discard ctx because db {} will erase soon: {}", dbId, ctx);
             return true;
         }
         long tableId = ctx.getTblId();
-        if (recycleBin.getTable(dbId, tableId) != null && !recycleBin.ensureEraseLater(tableId, currentTimeMs)) {
+        if (recycleBin.getTable(dbId, tableId) != null && !recycleBin.ensureEraseLater(dbId, tableId, currentTimeMs)) {
             LOG.warn("discard ctx because table {} will erase soon: {}", tableId, ctx);
             return true;
         }
         long partitionId = ctx.getPhysicalPartitionId();
         PhysicalPartition physicalPartition = recycleBin.getPhysicalPartition(partitionId);
         if (physicalPartition != null
-                && !recycleBin.ensureEraseLater(physicalPartition.getParentId(), currentTimeMs)) {
+                && !recycleBin.ensureEraseLater(dbId, physicalPartition.getParentId(), currentTimeMs)) {
             LOG.warn("discard ctx because partition {} will erase soon: {}", partitionId, ctx);
             return true;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -469,21 +469,21 @@ public class CatalogRecycleBinTest {
 
         // no need to set enable erase later if there are a lot of time left
         long now = System.currentTimeMillis();
-        Assertions.assertTrue(recycleBin.ensureEraseLater(db.getId(), now));
+        Assertions.assertTrue(recycleBin.ensureEraseLater(db.getId(), db.getId(), now));
         Assertions.assertFalse(recycleBin.enableEraseLater.contains(db.getId()));
 
         // no need to set enable erase later if already exipre
         long moreThanTenMinutesLater = now + 620 * 1000L;
-        Assertions.assertFalse(recycleBin.ensureEraseLater(db.getId(), moreThanTenMinutesLater));
+        Assertions.assertFalse(recycleBin.ensureEraseLater(db.getId(), db.getId(), moreThanTenMinutesLater));
         Assertions.assertFalse(recycleBin.enableEraseLater.contains(db.getId()));
 
         // now we should set enable erase later because we are about to expire
         long moreThanNineMinutesLater = now + 550 * 1000L;
-        Assertions.assertTrue(recycleBin.ensureEraseLater(db.getId(), moreThanNineMinutesLater));
+        Assertions.assertTrue(recycleBin.ensureEraseLater(db.getId(), db.getId(), moreThanNineMinutesLater));
         Assertions.assertTrue(recycleBin.enableEraseLater.contains(db.getId()));
 
         // if already expired, we should return false but won't erase the flag
-        Assertions.assertFalse(recycleBin.ensureEraseLater(db.getId(), moreThanTenMinutesLater));
+        Assertions.assertFalse(recycleBin.ensureEraseLater(db.getId(), db.getId(), moreThanTenMinutesLater));
         Assertions.assertTrue(recycleBin.enableEraseLater.contains(db.getId()));
     }
 
@@ -550,11 +550,11 @@ public class CatalogRecycleBinTest {
 
         // 3. set recyle later, check if recycle now
         CatalogRecycleBin.LATE_RECYCLE_INTERVAL_SECONDS = 10;
-        Assertions.assertFalse(recycleBin.ensureEraseLater(db1.getId(), now));  // already erased
-        Assertions.assertTrue(recycleBin.ensureEraseLater(db2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensureEraseLater(db1.getId(), db1.getId(), now));  // already erased
+        Assertions.assertTrue(recycleBin.ensureEraseLater(db2.getId(), db2.getId(), now));
         Assertions.assertEquals(0, recycleBin.enableEraseLater.size());
         recycleBin.idToRecycleTime.put(db2.getId(), expireFromNow + 1000);
-        Assertions.assertTrue(recycleBin.ensureEraseLater(db2.getId(), now));
+        Assertions.assertTrue(recycleBin.ensureEraseLater(db2.getId(), db2.getId(), now));
         Assertions.assertEquals(1, recycleBin.enableEraseLater.size());
         Assertions.assertTrue(recycleBin.enableEraseLater.contains(db2.getId()));
 
@@ -566,7 +566,7 @@ public class CatalogRecycleBinTest {
 
         // 5. will erase after expire time + latency time
         recycleBin.idToRecycleTime.put(db2.getId(), expireFromNow - 11000);
-        Assertions.assertFalse(recycleBin.ensureEraseLater(db2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensureEraseLater(db2.getId(), db2.getId(), now));
         recycleBin.eraseDatabase(now);
         Assertions.assertNull(recycleBin.getDatabase(db2.getId()));
         Assertions.assertEquals(0, recycleBin.idToRecycleTime.size());
@@ -618,11 +618,11 @@ public class CatalogRecycleBinTest {
 
         // 3. set recyle later, check if recycle now
         CatalogRecycleBin.LATE_RECYCLE_INTERVAL_SECONDS = 10;
-        Assertions.assertFalse(recycleBin.ensureEraseLater(table1.getId(), now));  // already erased
-        Assertions.assertTrue(recycleBin.ensureEraseLater(table2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensureEraseLater(dbId, table1.getId(), now));  // already erased
+        Assertions.assertTrue(recycleBin.ensureEraseLater(dbId, table2.getId(), now));
         Assertions.assertEquals(0, recycleBin.enableEraseLater.size());
         recycleBin.idToRecycleTime.put(table2.getId(), expireFromNow + 1000);
-        Assertions.assertTrue(recycleBin.ensureEraseLater(table2.getId(), now));
+        Assertions.assertTrue(recycleBin.ensureEraseLater(dbId, table2.getId(), now));
         Assertions.assertEquals(1, recycleBin.enableEraseLater.size());
         Assertions.assertTrue(recycleBin.enableEraseLater.contains(table2.getId()));
 
@@ -635,7 +635,7 @@ public class CatalogRecycleBinTest {
 
         // 5. will erase after expire time + latency time
         recycleBin.idToRecycleTime.put(table2.getId(), expireFromNow - 11000);
-        Assertions.assertFalse(recycleBin.ensureEraseLater(table2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensureEraseLater(dbId, table2.getId(), now));
         recycleBin.eraseTable(now);
         waitPartitionClearFinished(recycleBin, table2.getId(), now);
         Assertions.assertNull(recycleBin.getTable(dbId, table2.getId()));
@@ -678,11 +678,11 @@ public class CatalogRecycleBinTest {
 
         // 3. set recyle later, check if recycle now
         CatalogRecycleBin.LATE_RECYCLE_INTERVAL_SECONDS = 10;
-        Assertions.assertFalse(recycleBin.ensureEraseLater(p1.getId(), now));  // already erased
-        Assertions.assertTrue(recycleBin.ensureEraseLater(p2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensureEraseLater(dbId, p1.getId(), now));  // already erased
+        Assertions.assertTrue(recycleBin.ensureEraseLater(dbId, p2.getId(), now));
         Assertions.assertEquals(0, recycleBin.enableEraseLater.size());
         recycleBin.idToRecycleTime.put(p2.getId(), expireFromNow + 1000);
-        Assertions.assertTrue(recycleBin.ensureEraseLater(p2.getId(), now));
+        Assertions.assertTrue(recycleBin.ensureEraseLater(dbId, p2.getId(), now));
         Assertions.assertEquals(1, recycleBin.enableEraseLater.size());
         Assertions.assertTrue(recycleBin.enableEraseLater.contains(p2.getId()));
 
@@ -695,7 +695,7 @@ public class CatalogRecycleBinTest {
 
         // 5. will erase after expire time + latency time
         recycleBin.idToRecycleTime.put(p2.getId(), expireFromNow - 11000);
-        Assertions.assertFalse(recycleBin.ensureEraseLater(p2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensureEraseLater(dbId, p2.getId(), now));
         recycleBin.erasePartition(now);
         waitPartitionClearFinished(recycleBin, p2.getId(), now);
         Assertions.assertEquals(recycleBin.getPartition(p2.getId()), null);
@@ -871,12 +871,29 @@ public class CatalogRecycleBinTest {
         recycleBin.recyclePartition(info2);
 
         // With retention period: should return original recycle timestamp
-        long adjustedTime1 = Deencapsulation.invoke(recycleBin, "getAdjustedRecycleTimestamp", p1.getId());
+        long adjustedTime1 = Deencapsulation.invoke(recycleBin, "getAdjustedRecycleTimestamp", dbId, p1.getId());
         Assertions.assertEquals(recycleBin.idToRecycleTime.get(p1.getId()), adjustedTime1);
 
         // Without retention period: should return 0 for non-recoverable partition
-        long adjustedTime2 = Deencapsulation.invoke(recycleBin, "getAdjustedRecycleTimestamp", p2.getId());
+        long adjustedTime2 = Deencapsulation.invoke(recycleBin, "getAdjustedRecycleTimestamp", dbId, p2.getId());
         Assertions.assertEquals(0, adjustedTime2);
+    }
+
+    @Test
+    public void testGetAdjustedRecycleTimestampUsesDbIdForTableLookup() {
+        CatalogRecycleBin recycleBin = new CatalogRecycleBin();
+        long dbId = 1L;
+        long otherDbId = 2L;
+        Table table = new Table(101L, "tbl", Table.TableType.VIEW, null);
+        recycleBin.recycleTable(dbId, table, false);
+
+        long adjustedTime = Deencapsulation.invoke(
+                recycleBin, "getAdjustedRecycleTimestamp", dbId, table.getId());
+        Assertions.assertEquals(0, adjustedTime);
+
+        long adjustedTimeWithOtherDb = Deencapsulation.invoke(
+                recycleBin, "getAdjustedRecycleTimestamp", otherDbId, table.getId());
+        Assertions.assertEquals(recycleBin.idToRecycleTime.get(table.getId()), adjustedTimeWithOtherDb);
     }
 
     @Test


### PR DESCRIPTION
  ## Why I'm doing:

  `CatalogRecycleBin#getAdjustedRecycleTimestamp` rebuilt a temporary table-id map by traversing all recycled tables on every call. This is expensive when the recycle bin contains many tables, especially because the method is called from recycle-bin cleanup and tablet scheduling paths.

  ## What I'm doing:

  - Pass the existing `dbId` context into `getAdjustedRecycleTimestamp`, `timeExpired`, and `ensureEraseLater`.
  - Use `idToTableInfo.row(dbId).get(tableId)` for table lookup instead of scanning all recycled tables.
  - Update `TabletScheduler` call sites to pass the available `dbId`.
  - Add a regression test to verify table lookup is scoped by `dbId`.

  Fixes #N/A

  ## What type of PR is this:

  - [ ] BugFix
  - [ ] Feature
  - [x] Enhancement
  - [ ] Refactor
  - [ ] UT
  - [ ] Doc
  - [ ] Tool

  Does this PR entail a change in behavior?

  - [ ] Yes, this PR will result in a change in behavior.
  - [x] No, this PR will not result in a change in behavior.

  ## Checklist:

  - [x] I have added test cases for my bug fix or my new feature
  - [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] This is a backport pr

  ## Bugfix cherry-pick branch check:
  - [x] I have checked the version labels which the pr will be auto-backported to the target branch
    - [x] 4.1
    - [x] 4.0
    - [x] 3.5
    - [ ] 3.4