### PR TITLE
[BugFix] should only use base table's mv in AggregateJoinPushDownRule (backport #68600)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateJoinPushDownRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateJoinPushDownRule.java
@@ -131,13 +131,13 @@ public class AggregateJoinPushDownRule extends BaseMaterializedViewRewriteRule {
     public List<MaterializationContext> doPrune(OptExpression queryExpression,
                                                 OptimizerContext context,
                                                 List<MaterializationContext> mvCandidateContexts) {
-        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryExpression);
+        List<LogicalScanOperator> scanOperators = getScanOperator(queryExpression);
         List<MaterializationContext> validCandidateContexts = Lists.newArrayList();
         for (MaterializationContext mvContext : mvCandidateContexts) {
-            if (isLogicalSPG(mvContext.getMvExpression()) && validMv(mvContext, scanOperators)) {
+            if (!isLogicalSPG(mvContext.getMvExpression())) {
+                logMVRewrite(mvContext, this, "mv pruned: not logical SPG");
+            } else if (validMv(mvContext, scanOperators)) {
                 validCandidateContexts.add(mvContext);
-            } else {
-                logMVRewrite(mvContext, this, "mv pruned: not logical SPG or not contain all columns used in scan");
             }
         }
         return validCandidateContexts;
@@ -150,16 +150,40 @@ public class AggregateJoinPushDownRule extends BaseMaterializedViewRewriteRule {
         Set<String> mvUsedColNames = mvUsedColRefs.stream()
                 .map(ColumnRefOperator::getName)
                 .collect(Collectors.toSet());
+        boolean baseTableFoundInMv = false;
         for (LogicalScanOperator scanOperator : scanOperators) {
             if (scanOperator.getTable().getId() != baseTableId) {
                 continue;
             }
+            baseTableFoundInMv = true;
             // mv should contain all columns that used in at least one query
             if (mvContainsAllColumnsUsedInScan(mvUsedColNames, scanOperator)) {
                 return true;
             }
         }
+        if (baseTableFoundInMv) {
+            logMVRewrite(mvContext, this, "mv pruned: not contain all columns used in scan");
+        }
         return false;
+    }
+
+    private List<LogicalScanOperator> getScanOperator(OptExpression root) {
+        List<LogicalScanOperator> scanOperators = Lists.newArrayList();
+        getScanOperator(root, scanOperators);
+        return scanOperators;
+    }
+
+    private void getScanOperator(OptExpression root, List<LogicalScanOperator> scanOperators) {
+        if (root.getOp() instanceof LogicalScanOperator) {
+            scanOperators.add((LogicalScanOperator) root.getOp());
+        } else {
+            for (OptExpression child : root.getInputs()) {
+                if (child.getOp() instanceof LogicalAggregationOperator) {
+                    return;
+                }
+                getScanOperator(child, scanOperators);
+            }
+        }
     }
 
     private boolean mvContainsAllColumnsUsedInScan(Set<String> mvUsedColNames, LogicalScanOperator scanOperator) {


### PR DESCRIPTION
Backport of #68600 to `branch-3.5-cc`.

Original commit: b38e14ebcfbd95d000a12ad663080740ea4a066e
Original PR: https://github.com/StarRocks/starrocks/pull/68600

---

<!-- Original PR description below -->

## Why I'm doing:
```sql
explain

SELECT  COUNT(*) AS cnt
FROM
(
SELECT  pt,id,sum(gmv)
FROM test_base_table
WHERE pt ='2025-12-12'
AND id IN ( SELECT id FROM test_sub_table WHERE pt = '2025-12-12' GROUP BY id)
GROUP BY  pt,id
) T;

```

Both `test_base_table`'s mv `test_base_mv` and `test_sub_table`'s mv `test_sub_mv` should be used, but `test_base_mv` is **not** used currently

## What I'm doing:
The cause of this issue is that both `test_base_mv` and `test_sub_mv` are candidate mv, but `test_sub_mv` is selected as best mv in `BestMvSelector`  rather than `test_base_mv`.

This patch makes sure only `test_base_table`'s mv is selected as candidate mv in `AggregateJoinPushDownRule`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
<hr>This is an automatic backport of pull request #68571 done by [Mergify](https://mergify.com).
