### PR TITLE
[BugFix] Remap deduped source rowset's sstable via shared_rssid in MERGE

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -62,6 +62,17 @@ public:
 
     bool has_shared_rssid_mapping() const { return !_shared_rssid_map.empty(); }
 
+    // Returns the canonical rssid if |rssid| was deduped, else std::nullopt.
+    // Lets callers distinguish "explicit dedup remap" from "default offset map"
+    // without falling through map_rssid's offset path.
+    std::optional<uint32_t> shared_rssid_map_lookup(uint32_t rssid) const {
+        auto it = _shared_rssid_map.find(rssid);
+        if (it == _shared_rssid_map.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
     // Fills shared_rssid_map so that all rssids occupied by |rowset| map to
     // the corresponding rssid in |canonical_rowset|.
     void update_shared_rssid_map(const RowsetMetadataPB& rowset, const RowsetMetadataPB& canonical_rowset) {
@@ -608,13 +619,53 @@ Status merge_sstables(const std::vector<TabletMergeContext>& merge_contexts, Tab
                     out->mutable_delvec()->CopyFrom(dv_it->second);
                 }
             } else {
-                // No shared_rssid (legacy format): use rssid_offset
+                // No shared_rssid (legacy format): use rssid_offset.
                 if (sst.has_delvec() && sst.delvec().size() > 0) {
                     return Status::Corruption("Sstable has delvec but no shared_rssid, cannot project delvec");
                 }
+                // The high word of max_rss_rowid encodes the largest rssid present in
+                // the sstable's keys — for memtable-flush sstables this equals the
+                // source rowset's id (or id+max_segment_idx for multi-segment rowsets).
+                // If that source rowset is a duplicate of a canonical rowset already
+                // produced by an earlier child (shared_rssid_map hit), the blanket
+                // ctx.rssid_offset() translation would map the sstable's keys to the
+                // duplicate's *would-be* slot in the merged id space — a position that
+                // has no rowset in the merged metadata, since the duplicate was skipped
+                // in merge_rowsets. Subsequent INSERT publishes hit
+                // MetaFileBuilder::update_num_del_stat (meta_file.cpp:608) with
+                //   "unexpected segment id: <ghost_rssid> tablet id: <merged_tablet>"
+                // because PK index lookups return that ghost rssid which has no
+                // corresponding rowset.id+segment_idx mapping.
+                //
+                // Detect this by consulting shared_rssid_map for the sstable's source
+                // rssid. When it maps, switch to the shared_rssid projection: stamp
+                // shared_rssid with the canonical rssid, clear the blanket offset, and
+                // patch the high word of max_rss_rowid. The read path
+                // (persistent_index_sstable.cpp:207) then replaces every key's rssid
+                // with the canonical, which is the correct id for the dedup'd rowset.
+                int64_t high = static_cast<int64_t>(sst.max_rss_rowid() >> 32);
+                if (high >= 0 && high <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+                    auto source_rssid = static_cast<uint32_t>(high);
+                    // Use unconditional map_rssid only when it differs from the simple
+                    // offset translation — i.e. shared_rssid_map has an explicit entry
+                    // for this source rssid, indicating dedup.
+                    auto map_it = ctx.shared_rssid_map_lookup(source_rssid);
+                    if (map_it.has_value()) {
+                        out->set_shared_rssid(*map_it);
+                        // shared_version is required for the read-path remap branch
+                        // (persistent_index_sstable.cpp:207). Use the merged tablet's
+                        // version as a stable >0 marker; the actual numeric value is
+                        // not used for ordering, only for the ">0" gate.
+                        out->set_shared_version(new_metadata->version());
+                        out->set_rssid_offset(0); // do not double-transform
+                        uint64_t low = sst.max_rss_rowid() & 0xffffffffULL;
+                        out->set_max_rss_rowid((static_cast<uint64_t>(*map_it) << 32) | low);
+                        out->clear_delvec();
+                        continue;
+                    }
+                }
                 out->set_rssid_offset(static_cast<int32_t>(ctx.rssid_offset()));
                 uint64_t low = sst.max_rss_rowid() & 0xffffffffULL;
-                int64_t high = static_cast<int64_t>(sst.max_rss_rowid() >> 32);
                 out->set_max_rss_rowid((static_cast<uint64_t>(high + ctx.rssid_offset()) << 32) | low);
                 out->clear_delvec();
             }

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -4030,4 +4030,105 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_covers_a
                                                 _tablet_manager->lcrm_location(tablet_id, "parallel_orphan.crm")));
 }
 
+// merge_sstables's non-shared_rssid branch used to apply ctx.rssid_offset
+// blindly. When a sstable's source rowset is deduped against an earlier
+// child's canonical rowset (shared_rssid_map hit), the offset translation
+// would produce a "ghost" rssid pointing to the duplicate's would-be slot in
+// the merged id space — a position with no rowset, since the duplicate was
+// skipped in merge_rowsets. The downstream symptom is INSERT publish failing
+// at MetaFileBuilder::update_num_del_stat (meta_file.cpp:608) with
+// "unexpected segment id: <ghost> tablet id: <merged>".
+TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_remap_for_deduped_source_rowset) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Both children share rowset id=5 (memtable-flush sstable, no shared_rssid)
+    // plus a unique local rowset. Merge dedups id=5; the dedup'd sstable's
+    // effective rssid at read time must land on rowset.id=5 in merged metadata.
+    auto make_child = [&](int64_t tablet_id, uint32_t local_rowset_id, const std::string& local_seg) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(local_rowset_id + 1);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* shared_rs = meta->add_rowsets();
+        shared_rs->set_id(5);
+        shared_rs->set_version(1);
+        shared_rs->set_num_rows(10);
+        shared_rs->set_data_size(100);
+        shared_rs->add_segments("shared_seg.dat");
+        shared_rs->add_segment_size(100);
+        shared_rs->add_shared_segments(true);
+        auto* shared_sst = meta->mutable_sstable_meta()->add_sstables();
+        shared_sst->set_filename("shared_sst.sst");
+        shared_sst->set_filesize(256);
+        shared_sst->set_shared(true);
+        shared_sst->set_max_rss_rowid((static_cast<uint64_t>(5) << 32) | 99);
+        auto* local_rs = meta->add_rowsets();
+        local_rs->set_id(local_rowset_id);
+        local_rs->set_version(1);
+        local_rs->set_num_rows(10);
+        local_rs->set_data_size(100);
+        local_rs->add_segments(local_seg);
+        local_rs->add_segment_size(100);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a, 6, "a_local.dat");
+    auto meta_b = make_child(child_b, 7, "b_local.dat");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+
+    // Build the rssid coverage map the way meta_file.cpp:580-585 does when
+    // checking PK index consistency.
+    std::unordered_set<uint32_t> covered_rssids;
+    for (const auto& rowset : merged->rowsets()) {
+        for (int j = 0; j < rowset.segments_size(); ++j) {
+            covered_rssids.insert(rowset.id() + static_cast<uint32_t>(j));
+        }
+    }
+
+    // Every sstable in the merged metadata must have its read-time effective
+    // rssid covered by some rowset.id+segment_idx. Otherwise a future INSERT
+    // would hit "unexpected segment id" on publish.
+    for (const auto& sst : merged->sstable_meta().sstables()) {
+        uint32_t effective_rssid;
+        if (sst.has_shared_rssid() && sst.has_shared_version() && sst.shared_version() > 0) {
+            effective_rssid = sst.shared_rssid();
+        } else {
+            // For a key originally written with rssid=5 (the source rowset id):
+            effective_rssid = static_cast<uint32_t>(static_cast<int64_t>(5) + sst.rssid_offset());
+        }
+        EXPECT_TRUE(covered_rssids.count(effective_rssid))
+                << "sstable " << sst.filename() << " effective rssid " << effective_rssid
+                << " has no covering rowset.id+segment_idx in merged metadata";
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`merge_sstables`'s non-shared_rssid branch (`be/src/storage/lake/tablet_merger.cpp:610`) applied `ctx.rssid_offset()` blindly to every legacy memtable-flush sstable. When the sstable's source rowset (high word of `max_rss_rowid`) was a duplicate of another child's canonical rowset (`shared_rssid_map` hit, populated in `merge_rowsets` at `tablet_merger.cpp:247`), the blanket offset translated the sstable's keys to the duplicate's would-be slot in the merged id space — a position with no rowset, since `merge_rowsets` skipped the duplicate.

Downstream, an INSERT publish whose PK index lookup returns that ghost rssid hits the consistency check at `MetaFileBuilder::update_num_del_stat` (`be/src/storage/lake/meta_file.cpp:608`) with:

```
unexpected segment id: <ghost> tablet id: <merged_tablet>
```

The publish parks in `COMMITTED`. The next reshard job allocates its `commitVersion` via `getNextTransactionId()` and waits in `PREPARING` for `visibleVersion` to catch up — but the stuck publish blocks the chain, so `PREPARING` hangs indefinitely and the table is parked in `TABLET_RESHARD`.

This bug had been masking (and was masked by) a related ordering issue fixed in the companion PR for `update_next_rowset_id` (#72172); with the sstable ordering invariant restored, the dedup'd-rowset sstable remap surfaces.

### Reproducer (shared-data PK range distribution, 3-CN cluster)

1. Seed N rows on a range-distributed PK table.
2. Run repeated `SPLIT 1->8 / UPSERT / MERGE 8->1` cycles. Inherited shared rowsets get deduped on each MERGE; their memtable-flush sstables are legacy (no `shared_rssid`) and carry source rssids that match the deduped id.
3. After 2-3 cycles, an INSERT publish on a SPLIT child fails with:
   ```
   Fail to publish version for tablets:[[12094]],
   error msg: unexpected segment id: 90 tablet id: 12094
   ```
4. The next `MERGE_TABLET` job sits in `JOB_STATE=PREPARING` forever.

## What I'm doing:

In `merge_sstables`'s non-shared_rssid branch, derive the source rssid from the high word of the sstable's `max_rss_rowid`. If `shared_rssid_map` has an explicit entry for it, switch the output sstable to the shared_rssid projection:
- stamp `shared_rssid` with the canonical rssid
- set `shared_version` to the merged tablet's version (>0 so the read path takes the remap branch at `persistent_index_sstable.cpp:207`)
- clear `rssid_offset` to avoid double-transform
- patch the high word of `max_rss_rowid`

The read path then replaces every key's rssid with the canonical, matching the surviving `rowset.id+segment_idx` in the merged metadata. When `shared_rssid_map` has no entry, the existing offset path is preserved unchanged.

## Test

`test_tablet_merging_sstable_remap_for_deduped_source_rowset` constructs two children where both carry an identical shared rowset (id=5) plus a unique local rowset, with a legacy memtable-flush sstable encoding source rssid=5 and no `shared_rssid`. After MERGE, the test asserts every sstable's read-path effective rssid lands on a `rowset.id+segment_idx` that exists in the merged metadata — the exact invariant `meta_file.cpp:608` enforces.

All 66 `LakeTabletReshardTest` tests pass locally (65 existing + 1 new).

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Test plan

- [x] BE UT: 66/66 `LakeTabletReshardTest` PASS locally including new test
- [ ] CI: BUILD + BE UT + SQL-Tester green on this branch
- [ ] Integration: validate on the test cluster that v17 S172 5x SPLIT/MERGE/UPSERT cycles complete without the "unexpected segment id" hang