### PR TITLE
[BugFix] Preserve PK-index tombstones through rssid_offset / shared_rssid remap

### DIFF
--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/lake_persistent_index_key_value_merger.h"
 
+#include <limits>
+
 #include "base/debug/trace.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/config_rowset_fwd.h"
@@ -55,9 +57,17 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
         // this row has been deleted in this sst, skip it
         return Status::OK();
     }
+    // Tombstones encode NullIndexValue as (rssid=UINT32_MAX, rowid=UINT32_MAX); keep them
+    // untouched through both the shared-rssid overwrite and the rssid_offset shift. An
+    // unguarded offset adds to UINT32_MAX and wraps to a small valid-looking rssid, which
+    // later upserts would mistake for a live pointer and corrupt the publish delvec.
+    auto is_tombstone = [](const IndexValueWithVerPB& v) {
+        return v.rssid() == std::numeric_limits<uint32_t>::max();
+    };
     // fill shared version & rssid if have
     if (iter_ptr->shared_version() > 0) {
         for (size_t i = 0; i < index_value_ver.values_size(); ++i) {
+            if (is_tombstone(index_value_ver.values(i))) continue;
             index_value_ver.mutable_values(i)->set_version(iter_ptr->shared_version());
             index_value_ver.mutable_values(i)->set_rssid(iter_ptr->shared_rssid());
         }
@@ -65,6 +75,7 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
     if (iter_ptr->rssid_offset() != 0) {
         const int32_t rssid_offset = iter_ptr->rssid_offset();
         for (size_t i = 0; i < index_value_ver.values_size(); ++i) {
+            if (is_tombstone(index_value_ver.values(i))) continue;
             const int64_t rssid = static_cast<int64_t>(index_value_ver.values(i).rssid()) + rssid_offset;
             index_value_ver.mutable_values(i)->set_rssid(static_cast<uint32_t>(rssid));
         }

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -14,8 +14,6 @@
 
 #include "storage/lake/lake_persistent_index_key_value_merger.h"
 
-#include <limits>
-
 #include "base/debug/trace.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/config_rowset_fwd.h"
@@ -57,23 +55,23 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
         // this row has been deleted in this sst, skip it
         return Status::OK();
     }
-    // Tombstones encode NullIndexValue as (rssid=UINT32_MAX, rowid=UINT32_MAX); keep them
-    // untouched through both the shared-rssid overwrite and the rssid_offset shift. An
-    // unguarded offset adds to UINT32_MAX and wraps to a small valid-looking rssid, which
-    // later upserts would mistake for a live pointer and corrupt the publish delvec.
-    auto is_tombstone = [](const IndexValueWithVerPB& v) { return v.rssid() == std::numeric_limits<uint32_t>::max(); };
-    // fill shared version & rssid if have
+    // Tombstone-aware projection: see is_index_tombstone() in storage/lake/utils.h
+    // for why the rssid/rowid sentinel must be preserved. Version is independent of
+    // the NullIndexValue encoding and must be projected even onto tombstones — the
+    // dup-resolution below in this function and the time-travel multi_get path both
+    // key off version, and a tombstone left at its source-sstable version would
+    // lose ordering against live entries projected to shared_version.
     if (iter_ptr->shared_version() > 0) {
         for (size_t i = 0; i < index_value_ver.values_size(); ++i) {
-            if (is_tombstone(index_value_ver.values(i))) continue;
             index_value_ver.mutable_values(i)->set_version(iter_ptr->shared_version());
+            if (is_index_tombstone(index_value_ver.values(i))) continue;
             index_value_ver.mutable_values(i)->set_rssid(iter_ptr->shared_rssid());
         }
     }
     if (iter_ptr->rssid_offset() != 0) {
         const int32_t rssid_offset = iter_ptr->rssid_offset();
         for (size_t i = 0; i < index_value_ver.values_size(); ++i) {
-            if (is_tombstone(index_value_ver.values(i))) continue;
+            if (is_index_tombstone(index_value_ver.values(i))) continue;
             const int64_t rssid = static_cast<int64_t>(index_value_ver.values(i).rssid()) + rssid_offset;
             index_value_ver.mutable_values(i)->set_rssid(static_cast<uint32_t>(rssid));
         }

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -61,9 +61,7 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
     // untouched through both the shared-rssid overwrite and the rssid_offset shift. An
     // unguarded offset adds to UINT32_MAX and wraps to a small valid-looking rssid, which
     // later upserts would mistake for a live pointer and corrupt the publish delvec.
-    auto is_tombstone = [](const IndexValueWithVerPB& v) {
-        return v.rssid() == std::numeric_limits<uint32_t>::max();
-    };
+    auto is_tombstone = [](const IndexValueWithVerPB& v) { return v.rssid() == std::numeric_limits<uint32_t>::max(); };
     // fill shared version & rssid if have
     if (iter_ptr->shared_version() > 0) {
         for (size_t i = 0; i < index_value_ver.values_size(); ++i) {

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -16,6 +16,8 @@
 
 #include <butil/time.h> // NOLINT
 
+#include <limits>
+
 #include "base/debug/trace.h"
 #include "base/testutil/sync_point.h"
 #include "common/config_primary_key_fwd.h"
@@ -203,16 +205,28 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
                 continue;
             }
         }
+        // Tombstones encode NullIndexValue as (rssid=UINT32_MAX, rowid=UINT32_MAX); neither
+        // the shared_rssid overwrite nor the rssid_offset shift must touch them. Replacing
+        // rssid with a small shared_rssid, or adding a non-zero offset that wraps UINT32_MAX
+        // to a tiny value, would desynchronize the 64-bit value from NullIndexValue and the
+        // caller (e.g. PK-index upsert) would treat the tombstone as a live pointer into a
+        // real rowset, pushing bogus rowids into the publish delvec builder and tripping
+        // the delvec-consistency check.
+        auto is_tombstone = [](const IndexValueWithVerPB& v) {
+            return v.rssid() == std::numeric_limits<uint32_t>::max();
+        };
         // fill shared rssid & version if have
         if (_sstable_pb.has_shared_version() && _sstable_pb.shared_version() > 0) {
             DCHECK(_sstable_pb.has_shared_rssid());
             for (size_t j = 0; j < index_value_with_ver_pb.values_size(); ++j) {
+                if (is_tombstone(index_value_with_ver_pb.values(j))) continue;
                 index_value_with_ver_pb.mutable_values(j)->set_rssid(_sstable_pb.shared_rssid());
                 index_value_with_ver_pb.mutable_values(j)->set_version(_sstable_pb.shared_version());
             }
         }
         if (_sstable_pb.rssid_offset() != 0) {
             for (size_t j = 0; j < index_value_with_ver_pb.values_size(); ++j) {
+                if (is_tombstone(index_value_with_ver_pb.values(j))) continue;
                 const int64_t rssid =
                         static_cast<int64_t>(index_value_with_ver_pb.values(j).rssid()) + _sstable_pb.rssid_offset();
                 index_value_with_ver_pb.mutable_values(j)->set_rssid(static_cast<uint32_t>(rssid));

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -16,8 +16,6 @@
 
 #include <butil/time.h> // NOLINT
 
-#include <limits>
-
 #include "base/debug/trace.h"
 #include "base/testutil/sync_point.h"
 #include "common/config_primary_key_fwd.h"
@@ -205,28 +203,22 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
                 continue;
             }
         }
-        // Tombstones encode NullIndexValue as (rssid=UINT32_MAX, rowid=UINT32_MAX); neither
-        // the shared_rssid overwrite nor the rssid_offset shift must touch them. Replacing
-        // rssid with a small shared_rssid, or adding a non-zero offset that wraps UINT32_MAX
-        // to a tiny value, would desynchronize the 64-bit value from NullIndexValue and the
-        // caller (e.g. PK-index upsert) would treat the tombstone as a live pointer into a
-        // real rowset, pushing bogus rowids into the publish delvec builder and tripping
-        // the delvec-consistency check.
-        auto is_tombstone = [](const IndexValueWithVerPB& v) {
-            return v.rssid() == std::numeric_limits<uint32_t>::max();
-        };
-        // fill shared rssid & version if have
+        // Tombstone-aware projection: see is_index_tombstone() in storage/lake/utils.h
+        // for why the rssid/rowid sentinel must be preserved through both the
+        // shared_rssid overwrite and the rssid_offset shift. Version is independent of
+        // the NullIndexValue encoding and is projected onto every entry (including
+        // tombstones) so that the version-equality lookup below matches them.
         if (_sstable_pb.has_shared_version() && _sstable_pb.shared_version() > 0) {
             DCHECK(_sstable_pb.has_shared_rssid());
             for (size_t j = 0; j < index_value_with_ver_pb.values_size(); ++j) {
-                if (is_tombstone(index_value_with_ver_pb.values(j))) continue;
-                index_value_with_ver_pb.mutable_values(j)->set_rssid(_sstable_pb.shared_rssid());
                 index_value_with_ver_pb.mutable_values(j)->set_version(_sstable_pb.shared_version());
+                if (is_index_tombstone(index_value_with_ver_pb.values(j))) continue;
+                index_value_with_ver_pb.mutable_values(j)->set_rssid(_sstable_pb.shared_rssid());
             }
         }
         if (_sstable_pb.rssid_offset() != 0) {
             for (size_t j = 0; j < index_value_with_ver_pb.values_size(); ++j) {
-                if (is_tombstone(index_value_with_ver_pb.values(j))) continue;
+                if (is_index_tombstone(index_value_with_ver_pb.values(j))) continue;
                 const int64_t rssid =
                         static_cast<int64_t>(index_value_with_ver_pb.values(j).rssid()) + _sstable_pb.rssid_offset();
                 index_value_with_ver_pb.mutable_values(j)->set_rssid(static_cast<uint32_t>(rssid));

--- a/be/src/storage/lake/utils.h
+++ b/be/src/storage/lake/utils.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "common/statusor.h"
 #include "storage/persistent_index.h"
 
@@ -45,6 +47,19 @@ inline StatusOr<T> enhance_error_prompt(StatusOr<T> res) {
 
 inline IndexValue build_index_value(const IndexValueWithVerPB& value) {
     return IndexValue(((uint64_t)value.rssid() << 32 | value.rowid()));
+}
+
+// A tombstone in the persistent-index sstable encodes NullIndexValue as the full
+// pair (rssid=UINT32_MAX, rowid=UINT32_MAX). The packed 64-bit value compares
+// equal to NullIndexValue only while *both* halves are UINT32_MAX, so any code
+// that mutates rssid/rowid (e.g. shared_rssid overwrite, rssid_offset shift)
+// must skip these entries — otherwise the caller's NullIndexValue check
+// downgrades the tombstone to a live pointer and downstream upserts feed the
+// publish delvec builder with bogus rowids. Project version freely; only the
+// rssid/rowid pair is the sentinel.
+inline bool is_index_tombstone(const IndexValueWithVerPB& value) {
+    return value.rssid() == std::numeric_limits<uint32_t>::max() &&
+           value.rowid() == std::numeric_limits<uint32_t>::max();
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -914,8 +914,7 @@ TEST_F(PersistentIndexSstableTest, test_multi_get_preserves_tombstones_with_shar
     // decodes to NullIndexValue.
     KeyIndexSet found_versioned;
     std::vector<IndexValue> values_versioned(kNumTombstones, IndexValue(NullIndexValue));
-    ASSERT_OK(sst->multi_get(keys.data(), key_indexes, kSharedVersion, values_versioned.data(),
-                             &found_versioned));
+    ASSERT_OK(sst->multi_get(keys.data(), key_indexes, kSharedVersion, values_versioned.data(), &found_versioned));
     ASSERT_EQ(found_versioned.size(), static_cast<size_t>(kNumTombstones));
     for (int i = 0; i < kNumTombstones; i++) {
         ASSERT_EQ(NullIndexValue, values_versioned[i].get_value());

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -851,9 +851,8 @@ TEST_F(PersistentIndexSstableTest, test_multi_get_preserves_tombstones_with_rssi
     ASSERT_EQ(found.size(), static_cast<size_t>(kNumTombstones));
     for (int i = 0; i < kNumTombstones; i++) {
         ASSERT_EQ(NullIndexValue, values[i].get_value())
-                << "tombstone at key " << key_str[i] << " leaked non-null value 0x" << std::hex
-                << values[i].get_value() << " rssid=" << values[i].get_rssid()
-                << " rowid=" << values[i].get_rowid();
+                << "tombstone at key " << key_str[i] << " leaked non-null value 0x" << std::hex << values[i].get_value()
+                << " rssid=" << values[i].get_rssid() << " rowid=" << values[i].get_rowid();
     }
 }
 

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -796,4 +796,116 @@ TEST_F(PersistentIndexSstableTest, test_multiget_retry_after_clear_corrupted_cac
     ASSERT_EQ(IndexValue(0), values[0]);
 }
 
+// Tombstones are stored as (rssid=UINT32_MAX, rowid=UINT32_MAX) so that the
+// 64-bit packed value equals NullIndexValue on the way out. When the owning
+// sstable has a non-zero rssid_offset (child-tablet contribution after a
+// tablet merge), multi_get used to unconditionally add that offset to the
+// entry's rssid, wrapping UINT32_MAX to a small valid-looking rssid — the
+// caller then mistook the tombstone for a live pointer, pushed
+// rowid=UINT32_MAX into the publish delvec for N deleted keys, and tripped
+// the `cur_old + cur_add != cur_new` consistency check (1000 adds collapse
+// to 1 entry inside the Roaring bitmap).
+TEST_F(PersistentIndexSstableTest, test_multi_get_preserves_tombstones_with_rssid_offset) {
+    const int kNumTombstones = 16;
+    const int32_t kOffset = 11;
+
+    const std::string filename = "test_tombstones_rssid_offset.sst";
+    ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
+    phmap::btree_map<std::string, IndexValueWithVer, std::less<>> map;
+    for (int i = 0; i < kNumTombstones; i++) {
+        // IndexValue(NullIndexValue) packs to (rssid=UINT32_MAX, rowid=UINT32_MAX).
+        map.emplace(fmt::format("tomb_{:016X}", i), std::make_pair(100, IndexValue(NullIndexValue)));
+    }
+
+    uint64_t filesize = 0;
+    PersistentIndexSstableRangePB range_pb;
+    ASSERT_OK(PersistentIndexSstable::build_sstable(map, file.get(), &filesize, &range_pb));
+
+    auto sst = std::make_unique<PersistentIndexSstable>();
+    ASSIGN_OR_ABORT(auto read_file, fs::new_random_access_file(lake::join_path(kTestDir, filename)));
+    std::unique_ptr<Cache> cache_ptr;
+    cache_ptr.reset(new_lru_cache(1024));
+    PersistentIndexSstablePB sstable_pb;
+    sstable_pb.set_filename(filename);
+    sstable_pb.set_filesize(filesize);
+    sstable_pb.mutable_range()->CopyFrom(range_pb);
+    sstable_pb.mutable_fileset_id()->CopyFrom(UniqueId::gen_uid().to_proto());
+    sstable_pb.set_rssid_offset(kOffset);
+    ASSERT_OK(sst->init(std::move(read_file), sstable_pb, cache_ptr.get()));
+
+    std::vector<std::string> key_str(kNumTombstones);
+    std::vector<Slice> keys(kNumTombstones);
+    std::vector<IndexValue> values(kNumTombstones, IndexValue(NullIndexValue));
+    KeyIndexSet key_indexes;
+    KeyIndexSet found;
+    for (int i = 0; i < kNumTombstones; i++) {
+        key_str[i] = fmt::format("tomb_{:016X}", i);
+        keys[i] = Slice(key_str[i]);
+        key_indexes.insert(i);
+    }
+    ASSERT_OK(sst->multi_get(keys.data(), key_indexes, -1, values.data(), &found));
+
+    // Every tombstone must come back as NullIndexValue, NOT as
+    // (rssid=UINT32_MAX+kOffset wrap, rowid=UINT32_MAX) which would be a
+    // small valid-looking pointer (upsert would treat the key as live).
+    ASSERT_EQ(found.size(), static_cast<size_t>(kNumTombstones));
+    for (int i = 0; i < kNumTombstones; i++) {
+        ASSERT_EQ(NullIndexValue, values[i].get_value())
+                << "tombstone at key " << key_str[i] << " leaked non-null value 0x" << std::hex
+                << values[i].get_value() << " rssid=" << values[i].get_rssid()
+                << " rowid=" << values[i].get_rowid();
+    }
+}
+
+// Same invariant when shared_version / shared_rssid is used instead of
+// rssid_offset. A tombstone must not have its rssid overwritten with
+// shared_rssid — otherwise the caller sees a small live-looking pointer.
+TEST_F(PersistentIndexSstableTest, test_multi_get_preserves_tombstones_with_shared_rssid) {
+    const int kNumTombstones = 8;
+    const uint32_t kSharedRssid = 5;
+    const int64_t kSharedVersion = 42;
+
+    const std::string filename = "test_tombstones_shared_rssid.sst";
+    ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
+    phmap::btree_map<std::string, IndexValueWithVer, std::less<>> map;
+    for (int i = 0; i < kNumTombstones; i++) {
+        map.emplace(fmt::format("tomb2_{:016X}", i), std::make_pair(100, IndexValue(NullIndexValue)));
+    }
+
+    uint64_t filesize = 0;
+    PersistentIndexSstableRangePB range_pb;
+    ASSERT_OK(PersistentIndexSstable::build_sstable(map, file.get(), &filesize, &range_pb));
+
+    auto sst = std::make_unique<PersistentIndexSstable>();
+    ASSIGN_OR_ABORT(auto read_file, fs::new_random_access_file(lake::join_path(kTestDir, filename)));
+    std::unique_ptr<Cache> cache_ptr;
+    cache_ptr.reset(new_lru_cache(1024));
+    PersistentIndexSstablePB sstable_pb;
+    sstable_pb.set_filename(filename);
+    sstable_pb.set_filesize(filesize);
+    sstable_pb.mutable_range()->CopyFrom(range_pb);
+    sstable_pb.mutable_fileset_id()->CopyFrom(UniqueId::gen_uid().to_proto());
+    sstable_pb.set_shared_rssid(kSharedRssid);
+    sstable_pb.set_shared_version(kSharedVersion);
+    ASSERT_OK(sst->init(std::move(read_file), sstable_pb, cache_ptr.get()));
+
+    std::vector<std::string> key_str(kNumTombstones);
+    std::vector<Slice> keys(kNumTombstones);
+    std::vector<IndexValue> values(kNumTombstones, IndexValue(NullIndexValue));
+    KeyIndexSet key_indexes;
+    KeyIndexSet found;
+    for (int i = 0; i < kNumTombstones; i++) {
+        key_str[i] = fmt::format("tomb2_{:016X}", i);
+        keys[i] = Slice(key_str[i]);
+        key_indexes.insert(i);
+    }
+    ASSERT_OK(sst->multi_get(keys.data(), key_indexes, -1, values.data(), &found));
+
+    ASSERT_EQ(found.size(), static_cast<size_t>(kNumTombstones));
+    for (int i = 0; i < kNumTombstones; i++) {
+        ASSERT_EQ(NullIndexValue, values[i].get_value())
+                << "shared_rssid tombstone at key " << key_str[i] << " leaked non-null";
+    }
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -905,6 +905,21 @@ TEST_F(PersistentIndexSstableTest, test_multi_get_preserves_tombstones_with_shar
         ASSERT_EQ(NullIndexValue, values[i].get_value())
                 << "shared_rssid tombstone at key " << key_str[i] << " leaked non-null";
     }
+
+    // shared_version must still be projected onto tombstones so the time-travel
+    // multi_get path (`version >= 0`) matches them. Without the version projection,
+    // a versioned lookup walks past the tombstone and resurrects a stale live entry
+    // from an older sstable — exactly the ordering bug Codex flagged. Verify by
+    // querying at exactly shared_version and confirming each tombstone is found and
+    // decodes to NullIndexValue.
+    KeyIndexSet found_versioned;
+    std::vector<IndexValue> values_versioned(kNumTombstones, IndexValue(NullIndexValue));
+    ASSERT_OK(sst->multi_get(keys.data(), key_indexes, kSharedVersion, values_versioned.data(),
+                             &found_versioned));
+    ASSERT_EQ(found_versioned.size(), static_cast<size_t>(kNumTombstones));
+    for (int i = 0; i < kNumTombstones; i++) {
+        ASSERT_EQ(NullIndexValue, values_versioned[i].get_value());
+    }
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

A primary-key index sstable stores tombstones as `IndexValue(NullIndexValue)`,
i.e. the pair `(rssid = UINT32_MAX, rowid = UINT32_MAX)`. The packed 64-bit
value compares equal to `NullIndexValue` only while *both* halves are
`UINT32_MAX`, which is what the upsert path keys off when deciding whether
a key is live or already deleted.

When a sstable inherits a non-zero `rssid_offset` (per-child contribution
carried over to a post-merge tablet) or `shared_rssid` + `shared_version`,
`PersistentIndexSstable::multi_get` and `KeyValueMerger::merge` used to
unconditionally adjust every entry's `rssid`. For a tombstone this either
(a) added `rssid_offset` to `UINT32_MAX`, wrapping uint32_t arithmetic to a
small valid-looking rssid, or (b) overwrote `UINT32_MAX` with `shared_rssid`.
Either way the returned packed value no longer compared equal to
`NullIndexValue`. The caller (the publish-side persistent-index upsert) saw
the tombstone as a live pointer and pushed its rowid (= `UINT32_MAX`) into
the publish delvec builder. When the same sstable answered a batch of N
deleted keys, the builder received N identical `UINT32_MAX` rowids, the
Roaring-bitmap dedup collapsed them to 1 entry, and the
`cur_old + cur_add != cur_new` consistency check in `update_manager.cpp`
fired, wedging the transaction in `COMMITTED` state until it timed out.

Reproducer (shared-data PK range-distributed table, `enable_persistent_index = true`):

1. seed N rows
2. `ALTER TABLE ... SPLIT TABLETS (...)` to several children
3. `DELETE FROM ... WHERE id BETWEEN a AND b` — range straddling child boundaries
4. `ALTER TABLE ... MERGE TABLETS (...)` back into one tablet
5. INSERT the same `[a, b)` range with new values

Step 5 never publishes. BE logs:

```
delvec inconsistent tablet:X rssid:10 #old:0 #add:1000 #new:1 old_v:1 v:V
```

The specific rssid in the error depends on the inherited `rssid_offset`
(e.g. `UINT32_MAX + 11` wraps to `10`); other offsets produce other small
rssids but the same pattern, each happening to look like a valid rowset in
the merged tablet.

## What I'm doing:

Identify tombstones explicitly and skip the rssid/rowid mutations only —
keep projecting version onto them. The whole policy lives in one shared
helper next to `build_index_value` in `storage/lake/utils.h`:

```cpp
inline bool is_index_tombstone(const IndexValueWithVerPB& value) {
    return value.rssid() == std::numeric_limits<uint32_t>::max() &&
           value.rowid() == std::numeric_limits<uint32_t>::max();
}
```

Both halves of the sentinel are required so a real entry whose rssid
happens to equal `UINT32_MAX` (extremely unlikely but theoretically
reachable) can never be misidentified as a tombstone.

Two call sites use it:

- **`be/src/storage/lake/persistent_index_sstable.cpp::PersistentIndexSstable::multi_get`** —
  guard the `shared_rssid` overwrite and the `rssid_offset` add.
- **`be/src/storage/lake/lake_persistent_index_key_value_merger.cpp::KeyValueMerger::merge`** —
  same guard on both adjustments. The `max_rss_rowid` shift in the same
  block is left as-is; it is a per-sstable-range bound, not per-entry.

Crucially, both sites still **project version** onto every entry, including
tombstones. The dup-resolution in `KeyValueMerger::merge` and the
time-travel `version >= 0` filter in `multi_get` both key off version, so
leaving a tombstone at its source sstable's version would let live entries
written at `shared_version` win the ordering and resurrect stale records.
Only the rssid/rowid pair is preserved.

Tombstones are only produced through `PersistentIndexMemtable::erase`,
which writes `IndexValue(NullIndexValue) = (UINT32_MAX, UINT32_MAX)` into
the value. No other write path uses that pair, so the helper has no
collision with real data.

## Tests

Two new UTs in `PersistentIndexSstableTest`:

- `test_multi_get_preserves_tombstones_with_rssid_offset` — build an
  sstable whose entries are all tombstones, init its
  `PersistentIndexSstablePB` with `rssid_offset = 11`, call `multi_get`,
  assert every returned value is `NullIndexValue`. Without the fix this
  test observes wrapped-rssid values (e.g. `rssid = 10`).
- `test_multi_get_preserves_tombstones_with_shared_rssid` — same invariant
  under `shared_rssid` + `shared_version`. Additionally calls `multi_get`
  at exactly `shared_version` and asserts each tombstone is found and
  decodes to `NullIndexValue` — verifies that version projection still
  happens (the time-travel path requires it).

The end-to-end reproducer above also recovers: with the fix in place,
step 5 publishes in under a second and the final table contents match the
oracle.

Two pre-existing tests in the same suite
(`test_sst_open_retry_after_clear_corrupted_cache`,
`test_multiget_retry_after_clear_corrupted_cache`) fail on both the
baseline `main` branch and this branch — independent of this change and
out of scope.

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4