### PR TITLE
[BugFix] thrift 0.22: disable Common Lisp bindings

### DIFF
--- a/thirdparty/build-thirdparty-darwin.sh
+++ b/thirdparty/build-thirdparty-darwin.sh
@@ -590,6 +590,7 @@ build_thrift() {
         --without-java \
         --without-rs \
         --without-swift \
+        --without-cl \
         --with-cpp \
         --with-libevent="${libevent_prefix}" \
         --with-boost="${TP_INSTALL_DIR}" \

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -392,7 +392,7 @@ build_thrift() {
     --prefix=$TP_INSTALL_DIR --docdir=$TP_INSTALL_DIR/doc --enable-static --disable-shared --disable-tests \
     --disable-tutorial --without-qt4 --without-qt5 --without-csharp --without-erlang --without-nodejs \
     --without-lua --without-perl --without-php --without-php_extension --without-dart --without-ruby \
-    --without-haskell --without-go --without-haxe --without-d --without-python -without-java -without-rs --with-cpp \
+    --without-haskell --without-go --without-haxe --without-d --without-python -without-java -without-rs --without-cl --with-cpp \
     --with-libevent=$TP_INSTALL_DIR --with-boost=$TP_INSTALL_DIR --with-openssl=$TP_INSTALL_DIR
 
     if [ -f compiler/cpp/thrifty.hh ];then


### PR DESCRIPTION
## Why I'm doing:

thrift 0.22's autoconf auto-enables Common Lisp bindings whenever `sbcl`
is present on the host. The CL test then tries to fetch the quicklisp
`PURI` package and fails. Our existing `--without-<lang>` list missed
`--without-cl`, so hosts with `sbcl` (common on developer Macs via
Homebrew transitive deps) cannot build TP from scratch.

## What I'm doing:

Add `--without-cl` to thrift's `./configure` in both
`thirdparty/build-thirdparty.sh` (Linux) and
`thirdparty/build-thirdparty-darwin.sh` (Darwin).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.


## Verification

From-scratch TP builds succeed on hosts with `sbcl` installed.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

> N/A — build-tooling only. No runtime behavior, no user-facing feature,
> not a backport.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

> N/A — build-only change. Backport separately if older branches also
> need `--without-cl`.
