### PR TITLE
[Refactor] Introduce custom fmt formatters as preparation for fmt version bump

### DIFF
--- a/be/src/base/CMakeLists.txt
+++ b/be/src/base/CMakeLists.txt
@@ -45,6 +45,7 @@ ADD_BE_LIB(Base
   hash/hash_util.cpp
   hash/murmur_hash3.cpp
   failpoint/fail_point.cpp
+  format.cpp
   path/filesystem_util.cc
   process/lite_exec.cpp
   types/decimal12.cpp

--- a/be/src/base/compression/stream_compressor.cpp
+++ b/be/src/base/compression/stream_compressor.cpp
@@ -396,7 +396,7 @@ StatusOr<std::unique_ptr<StreamCompressor>> StreamCompressor::create_compressor(
         compressor = std::make_unique<ZstdStreamCompressor>();
         break;
     default:
-        return Status::InternalError(fmt::format("Unknown compress type: {}", static_cast<int>(type)));
+        return Status::InternalError(fmt::format("Unknown compress type: {}", type));
     }
 
     RETURN_IF_ERROR(compressor->init());

--- a/be/src/base/compression/stream_compressor.cpp
+++ b/be/src/base/compression/stream_compressor.cpp
@@ -35,6 +35,7 @@
 #include "base/compression/stream_compressor.h"
 
 #include <bzlib.h>
+#include <fmt/compile.h>
 #include <glog/logging.h>
 #include <zlib.h>
 
@@ -45,7 +46,7 @@
 #include "base/coding.h"
 #include "base/compression/compression_context_pool_singletons.h"
 #include "base/compression/compression_headers.h"
-#include "fmt/compile.h"
+#include "base/format.h"
 #include "gutil/strings/substitute.h"
 
 namespace starrocks {

--- a/be/src/base/compression/stream_decompressor.cpp
+++ b/be/src/base/compression/stream_decompressor.cpp
@@ -35,6 +35,7 @@
 #include "base/compression/stream_decompressor.h"
 
 #include <bzlib.h>
+#include <fmt/compile.h>
 #include <glog/logging.h>
 #include <zlib.h>
 
@@ -46,7 +47,7 @@
 #include "base/compression/compression_context_pool_singletons.h"
 #include "base/compression/compression_headers.h"
 #include "base/compression/lzo_decompressor_registry.h"
-#include "fmt/compile.h"
+#include "base/format.h"
 #include "gutil/strings/substitute.h"
 
 namespace starrocks {

--- a/be/src/base/compression/stream_decompressor.cpp
+++ b/be/src/base/compression/stream_decompressor.cpp
@@ -1150,7 +1150,7 @@ StatusOr<std::unique_ptr<StreamDecompressor>> StreamDecompressor::create_decompr
         decompressor = std::make_unique<LzoStreamDecompressor>();
         break;
     default:
-        return Status::InternalError(fmt::format("Unknown compress type: {}", static_cast<int>(type)));
+        return Status::InternalError(fmt::format("Unknown compress type: {}", type));
     }
 
     RETURN_IF_ERROR(decompressor->init());

--- a/be/src/base/format.cpp
+++ b/be/src/base/format.cpp
@@ -14,47 +14,67 @@
 
 #include "base/format.h"
 
-
-auto fmt::formatter<starrocks::CompressionTypePB>::format(const starrocks::CompressionTypePB value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::CompressionTypePB>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::CompressionTypePB>::format(const starrocks::CompressionTypePB value,
+                                                          format_context& ctx) const -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::CompressionTypePB>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }
 
-auto fmt::formatter<starrocks::EncryptionAlgorithmPB>::format(const starrocks::EncryptionAlgorithmPB value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::EncryptionAlgorithmPB>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::EncryptionAlgorithmPB>::format(const starrocks::EncryptionAlgorithmPB value,
+                                                              format_context& ctx) const -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::EncryptionAlgorithmPB>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }
 
-auto fmt::formatter<starrocks::EncryptionKeyTypePB>::format(const starrocks::EncryptionKeyTypePB value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::EncryptionKeyTypePB>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::EncryptionKeyTypePB>::format(const starrocks::EncryptionKeyTypePB value,
+                                                            format_context& ctx) const -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::EncryptionKeyTypePB>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }
 
-auto fmt::formatter<starrocks::NullEncodingPB>::format(const starrocks::NullEncodingPB value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::NullEncodingPB>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::NullEncodingPB>::format(const starrocks::NullEncodingPB value, format_context& ctx) const
+        -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::NullEncodingPB>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }
 
-auto fmt::formatter<starrocks::TStatusCode::type>::format(const starrocks::TStatusCode::type value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::TStatusCode::type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::TStatusCode::type>::format(const starrocks::TStatusCode::type value,
+                                                          format_context& ctx) const -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::TStatusCode::type>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }
 
-auto fmt::formatter<starrocks::TExprNodeType::type>::format(const starrocks::TExprNodeType::type value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::TExprNodeType::type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::TExprNodeType::type>::format(const starrocks::TExprNodeType::type value,
+                                                            format_context& ctx) const -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::TExprNodeType::type>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }
 
-auto fmt::formatter<starrocks::TFunctionBinaryType::type>::format(const starrocks::TFunctionBinaryType::type value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::TFunctionBinaryType::type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::TFunctionBinaryType::type>::format(const starrocks::TFunctionBinaryType::type value,
+                                                                  format_context& ctx) const
+        -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::TFunctionBinaryType::type>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }
 
-auto fmt::formatter<starrocks::SampleMethod::type>::format(const starrocks::SampleMethod::type value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::SampleMethod::type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::SampleMethod::type>::format(const starrocks::SampleMethod::type value,
+                                                           format_context& ctx) const -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::SampleMethod::type>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }
 
-auto fmt::formatter<starrocks::TFileType::type>::format(const starrocks::TFileType::type value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::TFileType::type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::TFileType::type>::format(const starrocks::TFileType::type value,
+                                                        format_context& ctx) const -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::TFileType::type>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }
 
-auto fmt::formatter<orc::TypeKind>::format(const orc::TypeKind value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<orc::TypeKind>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<orc::TypeKind>::format(const orc::TypeKind value, format_context& ctx) const
+        -> format_context::iterator {
+    return formatter<std::underlying_type_t<orc::TypeKind>>::format(starrocks::enum_to_underlying_type(value), ctx);
 }
 
-auto fmt::formatter<tparquet::Type::type>::format(const tparquet::Type::type value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::string>::format(tparquet::to_string(value), ctx);
+auto fmt::formatter<tparquet::Type::type>::format(const tparquet::Type::type value, format_context& ctx) const
+        -> format_context::iterator {
+    return formatter<std::string>::format(tparquet::to_string(value), ctx);
 }

--- a/be/src/base/format.cpp
+++ b/be/src/base/format.cpp
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/format.h"
+
+
+auto fmt::formatter<starrocks::CompressionTypePB>::format(const starrocks::CompressionTypePB value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::CompressionTypePB>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}
+
+auto fmt::formatter<starrocks::EncryptionAlgorithmPB>::format(const starrocks::EncryptionAlgorithmPB value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::EncryptionAlgorithmPB>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}
+
+auto fmt::formatter<starrocks::EncryptionKeyTypePB>::format(const starrocks::EncryptionKeyTypePB value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::EncryptionKeyTypePB>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}
+
+auto fmt::formatter<starrocks::NullEncodingPB>::format(const starrocks::NullEncodingPB value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::NullEncodingPB>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}
+
+auto fmt::formatter<starrocks::TStatusCode::type>::format(const starrocks::TStatusCode::type value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::TStatusCode::type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}
+
+auto fmt::formatter<starrocks::TExprNodeType::type>::format(const starrocks::TExprNodeType::type value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::TExprNodeType::type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}
+
+auto fmt::formatter<starrocks::TFunctionBinaryType::type>::format(const starrocks::TFunctionBinaryType::type value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::TFunctionBinaryType::type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}
+
+auto fmt::formatter<starrocks::SampleMethod::type>::format(const starrocks::SampleMethod::type value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::SampleMethod::type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}
+
+auto fmt::formatter<starrocks::TFileType::type>::format(const starrocks::TFileType::type value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::TFileType::type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}
+
+auto fmt::formatter<orc::TypeKind>::format(const orc::TypeKind value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<orc::TypeKind>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}
+
+auto fmt::formatter<tparquet::Type::type>::format(const tparquet::Type::type value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::string>::format(tparquet::to_string(value), ctx);
+}

--- a/be/src/base/format.cpp
+++ b/be/src/base/format.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "util/format.h"
+#include "base/format.h"
 
 
 auto fmt::formatter<starrocks::CompressionTypePB>::format(const starrocks::CompressionTypePB value, format_context& ctx) const -> format_context::iterator {

--- a/be/src/base/format.h
+++ b/be/src/base/format.h
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string_view>
+#include <string>
+#include <type_traits>
+
+#include <fmt/format.h>
+
+
+#include "gen_cpp/types.pb.h" // for CompressionTypePB
+#include "gen_cpp/encryption.pb.h" // for EncryptionAlgorithmPB, EncryptionKeyTypePB
+#include "gen_cpp/segment.pb.h" // for NullEncodingPB
+#include <orc/OrcFile.hh> // for TypeKind
+#include "gen_cpp/StatusCode_types.h" // for TStatusCode
+#include "gen_cpp/Exprs_types.h" // for TExprNodeType
+#include "gen_cpp/Types_types.h" // for TFunctionBinaryType, TFileType
+#include "gen_cpp/PlanNodes_types.h" // for SampleMethod
+#include "gen_cpp/parquet_types.h"
+
+/// Custom formatters for various commonly used types of external libraries (proto, thrift, orc, parquet, ...)
+namespace starrocks {
+
+template <typename E>
+requires std::is_enum_v<E>
+[[nodiscard]] constexpr auto enum_to_underlying_type(E enumerator) noexcept {
+  return static_cast<std::underlying_type_t<E>>(enumerator);
+}
+
+}  // namespace starrocks
+
+template <>
+struct fmt::formatter<starrocks::CompressionTypePB> : formatter<std::underlying_type_t<starrocks::CompressionTypePB>> {
+  auto format(starrocks::CompressionTypePB value, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<starrocks::EncryptionAlgorithmPB> : formatter<std::underlying_type_t<starrocks::EncryptionAlgorithmPB>> {
+  auto format(starrocks::EncryptionAlgorithmPB value, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<starrocks::EncryptionKeyTypePB> : formatter<std::underlying_type_t<starrocks::EncryptionKeyTypePB>> {
+  auto format(starrocks::EncryptionKeyTypePB value, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<starrocks::NullEncodingPB> : formatter<std::underlying_type_t<starrocks::NullEncodingPB>> {
+  auto format(starrocks::NullEncodingPB value, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<starrocks::TStatusCode::type> : formatter<std::underlying_type_t<starrocks::TStatusCode::type>> {
+  auto format(starrocks::TStatusCode::type value, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<starrocks::TExprNodeType::type> : formatter<std::underlying_type_t<starrocks::TExprNodeType::type>> {
+  auto format(starrocks::TExprNodeType::type value, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<starrocks::TFunctionBinaryType::type> : formatter<std::underlying_type_t<starrocks::TFunctionBinaryType::type>> {
+  auto format(starrocks::TFunctionBinaryType::type value, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<starrocks::SampleMethod::type> : formatter<std::underlying_type_t<starrocks::SampleMethod::type>> {
+  auto format(starrocks::SampleMethod::type value, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<starrocks::TFileType::type> : formatter<std::underlying_type_t<starrocks::TFileType::type>> {
+  auto format(starrocks::TFileType::type value, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<orc::TypeKind> : formatter<std::underlying_type_t<orc::TypeKind>> {
+  auto format(orc::TypeKind value, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct fmt::formatter<tparquet::Type::type> : formatter<std::string> {
+  auto format(tparquet::Type::type value, format_context& ctx) const -> format_context::iterator;
+};

--- a/be/src/base/format.h
+++ b/be/src/base/format.h
@@ -14,85 +14,88 @@
 
 #pragma once
 
-#include <string_view>
-#include <string>
-#include <type_traits>
-
 #include <fmt/format.h>
 
-
-#include "gen_cpp/types.pb.h" // for CompressionTypePB
-#include "gen_cpp/encryption.pb.h" // for EncryptionAlgorithmPB, EncryptionKeyTypePB
-#include "gen_cpp/segment.pb.h" // for NullEncodingPB
 #include <orc/OrcFile.hh> // for TypeKind
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include "gen_cpp/Exprs_types.h"      // for TExprNodeType
+#include "gen_cpp/PlanNodes_types.h"  // for SampleMethod
 #include "gen_cpp/StatusCode_types.h" // for TStatusCode
-#include "gen_cpp/Exprs_types.h" // for TExprNodeType
-#include "gen_cpp/Types_types.h" // for TFunctionBinaryType, TFileType
-#include "gen_cpp/PlanNodes_types.h" // for SampleMethod
+#include "gen_cpp/Types_types.h"      // for TFunctionBinaryType, TFileType
+#include "gen_cpp/encryption.pb.h"    // for EncryptionAlgorithmPB, EncryptionKeyTypePB
 #include "gen_cpp/parquet_types.h"
+#include "gen_cpp/segment.pb.h" // for NullEncodingPB
+#include "gen_cpp/types.pb.h"   // for CompressionTypePB
 
 /// Custom formatters for various commonly used types of external libraries (proto, thrift, orc, parquet, ...)
 namespace starrocks {
 
 template <typename E>
-requires std::is_enum_v<E>
-[[nodiscard]] constexpr auto enum_to_underlying_type(E enumerator) noexcept {
-  return static_cast<std::underlying_type_t<E>>(enumerator);
+requires std::is_enum_v<E>[[nodiscard]] constexpr auto enum_to_underlying_type(E enumerator) noexcept {
+    return static_cast<std::underlying_type_t<E>>(enumerator);
 }
 
-}  // namespace starrocks
+} // namespace starrocks
 
 template <>
 struct fmt::formatter<starrocks::CompressionTypePB> : formatter<std::underlying_type_t<starrocks::CompressionTypePB>> {
-  auto format(starrocks::CompressionTypePB value, format_context& ctx) const -> format_context::iterator;
+    auto format(starrocks::CompressionTypePB value, format_context& ctx) const -> format_context::iterator;
 };
 
 template <>
-struct fmt::formatter<starrocks::EncryptionAlgorithmPB> : formatter<std::underlying_type_t<starrocks::EncryptionAlgorithmPB>> {
-  auto format(starrocks::EncryptionAlgorithmPB value, format_context& ctx) const -> format_context::iterator;
+struct fmt::formatter<starrocks::EncryptionAlgorithmPB>
+        : formatter<std::underlying_type_t<starrocks::EncryptionAlgorithmPB>> {
+    auto format(starrocks::EncryptionAlgorithmPB value, format_context& ctx) const -> format_context::iterator;
 };
 
 template <>
-struct fmt::formatter<starrocks::EncryptionKeyTypePB> : formatter<std::underlying_type_t<starrocks::EncryptionKeyTypePB>> {
-  auto format(starrocks::EncryptionKeyTypePB value, format_context& ctx) const -> format_context::iterator;
+struct fmt::formatter<starrocks::EncryptionKeyTypePB>
+        : formatter<std::underlying_type_t<starrocks::EncryptionKeyTypePB>> {
+    auto format(starrocks::EncryptionKeyTypePB value, format_context& ctx) const -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<starrocks::NullEncodingPB> : formatter<std::underlying_type_t<starrocks::NullEncodingPB>> {
-  auto format(starrocks::NullEncodingPB value, format_context& ctx) const -> format_context::iterator;
+    auto format(starrocks::NullEncodingPB value, format_context& ctx) const -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<starrocks::TStatusCode::type> : formatter<std::underlying_type_t<starrocks::TStatusCode::type>> {
-  auto format(starrocks::TStatusCode::type value, format_context& ctx) const -> format_context::iterator;
+    auto format(starrocks::TStatusCode::type value, format_context& ctx) const -> format_context::iterator;
 };
 
 template <>
-struct fmt::formatter<starrocks::TExprNodeType::type> : formatter<std::underlying_type_t<starrocks::TExprNodeType::type>> {
-  auto format(starrocks::TExprNodeType::type value, format_context& ctx) const -> format_context::iterator;
+struct fmt::formatter<starrocks::TExprNodeType::type>
+        : formatter<std::underlying_type_t<starrocks::TExprNodeType::type>> {
+    auto format(starrocks::TExprNodeType::type value, format_context& ctx) const -> format_context::iterator;
 };
 
 template <>
-struct fmt::formatter<starrocks::TFunctionBinaryType::type> : formatter<std::underlying_type_t<starrocks::TFunctionBinaryType::type>> {
-  auto format(starrocks::TFunctionBinaryType::type value, format_context& ctx) const -> format_context::iterator;
+struct fmt::formatter<starrocks::TFunctionBinaryType::type>
+        : formatter<std::underlying_type_t<starrocks::TFunctionBinaryType::type>> {
+    auto format(starrocks::TFunctionBinaryType::type value, format_context& ctx) const -> format_context::iterator;
 };
 
 template <>
-struct fmt::formatter<starrocks::SampleMethod::type> : formatter<std::underlying_type_t<starrocks::SampleMethod::type>> {
-  auto format(starrocks::SampleMethod::type value, format_context& ctx) const -> format_context::iterator;
+struct fmt::formatter<starrocks::SampleMethod::type>
+        : formatter<std::underlying_type_t<starrocks::SampleMethod::type>> {
+    auto format(starrocks::SampleMethod::type value, format_context& ctx) const -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<starrocks::TFileType::type> : formatter<std::underlying_type_t<starrocks::TFileType::type>> {
-  auto format(starrocks::TFileType::type value, format_context& ctx) const -> format_context::iterator;
+    auto format(starrocks::TFileType::type value, format_context& ctx) const -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<orc::TypeKind> : formatter<std::underlying_type_t<orc::TypeKind>> {
-  auto format(orc::TypeKind value, format_context& ctx) const -> format_context::iterator;
+    auto format(orc::TypeKind value, format_context& ctx) const -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<tparquet::Type::type> : formatter<std::string> {
-  auto format(tparquet::Type::type value, format_context& ctx) const -> format_context::iterator;
+    auto format(tparquet::Type::type value, format_context& ctx) const -> format_context::iterator;
 };

--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -41,6 +41,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "base/format.h"
 #include "base/types/int128.h"
 #include "column/column.h"
 #include "column/column_viewer.h"

--- a/be/src/exec/file_scanner/json_scanner.cpp
+++ b/be/src/exec/file_scanner/json_scanner.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <utility>
 
+#include "base/format.h"
 #include "column/adaptive_nullable_column.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -251,8 +251,8 @@ void SinkBuffer::cancel_one_sinker(RuntimeState* const state) {
         VLOG_OPERATOR << fmt::format(
                 "fragment_instance_id {}, _is_finishing {}, _num_remaining_eos {}, "
                 "_num_sending_rpc {}, chunk is full {}",
-                print_id(_fragment_ctx->fragment_instance_id()), _is_finishing.load(), _num_remaining_eos.load(),
-                _num_sending_rpc.load(), is_full());
+                print_id(_fragment_ctx->fragment_instance_id()), _is_finishing, _num_remaining_eos, _num_sending_rpc,
+                is_full());
     }
 }
 

--- a/be/src/exec/pipeline/fetch_processor.cpp
+++ b/be/src/exec/pipeline/fetch_processor.cpp
@@ -227,8 +227,7 @@ StatusOr<FetchTaskPtr> FetchProcessor::_create_fetch_task(TupleId request_tuple_
         return std::make_shared<FetchTask>(std::move(task_ctx));
     }
     default:
-        return Status::InternalError(
-                fmt::format("Unknown row position type: {}", static_cast<uint8_t>(row_position_type)));
+        return Status::InternalError(fmt::format("Unknown row position type: {}", row_position_type));
     }
 }
 

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -87,7 +87,7 @@ void NLJoinProbeOperator::_advance_join_stage(JoinStage stage) const {
     DCHECK_LE(_join_stage, stage) << "current=" << _join_stage << ", advance to " << stage;
     if (_join_stage != stage) {
         _join_stage = stage;
-        VLOG(3) << fmt::format("operator {} enter join_stage {}", _driver_sequence, stage);
+        VLOG(3) << fmt::format("operator {} enter join_stage {}", _driver_sequence, static_cast<int>(stage));
     }
 }
 

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -87,7 +87,7 @@ void NLJoinProbeOperator::_advance_join_stage(JoinStage stage) const {
     DCHECK_LE(_join_stage, stage) << "current=" << _join_stage << ", advance to " << stage;
     if (_join_stage != stage) {
         _join_stage = stage;
-        VLOG(3) << fmt::format("operator {} enter join_stage {}", _driver_sequence, static_cast<int>(stage));
+        VLOG(3) << fmt::format("operator {} enter join_stage {}", _driver_sequence, stage);
     }
 }
 

--- a/be/src/exprs/arrow_function_call.cpp
+++ b/be/src/exprs/arrow_function_call.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <mutex>
 
+#include "base/format.h"
 #include "base/phmap/phmap.h"
 #include "column/chunk.h"
 #include "column/column.h"

--- a/be/src/exprs/expr_factory.cpp
+++ b/be/src/exprs/expr_factory.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "base/failpoint/fail_point.h"
+#include "base/format.h"
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "exprs/arithmetic_expr.h"

--- a/be/src/exprs/jsonpath.cpp
+++ b/be/src/exprs/jsonpath.cpp
@@ -342,6 +342,8 @@ StatusOr<JsonPath*> JsonPath::relativize(const JsonPath* other, JsonPath* output
 
 } // namespace starrocks
 
-auto fmt::formatter<starrocks::ArraySelectorType>::format(const starrocks::ArraySelectorType value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::ArraySelectorType>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::ArraySelectorType>::format(const starrocks::ArraySelectorType value,
+                                                          format_context& ctx) const -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::ArraySelectorType>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }

--- a/be/src/exprs/jsonpath.cpp
+++ b/be/src/exprs/jsonpath.cpp
@@ -21,6 +21,7 @@
 #include <boost/tokenizer.hpp>
 #include <memory>
 
+#include "base/format.h"
 #include "column/column_viewer.h"
 #include "common/compiler_util.h"
 #include "common/status.h"
@@ -340,3 +341,7 @@ StatusOr<JsonPath*> JsonPath::relativize(const JsonPath* other, JsonPath* output
 }
 
 } // namespace starrocks
+
+auto fmt::formatter<starrocks::ArraySelectorType>::format(const starrocks::ArraySelectorType value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::ArraySelectorType>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}

--- a/be/src/exprs/jsonpath.h
+++ b/be/src/exprs/jsonpath.h
@@ -16,6 +16,8 @@
 
 #include <utility>
 
+#include <fmt/format.h>
+
 #include "exprs/function_helper.h"
 #include "gutil/casts.h"
 #include "velocypack/vpack.h"
@@ -161,3 +163,8 @@ struct JsonPath {
 };
 
 } // namespace starrocks
+
+template <>
+struct fmt::formatter<starrocks::ArraySelectorType> : formatter<std::underlying_type_t<starrocks::ArraySelectorType>> {
+	auto format(starrocks::ArraySelectorType value, format_context& ctx) const -> format_context::iterator;
+};

--- a/be/src/exprs/jsonpath.h
+++ b/be/src/exprs/jsonpath.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <utility>
-
 #include <fmt/format.h>
+
+#include <utility>
 
 #include "exprs/function_helper.h"
 #include "gutil/casts.h"
@@ -166,5 +166,5 @@ struct JsonPath {
 
 template <>
 struct fmt::formatter<starrocks::ArraySelectorType> : formatter<std::underlying_type_t<starrocks::ArraySelectorType>> {
-	auto format(starrocks::ArraySelectorType value, format_context& ctx) const -> format_context::iterator;
+    auto format(starrocks::ArraySelectorType value, format_context& ctx) const -> format_context::iterator;
 };

--- a/be/src/formats/orc/orc_schema_builder.cpp
+++ b/be/src/formats/orc/orc_schema_builder.cpp
@@ -14,7 +14,9 @@
 
 #include "orc_schema_builder.h"
 
-#include "fmt/format.h"
+#include <fmt/format.h>
+
+#include "base/format.h"
 
 namespace starrocks {
 

--- a/be/src/formats/parquet/encoding_bss.h
+++ b/be/src/formats/parquet/encoding_bss.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 
 #include "base/bit/bit_util.h"
+#include "base/format.h"
 #include "base/simd/byte_stream_split.h"
 #include "base/string/faststring.h"
 #include "base/string/slice.h"

--- a/be/src/fs/encrypt_file.cpp
+++ b/be/src/fs/encrypt_file.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <fmt/format.h>
-
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>

--- a/be/src/fs/encrypt_file.cpp
+++ b/be/src/fs/encrypt_file.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fmt/format.h>
+
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>
@@ -25,8 +27,8 @@
 #include <cpuid.h>
 #endif
 
+#include "base/format.h"
 #include "base/utility/defer_op.h"
-#include "fmt/format.h"
 #include "fs/encrypt_file.h"
 #include "gutil/endian.h"
 #include "io/core/input_stream.h"

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -100,7 +100,8 @@ void FileSystem::on_file_write_close(WritableFile* file) {
 
 } // namespace starrocks
 
-auto fmt::formatter<starrocks::FileSystem::OpenMode>::format(const starrocks::FileSystem::OpenMode value, format_context& ctx) const
-    -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::FileSystem::OpenMode>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::FileSystem::OpenMode>::format(const starrocks::FileSystem::OpenMode value,
+                                                             format_context& ctx) const -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::FileSystem::OpenMode>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <unordered_map>
 
+#include "base/format.h"
 #include "common/config_local_io_fwd.h"
 #include "fs/bundle_file.h"
 #include "fs/encrypt_file.h"
@@ -98,3 +99,8 @@ void FileSystem::on_file_write_close(WritableFile* file) {
 }
 
 } // namespace starrocks
+
+auto fmt::formatter<starrocks::FileSystem::OpenMode>::format(const starrocks::FileSystem::OpenMode value, format_context& ctx) const
+    -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::FileSystem::OpenMode>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -9,14 +9,14 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <memory>
 #include <optional>
 #include <span>
 #include <string>
 #include <string_view>
 #include <utility>
-
-#include <fmt/format.h>
 
 #include "base/string/slice.h"
 #include "common/statusor.h"
@@ -413,6 +413,7 @@ public:
 } // namespace starrocks
 
 template <>
-struct fmt::formatter<starrocks::FileSystem::OpenMode> : formatter<std::underlying_type_t<starrocks::FileSystem::OpenMode>> {
-  auto format(starrocks::FileSystem::OpenMode value, format_context& ctx) const -> format_context::iterator;
+struct fmt::formatter<starrocks::FileSystem::OpenMode>
+        : formatter<std::underlying_type_t<starrocks::FileSystem::OpenMode>> {
+    auto format(starrocks::FileSystem::OpenMode value, format_context& ctx) const -> format_context::iterator;
 };

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -16,6 +16,8 @@
 #include <string_view>
 #include <utility>
 
+#include <fmt/format.h>
+
 #include "base/string/slice.h"
 #include "common/statusor.h"
 #include "fs/encryption.h"
@@ -409,3 +411,8 @@ public:
 };
 
 } // namespace starrocks
+
+template <>
+struct fmt::formatter<starrocks::FileSystem::OpenMode> : formatter<std::underlying_type_t<starrocks::FileSystem::OpenMode>> {
+  auto format(starrocks::FileSystem::OpenMode value, format_context& ctx) const -> format_context::iterator;
+};

--- a/be/src/fs/key_cache.cpp
+++ b/be/src/fs/key_cache.cpp
@@ -14,6 +14,7 @@
 
 #include "fs/key_cache.h"
 
+#include "base/format.h"
 #include "base/metrics.h"
 #include "base/url_coding.h"
 #include "base/utility/defer_op.h"

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -38,6 +38,7 @@
 #include <sstream>
 #include <string>
 
+#include "base/format.h"
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
 #include "common/config_compaction_fwd.h"

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -354,6 +354,9 @@ RowPositionDescriptor* RowPositionDescriptor::from_thrift(const TRowPositionDesc
 
 } // namespace starrocks
 
-auto fmt::formatter<starrocks::RowPositionDescriptor::Type>::format(const starrocks::RowPositionDescriptor::Type value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::RowPositionDescriptor::Type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::RowPositionDescriptor::Type>::format(const starrocks::RowPositionDescriptor::Type value,
+                                                                    format_context& ctx) const
+        -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::RowPositionDescriptor::Type>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -19,6 +19,7 @@
 #include <ios>
 #include <sstream>
 
+#include "base/format.h"
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "gen_cpp/Descriptors_types.h"
@@ -352,3 +353,7 @@ RowPositionDescriptor* RowPositionDescriptor::from_thrift(const TRowPositionDesc
 }
 
 } // namespace starrocks
+
+auto fmt::formatter<starrocks::RowPositionDescriptor::Type>::format(const starrocks::RowPositionDescriptor::Type value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::RowPositionDescriptor::Type>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -14,10 +14,9 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/stubs/common.h>
-
-#include <fmt/format.h>
 
 #include <cstdint>
 #include <memory_resource>
@@ -297,6 +296,7 @@ protected:
 } // namespace starrocks
 
 template <>
-struct fmt::formatter<starrocks::RowPositionDescriptor::Type> : formatter<std::underlying_type_t<starrocks::RowPositionDescriptor::Type>> {
-  auto format(starrocks::RowPositionDescriptor::Type value, format_context& ctx) const -> format_context::iterator;
+struct fmt::formatter<starrocks::RowPositionDescriptor::Type>
+        : formatter<std::underlying_type_t<starrocks::RowPositionDescriptor::Type>> {
+    auto format(starrocks::RowPositionDescriptor::Type value, format_context& ctx) const -> format_context::iterator;
 };

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -17,6 +17,8 @@
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/stubs/common.h>
 
+#include <fmt/format.h>
+
 #include <cstdint>
 #include <memory_resource>
 #include <optional>
@@ -293,3 +295,8 @@ protected:
 };
 
 } // namespace starrocks
+
+template <>
+struct fmt::formatter<starrocks::RowPositionDescriptor::Type> : formatter<std::underlying_type_t<starrocks::RowPositionDescriptor::Type>> {
+  auto format(starrocks::RowPositionDescriptor::Type value, format_context& ctx) const -> format_context::iterator;
+};

--- a/be/src/runtime/mysql_table_writer.cpp
+++ b/be/src/runtime/mysql_table_writer.cpp
@@ -179,6 +179,8 @@ Status MysqlTableWriter::_build_insert_sql(int from, int to, std::string_view* s
                             fmt::format_to(std::back_inserter(_stmt_buffer), "{}", (int32_t)viewer.value(i));
                         } else if constexpr (type == TYPE_JSON || type == TYPE_VARIANT) {
                             fmt::format_to(std::back_inserter(_stmt_buffer), "{}", *viewer.value(i));
+			} else if constexpr (std::is_same_v<RunTimeCppType<type>, Slice>) {
+                            fmt::format_to(std::back_inserter(_stmt_buffer), "{}", std::string_view(viewer.value(i)));
                         } else {
                             fmt::format_to(std::back_inserter(_stmt_buffer), "{}", viewer.value(i));
                         }

--- a/be/src/runtime/mysql_table_writer.cpp
+++ b/be/src/runtime/mysql_table_writer.cpp
@@ -179,7 +179,7 @@ Status MysqlTableWriter::_build_insert_sql(int from, int to, std::string_view* s
                             fmt::format_to(std::back_inserter(_stmt_buffer), "{}", (int32_t)viewer.value(i));
                         } else if constexpr (type == TYPE_JSON || type == TYPE_VARIANT) {
                             fmt::format_to(std::back_inserter(_stmt_buffer), "{}", *viewer.value(i));
-			} else if constexpr (std::is_same_v<RunTimeCppType<type>, Slice>) {
+                        } else if constexpr (std::is_same_v<RunTimeCppType<type>, Slice>) {
                             fmt::format_to(std::back_inserter(_stmt_buffer), "{}", std::string_view(viewer.value(i)));
                         } else {
                             fmt::format_to(std::back_inserter(_stmt_buffer), "{}", viewer.value(i));

--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 #include "base/concurrency/spinlock.h"
+#include "base/format.h"
 #include "base/utility/dynamic_util.h"
 #include "common/config_udf_fwd.h"
 #include "common/status.h"

--- a/be/src/storage/binlog_file_writer.cpp
+++ b/be/src/storage/binlog_file_writer.cpp
@@ -560,6 +560,8 @@ StatusOr<std::shared_ptr<BinlogFileWriter>> BinlogFileWriter::reopen(int64_t fil
 
 } // namespace starrocks
 
-auto fmt::formatter<starrocks::WriterState>::format(const starrocks::WriterState value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::WriterState>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::WriterState>::format(const starrocks::WriterState value, format_context& ctx) const
+        -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::WriterState>>::format(starrocks::enum_to_underlying_type(value),
+                                                                             ctx);
 }

--- a/be/src/storage/binlog_file_writer.cpp
+++ b/be/src/storage/binlog_file_writer.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/binlog_file_writer.h"
 
+#include "base/format.h"
 #include "base/hash/crc32c.h"
 #include "base/path/filesystem_util.h"
 #include "fs/fs_factory.h"

--- a/be/src/storage/binlog_file_writer.cpp
+++ b/be/src/storage/binlog_file_writer.cpp
@@ -559,3 +559,7 @@ StatusOr<std::shared_ptr<BinlogFileWriter>> BinlogFileWriter::reopen(int64_t fil
 }
 
 } // namespace starrocks
+
+auto fmt::formatter<starrocks::WriterState>::format(const starrocks::WriterState value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::WriterState>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}

--- a/be/src/storage/binlog_file_writer.h
+++ b/be/src/storage/binlog_file_writer.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include "base/compression/block_compression.h"
 #include "fs/fs.h"
 #include "gen_cpp/binlog.pb.h"
@@ -249,3 +251,8 @@ private:
 using BinlogFileWriterPtr = std::shared_ptr<BinlogFileWriter>;
 
 } // namespace starrocks
+
+template <>
+struct fmt::formatter<starrocks::WriterState> : formatter<std::underlying_type_t<starrocks::WriterState>> {
+  auto format(starrocks::WriterState value, format_context& ctx) const -> format_context::iterator;
+};

--- a/be/src/storage/binlog_file_writer.h
+++ b/be/src/storage/binlog_file_writer.h
@@ -254,5 +254,5 @@ using BinlogFileWriterPtr = std::shared_ptr<BinlogFileWriter>;
 
 template <>
 struct fmt::formatter<starrocks::WriterState> : formatter<std::underlying_type_t<starrocks::WriterState>> {
-  auto format(starrocks::WriterState value, format_context& ctx) const -> format_context::iterator;
+    auto format(starrocks::WriterState value, format_context& ctx) const -> format_context::iterator;
 };

--- a/be/src/storage/rowset/parsed_page.cpp
+++ b/be/src/storage/rowset/parsed_page.cpp
@@ -41,6 +41,7 @@
 
 #include "base/bit/rle_encoding.h"
 #include "base/compression/block_compression.h"
+#include "base/format.h"
 #include "base/simd/simd.h"
 #include "base/string/faststring.h"
 #include "column/append_with_mask.h"

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "base/format.h"
 #include "base/simd/simd.h"
 #include "base/utility/defer_op.h"
 #include "column/array_column.h"

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1944,6 +1944,8 @@ void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabl
 
 } // end namespace starrocks
 
-auto fmt::formatter<starrocks::TabletDropFlag>::format(const starrocks::TabletDropFlag value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::TabletDropFlag>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::TabletDropFlag>::format(const starrocks::TabletDropFlag value, format_context& ctx) const
+        -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::TabletDropFlag>>::format(
+            starrocks::enum_to_underlying_type(value), ctx);
 }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -41,6 +41,7 @@
 #include <ctime>
 #include <memory>
 
+#include "base/format.h"
 #include "base/path/path_util.h"
 #include "base/testutil/sync_point.h"
 #include "common/config_compaction_fwd.h"
@@ -1942,3 +1943,7 @@ void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabl
 }
 
 } // end namespace starrocks
+
+auto fmt::formatter<starrocks::TabletDropFlag>::format(const starrocks::TabletDropFlag value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::TabletDropFlag>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -43,6 +43,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include "agent/status.h"
 #include "base/concurrency/spinlock.h"
 #include "base/statusor.h"
@@ -332,3 +334,8 @@ inline bool TabletManager::LockTable::unlock(int64_t tablet_id) {
 }
 
 } // namespace starrocks
+
+template <>
+struct fmt::formatter<starrocks::TabletDropFlag> : formatter<std::underlying_type_t<starrocks::TabletDropFlag>> {
+  auto format(starrocks::TabletDropFlag value, format_context& ctx) const -> format_context::iterator;
+};

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <list>
 #include <map>
 #include <mutex>
@@ -42,8 +44,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#include <fmt/format.h>
 
 #include "agent/status.h"
 #include "base/concurrency/spinlock.h"
@@ -337,5 +337,5 @@ inline bool TabletManager::LockTable::unlock(int64_t tablet_id) {
 
 template <>
 struct fmt::formatter<starrocks::TabletDropFlag> : formatter<std::underlying_type_t<starrocks::TabletDropFlag>> {
-  auto format(starrocks::TabletDropFlag value, format_context& ctx) const -> format_context::iterator;
+    auto format(starrocks::TabletDropFlag value, format_context& ctx) const -> format_context::iterator;
 };

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -696,6 +696,8 @@ bool operator!=(const TabletMeta& a, const TabletMeta& b) {
 
 } // namespace starrocks
 
-auto fmt::formatter<starrocks::TabletState>::format(const starrocks::TabletState value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::underlying_type_t<starrocks::TabletState>>::format(starrocks::enum_to_underlying_type(value), ctx);
+auto fmt::formatter<starrocks::TabletState>::format(const starrocks::TabletState value, format_context& ctx) const
+        -> format_context::iterator {
+    return formatter<std::underlying_type_t<starrocks::TabletState>>::format(starrocks::enum_to_underlying_type(value),
+                                                                             ctx);
 }

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -37,6 +37,7 @@
 #include <memory>
 #include <sstream>
 
+#include "base/format.h"
 #include "base/uid_util.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
@@ -694,3 +695,7 @@ bool operator!=(const TabletMeta& a, const TabletMeta& b) {
 }
 
 } // namespace starrocks
+
+auto fmt::formatter<starrocks::TabletState>::format(const starrocks::TabletState value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::underlying_type_t<starrocks::TabletState>>::format(starrocks::enum_to_underlying_type(value), ctx);
+}

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -34,13 +34,13 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <mutex>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <vector>
-
-#include <fmt/format.h>
 
 #include "base/uid_util.h"
 #include "common/logging.h"
@@ -429,5 +429,5 @@ bool operator!=(const TabletMeta& a, const TabletMeta& b);
 
 template <>
 struct fmt::formatter<starrocks::TabletState> : formatter<std::underlying_type_t<starrocks::TabletState>> {
-  auto format(starrocks::TabletState value, format_context& ctx) const -> format_context::iterator;
+    auto format(starrocks::TabletState value, format_context& ctx) const -> format_context::iterator;
 };

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -40,6 +40,8 @@
 #include <string_view>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include "base/uid_util.h"
 #include "common/logging.h"
 #include "common/status.h"
@@ -424,3 +426,8 @@ bool operator==(const TabletMeta& a, const TabletMeta& b);
 bool operator!=(const TabletMeta& a, const TabletMeta& b);
 
 } // namespace starrocks
+
+template <>
+struct fmt::formatter<starrocks::TabletState> : formatter<std::underlying_type_t<starrocks::TabletState>> {
+  auto format(starrocks::TabletState value, format_context& ctx) const -> format_context::iterator;
+};

--- a/be/src/types/logical_type.cpp
+++ b/be/src/types/logical_type.cpp
@@ -315,6 +315,7 @@ const std::vector<LogicalType>& sortable_types() {
 
 } // namespace starrocks
 
-auto fmt::formatter<starrocks::LogicalType>::format(const starrocks::LogicalType value, format_context& ctx) const -> format_context::iterator {
-  return formatter<std::string_view>::format(starrocks::logical_type_to_string(value), ctx);
+auto fmt::formatter<starrocks::LogicalType>::format(const starrocks::LogicalType value, format_context& ctx) const
+        -> format_context::iterator {
+    return formatter<std::string_view>::format(starrocks::logical_type_to_string(value), ctx);
 }

--- a/be/src/types/logical_type.cpp
+++ b/be/src/types/logical_type.cpp
@@ -314,3 +314,7 @@ const std::vector<LogicalType>& sortable_types() {
 }
 
 } // namespace starrocks
+
+auto fmt::formatter<starrocks::LogicalType>::format(const starrocks::LogicalType value, format_context& ctx) const -> format_context::iterator {
+  return formatter<std::string_view>::format(starrocks::logical_type_to_string(value), ctx);
+}

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -16,6 +16,8 @@
 
 #include <ostream>
 
+#include <fmt/format.h>
+
 #include "base/utility/guard.h"
 #include "gen_cpp/Opcodes_types.h"
 #include "gen_cpp/Types_types.h"
@@ -387,3 +389,8 @@ inline std::ostream& operator<<(std::ostream& os, starrocks::LogicalType type) {
     os << starrocks::logical_type_to_string(type);
     return os;
 }
+
+template <>
+struct fmt::formatter<starrocks::LogicalType> : formatter<std::string_view> {
+  auto format(starrocks::LogicalType value, format_context& ctx) const -> format_context::iterator;
+};

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <ostream>
-
 #include <fmt/format.h>
+
+#include <ostream>
 
 #include "base/utility/guard.h"
 #include "gen_cpp/Opcodes_types.h"
@@ -392,5 +392,5 @@ inline std::ostream& operator<<(std::ostream& os, starrocks::LogicalType type) {
 
 template <>
 struct fmt::formatter<starrocks::LogicalType> : formatter<std::string_view> {
-  auto format(starrocks::LogicalType value, format_context& ctx) const -> format_context::iterator;
+    auto format(starrocks::LogicalType value, format_context& ctx) const -> format_context::iterator;
 };

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -607,7 +607,7 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         }
         default:
             DCHECK(false) << "unsupport UDF TYPE" << type_desc.type;
-            return Status::NotSupported(fmt::format("unsupport UDF TYPE:{}", static_cast<int>(type_desc.type)));
+            return Status::NotSupported(fmt::format("unsupport UDF TYPE:{}", type_desc.type));
         }
     }
     return Status::OK();


### PR DESCRIPTION
## Why I'm doing:

Follow up to https://github.com/StarRocks/starrocks/pull/72022

Fix code that does not compile with more recent {fmt} versions anymore (in preparation to a planned {fmt} version upgrade). Future versions of fmt do not allow for many implicit conversions anymore.

## What I'm doing:

- 96cdd200fe60d778e7cd1e0507df12d6a01df5aa: revert the changes from https://github.com/StarRocks/starrocks/pull/72022 because it was realized that always using `static_cast` for the enum values does not scale well. 
  - Instead, we want to have a central place where formatting of enum types is handled s.t. in the future one can do adjustments in a single place instead of searching for all enum usages in fmt calls
  - Example: Maybe in the future one does not want to format an enum to its integer value but to a true string representation. Doing this would be a lot of search and replace without a custom formatter. With the approach in the next commits, there is a single place where one needs to adjust the formatting logic
- 454d49af56d6f23dbad077dff23d589304b092f8: Introduce a utility for formatting third party enum type values in `util/format.h`
- 149e9a2f356ac556a42526847b34f01a91494507: Include the previously used utility in code that would break with future {fmt} versions (because the code relied on implicit enum conversions)
  - Now, instead of implicit enum conversions the custom formatter will be used
- 6b8b33c0579883f888ad200443b026e43a167709: Introduce custom `{fmt}` formatters for various SR native enum types
- a5390cb215bbaaa4a06fe1d793b604e11274cfdc: For internal enum types (private members) a fallback to static cast is done since no custom formatter can be introduced
- 303cb8db70a4384d2631d5c51224090e54f95aca: Adapt implicit `Slice` to `std::string_view` cast in `{fmt}` call to be more explicit
  - With the current fmt version, the following is allowed: `fmt::format("{}", Slice(...));` because `Slice` has an implicit conversion operator to `std::string_view`
  - In future `{fmt}` versions implicit conversions are not allowed anymore and thus `fmt::format("{}", Slice(...));` will not compile with more recent fmt versions anymore
  - A fix for this while keeping the existing behavior is to make the implicit `std::string_view` cast an explicit one

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: For some `enum` types a custom formatter was introduced that now uses existing string representations if available instead of the integer conversion. For example, before `LogicalType` was cast to int when formatted using `{fmt}`. Now, it will use `starrocks::logical_type_to_string` representation instead. Since this formatting was only used in logging/exception messages, I considered it to be more readable. If there is a concern regarding this, I can change back to integer representation again.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
