### PR TITLE
[BugFix] Drop compaction on SPLITTING cross-publish for range distribution tablet

### DIFF
--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -351,8 +351,35 @@ Status convert_txn_log_for_merging(TxnLogPB* txn_log) {
 }
 
 // Transform |txn_log| for publish on one of the split child tablets.
+//
+// Compaction ops are dropped on cross-publish, mirroring the merging-side
+// handling (see convert_txn_log_for_merging above). The reason is the same in
+// the other direction: a compaction transaction committed on the parent before
+// the split has its rows-mapper file (.lcrm) and output rowset built against
+// the parent tablet's full key range. Each split child only owns a subrange,
+// so when the conflict resolver runs for its op_compaction publish on the
+// child it iterates fewer segment rows than the mapper's stored row_count and
+// `RowsMapperIterator::status()` rejects the publish with
+//   "Chunk vs rows mapper's row count mismatch. <N> vs <total>"
+// (see storage/rows_mapper.cpp:155, storage/primary_key_compaction_conflict_resolver.cpp:124,175).
+// Because the compaction's input rowsets are still present in every child's
+// metadata (shared via set_all_data_files_shared), it is safe to drop the
+// compaction here — background compaction on the child will rerun it. The
+// compaction's output files were written under the parent tablet's path and
+// are deleted async so they do not leak. The async cleanup is gated to a
+// single child (split_index == 0) because publish runs convert_txn_log once
+// per split child against the same parent txn_log; without the gate the
+// identical output paths would be queued for deletion split_count times.
 Status convert_txn_log_for_splitting(TxnLogPB* txn_log, const TabletMetadataPtr& base_tablet_metadata,
                                      const PublishTabletInfo& publish_tablet_info) {
+    if (txn_log->has_op_compaction() || txn_log->has_op_parallel_compaction()) {
+        if (publish_tablet_info.get_split_index() == 0) {
+            delete_files_async(tablet_reshard_helper::collect_compaction_output_file_paths(
+                    *txn_log, ExecEnv::GetInstance()->lake_tablet_manager()));
+        }
+        txn_log->clear_op_compaction();
+        txn_log->clear_op_parallel_compaction();
+    }
     tablet_reshard_helper::set_all_data_files_shared(txn_log);
     RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_ranges(txn_log, base_tablet_metadata->range()));
     tablet_reshard_helper::update_txn_log_data_stats(txn_log, publish_tablet_info.get_split_count(),

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1685,18 +1685,14 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for
 
     EXPECT_EQ(publish_tablet_info.get_tablet_id_in_metadata(), converted->tablet_id());
     expect_shared_and_range(converted->op_write().rowset(), 10, 15);
-    expect_shared_and_range(converted->op_compaction().output_rowset(), 12, 20);
-    ASSERT_TRUE(converted->op_compaction().has_output_sstable());
-    EXPECT_TRUE(converted->op_compaction().output_sstable().shared());
-    ASSERT_EQ(1, converted->op_compaction().output_sstables_size());
-    EXPECT_TRUE(converted->op_compaction().output_sstables(0).shared());
+    // op_compaction and op_parallel_compaction are dropped on SPLITTING cross-publish
+    // (see convert_txn_log_for_splitting); range narrowing is exercised on the surviving
+    // op_write / op_schema_change / op_replication payloads. Drop coverage lives in
+    // test_convert_txn_log_splitting_drops_op_compaction* tests.
+    EXPECT_FALSE(converted->has_op_compaction());
+    EXPECT_FALSE(converted->has_op_parallel_compaction());
     expect_shared_and_range(converted->op_schema_change().rowsets(0), 10, 20);
     expect_shared_and_range(converted->op_replication().op_writes(0).rowset(), 18, 20);
-    expect_shared_and_range(converted->op_parallel_compaction().subtask_compactions(0).output_rowset(), 19, 20);
-    ASSERT_TRUE(converted->op_parallel_compaction().has_output_sstable());
-    EXPECT_TRUE(converted->op_parallel_compaction().output_sstable().shared());
-    ASSERT_EQ(1, converted->op_parallel_compaction().output_sstables_size());
-    EXPECT_TRUE(converted->op_parallel_compaction().output_sstables(0).shared());
 }
 
 // --- New tests for split-then-merge correctness ---
@@ -3939,6 +3935,115 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_merging_drops_op_parallel_com
 
     EXPECT_FALSE(converted->has_op_parallel_compaction());
     EXPECT_EQ(merged_tablet_id, converted->tablet_id());
+}
+
+// --- Tests for SPLITTING cross-publish drop-as-empty-compaction ---
+//
+// Symmetric to the MERGING tests above. A pre-split compaction txn whose
+// publish lands on a SPLIT child has the rows-mapper (.lcrm) and output rowset
+// shaped against the parent tablet's full key range. Each child only owns a
+// subrange, so when the conflict resolver runs over its op_compaction the
+// segment iteration consumes fewer rows than the mapper's stored row_count,
+// and `RowsMapperIterator::status()` (storage/rows_mapper.cpp:155) hard-fails
+// the publish with "Chunk vs rows mapper's row count mismatch", wedging
+// CLEANING. Convert_txn_log must therefore drop op_compaction /
+// op_parallel_compaction during SPLITTING cross-publish (mirroring MERGING),
+// leaving op_write payloads intact and preserving the child range / data-stat
+// adjustments.
+
+TEST_F(LakeTabletReshardTest, test_convert_txn_log_splitting_drops_op_compaction) {
+    const int64_t source_tablet_id = next_id();
+    const int64_t child_tablet_id = next_id();
+    auto log = make_op_compaction_log(source_tablet_id);
+
+    // Base metadata only needs a range — the splitter narrows op_write rowset
+    // ranges against it. op_compaction is unconditionally dropped before any
+    // range-narrowing runs, so the range value is irrelevant for this test.
+    auto base_metadata = std::make_shared<TabletMetadataPB>();
+    base_metadata->set_id(source_tablet_id);
+    base_metadata->set_version(1);
+    base_metadata->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+    base_metadata->mutable_range()->set_lower_bound_included(true);
+    base_metadata->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
+    base_metadata->mutable_range()->set_upper_bound_included(false);
+
+    lake::PublishTabletInfo info(lake::PublishTabletInfo::SPLITTING_TABLET, source_tablet_id, child_tablet_id, 4, 0);
+    ASSIGN_OR_ABORT(auto converted, lake::convert_txn_log(log, base_metadata, info));
+
+    // Compaction payload cleared — apply becomes a no-op. The child tablet's
+    // background compaction will rerun the merge over its own range.
+    EXPECT_FALSE(converted->has_op_compaction());
+    EXPECT_FALSE(converted->has_op_parallel_compaction());
+    // Other fields preserved.
+    EXPECT_EQ(child_tablet_id, converted->tablet_id());
+    EXPECT_EQ(log->txn_id(), converted->txn_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_convert_txn_log_splitting_drops_op_parallel_compaction) {
+    const int64_t source_tablet_id = next_id();
+    const int64_t child_tablet_id = next_id();
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(source_tablet_id);
+    log->set_txn_id(2030);
+    auto* op_parallel_compaction = log->mutable_op_parallel_compaction();
+    for (int i = 0; i < 2; ++i) {
+        auto* subtask = op_parallel_compaction->add_subtask_compactions();
+        subtask->mutable_output_rowset()->add_segments(fmt::format("split_subtask_seg_{}.dat", i));
+        subtask->mutable_output_sstable()->set_filename(fmt::format("split_subtask_{}.sst", i));
+    }
+
+    auto base_metadata = std::make_shared<TabletMetadataPB>();
+    base_metadata->set_id(source_tablet_id);
+    base_metadata->set_version(1);
+    base_metadata->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+    base_metadata->mutable_range()->set_lower_bound_included(true);
+    base_metadata->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
+    base_metadata->mutable_range()->set_upper_bound_included(false);
+
+    lake::PublishTabletInfo info(lake::PublishTabletInfo::SPLITTING_TABLET, source_tablet_id, child_tablet_id, 2, 1);
+    ASSIGN_OR_ABORT(auto converted, lake::convert_txn_log(log, base_metadata, info));
+
+    EXPECT_FALSE(converted->has_op_parallel_compaction());
+    EXPECT_EQ(child_tablet_id, converted->tablet_id());
+}
+
+// Regression: op_write-only logs through SPLITTING cross-publish must NOT have
+// their op_write fields cleared by the new compaction-drop path. Only the
+// compaction ops are dropped; op_write is preserved (and gets shared-flag /
+// range / data-stat adjustments applied to it).
+TEST_F(LakeTabletReshardTest, test_convert_txn_log_splitting_op_write_preserved) {
+    const int64_t source_tablet_id = next_id();
+    const int64_t child_tablet_id = next_id();
+
+    auto base_metadata = std::make_shared<TabletMetadataPB>();
+    base_metadata->set_id(source_tablet_id);
+    base_metadata->set_version(1);
+    base_metadata->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(10));
+    base_metadata->mutable_range()->set_lower_bound_included(true);
+    base_metadata->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(20));
+    base_metadata->mutable_range()->set_upper_bound_included(false);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(source_tablet_id);
+    log->set_txn_id(3000);
+    auto* rowset = log->mutable_op_write()->mutable_rowset();
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(60);
+    rowset->set_data_size(600);
+    rowset->add_segments("write_seg.dat");
+    rowset->add_segment_size(600);
+
+    lake::PublishTabletInfo info(lake::PublishTabletInfo::SPLITTING_TABLET, source_tablet_id, child_tablet_id, 3, 0);
+    ASSIGN_OR_ABORT(auto converted, lake::convert_txn_log(log, base_metadata, info));
+
+    ASSERT_TRUE(converted->has_op_write());
+    EXPECT_EQ(child_tablet_id, converted->tablet_id());
+    // Splitter scaled num_rows / data_size by split_count and applied
+    // shared-flag to op_write rowset.
+    EXPECT_EQ(20, converted->op_write().rowset().num_rows());
+    EXPECT_EQ(200, converted->op_write().rowset().data_size());
+    ASSERT_TRUE(converted->op_write().rowset().shared_segments_size() > 0);
+    EXPECT_TRUE(converted->op_write().rowset().shared_segments(0));
 }
 
 // Regression: op_parallel_compaction subtasks synthesized by


### PR DESCRIPTION
## Why I'm doing:

Symmetric to PR #71978 (the same fix on the MERGING side). A pre-split
compaction transaction whose publish lands on a SPLIT child has its
rows-mapper file (.lcrm) and output rowset built against the parent
tablet's full key range. Each split child only owns a subrange, so when
publish runs \`LakePrimaryKeyCompactionConflictResolver::execute_without_update_index\`
the segment iteration sees fewer rows than the mapper file's stored
\`row_count\`, and \`RowsMapperIterator::status()\` rejects the publish with

\`\`\`
Chunk vs rows mapper's row count mismatch. <consumed> vs <total>
\`\`\`

(see \`storage/rows_mapper.cpp:155\`, \`primary_key_compaction_conflict_resolver.cpp:124,175\`).
The compaction txn cannot publish on any child, the SPLIT job parks in
\`CLEANING\` waiting on \`isPreviousTransactionsFinished\`, and the table is
permanently stuck in \`TABLET_RESHARD\` state.

Reproducer (shared-data PK range distribution, 3-CN cluster):

1. seed N rows
2. issue a handful of \`DELETE\`s (kicks an auto-compaction in the background)
3. \`ALTER TABLE … SPLIT TABLETS (…) PROPERTIES (\"tablet_reshard_target_size\" = \"-K\")\`
4. \`SHOW PROC \"/transactions/<db>/running\"\` — both the \`COMPACTION_…\`
   and any subsequent \`delete_…\` txns sit in COMMITTED with the row-count
   mismatch error against \`staros://<parent_tablet>/data/<uuid>.lcrm\`
5. \`tablet_reshard_jobs.JOB_STATE = CLEANING\` and never advances.

## What I'm doing:

In \`convert_txn_log_for_splitting()\` drop \`op_compaction\` /
\`op_parallel_compaction\` (mirroring \`convert_txn_log_for_merging()\` from
PR #71978). The compaction's input rowsets remain present in every
child's metadata because \`set_all_data_files_shared\` carries them across,
so dropping the compaction is safe — background compaction on each child
will rerun the merge over its own range. The compaction's output files
were written under the parent tablet's path; they are deleted async via
\`delete_files_async(collect_compaction_output_file_paths(...))\` so they
do not leak.

## Tests:

- \`test_convert_txn_log_splitting_drops_op_compaction\`: a compaction
  log routed through SPLITTING_TABLET cross-publish has its
  \`op_compaction\` cleared.
- \`test_convert_txn_log_splitting_drops_op_parallel_compaction\`: same
  for parallel compaction.
- \`test_convert_txn_log_splitting_op_write_preserved\`: regression
  guard that \`op_write\` payloads still flow through (with shared-flag,
  range-narrowing, and \`num_rows\` / \`data_size\` split-scaling intact),
  so the new compaction-drop branch does not over-clear.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4