### PR TITLE
[BugFix] Distinguish bundled segment slices in page/segment caches

### DIFF
--- a/be/src/fs/bundle_file.cpp
+++ b/be/src/fs/bundle_file.cpp
@@ -149,4 +149,12 @@ StatusOr<int64_t> BundleSeekableInputStream::read(void* data, int64_t count) {
     return _stream->read(data, count);
 }
 
+std::string BundleSeekableInputStream::page_cache_key(int64_t stream_offset) const {
+    // Fold the slice base offset into the offset and delegate to the base's default impl. The
+    // default uses virtual filename(), which dispatches back to this slice's filename()
+    // (which forwards to _stream->filename()) — so the key is encoded against the underlying
+    // physical file's name, not against _stream's possibly-empty _filename member.
+    return SeekableInputStream::page_cache_key(_offset + stream_offset);
+}
+
 } // namespace starrocks

--- a/be/src/fs/bundle_file.h
+++ b/be/src/fs/bundle_file.h
@@ -112,6 +112,11 @@ public:
     Status touch_cache(int64_t offset, size_t length) override;
     StatusOr<std::unique_ptr<io::NumericStatistics>> get_numeric_statistics() override;
 
+    // Override so two slices of the same physical file produce distinct keys at the same
+    // stream-relative offset: we fold the slice base offset into the key, yielding a key
+    // that names the page's absolute position in the physical file.
+    std::string page_cache_key(int64_t stream_offset) const override;
+
 private:
     std::shared_ptr<io::SeekableInputStream> _stream;
     int64_t _offset = 0;

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -56,7 +56,11 @@ StatusOr<std::unique_ptr<RandomAccessFile>> FileSystem::new_random_access_file_w
         auto bundle_file = std::make_unique<BundleSeekableInputStream>(
                 file->stream(), file_info.bundle_file_offset.value(), file_info.size.value());
         RETURN_IF_ERROR(bundle_file->init());
-        return std::make_unique<RandomAccessFile>(std::move(bundle_file), file->filename(), file->is_cache_hit());
+        // Pass the slice's base offset to the outer RandomAccessFile so its page_cache_key folds
+        // it in. The outer wrapper otherwise sees only `path` and would produce identical keys
+        // for every slice of the same physical file.
+        return std::make_unique<RandomAccessFile>(std::move(bundle_file), file->filename(), file->is_cache_hit(),
+                                                  file_info.bundle_file_offset.value());
     } else {
         return new_random_access_file(opts, file_info);
     }

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -74,6 +74,17 @@ struct FileInfo {
     std::shared_ptr<FileSystem> fs;
     // It is used to store the file offset of the bundle file.
     std::optional<int64_t> bundle_file_offset;
+
+    // Cache key uniquely identifying this FileInfo as a *slice* of a physical file. Caches keyed
+    // on file identity (e.g. lake metacache for Segments) must use this rather than `path` so two
+    // slices of the same physical file at different `bundle_file_offset` get distinct entries.
+    // Non-bundled files collapse to the path alone, preserving the pre-existing cache layout.
+    std::string cache_key() const {
+        if (bundle_file_offset.has_value() && bundle_file_offset.value() > 0) {
+            return path + "#" + std::to_string(bundle_file_offset.value());
+        }
+        return path;
+    }
 };
 
 struct FileWriteStat {
@@ -321,17 +332,28 @@ public:
               _stream(std::move(stream)),
               _name(std::move(name)) {}
 
-    explicit RandomAccessFile(std::shared_ptr<io::SeekableInputStream> stream, std::string name, bool is_cache_hit)
+    explicit RandomAccessFile(std::shared_ptr<io::SeekableInputStream> stream, std::string name, bool is_cache_hit,
+                              int64_t bundle_offset = 0)
             : io::SeekableInputStreamWrapper(stream.get(), kDontTakeOwnership),
               _stream(std::move(stream)),
               _name(std::move(name)),
-              _is_cache_hit(is_cache_hit) {}
+              _is_cache_hit(is_cache_hit),
+              _bundle_offset(bundle_offset) {}
 
     std::shared_ptr<io::SeekableInputStream> stream() { return _stream; }
 
     const std::string& filename() const override { return _name; }
 
     bool is_cache_hit() const override { return _is_cache_hit; }
+
+    // When this RandomAccessFile names a bundled-slice view of a physical file (the wrapper
+    // hides the slice's start offset behind a stream-relative coordinate), the slice's base
+    // offset must be folded into the page-cache key, otherwise two slices that share the same
+    // physical-file `_name` collide at the same stream-relative offset. For non-bundled files
+    // `_bundle_offset` is 0 and the encoding is `(path, stream_offset)` as before.
+    std::string page_cache_key(int64_t stream_offset) const override {
+        return io::SeekableInputStream::page_cache_key(_bundle_offset + stream_offset);
+    }
 
     static std::unique_ptr<RandomAccessFile> from(std::unique_ptr<io::SeekableInputStream> stream,
                                                   const std::string& name, bool is_cache_hit,
@@ -342,6 +364,9 @@ private:
     std::string _name;
     // for cachefs in fs_starlet
     bool _is_cache_hit{false};
+    // Slice base offset within the underlying physical file when this RandomAccessFile wraps a
+    // BundleSeekableInputStream; 0 otherwise. Used only by page_cache_key to keep slices distinct.
+    int64_t _bundle_offset{0};
 };
 
 // A file abstraction for sequential writing.  The implementation

--- a/be/src/io/core/seekable_input_stream.cpp
+++ b/be/src/io/core/seekable_input_stream.cpp
@@ -45,4 +45,18 @@ StatusOr<std::string> SeekableInputStream::read_all() {
     return std::move(ret);
 }
 
+std::string SeekableInputStream::page_cache_key(int64_t stream_offset) const {
+    // Use the virtual filename() rather than the _filename member: many subclasses (e.g.
+    // RandomAccessFile, MemoryFileInputStream, S3InputStream) override filename() to return a
+    // value held in their own member while leaving _filename unset, so reading _filename here
+    // would return an empty string and silently collapse the keys of every file to the same
+    // (empty, offset) prefix.
+    const std::string& fname = filename();
+    std::string key;
+    key.reserve(fname.size() + sizeof(stream_offset));
+    key.append(fname);
+    key.append(reinterpret_cast<const char*>(&stream_offset), sizeof(stream_offset));
+    return key;
+}
+
 } // namespace starrocks::io

--- a/be/src/io/core/seekable_input_stream.h
+++ b/be/src/io/core/seekable_input_stream.h
@@ -89,6 +89,13 @@ public:
 
     virtual bool is_encrypted() const { return false; };
 
+    // Cache key for the page hosted at `stream_offset` bytes within this stream. The default
+    // encodes (filename, stream_offset). Streams whose `filename()` is shared with other streams
+    // (e.g. BundleSeekableInputStream slices of one physical file) must override to fold their
+    // disambiguator into the key, so callers never need to know whether the underlying stream
+    // is a slice.
+    virtual std::string page_cache_key(int64_t stream_offset) const;
+
 protected:
     std::string _filename = "";
 };
@@ -144,6 +151,11 @@ public:
     bool is_encrypted() const override { return _impl->is_encrypted(); };
 
     Status touch_cache(int64_t offset, size_t length) override { return _impl->touch_cache(offset, length); }
+
+    // Intentionally do NOT forward page_cache_key to _impl. Wrappers like RandomAccessFile carry
+    // the path on themselves (overriding filename() but leaving _impl's _filename empty), so
+    // delegating would lose the name and return a key like (empty, offset). Inheriting the base
+    // default makes virtual filename() dispatch back to this wrapper and pick up the right name.
 
 private:
     SeekableInputStream* _impl;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -1348,7 +1348,15 @@ StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, i
     //       for example, in tablet X, segment `a` has segment id 10, if partial compaction happens,
     //                    in tablet X+1, segment `a` might still exists, but its actual id will not be 10.
     //       but in meta cache, segment `a` still has segment id 10, it is not changed.
-    auto segment = metacache()->lookup_segment(segment_info.path);
+    //
+    // A bundled data file can be referenced by multiple rowsets at different byte ranges
+    // (distinct bundle_file_offsets). The ranges contain different rows, so each must produce
+    // its own Segment bound to its own slice. Keying the cache on path alone would let the
+    // first-loaded slice be returned for every other offset, silently replacing later slices'
+    // data with the first one. FileInfo::cache_key() folds bundle_file_offset into the key
+    // for bundled slices and falls back to path for non-bundled segments.
+    const std::string cache_key = segment_info.cache_key();
+    auto segment = metacache()->lookup_segment(cache_key);
     if (segment == nullptr) {
         std::shared_ptr<FileSystem> fs;
         if (segment_info.fs) {
@@ -1360,7 +1368,7 @@ StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, i
         if (fill_meta_cache) {
             // NOTE: the returned segment may be not the same as the parameter passed in
             // Use the one in cache if the same key already exists
-            if (auto cached_segment = _metacache->cache_segment_if_absent(segment_info.path, segment);
+            if (auto cached_segment = _metacache->cache_segment_if_absent(cache_key, segment);
                 cached_segment != nullptr) {
                 segment = cached_segment;
             }

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -140,20 +140,6 @@ Status PageIO::write_page(WritableFile* wfile, const std::vector<Slice>& body, c
     return Status::OK();
 }
 
-// The unique key identifying entries in the page cache.
-// Each cached page corresponds to a specific offset within
-// a file.
-//
-// TODO(zc): Now we use file name(std::string) as a part of key,
-//  which is not efficient. We should make it better later
-std::string encode_cache_key(const std::string& fname, int64_t offset) {
-    std::string str;
-    str.reserve(fname.size() + sizeof(offset));
-    str.append(fname);
-    str.append((char*)&offset, sizeof(offset));
-    return str;
-}
-
 #if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
 Status drop_local_cache_data(const std::string& fname) {
     if (!config::lake_clear_corrupted_cache_data) {
@@ -326,7 +312,11 @@ static Status read_and_decompress_page_internal(const PageReadOptions& opts, Pag
     bool page_cache_available = (cache != nullptr) && cache->available();
 #endif
     PageCacheHandle cache_handle;
-    std::string cache_key = encode_cache_key(opts.read_file->filename(), opts.page_pointer.offset);
+    // Let the stream produce its own page-cache key for opts.page_pointer.offset. For non-bundled
+    // streams this is just (filename, offset); for bundle slices the override folds in the slice
+    // base offset so two slices of the same physical file never collide at equal stream-relative
+    // offsets. Callers do not need to know whether the stream is a slice.
+    std::string cache_key = opts.read_file->page_cache_key(opts.page_pointer.offset);
     if (opts.use_page_cache && page_cache_available && cache->lookup(cache_key, &cache_handle)) {
         return parse_page_from_cache(handle, body, footer, &cache_handle, opts);
     }

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -678,7 +678,12 @@ void Segment::turn_off_batch_update_cache_size() {
         if (_dirty_cache_counter.exchange(0) > 0) {
             if (_tablet_manager != nullptr) {
                 auto mem_cost = mem_usage();
-                _tablet_manager->update_segment_cache_size(file_name(), mem_cost, reinterpret_cast<intptr_t>(this));
+                // Use FileInfo::cache_key() so this matches the key load_segment registered under;
+                // a path-only key would miss for bundled slices (non-zero bundle_file_offset) and
+                // their cache entries would never get the post-open memory cost, defeating
+                // metacache capacity control.
+                _tablet_manager->update_segment_cache_size(_segment_file_info.cache_key(), mem_cost,
+                                                           reinterpret_cast<intptr_t>(this));
             }
         }
     }
@@ -689,7 +694,8 @@ void Segment::update_cache_size() {
         // could be race condition on this `_batch_on_flags_counter` check, but it is ok to be inaccurate in such case.
         if (_batch_on_flags_counter.load(std::memory_order_relaxed) == 0) {
             auto mem_cost = mem_usage();
-            _tablet_manager->update_segment_cache_size(file_name(), mem_cost, reinterpret_cast<intptr_t>(this));
+            _tablet_manager->update_segment_cache_size(_segment_file_info.cache_key(), mem_cost,
+                                                       reinterpret_cast<intptr_t>(this));
         } else {
             // under batch mode, only increase the _dirty_cache_counter
             _dirty_cache_counter.fetch_add(1, std::memory_order_relaxed);

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -38,6 +38,7 @@
 #include "storage/lake/update_manager.h"
 #include "storage/lake/versioned_tablet.h"
 #include "storage/options.h"
+#include "storage/rowset/segment.h"
 #include "storage/tablet_schema.h"
 #include "test_util.h"
 
@@ -1248,6 +1249,73 @@ TEST_F(LakeTabletManagerTest, test_get_schema_file_concurrently) {
     for (auto&& t : bthreads) {
         bthread_join(t, nullptr);
     }
+}
+
+// Bundle-format segments let multiple rowsets point at the same physical file at disjoint
+// byte ranges. Keying the segment cache on path alone would return the first-loaded slice to
+// every later caller, silently replacing their data. The key must include the bundle offset.
+TEST_F(LakeTabletManagerTest, segment_cache_key_distinguishes_bundle_slices) {
+    FileInfo plain{.path = "oss://bucket/data/abc.dat"};
+    FileInfo slice0{.path = "oss://bucket/data/abc.dat"};
+    FileInfo slice1{.path = "oss://bucket/data/abc.dat"};
+    slice0.bundle_file_offset = 0;
+    slice1.bundle_file_offset = 10704;
+
+    const auto plain_key = plain.cache_key();
+    const auto slice0_key = slice0.cache_key();
+    const auto slice1_key = slice1.cache_key();
+
+    // offset absent or zero collapses to the legacy path-only key so the cache layout for
+    // non-bundled segments is unchanged.
+    EXPECT_EQ(plain.path, plain_key);
+    EXPECT_EQ(plain_key, slice0_key);
+
+    // A non-zero bundle offset must fork off its own key; otherwise slice1 would collide with
+    // slice0 and receive slice0's Segment on cache hit.
+    EXPECT_NE(plain_key, slice1_key);
+    EXPECT_THAT(slice1_key, testing::HasSubstr("#10704"));
+}
+
+TEST_F(LakeTabletManagerTest, load_segment_returns_distinct_slices_for_same_path) {
+    // Construct a real file that encodes two back-to-back segments (a common shape produced
+    // by cross-boundary UPSERTs written through BundleWritableFile). We cannot call the full
+    // load_segment+open() path here without a SegmentWriter scaffold — Segment::open parses the
+    // bundle slice's footer — so the cheapest correctness check is that load_segment routes
+    // two different bundle offsets to distinct metacache entries. That is the specific
+    // invariant the cache-key fix protects.
+    const std::string path = _location_provider->segment_location(1, "segment_slice_test.dat");
+    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(path));
+    const std::string payload_a(1024, 'A');
+    const std::string payload_b(2048, 'B');
+    {
+        WritableFileOptions opts;
+        ASSIGN_OR_ABORT(auto of, fs->new_writable_file(opts, path));
+        ASSERT_OK(of->append(payload_a));
+        ASSERT_OK(of->append(payload_b));
+        ASSERT_OK(of->close());
+    }
+
+    FileInfo info_a{.path = path};
+    info_a.size = payload_a.size();
+    info_a.bundle_file_offset = 0;
+
+    FileInfo info_b{.path = path};
+    info_b.size = payload_b.size();
+    info_b.bundle_file_offset = static_cast<int64_t>(payload_a.size());
+
+    const auto key_a = info_a.cache_key();
+    const auto key_b = info_b.cache_key();
+    ASSERT_NE(key_a, key_b);
+
+    // Seed the metacache with a marker for key_a, prove a lookup by key_b does NOT find it.
+    // This mirrors the failure mode pre-fix: lookup by path-only would collide.
+    auto marker = std::make_shared<Segment>(fs, info_a, /*segment_id*/ 0, nullptr, _tablet_manager);
+    auto cached = _tablet_manager->metacache()->cache_segment_if_absent(key_a, marker);
+    ASSERT_NE(cached, nullptr);
+    EXPECT_EQ(_tablet_manager->metacache()->lookup_segment(key_a).get(), marker.get());
+    EXPECT_EQ(_tablet_manager->metacache()->lookup_segment(key_b), nullptr);
+
+    ASSERT_OK(fs->delete_file(path));
 }
 
 #ifdef USE_STAROS

--- a/be/test/storage/rowset/page_io_test.cpp
+++ b/be/test/storage/rowset/page_io_test.cpp
@@ -20,6 +20,7 @@
 #include "base/testutil/assert.h"
 #include "cache/mem_cache/lrucache_engine.h"
 #include "cache/mem_cache/page_cache.h"
+#include "fs/bundle_file.h"
 #include "fs/fs_memory.h"
 #include "storage/rowset/binary_plain_page.h"
 #include "storage/rowset/bitshuffle_page.h"
@@ -307,6 +308,202 @@ TEST_F(PageIOTest, test_corrupted_cache) {
     PageFooterPB read_footer;
     Status s = PageIO::read_and_decompress_page(read_opts, &handle, &body, &read_footer);
     ASSERT_TRUE(s.is_corruption());
+}
+
+// Two slices of the same bundled data file must not collide in the page cache.
+//
+// Pre-fix, the page cache key was (filename, page_pointer.offset). page_pointer.offset is
+// stream-relative for BundleSeekableInputStream, so two slices at different bundle offsets
+// produced identical keys at equal intra-slice positions. A cross-boundary UPSERT that
+// packs multiple child tablets' writes into one physical file (and a subsequent MERGE that
+// collects those slices into one tablet) therefore made slice B return slice A's cached
+// bytes — silently duplicating slice A and erasing slice B from query results.
+//
+// Fix: mix in the stream's bundle_file_offset so the key names the page's unique absolute
+// position in the physical file. This test writes two distinct pages back-to-back into one
+// file, exposes them via BundleSeekableInputStream wrappers at offsets 0 and page_a_size,
+// and confirms a cache warm on slice A does not bleed into slice B.
+TEST_F(PageIOTest, test_bundle_slices_do_not_collide_in_page_cache) {
+    WritableFileOptions write_opts;
+    write_opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ASSERT_FAIL(auto write_file, _fs->new_writable_file(write_opts, "/test_bundle_slices"));
+
+    PagePointer result_a;
+    std::vector<int32_t> values_a{1, 2, 3};
+    OwnedSlice page_a = _build_data_page(values_a);
+    PageFooterPB footer_a = _build_page_footer(page_a.slice().size);
+    std::vector<Slice> page_a_body{page_a.slice()};
+    ASSERT_OK(PageIO::write_page(write_file.get(), page_a_body, footer_a, &result_a));
+    uint64_t slice_a_size = write_file->size();
+
+    PagePointer result_b;
+    std::vector<int32_t> values_b{10, 20, 30};
+    OwnedSlice page_b = _build_data_page(values_b);
+    PageFooterPB footer_b = _build_page_footer(page_b.slice().size);
+    std::vector<Slice> page_b_body{page_b.slice()};
+    ASSERT_OK(PageIO::write_page(write_file.get(), page_b_body, footer_b, &result_b));
+    ASSERT_OK(write_file->close());
+    const uint64_t slice_b_size = write_file->size() - slice_a_size;
+    ASSERT_GT(slice_a_size, 0u);
+    ASSERT_GT(slice_b_size, 0u);
+
+    ASSIGN_OR_ASSERT_FAIL(auto raw_a, _fs->new_random_access_file("/test_bundle_slices"));
+    ASSIGN_OR_ASSERT_FAIL(auto raw_b, _fs->new_random_access_file("/test_bundle_slices"));
+    auto slice_a = std::make_shared<BundleSeekableInputStream>(raw_a->stream(), /*offset=*/0, slice_a_size);
+    auto slice_b = std::make_shared<BundleSeekableInputStream>(raw_b->stream(),
+                                                               /*offset=*/slice_a_size, slice_b_size);
+    ASSERT_OK(slice_a->init());
+    ASSERT_OK(slice_b->init());
+
+    // Sanity: the two slices must produce different page-cache keys for the same stream-relative
+    // offset; otherwise the fix being tested is not even exercised.
+    ASSERT_NE(slice_a->page_cache_key(0), slice_b->page_cache_key(0));
+
+    // Warm the cache with slice A's page at stream-relative offset 0.
+    PageReadOptions read_opts_a = _build_read_options(slice_a.get(), 0, slice_a_size, true);
+    {
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(read_opts_a, &handle, &body, &read_footer));
+    }
+    {
+        // second read is a cache hit on slice A
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(read_opts_a, &handle, &body, &read_footer));
+        ASSERT_EQ(_stats.cached_pages_num, 1);
+    }
+
+    // Now read slice B at stream-relative offset 0. The stream's bundle_file_offset is
+    // slice_a_size, so the key must differ from slice A's — otherwise this lookup hits slice
+    // A's cached bytes and decodes `{1,2,3}` instead of `{10,20,30}`.
+    PageReadOptions read_opts_b = _build_read_options(slice_b.get(), 0, slice_b_size, true);
+    const auto cached_before = _stats.cached_pages_num;
+    {
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(read_opts_b, &handle, &body, &read_footer));
+
+        // This must be a cache miss: the cache key included slice B's bundle offset.
+        ASSERT_EQ(_stats.cached_pages_num, cached_before);
+
+        // And the decoded bytes must be slice B's content, not slice A's.
+        BitShufflePageDecoder<TYPE_INT> decoder(body);
+        ASSERT_OK(decoder.init());
+        size_t size = 10;
+        Int32Column col;
+        ASSERT_OK(decoder.next_batch(&size, &col));
+        ASSERT_EQ(col.debug_string(), "[10, 20, 30]");
+    }
+}
+
+// Production wraps a BundleSeekableInputStream inside a RandomAccessFile carrying the physical
+// path, so the slice base offset is held by an inner stream the outer wrapper does not consult
+// when producing a key. RandomAccessFile must therefore carry the bundle offset itself and fold
+// it into page_cache_key — otherwise two slices of the same physical file produce identical
+// (path, stream_offset) keys at the same intra-slice offset and collide in the page cache.
+TEST_F(PageIOTest, test_random_access_file_carries_bundle_offset_into_cache_key) {
+    WritableFileOptions write_opts;
+    write_opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ASSERT_FAIL(auto wf, _fs->new_writable_file(write_opts, "/bundle_via_rfile"));
+    const std::string payload_a(1024, 'A');
+    const std::string payload_b(2048, 'B');
+    ASSERT_OK(wf->append(payload_a));
+    ASSERT_OK(wf->append(payload_b));
+    ASSERT_OK(wf->close());
+
+    ASSIGN_OR_ASSERT_FAIL(auto raw_a, _fs->new_random_access_file("/bundle_via_rfile"));
+    ASSIGN_OR_ASSERT_FAIL(auto raw_b, _fs->new_random_access_file("/bundle_via_rfile"));
+    auto bundle_a = std::make_shared<BundleSeekableInputStream>(raw_a->stream(), /*offset=*/0, payload_a.size());
+    auto bundle_b = std::make_shared<BundleSeekableInputStream>(raw_b->stream(),
+                                                                /*offset=*/payload_a.size(), payload_b.size());
+
+    RandomAccessFile rf_a(std::move(bundle_a), "/bundle_via_rfile", /*is_cache_hit=*/false, /*bundle_offset=*/0);
+    RandomAccessFile rf_b(std::move(bundle_b), "/bundle_via_rfile", /*is_cache_hit=*/false,
+                          /*bundle_offset=*/static_cast<int64_t>(payload_a.size()));
+
+    ASSERT_EQ(rf_a.filename(), rf_b.filename());
+    ASSERT_NE(rf_a.page_cache_key(0), rf_b.page_cache_key(0));
+}
+
+// Two distinct physical files must produce different page-cache keys at the same offset,
+// even though most concrete SeekableInputStream subclasses (S3InputStream, MemoryFileInputStream,
+// HdfsInputStream, ...) leave the inherited _filename member empty and only override the virtual
+// filename(). A naive default that reads _filename would collapse every file's keys to
+// (empty, offset) and let production page-cache lookups for file A return file B's bytes.
+TEST_F(PageIOTest, test_distinct_files_do_not_collide_in_page_cache) {
+    std::vector<int32_t> values_a{1, 2, 3};
+    std::vector<int32_t> values_b{10, 20, 30};
+    OwnedSlice page_a = _build_data_page(values_a);
+    OwnedSlice page_b = _build_data_page(values_b);
+    PageFooterPB footer_a = _build_page_footer(page_a.slice().size);
+    PageFooterPB footer_b = _build_page_footer(page_b.slice().size);
+
+    WritableFileOptions write_opts;
+    write_opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ASSERT_FAIL(auto write_a, _fs->new_writable_file(write_opts, "/distinct_files_A"));
+    PagePointer result_a;
+    std::vector<Slice> page_a_body{page_a.slice()};
+    ASSERT_OK(PageIO::write_page(write_a.get(), page_a_body, footer_a, &result_a));
+    ASSERT_OK(write_a->close());
+    uint64_t file_a_size = write_a->size();
+
+    ASSIGN_OR_ASSERT_FAIL(auto write_b, _fs->new_writable_file(write_opts, "/distinct_files_B"));
+    PagePointer result_b;
+    std::vector<Slice> page_b_body{page_b.slice()};
+    ASSERT_OK(PageIO::write_page(write_b.get(), page_b_body, footer_b, &result_b));
+    ASSERT_OK(write_b->close());
+    uint64_t file_b_size = write_b->size();
+
+    ASSIGN_OR_ASSERT_FAIL(auto read_a, _fs->new_random_access_file("/distinct_files_A"));
+    ASSIGN_OR_ASSERT_FAIL(auto read_b, _fs->new_random_access_file("/distinct_files_B"));
+
+    // Pre-condition: the wrappers report distinct names. If they didn't, the test below could
+    // trivially pass for a different reason.
+    ASSERT_NE(read_a->filename(), read_b->filename());
+
+    // The keys must differ at the same stream-relative offset 0; otherwise file B's lookup at
+    // offset 0 would hit file A's cached bytes in production. page_cache_key must dispatch
+    // through the virtual filename() so it picks up RandomAccessFile's _name rather than the
+    // empty _filename member buried on the underlying stream.
+    ASSERT_NE(read_a->page_cache_key(0), read_b->page_cache_key(0));
+
+    // End-to-end: warm the cache from file A, then read file B at the same offset and confirm
+    // we decode B's bytes (not A's).
+    PageReadOptions read_opts_a = _build_read_options(read_a.get(), 0, file_a_size, true);
+    {
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(read_opts_a, &handle, &body, &read_footer));
+    }
+    {
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(read_opts_a, &handle, &body, &read_footer));
+        ASSERT_EQ(_stats.cached_pages_num, 1);
+    }
+
+    PageReadOptions read_opts_b = _build_read_options(read_b.get(), 0, file_b_size, true);
+    const auto cached_before = _stats.cached_pages_num;
+    {
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(read_opts_b, &handle, &body, &read_footer));
+        ASSERT_EQ(_stats.cached_pages_num, cached_before);
+
+        BitShufflePageDecoder<TYPE_INT> decoder(body);
+        ASSERT_OK(decoder.init());
+        size_t size = 10;
+        Int32Column col;
+        ASSERT_OK(decoder.next_batch(&size, &col));
+        ASSERT_EQ(col.debug_string(), "[10, 20, 30]");
+    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Multiple caches in shared-data key on `(filename, offset)` or `filename`
without a slice disambiguator. When a physical `.dat` file is written in
**bundle format** (a single file holding per-tablet slices at different
offsets), two slices of the same file can therefore collide on the same
cache key, and a lookup for slice B returns slice A's cached bytes —
slice A silently duplicates in query results, slice B vanishes.

### The data-loss path: storage page cache

`be/src/storage/rowset/page_io.cpp::read_and_decompress_page` keyed the
page cache on `encode_cache_key(read_file->filename(), page_pointer.offset)`.
For a `BundleSeekableInputStream`, `page_pointer.offset` is
**stream-relative** (0-based within the slice), so two slices of the same
bundled file produce identical cache keys at equal intra-slice positions.

Reproducer on a shared-data primary-key range-distributed table:

```
INSERT  0..20000     salt=0
UPSERT  5000..15000  salt=1
ALTER TABLE ... SPLIT TABLETS (...)                          -- four children
UPSERT  10000..25000 salt=2     -- two batches straddle child boundaries
                                -- → written as bundled files
ALTER TABLE ... MERGE TABLETS (...)                          -- one tablet again
```

After the merge, `SELECT COUNT(DISTINCT id)` returns 22,998 instead of
25,000. 1,998 ids appear twice (slice-A rows read twice), 2,002 ids
disappear entirely (slice-B rows replaced by slice-A's cached pages). The
missing-id ranges are exactly the offset-1 slice contents of the two
bundled segments.

Runtime verification: setting `disable_storage_page_cache=true` on all CNs
and repeating the same flow returns 25000/25000/25000 — confirming the
page cache is the sole source of the corruption.

### Two adjacent defense-in-depth fixes (same mechanism)

1. **Lake Segment metacache.** `TabletManager::load_segment` keyed on
   `segment_info.path` alone. Two rowsets of a bundled file in one tablet
   would share a `Segment` object whose `_segment_file_info` was bound to
   whichever slice loaded first. In isolation this does not cause the
   symptom above — the page cache collision is what corrupts reads — but
   it is the same fragility, and any future read path that bypasses the
   page cache would surface the bug.
2. **Segment cache-size refresh.** `Segment::update_cache_size` and
   `turn_off_batch_update_cache_size` still passed `file_name()` (path
   only) to `update_segment_cache_size` after the Segment-cache key was
   forked. For segments with non-zero `bundle_file_offset` the lookup in
   `cache_segment_if_present` would miss, leaving the cache entry's
   memory cost unrefreshed.

### Audit of other `(filename, offset)`-style caches

Every adjacent cache was reviewed for the same class of bug; none are
affected:

| Cache | File | Why it is safe |
|---|---|---|
| Parquet page cache | `formats/parquet/page_reader.cpp` | External-table only; parquet writers do not use `BundleWritableFile`. |
| HDFS/Iceberg `CacheInputStream` block cache | `io/cache_input_stream.cpp` | External-table only; lake-native never wraps a bundle stream in this layer; key already includes `modification_time`. |
| SST block cache | `storage/sstable/table.cpp` | `(cache_id, handle.offset)` with per-Table `cache_id` from `block_cache->new_id()`; SST files are not written via `BundleWritableFile`. |
| Delvec cache | `lake/meta_file.cpp::delvec_cache_key` | `(tablet_id, DelvecPagePB)`; delvec files are not bundled; `DelvecPagePB` embeds version + offset + size. |
| Legacy rowset metadata cache | `rowset/metadata_cache.cpp` | Keyed by `rowset_id_str`; no file offset. |
| Tablet metadata cache | `lake/tablet_manager.cpp` | Keyed by `tablet_metadata_location(tablet_id, version)`. |

The only writer that produces bundles is `BundleWritableFileContext`, wired
only into `DeltaWriter` / `GeneralTabletWriter` / `PkTabletWriter` (data
segments); `PkTabletSSTWriter` uses `fs->new_writable_file` directly, so
sstables are never bundled.

## What I'm doing:

Encapsulate the slice disambiguator on the types that carry it, instead
of leaving each cache call site to know about BundleFile. Three caches
share one principle: **the cache key must name the page/segment's
position in the physical file, not in the slice.**

### 1. Page cache — `be/src/storage/rowset/page_io.cpp`

- New virtual `io::SeekableInputStream::page_cache_key(int64_t stream_offset)`.
  Default encodes `(filename, stream_offset)` (the existing binary format,
  moved out of `page_io.cpp`).
- `BundleSeekableInputStream` overrides it to fold its slice base offset
  into the encoding, returning a key unique to the page's absolute byte
  position in the physical file.
- `SeekableInputStreamWrapper` forwards to `_impl`; all wrappers
  (`CacheInputStream`, `CountedSeekableInputStream`,
  `ThrottledSeekableInputStream`, `EncryptSeekableInputStream`) inherit
  it automatically.
- `read_and_decompress_page` calls
  `read_file->page_cache_key(opts.page_pointer.offset)` and never names
  `bundle_file_offset`.

### 2. Lake Segment metacache — `be/src/fs/fs.h`, `be/src/storage/lake/tablet_manager.cpp`

- New `FileInfo::cache_key()` returns `"<path>#<offset>"` for bundled
  slices (`bundle_file_offset > 0`) and the bare `path` otherwise.
  Non-bundled layout unchanged.
- `TabletManager::load_segment` keys both `lookup_segment` and
  `cache_segment_if_absent` on `segment_info.cache_key()`.

### 3. Segment cache-size refresh — `be/src/storage/rowset/segment.cpp`

- `Segment::update_cache_size` and `turn_off_batch_update_cache_size`
  route through `_segment_file_info.cache_key()`, so the insert key (set
  by `load_segment`) and the update-size key stay identical for bundled
  slices by construction.

The previous public `SeekableInputStream::bundle_file_offset()` accessor
and the static `TabletManager::segment_cache_key()` helper are removed;
the BundleFile detail only exists inside
`BundleSeekableInputStream::page_cache_key` and `FileInfo::cache_key`.
Future caches keyed on stream/file identity get correct bundled-slice
handling without any new conditionals.

## Tests

New unit tests:

- `PageIOTest.test_bundle_slices_do_not_collide_in_page_cache` writes two
  distinct pages back-to-back into one physical file, wraps each with its
  own `BundleSeekableInputStream` at offsets 0 and `slice_a_size`, warms
  the cache on slice A, then reads slice B at the same stream-relative
  offset 0 and asserts (1) cache miss and (2) the decoded bytes are slice
  B's, not A's.
- `LakeTabletManagerTest.segment_cache_key_distinguishes_bundle_slices`
  covers the `FileInfo::cache_key()` rule directly.
- `LakeTabletManagerTest.load_segment_returns_distinct_slices_for_same_path`
  seeds the metacache at one offset and confirms the lookup at another
  does not collide.

Existing `PageIOTest` and `LakeTabletManagerTest` suites remain green
(6/6 and 26/26 respectively).

End-to-end verification on a shared-data test cluster with the reproducer
above: the post-merge `SELECT COUNT(DISTINCT id)` returns 25,000 with all
expected per-id values, where the same recipe previously returned 22,998
with mixed slice-A / slice-B corruption.

Fixes https://github.com/StarRocks/starrocks/issues/64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4