### PR TITLE
[BugFix] Restrict Ranger root bypass to StarRocks-internal controller

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/RangerAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/RangerAccessController.java
@@ -113,10 +113,6 @@ public abstract class RangerAccessController extends ExternalAccessController im
     protected void hasPermission(RangerAccessResourceImpl resource, UserIdentity user, Set<String> groups,
                                  PrivilegeType privilegeType)
             throws AccessDeniedException {
-        // root user bypasses Ranger authorization entirely
-        if (UserIdentity.ROOT.equals(user)) {
-            return;
-        }
         String accessType;
         if (privilegeType.equals(PrivilegeType.ANY)) {
             accessType = RangerPolicyEngine.ANY_ACCESS;

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/starrocks/RangerStarRocksAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/starrocks/RangerStarRocksAccessController.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.authorization.ranger.starrocks;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.PrivilegeType;
@@ -29,9 +30,11 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.pipe.PipeName;
+import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Locale.ENGLISH;
 
@@ -488,5 +491,18 @@ public class RangerStarRocksAccessController extends RangerAccessController {
     @Override
     public void checkAnyActionOnWarehouse(ConnectContext context, String name) throws AccessDeniedException {
         throw new AccessDeniedException();
+    }
+
+    @Override
+    @VisibleForTesting
+    public void hasPermission(RangerAccessResourceImpl resource, UserIdentity user, Set<String> groups,
+                                 PrivilegeType privilegeType)
+            throws AccessDeniedException {
+        // Restrict Ranger root bypass to StarRocks-internal controller.
+        // External resources (Hive/Iceberg/Hudi/...) must still be evaluated by their own Ranger policies.
+        if (UserIdentity.ROOT.equals(user)) {
+            return;
+        }
+        super.hasPermission(resource, user, groups, privilegeType);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
`RangerAccessController.hasPermission()` short-circuits authorization when
  the current user is the built-in `root`. Because the check lives in the
  abstract base class, every subclass inherits it — including
  `RangerHiveAccessController`, etc.

  As a result, the StarRocks `root` user implicitly becomes a super-user on
  **all** external Ranger-protected catalogs and bypasses the policies
  owned by the external system (Hive Ranger, Iceberg Ranger, ...). This
  breaks the data-lake authorization boundary.

## What I'm doing:
 1. **`RangerAccessController` (base):** removed the `UserIdentity.ROOT`
     short-circuit from `hasPermission`. External Ranger controllers now
     always evaluate Ranger policies, even for the StarRocks `root` user.
  2. **`RangerStarRocksAccessController`:** override `hasPermission` and
     keep the `root` bypass there. The bypass is semantically correct only
     for the StarRocks-internal service, where `root` is the built-in
     super-user. Annotated with `@VisibleForTesting` since the override
     widens visibility to allow direct unit-test invocation.

Fixes #72198


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1.0
  - [x] 4.0.9
  - [x] 4.0.8

