### PR TITLE
[Enhancement] Parallelize phase 2 (index.upsert) of non-SST condition merge

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -368,6 +368,8 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     // Check if parallel row-mode partial update is applicable.
     int32_t condition_column = _get_condition_column(op_write, *tablet_schema);
     const bool has_condition_update = (condition_column >= 0);
+    // Skip early sst compact when condition update with pregenerate sst files.
+    bool skip_early_sst_compact = false;
     const bool is_row_mode_partial_update =
             op_write.has_txn_meta() && op_write.rewrite_segments_size() > 0 && op_write.rowset().num_rows() > 0;
     const bool use_parallel_partial_update = config::enable_pk_index_parallel_execution && is_row_mode_partial_update &&
@@ -460,6 +462,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                     dv_generated_during_merge_update->init(metadata->version(), itr->second.data(), itr->second.size());
                     builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
                 }
+                skip_early_sst_compact = true;
             } else {
                 // NON-SST CONDITION MERGE PATH:
                 // When SST files are absent, new-row condition values are read from the freshly
@@ -494,7 +497,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                     async_compact_cb = nullptr;
                 }
             }
-            if (async_compact_cb == nullptr && !has_condition_update &&
+            if (async_compact_cb == nullptr && !skip_early_sst_compact &&
                 index.current_fileset_index() - current_fileset_start_idx >=
                         config::pk_index_early_sst_compaction_threshold) {
                 TRACE_COUNTER_INCREMENT("early_sst_compact_times", 1);
@@ -1164,7 +1167,6 @@ Status UpdateManager::_do_update_with_condition_parallel(const RowsetUpdateState
     }
 
     if (token) {
-        TRACE_COUNTER_SCOPE_LATENCY_US("parallel_condition_update_wait_us");
         // Barrier: Wait for all submitted tasks to complete before proceeding
         // IMPORTANT: Ensures all deletions are collected before returning
         token->wait();
@@ -1342,29 +1344,109 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
     }
 
     if (token) {
-        TRACE_COUNTER_SCOPE_LATENCY_US("parallel_condition_update_wait_us");
+        TRACE_COUNTER_SCOPE_LATENCY_US("condition_update_compare_phase_us");
         token->wait();
     }
     RETURN_IF_ERROR(status);
     RETURN_IF_ERROR(upsert->status());
 
-    // Serial merge: apply index.upsert to each chunk's winner ranges and record new-losers.
-    // rowid_start=chunk_offset ensures the index records rowids that match the segment file layout.
+    // PHASE 2: apply index.upsert for each chunk's winners.
+    //
+    // For cloud-native persistent index, every chunk's winning rows are compacted into a single
+    // contiguous PK column and submitted via the parallel-publish overload
+    // `index.upsert(rssid, rowids, pks, stat, ctx)`. The active-memtable write happens
+    // synchronously here (the memtable is not thread-safe), while the SST / inactive-memtable
+    // lookup of replaced old values is offloaded to ctx->token. Replaced old rowids are appended
+    // to `new_deletes` by the lookup tasks under `upsert_mutex`.
+    //
+    // WHY compact-per-chunk instead of one task per winner range:
+    //   build_persistent_keys() materializes one Slice per row of the *whole* chunk PK column
+    //   on the binary/string path, so a per-range slot would cost chunk_size Slices regardless
+    //   of range size. Fragmented winner ranges (e.g. alternating winners and losers) would
+    //   then accumulate O(num_ranges * chunk_size) live Slices across all in-flight slots, which
+    //   can blow up memory for large publishes. Compacting bounds each slot's per-row buffers
+    //   to the actual winner count.
+    //
+    // For local persistent index (non-cloud-native), the parallel-publish overload is not
+    // supported, so we fall back to the serial sliced upsert keyed by chunk_offset.
     const uint32_t rssid = rowset_id + upsert_idx;
+    const bool use_parallel_upsert = (token != nullptr) && use_cloud_native_pk_index(*params.metadata);
+    if (use_parallel_upsert) {
+        std::mutex upsert_mutex;
+        Status upsert_status = Status::OK();
+        ParallelPublishContext upsert_ctx{
+                .token = token.get(), .mutex = &upsert_mutex, .deletes = new_deletes, .status = &upsert_status};
+        for (const auto& result : chunk_results) {
+            // pk_column is guaranteed non-null when the compare task returned OK; if any task
+            // had failed we would have bailed at the RETURN_IF_ERROR(status) above the barrier.
+            DCHECK(result->pk_column != nullptr);
+            if (result->winner_ranges.empty()) {
+                continue;
+            }
+            size_t total_winners = 0;
+            for (const auto& range : result->winner_ranges) {
+                total_winners += static_cast<size_t>(range.second - range.first);
+            }
+            if (total_winners == 0) {
+                continue;
+            }
+            // Compact winner indices and absolute rowids; build a winner-only PK column so the
+            // submitted lookup task only sees `total_winners` keys.
+            std::vector<uint32_t> winner_local_indices;
+            winner_local_indices.reserve(total_winners);
+            std::vector<uint32_t> winner_rowids;
+            winner_rowids.reserve(total_winners);
+            const auto chunk_offset = static_cast<uint32_t>(result->chunk_offset);
+            for (const auto& range : result->winner_ranges) {
+                for (uint32_t i = range.first; i < range.second; ++i) {
+                    winner_local_indices.push_back(i);
+                    winner_rowids.push_back(chunk_offset + i);
+                }
+            }
+            auto winner_pk_column = result->pk_column->clone_empty();
+            winner_pk_column->append_selective(*result->pk_column, winner_local_indices.data(), 0,
+                                               winner_local_indices.size());
+            // Allocate the slot and move the compacted column into it BEFORE submission so the
+            // backing Slice array stays alive for the lookup task.
+            upsert_ctx.extend_slots();
+            auto* slot = upsert_ctx.slots.back().get();
+            slot->pk_column = std::move(winner_pk_column);
+            auto st = index.upsert(rssid, winner_rowids, *slot->pk_column, /*stat=*/nullptr, &upsert_ctx);
+            if (!st.ok()) {
+                std::lock_guard<std::mutex> lock(upsert_mutex);
+                upsert_status.update(st);
+            }
+        }
+        {
+            TRACE_COUNTER_SCOPE_LATENCY_US("condition_update_upsert_phase_us");
+            token->wait();
+        }
+        RETURN_IF_ERROR(upsert_status);
+        // Persist the active-memtable batch built up by the parallel upserts.
+        RETURN_IF_ERROR(index.flush_memtable());
+    } else {
+        // Serial fallback: rowid_start=chunk_offset so the index records rowids matching the
+        // segment file layout for each contiguous winner range.
+        for (const auto& result : chunk_results) {
+            DCHECK(result->pk_column != nullptr);
+            for (const auto& range : result->winner_ranges) {
+                RETURN_IF_ERROR(index.upsert(rssid, static_cast<uint32_t>(result->chunk_offset), *result->pk_column,
+                                             range.first, range.second, new_deletes));
+            }
+        }
+    }
+
+    // Append new-loser rowids to new_deletes. Safe to do here: phase 2 lookup tasks only
+    // append old rowids for displaced index entries (whose rssids are different from the
+    // freshly-ingested segment's rssid), and we are past the token barrier anyway.
     for (const auto& result : chunk_results) {
-        if (result->pk_column == nullptr) {
+        if (result->new_loser_local_ids.empty()) {
             continue;
         }
-        for (const auto& range : result->winner_ranges) {
-            RETURN_IF_ERROR(index.upsert(rssid, static_cast<uint32_t>(result->chunk_offset), *result->pk_column,
-                                         range.first, range.second, new_deletes));
-        }
-        if (!result->new_loser_local_ids.empty()) {
-            auto& seg_deletes = (*new_deletes)[rssid];
-            seg_deletes.reserve(seg_deletes.size() + result->new_loser_local_ids.size());
-            for (uint32_t local : result->new_loser_local_ids) {
-                seg_deletes.push_back(static_cast<uint32_t>(result->chunk_offset) + local);
-            }
+        auto& seg_deletes = (*new_deletes)[rssid];
+        seg_deletes.reserve(seg_deletes.size() + result->new_loser_local_ids.size());
+        for (uint32_t local : result->new_loser_local_ids) {
+            seg_deletes.push_back(static_cast<uint32_t>(result->chunk_offset) + local);
         }
     }
     return Status::OK();

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1511,6 +1511,27 @@ Status PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Column& 
     }
 }
 
+Status PrimaryIndex::upsert(uint32_t rssid, const std::vector<uint32_t>& rowids, const Column& pks, IOStat* stat,
+                            ParallelPublishContext* ctx) {
+    DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    if (_persistent_index != nullptr) {
+        auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
+        const uint32_t n = pks.size();
+        DCHECK_EQ(rowids.size(), n);
+        DCHECK(ctx != nullptr && !ctx->slots.empty());
+        auto slot = ctx->slots.back().get();
+        slot->values.reserve(n);
+        slot->old_values.resize(n, NullIndexValue);
+        ASSIGN_OR_RETURN(const Slice* vkeys, build_persistent_keys(pks, _key_size, 0, n, &slot->keys));
+        RETURN_IF_ERROR(_build_persistent_values(rssid, rowids, 0, n, &slot->values));
+        RETURN_IF_ERROR(_persistent_index->upsert(n, vkeys, reinterpret_cast<IndexValue*>(slot->values.data()),
+                                                  reinterpret_cast<IndexValue*>(slot->old_values.data()), stat, ctx));
+        return Status::OK();
+    } else {
+        return Status::NotSupported("rowids upsert with thread pool is not supported in memory primary index");
+    }
+}
+
 Status PrimaryIndex::_replace_persistent_index_by_indexes(uint32_t rssid, uint32_t rowid_start,
                                                           const std::vector<uint32_t>& replace_indexes,
                                                           const Column& pks) {

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -80,6 +80,25 @@ public:
     Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, IOStat* stat = nullptr,
                   ParallelPublishContext* ctx = nullptr);
 
+    // Parallel-publish overload that upserts an arbitrary subset of rows by absolute rowids:
+    // pks[i] is upserted at (rssid, rowids[i]). The active-memtable write happens synchronously
+    // in the caller; the SST/inactive-memtable lookup of replaced old values is submitted to
+    // ctx->token. Each call requires its own slot in `ctx` (caller must `extend_slots()` first).
+    //
+    // Replaced old rowids are appended to `ctx->deletes` under `ctx->mutex` by the lookup task.
+    // Caller is expected to drive `ctx->token->wait()` and `flush_memtable()` once all upsert
+    // submissions are done.
+    //
+    // Only supported on cloud-native persistent index (returns NotSupported otherwise).
+    //
+    // WHY this takes a compact (rowids, pks) rather than a sliced (idx_begin, idx_end) view:
+    // build_persistent_keys() materializes one Slice per row of the *whole* binary/string PK
+    // column, so a per-range slot would cost chunk_size Slices regardless of range size and
+    // multiplicatively blow up memory when winner ranges are fragmented. Compacting before
+    // submission keeps each slot's per-row buffers proportional to the actual upsert size.
+    Status upsert(uint32_t rssid, const std::vector<uint32_t>& rowids, const Column& pks, IOStat* stat,
+                  ParallelPublishContext* ctx);
+
     // replace old values and insert when key not exist.
     // Used in compaction apply & publish.
     // [not thread-safe]

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -616,6 +616,104 @@ TEST_P(ConditionUpdateTest, test_condition_update_no_sst_parallel_all_new_keys) 
               }));
 }
 
+// Stresses the per-chunk compact path of the phase-2 parallel index.upsert in
+// `_do_update_with_condition`: every other row in the condition update is a loser
+// (existing c1 wins) and every other row is a winner (new c1 wins). With a 50/50
+// alternating pattern the compare phase emits the maximum number of winner ranges
+// per chunk (run-length 1), which is the worst case for the per-range slot scheme
+// the PR replaced. The expected merged state mixes baseline rows and update rows
+// row-by-row.
+TEST_P(ConditionUpdateTest, test_condition_update_no_sst_parallel_fragmented_winners) {
+    ConfigResetGuard<bool> guard(&config::enable_pk_index_parallel_execution, true);
+
+    const int64_t chunk_size = 5 * 4096; // 20K rows, multiple per-segment chunks
+    ConfigResetGuard<int64_t> guard2(&config::pk_index_parallel_execution_min_rows, 4096);
+
+    auto baseline = generate_data(chunk_size, 0, 3, 4); // baseline c1=k*3, c2=k*4
+    auto indexes = std::vector<uint32_t>(chunk_size);
+    for (int i = 0; i < chunk_size; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(baseline, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Build an alternating chunk: even rows have c1=k*2 (loser, < baseline c1=k*3),
+    // odd rows have c1=k*4 (winner, > baseline). c2 in update is k*9.
+    Chunk alt;
+    {
+        std::vector<int> v0(chunk_size);
+        std::vector<int> v1(chunk_size);
+        std::vector<int> v2(chunk_size);
+        std::vector<std::string> key_col_str(chunk_size);
+        std::vector<Slice> key_col(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            v0[i] = i;
+            key_col_str[i] = std::to_string(v0[i]);
+            key_col[i] = Slice(key_col_str[i]);
+            v1[i] = (i % 2 == 0) ? v0[i] * 2 : v0[i] * 4;
+            v2[i] = v0[i] * 9;
+        }
+        auto c0 = BinaryColumn::create();
+        auto c1 = Int32Column::create();
+        auto c2 = Int32Column::create();
+        c0->append_strings(key_col.data(), key_col.size());
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        c2->append_numbers(v2.data(), v2.size() * sizeof(int));
+        alt = Chunk({std::move(c0), std::move(c1), std::move(c2)}, _schema);
+    }
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_merge_condition("c1")
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(alt, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Even rows: baseline wins, c1=k*3, c2=k*4.
+    // Odd rows: update wins, c1=k*4, c2=k*9.
+    // k=0 is a special case (every multiplier collapses to 0); both winner and loser produce
+    // c1=0, c2=0, so accept either combination there.
+    ASSERT_EQ(chunk_size, check(version, [](int c0, int c1, int c2) {
+                  if (c0 == 0) {
+                      return c1 == 0 && c2 == 0;
+                  }
+                  if (c0 % 2 == 0) {
+                      return c1 == c0 * 3 && c2 == c0 * 4;
+                  }
+                  return c1 == c0 * 4 && c2 == c0 * 9;
+              }));
+}
+
 INSTANTIATE_TEST_SUITE_P(ConditionUpdateTest, ConditionUpdateTest, ::testing::Values(PrimaryKeyParam{true}));
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

> **Note**: This PR is stacked on top of #72112 (parallel-condition-merge). Until that merges, this PR's diff includes the three phase-1 commits as well. Once #72112 lands, I will rebase this branch onto `main` and only the phase-2 commit will remain in the PR diff.

PR #72112 parallelized phase 1 (the chunk-level compare phase) of `_do_update_with_condition`, taking publish latency from ~13s to ~6.5s on a 4 GB single-tablet condition update. The remaining 6.5s is now dominated by phase 2 — the post-barrier loop calling `index.upsert(rssid, rowid_start, pks, idx_begin, idx_end, deletes)` once per winner range, serially.

`LakePersistentIndex::upsert(... ctx)` already supports a parallel-publish path: the active-memtable write is serial (memtable is not thread-safe) but the SST / inactive-memtable lookup of replaced old values is offloaded to `ctx->token`. We just weren't feeding it a context.

## What I'm doing:

1. Add a public `PrimaryIndex::upsert` overload taking `(rssid, rowid_start, pks, idx_begin, idx_end, IOStat*, ParallelPublishContext*)` that forwards to the existing private `_upsert_into_persistent_index(... ctx)`. Returns `NotSupported` on the in-memory primary index, which mirrors the existing parallel-upsert overload's behavior.

2. Rewire the post-barrier section of `_do_update_with_condition` (added in #72112):
   - For each chunk's winner range, `extend_slots()` then submit via the new API. Each submission fires off a SST/inactive-memtable lookup task on the shared `pk_index_execution_thread_pool` token; the lookup task appends replaced old rowids to `new_deletes` under the context mutex.
   - After all submissions, `token->wait()` then `flush_memtable()` to persist the accumulated batch atomically.
   - Append `new_loser` rowids to `new_deletes` after the barrier (safe: lookup tasks only touch deletes for *displaced old rssids*, not the freshly-ingested new rssid).
   - Falls back to the existing serial sliced upsert when `enable_pk_index_parallel_execution=false` or the PK index is non-cloud-native.

The active-memtable write itself stays serial in the orchestrator thread, which is the same constraint `LakePrimaryIndex::parallel_upsert` operates under for the no-condition path.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4