### PR TITLE
[UT] Add regression test for GCS cache key with underscore bucket names

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/fs/hdfs/HdfsFsManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/hdfs/HdfsFsManagerTest.java
@@ -262,6 +262,51 @@ public class HdfsFsManagerTest {
         testFileSystemCache(blobProperties, Pair.create(wasbsPath1, wasbsPath2), Pair.create(wasbsPath3, wasbsPath4));
     }
 
+    /**
+     * Regression test for issue #66504: GCS Broker Load incorrectly reuses the
+     * bucket from a previous job when bucket names contain underscores.
+     *
+     * Root cause: java.net.URI.getHost() returns null for authorities containing
+     * underscores (DNS hostname rules forbid them). The pre-fix cache key was
+     * scheme + "://" + host, which collapsed every such bucket to the literal
+     * string "gs://null" and caused Job 2 to receive the cached FileSystem from
+     * Job 1. Fixed by PR #68901 which switched the key to use getAuthority().
+     */
+    @Test
+    public void testGcsFileSystemCache() throws StarRocksException, IOException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CloudConfigurationConstants.GCP_GCS_USE_COMPUTE_ENGINE_SERVICE_ACCOUNT, "true");
+
+        // Sanity-check the regression trigger: getHost() is null for both,
+        // so any cache keyed on host would collide on "gs://null".
+        Assertions.assertNull(java.net.URI.create("gs://bucket_us/abc").getHost());
+        Assertions.assertNull(java.net.URI.create("gs://bucket_us_west1/xyz").getHost());
+
+        // Same underscore-bearing bucket, different key paths -> must share the cached FS.
+        HdfsFs fs1 = fileSystemManager.getFileSystem(
+                "gs://bucket_us/abc/file1.parquet", properties, null);
+        HdfsFs fs2 = fileSystemManager.getFileSystem(
+                "gs://bucket_us/xyz/file2.parquet", properties, null);
+        Assertions.assertSame(fs1, fs2);
+
+        // Two distinct underscore-bearing buckets -> must NOT share the cached FS.
+        HdfsFs fs3 = fileSystemManager.getFileSystem(
+                "gs://bucket_us/abc/file1.parquet", properties, null);
+        HdfsFs fs4 = fileSystemManager.getFileSystem(
+                "gs://bucket_us_west1/xyz/file2.parquet", properties, null);
+        try {
+            Assertions.assertNotSame(fs3, fs4);
+        } finally {
+            fs4.getDFSFileSystem().close();
+        }
+        try {
+            // Pre-fix behavior would hand back the bucket_us FS for bucket_us_west1.
+            Assertions.assertSame(fs1, fs3);
+        } finally {
+            fs3.getDFSFileSystem().close();
+        }
+    }
+
     private void testFileSystemCache(Map<String, String> properties, Pair<String, String> sameFsPaths,
                                      Pair<String, String> differentFsPaths) throws StarRocksException, IOException {
         HdfsFs fs1 = fileSystemManager.getFileSystem(sameFsPaths.first, properties, null);


### PR DESCRIPTION
Issue #66504: Broker Load reuses the bucket from a previous job when GCS bucket names contain underscores. Root cause was URI.getHost() returning null for such authorities, collapsing distinct buckets to the same cache key "gs://null". Fixed by #68901 which switched the key to getAuthority(); this test verifies and guards that fix.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
