### PR TITLE
[Doc] Add JDBC native_query documentation

### DIFF
--- a/docs/en/data_source/catalog/jdbc_catalog.md
+++ b/docs/en/data_source/catalog/jdbc_catalog.md
@@ -216,6 +216,19 @@ DROP Catalog jdbc0;
    SELECT * FROM <table_name>;
    ```
 
+## Query JDBC data with native SQL
+
+If a query against a JDBC source cannot be expressed as a single external table scan, for example, because it needs remote joins, remote views, vendor-specific predicates, or a pre-filtered subquery, you can use the `native_query()` table function.
+
+```SQL
+SELECT *
+FROM TABLE(jdbc0.native_query(
+    'SELECT id, name FROM dim_user'
+));
+```
+
+For syntax details, parameter rules, and more examples, see [`native_query()`](../../sql-reference/sql-functions/table-functions/native_query.md).
+
 ## FAQ
 
 What do I do if an error suggesting "Malformed database URL, failed to parse the main URL sections" is thrown?

--- a/docs/en/sql-reference/sql-functions/table-functions/native_query.md
+++ b/docs/en/sql-reference/sql-functions/table-functions/native_query.md
@@ -1,0 +1,90 @@
+---
+displayed_sidebar: docs
+toc_max_heading_level: 4
+---
+
+# `native_query`
+
+`native_query()` is a JDBC query table function. It sends a `SELECT` statement directly to a JDBC catalog, infers the result schema from the remote database, and exposes the result as a regular StarRocks table relation.
+
+Use this function when a query against a JDBC source cannot be expressed as a single external table scan, for example, when the query needs remote joins, remote views, vendor-specific predicates, or a pre-filtered subquery.
+
+## Syntax
+
+```SQL
+TABLE(<catalog_name>.native_query('<sql>'))
+```
+
+## Parameters
+
+- `catalog_name`: The name of an existing JDBC catalog.
+- `sql`: A string literal that contains one remote `SELECT` query. If the remote query itself contains single quotes, escape them by doubling them, for example, `''2026-01-01''`.
+
+## Return value
+
+Returns a table whose schema is inferred from the result metadata of the remote query.
+
+After `native_query()` returns the remote result set, StarRocks can continue to apply local filters, joins, projections, aggregations, and `INSERT INTO` processing on top of that result.
+
+## Usage notes
+
+- `native_query()` is supported only for JDBC catalogs.
+- You must call `native_query()` with `TABLE()`.
+- `native_query()` accepts exactly one argument, and the argument must be a string literal.
+- Named arguments are not supported.
+- The pass-through SQL must start with `SELECT`. `WITH` queries and non-`SELECT` statements are not supported.
+- A table alias is supported, but a column alias list after the table function is not supported. If you need specific output column names, define the aliases inside the pass-through SQL itself.
+- The output columns should have distinct names. If the remote query returns duplicate column names, assign unique aliases in the pass-through SQL.
+- The current user must have the `USAGE` privilege on the target JDBC catalog.
+
+## Examples
+
+Example 1: Query a remote table through a JDBC catalog.
+
+```SQL
+SELECT *
+FROM TABLE(pg_jdbc.native_query(
+    'SELECT c_custkey, c_name, c_nationkey FROM customer'
+));
+```
+
+Example 2: Use database-native filtering in the pass-through SQL, and then apply additional filtering in StarRocks.
+
+```SQL
+SELECT *
+FROM TABLE(pg_jdbc.native_query(
+    'SELECT id, email FROM app_user WHERE email ILIKE ''%starrocks.com'''
+)) AS t
+WHERE t.id < 100;
+```
+
+Example 3: Join the remote query result with a local StarRocks table.
+
+```SQL
+SELECT local_ids.id, remote_users.name
+FROM local_ids
+JOIN TABLE(pg_jdbc.native_query(
+    'SELECT id, name FROM dim_user'
+)) AS remote_users
+ON local_ids.id = remote_users.id;
+```
+
+Example 4: Load the remote query result into an internal StarRocks table.
+
+```SQL
+INSERT INTO sr_orders_stage
+SELECT order_id, customer_id, amount
+FROM TABLE(pg_jdbc.native_query(
+    'SELECT order_id, customer_id, amount
+     FROM orders
+     WHERE order_date >= DATE ''2026-01-01'''
+));
+```
+
+## Related topics
+
+- [JDBC catalog](../../../data_source/catalog/jdbc_catalog.md)
+
+## keywords
+
+table function, jdbc, native query, jdbc catalog

--- a/docs/ja/data_source/catalog/jdbc_catalog.md
+++ b/docs/ja/data_source/catalog/jdbc_catalog.md
@@ -216,6 +216,19 @@ DROP Catalog jdbc0;
    SELECT * FROM <table_name>;
    ```
 
+## ネイティブ SQL を使って JDBC データをクエリする
+
+JDBC データソースに対するクエリを単一の external table scan として表現できない場合、たとえばリモート Join、リモートビュー、データベース固有の述語、または事前に絞り込んだサブクエリが必要な場合は、`native_query()` テーブル関数を使用できます。
+
+```SQL
+SELECT *
+FROM TABLE(jdbc0.native_query(
+    'SELECT id, name FROM dim_user'
+));
+```
+
+構文、パラメータルール、および追加例については、[`native_query()`](../../sql-reference/sql-functions/table-functions/native_query.md) を参照してください。
+
 ## FAQ
 
 「Malformed database URL, failed to parse the main URL sections」というエラーが発生した場合はどうすればよいですか？

--- a/docs/ja/sql-reference/sql-functions/table-functions/native_query.md
+++ b/docs/ja/sql-reference/sql-functions/table-functions/native_query.md
@@ -1,0 +1,90 @@
+---
+displayed_sidebar: docs
+toc_max_heading_level: 4
+---
+
+# `native_query`
+
+`native_query()` は JDBC クエリ用のテーブル関数です。`SELECT` 文を JDBC catalog に直接送信し、リモートデータベースが返す結果メタデータからスキーマを推論して、その結果を通常の StarRocks のテーブルリレーションとして公開します。
+
+この関数は、JDBC データソースに対するクエリを単一の external table scan として表現できない場合に使用します。たとえば、リモート側で Join を実行したい場合、リモートビューを参照したい場合、データベース固有の述語を使いたい場合、またはリモート側で事前にサブクエリによる絞り込みを行いたい場合です。
+
+## 構文
+
+```SQL
+TABLE(<catalog_name>.native_query('<sql>'))
+```
+
+## パラメータ
+
+- `catalog_name`: 既存の JDBC catalog 名。
+- `sql`: リモート側で実行する 1 つの `SELECT` クエリを含む文字列リテラル。リモート SQL 自体にシングルクォートが含まれる場合は、`''2026-01-01''` のように 2 つ重ねてエスケープします。
+
+## 戻り値
+
+リモートクエリの結果メタデータから推論されたスキーマを持つテーブルを返します。
+
+`native_query()` がリモート結果セットを返した後も、StarRocks はその結果に対してローカルのフィルタ、Join、投影、集約、および `INSERT INTO` 処理を継続して適用できます。
+
+## 使用上の注意
+
+- `native_query()` は JDBC catalog でのみサポートされます。
+- `native_query()` は必ず `TABLE()` で呼び出す必要があります。
+- `native_query()` は引数を 1 つだけ受け取り、その引数は文字列リテラルでなければなりません。
+- 名前付き引数はサポートされていません。
+- パススルー SQL は `SELECT` で始まる必要があります。`WITH` クエリおよび `SELECT` 以外の文はサポートされていません。
+- テーブルエイリアスはサポートされますが、テーブル関数の後ろに列エイリアスのリストを付けることはできません。出力列名を指定したい場合は、パススルー SQL の中で列エイリアスを定義してください。
+- 出力列名は一意である必要があります。リモートクエリが重複した列名を返す場合は、パススルー SQL で一意な列エイリアスを付けてください。
+- 現在のユーザーには、対象 JDBC catalog に対する `USAGE` 権限が必要です。
+
+## 例
+
+例 1: JDBC catalog 経由でリモートテーブルをクエリします。
+
+```SQL
+SELECT *
+FROM TABLE(pg_jdbc.native_query(
+    'SELECT c_custkey, c_name, c_nationkey FROM customer'
+));
+```
+
+例 2: パススルー SQL でデータベース固有のフィルタリングを行い、その後 StarRocks 側で追加フィルタを適用します。
+
+```SQL
+SELECT *
+FROM TABLE(pg_jdbc.native_query(
+    'SELECT id, email FROM app_user WHERE email ILIKE ''%starrocks.com'''
+)) AS t
+WHERE t.id < 100;
+```
+
+例 3: リモートクエリ結果をローカルの StarRocks テーブルと Join します。
+
+```SQL
+SELECT local_ids.id, remote_users.name
+FROM local_ids
+JOIN TABLE(pg_jdbc.native_query(
+    'SELECT id, name FROM dim_user'
+)) AS remote_users
+ON local_ids.id = remote_users.id;
+```
+
+例 4: リモートクエリ結果を StarRocks の内部テーブルにロードします。
+
+```SQL
+INSERT INTO sr_orders_stage
+SELECT order_id, customer_id, amount
+FROM TABLE(pg_jdbc.native_query(
+    'SELECT order_id, customer_id, amount
+     FROM orders
+     WHERE order_date >= DATE ''2026-01-01'''
+));
+```
+
+## 関連トピック
+
+- [JDBC catalog](../../../data_source/catalog/jdbc_catalog.md)
+
+## キーワード
+
+table function, jdbc, native query, jdbc catalog

--- a/docs/zh/data_source/catalog/jdbc_catalog.md
+++ b/docs/zh/data_source/catalog/jdbc_catalog.md
@@ -217,6 +217,19 @@ DROP Catalog jdbc0;
    SELECT * FROM <table_name>;
    ```
 
+## 使用原生 SQL 查询 JDBC 数据
+
+如果针对 JDBC 数据源的查询无法表示为一次简单的外表扫描，例如需要在远端执行 Join、访问远端视图、使用数据库方言特有谓词，或者先在远端做子查询过滤，您可以使用 `native_query()` 表函数。
+
+```SQL
+SELECT *
+FROM TABLE(jdbc0.native_query(
+    'SELECT id, name FROM dim_user'
+));
+```
+
+更多语法、参数规则和示例，请参见 [`native_query()`](../../sql-reference/sql-functions/table-functions/native_query.md)。
+
 ## 常见问题
 
 系统返回 "Malformed database URL, failed to parse the main URL sections" 报错应该如何处理？

--- a/docs/zh/sql-reference/sql-functions/table-functions/native_query.md
+++ b/docs/zh/sql-reference/sql-functions/table-functions/native_query.md
@@ -1,0 +1,90 @@
+---
+displayed_sidebar: docs
+toc_max_heading_level: 4
+---
+
+# `native_query`
+
+`native_query()` 是一种 JDBC 查询表函数。它会将 `SELECT` 语句直接下发到 JDBC Catalog 对应的远端数据库，根据远端查询结果的元数据推断返回 Schema，并将结果作为普通的 StarRocks 表关系暴露出来。
+
+当针对 JDBC 数据源的查询无法表示为一次简单的外表扫描时，可以使用该函数，例如：需要在远端执行 Join、访问远端视图、使用数据库方言特有谓词，或者先在远端做子查询过滤。
+
+## 语法
+
+```SQL
+TABLE(<catalog_name>.native_query('<sql>'))
+```
+
+## 参数说明
+
+- `catalog_name`：已有 JDBC Catalog 的名称。
+- `sql`：一个字符串字面量，包含一条远端执行的 `SELECT` 查询。如果远端 SQL 本身包含单引号，需要使用双单引号转义，例如 `''2026-01-01''`。
+
+## 返回值
+
+返回一张表，表的 Schema 根据远端查询结果的元数据自动推断。
+
+`native_query()` 返回远端结果集后，StarRocks 仍然可以继续在其上执行本地过滤、Join、投影、聚合，以及 `INSERT INTO` 等处理。
+
+## 使用说明
+
+- `native_query()` 仅支持 JDBC Catalog。
+- 调用 `native_query()` 时必须使用 `TABLE()` 包裹。
+- `native_query()` 仅接受一个参数，并且该参数必须是字符串字面量。
+- 不支持命名参数。
+- 透传 SQL 必须以 `SELECT` 开头。不支持 `WITH` 查询，也不支持非 `SELECT` 语句。
+- 支持为表函数结果指定表别名，但不支持在表函数后追加列别名列表。如果需要指定输出列名，请直接在透传 SQL 内部定义列别名。
+- 输出列名应保持唯一。如果远端查询返回了重复列名，请在透传 SQL 中为这些列指定唯一别名。
+- 当前用户必须拥有目标 JDBC Catalog 的 `USAGE` 权限。
+
+## 示例
+
+示例一：通过 JDBC Catalog 查询远端表。
+
+```SQL
+SELECT *
+FROM TABLE(pg_jdbc.native_query(
+    'SELECT c_custkey, c_name, c_nationkey FROM customer'
+));
+```
+
+示例二：在透传 SQL 中使用数据库原生过滤能力，然后在 StarRocks 侧继续追加过滤。
+
+```SQL
+SELECT *
+FROM TABLE(pg_jdbc.native_query(
+    'SELECT id, email FROM app_user WHERE email ILIKE ''%starrocks.com'''
+)) AS t
+WHERE t.id < 100;
+```
+
+示例三：将远端查询结果与本地 StarRocks 表做 Join。
+
+```SQL
+SELECT local_ids.id, remote_users.name
+FROM local_ids
+JOIN TABLE(pg_jdbc.native_query(
+    'SELECT id, name FROM dim_user'
+)) AS remote_users
+ON local_ids.id = remote_users.id;
+```
+
+示例四：将远端查询结果写入 StarRocks 内表。
+
+```SQL
+INSERT INTO sr_orders_stage
+SELECT order_id, customer_id, amount
+FROM TABLE(pg_jdbc.native_query(
+    'SELECT order_id, customer_id, amount
+     FROM orders
+     WHERE order_date >= DATE ''2026-01-01'''
+));
+```
+
+## 相关文档
+
+- [JDBC Catalog](../../../data_source/catalog/jdbc_catalog.md)
+
+## keywords
+
+表函数，JDBC，native query，JDBC Catalog


### PR DESCRIPTION
## Why I'm doing:

The JDBC `native_query()` feature was added in [#72005](https://github.com/StarRocks/starrocks/pull/72005), but it does not have user-facing documentation yet.

## What I'm doing:

- Add a dedicated `native_query()` function document under `docs/en`, `docs/zh`, and `docs/ja`
- Add entry links from the JDBC catalog documents in `docs/en`, `docs/zh`, and `docs/ja`
- Document syntax, parameter rules, usage notes, and examples for querying JDBC data with pass-through SQL

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Validation

- `git diff --cached --check`
- Full Docusaurus build was not run for this docs-only change.