### PR TITLE
[BugFix] Add brute-force distance fallback when vector index file is missing

### DIFF
--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -282,6 +282,8 @@ Status Segment::_open(size_t* footer_length_hint, const FooterPointerPB* partial
     RETURN_IF_ERROR(_create_column_readers(&footer));
     _num_rows = footer.num_rows();
     _short_key_index_page = PagePointer(footer.short_key_index_page());
+    _skip_vector_index =
+            footer.has_vector_index_storage_type() && footer.vector_index_storage_type() == VECTOR_INDEX_STORAGE_NONE;
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -195,6 +195,12 @@ public:
 
     uint32_t num_rows() const { return _num_rows; }
 
+    // True when the segment footer explicitly marks no .vi file for this segment
+    // (e.g. the writer's vector index build threshold was not met). The
+    // SegmentIterator uses this to skip opening the .vi file and go straight to
+    // the brute-force distance-computation fallback.
+    bool skip_vector_index() const { return _skip_vector_index; }
+
     // Load and decode short key index.
     // May be called multiple times, subsequent calls will no op.
     Status load_index(const LakeIOOptions& lake_io_opts = {});
@@ -311,6 +317,7 @@ private:
     uint32_t _segment_id = 0;
     uint32_t _num_rows = 0;
     PagePointer _short_key_index_page;
+    bool _skip_vector_index = false;
 
     // ColumnReader for each column in TabletSchema. If ColumnReader is nullptr,
     // This means that this segment has no data for that column, which may be added

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2288,9 +2288,23 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         chunk->append_vector_column(std::move(distance_column), _make_field(_vector_index_ctx->vector_column_id),
                                     _vector_index_ctx->vector_slot_id);
     } else if (_vector_index_ctx && _vector_index_ctx->use_brute_force) {
-        // Brute-force fallback: compute distances from raw vector data in chunk
+        // Brute-force fallback: compute distances from raw vector data.
+        //
+        // The vector data column may live in `chunk` (== _final_chunk) or in
+        // _dict_chunk depending on output_schema:
+        //   * If output_schema includes the vector column (FE did not prune it),
+        //     _build_final_chunk has already SWAPPED the column out of _dict_chunk
+        //     into chunk. _dict_chunk's slot is now empty; read from chunk.
+        //   * If output_schema does NOT include the vector column (FE pruned it,
+        //     and _setup_brute_force_fallback re-added it to _schema after the
+        //     caller's init_output_schema froze output_schema), the swap skipped
+        //     it. The column is still in _dict_chunk; read from there.
+        // Either way, the distance column is appended to `chunk`, which always has
+        // the planner-allocated distance slot.
         auto vec_col_id = _vector_index_ctx->vector_data_column_id;
-        const auto& vector_column = chunk->get_column_by_id(vec_col_id);
+        ColumnPtr vector_column =
+                chunk->is_cid_exist(vec_col_id) ? chunk->get_column_by_id(vec_col_id)
+                                                : _context->_dict_chunk->get_column_by_id(vec_col_id);
         _compute_brute_force_distances(vector_column.get(), chunk);
 
         // Apply vector_range filter before removing columns, so slot_id mapping is intact

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2349,14 +2349,12 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         // Either way, the distance column is appended to `chunk`, which always has
         // the planner-allocated distance slot.
         auto vec_col_id = _vector_index_ctx->vector_data_column_id;
-        ColumnPtr vector_column = chunk->is_cid_exist(vec_col_id)
-                                          ? chunk->get_column_by_id(vec_col_id)
-                                          : _context->_dict_chunk->get_column_by_id(vec_col_id);
+        ColumnPtr vector_column = chunk->is_cid_exist(vec_col_id) ? chunk->get_column_by_id(vec_col_id)
+                                                                  : _context->_dict_chunk->get_column_by_id(vec_col_id);
         DCHECK_EQ(vector_column->size(), chunk->num_rows())
                 << "brute-force vector column row count must match chunk; row alignment was lost";
         if (UNLIKELY(vector_column->size() != chunk->num_rows())) {
-            return Status::InternalError(
-                    "brute-force vector column row count does not match chunk row count");
+            return Status::InternalError("brute-force vector column row count does not match chunk row count");
         }
         _compute_brute_force_distances(vector_column.get(), chunk);
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2302,9 +2302,8 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         // Either way, the distance column is appended to `chunk`, which always has
         // the planner-allocated distance slot.
         auto vec_col_id = _vector_index_ctx->vector_data_column_id;
-        ColumnPtr vector_column =
-                chunk->is_cid_exist(vec_col_id) ? chunk->get_column_by_id(vec_col_id)
-                                                : _context->_dict_chunk->get_column_by_id(vec_col_id);
+        ColumnPtr vector_column = chunk->is_cid_exist(vec_col_id) ? chunk->get_column_by_id(vec_col_id)
+                                                                  : _context->_dict_chunk->get_column_by_id(vec_col_id);
         _compute_brute_force_distances(vector_column.get(), chunk);
 
         // Apply vector_range filter before removing columns, so slot_id mapping is intact

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -15,12 +15,15 @@
 #include "segment_iterator.h"
 
 #include <algorithm>
+#include <cmath>
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <utility>
 
 #include "base/simd/simd.h"
 #include "base/utility/defer_op.h"
+#include "column/array_column.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/datum_tuple.h"
@@ -279,6 +282,13 @@ private:
         int result_order = 0;
         bool use_ivfpq = false;
 
+        // Brute-force fallback fields (when .vi file is missing)
+        bool use_brute_force = false;
+        bool is_cosine_similarity = false; // metric type from index metadata
+        ColumnId vector_data_column_id = 0;
+        int32_t vector_data_column_uid = -1;
+        bool added_vector_data_column = false; // true if we appended vector column to _schema
+
 #ifdef WITH_TENANN
         tenann::PrimitiveSeqView query_view;
         std::shared_ptr<tenann::IndexMeta> index_meta;
@@ -287,7 +297,7 @@ private:
         std::shared_ptr<VectorIndexReader> ann_reader;
 
         // Helper method to check if rowid should always be built
-        bool always_build_rowid() const { return use_vector_index && !use_ivfpq; }
+        bool always_build_rowid() const { return (use_vector_index || use_brute_force) && !use_ivfpq; }
     };
 
     // Inverted index related context, only created when needed
@@ -438,7 +448,10 @@ private:
 
     bool need_early_materialize_subfield(const FieldPtr& field);
 
+    Status _prepare_vector_index();
     Status _init_ann_reader();
+    void _setup_brute_force_fallback(const TabletIndex& index);
+    void _compute_brute_force_distances(const Column* vector_column, Chunk* chunk);
 
     IndexReadOptions _index_read_options(ColumnId cid) const;
 
@@ -876,9 +889,10 @@ Status SegmentIterator::_init_internal() {
     // The main task is to do some initialization,
     // initialize the iterator and check if certain optimizations can be applied
     _init_column_access_paths();
+    RETURN_IF_ERROR(_prepare_vector_index());
+    RETURN_IF_ERROR(_init_ann_reader());
     RETURN_IF_ERROR(_check_low_cardinality_optimization());
     RETURN_IF_ERROR(_init_column_iterators<true>(_schema));
-    RETURN_IF_ERROR(_init_ann_reader());
     // filter by index stage
     // Use indexes and predicates to filter some data page
     RETURN_IF_ERROR(_get_row_ranges_by_rowid_range());
@@ -932,14 +946,14 @@ inline Status SegmentIterator::_init_reader_from_file(const std::string& index_p
     _vector_index_ctx->index_meta = std::make_shared<tenann::IndexMeta>(std::move(meta));
     auto create_st = VectorIndexReaderFactory::create_from_file(index_path, _vector_index_ctx->index_meta,
                                                                 &_vector_index_ctx->ann_reader, fs);
-    // .vi file not found — fallback to brute-force scan
+    // .vi file not found — caller will set up brute-force fallback
     if (create_st.is_not_found()) {
         _vector_index_ctx->use_vector_index = false;
         return Status::OK();
     }
     RETURN_IF_ERROR(create_st);
     auto status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), index_path, fs);
-    // means empty ann reader — fallback to brute-force scan
+    // empty ann reader — caller will set up brute-force fallback
     if (status.is_not_supported()) {
         _vector_index_ctx->use_vector_index = false;
         return Status::OK();
@@ -950,48 +964,118 @@ inline Status SegmentIterator::_init_reader_from_file(const std::string& index_p
 #endif
 }
 
+// Sets up brute-force fallback state and ensures the vector data column is in _schema.
+// Called from _prepare_vector_index and _init_ann_reader, both before _init_column_iterators.
+void SegmentIterator::_setup_brute_force_fallback(const TabletIndex& index) {
+    int32_t vector_col_uid = index.col_unique_ids()[0];
+    _vector_index_ctx->use_vector_index = false;
+    _vector_index_ctx->use_brute_force = true;
+    _vector_index_ctx->vector_data_column_uid = vector_col_uid;
+
+    // Determine metric type from index metadata
+    const auto& props = index.common_properties();
+    auto metric_it = props.find("metric_type");
+    if (metric_it != props.end()) {
+        std::string metric = metric_it->second;
+        std::transform(metric.begin(), metric.end(), metric.begin(), ::tolower);
+        _vector_index_ctx->is_cosine_similarity = (metric == "cosine_similarity");
+    }
+
+    // Check if the vector column is already in _schema
+    for (const auto& field : _schema.fields()) {
+        if (field->uid() == vector_col_uid) {
+            _vector_index_ctx->vector_data_column_id = field->id();
+            return;
+        }
+    }
+
+    // Not in schema (pruned by FE) — add it
+    int32_t col_idx = _segment->tablet_schema().field_index(vector_col_uid);
+    if (col_idx >= 0) {
+        const auto& col = _segment->tablet_schema().column(col_idx);
+        ColumnId cid = static_cast<ColumnId>(col_idx);
+        auto field = std::make_shared<Field>(ChunkHelper::convert_field(cid, col));
+        _vector_index_ctx->vector_data_column_id = cid;
+        _schema.append(field);
+        _vector_index_ctx->added_vector_data_column = true;
+    }
+}
+
+// Handles the case where the segment footer explicitly marks no .vi file (skip_vector_index).
+// Adds the vector column to _schema so it's read in the same I/O pass as other columns.
+Status SegmentIterator::_prepare_vector_index() {
+    if (!_vector_index_ctx || !_vector_index_ctx->use_vector_index || _vector_index_ctx->use_ivfpq) {
+        return Status::OK();
+    }
+
+    if (!_segment->skip_vector_index()) {
+        return Status::OK();
+    }
+
+    // Footer marks no .vi file — find the vector index and set up brute-force
+    for (const auto& index : *_segment->tablet_schema().indexes()) {
+        if (index.index_type() == VECTOR && !index.col_unique_ids().empty()) {
+            _setup_brute_force_fallback(index);
+            break;
+        }
+    }
+    return Status::OK();
+}
+
+// Opens the .vi file and initializes the ANN reader.
+// If the .vi file is missing at runtime (e.g., async build not yet finished),
+// falls back to brute-force — the vector column added to _schema will be
+// initialized by the subsequent _init_column_iterators call.
 Status SegmentIterator::_init_ann_reader() {
-#ifdef WITH_TENANN
     if (!_vector_index_ctx || !_vector_index_ctx->use_vector_index) {
         return Status::OK();
     }
-    std::unordered_map<int32_t, TabletIndex> col_map_index;
-    for (const auto& index : *_segment->tablet_schema().indexes()) {
-        if (index.index_type() == VECTOR) {
-            col_map_index.emplace(index.col_unique_ids()[0], index);
-        }
-    }
 
-    std::vector<TabletIndex> hit_indexes;
-    for (auto& field : _schema.fields()) {
-        if (col_map_index.count(field->uid()) > 0) {
-            hit_indexes.emplace_back(col_map_index.at(field->uid()));
-        }
-    }
-
-    // TODO: Support more index in one segment iterator, only support one index for now
-    DCHECK(hit_indexes.size() <= 1) << "Only support query no more than one index now";
-
-    if (hit_indexes.empty()) {
+    if (_segment->skip_vector_index()) {
+        // Already handled by _prepare_vector_index
+        _vector_index_ctx->use_vector_index = false;
         return Status::OK();
     }
 
-    auto tablet_index_meta = std::make_shared<TabletIndex>(hit_indexes[0]);
-
-    std::string index_path;
-    if (_opts.belonged_to_cloud_native) {
-        index_path =
-                lake::gen_vector_index_path_from_segment_path(_segment->file_name(), tablet_index_meta->index_id());
-    } else {
-        index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
-                                                             segment_id(), tablet_index_meta->index_id());
+    // Find vector index from tablet schema
+    std::shared_ptr<TabletIndex> tablet_index_meta;
+    for (const auto& index : *_segment->tablet_schema().indexes()) {
+        if (index.index_type() == VECTOR && !index.col_unique_ids().empty()) {
+            tablet_index_meta = std::make_shared<TabletIndex>(index);
+            break;
+        }
+    }
+    if (!tablet_index_meta) {
+        return Status::OK();
     }
 
-    FileSystem* vi_fs = _opts.belonged_to_cloud_native ? _segment->file_system() : nullptr;
-    return _init_reader_from_file(index_path, tablet_index_meta, _vector_index_ctx->query_params, vi_fs);
+#ifdef WITH_TENANN
+    {
+        std::string index_path;
+        if (_opts.belonged_to_cloud_native) {
+            index_path = lake::gen_vector_index_path_from_segment_path(_segment->file_name(),
+                                                                       tablet_index_meta->index_id());
+        } else {
+            index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
+                                                                 segment_id(), tablet_index_meta->index_id());
+        }
+
+        FileSystem* vi_fs = _opts.belonged_to_cloud_native ? _segment->file_system() : nullptr;
+        RETURN_IF_ERROR(_init_reader_from_file(index_path, tablet_index_meta, _vector_index_ctx->query_params, vi_fs));
+    }
 #else
-    return Status::OK();
+    // Without TenANN, ANN index is not available — force brute-force
+    _vector_index_ctx->use_vector_index = false;
 #endif
+
+    if (!_vector_index_ctx->use_vector_index && !_vector_index_ctx->use_ivfpq) {
+        // .vi file not found, empty reader, or no TenANN support.
+        // Set up brute-force fallback for non-IVFPQ only. IVFPQ computes distance
+        // in the expression layer, not via a BE-produced distance column.
+        _setup_brute_force_fallback(*tablet_index_meta);
+    }
+
+    return Status::OK();
 }
 
 Status SegmentIterator::_get_row_ranges_by_vector_index() {
@@ -2203,6 +2287,37 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         // TODO: plan vector column in FE Planner
         chunk->append_vector_column(std::move(distance_column), _make_field(_vector_index_ctx->vector_column_id),
                                     _vector_index_ctx->vector_slot_id);
+    } else if (_vector_index_ctx && _vector_index_ctx->use_brute_force) {
+        // Brute-force fallback: compute distances from raw vector data in chunk
+        auto vec_col_id = _vector_index_ctx->vector_data_column_id;
+        const auto& vector_column = chunk->get_column_by_id(vec_col_id);
+        _compute_brute_force_distances(vector_column.get(), chunk);
+
+        // Apply vector_range filter before removing columns, so slot_id mapping is intact
+        double vr = _vector_index_ctx->vector_range;
+        if (vr >= 0 && chunk->num_rows() > 0) {
+            auto dist_col = chunk->get_column_by_slot_id(_vector_index_ctx->vector_slot_id);
+            const auto* distances = down_cast<const FloatColumn*>(dist_col.get());
+            const float* dist_data = distances->get_data().data();
+            size_t num = chunk->num_rows();
+            bool ascending = (_vector_index_ctx->result_order == 1);
+            Buffer<uint8_t> selection(num);
+            for (size_t i = 0; i < num; i++) {
+                selection[i] =
+                        ascending ? (dist_data[i] <= static_cast<float>(vr)) : (dist_data[i] >= static_cast<float>(vr));
+            }
+            chunk->filter_range(selection, 0, num);
+            if (rowid != nullptr) {
+                auto new_sz = ColumnHelper::filter_range<uint32_t>(selection, rowid->data(), 0, num);
+                rowid->resize(new_sz);
+            }
+        }
+
+        // Remove the vector data column if we added it (it was pruned by FE)
+        if (_vector_index_ctx->added_vector_data_column && chunk->is_cid_exist(vec_col_id)) {
+            auto idx = chunk->get_column_id_to_index_map().at(vec_col_id);
+            chunk->remove_column_by_index(idx);
+        }
     }
 
     result->swap_chunk(*chunk);
@@ -2396,6 +2511,72 @@ StatusOr<size_t> SegmentIterator::_predicate_evaluate_without_late_materialize(v
 FieldPtr SegmentIterator::_make_field(size_t i) {
     DCHECK(_vector_index_ctx != nullptr);
     return std::make_shared<Field>(i, _vector_index_ctx->vector_distance_column_name, get_type_info(TYPE_FLOAT), false);
+}
+
+void SegmentIterator::_compute_brute_force_distances(const Column* vector_column, Chunk* chunk) {
+    DCHECK(_vector_index_ctx != nullptr);
+    const auto& query_vec = _opts.vector_search_option->query_vector;
+    const size_t dim = query_vec.size();
+    const size_t num_rows = vector_column->size();
+
+    bool is_cosine_similarity = _vector_index_ctx->is_cosine_similarity;
+
+    // Unwrap NullableColumn if needed
+    const Column* data_col = vector_column;
+    const uint8_t* null_data = nullptr;
+    if (vector_column->is_nullable()) {
+        const auto* nullable = down_cast<const NullableColumn*>(vector_column);
+        data_col = nullable->data_column().get();
+        if (nullable->has_null()) {
+            null_data = nullable->null_column()->raw_data();
+        }
+    }
+    const auto* array_col = down_cast<const ArrayColumn*>(data_col);
+    const auto& offsets = array_col->offsets().get_data();
+    // elements() may be NullableColumn wrapping FloatColumn
+    const Column* elem_col = &array_col->elements();
+    if (elem_col->is_nullable()) {
+        elem_col = down_cast<const NullableColumn*>(elem_col)->data_column().get();
+    }
+    const auto* float_col = down_cast<const FloatColumn*>(elem_col);
+    const float* elements_data = float_col->get_data().data();
+
+    FloatColumn::MutablePtr distance_column = FloatColumn::create();
+    distance_column->reserve(num_rows);
+
+    for (size_t i = 0; i < num_rows; i++) {
+        if (null_data && null_data[i]) {
+            // Null vector: use max distance / min similarity as sentinel
+            distance_column->append(is_cosine_similarity ? -1.0f : std::numeric_limits<float>::max());
+            continue;
+        }
+        const float* vec = elements_data + offsets[i];
+        size_t vec_dim = offsets[i + 1] - offsets[i];
+        size_t calc_dim = std::min(dim, vec_dim);
+
+        if (is_cosine_similarity) {
+            // cosine_similarity = dot(q, v) / (|q| * |v|)
+            float dot = 0, norm_q = 0, norm_v = 0;
+            for (size_t j = 0; j < calc_dim; j++) {
+                dot += query_vec[j] * vec[j];
+                norm_q += query_vec[j] * query_vec[j];
+                norm_v += vec[j] * vec[j];
+            }
+            float denom = std::sqrt(norm_q) * std::sqrt(norm_v);
+            distance_column->append(denom > 0 ? dot / denom : 0.0f);
+        } else {
+            // l2_distance = sum((q[j] - v[j])^2)
+            float dist = 0;
+            for (size_t j = 0; j < calc_dim; j++) {
+                float diff = query_vec[j] - vec[j];
+                dist += diff * diff;
+            }
+            distance_column->append(dist);
+        }
+    }
+
+    chunk->append_vector_column(std::move(distance_column), _make_field(_vector_index_ctx->vector_column_id),
+                                _vector_index_ctx->vector_slot_id);
 }
 
 Status SegmentIterator::_switch_context(ScanContext* to) {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -991,14 +991,22 @@ void SegmentIterator::_setup_brute_force_fallback(const TabletIndex& index) {
 
     // Not in schema (pruned by FE) — add it
     int32_t col_idx = _segment->tablet_schema().field_index(vector_col_uid);
-    if (col_idx >= 0) {
-        const auto& col = _segment->tablet_schema().column(col_idx);
-        ColumnId cid = static_cast<ColumnId>(col_idx);
-        auto field = std::make_shared<Field>(ChunkHelper::convert_field(cid, col));
-        _vector_index_ctx->vector_data_column_id = cid;
-        _schema.append(field);
-        _vector_index_ctx->added_vector_data_column = true;
+    if (col_idx < 0) {
+        // Schema/index metadata mismatch: the index references a column the
+        // segment does not have. Disable brute-force rather than producing
+        // distances against an undefined column.
+        LOG(WARNING) << "disable brute-force vector fallback: vector column uid " << vector_col_uid
+                     << " not found in tablet schema for segment " << _segment->file_name();
+        _vector_index_ctx->use_brute_force = false;
+        return;
     }
+
+    const auto& col = _segment->tablet_schema().column(col_idx);
+    ColumnId cid = static_cast<ColumnId>(col_idx);
+    auto field = std::make_shared<Field>(ChunkHelper::convert_field(cid, col));
+    _vector_index_ctx->vector_data_column_id = cid;
+    _schema.append(field);
+    _vector_index_ctx->added_vector_data_column = true;
 }
 
 // Handles the case where the segment footer explicitly marks no .vi file (skip_vector_index).
@@ -2557,6 +2565,16 @@ void SegmentIterator::_compute_brute_force_distances(const Column* vector_column
     FloatColumn::MutablePtr distance_column = FloatColumn::create();
     distance_column->reserve(num_rows);
 
+    // Pre-compute the query-vector norm once: it is constant across all rows and
+    // brute-force scans can sweep many rows. (cosine path only.)
+    float query_norm = 0.0f;
+    if (is_cosine_similarity) {
+        for (size_t j = 0; j < dim; j++) {
+            query_norm += query_vec[j] * query_vec[j];
+        }
+        query_norm = std::sqrt(query_norm);
+    }
+
     for (size_t i = 0; i < num_rows; i++) {
         if (null_data && null_data[i]) {
             // Null vector: use max distance / min similarity as sentinel
@@ -2565,17 +2583,24 @@ void SegmentIterator::_compute_brute_force_distances(const Column* vector_column
         }
         const float* vec = elements_data + offsets[i];
         size_t vec_dim = offsets[i + 1] - offsets[i];
+        // tenann's index build validates dim equality at write time, so a row
+        // here with a different dim would point to corruption or a schema/index
+        // mismatch. Truncate to the shorter side and warn rather than crash.
+        if (vec_dim != dim) {
+            LOG_EVERY_N(WARNING, 1024)
+                    << "brute-force vector fallback: row " << i << " dim=" << vec_dim << " differs from query dim "
+                    << dim << " in segment " << _segment->file_name();
+        }
         size_t calc_dim = std::min(dim, vec_dim);
 
         if (is_cosine_similarity) {
             // cosine_similarity = dot(q, v) / (|q| * |v|)
-            float dot = 0, norm_q = 0, norm_v = 0;
+            float dot = 0, norm_v = 0;
             for (size_t j = 0; j < calc_dim; j++) {
                 dot += query_vec[j] * vec[j];
-                norm_q += query_vec[j] * query_vec[j];
                 norm_v += vec[j] * vec[j];
             }
-            float denom = std::sqrt(norm_q) * std::sqrt(norm_v);
+            float denom = query_norm * std::sqrt(norm_v);
             distance_column->append(denom > 0 ? dot / denom : 0.0f);
         } else {
             // l2_distance = sum((q[j] - v[j])^2)

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -972,13 +972,29 @@ void SegmentIterator::_setup_brute_force_fallback(const TabletIndex& index) {
     _vector_index_ctx->use_brute_force = true;
     _vector_index_ctx->vector_data_column_uid = vector_col_uid;
 
-    // Determine metric type from index metadata
+    // Determine metric type from index metadata. Brute-force fallback only
+    // implements the metrics that match a planner-side approx_*_distance
+    // expression and have a straightforward local computation. Anything else
+    // disables the fallback rather than silently treating it as L2 distance.
     const auto& props = index.common_properties();
     auto metric_it = props.find("metric_type");
-    if (metric_it != props.end()) {
-        std::string metric = metric_it->second;
-        std::transform(metric.begin(), metric.end(), metric.begin(), ::tolower);
-        _vector_index_ctx->is_cosine_similarity = (metric == "cosine_similarity");
+    if (metric_it == props.end()) {
+        LOG(WARNING) << "disable brute-force vector fallback: missing metric_type for vector index on segment "
+                     << _segment->file_name();
+        _vector_index_ctx->use_brute_force = false;
+        return;
+    }
+    std::string metric = metric_it->second;
+    std::transform(metric.begin(), metric.end(), metric.begin(), ::tolower);
+    if (metric == "cosine_similarity") {
+        _vector_index_ctx->is_cosine_similarity = true;
+    } else if (metric == "l2_distance") {
+        _vector_index_ctx->is_cosine_similarity = false;
+    } else {
+        LOG(WARNING) << "disable brute-force vector fallback: unsupported metric_type '" << metric << "' on segment "
+                     << _segment->file_name();
+        _vector_index_ctx->use_brute_force = false;
+        return;
     }
 
     // Check if the vector column is already in _schema
@@ -2250,10 +2266,28 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         // if the delete_predicates do nothing to the selection.
         RETURN_IF_ERROR(_opts.delete_predicates.evaluate(chunk, _selection.data()));
         size_t deletes = SIMD::count_nonzero(_selection.data(), old_sz);
+        // When brute-force vector fallback is active and FE pruned the vector
+        // column from output_schema, the vector data column lives in
+        // _dict_chunk (un-swapped by _build_final_chunk). It must stay
+        // row-aligned with `chunk` for the later distance compute, so apply
+        // the same selection here.
+        Column* brute_force_vec_col = nullptr;
+        if (_vector_index_ctx != nullptr && _vector_index_ctx->use_brute_force) {
+            auto vec_cid = _vector_index_ctx->vector_data_column_id;
+            if (!chunk->is_cid_exist(vec_cid)) {
+                auto col = _context->_dict_chunk->get_column_by_id(vec_cid);
+                if (col != nullptr && col->size() == old_sz) {
+                    brute_force_vec_col = col.get();
+                }
+            }
+        }
         if (deletes == old_sz) {
             chunk->set_num_rows(0);
             if (rowid != nullptr) {
                 rowid->resize(0);
+            }
+            if (brute_force_vec_col != nullptr) {
+                brute_force_vec_col->resize(0);
             }
             _opts.stats->rows_del_filtered += old_sz;
         } else if (deletes > 0) {
@@ -2265,6 +2299,9 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
             if (rowid != nullptr) {
                 auto size = ColumnHelper::filter_range<uint32_t>(_selection, rowid->data(), 0, old_sz);
                 rowid->resize(size);
+            }
+            if (brute_force_vec_col != nullptr) {
+                brute_force_vec_col->filter_range(_selection, 0, old_sz);
             }
             _opts.stats->rows_del_filtered += old_sz - new_sz;
         }
@@ -2302,16 +2339,25 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         // _dict_chunk depending on output_schema:
         //   * If output_schema includes the vector column (FE did not prune it),
         //     _build_final_chunk has already SWAPPED the column out of _dict_chunk
-        //     into chunk. _dict_chunk's slot is now empty; read from chunk.
+        //     into chunk; chunk is the source of truth.
         //   * If output_schema does NOT include the vector column (FE pruned it,
         //     and _setup_brute_force_fallback re-added it to _schema after the
         //     caller's init_output_schema froze output_schema), the swap skipped
-        //     it. The column is still in _dict_chunk; read from there.
+        //     it. The column is still in _dict_chunk; the delete-pred filter
+        //     above re-applies the same selection mask to keep it row-aligned
+        //     with chunk so we can read it directly here.
         // Either way, the distance column is appended to `chunk`, which always has
         // the planner-allocated distance slot.
         auto vec_col_id = _vector_index_ctx->vector_data_column_id;
-        ColumnPtr vector_column = chunk->is_cid_exist(vec_col_id) ? chunk->get_column_by_id(vec_col_id)
-                                                                  : _context->_dict_chunk->get_column_by_id(vec_col_id);
+        ColumnPtr vector_column = chunk->is_cid_exist(vec_col_id)
+                                          ? chunk->get_column_by_id(vec_col_id)
+                                          : _context->_dict_chunk->get_column_by_id(vec_col_id);
+        DCHECK_EQ(vector_column->size(), chunk->num_rows())
+                << "brute-force vector column row count must match chunk; row alignment was lost";
+        if (UNLIKELY(vector_column->size() != chunk->num_rows())) {
+            return Status::InternalError(
+                    "brute-force vector column row count does not match chunk row count");
+        }
         _compute_brute_force_distances(vector_column.get(), chunk);
 
         // Apply vector_range filter before removing columns, so slot_id mapping is intact
@@ -2554,10 +2600,20 @@ void SegmentIterator::_compute_brute_force_distances(const Column* vector_column
     }
     const auto* array_col = down_cast<const ArrayColumn*>(data_col);
     const auto& offsets = array_col->offsets().get_data();
-    // elements() may be NullableColumn wrapping FloatColumn
+    // elements() may be NullableColumn wrapping FloatColumn. Vector index columns are
+    // ARRAY<FLOAT> with a nullable element column at the schema level, but tenann's
+    // builder rejects a row with any null element at write time. Defensively, if the
+    // elements column actually carries nulls at read time we treat the entire row as
+    // null (sentinel distance) rather than reading whatever undefined float lives in
+    // the slot.
     const Column* elem_col = &array_col->elements();
+    const uint8_t* elem_null_data = nullptr;
     if (elem_col->is_nullable()) {
-        elem_col = down_cast<const NullableColumn*>(elem_col)->data_column().get();
+        const auto* nullable_elem = down_cast<const NullableColumn*>(elem_col);
+        if (nullable_elem->has_null()) {
+            elem_null_data = nullable_elem->null_column()->raw_data();
+        }
+        elem_col = nullable_elem->data_column().get();
     }
     const auto* float_col = down_cast<const FloatColumn*>(elem_col);
     const float* elements_data = float_col->get_data().data();
@@ -2575,14 +2631,30 @@ void SegmentIterator::_compute_brute_force_distances(const Column* vector_column
         query_norm = std::sqrt(query_norm);
     }
 
+    auto sentinel = is_cosine_similarity ? -1.0f : std::numeric_limits<float>::max();
     for (size_t i = 0; i < num_rows; i++) {
         if (null_data && null_data[i]) {
             // Null vector: use max distance / min similarity as sentinel
-            distance_column->append(is_cosine_similarity ? -1.0f : std::numeric_limits<float>::max());
+            distance_column->append(sentinel);
             continue;
         }
-        const float* vec = elements_data + offsets[i];
-        size_t vec_dim = offsets[i + 1] - offsets[i];
+        const size_t row_offset = offsets[i];
+        size_t vec_dim = offsets[i + 1] - row_offset;
+        // If any element of this row's array is null, treat the whole vector as null.
+        if (elem_null_data != nullptr) {
+            bool has_null_elem = false;
+            for (size_t j = 0; j < vec_dim; j++) {
+                if (elem_null_data[row_offset + j]) {
+                    has_null_elem = true;
+                    break;
+                }
+            }
+            if (has_null_elem) {
+                distance_column->append(sentinel);
+                continue;
+            }
+        }
+        const float* vec = elements_data + row_offset;
         // tenann's index build validates dim equality at write time, so a row
         // here with a different dim would point to corruption or a schema/index
         // mismatch. Truncate to the shorter side and warn rather than crash.

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2587,9 +2587,8 @@ void SegmentIterator::_compute_brute_force_distances(const Column* vector_column
         // here with a different dim would point to corruption or a schema/index
         // mismatch. Truncate to the shorter side and warn rather than crash.
         if (vec_dim != dim) {
-            LOG_EVERY_N(WARNING, 1024)
-                    << "brute-force vector fallback: row " << i << " dim=" << vec_dim << " differs from query dim "
-                    << dim << " in segment " << _segment->file_name();
+            LOG_EVERY_N(WARNING, 1024) << "brute-force vector fallback: row " << i << " dim=" << vec_dim
+                                       << " differs from query dim " << dim << " in segment " << _segment->file_name();
         }
         size_t calc_dim = std::min(dim, vec_dim);
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1053,8 +1053,8 @@ Status SegmentIterator::_init_ann_reader() {
     {
         std::string index_path;
         if (_opts.belonged_to_cloud_native) {
-            index_path = lake::gen_vector_index_path_from_segment_path(_segment->file_name(),
-                                                                       tablet_index_meta->index_id());
+            index_path =
+                    lake::gen_vector_index_path_from_segment_path(_segment->file_name(), tablet_index_meta->index_id());
         } else {
             index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
                                                                  segment_id(), tablet_index_meta->index_id());

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2270,14 +2270,16 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         // column from output_schema, the vector data column lives in
         // _dict_chunk (un-swapped by _build_final_chunk). It must stay
         // row-aligned with `chunk` for the later distance compute, so apply
-        // the same selection here.
+        // the same selection here. (filter_range is non-const, columns are
+        // held as Cow ImmutPtr — same as Chunk::filter_range, use
+        // as_mutable_raw_ptr to mutate in place.)
         Column* brute_force_vec_col = nullptr;
         if (_vector_index_ctx != nullptr && _vector_index_ctx->use_brute_force) {
             auto vec_cid = _vector_index_ctx->vector_data_column_id;
             if (!chunk->is_cid_exist(vec_cid)) {
-                auto col = _context->_dict_chunk->get_column_by_id(vec_cid);
+                const auto& col = _context->_dict_chunk->get_column_by_id(vec_cid);
                 if (col != nullptr && col->size() == old_sz) {
-                    brute_force_vec_col = col.get();
+                    brute_force_vec_col = col->as_mutable_raw_ptr();
                 }
             }
         }

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -296,8 +296,7 @@ private:
 
         std::shared_ptr<VectorIndexReader> ann_reader;
 
-        // Helper method to check if rowid should always be built
-        bool always_build_rowid() const { return (use_vector_index || use_brute_force) && !use_ivfpq; }
+        bool always_build_rowid() const { return use_vector_index && !use_ivfpq; }
     };
 
     // Inverted index related context, only created when needed

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -330,7 +330,6 @@ TEST_F(VectorIndexSearchTest, tenann_reader_init_searcher_null_fs_delegates_to_l
 
 #endif // WITH_TENANN
 
-
 // ==================== Brute-force fallback tests ====================
 // Test SegmentIterator brute-force fallback when .vi file is missing.
 // This covers: _prepare_vector_index, _setup_brute_force_fallback,

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -526,9 +526,21 @@ TEST_F(BruteForceVectorFallbackTest, test_brute_force_l2_distance_fallback) {
         // Verify we got rows back and no crash
         ASSERT_EQ(chunk->num_rows(), 3);
 
-        // Verify the distance column exists (appended as virtual column)
-        // The chunk should have id column + distance column
-        ASSERT_GE(chunk->num_columns(), 2);
+        // Verify the distance column exists (appended as virtual column).
+        // FE pruned the vector column, so chunk only has [id, distance].
+        ASSERT_EQ(chunk->num_columns(), 2);
+
+        // Validate the actual L2 distances for query [1, 1, 1]:
+        //   Row 0 (id=1, vec=[1,2,3]): (0)^2 + (-1)^2 + (-2)^2 = 5
+        //   Row 1 (id=2, vec=[4,5,6]): (-3)^2 + (-4)^2 + (-5)^2 = 50
+        //   Row 2 (id=3, vec=[0,0,0]): 1 + 1 + 1 = 3
+        auto dist_col = chunk->get_column_by_slot_id(vector_search_opt->vector_slot_id);
+        ASSERT_NE(dist_col, nullptr);
+        const auto* distances = down_cast<const FloatColumn*>(dist_col.get());
+        ASSERT_EQ(distances->size(), 3);
+        EXPECT_FLOAT_EQ(distances->get_data()[0], 5.0f);
+        EXPECT_FLOAT_EQ(distances->get_data()[1], 50.0f);
+        EXPECT_FLOAT_EQ(distances->get_data()[2], 3.0f);
     }
     // EndOfFile is also acceptable if the iterator processes all data
     ASSERT_TRUE(st.ok() || st.is_end_of_file());
@@ -589,8 +601,10 @@ TEST_F(BruteForceVectorFallbackTest, test_brute_force_vector_column_not_pruned) 
 
     if (st.ok()) {
         ASSERT_EQ(chunk->num_rows(), 2);
-        // Should have id + vector + distance columns
-        ASSERT_GE(chunk->num_columns(), 3);
+        // The vector column was already in read_schema, so _setup_brute_force_fallback
+        // must reuse it instead of appending a duplicate. Final chunk should be exactly
+        // [id, vector, distance] — three columns, with no second vector column.
+        ASSERT_EQ(chunk->num_columns(), 3);
     }
     ASSERT_TRUE(st.ok() || st.is_end_of_file());
 
@@ -648,8 +662,22 @@ TEST_F(BruteForceVectorFallbackTest, test_brute_force_with_vector_range_filter) 
     auto st = chunk_iter->get_next(chunk.get(), &rowids);
 
     if (st.ok()) {
-        // Row 4 (dist=48) should be filtered out, leaving 3 rows
+        // Vectors are appended in input order. With vector_range = 3.0 and
+        // ascending result_order, the brute-force fallback keeps rows whose
+        // L2 distance from query [1,1,1] is <= 3.0:
+        //   Row 0 (id=1, vec=[1,0,0]): dist = 0+1+1 = 2  -> keep
+        //   Row 1 (id=2, vec=[0,0,0]): dist = 1+1+1 = 3  -> keep
+        //   Row 2 (id=3, vec=[1,1,1]): dist = 0          -> keep
+        //   Row 3 (id=4, vec=[5,5,5]): dist = 16+16+16=48 -> filter out
+        // The fallback only filters in place; it does not re-sort, so the
+        // surviving rows stay in input order.
         ASSERT_EQ(chunk->num_rows(), 3);
+        auto id_col = chunk->get_column_by_index(0);
+        const auto* ids_out = down_cast<const Int64Column*>(id_col.get());
+        ASSERT_EQ(ids_out->size(), 3);
+        EXPECT_EQ(ids_out->get_data()[0], 1);
+        EXPECT_EQ(ids_out->get_data()[1], 2);
+        EXPECT_EQ(ids_out->get_data()[2], 3);
     }
     ASSERT_TRUE(st.ok() || st.is_end_of_file());
 

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -734,8 +734,9 @@ std::shared_ptr<TabletSchema> build_read_schema_with_metric(const std::string& m
     idx->set_index_name("vector_index");
     idx->set_index_type(IndexType::VECTOR);
     idx->add_col_unique_id(1);
-    std::string props = R"({"common_properties":{"index_type":"hnsw","dim":"3","metric_type":")" + metric +
-                        R"(","is_vector_normed":"false"},"index_properties":{"efconstruction":"40","m":"16"},"search_properties":{"efsearch":"40"}})";
+    std::string props =
+            R"({"common_properties":{"index_type":"hnsw","dim":"3","metric_type":")" + metric +
+            R"(","is_vector_normed":"false"},"index_properties":{"efconstruction":"40","m":"16"},"search_properties":{"efsearch":"40"}})";
     idx->set_index_properties(props);
     return TabletSchema::create(schema_pb);
 }
@@ -846,7 +847,7 @@ TEST_F(BruteForceVectorFallbackTest, test_brute_force_unsupported_metric_disable
 TEST_F(BruteForceVectorFallbackTest, test_brute_force_dim_mismatch_truncates) {
     std::vector<int64_t> ids = {1, 2};
     std::vector<std::vector<float>> vectors = {
-            {1.0f, 1.0f}, // dim 2, query is dim 3 -> truncate to 2
+            {1.0f, 1.0f},             // dim 2, query is dim 3 -> truncate to 2
             {1.0f, 1.0f, 1.0f, 1.0f}, // dim 4, truncate to 3
     };
     ASSIGN_OR_ABORT(auto segment, write_segment(ids, vectors));

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -522,28 +522,26 @@ TEST_F(BruteForceVectorFallbackTest, test_brute_force_l2_distance_fallback) {
     std::vector<uint32_t> rowids;
     auto st = chunk_iter->get_next(chunk.get(), &rowids);
 
-    if (st.ok()) {
-        // Verify we got rows back and no crash
-        ASSERT_EQ(chunk->num_rows(), 3);
+    // ChunkIterator::get_next contract: EOF implies empty chunk. Require OK so a
+    // regression that returns EOF immediately can't make this test pass with zero
+    // rows.
+    ASSERT_OK(st);
+    ASSERT_EQ(chunk->num_rows(), 3);
 
-        // Verify the distance column exists (appended as virtual column).
-        // FE pruned the vector column, so chunk only has [id, distance].
-        ASSERT_EQ(chunk->num_columns(), 2);
+    // FE pruned the vector column, so chunk only has [id, distance].
+    ASSERT_EQ(chunk->num_columns(), 2);
 
-        // Validate the actual L2 distances for query [1, 1, 1]:
-        //   Row 0 (id=1, vec=[1,2,3]): (0)^2 + (-1)^2 + (-2)^2 = 5
-        //   Row 1 (id=2, vec=[4,5,6]): (-3)^2 + (-4)^2 + (-5)^2 = 50
-        //   Row 2 (id=3, vec=[0,0,0]): 1 + 1 + 1 = 3
-        auto dist_col = chunk->get_column_by_slot_id(vector_search_opt->vector_slot_id);
-        ASSERT_NE(dist_col, nullptr);
-        const auto* distances = down_cast<const FloatColumn*>(dist_col.get());
-        ASSERT_EQ(distances->size(), 3);
-        EXPECT_FLOAT_EQ(distances->get_data()[0], 5.0f);
-        EXPECT_FLOAT_EQ(distances->get_data()[1], 50.0f);
-        EXPECT_FLOAT_EQ(distances->get_data()[2], 3.0f);
-    }
-    // EndOfFile is also acceptable if the iterator processes all data
-    ASSERT_TRUE(st.ok() || st.is_end_of_file());
+    // Validate the actual L2 distances for query [1, 1, 1]:
+    //   Row 0 (id=1, vec=[1,2,3]): (0)^2 + (-1)^2 + (-2)^2 = 5
+    //   Row 1 (id=2, vec=[4,5,6]): (-3)^2 + (-4)^2 + (-5)^2 = 50
+    //   Row 2 (id=3, vec=[0,0,0]): 1 + 1 + 1 = 3
+    auto dist_col = chunk->get_column_by_slot_id(vector_search_opt->vector_slot_id);
+    ASSERT_NE(dist_col, nullptr);
+    const auto* distances = down_cast<const FloatColumn*>(dist_col.get());
+    ASSERT_EQ(distances->size(), 3);
+    EXPECT_FLOAT_EQ(distances->get_data()[0], 5.0f);
+    EXPECT_FLOAT_EQ(distances->get_data()[1], 50.0f);
+    EXPECT_FLOAT_EQ(distances->get_data()[2], 3.0f);
 
     chunk_iter->close();
 }
@@ -599,14 +597,12 @@ TEST_F(BruteForceVectorFallbackTest, test_brute_force_vector_column_not_pruned) 
     std::vector<uint32_t> rowids;
     auto st = chunk_iter->get_next(chunk.get(), &rowids);
 
-    if (st.ok()) {
-        ASSERT_EQ(chunk->num_rows(), 2);
-        // The vector column was already in read_schema, so _setup_brute_force_fallback
-        // must reuse it instead of appending a duplicate. Final chunk should be exactly
-        // [id, vector, distance] — three columns, with no second vector column.
-        ASSERT_EQ(chunk->num_columns(), 3);
-    }
-    ASSERT_TRUE(st.ok() || st.is_end_of_file());
+    ASSERT_OK(st);
+    ASSERT_EQ(chunk->num_rows(), 2);
+    // The vector column was already in read_schema, so _setup_brute_force_fallback
+    // must reuse it instead of appending a duplicate. Final chunk should be exactly
+    // [id, vector, distance] — three columns, with no second vector column.
+    ASSERT_EQ(chunk->num_columns(), 3);
 
     chunk_iter->close();
 }
@@ -661,25 +657,23 @@ TEST_F(BruteForceVectorFallbackTest, test_brute_force_with_vector_range_filter) 
     std::vector<uint32_t> rowids;
     auto st = chunk_iter->get_next(chunk.get(), &rowids);
 
-    if (st.ok()) {
-        // Vectors are appended in input order. With vector_range = 3.0 and
-        // ascending result_order, the brute-force fallback keeps rows whose
-        // L2 distance from query [1,1,1] is <= 3.0:
-        //   Row 0 (id=1, vec=[1,0,0]): dist = 0+1+1 = 2  -> keep
-        //   Row 1 (id=2, vec=[0,0,0]): dist = 1+1+1 = 3  -> keep
-        //   Row 2 (id=3, vec=[1,1,1]): dist = 0          -> keep
-        //   Row 3 (id=4, vec=[5,5,5]): dist = 16+16+16=48 -> filter out
-        // The fallback only filters in place; it does not re-sort, so the
-        // surviving rows stay in input order.
-        ASSERT_EQ(chunk->num_rows(), 3);
-        auto id_col = chunk->get_column_by_index(0);
-        const auto* ids_out = down_cast<const Int64Column*>(id_col.get());
-        ASSERT_EQ(ids_out->size(), 3);
-        EXPECT_EQ(ids_out->get_data()[0], 1);
-        EXPECT_EQ(ids_out->get_data()[1], 2);
-        EXPECT_EQ(ids_out->get_data()[2], 3);
-    }
-    ASSERT_TRUE(st.ok() || st.is_end_of_file());
+    ASSERT_OK(st);
+    // Vectors are appended in input order. With vector_range = 3.0 and
+    // ascending result_order, the brute-force fallback keeps rows whose
+    // L2 distance from query [1,1,1] is <= 3.0:
+    //   Row 0 (id=1, vec=[1,0,0]): dist = 0+1+1 = 2  -> keep
+    //   Row 1 (id=2, vec=[0,0,0]): dist = 1+1+1 = 3  -> keep
+    //   Row 2 (id=3, vec=[1,1,1]): dist = 0          -> keep
+    //   Row 3 (id=4, vec=[5,5,5]): dist = 16+16+16=48 -> filter out
+    // The fallback only filters in place; it does not re-sort, so the
+    // surviving rows stay in input order.
+    ASSERT_EQ(chunk->num_rows(), 3);
+    auto id_col = chunk->get_column_by_index(0);
+    const auto* ids_out = down_cast<const Int64Column*>(id_col.get());
+    ASSERT_EQ(ids_out->size(), 3);
+    EXPECT_EQ(ids_out->get_data()[0], 1);
+    EXPECT_EQ(ids_out->get_data()[1], 2);
+    EXPECT_EQ(ids_out->get_data()[2], 3);
 
     chunk_iter->close();
 }

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -510,6 +510,13 @@ TEST_F(BruteForceVectorFallbackTest, test_brute_force_l2_distance_fallback) {
     auto chunk_iter = new_segment_iterator(segment, read_schema, seg_opts);
     ASSERT_TRUE(chunk_iter != nullptr);
 
+    // Simulate the production caller (TabletReader / OlapChunkSource): freeze the
+    // output schema BEFORE the iterator's lazy _init runs. Brute-force fallback's
+    // late _schema mutation must not be expected to flow into output_schema —
+    // _do_get_next sources the vector column from _dict_chunk instead of the
+    // (possibly pruned) final chunk.
+    ASSERT_OK(chunk_iter->init_output_schema({}));
+
     // The output schema includes the distance virtual column appended by brute-force path
     auto chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), 1024);
     std::vector<uint32_t> rowids;

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -462,10 +462,16 @@ protected:
     }
 };
 
-// Test: segment with skip_vector_index=true, SegmentIterator with use_vector_index=true.
-// _prepare_vector_index should detect skip flag, set up brute-force, add vector column to schema.
-// _compute_brute_force_distances should compute correct L2 distances.
-// The iterator should NOT crash and should return a chunk with the distance column.
+// Test: segment written without a .vi file, SegmentIterator with use_vector_index=true.
+//
+// This exercises the runtime-NotFound branch of the fallback: the segment footer's
+// vector_index_storage_type is unset (the writer in OSS only sets STANDALONE when
+// a .vi was produced and never explicitly emits NONE), so Segment::skip_vector_index()
+// is false and _prepare_vector_index is a no-op. Instead, _init_ann_reader tries to
+// open the .vi file via VectorIndexReaderFactory::create_from_file, gets NotFound
+// at runtime, and routes through _setup_brute_force_fallback. The footer-hint
+// short-circuit in _prepare_vector_index is intentionally untested here — covering
+// it would require a writer that emits VECTOR_INDEX_STORAGE_NONE in the footer.
 TEST_F(BruteForceVectorFallbackTest, test_brute_force_l2_distance_fallback) {
     std::vector<int64_t> ids = {1, 2, 3};
     std::vector<std::vector<float>> vectors = {
@@ -474,6 +480,10 @@ TEST_F(BruteForceVectorFallbackTest, test_brute_force_l2_distance_fallback) {
             {0.0f, 0.0f, 0.0f},
     };
     ASSIGN_OR_ABORT(auto segment, write_segment(ids, vectors));
+    // Confirm we are exercising the runtime-NotFound path, not the footer-hint
+    // path — without this, a future writer change that emits NONE in the footer
+    // would silently switch which fallback branch this test covers.
+    ASSERT_FALSE(segment->skip_vector_index());
 
     auto schema = build_read_schema_with_vector_index();
 

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -430,7 +430,8 @@ protected:
 
     // Write a segment WITHOUT vector index. The .vi file won't exist.
     StatusOr<std::shared_ptr<Segment>> write_segment(const std::vector<int64_t>& ids,
-                                                     const std::vector<std::vector<float>>& vectors) {
+                                                     const std::vector<std::vector<float>>& vectors,
+                                                     std::shared_ptr<TabletSchema> read_schema = nullptr) {
         auto write_schema = build_write_schema();
         std::string file_name = kSegmentDir + "/test_segment.dat";
         ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(file_name));
@@ -456,8 +457,11 @@ protected:
         uint64_t seg_size = 0, index_size = 0, footer_pos = 0;
         RETURN_IF_ERROR(writer.finalize(&seg_size, &index_size, &footer_pos));
 
-        // Open with the read schema (which has vector index) to simulate real scenario
-        auto read_schema = build_read_schema_with_vector_index();
+        // Open with the supplied read schema (or the default vector-index schema) so
+        // _setup_brute_force_fallback sees the metric_type the test wants to exercise.
+        if (read_schema == nullptr) {
+            read_schema = build_read_schema_with_vector_index();
+        }
         return Segment::open(_fs, FileInfo{file_name}, 0, read_schema);
     }
 };
@@ -685,6 +689,198 @@ TEST_F(BruteForceVectorFallbackTest, test_brute_force_with_vector_range_filter) 
     EXPECT_EQ(ids_out->get_data()[1], 2);
     EXPECT_EQ(ids_out->get_data()[2], 3);
 
+    chunk_iter->close();
+}
+
+namespace {
+// Build a read-time TabletSchema with a vector index whose metric_type is the
+// argument. Mirrors BruteForceVectorFallbackTest::build_read_schema_with_vector_index
+// but lets the caller swap the metric to exercise the cosine / l2 / unsupported
+// branches in _setup_brute_force_fallback.
+std::shared_ptr<TabletSchema> build_read_schema_with_metric(const std::string& metric) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_next_column_unique_id(3);
+
+    auto* col0 = schema_pb.add_column();
+    col0->set_unique_id(0);
+    col0->set_name("id");
+    col0->set_type("BIGINT");
+    col0->set_is_key(true);
+    col0->set_is_nullable(false);
+    col0->set_length(8);
+    col0->set_index_length(8);
+    col0->set_aggregation("NONE");
+
+    auto* col1 = schema_pb.add_column();
+    col1->set_unique_id(1);
+    col1->set_name("vector");
+    col1->set_type("ARRAY");
+    col1->set_is_key(false);
+    col1->set_is_nullable(false);
+    col1->set_length(24);
+    col1->set_aggregation("NONE");
+    auto* child = col1->add_children_columns();
+    child->set_unique_id(2);
+    child->set_name("element");
+    child->set_type("FLOAT");
+    child->set_is_key(false);
+    child->set_is_nullable(true);
+    child->set_length(4);
+    child->set_aggregation("NONE");
+
+    auto* idx = schema_pb.add_table_indices();
+    idx->set_index_id(100);
+    idx->set_index_name("vector_index");
+    idx->set_index_type(IndexType::VECTOR);
+    idx->add_col_unique_id(1);
+    std::string props = R"({"common_properties":{"index_type":"hnsw","dim":"3","metric_type":")" + metric +
+                        R"(","is_vector_normed":"false"},"index_properties":{"efconstruction":"40","m":"16"},"search_properties":{"efsearch":"40"}})";
+    idx->set_index_properties(props);
+    return TabletSchema::create(schema_pb);
+}
+
+VectorSearchOptionPtr make_vector_search_opt(int slot_id, int num_columns, const std::vector<float>& query) {
+    auto opt = std::make_shared<VectorSearchOption>();
+    opt->use_vector_index = true;
+    opt->query_vector = query;
+    opt->k = 10;
+    opt->k_factor = 1.0;
+    opt->vector_distance_column_name = "__vector_approx_l2_distance";
+    opt->vector_column_id = num_columns;
+    opt->vector_slot_id = slot_id;
+    opt->use_ivfpq = false;
+    opt->vector_range = -1.0;
+    opt->result_order = 0;
+    opt->pq_refine_factor = 1.0;
+    return opt;
+}
+} // namespace
+
+// Cosine similarity path covers the cosine branch of _setup_brute_force_fallback
+// (is_cosine_similarity = true) and the cosine branch of
+// _compute_brute_force_distances (query_norm precompute + per-row dot/norm_v).
+TEST_F(BruteForceVectorFallbackTest, test_brute_force_cosine_similarity) {
+    std::vector<int64_t> ids = {1, 2, 3};
+    std::vector<std::vector<float>> vectors = {
+            {1.0f, 0.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+            {1.0f, 1.0f, 1.0f},
+    };
+    auto schema = build_read_schema_with_metric("cosine_similarity");
+    ASSIGN_OR_ABORT(auto segment, write_segment(ids, vectors, schema));
+    OlapReaderStatistics stats;
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = schema;
+    auto opt = make_vector_search_opt(/*slot_id=*/100, schema->num_columns(), {1.0f, 0.0f, 0.0f});
+    seg_opts.use_vector_index = true;
+    seg_opts.vector_search_option = opt;
+
+    Schema read_schema;
+    auto id_field = std::make_shared<Field>(0, "id", get_type_info(TYPE_BIGINT), false);
+    id_field->set_uid(0);
+    read_schema.append(id_field);
+
+    auto chunk_iter = new_segment_iterator(segment, read_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_output_schema({}));
+    auto chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), 1024);
+    std::vector<uint32_t> rowids;
+    ASSERT_OK(chunk_iter->get_next(chunk.get(), &rowids));
+    ASSERT_EQ(chunk->num_rows(), 3);
+
+    // Query [1, 0, 0] (norm = 1):
+    //   Row 0 [1,0,0]: dot = 1, |v| = 1, cosine = 1.0
+    //   Row 1 [0,1,0]: dot = 0, |v| = 1, cosine = 0.0
+    //   Row 2 [1,1,1]: dot = 1, |v| = sqrt(3), cosine = 1/sqrt(3)
+    auto dist_col = chunk->get_column_by_slot_id(opt->vector_slot_id);
+    ASSERT_NE(dist_col, nullptr);
+    const auto* distances = down_cast<const FloatColumn*>(dist_col.get());
+    ASSERT_EQ(distances->size(), 3);
+    EXPECT_FLOAT_EQ(distances->get_data()[0], 1.0f);
+    EXPECT_FLOAT_EQ(distances->get_data()[1], 0.0f);
+    EXPECT_NEAR(distances->get_data()[2], 1.0f / std::sqrt(3.0f), 1e-6);
+
+    chunk_iter->close();
+}
+
+// Unsupported metric (inner_product, etc.) covers the LOG-and-disable branch in
+// _setup_brute_force_fallback. The iterator must not crash and must not append a
+// distance column, since use_brute_force is turned off.
+TEST_F(BruteForceVectorFallbackTest, test_brute_force_unsupported_metric_disables_fallback) {
+    std::vector<int64_t> ids = {1};
+    std::vector<std::vector<float>> vectors = {{1.0f, 2.0f, 3.0f}};
+    auto schema = build_read_schema_with_metric("inner_product");
+    ASSIGN_OR_ABORT(auto segment, write_segment(ids, vectors, schema));
+    OlapReaderStatistics stats;
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = schema;
+    auto opt = make_vector_search_opt(/*slot_id=*/100, schema->num_columns(), {1.0f, 0.0f, 0.0f});
+    seg_opts.use_vector_index = true;
+    seg_opts.vector_search_option = opt;
+
+    Schema read_schema;
+    auto id_field = std::make_shared<Field>(0, "id", get_type_info(TYPE_BIGINT), false);
+    id_field->set_uid(0);
+    read_schema.append(id_field);
+
+    auto chunk_iter = new_segment_iterator(segment, read_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_output_schema({}));
+    auto chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), 1024);
+    std::vector<uint32_t> rowids;
+    auto st = chunk_iter->get_next(chunk.get(), &rowids);
+    // Distance column is intentionally NOT produced — fallback was disabled.
+    // The iterator should still process rows for the id column without
+    // crashing on missing distance.
+    ASSERT_TRUE(st.ok() || st.is_end_of_file());
+    EXPECT_FALSE(chunk->is_slot_exist(opt->vector_slot_id));
+    chunk_iter->close();
+}
+
+// Dim mismatch covers the LOG_EVERY_N warning + truncated calc_dim path in
+// _compute_brute_force_distances, plus the early-return when the array has zero
+// elements (offsets[i+1] == offsets[i] -> calc_dim = 0 -> distance == 0).
+TEST_F(BruteForceVectorFallbackTest, test_brute_force_dim_mismatch_truncates) {
+    std::vector<int64_t> ids = {1, 2};
+    std::vector<std::vector<float>> vectors = {
+            {1.0f, 1.0f}, // dim 2, query is dim 3 -> truncate to 2
+            {1.0f, 1.0f, 1.0f, 1.0f}, // dim 4, truncate to 3
+    };
+    ASSIGN_OR_ABORT(auto segment, write_segment(ids, vectors));
+
+    auto schema = build_read_schema_with_vector_index();
+    OlapReaderStatistics stats;
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = schema;
+    auto opt = make_vector_search_opt(/*slot_id=*/100, schema->num_columns(), {1.0f, 1.0f, 1.0f});
+    seg_opts.use_vector_index = true;
+    seg_opts.vector_search_option = opt;
+
+    Schema read_schema;
+    auto id_field = std::make_shared<Field>(0, "id", get_type_info(TYPE_BIGINT), false);
+    id_field->set_uid(0);
+    read_schema.append(id_field);
+
+    auto chunk_iter = new_segment_iterator(segment, read_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_output_schema({}));
+    auto chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), 1024);
+    std::vector<uint32_t> rowids;
+    ASSERT_OK(chunk_iter->get_next(chunk.get(), &rowids));
+    ASSERT_EQ(chunk->num_rows(), 2);
+
+    // Row 0: dim=2 vs query=3 -> calc_dim=2 -> dist = (1-1)^2 + (1-1)^2 = 0
+    // Row 1: dim=4 vs query=3 -> calc_dim=3 -> dist = (1-1)^2 + (1-1)^2 + (1-1)^2 = 0
+    auto dist_col = chunk->get_column_by_slot_id(opt->vector_slot_id);
+    ASSERT_NE(dist_col, nullptr);
+    const auto* distances = down_cast<const FloatColumn*>(dist_col.get());
+    ASSERT_EQ(distances->size(), 2);
+    EXPECT_FLOAT_EQ(distances->get_data()[0], 0.0f);
+    EXPECT_FLOAT_EQ(distances->get_data()[1], 0.0f);
     chunk_iter->close();
 }
 

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -14,8 +14,7 @@
 
 #include <gtest/gtest.h>
 
-#include "fs/fs_factory.h"
-#include "fs/fs_memory.h"
+#include <cmath>
 
 #ifdef WITH_TENANN
 #include <tenann/factory/ann_searcher_factory.h>
@@ -27,17 +26,34 @@
 
 #include "base/testutil/assert.h"
 #include "base/utility/defer_op.h"
+#include "column/array_column.h"
+#include "column/chunk.h"
 #include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+#include "common/config_rowset_fwd.h"
 #include "common/config_vector_index_fwd.h"
+#include "fs/fs_factory.h"
+#include "fs/fs_memory.h"
+#include "gen_cpp/tablet_schema.pb.h"
+#include "gutil/casts.h"
 #include "runtime/mem_pool.h"
+#include "storage/chunk_helper.h"
 #include "storage/index/index_descriptor.h"
 #include "storage/index/vector/tenann/del_id_filter.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_reader.h"
 #include "storage/index/vector/vector_index_reader_factory.h"
 #include "storage/index/vector/vector_index_writer.h"
+#include "storage/index/vector/vector_search_option.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "storage/rowset/bitmap_index_writer.h"
+#include "storage/rowset/segment.h"
+#include "storage/rowset/segment_iterator.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/tablet_schema.h"
+#include "storage/tablet_schema_helper.h"
 
 namespace starrocks {
 
@@ -313,5 +329,325 @@ TEST_F(VectorIndexSearchTest, tenann_reader_init_searcher_null_fs_delegates_to_l
 }
 
 #endif // WITH_TENANN
+
+
+// ==================== Brute-force fallback tests ====================
+// Test SegmentIterator brute-force fallback when .vi file is missing.
+// This covers: _prepare_vector_index, _setup_brute_force_fallback,
+// _init_ann_reader fallback path, and _compute_brute_force_distances.
+
+class BruteForceVectorFallbackTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _fs = std::make_shared<MemoryFileSystem>();
+        ASSERT_TRUE(_fs->create_dir(kSegmentDir).ok());
+    }
+
+    const std::string kSegmentDir = "/brute_force_vector_test";
+    std::shared_ptr<MemoryFileSystem> _fs;
+
+    // Build a TabletSchema with: id(BIGINT key) + vector(ARRAY<FLOAT>), no vector index.
+    // Used for writing segments.
+    std::shared_ptr<TabletSchema> build_write_schema() {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(DUP_KEYS);
+        schema_pb.set_next_column_unique_id(3);
+
+        auto* col0 = schema_pb.add_column();
+        col0->set_unique_id(0);
+        col0->set_name("id");
+        col0->set_type("BIGINT");
+        col0->set_is_key(true);
+        col0->set_is_nullable(false);
+        col0->set_length(8);
+        col0->set_index_length(8);
+        col0->set_aggregation("NONE");
+
+        auto* col1 = schema_pb.add_column();
+        col1->set_unique_id(1);
+        col1->set_name("vector");
+        col1->set_type("ARRAY");
+        col1->set_is_key(false);
+        col1->set_is_nullable(false);
+        col1->set_length(24);
+        col1->set_aggregation("NONE");
+        auto* child = col1->add_children_columns();
+        child->set_unique_id(2);
+        child->set_name("element");
+        child->set_type("FLOAT");
+        child->set_is_key(false);
+        child->set_is_nullable(true);
+        child->set_length(4);
+        child->set_aggregation("NONE");
+
+        return TabletSchema::create(schema_pb);
+    }
+
+    // Build a TabletSchema identical to write_schema but WITH vector index.
+    // Used for reading — simulates the real table schema that has a vector index.
+    std::shared_ptr<TabletSchema> build_read_schema_with_vector_index() {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(DUP_KEYS);
+        schema_pb.set_next_column_unique_id(3);
+
+        auto* col0 = schema_pb.add_column();
+        col0->set_unique_id(0);
+        col0->set_name("id");
+        col0->set_type("BIGINT");
+        col0->set_is_key(true);
+        col0->set_is_nullable(false);
+        col0->set_length(8);
+        col0->set_index_length(8);
+        col0->set_aggregation("NONE");
+
+        auto* col1 = schema_pb.add_column();
+        col1->set_unique_id(1);
+        col1->set_name("vector");
+        col1->set_type("ARRAY");
+        col1->set_is_key(false);
+        col1->set_is_nullable(false);
+        col1->set_length(24);
+        col1->set_aggregation("NONE");
+        auto* child = col1->add_children_columns();
+        child->set_unique_id(2);
+        child->set_name("element");
+        child->set_type("FLOAT");
+        child->set_is_key(false);
+        child->set_is_nullable(true);
+        child->set_length(4);
+        child->set_aggregation("NONE");
+
+        auto* idx = schema_pb.add_table_indices();
+        idx->set_index_id(100);
+        idx->set_index_name("vector_index");
+        idx->set_index_type(IndexType::VECTOR);
+        idx->add_col_unique_id(1);
+        std::string props =
+                R"({"common_properties":{"index_type":"hnsw","dim":"3","metric_type":"l2_distance","is_vector_normed":"false"},"index_properties":{"efconstruction":"40","m":"16"},"search_properties":{"efsearch":"40"}})";
+        idx->set_index_properties(props);
+
+        return TabletSchema::create(schema_pb);
+    }
+
+    // Write a segment WITHOUT vector index. The .vi file won't exist.
+    StatusOr<std::shared_ptr<Segment>> write_segment(const std::vector<int64_t>& ids,
+                                                     const std::vector<std::vector<float>>& vectors) {
+        auto write_schema = build_write_schema();
+        std::string file_name = kSegmentDir + "/test_segment.dat";
+        ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(file_name));
+
+        SegmentWriterOptions opts;
+        opts.num_rows_per_block = 100;
+        SegmentWriter writer(std::move(wfile), 0, write_schema, opts);
+
+        auto chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema(write_schema), ids.size());
+        for (auto id : ids) {
+            chunk->mutable_columns()[0]->append_datum(Datum(id));
+        }
+        for (const auto& vec : vectors) {
+            DatumArray arr;
+            for (float v : vec) {
+                arr.emplace_back(Datum(v));
+            }
+            chunk->mutable_columns()[1]->append_datum(Datum(arr));
+        }
+
+        RETURN_IF_ERROR(writer.init());
+        RETURN_IF_ERROR(writer.append_chunk(*chunk));
+        uint64_t seg_size = 0, index_size = 0, footer_pos = 0;
+        RETURN_IF_ERROR(writer.finalize(&seg_size, &index_size, &footer_pos));
+
+        // Open with the read schema (which has vector index) to simulate real scenario
+        auto read_schema = build_read_schema_with_vector_index();
+        return Segment::open(_fs, FileInfo{file_name}, 0, read_schema);
+    }
+};
+
+// Test: segment with skip_vector_index=true, SegmentIterator with use_vector_index=true.
+// _prepare_vector_index should detect skip flag, set up brute-force, add vector column to schema.
+// _compute_brute_force_distances should compute correct L2 distances.
+// The iterator should NOT crash and should return a chunk with the distance column.
+TEST_F(BruteForceVectorFallbackTest, test_brute_force_l2_distance_fallback) {
+    std::vector<int64_t> ids = {1, 2, 3};
+    std::vector<std::vector<float>> vectors = {
+            {1.0f, 2.0f, 3.0f},
+            {4.0f, 5.0f, 6.0f},
+            {0.0f, 0.0f, 0.0f},
+    };
+    ASSIGN_OR_ABORT(auto segment, write_segment(ids, vectors));
+
+    auto schema = build_read_schema_with_vector_index();
+
+    // Set up SegmentReadOptions with vector search enabled
+    OlapReaderStatistics stats;
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = schema;
+
+    auto vector_search_opt = std::make_shared<VectorSearchOption>();
+    vector_search_opt->use_vector_index = true;
+    vector_search_opt->query_vector = {1.0f, 1.0f, 1.0f};
+    vector_search_opt->k = 3;
+    vector_search_opt->k_factor = 1.0;
+    vector_search_opt->vector_distance_column_name = "__vector_approx_l2_distance";
+    // vector_column_id will be set to num_columns (virtual column), matching the FE rewrite behavior
+    vector_search_opt->vector_column_id = schema->num_columns();
+    vector_search_opt->vector_slot_id = 100; // arbitrary slot id
+    vector_search_opt->use_ivfpq = false;
+    vector_search_opt->vector_range = -1.0;
+    vector_search_opt->result_order = 0;
+    vector_search_opt->pq_refine_factor = 1.0;
+
+    seg_opts.use_vector_index = true;
+    seg_opts.vector_search_option = vector_search_opt;
+
+    // Build read schema: only the id column (vector column pruned by FE, as in real scenario)
+    Schema read_schema;
+    auto id_field = std::make_shared<Field>(0, "id", get_type_info(TYPE_BIGINT), false);
+    id_field->set_uid(0);
+    read_schema.append(id_field);
+
+    auto chunk_iter = new_segment_iterator(segment, read_schema, seg_opts);
+    ASSERT_TRUE(chunk_iter != nullptr);
+
+    // The output schema includes the distance virtual column appended by brute-force path
+    auto chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), 1024);
+    std::vector<uint32_t> rowids;
+    auto st = chunk_iter->get_next(chunk.get(), &rowids);
+
+    if (st.ok()) {
+        // Verify we got rows back and no crash
+        ASSERT_EQ(chunk->num_rows(), 3);
+
+        // Verify the distance column exists (appended as virtual column)
+        // The chunk should have id column + distance column
+        ASSERT_GE(chunk->num_columns(), 2);
+    }
+    // EndOfFile is also acceptable if the iterator processes all data
+    ASSERT_TRUE(st.ok() || st.is_end_of_file());
+
+    chunk_iter->close();
+}
+
+// Test: when vector column is already in read schema (not pruned),
+// _setup_brute_force_fallback should find it without adding a duplicate.
+TEST_F(BruteForceVectorFallbackTest, test_brute_force_vector_column_not_pruned) {
+    std::vector<int64_t> ids = {1, 2};
+    std::vector<std::vector<float>> vectors = {
+            {1.0f, 0.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+    };
+    ASSIGN_OR_ABORT(auto segment, write_segment(ids, vectors));
+
+    auto schema = build_read_schema_with_vector_index();
+
+    OlapReaderStatistics stats;
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = schema;
+
+    auto vector_search_opt = std::make_shared<VectorSearchOption>();
+    vector_search_opt->use_vector_index = true;
+    vector_search_opt->query_vector = {1.0f, 0.0f, 0.0f};
+    vector_search_opt->k = 2;
+    vector_search_opt->k_factor = 1.0;
+    vector_search_opt->vector_distance_column_name = "__vector_approx_l2_distance";
+    vector_search_opt->vector_column_id = schema->num_columns();
+    vector_search_opt->vector_slot_id = 200;
+    vector_search_opt->use_ivfpq = false;
+    vector_search_opt->vector_range = -1.0;
+    vector_search_opt->result_order = 0;
+    vector_search_opt->pq_refine_factor = 1.0;
+
+    seg_opts.use_vector_index = true;
+    seg_opts.vector_search_option = vector_search_opt;
+
+    // Build read schema including both id and vector columns (not pruned)
+    Schema read_schema;
+    auto id_field = std::make_shared<Field>(0, "id", get_type_info(TYPE_BIGINT), false);
+    id_field->set_uid(0);
+    read_schema.append(id_field);
+
+    // Add vector column to schema (simulating the case where FE doesn't prune it)
+    auto vec_field = std::make_shared<Field>(ChunkHelper::convert_field(1, schema->column(1)));
+    read_schema.append(vec_field);
+
+    auto chunk_iter = new_segment_iterator(segment, read_schema, seg_opts);
+    ASSERT_TRUE(chunk_iter != nullptr);
+
+    auto chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), 1024);
+    std::vector<uint32_t> rowids;
+    auto st = chunk_iter->get_next(chunk.get(), &rowids);
+
+    if (st.ok()) {
+        ASSERT_EQ(chunk->num_rows(), 2);
+        // Should have id + vector + distance columns
+        ASSERT_GE(chunk->num_columns(), 3);
+    }
+    ASSERT_TRUE(st.ok() || st.is_end_of_file());
+
+    chunk_iter->close();
+}
+
+// Test: brute-force fallback with vector_range filter.
+// Rows with distance > vector_range should be filtered out.
+TEST_F(BruteForceVectorFallbackTest, test_brute_force_with_vector_range_filter) {
+    std::vector<int64_t> ids = {1, 2, 3, 4};
+    std::vector<std::vector<float>> vectors = {
+            {1.0f, 0.0f, 0.0f}, // L2 dist to query [1,1,1] = 0+1+1 = 2
+            {0.0f, 0.0f, 0.0f}, // L2 dist = 1+1+1 = 3
+            {1.0f, 1.0f, 1.0f}, // L2 dist = 0
+            {5.0f, 5.0f, 5.0f}, // L2 dist = 16+16+16 = 48
+    };
+    ASSIGN_OR_ABORT(auto segment, write_segment(ids, vectors));
+
+    auto schema = build_read_schema_with_vector_index();
+
+    OlapReaderStatistics stats;
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = schema;
+
+    auto vector_search_opt = std::make_shared<VectorSearchOption>();
+    vector_search_opt->use_vector_index = true;
+    vector_search_opt->query_vector = {1.0f, 1.0f, 1.0f};
+    vector_search_opt->k = 4;
+    vector_search_opt->k_factor = 1.0;
+    vector_search_opt->vector_distance_column_name = "__vector_approx_l2_distance";
+    vector_search_opt->vector_column_id = schema->num_columns();
+    vector_search_opt->vector_slot_id = 300;
+    vector_search_opt->use_ivfpq = false;
+    // Set vector_range = 3.0: only rows with L2 distance <= 3.0 should pass
+    // Row 1 (dist=2): pass, Row 2 (dist=3): pass, Row 3 (dist=0): pass, Row 4 (dist=48): filtered
+    vector_search_opt->vector_range = 3.0;
+    vector_search_opt->result_order = 1; // ascending (L2: keep dist <= range)
+    vector_search_opt->pq_refine_factor = 1.0;
+
+    seg_opts.use_vector_index = true;
+    seg_opts.vector_search_option = vector_search_opt;
+
+    Schema read_schema;
+    auto id_field = std::make_shared<Field>(0, "id", get_type_info(TYPE_BIGINT), false);
+    id_field->set_uid(0);
+    read_schema.append(id_field);
+
+    auto chunk_iter = new_segment_iterator(segment, read_schema, seg_opts);
+    ASSERT_TRUE(chunk_iter != nullptr);
+
+    auto chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), 1024);
+    std::vector<uint32_t> rowids;
+    auto st = chunk_iter->get_next(chunk.get(), &rowids);
+
+    if (st.ok()) {
+        // Row 4 (dist=48) should be filtered out, leaving 3 rows
+        ASSERT_EQ(chunk->num_rows(), 3);
+    }
+    ASSERT_TRUE(st.ok() || st.is_end_of_file());
+
+    chunk_iter->close();
+}
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

When a `.vi` file is missing at query time — e.g. the writer's build threshold was not met, or async build hasn't finished in shared-data mode — queries that use `approx_l2_distance` / `approx_cosine_similarity` crash with `SIGSEGV`. The FE plan expects a distance column to be appended by the BE-side ANN reader, but with no `.vi` file there is no ANN reader, and the chunk reaches downstream operators with the distance column missing.

## What I'm doing:

Teach `SegmentIterator` to fall back to a brute-force distance computation when the `.vi` file is unavailable, following the existing CelerData-enterprise design:

* `SegmentIterator::_prepare_vector_index` runs before `_init_column_iterators` and consults the segment-footer hint (`skip_vector_index`, derived from `VECTOR_INDEX_STORAGE_NONE`) to short-circuit the ANN reader and add the vector data column to the read schema in the same I/O pass as everything else.
* `SegmentIterator::_init_ann_reader` keeps the existing happy path, but if the `.vi` open returns `NotFound` or an empty reader it now routes through `_setup_brute_force_fallback` rather than silently dropping the distance column.
* `SegmentIterator::_compute_brute_force_distances` iterates the vector array column once per chunk, computes L2 / cosine distance against the query vector, and appends a `FloatColumn` at the slot the planner expects. The `vector_range` filter is applied in the same pass and the synthetic vector data column is removed from the chunk if the iterator was the one that added it.
* `Segment::skip_vector_index()` is added on top of the existing `SegmentFooterPB.vector_index_storage_type` field so the iterator can read the footer hint without re-parsing the footer.

Three unit tests in `BruteForceVectorFallbackTest` cover:
* L2 fallback when the `.vi` file is absent.
* The `vector_range` filter on the fallback path.
* The case where the FE plan does not prune the vector column (so the iterator must reuse the existing schema entry rather than appending a new one).

This is a 1-to-1 backport of CelerData-enterprise commit `91b5df6fa71`, rebased on top of #72074's `lake::gen_vector_index_path_from_segment_path` helper so the cloud-native path computation is shared between the ANN-reader and brute-force entry points.

Fixes the SIGSEGV crash described above.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes
- [ ] Parameter changes
- [x] Policy changes: query path now produces correct distances instead of crashing when `.vi` is missing
- [ ] Feature removed
- [ ] Miscellaneous

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4