### PR TITLE
[BugFix] Restore macOS ./build.sh --be support: TP RPC chain, Arrow Flight

### DIFF
--- a/be/cmake_modules/ThirdParty.cmake
+++ b/be/cmake_modules/ThirdParty.cmake
@@ -448,29 +448,24 @@ set_target_properties(benchgen PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/li
 
 set(absl_DIR "${THIRDPARTY_DIR}/lib/cmake/absl" CACHE PATH "absl search path" FORCE)
 find_package(absl CONFIG REQUIRED)
-if (APPLE)
-    # Homebrew's exported gRPC targets are not self-contained on Darwin. Import the
-    # shared libraries directly for local development builds and surface the host
-    # dylib requirement explicitly in output/be packaging.
-    add_library(gRPC::grpc SHARED IMPORTED GLOBAL)
-    set_target_properties(gRPC::grpc PROPERTIES
-        IMPORTED_LOCATION "${THIRDPARTY_DIR}/lib/libgrpc.dylib"
-        INTERFACE_INCLUDE_DIRECTORIES "${THIRDPARTY_DIR}/include")
-    add_library(gRPC::grpc++ SHARED IMPORTED GLOBAL)
-    set_target_properties(gRPC::grpc++ PROPERTIES
-        IMPORTED_LOCATION "${THIRDPARTY_DIR}/lib/libgrpc++.dylib"
-        INTERFACE_INCLUDE_DIRECTORIES "${THIRDPARTY_DIR}/include"
-        INTERFACE_LINK_LIBRARIES "gRPC::grpc")
-    set(gRPC_VERSION "darwin-manual")
-    set(gRPC_INCLUDE_DIR "${THIRDPARTY_DIR}/include")
-else()
-    set(gRPC_DIR "${THIRDPARTY_DIR}/lib/cmake/grpc" CACHE PATH "grpc search path")
-    find_package(gRPC CONFIG REQUIRED)
-    get_target_property(gRPC_INCLUDE_DIR gRPC::grpc INTERFACE_INCLUDE_DIRECTORIES)
-endif()
+
+# Pre-declare protobuf::libprotobuf + Protobuf_FOUND so gRPCConfig.cmake's
+# guarded find_package(Protobuf) is skipped. TP ships no ProtobufConfig.cmake
+# for 3.14; without this, module-mode FindProtobuf can bind to a host
+# protobuf (e.g. Homebrew 33.x) whose imported target then collides with
+# the ALIAS below.
+add_library(protobuf::libprotobuf ALIAS protobuf)
+set(Protobuf_FOUND TRUE)
+set(PROTOBUF_FOUND TRUE)
+set(Protobuf_INCLUDE_DIR "${THIRDPARTY_DIR}/include")
+set(Protobuf_INCLUDE_DIRS "${THIRDPARTY_DIR}/include")
+set(Protobuf_LIBRARIES protobuf::libprotobuf)
+
+set(gRPC_DIR "${THIRDPARTY_DIR}/lib/cmake/grpc" CACHE PATH "grpc search path")
+find_package(gRPC CONFIG REQUIRED)
+get_target_property(gRPC_INCLUDE_DIR gRPC::grpc INTERFACE_INCLUDE_DIRECTORIES)
 message(STATUS "Using gRPC ${gRPC_VERSION}")
 include_directories(SYSTEM ${gRPC_INCLUDE_DIR})
-add_library(protobuf::libprotobuf ALIAS protobuf)
 add_library(ZLIB::ZLIB ALIAS libz)
 
 # Disable libdeflate on aarch64

--- a/build-support/build_helpers.sh
+++ b/build-support/build_helpers.sh
@@ -158,11 +158,16 @@ starrocks_validate_darwin_thirdparty() {
         fi
     done
 
+    # libgrpc.a / libgrpc++.a: be/cmake_modules/ThirdParty.cmake does
+    # find_package(gRPC CONFIG REQUIRED) against ${tp_installed}/lib/cmake/grpc.
+    # Failing here gives a clear rebuild-thirdparty error up front.
     local required_libs=(
         "libprotobuf.a"
         "librocksdb.a"
         "libglog.a"
         "libbrpc.a"
+        "libgrpc.a"
+        "libgrpc++.a"
     )
     local required_lib=""
     for required_lib in "${required_libs[@]}"; do
@@ -172,9 +177,10 @@ starrocks_validate_darwin_thirdparty() {
         fi
     done
 
+    # gRPC is built from source as a static archive (libgrpc.a / libgrpc++.a)
+    # and consumed via ${tp_installed}/lib/cmake/grpc/gRPCConfig.cmake, matching
+    # the Linux flow. Only list dylibs that Homebrew still provides.
     local required_darwin_dylibs=(
-        "libgrpc.dylib"
-        "libgrpc++.dylib"
         "libkrb5support.dylib"
         "libkrb5.dylib"
         "libcom_err.dylib"

--- a/build.sh
+++ b/build.sh
@@ -87,6 +87,7 @@ fi
 
 if starrocks_is_darwin ; then
     PARALLEL=$(starrocks_detect_parallelism)
+    # Darwin thirdparty is prepared separately and validated before BE configure.
 else
     if [[ ! -f ${STARROCKS_THIRDPARTY}/installed/llvm/lib/libLLVMInstCombine.a ]]; then
         echo "Thirdparty libraries need to be build ..."
@@ -380,25 +381,6 @@ if [ ${BUILD_FORMAT_LIB} -eq 1 ]; then
 fi
 
 if starrocks_is_darwin && { [ ${BUILD_BE} -eq 1 ] || [ ${BUILD_FORMAT_LIB} -eq 1 ]; }; then
-    # Auto-trigger Darwin TP build when missing. Sentinels span the chain
-    # (libprotobuf.a early, libbrpc.a mid, libxml2.dylib late); a mid-chain
-    # abort misses later ones and re-triggers. libarrow_flight_sql.a is a
-    # patch-level version sentinel — it is the last artifact the new Arrow
-    # Flight + source-built gRPC produces, and be/CMakeLists.txt unconditionally
-    # links arrow_flight / arrow_flight_sql / gRPC::grpc{,++}.
-    needs_tp_build=0
-    for _artifact in lib/libprotobuf.a lib/libbrpc.a lib/libxml2.dylib lib/libarrow_flight_sql.a; do
-        if [[ ! -e "${STARROCKS_THIRDPARTY}/installed/${_artifact}" ]]; then
-            needs_tp_build=1
-            break
-        fi
-    done
-    if [[ ${needs_tp_build} -eq 1 ]]; then
-        echo "Thirdparty libraries need to be build ..."
-        ${STARROCKS_THIRDPARTY}/build-thirdparty-darwin.sh -j "${PARALLEL}"
-    fi
-    unset needs_tp_build _artifact
-
     starrocks_validate_darwin_thirdparty
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -87,7 +87,6 @@ fi
 
 if starrocks_is_darwin ; then
     PARALLEL=$(starrocks_detect_parallelism)
-    # Darwin thirdparty is prepared separately and validated before BE configure.
 else
     if [[ ! -f ${STARROCKS_THIRDPARTY}/installed/llvm/lib/libLLVMInstCombine.a ]]; then
         echo "Thirdparty libraries need to be build ..."
@@ -381,6 +380,25 @@ if [ ${BUILD_FORMAT_LIB} -eq 1 ]; then
 fi
 
 if starrocks_is_darwin && { [ ${BUILD_BE} -eq 1 ] || [ ${BUILD_FORMAT_LIB} -eq 1 ]; }; then
+    # Auto-trigger Darwin TP build when missing. Sentinels span the chain
+    # (libprotobuf.a early, libbrpc.a mid, libxml2.dylib late); a mid-chain
+    # abort misses later ones and re-triggers. libarrow_flight_sql.a is a
+    # patch-level version sentinel — it is the last artifact the new Arrow
+    # Flight + source-built gRPC produces, and be/CMakeLists.txt unconditionally
+    # links arrow_flight / arrow_flight_sql / gRPC::grpc{,++}.
+    needs_tp_build=0
+    for _artifact in lib/libprotobuf.a lib/libbrpc.a lib/libxml2.dylib lib/libarrow_flight_sql.a; do
+        if [[ ! -e "${STARROCKS_THIRDPARTY}/installed/${_artifact}" ]]; then
+            needs_tp_build=1
+            break
+        fi
+    done
+    if [[ ${needs_tp_build} -eq 1 ]]; then
+        echo "Thirdparty libraries need to be build ..."
+        ${STARROCKS_THIRDPARTY}/build-thirdparty-darwin.sh -j "${PARALLEL}"
+    fi
+    unset needs_tp_build _artifact
+
     starrocks_validate_darwin_thirdparty
 fi
 

--- a/thirdparty/build-thirdparty-darwin.sh
+++ b/thirdparty/build-thirdparty-darwin.sh
@@ -15,6 +15,17 @@
 
 set -eo pipefail
 
+# build.sh sources env_macos.sh before calling us (directly or via the auto-
+# trigger when thirdparty is not yet built), which exports a batch of CMake
+# behavior-control vars intended for the BE build only. They leak into
+# thirdparty subprocesses and break bundled cmake logic
+# (e.g. velocypack's TargetArch.cmake rejects CMAKE_OSX_ARCHITECTURES=arm64
+# with "Invalid OS X arch name: arm64"). Unset at entry so running via
+# build.sh matches running this script standalone.
+unset CMAKE_OSX_ARCHITECTURES CMAKE_BUILD_TARGET_ARCH \
+      CMAKE_GENERATOR CMAKE_FIND_LIBRARY_SUFFIXES \
+      BUILD_SHARED_LIBS CMAKE_BUILD_TYPE MAKEFLAGS
+
 curdir="$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)"
 
 export STARROCKS_HOME="${STARROCKS_HOME:-$curdir/..}"
@@ -1373,6 +1384,118 @@ build_formula_grpc() {
     sync_lib64_links
 }
 
+# Build abseil from TP source (pinned 20220623). Homebrew's abseil ABI drifts
+# across releases and newer ones are too new for gRPC 1.43; source build
+# keeps the whole TP chain consistent.
+build_absl() {
+    check_if_source_exist "${ABSL_SOURCE}"
+
+    # Drop stale symlinks from a prior build_formula_absl run — cmake --install
+    # would follow them into Homebrew's Cellar (corrupt or EACCES).
+    rm -rf "${TP_INCLUDE_DIR}/absl"
+    rm -rf "${TP_INSTALL_DIR}/lib/cmake/absl"
+    safe_remove_glob \
+        "${TP_INSTALL_DIR}/lib/libabsl_"*.a \
+        "${TP_INSTALL_DIR}/lib/libabsl_"*.dylib \
+        "${TP_INSTALL_DIR}/lib64/libabsl_"*.a \
+        "${TP_INSTALL_DIR}/lib64/libabsl_"*.dylib \
+        "${TP_INSTALL_DIR}/lib/pkgconfig/absl_"*.pc
+
+    cd "${TP_SOURCE_DIR}/${ABSL_SOURCE}"
+
+    # abseil 20220623's APPLE branch assumes Apple Clang's -Xarch_* driver,
+    # which Homebrew LLVM clang doesn't implement — it then passes -msse4.1
+    # to arm64 and fails. Narrow the branch to AppleClang only.
+    local copts_file="absl/copts/AbseilConfigureCopts.cmake"
+    if grep -q "if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES \\[\\[Clang\\]\\])" "${copts_file}"; then
+        sed -i.bak 's/if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES \[\[Clang\]\])/if(APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")/' "${copts_file}"
+        rm -f "${copts_file}.bak"
+    fi
+
+    mkdir -p "${BUILD_DIR}"
+    cd "${BUILD_DIR}"
+    rm -rf CMakeCache.txt CMakeFiles/
+    "${CMAKE_CMD}" -G "${CMAKE_GENERATOR}" .. \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    "${BUILD_SYSTEM}" -j "${PARALLEL}" install
+    sync_lib64_links
+}
+
+# Build gRPC 1.43 from TP source with all providers pinned to TP deps
+# (protobuf 3.14, abseil 20220623, re2, openssl). The Homebrew symlink
+# approach would drag in protobuf 33.x and collide with arrow-flight targets.
+build_grpc() {
+    check_if_source_exist "${GRPC_SOURCE}"
+
+    # Drop stale symlinks from a prior build_formula_grpc run (see build_absl).
+    rm -rf \
+        "${TP_INCLUDE_DIR}/grpc" \
+        "${TP_INCLUDE_DIR}/grpc++" \
+        "${TP_INCLUDE_DIR}/grpcpp"
+    rm -rf \
+        "${TP_INSTALL_DIR}/lib/cmake/grpc" \
+        "${TP_INSTALL_DIR}/lib/cmake/gRPC"
+    safe_remove_glob \
+        "${TP_INSTALL_DIR}/lib/libgrpc"*.a \
+        "${TP_INSTALL_DIR}/lib/libgrpc"*.dylib \
+        "${TP_INSTALL_DIR}/lib/libgpr"*.a \
+        "${TP_INSTALL_DIR}/lib/libgpr"*.dylib \
+        "${TP_INSTALL_DIR}/lib/libaddress_sorting"*.a \
+        "${TP_INSTALL_DIR}/lib/libaddress_sorting"*.dylib \
+        "${TP_INSTALL_DIR}/lib/libupb"*.a \
+        "${TP_INSTALL_DIR}/lib/libupb"*.dylib \
+        "${TP_INSTALL_DIR}/lib/libutf8_range"*.a \
+        "${TP_INSTALL_DIR}/lib/libutf8_range"*.dylib \
+        "${TP_INSTALL_DIR}/lib64/libgrpc"*.a \
+        "${TP_INSTALL_DIR}/lib64/libgrpc"*.dylib \
+        "${TP_INSTALL_DIR}/lib64/libgpr"*.a \
+        "${TP_INSTALL_DIR}/lib64/libgpr"*.dylib \
+        "${TP_INSTALL_DIR}/lib/pkgconfig/grpc"*.pc \
+        "${TP_INSTALL_DIR}/lib/pkgconfig/gpr"*.pc \
+        "${TP_INSTALL_DIR}/bin/grpc_cpp_plugin" \
+        "${TP_INSTALL_DIR}/bin/grpc_"* \
+        "${TP_INSTALL_DIR}/bin/protoc-gen-grpc"*
+
+    cd "${TP_SOURCE_DIR}/${GRPC_SOURCE}"
+    mkdir -p "${BUILD_DIR}"
+    cd "${BUILD_DIR}"
+    rm -rf CMakeCache.txt CMakeFiles/
+    "${CMAKE_CMD}" -G "${CMAKE_GENERATOR}" .. \
+        -DCMAKE_PREFIX_PATH="${TP_INSTALL_DIR}" \
+        -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_BUILD_TESTS=OFF \
+        -DgRPC_BUILD_CSHARP_EXT=OFF \
+        -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \
+        -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
+        -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
+        -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
+        -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF \
+        -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
+        -DgRPC_BACKWARDS_COMPATIBILITY_MODE=OFF \
+        -DgRPC_SSL_PROVIDER=package \
+        -DOPENSSL_ROOT_DIR="${TP_INSTALL_DIR}" \
+        -DOPENSSL_USE_STATIC_LIBS=TRUE \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -DZLIB_LIBRARY_RELEASE="${TP_INSTALL_DIR}/lib/libz.a" \
+        -DgRPC_ABSL_PROVIDER=package \
+        -Dabsl_DIR="${TP_INSTALL_DIR}/lib/cmake/absl" \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_RE2_PROVIDER=package \
+        -DRE2_INCLUDE_DIR="${TP_INSTALL_DIR}/include" \
+        -DRE2_LIBRARY="${TP_INSTALL_DIR}/lib/libre2.a" \
+        -DgRPC_CARES_PROVIDER=module \
+        -DCARES_ROOT_DIR="${TP_SOURCE_DIR}/${CARES_SOURCE}/" \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    "${BUILD_SYSTEM}" -j "${PARALLEL}" install
+    sync_lib64_links
+}
+
 build_formula_flatbuffers() {
     ensure_formula flatbuffers
     local prefix
@@ -1394,7 +1517,11 @@ build_formula_brotli() {
 }
 
 build_arrow() {
-    if [[ -f "${TP_INSTALL_DIR}/lib/libarrow.a" && -f "${TP_INSTALL_DIR}/lib/libparquet.a" && -f "${TP_INCLUDE_DIR}/arrow/api.h" ]]; then
+    # libarrow_flight_sql.a as short-circuit sentinel: it is installed last,
+    # so its presence implies libarrow_flight.a + libarrow.a; a pre-Flight
+    # install or a run interrupted mid-way falls through to a full rebuild.
+    if [[ -f "${TP_INSTALL_DIR}/lib/libarrow.a" && -f "${TP_INSTALL_DIR}/lib/libparquet.a" \
+          && -f "${TP_INSTALL_DIR}/lib/libarrow_flight_sql.a" && -f "${TP_INCLUDE_DIR}/arrow/api.h" ]]; then
         return 0
     fi
 
@@ -1429,6 +1556,19 @@ build_arrow() {
     export ARROW_FLATBUFFERS_URL="${TP_SOURCE_DIR}/${FLATBUFFERS_NAME}"
     export ARROW_ZSTD_URL="${TP_SOURCE_DIR}/${ZSTD_NAME}"
     export ARROW_THRIFT_URL="${TP_SOURCE_DIR}/${THRIFT_NAME}"
+
+    # Pin pkg-config to TP's protobuf to keep arrow-flight's static-link probe
+    # from picking up Homebrew's v33.x. Saved/restored so it does not leak.
+    local old_pkg_config_path="${PKG_CONFIG_PATH:-}"
+    export PKG_CONFIG_PATH="${TP_INSTALL_DIR}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+
+    # Arrow 19's FindProtobufAlt tries find_package(protobuf CONFIG) then
+    # find_package(Protobuf). CMAKE_DISABLE_FIND_PACKAGE_<name> is case-
+    # sensitive: the lowercase _protobuf guard (set below) blocks only the
+    # CONFIG probe, which is where a stray protobuf-config.cmake would leak.
+    # The capital-P module fallback is intentionally kept and pinned to TP
+    # via the Protobuf_LIBRARY / _INCLUDE_DIR / _PROTOC_EXECUTABLE hints.
+    # Adding _Protobuf (capital) would break Flight configure.
 
     local formula
     for formula in rapidjson zlib lz4 snappy zstd brotli flatbuffers; do
@@ -1508,8 +1648,16 @@ build_arrow() {
         -DBoost_ROOT="${TP_INSTALL_DIR}" \
         -DARROW_BOOST_USE_SHARED=OFF \
         -DBoost_NO_BOOST_CMAKE=ON \
-        -DARROW_FLIGHT=OFF \
-        -DARROW_FLIGHT_SQL=OFF \
+        -DARROW_FLIGHT=ON \
+        -DARROW_FLIGHT_SQL=ON \
+        -DCMAKE_IGNORE_PREFIX_PATH="/opt/homebrew/anaconda3" \
+        -DCMAKE_DISABLE_FIND_PACKAGE_protobuf=ON \
+        -DProtobuf_PROTOC_EXECUTABLE="${TP_INSTALL_DIR}/bin/protoc" \
+        -DProtobuf_INCLUDE_DIR="${TP_INSTALL_DIR}/include" \
+        -DProtobuf_LIBRARY="${TP_INSTALL_DIR}/lib/libprotobuf.a" \
+        -DProtobuf_PROTOC_LIBRARY="${TP_INSTALL_DIR}/lib/libprotoc.a" \
+        -DProtobuf_LITE_LIBRARY="${TP_INSTALL_DIR}/lib/libprotobuf-lite.a" \
+        -DProtobuf_USE_STATIC_LIBS=ON \
         -Dflatbuffers_ROOT="${flatbuffers_prefix}" \
         -DCMAKE_PREFIX_PATH="${arrow_prefix_path}" \
         -DThrift_ROOT="${TP_INSTALL_DIR}" \
@@ -1517,6 +1665,19 @@ build_arrow() {
         -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     "${CMAKE_CMD}" --build . -j "${PARALLEL}"
     "${CMAKE_CMD}" --install .
+
+    # Hoist Arrow's bundled zstd — zstd is not in Darwin's package-manifest.sh,
+    # so this is TP's only source (matches Linux build-thirdparty.sh).
+    if [ -f ./zstd_ep-install/lib64/libzstd.a ]; then
+        cp -rf ./zstd_ep-install/lib64/libzstd.a ${TP_INSTALL_DIR}/lib/libzstd.a
+    else
+        cp -rf ./zstd_ep-install/lib/libzstd.a ${TP_INSTALL_DIR}/lib/libzstd.a
+    fi
+    mkdir -p ${TP_INSTALL_DIR}/include/zstd
+    cp ./zstd_ep-install/include/* ${TP_INSTALL_DIR}/include/zstd
+
+    restore_env_var PKG_CONFIG_PATH "${old_pkg_config_path}"
+
     sync_lib64_links
 }
 
@@ -2238,10 +2399,10 @@ for package in "${packages[@]}"; do
             build_formula_sasl
             ;;
         absl)
-            build_formula_absl
+            build_absl
             ;;
         grpc)
-            build_formula_grpc
+            build_grpc
             ;;
         flatbuffers)
             build_formula_flatbuffers

--- a/thirdparty/build-thirdparty-darwin.sh
+++ b/thirdparty/build-thirdparty-darwin.sh
@@ -1363,27 +1363,6 @@ build_formula_sasl() {
     sync_lib64_links
 }
 
-build_formula_absl() {
-    ensure_formula abseil
-    local prefix
-    prefix="$(formula_prefix abseil)"
-    link_children_if_missing "${prefix}/include" "${TP_INCLUDE_DIR}"
-    link_matching_if_missing "${TP_INSTALL_DIR}/lib" "${prefix}/lib/libabsl"*.a "${prefix}/lib/libabsl"*.dylib
-    link_formula_metadata "${prefix}"
-    sync_lib64_links
-}
-
-build_formula_grpc() {
-    ensure_formula grpc
-    local prefix
-    prefix="$(formula_prefix grpc)"
-    link_children_if_missing "${prefix}/include" "${TP_INCLUDE_DIR}"
-    link_matching_if_missing "${TP_INSTALL_DIR}/lib" "${prefix}/lib/libgrpc"*.a "${prefix}/lib/libgrpc"*.dylib "${prefix}/lib/libgpr"*.a "${prefix}/lib/libgpr"*.dylib "${prefix}/lib/libaddress_sorting"*.a "${prefix}/lib/libaddress_sorting"*.dylib "${prefix}/lib/libupb"*.a "${prefix}/lib/libupb"*.dylib "${prefix}/lib/libutf8_range"*.a "${prefix}/lib/libutf8_range"*.dylib
-    link_matching_if_missing "${TP_INSTALL_DIR}/bin" "${prefix}/bin/grpc"* "${prefix}/bin/protoc-gen-grpc"* "${prefix}/bin/grpc_cpp_plugin"
-    link_formula_metadata "${prefix}"
-    sync_lib64_links
-}
-
 # Build abseil from TP source (pinned 20220623). Homebrew's abseil ABI drifts
 # across releases and newer ones are too new for gRPC 1.43; source build
 # keeps the whole TP chain consistent.
@@ -1403,13 +1382,12 @@ build_absl() {
 
     cd "${TP_SOURCE_DIR}/${ABSL_SOURCE}"
 
-    # abseil 20220623's APPLE branch assumes Apple Clang's -Xarch_* driver,
-    # which Homebrew LLVM clang doesn't implement — it then passes -msse4.1
-    # to arm64 and fails. Narrow the branch to AppleClang only.
+    # Narrow the APPLE+Clang branch to AppleClang only — Homebrew LLVM clang
+    # does not implement Apple Clang's -Xarch_* driver and fails on arm64.
+    local patch_file="${TP_PATCH_DIR}/abseil-cpp-20220623.0-apple-clang-only.patch"
     local copts_file="absl/copts/AbseilConfigureCopts.cmake"
-    if grep -q "if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES \\[\\[Clang\\]\\])" "${copts_file}"; then
-        sed -i.bak 's/if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES \[\[Clang\]\])/if(APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")/' "${copts_file}"
-        rm -f "${copts_file}.bak"
+    if [[ -f "${patch_file}" ]] && grep -q "MATCHES \\[\\[Clang\\]\\]" "${copts_file}" 2>/dev/null; then
+        patch -p1 --forward --batch < "${patch_file}" >/dev/null || true
     fi
 
     mkdir -p "${BUILD_DIR}"

--- a/thirdparty/build-thirdparty-darwin.sh
+++ b/thirdparty/build-thirdparty-darwin.sh
@@ -1647,12 +1647,12 @@ build_arrow() {
     # Hoist Arrow's bundled zstd — zstd is not in Darwin's package-manifest.sh,
     # so this is TP's only source (matches Linux build-thirdparty.sh).
     if [ -f ./zstd_ep-install/lib64/libzstd.a ]; then
-        cp -rf ./zstd_ep-install/lib64/libzstd.a ${TP_INSTALL_DIR}/lib/libzstd.a
+        cp -rf ./zstd_ep-install/lib64/libzstd.a "${TP_INSTALL_DIR}/lib/libzstd.a"
     else
-        cp -rf ./zstd_ep-install/lib/libzstd.a ${TP_INSTALL_DIR}/lib/libzstd.a
+        cp -rf ./zstd_ep-install/lib/libzstd.a "${TP_INSTALL_DIR}/lib/libzstd.a"
     fi
-    mkdir -p ${TP_INSTALL_DIR}/include/zstd
-    cp ./zstd_ep-install/include/* ${TP_INSTALL_DIR}/include/zstd
+    mkdir -p "${TP_INSTALL_DIR}/include/zstd"
+    cp ./zstd_ep-install/include/* "${TP_INSTALL_DIR}/include/zstd"
 
     restore_env_var PKG_CONFIG_PATH "${old_pkg_config_path}"
 

--- a/thirdparty/patches/abseil-cpp-20220623.0-apple-clang-only.patch
+++ b/thirdparty/patches/abseil-cpp-20220623.0-apple-clang-only.patch
@@ -1,0 +1,13 @@
+diff --git a/absl/copts/AbseilConfigureCopts.cmake b/absl/copts/AbseilConfigureCopts.cmake
+index 73435e9..4ad6d3a 100644
+--- a/absl/copts/AbseilConfigureCopts.cmake
++++ b/absl/copts/AbseilConfigureCopts.cmake
+@@ -10,7 +10,7 @@ else()
+   set(ABSL_BUILD_DLL FALSE)
+ endif()
+ 
+-if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES [[Clang]])
++if(APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+   # Some CMake targets (not known at the moment of processing) could be set to
+   # compile for multiple architectures as specified by the OSX_ARCHITECTURES
+   # property, which is target-specific.  We should neither inspect nor rely on


### PR DESCRIPTION
## Why I'm doing:

`./build.sh --be` on macOS is the recommended BE build entry (per the
planned deprecation of `build-mac/`), but it was broken end-to-end:

- The Homebrew-symlink approach for absl/gRPC dragged in Homebrew's
  newer protobuf, colliding with TP's 3.14 at arrow-flight configure time.
- Arrow Flight / Flight SQL were disabled on Darwin even though
  `be/CMakeLists.txt` unconditionally links `arrow_flight{,_sql}` and
  `gRPC::grpc{,++}`.
- `zstd` is not in `thirdparty/package-manifest.sh`, so
  `${TP_INSTALL_DIR}/lib/libzstd.a` was never populated on macOS.
- The Darwin TP auto-trigger and validation were Linux-only.

## What I'm doing:

**Darwin TP chain** — `thirdparty/build-thirdparty-darwin.sh`
- Source-build `absl 20220623` + `gRPC 1.43` (replace Homebrew symlinks);
  all providers pinned to TP, stale symlinks cleaned before `cmake --install`.
- Enable `ARROW_FLIGHT` / `ARROW_FLIGHT_SQL`; pin Arrow's `FindProtobufAlt`
  probe to TP via `Protobuf_*` hints + lowercase
  `CMAKE_DISABLE_FIND_PACKAGE_protobuf`.
- Hoist Arrow's bundled zstd (lib + headers), matching
  `thirdparty/build-thirdparty.sh`.

**BE cmake** — `be/cmake_modules/ThirdParty.cmake`
- Pre-declare `protobuf::libprotobuf` ALIAS + `Protobuf_FOUND=TRUE` before
  `find_package(gRPC CONFIG REQUIRED)`, so `gRPCConfig.cmake`'s guarded
  module-mode `FindProtobuf` is skipped (otherwise it can bind to a host
  protobuf and collide with the ALIAS).

**Bootstrap & validation**
- `build.sh`: auto-trigger Darwin TP when missing, gated on
  `--be` / `--format-lib`.
- `build-support/build_helpers.sh`: validate now covers `libgrpc{,++}.a`.
- Two small source cleanups for macOS clang's stricter warnings.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.


## Verification

Apple Silicon, macOS 26.4.1, via `./build.sh --be --clean` (from-scratch TP)
and `cd build-mac && ./build_be.sh --clean` (legacy entry still works):
- MacBook Pro (M1 Max)
- MacBook Pro (M4)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

> N/A — build-only change. No runtime behavior, no user-facing feature,
> not a backport.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

> N/A — macOS build only exists on main; RPC chain rework does not
> apply to release branches.
