### PR TITLE
[auto-perf-opt] Admission control on PK-index cold rebuilds

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -481,6 +481,19 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
+// Per-CN admission cap on concurrent cold rebuilds in `LakePersistentIndex::load_from_lake_tablet`.
+// During cold-burst scenarios (BE restart, scale-out, first publish after a long idle window) the
+// publish-version pool can dispatch tens of cold rebuilds in the same ~100 ms window. Each rebuild
+// is OSS-RTT- and CPU-bound (multi_get + del_cost dominate the per-task wall time); when they all
+// run together they contend on local CPU and OSS bandwidth, which inflates the per-task time and
+// produces a tail of 7-11 s upsert Max events. Capping concurrency to a small N keeps each admitted
+// task with enough dedicated CPU/IO bandwidth to finish quickly, smoothing the burst from a
+// high-peak/short-duration shape into a lower-peak/longer-duration one. Set <= 0 to disable
+// admission control entirely (legacy behavior). Backed by a process-wide `std::mutex` +
+// `condition_variable` (NOT a threadpool token), so callers from `cloud_native_pk_index_execution`
+// or other internal pools cannot deadlock. Wait time is reported via TRACE counter
+// `cold_rebuild_admission_wait_us`.
+CONF_mInt32(pk_index_cold_rebuild_max_concurrent, "8");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 // The parameters for pk index size-tiered compaction strategy.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -713,6 +713,7 @@
         "pk_index_parallel_execution_min_rows",
         "pk_index_memtable_max_count",
         "pk_index_memtable_max_wait_flush_timeout_ms",
+        "pk_index_cold_rebuild_max_concurrent",
         "pk_index_size_tiered_min_level_size",
         "pk_index_size_tiered_level_multiplier",
         "pk_index_size_tiered_max_level",

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -77,6 +77,20 @@ CONF_mInt64(pk_index_parallel_execution_min_rows, "16384");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 
+// Per-CN admission cap on concurrent cold rebuilds in `LakePersistentIndex::load_from_lake_tablet`.
+// During cold-burst scenarios (BE restart, scale-out, first publish after a long idle window) the
+// publish-version pool can dispatch tens of cold rebuilds in the same ~100 ms window. Each rebuild
+// is OSS-RTT- and CPU-bound (multi_get + del_cost dominate the per-task wall time); when they all
+// run together they contend on local CPU and OSS bandwidth, which inflates the per-task time and
+// produces a tail of 7-11 s upsert Max events. Capping concurrency to a small N keeps each admitted
+// task with enough dedicated CPU/IO bandwidth to finish quickly, smoothing the burst from a
+// high-peak/short-duration shape into a lower-peak/longer-duration one. Set <= 0 to disable
+// admission control entirely (legacy behavior). Backed by a process-wide `std::mutex` +
+// `condition_variable` (NOT a threadpool token), so callers from `cloud_native_pk_index_execution`
+// or other internal pools cannot deadlock. Wait time is reported via TRACE counter
+// `cold_rebuild_admission_wait_us`.
+CONF_mInt32(pk_index_cold_rebuild_max_concurrent, "8");
+
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -14,6 +14,9 @@
 
 #include "storage/lake/lake_persistent_index.h"
 
+#include <condition_variable>
+#include <mutex>
+
 #include "base/debug/trace.h"
 #include "base/utility/defer_op.h"
 #include "column/column_helper.h"
@@ -45,6 +48,52 @@
 #include "storage/sstable/table_builder.h"
 
 namespace starrocks::lake {
+
+namespace {
+
+// Process-wide admission gate for `LakePersistentIndex::load_from_lake_tablet` cold rebuilds.
+// Caps how many cold rebuilds can run concurrently on this BE; the rest wait on a
+// `condition_variable` until a slot frees up. Backed by a `std::mutex`, NOT a threadpool token,
+// so the wait is safe from any thread (including publish-pool workers and
+// `cloud_native_pk_index_execution` workers) and never trips the pool self-submit FATAL check.
+class ColdRebuildAdmission {
+public:
+    static ColdRebuildAdmission& instance() {
+        static ColdRebuildAdmission g;
+        return g;
+    }
+
+    // Acquire a slot. Returns the wait time in microseconds (0 if admitted immediately or
+    // if `max_concurrent <= 0`, in which case the gate is bypassed).
+    int64_t acquire(int max_concurrent) {
+        if (max_concurrent <= 0) {
+            return 0;
+        }
+        const int64_t t0 = GetCurrentTimeMicros();
+        std::unique_lock<std::mutex> lk(_mu);
+        _cv.wait(lk, [this, max_concurrent] { return _in_flight < max_concurrent; });
+        ++_in_flight;
+        return GetCurrentTimeMicros() - t0;
+    }
+
+    void release(int max_concurrent) {
+        if (max_concurrent <= 0) {
+            return;
+        }
+        {
+            std::lock_guard<std::mutex> lk(_mu);
+            --_in_flight;
+        }
+        _cv.notify_one();
+    }
+
+private:
+    std::mutex _mu;
+    std::condition_variable _cv;
+    int _in_flight = 0;
+};
+
+} // namespace
 
 LakePersistentIndex::LakePersistentIndex(TabletManager* tablet_mgr, int64_t tablet_id)
         : PersistentIndex(""), _tablet_mgr(tablet_mgr), _tablet_id(tablet_id) {}
@@ -1047,6 +1096,15 @@ std::pair<size_t, int64_t> LakePersistentIndex::need_rebuild_counts(const Tablet
 Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
                                                   int64_t base_version, const MetaFileBuilder* builder) {
     TRACE_COUNTER_SCOPE_LATENCY_US("pindex_load_from_lake_tablet_us");
+    // Cold-rebuild admission control. During a cold burst (BE restart, scale-out, first publish
+    // after a long idle window) the publish-version pool can dispatch tens of cold rebuilds in the
+    // same ~100 ms window, all of which contend on local CPU and OSS bandwidth. A small
+    // process-wide cap gives each admitted rebuild enough dedicated headroom to finish faster,
+    // smoothing the burst tail. `pk_index_cold_rebuild_max_concurrent <= 0` disables the gate.
+    const int cold_rebuild_cap = config::pk_index_cold_rebuild_max_concurrent;
+    const int64_t admission_wait_us = ColdRebuildAdmission::instance().acquire(cold_rebuild_cap);
+    DeferOp release_admission([cold_rebuild_cap]() { ColdRebuildAdmission::instance().release(cold_rebuild_cap); });
+    TRACE_COUNTER_INCREMENT("cold_rebuild_admission_wait_us", admission_wait_us);
     // 1. create and set key column schema
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata->schema());
     vector<ColumnId> pk_columns(tablet_schema->num_key_columns());


### PR DESCRIPTION
## Summary

Adds a per-CN cap on concurrent `LakePersistentIndex::load_from_lake_tablet`
cold-rebuild executions, gated by new BE config
`pk_index_cold_rebuild_max_concurrent` (default 8; `<=0` disables).

## Motivation

In cold-burst scenarios (BE restart, scale-out, first publish after a long
idle window) the publish-version pool can dispatch tens of cold rebuilds in
the same ~100 ms window. Each rebuild's wall time is dominated by
`multi_get_us` + `rebuild_index_del_cost_us` — both OSS-RTT- and CPU-bound.
Running 30+ concurrently contends on local CPU and OSS bandwidth, inflating
the per-task wall time and producing a visible 7-11 s upsert Max tail in
publish-version traces (observed on shared-data clusters with PK-index
tables, 6 CN × ~30 tablets/burst).

## Mechanism

A process-wide `std::mutex` + `condition_variable` gates entry to the
function. Critically this is a plain CV wait — **NOT** a threadpool token
wait — so it is safe to call from any thread, including:

- Publish-version pool workers (typical caller path).
- `cloud_native_pk_index_execution` workers (inner pool, reachable via
  `_apply_thread_pool` replay during BE startup).
- BE startup `_apply_thread_pool` replay itself.

A token-based gate would risk pool self-submit `LOG(FATAL)` via
`ThreadPool::check_not_pool_thread_unlocked`; the plain CV is unaffected.

On acquire, wait time is recorded in TRACE counter
`cold_rebuild_admission_wait_us` so post-run analysis can quantify
admission contention. If the gate never fires under cold burst, the counter
stays 0 and admission control is effectively a no-op.

## Default tuning

`pk_index_cold_rebuild_max_concurrent = 8`. Each rebuild is naturally
CPU-bound at ~1-3 active cores per task; on a 16 vCPU CN, 8 concurrent
rebuilds leaves headroom while strictly limiting the OSS bandwidth
contention that drives the tail. Operators can tune via
`set config pk_index_cold_rebuild_max_concurrent` at runtime; set `<= 0`
to revert to legacy behavior.

## Files

- `be/src/common/config.h` — new `pk_index_cold_rebuild_max_concurrent` config.
- `be/src/common/config_fwd_headers_manifest.json` — register config.
- `be/src/common/config_primary_key_fwd.h` — regenerated by
  `build-support/gen_config_fwd_headers.py`.
- `be/src/storage/lake/lake_persistent_index.cpp` — admission gate on
  `load_from_lake_tablet` entry, anonymous-namespace `ColdRebuildAdmission`
  singleton.

## Test plan

- [ ] Build BE on TSP.
- [ ] Deploy on the realtime-benchmark 6 CN shared-data test cluster.
- [ ] Trigger a cold burst (BE restart, then immediately run upsert
      workload). Compare cold-burst upsert P99 / Max distribution against a
      pre-PR baseline.
- [ ] Inspect `cold_rebuild_admission_wait_us` in publish-version traces
      to confirm the gate fires when expected.
- [ ] Verify `set config pk_index_cold_rebuild_max_concurrent = 0` reverts
      to legacy behavior at runtime (no BE restart needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)