### PR TITLE
[Refactor] Address BE source warnings exposed by macOS clang

### DIFF
--- a/be/src/exec/file_scanner/json_scanner.cpp
+++ b/be/src/exec/file_scanner/json_scanner.cpp
@@ -589,7 +589,7 @@ Status JsonReader::_construct_row_without_jsonpath(simdjson::ondemand::object* r
                 DCHECK(_envelope_type != TEnvelopeType::DEBEZIUM || _cdc_op != 0xFF);
                 uint8_t op_val = _envelope_type != TEnvelopeType::NONE ? _cdc_op : 0;
                 if (column->is_binary()) {
-                    column->append_strings(&kCdcOpSlices[op_val], 1);
+                    (void)column->append_strings(&kCdcOpSlices[op_val], 1);
                 } else {
                     column->append_datum(Datum(op_val));
                 }
@@ -619,7 +619,7 @@ Status JsonReader::_construct_row_with_jsonpath(simdjson::ondemand::object* row,
                 DCHECK(_envelope_type != TEnvelopeType::DEBEZIUM || _cdc_op != 0xFF);
                 uint8_t op_val = _envelope_type != TEnvelopeType::NONE ? _cdc_op : 0;
                 if (column->is_binary()) {
-                    column->append_strings(&kCdcOpSlices[op_val], 1);
+                    (void)column->append_strings(&kCdcOpSlices[op_val], 1);
                 } else {
                     column->append_datum(Datum(op_val));
                 }
@@ -654,7 +654,7 @@ Status JsonReader::_construct_row_with_jsonpath(simdjson::ondemand::object* row,
                     DCHECK(_envelope_type != TEnvelopeType::DEBEZIUM || _cdc_op != 0xFF);
                     uint8_t op_val = _envelope_type != TEnvelopeType::NONE ? _cdc_op : 0;
                     if (column->is_binary()) {
-                        column->append_strings(&kCdcOpSlices[op_val], 1);
+                        (void)column->append_strings(&kCdcOpSlices[op_val], 1);
                     } else {
                         column->append_datum(Datum(op_val));
                     }

--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -1304,18 +1304,6 @@ StatusOr<std::optional<VariantRowValue>> VariantColumnReader::build_variant_bind
     return std::optional<VariantRowValue>(std::move(built));
 }
 
-static const ShreddedFieldNode* find_node_by_path(const std::vector<ShreddedFieldNode>& nodes,
-                                                  const std::string& target_path) {
-    for (const auto& node : nodes) {
-        if (node.full_path == target_path) return &node;
-        if (!node.children.empty()) {
-            auto* found = find_node_by_path(node.children, target_path);
-            if (found != nullptr) return found;
-        }
-    }
-    return nullptr;
-}
-
 // Auto-discover binding paths from the shredded_fields tree when no explicit shredded_paths are
 // provided.  Stops at ARRAY boundaries (does not recurse into array element children) and at SCALAR
 // leaves.  Struct-like NONE nodes are recursed.


### PR DESCRIPTION
## Why I'm doing:

Two minor BE source-level adjustments surfaced when building on macOS
with Homebrew clang's stricter warning settings. Split out from #72158
per reviewer request.

## What I'm doing:

- `be/src/exec/file_scanner/json_scanner.cpp`: explicit `(void)` cast on
  `column->append_strings()` return value to silence `[[nodiscard]]`
  warnings. Three call sites at the CDC envelope path; the original
  code intentionally ignored the return, the cast just makes that
  explicit.
- `be/src/formats/parquet/complex_column_reader.cpp`: drop the unused
  static `find_node_by_path` function (dead code, no callers).

No logic change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.


## Verification

Compiles cleanly on:
- macOS Apple Silicon, Homebrew LLVM clang (warnings now silent)
- Linux (no diff in generated code)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

> N/A — refactor only, no behavior change.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

> N/A — not a bugfix, no backport needed.
