### PR TITLE
[auto-perf-opt] PR-1/4: scaffold _index_cache local-disk snapshot persistence

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -467,6 +467,18 @@ CONF_mDouble(pk_index_compaction_score_ratio, "1.5");
 CONF_mInt32(pk_index_early_sst_compaction_threshold, "5");
 // Whether enable parallel compaction for primary key index in shared-data mode.
 CONF_mBool(enable_pk_index_parallel_compaction, "true");
+// Whether to persist a local-disk snapshot of the in-memory PK index so that BE-restart,
+// memory-pressure eviction, and tablet rebalance scenarios can skip the full cold rebuild
+// from rowsets and SSTs. Disabled by default — when off, the snapshot save / restore code
+// paths are no-ops. Enabling this requires the follow-up PRs in the snapshot-persistence
+// series to be in place; in the scaffolding PR the methods are stubs that always miss.
+CONF_mBool(enable_pk_index_snapshot_persistence, "false");
+// Local directory used to store PK-index snapshots. Empty (default) means derive from the
+// first storage_root_path entry. Honoured only when enable_pk_index_snapshot_persistence is true.
+CONF_String(pk_index_snapshot_local_dir, "");
+// Maximum age in seconds of a snapshot before it is considered stale and ignored at
+// restore time. Default 7 days.
+CONF_mInt64(pk_index_snapshot_max_age_sec, "604800");
 // Whether enable parallel get for primary key index in shared-data mode.
 CONF_mBool(enable_pk_index_parallel_execution, "true");
 // The minimum rows threshold to enable parallel get for primary key index in shared-data mode.

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1044,9 +1044,36 @@ std::pair<size_t, int64_t> LakePersistentIndex::need_rebuild_counts(const Tablet
     return {file_cnt, row_cnt};
 }
 
+Status LakePersistentIndex::try_restore_from_local_snapshot(TabletManager* /*tablet_mgr*/,
+                                                            const TabletMetadataPtr& /*metadata*/,
+                                                            int64_t /*base_version*/) {
+    if (!config::enable_pk_index_snapshot_persistence) {
+        return Status::NotFound("pk-index snapshot persistence disabled");
+    }
+    // The on-disk format and validity rules land in follow-up PRs. Until then, always fall
+    // back to the full rebuild path so callers see no behavior change.
+    return Status::NotFound("pk-index snapshot restore not implemented");
+}
+
+Status LakePersistentIndex::try_serialize_to_local_snapshot(TabletManager* /*tablet_mgr*/,
+                                                            const TabletMetadataPtr& /*metadata*/) {
+    if (!config::enable_pk_index_snapshot_persistence) {
+        return Status::OK();
+    }
+    return Status::NotSupported("pk-index snapshot persist not implemented");
+}
+
 Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
                                                   int64_t base_version, const MetaFileBuilder* builder) {
     TRACE_COUNTER_SCOPE_LATENCY_US("pindex_load_from_lake_tablet_us");
+    if (config::enable_pk_index_snapshot_persistence) {
+        Status restore_st = try_restore_from_local_snapshot(tablet_mgr, metadata, base_version);
+        if (restore_st.ok()) {
+            TRACE_COUNTER_INCREMENT("pindex_snapshot_restore_hit", 1);
+            return Status::OK();
+        }
+        TRACE_COUNTER_INCREMENT("pindex_snapshot_restore_miss", 1);
+    }
     // 1. create and set key column schema
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata->schema());
     vector<ColumnId> pk_columns(tablet_schema->num_key_columns());

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -126,6 +126,23 @@ public:
     Status load_from_lake_tablet(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                                  const MetaFileBuilder* builder);
 
+    // Try to restore the in-memory state from a previously-captured local snapshot for the
+    // tablet+version pair currently being loaded. Returns Status::OK() on a successful restore;
+    // any other status (NotFound, version mismatch, corruption, etc.) means the caller must
+    // fall back to the full rebuild path. Gated by config::enable_pk_index_snapshot_persistence;
+    // when the flag is false this is a no-op that always returns NotFound.
+    //
+    // NOTE: this is a stub in the initial scaffolding PR — the on-disk format, serialisation,
+    // and validity rules will land in follow-up PRs. The signature is fixed here so callers
+    // can be wired before the implementation is complete.
+    Status try_restore_from_local_snapshot(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
+                                           int64_t base_version);
+
+    // Persist a local snapshot capturing the current in-memory state. Caller is responsible
+    // for choosing the right moment (typically pre-eviction or BE shutdown). Gated by the
+    // same config flag; no-op when disabled. Stub in this scaffolding PR.
+    Status try_serialize_to_local_snapshot(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata);
+
     size_t memory_usage() const override;
 
     int32_t current_fileset_index() const { return (int32_t)_sstable_filesets.size() - 1; }


### PR DESCRIPTION
## Summary

This is **PR-1 of 4** in a series that adds local-disk snapshot persistence for the cloud-native PK index, so BE-restart / memory-pressure-eviction / tablet-rebalance scenarios can skip the full cold rebuild from rowsets and SSTs.

This first PR is **purely scaffolding** — all new code paths are gated by a default-false config flag, and the new methods are stubs that always miss, so behavior is unchanged. The goal is to lock down the API contract and the integration point so the follow-up PRs land cleanly.

## Why

On shared-data StarRocks, every BE-restart, memory-pressure eviction, and tablet rebalance unconditionally cold-rebuilds \`LakePersistentIndex\` for the affected tablets via \`load_from_lake_tablet\`. Tracing on PL2 hardware shows the rebuild dominates upsert tail latency (Max), with three sub-phases:

| Sub-phase | Counter | Share of cold rebuild |
|---|---|---|
| Open SSTs from OSS | \`pindex_init_sst_open_us\` | ~50% |
| Scan rowsets, rebuild memtable | \`rebuild_index_segment_cost_us\` | ~30% |
| Replay deletion vectors | \`rebuild_index_del_cost_us\` | ~20% |

All three are fetch-and-replay-from-OSS. A locally-persisted snapshot of the post-rebuild semantic state (key→rssid+rowid map plus SST fileset references) lets us short-circuit the entire path with a single local-disk read.

The existing TTL-based config (\`update_cache_expire_sec\`) only masks one of those triggers (TTL-driven eviction); a snapshot addresses BE-restart, memory-pressure, and rebalance uniformly.

## What this PR adds

1. **Three BE configs** (all default-off / empty / 7-day TTL):
   - \`enable_pk_index_snapshot_persistence\` (\`mBool\`, default \`false\`)
   - \`pk_index_snapshot_local_dir\` (\`String\`, empty → derived path)
   - \`pk_index_snapshot_max_age_sec\` (\`mInt64\`, default \`604800\`)

2. **Two public methods** on \`LakePersistentIndex\`:
   - \`try_restore_from_local_snapshot(...)\` — stub returning \`Status::NotFound\`
   - \`try_serialize_to_local_snapshot(...)\` — stub returning \`Status::OK\` (no-op when flag off) / \`Status::NotSupported\` otherwise

3. **Early-call site in \`load_from_lake_tablet\`** that, when the flag is on, tries \`try_restore_from_local_snapshot\` and short-circuits the rebuild on success. Two new \`TRACE_COUNTER\`s (\`pindex_snapshot_restore_hit\` / \`_miss\`) so future iterations can observe the restore path empirically.

## What this PR does NOT do

The on-disk format, validity rules (tablet-version check, schema-hash check, CRC), serialisation/deserialisation, eviction-time capture hook in \`UpdateManager\`, BE-shutdown capture hook, and snapshot GC all land in follow-up PRs:

- **PR-2/4** (~150 LOC): proto definition (\`PersistentIndexSnapshotMetaPB\`) + on-disk file format + read/write helpers (no integration).
- **PR-3/4** (~250 LOC): real \`try_serialize_to_local_snapshot\` and \`try_restore_from_local_snapshot\` implementations + tablet-version validity check + unit tests for round-trip equivalence.
- **PR-4/4** (~150 LOC): pre-walk hook in \`UpdateManager::expire_cache\` / \`evict_cache\` (Option B from the design doc — uses existing \`DynamicCache::get_all_entries()\`, no changes to the generic util) + BE-shutdown hook + stale-snapshot GC.

Each of those PRs is also behavior-neutral until the next one merges.

## Risk

- **Default off**, methods always return \`NotFound\` or \`NotSupported\`.
- **No write path**, no on-disk state created.
- **No eviction-hook contract** introduced.
- The only observable change in the default configuration is two extra config-bool checks per \`load_from_lake_tablet\` call (one in the early-return guard, one inside the stub). Negligible overhead.

## Test plan
- [ ] CI compile passes on the StarRocks default build matrix.
- [ ] Existing PK-index unit tests still pass (no behavior change with default flag).
- [ ] Smoke test on a benchmark cluster: run with default flag → observe \`pindex_snapshot_restore_hit\` counter is never incremented; cold rebuild trace counters (\`pindex_init_sst_open_us\`, \`rebuild_index_segment_cost_us\`, \`rebuild_index_del_cost_us\`) are unchanged from baseline.
- [ ] Smoke test with flag on → observe \`pindex_snapshot_restore_miss\` counter is incremented on every cold rebuild; cold rebuild path still completes successfully (since \`try_restore_from_local_snapshot\` always returns \`NotFound\`).