### PR TITLE
[Enhancement] Avoid O(N) table scan in CatalogRecycleBin recycle-time lookup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -333,71 +333,89 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
         return GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isDeletionSafeToExecute(originalRecycleTime);
     }
 
-    private synchronized long getAdjustedRecycleTimestamp(long id) {
-        Map<Long, RecycleTableInfo> idToRecycleTableInfo =  Maps.newHashMap();
-        for (Map<Long, RecycleTableInfo> tableEntry : idToTableInfo.rowMap().values()) {
-            for (Map.Entry<Long, RecycleTableInfo> entry : tableEntry.entrySet()) {
-                idToRecycleTableInfo.put(entry.getKey(), entry.getValue());
-            }
+    private synchronized long getAdjustedRecycleTimestampForDb(long dbId) {
+        RecycleDatabaseInfo databaseInfo = idToDatabase.get(dbId);
+        if (databaseInfo != null && !databaseInfo.isRecoverable()) {
+            return 0;
         }
+        return idToRecycleTime.get(dbId);
+    }
 
-        RecycleTableInfo tableInfo = idToRecycleTableInfo.get(id);
+    private synchronized long getAdjustedRecycleTimestampForTable(long dbId, long tableId) {
+        RecycleTableInfo tableInfo = idToTableInfo.get(dbId, tableId);
         if (tableInfo != null && !tableInfo.isRecoverable()) {
             return 0;
         }
+        return idToRecycleTime.get(tableId);
+    }
 
-        RecyclePartitionInfo partitionInfo = idToPartition.get(id);
+    private synchronized long getAdjustedRecycleTimestampForPartition(long partitionId) {
+        RecyclePartitionInfo partitionInfo = idToPartition.get(partitionId);
         if (partitionInfo != null && !partitionInfo.isRecoverable()) {
             if (partitionInfo.getRetentionPeriod() > 0) {
                 // partition retention period is set, return the original recycle timestamp
-                return idToRecycleTime.get(id);
+                return idToRecycleTime.get(partitionId);
             } else {
                 return 0;
             }
         }
+        return idToRecycleTime.get(partitionId);
+    }
 
-        RecycleDatabaseInfo databaseInfo = idToDatabase.get(id);
-        if (databaseInfo != null && !databaseInfo.isRecoverable()) {
-            return 0;
-        }
-
-        return idToRecycleTime.get(id);
+    private long defaultExpireMs() {
+        return max(Config.catalog_trash_expire_second * 1000L, Config.catalog_recycle_bin_erase_min_latency_ms);
     }
 
     /**
      * if we can erase this instance, we should check if anyone enable erase later.
      * Only used by main loop.
      */
-    private synchronized boolean timeExpired(long id, long currentTimeMs) {
-        long latencyMs = currentTimeMs - getAdjustedRecycleTimestamp(id);
-        long expireMs = max(Config.catalog_trash_expire_second * 1000L, Config.catalog_recycle_bin_erase_min_latency_ms);
-        // customize expireMs for partition that need to be retained for a configurable period
-        if (idToPartition.containsKey(id)) {
-            RecyclePartitionInfo recyclePartitionInfo = idToPartition.get(id);
-            if (recyclePartitionInfo.getRetentionPeriod() > 0) {
-                // retain the partition alive for `tabletReservePeriod` seconds
-                // while retention period is set, `catalog_trash_expire_second` will not take effect and the partition
-                // is assumed to have been set un-recoverable (i.e. partition is not recoverable)
-                expireMs = max(recyclePartitionInfo.getRetentionPeriod() * 1000, Config.catalog_recycle_bin_erase_min_latency_ms);
-            }
+    private synchronized boolean timeExpiredForDb(long dbId, long currentTimeMs) {
+        long latencyMs = currentTimeMs - getAdjustedRecycleTimestampForDb(dbId);
+        long expireMs = defaultExpireMs();
+        if (enableEraseLater.contains(dbId)) {
+            expireMs += LATE_RECYCLE_INTERVAL_SECONDS * 1000L;
         }
-        if (enableEraseLater.contains(id)) {
-            // if enableEraseLater is set, extend the timeout by LATE_RECYCLE_INTERVAL_SECONDS
+        return latencyMs > expireMs;
+    }
+
+    private synchronized boolean timeExpiredForTable(long dbId, long tableId, long currentTimeMs) {
+        long latencyMs = currentTimeMs - getAdjustedRecycleTimestampForTable(dbId, tableId);
+        long expireMs = defaultExpireMs();
+        if (enableEraseLater.contains(tableId)) {
+            expireMs += LATE_RECYCLE_INTERVAL_SECONDS * 1000L;
+        }
+        return latencyMs > expireMs;
+    }
+
+    private synchronized boolean timeExpiredForPartition(long partitionId, long currentTimeMs) {
+        long latencyMs = currentTimeMs - getAdjustedRecycleTimestampForPartition(partitionId);
+        long expireMs = defaultExpireMs();
+        // customize expireMs for partition that need to be retained for a configurable period
+        RecyclePartitionInfo recyclePartitionInfo = idToPartition.get(partitionId);
+        if (recyclePartitionInfo != null && recyclePartitionInfo.getRetentionPeriod() > 0) {
+            // retain the partition alive for `tabletReservePeriod` seconds
+            // while retention period is set, `catalog_trash_expire_second` will not take effect and the partition
+            // is assumed to have been set un-recoverable (i.e. partition is not recoverable)
+            expireMs = max(recyclePartitionInfo.getRetentionPeriod() * 1000, Config.catalog_recycle_bin_erase_min_latency_ms);
+        }
+        if (enableEraseLater.contains(partitionId)) {
             expireMs += LATE_RECYCLE_INTERVAL_SECONDS * 1000L;
         }
         return latencyMs > expireMs;
     }
 
     private synchronized boolean canEraseDatabase(RecycleDatabaseInfo databaseInfo, long currentTimeMs) {
+        long dbId = databaseInfo.getDb().getId();
         if (RunMode.isSharedDataMode() && GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
-                            .isDbInClusterSnapshotInfo(databaseInfo.getDb().getId())) {
+                            .isDbInClusterSnapshotInfo(dbId)) {
             return false;
         }
-        if (!checkValidDeletionByClusterSnapshot(databaseInfo.getDb().getId())) {
+        if (!checkValidDeletionByClusterSnapshot(dbId)) {
             return false;
         }
 
-        if (timeExpired(databaseInfo.getDb().getId(), currentTimeMs)) {
+        if (timeExpiredForDb(dbId, currentTimeMs)) {
             return true;
         }
 
@@ -405,38 +423,41 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
     }
 
     private synchronized boolean canEraseTable(RecycleTableInfo tableInfo, long currentTimeMs) {
+        long dbId = tableInfo.getDbId();
+        long tableId = tableInfo.getTable().getId();
         if (RunMode.isSharedDataMode() && GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
-                            .isTableInClusterSnapshotInfo(tableInfo.getDbId(), tableInfo.getTable().getId())) {
+                            .isTableInClusterSnapshotInfo(dbId, tableId)) {
             return false;
         }
 
-        if (!checkValidDeletionByClusterSnapshot(tableInfo.getTable().getId())) {
+        if (!checkValidDeletionByClusterSnapshot(tableId)) {
             return false;
         }
 
-        if (timeExpired(tableInfo.getTable().getId(), currentTimeMs)) {
+        if (timeExpiredForTable(dbId, tableId, currentTimeMs)) {
             return true;
         }
 
         // database is force dropped, the table can not be recovered, erase it.
-        if (GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIncludeRecycleBin(tableInfo.getDbId()) == null) {
+        if (GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIncludeRecycleBin(dbId) == null) {
             return true;
         }
         return false;
     }
 
     private synchronized boolean canErasePartition(RecyclePartitionInfo partitionInfo, long currentTimeMs) {
+        long partitionId = partitionInfo.getPartition().getId();
         if (RunMode.isSharedDataMode() && GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
                             .isPartitionInClusterSnapshotInfo(partitionInfo.getDbId(),
-                                    partitionInfo.getTableId(), partitionInfo.getPartition().getId())) {
+                                    partitionInfo.getTableId(), partitionId)) {
             return false;
         }
 
-        if (!checkValidDeletionByClusterSnapshot(partitionInfo.getPartition().getId())) {
+        if (!checkValidDeletionByClusterSnapshot(partitionId)) {
             return false;
         }
 
-        if (timeExpired(partitionInfo.getPartition().getId(), currentTimeMs)) {
+        if (timeExpiredForPartition(partitionId, currentTimeMs)) {
             return true;
         }
 
@@ -455,29 +476,53 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
         return false;
     }
 
-    /**
-     * make sure there are still some time before the subject is erased
-     */
-    public synchronized boolean ensureEraseLater(long id, long currentTimeMs) {
-        // 1. not in idToRecycleTime, maybe already erased, sorry it's too late!
-        if (!idToRecycleTime.containsKey(id)) {
-            return false;
-        }
-        // 2. will expire after quite a long time, don't worry
-        long latency = currentTimeMs - getAdjustedRecycleTimestamp(id);
+    private boolean ensureEraseLaterCommon(long id, long currentTimeMs, long adjustedRecycleTimestamp) {
+        // will expire after quite a long time, don't worry
+        long latency = currentTimeMs - adjustedRecycleTimestamp;
         if (latency < (Config.catalog_trash_expire_second - LATE_RECYCLE_INTERVAL_SECONDS) * 1000L) {
             return true;
         }
-        // 3. check valid by cluster snapshot
+        // check valid by cluster snapshot
         if (!checkValidDeletionByClusterSnapshot(id)) {
             return true;
-        } 
-        // 4. already expired, sorry.
+        }
+        // already expired, sorry.
         if (latency > Config.catalog_trash_expire_second * 1000L) {
             return false;
         }
         enableEraseLater.add(id);
         return true;
+    }
+
+    /**
+     * make sure there are still some time before the database is erased
+     */
+    public synchronized boolean ensureDatabaseEraseLater(long dbId, long currentTimeMs) {
+        // not in idToRecycleTime, maybe already erased, sorry it's too late!
+        if (!idToRecycleTime.containsKey(dbId)) {
+            return false;
+        }
+        return ensureEraseLaterCommon(dbId, currentTimeMs, getAdjustedRecycleTimestampForDb(dbId));
+    }
+
+    /**
+     * make sure there are still some time before the table is erased
+     */
+    public synchronized boolean ensureTableEraseLater(long dbId, long tableId, long currentTimeMs) {
+        if (!idToRecycleTime.containsKey(tableId)) {
+            return false;
+        }
+        return ensureEraseLaterCommon(tableId, currentTimeMs, getAdjustedRecycleTimestampForTable(dbId, tableId));
+    }
+
+    /**
+     * make sure there are still some time before the partition is erased
+     */
+    public synchronized boolean ensurePartitionEraseLater(long partitionId, long currentTimeMs) {
+        if (!idToRecycleTime.containsKey(partitionId)) {
+            return false;
+        }
+        return ensureEraseLaterCommon(partitionId, currentTimeMs, getAdjustedRecycleTimestampForPartition(partitionId));
     }
 
     protected synchronized void eraseDatabase(long currentTimeMs) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -587,19 +587,20 @@ public class TabletScheduler extends LeaderDaemon {
     protected boolean checkIfTabletExpired(TabletSchedCtx ctx, CatalogRecycleBin recycleBin, long currentTimeMs) {
         // check if about to erase
         long dbId = ctx.getDbId();
-        if (recycleBin.getDatabase(dbId) != null && !recycleBin.ensureEraseLater(dbId, currentTimeMs)) {
+        if (recycleBin.getDatabase(dbId) != null && !recycleBin.ensureDatabaseEraseLater(dbId, currentTimeMs)) {
             LOG.warn("discard ctx because db {} will erase soon: {}", dbId, ctx);
             return true;
         }
         long tableId = ctx.getTblId();
-        if (recycleBin.getTable(dbId, tableId) != null && !recycleBin.ensureEraseLater(tableId, currentTimeMs)) {
+        if (recycleBin.getTable(dbId, tableId) != null
+                && !recycleBin.ensureTableEraseLater(dbId, tableId, currentTimeMs)) {
             LOG.warn("discard ctx because table {} will erase soon: {}", tableId, ctx);
             return true;
         }
         long partitionId = ctx.getPhysicalPartitionId();
         PhysicalPartition physicalPartition = recycleBin.getPhysicalPartition(partitionId);
         if (physicalPartition != null
-                && !recycleBin.ensureEraseLater(physicalPartition.getParentId(), currentTimeMs)) {
+                && !recycleBin.ensurePartitionEraseLater(physicalPartition.getParentId(), currentTimeMs)) {
             LOG.warn("discard ctx because partition {} will erase soon: {}", partitionId, ctx);
             return true;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -469,21 +469,21 @@ public class CatalogRecycleBinTest {
 
         // no need to set enable erase later if there are a lot of time left
         long now = System.currentTimeMillis();
-        Assertions.assertTrue(recycleBin.ensureEraseLater(db.getId(), now));
+        Assertions.assertTrue(recycleBin.ensureDatabaseEraseLater(db.getId(), now));
         Assertions.assertFalse(recycleBin.enableEraseLater.contains(db.getId()));
 
         // no need to set enable erase later if already exipre
         long moreThanTenMinutesLater = now + 620 * 1000L;
-        Assertions.assertFalse(recycleBin.ensureEraseLater(db.getId(), moreThanTenMinutesLater));
+        Assertions.assertFalse(recycleBin.ensureDatabaseEraseLater(db.getId(), moreThanTenMinutesLater));
         Assertions.assertFalse(recycleBin.enableEraseLater.contains(db.getId()));
 
         // now we should set enable erase later because we are about to expire
         long moreThanNineMinutesLater = now + 550 * 1000L;
-        Assertions.assertTrue(recycleBin.ensureEraseLater(db.getId(), moreThanNineMinutesLater));
+        Assertions.assertTrue(recycleBin.ensureDatabaseEraseLater(db.getId(), moreThanNineMinutesLater));
         Assertions.assertTrue(recycleBin.enableEraseLater.contains(db.getId()));
 
         // if already expired, we should return false but won't erase the flag
-        Assertions.assertFalse(recycleBin.ensureEraseLater(db.getId(), moreThanTenMinutesLater));
+        Assertions.assertFalse(recycleBin.ensureDatabaseEraseLater(db.getId(), moreThanTenMinutesLater));
         Assertions.assertTrue(recycleBin.enableEraseLater.contains(db.getId()));
     }
 
@@ -550,11 +550,11 @@ public class CatalogRecycleBinTest {
 
         // 3. set recyle later, check if recycle now
         CatalogRecycleBin.LATE_RECYCLE_INTERVAL_SECONDS = 10;
-        Assertions.assertFalse(recycleBin.ensureEraseLater(db1.getId(), now));  // already erased
-        Assertions.assertTrue(recycleBin.ensureEraseLater(db2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensureDatabaseEraseLater(db1.getId(), now));  // already erased
+        Assertions.assertTrue(recycleBin.ensureDatabaseEraseLater(db2.getId(), now));
         Assertions.assertEquals(0, recycleBin.enableEraseLater.size());
         recycleBin.idToRecycleTime.put(db2.getId(), expireFromNow + 1000);
-        Assertions.assertTrue(recycleBin.ensureEraseLater(db2.getId(), now));
+        Assertions.assertTrue(recycleBin.ensureDatabaseEraseLater(db2.getId(), now));
         Assertions.assertEquals(1, recycleBin.enableEraseLater.size());
         Assertions.assertTrue(recycleBin.enableEraseLater.contains(db2.getId()));
 
@@ -566,7 +566,7 @@ public class CatalogRecycleBinTest {
 
         // 5. will erase after expire time + latency time
         recycleBin.idToRecycleTime.put(db2.getId(), expireFromNow - 11000);
-        Assertions.assertFalse(recycleBin.ensureEraseLater(db2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensureDatabaseEraseLater(db2.getId(), now));
         recycleBin.eraseDatabase(now);
         Assertions.assertNull(recycleBin.getDatabase(db2.getId()));
         Assertions.assertEquals(0, recycleBin.idToRecycleTime.size());
@@ -618,11 +618,11 @@ public class CatalogRecycleBinTest {
 
         // 3. set recyle later, check if recycle now
         CatalogRecycleBin.LATE_RECYCLE_INTERVAL_SECONDS = 10;
-        Assertions.assertFalse(recycleBin.ensureEraseLater(table1.getId(), now));  // already erased
-        Assertions.assertTrue(recycleBin.ensureEraseLater(table2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensureTableEraseLater(dbId, table1.getId(), now));  // already erased
+        Assertions.assertTrue(recycleBin.ensureTableEraseLater(dbId, table2.getId(), now));
         Assertions.assertEquals(0, recycleBin.enableEraseLater.size());
         recycleBin.idToRecycleTime.put(table2.getId(), expireFromNow + 1000);
-        Assertions.assertTrue(recycleBin.ensureEraseLater(table2.getId(), now));
+        Assertions.assertTrue(recycleBin.ensureTableEraseLater(dbId, table2.getId(), now));
         Assertions.assertEquals(1, recycleBin.enableEraseLater.size());
         Assertions.assertTrue(recycleBin.enableEraseLater.contains(table2.getId()));
 
@@ -635,7 +635,7 @@ public class CatalogRecycleBinTest {
 
         // 5. will erase after expire time + latency time
         recycleBin.idToRecycleTime.put(table2.getId(), expireFromNow - 11000);
-        Assertions.assertFalse(recycleBin.ensureEraseLater(table2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensureTableEraseLater(dbId, table2.getId(), now));
         recycleBin.eraseTable(now);
         waitPartitionClearFinished(recycleBin, table2.getId(), now);
         Assertions.assertNull(recycleBin.getTable(dbId, table2.getId()));
@@ -678,11 +678,11 @@ public class CatalogRecycleBinTest {
 
         // 3. set recyle later, check if recycle now
         CatalogRecycleBin.LATE_RECYCLE_INTERVAL_SECONDS = 10;
-        Assertions.assertFalse(recycleBin.ensureEraseLater(p1.getId(), now));  // already erased
-        Assertions.assertTrue(recycleBin.ensureEraseLater(p2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensurePartitionEraseLater(p1.getId(), now));  // already erased
+        Assertions.assertTrue(recycleBin.ensurePartitionEraseLater(p2.getId(), now));
         Assertions.assertEquals(0, recycleBin.enableEraseLater.size());
         recycleBin.idToRecycleTime.put(p2.getId(), expireFromNow + 1000);
-        Assertions.assertTrue(recycleBin.ensureEraseLater(p2.getId(), now));
+        Assertions.assertTrue(recycleBin.ensurePartitionEraseLater(p2.getId(), now));
         Assertions.assertEquals(1, recycleBin.enableEraseLater.size());
         Assertions.assertTrue(recycleBin.enableEraseLater.contains(p2.getId()));
 
@@ -695,7 +695,7 @@ public class CatalogRecycleBinTest {
 
         // 5. will erase after expire time + latency time
         recycleBin.idToRecycleTime.put(p2.getId(), expireFromNow - 11000);
-        Assertions.assertFalse(recycleBin.ensureEraseLater(p2.getId(), now));
+        Assertions.assertFalse(recycleBin.ensurePartitionEraseLater(p2.getId(), now));
         recycleBin.erasePartition(now);
         waitPartitionClearFinished(recycleBin, p2.getId(), now);
         Assertions.assertEquals(recycleBin.getPartition(p2.getId()), null);
@@ -871,11 +871,11 @@ public class CatalogRecycleBinTest {
         recycleBin.recyclePartition(info2);
 
         // With retention period: should return original recycle timestamp
-        long adjustedTime1 = Deencapsulation.invoke(recycleBin, "getAdjustedRecycleTimestamp", p1.getId());
+        long adjustedTime1 = Deencapsulation.invoke(recycleBin, "getAdjustedRecycleTimestampForPartition", p1.getId());
         Assertions.assertEquals(recycleBin.idToRecycleTime.get(p1.getId()), adjustedTime1);
 
         // Without retention period: should return 0 for non-recoverable partition
-        long adjustedTime2 = Deencapsulation.invoke(recycleBin, "getAdjustedRecycleTimestamp", p2.getId());
+        long adjustedTime2 = Deencapsulation.invoke(recycleBin, "getAdjustedRecycleTimestampForPartition", p2.getId());
         Assertions.assertEquals(0, adjustedTime2);
     }
 


### PR DESCRIPTION
  ## Why I'm doing:

  `CatalogRecycleBin.getAdjustedRecycleTimestamp(long id)` flattens the entire
  `idToTableInfo` Guava Table into a fresh `HashMap` on every call:

  ```java
  Map<Long, RecycleTableInfo> idToRecycleTableInfo = Maps.newHashMap();
  for (Map<Long, RecycleTableInfo> tableEntry : idToTableInfo.rowMap().values()) {
      for (Map.Entry<Long, RecycleTableInfo> entry : tableEntry.entrySet()) {
          idToRecycleTableInfo.put(entry.getKey(), entry.getValue());
      }
  }
  ```

  It is called from `timeExpired` (invoked for every item in `canEraseDatabase`
  / `canEraseTable` / `canErasePartition` inside the main erase loop) and from
  `ensureEraseLater`. With many recycled tables this becomes O(N²) on the erase
  path and a hot spot for `TabletScheduler.checkIfTabletExpired`.

  The root cause is that `idToTableInfo` is keyed by `(dbId, tableId)`, so a
  single-argument lookup by `id` has to scan every row. All callers already
  know the correct `dbId` from `RecycleTableInfo.getDbId()` or
  `TabletSchedCtx.getDbId()`, so the fix is to thread that context through the
  APIs instead of re-deriving it.

  ## What I'm doing:

  Split the three generic helpers by recycle-bin entry type. Each variant uses
  a direct O(1) lookup in the map it actually needs:

  - `getAdjustedRecycleTimestamp(long id)` →
    - `getAdjustedRecycleTimestampForDb(long dbId)`
    - `getAdjustedRecycleTimestampForTable(long dbId, long tableId)` — uses
      `idToTableInfo.get(dbId, tableId)` directly, no more rowMap flatten
    - `getAdjustedRecycleTimestampForPartition(long partitionId)`
  - `timeExpired(long id, long)` →
    `timeExpiredForDb` / `timeExpiredForTable(dbId, tableId, ...)` /
    `timeExpiredForPartition`. The partition-retention branch is scoped to the
    partition variant only.
  - `ensureEraseLater(long id, long)` →
    `ensureDatabaseEraseLater(dbId, ...)` /
    `ensureTableEraseLater(dbId, tableId, ...)` /
    `ensurePartitionEraseLater(partitionId, ...)`. Shared steps live in a
    private `ensureEraseLaterCommon` helper, with the `idToRecycleTime`
    "already erased" short-circuit kept in each public entry point to preserve
    the original evaluation order.

  Callers:
  - `canEraseDatabase` / `canEraseTable` / `canErasePartition` now call the
    matching typed variants.
  - `TabletScheduler.checkIfTabletExpired` calls the three typed
    `ensureXxxEraseLater` variants corresponding to its db/table/partition
    branches.
  - `CatalogRecycleBinTest` updated to the new signatures.

  No reverse-index data structure is introduced — behavior, synchronization,
  serialization format, and public semantics are unchanged.

  Fixes #issue

  ## What type of PR is this:

  - [ ] BugFix
  - [ ] Feature
  - [x] Enhancement
  - [ ] Refactor
  - [ ] UT
  - [ ] Doc
  - [ ] Tool

  Does this PR entail a change in behavior?

  - [ ] Yes, this PR will result in a change in behavior.
  - [x] No, this PR will not result in a change in behavior.

  If yes, please specify the type of change:

  - [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
  - [ ] Parameter changes: default values, similar parameters but with different default values
  - [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
  - [ ] Feature removed
  - [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

  ## Checklist:

  - [x] I have added test cases for my bug fix or my new feature
  - [ ] This pr needs user documentation (for new or modified features or behaviors)
    - [ ] I have added documentation for my new feature or new function
    - [ ] This pr needs auto generate documentation
  - [ ] This is a backport pr

  ## Bugfix cherry-pick branch check:
  - [x] I have checked the version labels which the pr will be auto-backported to the target branch
    - [x] 4.1
    - [x] 4.0
    - [x] 3.5
    - [ ] 3.4