### PR TITLE
[BugFix] CompactionScheduler: relax DB READ to IS + table-READ in startCompaction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -307,13 +307,20 @@ public class CompactionScheduler extends Daemon {
         PhysicalPartition partition;
         Map<Long, List<Long>> beToTablets;
 
+        // Intensive path: IS on DB + READ on this one table. The critical section
+        // only reads / mutates state of one known table (partition lookup,
+        // collectPartitionTablets, beginTransaction, setMinRetainVersion). Concurrent
+        // schema change on this table takes IX + table-WRITE which still conflicts
+        // with our table-READ, preserving the "no shadow index appears before
+        // beginTransaction" invariant the original comment below relies on.
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = partitionIdentifier.getTableId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
 
         try {
             // lake table or lake materialized view
             table = (OlapTable) stateMgr.getLocalMetastore()
-                        .getTable(db.getId(), partitionIdentifier.getTableId());
+                        .getTable(db.getId(), tableId);
 
             // Compact a table of SCHEMA_CHANGE state does not make much sense, because the compacted data
             // will not be used after the schema change job finished.
@@ -335,8 +342,8 @@ public class CompactionScheduler extends Daemon {
                 return null;
             }
 
-            // Note: call `beginTransaction()` in the scope of database reader lock to make sure no shadow index will
-            // be added to this table(i.e., no schema change) before calling `beginTransaction()`.
+            // Note: call `beginTransaction()` while holding the per-table READ lock (intensive path) to make sure
+            // no shadow index will be added to this table (i.e., no schema change) before calling `beginTransaction()`.
             txnId = beginTransaction(partitionIdentifier, partition, info.computeResource);
 
             partition.setMinRetainVersion(currentVersion);
@@ -348,7 +355,7 @@ public class CompactionScheduler extends Daemon {
             LOG.error("Unknown error: {}", e.getMessage());
             return null;
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
 
         long nextCompactionInterval = Config.lake_compaction_interval_ms_on_success;


### PR DESCRIPTION
startCompaction held a DB-wide READ lock across what is effectively a single-table critical section: one getTable lookup, one partition read, collectPartitionTablets, beginTransaction, and setMinRetainVersion.

The critical section only needs to prevent concurrent schema change on the one table being compacted. Switch to the intensive-lock path: IS on DB + READ on that table via lockTableWithIntensiveDbLock. The existing load-bearing invariant ("no shadow index will be added to this table before beginTransaction", per the comment in the method) is preserved because schema change still takes IX + table WRITE, which conflicts with the per-table READ.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
