### PR TITLE
[BugFix] Enable memory limit check in olap table scan (backport #68650)

### DIFF
--- a/be/src/column/chunk_extra_data.cpp
+++ b/be/src/column/chunk_extra_data.cpp
@@ -81,18 +81,18 @@ int64_t ChunkExtraColumnsData::max_serialized_size(const int encode_level) {
     return serialized_size;
 }
 
-uint8_t* ChunkExtraColumnsData::serialize(uint8_t* buff, bool sorted, const int encode_level) {
+StatusOr<uint8_t*> ChunkExtraColumnsData::serialize(uint8_t* buff, bool sorted, const int encode_level) {
     DCHECK_EQ(encode_level, 0);
     for (auto& column : _columns) {
-        buff = serde::ColumnArraySerde::serialize(*column, buff, sorted, encode_level);
+        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(*column, buff, sorted, encode_level));
     }
     return buff;
 }
 
-const uint8_t* ChunkExtraColumnsData::deserialize(const uint8_t* buff, bool sorted, const int encode_level) {
+StatusOr<const uint8_t*> ChunkExtraColumnsData::deserialize(const uint8_t* buff, bool sorted, const int encode_level) {
     DCHECK_EQ(encode_level, 0);
     for (auto& column : _columns) {
-        buff = serde::ColumnArraySerde::deserialize(buff, column.get(), sorted, encode_level);
+        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::deserialize(buff, column.get(), sorted, encode_level));
     }
     return buff;
 }

--- a/be/src/column/chunk_extra_data.h
+++ b/be/src/column/chunk_extra_data.h
@@ -56,8 +56,8 @@ public:
     size_t bytes_usage(size_t from, size_t size) const;
 
     int64_t max_serialized_size(const int encode_level = 0);
-    uint8_t* serialize(uint8_t* buff, bool sorted = false, const int encode_level = 0);
-    const uint8_t* deserialize(const uint8_t* buff, bool sorted = false, const int encode_level = 0);
+    StatusOr<uint8_t*> serialize(uint8_t* buff, bool sorted = false, const int encode_level = 0);
+    StatusOr<const uint8_t*> deserialize(const uint8_t* buff, bool sorted = false, const int encode_level = 0);
 
     static ChunkExtraColumnsData* as_raw(const ChunkExtraDataPtr& extra_data);
 

--- a/be/src/common/object_pool.h
+++ b/be/src/common/object_pool.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -40,9 +41,11 @@ public:
 
     template <class T>
     T* add(T* t) {
+        std::unique_ptr<T> uniq(t);
         // TODO: Consider using a lock-free structure.
         std::lock_guard<SpinLock> l(_lock);
         _objects.emplace_back(Element{t, [](void* obj) { delete reinterpret_cast<T*>(obj); }});
+        uniq.release();
         return t;
     }
 

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -102,7 +102,7 @@ protected:
     pipeline::ScanSplitContext* _split_context = nullptr;
 
     virtual Status _init_chunk_if_needed(ChunkPtr* chunk, size_t n) {
-        *chunk = ChunkHelper::new_chunk(*_tuple_desc, n);
+        ASSIGN_OR_RETURN(*chunk, ChunkHelper::new_chunk_checked(*_tuple_desc, n));
         return Status::OK();
     }
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -864,8 +864,8 @@ Status HiveDataSource::_init_chunk_if_needed(ChunkPtr* chunk, size_t n) {
     if ((*chunk) != nullptr && (*chunk)->num_columns() != 0) {
         return Status::OK();
     }
+    ASSIGN_OR_RETURN(*chunk, ChunkHelper::new_chunk_checked(*_tuple_desc, n));
 
-    *chunk = ChunkHelper::new_chunk(*_tuple_desc, n);
     return Status::OK();
 }
 

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -138,7 +138,9 @@ Status IcebergDeleteBuilder::build_parquet(const TIcebergDeleteFile& delete_file
     RETURN_IF_ERROR(reader->init(scanner_ctx.get()));
 
     while (true) {
-        ChunkPtr chunk = ChunkHelper::new_chunk(slot_descriptors, _runtime_state->chunk_size());
+        ASSIGN_OR_RETURN(ChunkPtr chunk,
+                         ChunkHelper::new_chunk_checked(slot_descriptors, _runtime_state->chunk_size()));
+
         Status status = reader->get_next(&chunk);
         if (status.is_end_of_file()) {
             break;

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
@@ -419,8 +419,7 @@ Status MemLimitedChunkQueue::_flush() {
     // 2. serialize data
     for (auto& chunk : chunks) {
         for (const auto& column : chunk->columns()) {
-            buf = serde::ColumnArraySerde::serialize(*column, buf, false, _opts.encode_level);
-            RETURN_IF(buf == nullptr, Status::InternalError("serialize data error"));
+            ASSIGN_OR_RETURN(buf, serde::ColumnArraySerde::serialize(*column, buf, false, _opts.encode_level));
         }
     }
     size_t content_length = buf - begin;
@@ -524,8 +523,8 @@ Status MemLimitedChunkQueue::_load(Block* block) {
     for (auto& chunk : chunks) {
         chunk = _chunk_builder->clone_empty();
         for (auto& column : chunk->columns()) {
-            read_cursor = serde::ColumnArraySerde::deserialize(read_cursor, column.get(), false, _opts.encode_level);
-            RETURN_IF(read_cursor == nullptr, Status::InternalError("deserialize failed"));
+            ASSIGN_OR_RETURN(read_cursor, serde::ColumnArraySerde::deserialize(read_cursor, column.get(), false,
+                                                                               _opts.encode_level));
         }
     }
     {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/pipeline/scan/olap_chunk_source.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <string_view>
 #include <unordered_map>
@@ -22,6 +23,7 @@
 #include "column/column_access_path.h"
 #include "column/field.h"
 #include "common/status.h"
+#include "common/statusor.h"
 #include "exec/olap_scan_node.h"
 #include "exec/olap_scan_prepare.h"
 #include "exec/pipeline/scan/olap_scan_context.h"
@@ -568,7 +570,9 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
 }
 
 Status OlapChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
-    chunk->reset(ChunkHelper::new_chunk_pooled(_prj_iter->output_schema(), _runtime_state->chunk_size()));
+    ASSIGN_OR_RETURN(auto chunk_ptr,
+                     ChunkHelper::new_chunk_pooled_checked(_prj_iter->output_schema(), _runtime_state->chunk_size()));
+    chunk->reset(chunk_ptr);
     auto scope = IOProfiler::scope(IOProfiler::TAG_QUERY, _tablet->tablet_id());
     return _read_chunk_from_storage(_runtime_state, (*chunk).get());
 }

--- a/be/src/exprs/runtime_filter_bank.h
+++ b/be/src/exprs/runtime_filter_bank.h
@@ -60,12 +60,13 @@ public:
     static size_t max_runtime_filter_serialized_size_for_skew_boradcast_join(const ColumnPtr& column);
     static size_t serialize_runtime_filter(RuntimeState* state, const RuntimeFilter* rf, uint8_t* data);
     static size_t serialize_runtime_filter(int rf_version, const RuntimeFilter* rf, uint8_t* data);
-    static size_t serialize_runtime_filter_for_skew_broadcast_join(const ColumnPtr& column, bool eq_null,
-                                                                   uint8_t* data);
+    static StatusOr<size_t> serialize_runtime_filter_for_skew_broadcast_join(const ColumnPtr& column, bool eq_null,
+                                                                             uint8_t* data);
     static int deserialize_runtime_filter(ObjectPool* pool, RuntimeFilter** rf, const uint8_t* data, size_t size);
-    static int deserialize_runtime_filter_for_skew_broadcast_join(ObjectPool* pool, SkewBroadcastRfMaterial** material,
-                                                                  const uint8_t* data, size_t size,
-                                                                  const PTypeDesc& ptype);
+    static StatusOr<int> deserialize_runtime_filter_for_skew_broadcast_join(ObjectPool* pool,
+                                                                            SkewBroadcastRfMaterial** material,
+                                                                            const uint8_t* data, size_t size,
+                                                                            const PTypeDesc& ptype);
 
     static RuntimeFilter* create_runtime_empty_filter(ObjectPool* pool, LogicalType type, int8_t join_mode);
     static RuntimeFilter* create_runtime_bloom_filter(ObjectPool* pool, LogicalType type, int8_t join_mode);

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -23,6 +23,7 @@
 #include "column/chunk.h"
 #include "common/config.h"
 #include "common/status.h"
+#include "common/statusor.h"
 #include "exec/exec_node.h"
 #include "exec/hdfs_scanner.h"
 #include "exprs/expr.h"
@@ -105,7 +106,7 @@ Status GroupReader::prepare() {
     }
 
     RETURN_IF_ERROR(_rewrite_conjunct_ctxs_to_predicates(&_is_group_filtered));
-    _init_read_chunk();
+    RETURN_IF_ERROR(_init_read_chunk());
 
     if (!_is_group_filtered) {
         _range_iter = _range.new_iterator();
@@ -474,13 +475,14 @@ void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::I
     *end_offset = end;
 }
 
-void GroupReader::_init_read_chunk() {
+Status GroupReader::_init_read_chunk() {
     std::vector<SlotDescriptor*> read_slots;
     for (const auto& column : _param.read_cols) {
         read_slots.emplace_back(column.slot_desc);
     }
     size_t chunk_size = _param.chunk_size;
-    _read_chunk = ChunkHelper::new_chunk(read_slots, chunk_size);
+    ASSIGN_OR_RETURN(_read_chunk, ChunkHelper::new_chunk_checked(read_slots, chunk_size));
+    return Status::OK();
 }
 
 void GroupReader::_use_as_dict_filter_column(int col_idx, SlotId slot_id, std::vector<std::string>& sub_field_path) {

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -154,7 +154,7 @@ private:
     bool _try_to_use_dict_filter(const GroupReaderParam::Column& column, ExprContext* ctx,
                                  std::vector<std::string>& sub_field_path, bool is_decode_needed);
 
-    void _init_read_chunk();
+    Status _init_read_chunk();
 
     Status _read_range(const std::vector<int>& read_columns, const Range<uint64_t>& range, const Filter* filter,
                        ChunkPtr* chunk);

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -470,7 +470,7 @@ private:
 
 #define TRY_CATCH_ALLOC_SCOPE_START() \
     try {                             \
-        SCOPED_SET_CATCHED(true);
+        SCOPED_SET_CATCHED(CurrentThread::current().check_mem_limit());
 
 #define TRY_CATCH_ALLOC_SCOPE_END()                                                                                    \
     }                                                                                                                  \

--- a/be/src/runtime/raw_container_checked.h
+++ b/be/src/runtime/raw_container_checked.h
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <vector>
+
+#include "common/status.h"
+#include "runtime/current_thread.h"
+#include "util/raw_container.h"
+
+namespace starrocks::raw {
+
+template <VecContainer Container>
+inline Status stl_vector_resize_uninitialized_checked(Container* vec, size_t new_size) {
+    TRY_CATCH_ALLOC_SCOPE_START()
+    using T = typename Container::value_type;
+    ((RawVector<T, typename Container::allocator_type>*)vec)->resize(new_size);
+    return Status::OK();
+    TRY_CATCH_ALLOC_SCOPE_END()
+}
+
+template <VecContainer Container>
+inline Status stl_vector_resize_uninitialized_checked(Container* vec, size_t reserve_size, size_t new_size) {
+    TRY_CATCH_ALLOC_SCOPE_START()
+    using T = typename Container::value_type;
+    ((RawVector<T, typename Container::allocator_type>*)vec)->resize(reserve_size);
+    vec->resize(new_size);
+    return Status::OK();
+    TRY_CATCH_ALLOC_SCOPE_END()
+}
+
+} // namespace starrocks::raw

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -255,9 +255,10 @@ void RuntimeFilterPort::publish_skew_boradcast_join_key_columns(RuntimeFilterBui
     std::string* rf_data = params.mutable_data();
     size_t max_size = RuntimeFilterHelper::max_runtime_filter_serialized_size_for_skew_boradcast_join(keyColumn);
     rf_data->resize(max_size);
-    size_t actual_size = RuntimeFilterHelper::serialize_runtime_filter_for_skew_broadcast_join(
+    auto actual_size = RuntimeFilterHelper::serialize_runtime_filter_for_skew_broadcast_join(
             keyColumn, null_safe, reinterpret_cast<uint8_t*>(rf_data->data()));
-    rf_data->resize(actual_size);
+    RETURN_IF(!actual_size.status().ok(), (void)nullptr);
+    rf_data->resize(actual_size.value());
     *(params.mutable_columntype()) = type_desc.to_protobuf();
     state->exec_env()->runtime_filter_worker()->send_part_runtime_filter(std::move(params), rf_desc->merge_nodes(),
                                                                          timeout_ms, rpc_http_min_size,
@@ -500,10 +501,10 @@ void RuntimeFilterMerger::store_skew_broadcast_join_runtime_filter(PTransmitRunt
 
     // store material of broadcast join rf
     status->skew_broadcast_rf_material = nullptr;
-    int rf_version = RuntimeFilterHelper::deserialize_runtime_filter_for_skew_broadcast_join(
+    auto rf_version = RuntimeFilterHelper::deserialize_runtime_filter_for_skew_broadcast_join(
             &(status->pool), &(status->skew_broadcast_rf_material),
             reinterpret_cast<const uint8_t*>(params.data().data()), params.data().size(), params.columntype());
-
+    RETURN_IF(!rf_version.ok(), (void)nullptr);
     if (status->skew_broadcast_rf_material == nullptr) {
         // something wrong with deserialization.
         return;
@@ -513,7 +514,7 @@ void RuntimeFilterMerger::store_skew_broadcast_join_runtime_filter(PTransmitRunt
     if (status->filters.size() < status->expect_number) return;
 
     // this only happens when boradcast's rf is the last rf instance arrived
-    _send_total_runtime_filter(rf_version, filter_id);
+    _send_total_runtime_filter(rf_version.value(), filter_id);
 }
 
 struct BatchClosuresJoinAndClean {

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -31,6 +31,7 @@
 #include "column/nullable_column.h"
 #include "column/object_column.h"
 #include "column/struct_column.h"
+#include "common/statusor.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptors.h"
 #include "serde/protobuf_serde.h"
@@ -391,15 +392,17 @@ public:
                serde::ColumnArraySerde::max_serialized_size(*column.data_column(), encode_level);
     }
 
-    static uint8_t* serialize(const NullableColumn& column, uint8_t* buff, const int encode_level) {
-        buff = serde::ColumnArraySerde::serialize(*column.null_column(), buff, false, encode_level);
-        buff = serde::ColumnArraySerde::serialize(*column.data_column(), buff, false, encode_level);
+    static StatusOr<uint8_t*> serialize(const NullableColumn& column, uint8_t* buff, const int encode_level) {
+        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(*column.null_column(), buff, false, encode_level));
+        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(*column.data_column(), buff, false, encode_level));
         return buff;
     }
 
-    static const uint8_t* deserialize(const uint8_t* buff, NullableColumn* column, const int encode_level) {
-        buff = serde::ColumnArraySerde::deserialize(buff, column->null_column().get(), false, encode_level);
-        buff = serde::ColumnArraySerde::deserialize(buff, column->data_column().get(), false, encode_level);
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, NullableColumn* column, const int encode_level) {
+        ASSIGN_OR_RETURN(buff,
+                         serde::ColumnArraySerde::deserialize(buff, column->null_column().get(), false, encode_level));
+        ASSIGN_OR_RETURN(buff,
+                         serde::ColumnArraySerde::deserialize(buff, column->data_column().get(), false, encode_level));
         column->update_has_null();
         return buff;
     }
@@ -412,15 +415,17 @@ public:
                serde::ColumnArraySerde::max_serialized_size(column.elements(), encode_level);
     }
 
-    static uint8_t* serialize(const ArrayColumn& column, uint8_t* buff, const int encode_level) {
-        buff = serde::ColumnArraySerde::serialize(column.offsets(), buff, true, encode_level);
-        buff = serde::ColumnArraySerde::serialize(column.elements(), buff, false, encode_level);
+    static StatusOr<uint8_t*> serialize(const ArrayColumn& column, uint8_t* buff, const int encode_level) {
+        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(column.offsets(), buff, true, encode_level));
+        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(column.elements(), buff, false, encode_level));
         return buff;
     }
 
-    static const uint8_t* deserialize(const uint8_t* buff, ArrayColumn* column, const int encode_level) {
-        buff = serde::ColumnArraySerde::deserialize(buff, column->offsets_column().get(), true, encode_level);
-        buff = serde::ColumnArraySerde::deserialize(buff, column->elements_column().get(), false, encode_level);
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, ArrayColumn* column, const int encode_level) {
+        ASSIGN_OR_RETURN(
+                buff, serde::ColumnArraySerde::deserialize(buff, column->offsets_column().get(), true, encode_level));
+        ASSIGN_OR_RETURN(
+                buff, serde::ColumnArraySerde::deserialize(buff, column->elements_column().get(), false, encode_level));
         return buff;
     }
 };
@@ -433,17 +438,20 @@ public:
                serde::ColumnArraySerde::max_serialized_size(column.values(), encode_level);
     }
 
-    static uint8_t* serialize(const MapColumn& column, uint8_t* buff, const int encode_level) {
-        buff = serde::ColumnArraySerde::serialize(column.offsets(), buff, true, encode_level);
-        buff = serde::ColumnArraySerde::serialize(column.keys(), buff, false, encode_level);
-        buff = serde::ColumnArraySerde::serialize(column.values(), buff, false, encode_level);
+    static StatusOr<uint8_t*> serialize(const MapColumn& column, uint8_t* buff, const int encode_level) {
+        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(column.offsets(), buff, true, encode_level));
+        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(column.keys(), buff, false, encode_level));
+        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(column.values(), buff, false, encode_level));
         return buff;
     }
 
-    static const uint8_t* deserialize(const uint8_t* buff, MapColumn* column, const int encode_level) {
-        buff = serde::ColumnArraySerde::deserialize(buff, column->offsets_column().get(), true, encode_level);
-        buff = serde::ColumnArraySerde::deserialize(buff, column->keys_column().get(), false, encode_level);
-        buff = serde::ColumnArraySerde::deserialize(buff, column->values_column().get(), false, encode_level);
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, MapColumn* column, const int encode_level) {
+        ASSIGN_OR_RETURN(
+                buff, serde::ColumnArraySerde::deserialize(buff, column->offsets_column().get(), true, encode_level));
+        ASSIGN_OR_RETURN(buff,
+                         serde::ColumnArraySerde::deserialize(buff, column->keys_column().get(), false, encode_level));
+        ASSIGN_OR_RETURN(
+                buff, serde::ColumnArraySerde::deserialize(buff, column->values_column().get(), false, encode_level));
         return buff;
     }
 };
@@ -458,16 +466,16 @@ public:
         return size;
     }
 
-    static uint8_t* serialize(const StructColumn& column, uint8_t* buff, const int encode_level) {
+    static StatusOr<uint8_t*> serialize(const StructColumn& column, uint8_t* buff, const int encode_level) {
         for (const auto& field : column.fields()) {
-            buff = serde::ColumnArraySerde::serialize(*field, buff, false, encode_level);
+            ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(*field, buff, false, encode_level));
         }
         return buff;
     }
 
-    static const uint8_t* deserialize(const uint8_t* buff, StructColumn* column, const int encode_level) {
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, StructColumn* column, const int encode_level) {
         for (auto& field : column->fields_column()) {
-            buff = serde::ColumnArraySerde::deserialize(buff, field.get(), false, encode_level);
+            ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::deserialize(buff, field.get(), false, encode_level));
         }
         return buff;
     }
@@ -480,16 +488,17 @@ public:
                serde::ColumnArraySerde::max_serialized_size(*column.data_column(), encode_level);
     }
 
-    static uint8_t* serialize(const ConstColumn& column, uint8_t* buff, const int encode_level) {
+    static StatusOr<uint8_t*> serialize(const ConstColumn& column, uint8_t* buff, const int encode_level) {
         buff = write_little_endian_64(column.size(), buff);
-        buff = serde::ColumnArraySerde::serialize(*column.data_column(), buff, false, encode_level);
+        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(*column.data_column(), buff, false, encode_level));
         return buff;
     }
 
-    static const uint8_t* deserialize(const uint8_t* buff, ConstColumn* column, const int encode_level) {
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, ConstColumn* column, const int encode_level) {
         uint64_t size = 0;
         buff = read_little_endian_64(buff, &size);
-        buff = serde::ColumnArraySerde::deserialize(buff, column->data_column().get(), false, encode_level);
+        ASSIGN_OR_RETURN(buff,
+                         serde::ColumnArraySerde::deserialize(buff, column->data_column().get(), false, encode_level));
         column->resize(size);
         return buff;
     }
@@ -561,27 +570,27 @@ public:
             : ColumnVisitorAdapter(this), _buff(buff), _cur(buff), _sorted(sorted), _encode_level(encode_level) {}
 
     Status do_visit(const NullableColumn& column) {
-        _cur = NullableColumnSerde::serialize(column, _cur, _encode_level);
+        ASSIGN_OR_RETURN(_cur, NullableColumnSerde::serialize(column, _cur, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(const ConstColumn& column) {
-        _cur = ConstColumnSerde::serialize(column, _cur, _encode_level);
+        ASSIGN_OR_RETURN(_cur, ConstColumnSerde::serialize(column, _cur, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(const ArrayColumn& column) {
-        _cur = ArrayColumnSerde::serialize(column, _cur, _encode_level);
+        ASSIGN_OR_RETURN(_cur, ArrayColumnSerde::serialize(column, _cur, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(const MapColumn& column) {
-        _cur = MapColumnSerde::serialize(column, _cur, _encode_level);
+        ASSIGN_OR_RETURN(_cur, MapColumnSerde::serialize(column, _cur, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(const StructColumn& column) {
-        _cur = StructColumnSerde::serialize(column, _cur, _encode_level);
+        ASSIGN_OR_RETURN(_cur, StructColumnSerde::serialize(column, _cur, _encode_level));
         return Status::OK();
     }
 
@@ -633,27 +642,27 @@ public:
               _encode_level(encode_level) {}
 
     Status do_visit(NullableColumn* column) {
-        _cur = NullableColumnSerde::deserialize(_cur, column, _encode_level);
+        ASSIGN_OR_RETURN(_cur, NullableColumnSerde::deserialize(_cur, column, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(ConstColumn* column) {
-        _cur = ConstColumnSerde::deserialize(_cur, column, _encode_level);
+        ASSIGN_OR_RETURN(_cur, ConstColumnSerde::deserialize(_cur, column, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(ArrayColumn* column) {
-        _cur = ArrayColumnSerde::deserialize(_cur, column, _encode_level);
+        ASSIGN_OR_RETURN(_cur, ArrayColumnSerde::deserialize(_cur, column, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(MapColumn* column) {
-        _cur = MapColumnSerde::deserialize(_cur, column, _encode_level);
+        ASSIGN_OR_RETURN(_cur, MapColumnSerde::deserialize(_cur, column, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(StructColumn* column) {
-        _cur = StructColumnSerde::deserialize(_cur, column, _encode_level);
+        ASSIGN_OR_RETURN(_cur, StructColumnSerde::deserialize(_cur, column, _encode_level));
         return Status::OK();
     }
 
@@ -704,18 +713,18 @@ int64_t ColumnArraySerde::max_serialized_size(const Column& column, const int en
     return st.ok() ? visitor.size() : 0;
 }
 
-uint8_t* ColumnArraySerde::serialize(const Column& column, uint8_t* buff, bool sorted, const int encode_level) {
+StatusOr<uint8_t*> ColumnArraySerde::serialize(const Column& column, uint8_t* buff, bool sorted,
+                                               const int encode_level) {
     ColumnSerializingVisitor visitor(buff, sorted, encode_level);
-    auto st = column.accept(&visitor);
-    LOG_IF(WARNING, !st.ok()) << st;
-    return st.ok() ? visitor.cur() : nullptr;
+    RETURN_IF_ERROR(column.accept(&visitor));
+    return visitor.cur();
 }
 
-const uint8_t* ColumnArraySerde::deserialize(const uint8_t* data, Column* column, bool sorted, const int encode_level) {
+StatusOr<const uint8_t*> ColumnArraySerde::deserialize(const uint8_t* data, Column* column, bool sorted,
+                                                       const int encode_level) {
     ColumnDeserializingVisitor visitor(data, sorted, encode_level);
-    auto st = column->accept_mutable(&visitor);
-    LOG_IF(WARNING, !st.ok()) << st;
-    return st.ok() ? visitor.cur() : nullptr;
+    RETURN_IF_ERROR(column->accept_mutable(&visitor));
+    return visitor.cur();
 }
 
 } // namespace starrocks::serde

--- a/be/src/serde/column_array_serde.h
+++ b/be/src/serde/column_array_serde.h
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 
+#include "common/statusor.h"
+
 namespace starrocks {
 struct TypeDescriptor;
 }
@@ -33,11 +35,12 @@ public:
     static int64_t max_serialized_size(const Column& column, const int encode_level = 0);
 
     // Return nullptr on error.
-    static uint8_t* serialize(const Column& column, uint8_t* buff, bool sorted = false, const int encode_level = 0);
+    static StatusOr<uint8_t*> serialize(const Column& column, uint8_t* buff, bool sorted = false,
+                                        const int encode_level = 0);
 
     // Return nullptr on error.
-    static const uint8_t* deserialize(const uint8_t* buff, Column* column, bool sorted = false,
-                                      const int encode_level = 0);
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, Column* column, bool sorted = false,
+                                                const int encode_level = 0);
 };
 
 } //  namespace starrocks::serde

--- a/be/src/storage/aggregate_iterator.cpp
+++ b/be/src/storage/aggregate_iterator.cpp
@@ -61,7 +61,7 @@ public:
     Status init_encoded_schema(ColumnIdToGlobalDictMap& dict_maps) override {
         RETURN_IF_ERROR(ChunkIterator::init_encoded_schema(dict_maps));
         RETURN_IF_ERROR(_child->init_encoded_schema(dict_maps));
-        _curr_chunk = ChunkHelper::new_chunk(encoded_schema(), _chunk_size);
+        ASSIGN_OR_RETURN(_curr_chunk, ChunkHelper::new_chunk_checked(encoded_schema(), _chunk_size));
         _aggregator = std::make_unique<ChunkAggregator>(&encoded_schema(), _chunk_size, _pre_aggregate_factor / 100,
                                                         _is_vertical_merge, _is_key);
         return Status::OK();
@@ -70,7 +70,7 @@ public:
     Status init_output_schema(const std::unordered_set<uint32_t>& unused_output_column_ids) override {
         RETURN_IF_ERROR(ChunkIterator::init_output_schema(unused_output_column_ids));
         RETURN_IF_ERROR(_child->init_output_schema(unused_output_column_ids));
-        _curr_chunk = ChunkHelper::new_chunk(output_schema(), _chunk_size);
+        ASSIGN_OR_RETURN(_curr_chunk, ChunkHelper::new_chunk_checked(output_schema(), _chunk_size));
         _aggregator = std::make_unique<ChunkAggregator>(&output_schema(), _chunk_size, _pre_aggregate_factor / 100,
                                                         _is_vertical_merge, _is_key);
         return Status::OK();

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -449,6 +449,35 @@ ChunkUniquePtr ChunkHelper::new_chunk(const std::vector<SlotDescriptor*>& slots,
     return chunk;
 }
 
+// create object column then reserve is exception safe.
+
+StatusOr<Chunk*> ChunkHelper::new_chunk_pooled_checked(const Schema& schema, size_t n) {
+    TRY_CATCH_ALLOC_SCOPE_START()
+    auto* chunk = ChunkHelper::new_chunk_pooled(schema, n);
+    return chunk;
+    TRY_CATCH_ALLOC_SCOPE_END();
+}
+
+StatusOr<ChunkUniquePtr> ChunkHelper::new_chunk_checked(const Schema& schema, size_t n) {
+    TRY_CATCH_ALLOC_SCOPE_START()
+    ChunkUniquePtr chunk;
+    chunk = ChunkHelper::new_chunk(schema, n);
+    return chunk;
+    TRY_CATCH_ALLOC_SCOPE_END();
+}
+
+StatusOr<ChunkUniquePtr> ChunkHelper::new_chunk_checked(const std::vector<SlotDescriptor*>& slots, size_t n) {
+    TRY_CATCH_ALLOC_SCOPE_START()
+    ChunkUniquePtr chunk;
+    chunk = ChunkHelper::new_chunk(slots, n);
+    return chunk;
+    TRY_CATCH_ALLOC_SCOPE_END();
+}
+
+StatusOr<ChunkUniquePtr> ChunkHelper::new_chunk_checked(const TupleDescriptor& tuple_desc, size_t n) {
+    return ChunkHelper::new_chunk_checked(tuple_desc.slots(), n);
+}
+
 void ChunkHelper::reorder_chunk(const TupleDescriptor& tuple_desc, Chunk* chunk) {
     return reorder_chunk(tuple_desc.slots(), chunk);
 }

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -71,6 +71,13 @@ public:
 
     static Chunk* new_chunk_pooled(const Schema& schema, size_t n);
 
+    // a wrapper of new_chunk_pooled with memory check
+    static StatusOr<Chunk*> new_chunk_pooled_checked(const Schema& schema, size_t n);
+    // a wrapper of new_chunk with memory check
+    static StatusOr<ChunkUniquePtr> new_chunk_checked(const Schema& schema, size_t n);
+    static StatusOr<ChunkUniquePtr> new_chunk_checked(const std::vector<SlotDescriptor*>& slots, size_t n);
+    static StatusOr<ChunkUniquePtr> new_chunk_checked(const TupleDescriptor& tuple_desc, size_t n);
+
     // Create a vectorized column from field .
     // REQUIRE: |type| must be scalar type.
     static MutableColumnPtr column_from_field_type(LogicalType type, bool nullable);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -592,11 +592,8 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
         ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
         // serialize to column
         auto pkc = pk_column->clone();
-        if (serde::ColumnArraySerde::deserialize(reinterpret_cast<const uint8_t*>(read_buffer.data()), pkc.get()) ==
-            nullptr) {
-            // Deserialze will fail when del file is corrupted.
-            return Status::InternalError("column deserialization failed");
-        }
+        using Serd = serde::ColumnArraySerde;
+        RETURN_IF_ERROR(Serd::deserialize(reinterpret_cast<const uint8_t*>(read_buffer.data()), pkc.get()));
         // We can't insert delete operation to index directly, because some delete operation is
         // older than current item, and we need to igore these delete operations.
         std::vector<IndexValue> found_values(pkc->size(), IndexValue(NullIndexValue));

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -72,9 +72,7 @@ Status HorizontalPkTabletWriter::flush_del_file(const Column& deletes) {
     }
     size_t sz = serde::ColumnArraySerde::max_serialized_size(deletes);
     std::vector<uint8_t> content(sz);
-    if (serde::ColumnArraySerde::serialize(deletes, content.data()) == nullptr) {
-        return Status::InternalError("deletes column serialize failed");
-    }
+    RETURN_IF_ERROR(serde::ColumnArraySerde::serialize(deletes, content.data()));
     RETURN_IF_ERROR(of->append(Slice(content.data(), content.size())));
     RETURN_IF_ERROR(of->close());
     _files.emplace_back(FileInfo{std::move(name), content.size(), encryption_meta});

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -807,10 +807,8 @@ Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStatePa
     ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file(opts, params.tablet->del_location(path)));
     ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
     auto col = pk_column->clone();
-    if (serde::ColumnArraySerde::deserialize(reinterpret_cast<const uint8_t*>(read_buffer.data()), col.get()) ==
-        nullptr) {
-        return Status::InternalError("column deserialization failed");
-    }
+    using Serd = serde::ColumnArraySerde;
+    RETURN_IF_ERROR(Serd::deserialize(reinterpret_cast<const uint8_t*>(read_buffer.data()), col.get()));
     col->raw_data();
     _memory_usage += col->memory_usage();
     _deletes[del_id] = std::move(col);

--- a/be/src/storage/primary_key_recover.cpp
+++ b/be/src/storage/primary_key_recover.cpp
@@ -65,9 +65,7 @@ Status PrimaryKeyRecover::recover() {
                         std::vector<uint8_t> read_buffer(file_size);
                         RETURN_IF_ERROR(read_file->read_at_fully(0, read_buffer.data(), read_buffer.size()));
                         auto col = pk_column->clone();
-                        if (serde::ColumnArraySerde::deserialize(read_buffer.data(), col.get()) == nullptr) {
-                            return Status::InternalError("column deserialization failed");
-                        }
+                        RETURN_IF_ERROR(serde::ColumnArraySerde::deserialize(read_buffer.data(), col.get()));
                         RETURN_IF_ERROR(index.erase(*col, &new_deletes));
                         del_index++;
                     } else {

--- a/be/src/storage/projection_iterator.cpp
+++ b/be/src/storage/projection_iterator.cpp
@@ -75,7 +75,7 @@ void ProjectionIterator::build_index_map(const Schema& output, const Schema& inp
 Status ProjectionIterator::do_get_next(Chunk* chunk) {
     if (_chunk == nullptr) {
         DCHECK_GT(_child->output_schema().num_fields(), 0);
-        _chunk = ChunkHelper::new_chunk(_child->output_schema(), _chunk_size);
+        ASSIGN_OR_RETURN(_chunk, ChunkHelper::new_chunk_checked(_child->output_schema(), _chunk_size));
     }
     _chunk->reset();
     Status st = _child->get_next(_chunk.get());

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -688,9 +688,7 @@ Status HorizontalRowsetWriter::flush_chunk_with_deletes(const Chunk& upserts, co
         ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(wopts, file_path));
         size_t sz = serde::ColumnArraySerde::max_serialized_size(deletes);
         std::vector<uint8_t> content(sz);
-        if (serde::ColumnArraySerde::serialize(deletes, content.data()) == nullptr) {
-            return Status::InternalError("deletes column serialize failed");
-        }
+        RETURN_IF_ERROR(serde::ColumnArraySerde::serialize(deletes, content.data()));
         RETURN_IF_ERROR(wfile->append(Slice(content.data(), content.size())));
         if (config::sync_tablet_meta) {
             RETURN_IF_ERROR(wfile->sync());

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1610,12 +1610,13 @@ Status SegmentIterator::_switch_context(ScanContext* to) {
     }
 
     if (to->_read_chunk == nullptr) {
-        to->_read_chunk = ChunkHelper::new_chunk(to->_read_schema, _reserve_chunk_size);
+        ASSIGN_OR_RETURN(to->_read_chunk, ChunkHelper::new_chunk_checked(to->_read_schema, _reserve_chunk_size));
     }
 
     if (to->_has_dict_column) {
         if (to->_dict_chunk == nullptr) {
-            to->_dict_chunk = ChunkHelper::new_chunk(to->_dict_decode_schema, _reserve_chunk_size);
+            ASSIGN_OR_RETURN(to->_dict_chunk,
+                             ChunkHelper::new_chunk_checked(to->_dict_decode_schema, _reserve_chunk_size));
         }
     } else {
         to->_dict_chunk = to->_read_chunk;
@@ -1650,15 +1651,16 @@ Status SegmentIterator::_switch_context(ScanContext* to) {
                 output_schema_idx++;
             }
         }
-
-        to->_final_chunk = ChunkHelper::new_chunk(final_chunk_schema, _reserve_chunk_size);
+        ASSIGN_OR_RETURN(to->_final_chunk, ChunkHelper::new_chunk_checked(final_chunk_schema, _reserve_chunk_size));
     } else {
-        to->_final_chunk = ChunkHelper::new_chunk(this->output_schema(), _reserve_chunk_size);
+        ASSIGN_OR_RETURN(to->_final_chunk, ChunkHelper::new_chunk_checked(this->output_schema(), _reserve_chunk_size));
     }
-
-    to->_adapt_global_dict_chunk = to->_has_force_dict_encode
-                                           ? ChunkHelper::new_chunk(this->output_schema(), _reserve_chunk_size)
-                                           : to->_final_chunk;
+    if (to->_has_force_dict_encode) {
+        ASSIGN_OR_RETURN(to->_adapt_global_dict_chunk,
+                         ChunkHelper::new_chunk_checked(this->output_schema(), _reserve_chunk_size));
+    } else {
+        to->_adapt_global_dict_chunk = to->_final_chunk;
+    }
 
     _context = to;
     return Status::OK();

--- a/be/src/storage/rowset/storage_page_decoder.cpp
+++ b/be/src/storage/rowset/storage_page_decoder.cpp
@@ -16,6 +16,7 @@
 
 #include "gen_cpp/segment.pb.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/raw_container_checked.h"
 #include "storage/rowset/bitshuffle_wrapper.h"
 #include "util/coding.h"
 

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -85,9 +85,7 @@ Status RowsetUpdateState::_load_deletes(Rowset* rowset, uint32_t idx, Column* pk
     TRY_CATCH_BAD_ALLOC(read_buffer.resize(file_size));
     RETURN_IF_ERROR(read_file->read_at_fully(0, read_buffer.data(), read_buffer.size()));
     auto col = pk_column->clone();
-    if (serde::ColumnArraySerde::deserialize(read_buffer.data(), col.get()) == nullptr) {
-        return Status::InternalError("column deserialization failed");
-    }
+    RETURN_IF_ERROR(serde::ColumnArraySerde::deserialize(read_buffer.data(), col.get()));
     TRY_CATCH_BAD_ALLOC(col->raw_data());
     _memory_usage += col != nullptr ? col->memory_usage() : 0;
     _deletes[idx] = std::move(col);

--- a/be/src/util/raw_container.h
+++ b/be/src/util/raw_container.h
@@ -128,18 +128,12 @@ public:
     bool operator==(const AlignmentAllocator<T, N>& other) const { return true; }
 };
 
-// https://github.com/StarRocks/starrocks/issues/233
-// older versions of CXX11 string abi are cow semantic and our optimization to provide raw_string causes crashes.
-//
-// So we can't use this optimization when we detect a link to an old version of abi,
-// and this may affect performance. So we strongly recommend to use the new version of abi
-//
+// see details about ABI compatibility issue https://github.com/StarRocks/starrocks/issues/233
 #if _GLIBCXX_USE_CXX11_ABI
 using RawString = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 0>>;
 using RawStringPad16 = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 16>>;
 #else
-using RawString = std::string;
-using RawStringPad16 = std::string;
+#error "Cannot use RawString optimization with old CXX11 ABI"
 #endif
 // From cpp reference: "A trivial destructor is a destructor that performs no action. Objects with
 // trivial destructors don't require a delete-expression and may be disposed of by simply
@@ -156,11 +150,16 @@ using RawVector = std::vector<T, RawAllocator<T, 0, Alloc>>;
 template <class T, class Alloc = std::allocator<T>>
 using RawVectorPad16 = std::vector<T, RawAllocator<T, 16, Alloc>>;
 
-template <typename Container, typename T = typename Container::value_type>
-inline typename std::enable_if<
-        std::is_same<Container, std::vector<typename Container::value_type, typename Container::allocator_type>>::value,
-        void>::type
-make_room(Container* v, size_t n) {
+template <typename Container>
+concept VecContainer = requires(Container c) {
+    typename Container::value_type;
+    typename Container::allocator_type;
+}
+&&std::same_as<Container, std::vector<typename Container::value_type, typename Container::allocator_type>>;
+
+template <VecContainer Container>
+inline void make_room(Container* v, size_t n) {
+    using T = typename Container::value_type;
     RawVector<T, typename Container::allocator_type> rv;
     rv.resize(n);
     v->swap(reinterpret_cast<Container&>(rv));
@@ -172,14 +171,17 @@ inline void make_room(std::string* s, size_t n) {
     s->swap(reinterpret_cast<std::string&>(rs));
 }
 
-template <typename Container, typename T = typename Container::value_type>
-inline typename std::enable_if<
-        std::is_same<Container, std::vector<typename Container::value_type, typename Container::allocator_type>>::value,
-        void>::type
-stl_vector_resize_uninitialized(Container* vec, size_t new_size) {
-    using DstType __attribute__((may_alias)) = RawVector<T, typename Container::allocator_type>;
-    ((DstType*)vec)->resize(new_size);
-    asm volatile("" : : : "memory");
+template <VecContainer Container>
+inline void stl_vector_resize_uninitialized(Container* vec, size_t new_size) {
+    using T = typename Container::value_type;
+    ((RawVector<T, typename Container::allocator_type>*)vec)->resize(new_size);
+}
+
+template <VecContainer Container>
+inline void stl_vector_resize_uninitialized(Container* vec, size_t reserve_size, size_t new_size) {
+    using T = typename Container::value_type;
+    ((RawVector<T, typename Container::allocator_type>*)vec)->resize(reserve_size);
+    vec->resize(new_size);
 }
 
 inline void stl_string_resize_uninitialized(std::string* str, size_t new_size) {

--- a/be/test/serde/column_array_serde_test.cpp
+++ b/be/test/serde/column_array_serde_test.cpp
@@ -24,7 +24,9 @@
 #include "column/fixed_length_column.h"
 #include "column/json_column.h"
 #include "column/nullable_column.h"
+#include "common/statusor.h"
 #include "gutil/strings/substitute.h"
+#include "testutil/assert.h"
 #include "testutil/parallel_test.h"
 #include "util/json.h"
 
@@ -49,8 +51,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, json_column) {
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
-    auto p1 = ColumnArraySerde::serialize(*c1, buffer.data());
-    auto p2 = ColumnArraySerde::deserialize(buffer.data(), c2.get());
+    ASSIGN_OR_ABORT(auto p1, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSIGN_OR_ABORT(auto p2, ColumnArraySerde::deserialize(buffer.data(), c2.get()));
     ASSERT_EQ(buffer.data() + buffer.size(), p1);
     ASSERT_EQ(buffer.data() + buffer.size(), p2);
 
@@ -67,8 +69,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, json_column) {
     // no effect
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1), level);
-        p1 = ColumnArraySerde::serialize(*c1, buffer.data(), false, level);
-        p2 = ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level);
+        ASSIGN_OR_ABORT(auto p1, ColumnArraySerde::serialize(*c1, buffer.data(), false, level));
+        ASSIGN_OR_ABORT(auto p2, ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level));
         ASSERT_EQ(buffer.data() + buffer.size(), p1);
         ASSERT_EQ(buffer.data() + buffer.size(), p2);
 
@@ -98,8 +100,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, decimal_column) {
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
-    auto p1 = ColumnArraySerde::serialize(*c1, buffer.data());
-    auto p2 = ColumnArraySerde::deserialize(buffer.data(), c2.get());
+    ASSIGN_OR_ABORT(auto p1, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSIGN_OR_ABORT(auto p2, ColumnArraySerde::deserialize(buffer.data(), c2.get()));
     ASSERT_EQ(buffer.data() + buffer.size(), p1);
     ASSERT_EQ(buffer.data() + buffer.size(), p2);
     for (size_t i = 0; i < c1->size(); i++) {
@@ -108,8 +110,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, decimal_column) {
 
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1, level));
-        ColumnArraySerde::serialize(*c1, buffer.data(), false, level);
-        ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level);
+        ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data(), false, level));
+        ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level));
         for (size_t i = 0; i < c1->size(); i++) {
             ASSERT_EQ(c1->get_data()[i], c2->get_data()[i]);
         }
@@ -127,16 +129,18 @@ PARALLEL_TEST(ColumnArraySerdeTest, int_column) {
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::serialize(*c1, buffer.data()));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSIGN_OR_ABORT(auto p1, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSIGN_OR_ABORT(auto p2, ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSERT_EQ(buffer.data() + buffer.size(), p1);
+    ASSERT_EQ(buffer.data() + buffer.size(), p2);
     for (size_t i = 0; i < numbers.size(); i++) {
         ASSERT_EQ(c1->get_data()[i], c2->get_data()[i]);
     }
 
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1, level));
-        ColumnArraySerde::serialize(*c1, buffer.data(), false, level);
-        ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level);
+        ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data(), false, level));
+        ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level));
         for (size_t i = 0; i < numbers.size(); i++) {
             ASSERT_EQ(c1->get_data()[i], c2->get_data()[i]);
         }
@@ -144,8 +148,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, int_column) {
 
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1, level));
-        ColumnArraySerde::serialize(*c1, buffer.data(), true, level);
-        ColumnArraySerde::deserialize(buffer.data(), c2.get(), true, level);
+        ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data(), true, level));
+        ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), c2.get(), true, level));
         for (size_t i = 0; i < numbers.size(); i++) {
             ASSERT_EQ(c1->get_data()[i], c2->get_data()[i]);
         }
@@ -163,16 +167,18 @@ PARALLEL_TEST(ColumnArraySerdeTest, double_column) {
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::serialize(*c1, buffer.data()));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSIGN_OR_ABORT(auto p1, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSIGN_OR_ABORT(auto p2, ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSERT_EQ(buffer.data() + buffer.size(), p1);
+    ASSERT_EQ(buffer.data() + buffer.size(), p2);
     for (size_t i = 0; i < numbers.size(); i++) {
         ASSERT_EQ(c1->get_data()[i], c2->get_data()[i]);
     }
 
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1, level));
-        ColumnArraySerde::serialize(*c1, buffer.data(), false, level);
-        ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level);
+        ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data(), false, level));
+        ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level));
         for (size_t i = 0; i < numbers.size(); i++) {
             ASSERT_EQ(c1->get_data()[i], c2->get_data()[i]);
         }
@@ -193,8 +199,10 @@ PARALLEL_TEST(ColumnArraySerdeTest, nullable_int32_column) {
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::serialize(*c1, buffer.data()));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSIGN_OR_ABORT(auto p1, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSIGN_OR_ABORT(auto p2, ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSERT_EQ(buffer.data() + buffer.size(), p1);
+    ASSERT_EQ(buffer.data() + buffer.size(), p2);
     for (size_t i = 0; i < c1->size(); i++) {
         ASSERT_EQ(c1->is_null(i), c2->is_null(i));
         if (!c1->is_null(i)) {
@@ -204,8 +212,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, nullable_int32_column) {
 
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1, level));
-        ColumnArraySerde::serialize(*c1, buffer.data(), false, level);
-        ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level);
+        ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data(), false, level));
+        ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level));
         for (size_t i = 0; i < c1->size(); i++) {
             ASSERT_EQ(c1->is_null(i), c2->is_null(i));
             if (!c1->is_null(i)) {
@@ -226,16 +234,18 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column) {
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::serialize(*c1, buffer.data()));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSIGN_OR_ABORT(auto p1, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSIGN_OR_ABORT(auto p2, ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSERT_EQ(buffer.data() + buffer.size(), p1);
+    ASSERT_EQ(buffer.data() + buffer.size(), p2);
     for (size_t i = 0; i < c1->size(); i++) {
         ASSERT_EQ(c1->get_slice(i), c2->get_slice(i));
     }
 
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1, level));
-        ColumnArraySerde::serialize(*c1, buffer.data(), false, level);
-        ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level);
+        ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data(), false, level));
+        ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level));
         for (size_t i = 0; i < c1->size(); i++) {
             ASSERT_EQ(c1->get_slice(i), c2->get_slice(i));
         }
@@ -253,16 +263,18 @@ PARALLEL_TEST(ColumnArraySerdeTest, large_binary_column) {
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::serialize(*c1, buffer.data()));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSIGN_OR_ABORT(auto p1, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSIGN_OR_ABORT(auto p2, ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSERT_EQ(buffer.data() + buffer.size(), p1);
+    ASSERT_EQ(buffer.data() + buffer.size(), p2);
     for (size_t i = 0; i < c1->size(); i++) {
         ASSERT_EQ(c1->get_slice(i), c2->get_slice(i));
     }
 
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1, level));
-        ColumnArraySerde::serialize(*c1, buffer.data(), false, level);
-        ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level);
+        ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data(), false, level));
+        ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level));
         for (size_t i = 0; i < c1->size(); i++) {
             ASSERT_EQ(c1->get_slice(i), c2->get_slice(i));
         }
@@ -285,8 +297,10 @@ PARALLEL_TEST(ColumnArraySerdeTest, const_column) {
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::serialize(*c1, buffer.data()));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSIGN_OR_ABORT(auto p1, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSIGN_OR_ABORT(auto p2, ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSERT_EQ(buffer.data() + buffer.size(), p1);
+    ASSERT_EQ(buffer.data() + buffer.size(), p2);
     ASSERT_EQ(c1->size(), c2->size());
     for (size_t i = 0; i < c1->size(); i++) {
         ASSERT_EQ(c1->get(i).get_int32(), c2->get(i).get_int32());
@@ -294,8 +308,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, const_column) {
 
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1, level));
-        ColumnArraySerde::serialize(*c1, buffer.data(), false, level);
-        ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level);
+        ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data(), false, level));
+        ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level));
         for (size_t i = 0; i < c1->size(); i++) {
             ASSERT_EQ(c1->get(i).get_int32(), c2->get(i).get_int32());
         }
@@ -325,25 +339,28 @@ PARALLEL_TEST(ColumnArraySerdeTest, array_column) {
 
     std::vector<uint8_t> buffer;
     buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSIGN_OR_ABORT(auto p1, ColumnArraySerde::serialize(*c1, buffer.data()));
+    ASSERT_EQ(buffer.data() + buffer.size(), p1);
 
     UInt32Column::Ptr off2 = UInt32Column::create();
     NullableColumn::Ptr elem2 = NullableColumn::create(Int32Column::create(), NullColumn ::create());
     ArrayColumn::Ptr c2 = ArrayColumn::create(elem1, off2);
 
-    ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSIGN_OR_ABORT(auto p2, ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSERT_EQ(buffer.data() + buffer.size(), p2);
     ASSERT_EQ("[1,2,3]", c2->debug_item(0));
     ASSERT_EQ("[4,5,6]", c2->debug_item(1));
 
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1, level));
-        ColumnArraySerde::serialize(*c1, buffer.data(), false, level);
+        ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data(), false, level));
 
         off2 = UInt32Column::create();
         elem2 = NullableColumn::create(Int32Column::create(), NullColumn ::create());
         c2 = ArrayColumn::create(elem1, off2);
 
-        ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level);
+        ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level));
+
         ASSERT_EQ("[1,2,3]", c2->debug_item(0));
         ASSERT_EQ("[4,5,6]", c2->debug_item(1));
     }


### PR DESCRIPTION
Backport of #68650 to `branch-3.5-cc`.

Original commit: 61691e85b55637f3936703f190faff05789bfffc
Original PR: https://github.com/StarRocks/starrocks/pull/68650

---

<!-- Original PR description below -->

## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10528

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


---

> [!NOTE]
> Convert column (de)serialization to StatusOr and add mem-limit-checked chunk allocation, updating readers, spill/exchange, runtime filters, and page IO for robust error propagation and memory safety.
> 
> - **API Changes**:
>   - `serde::ColumnArraySerde::{serialize,deserialize}` now return `StatusOr`, removing nullptr error signals.
>   - New `ChunkHelper::{new_chunk_checked,new_chunk_pooled_checked}` wrappers with mem-limit awareness.
>   - Introduce `raw::stl_vector_resize_uninitialized_checked` helpers; add `runtime/raw_container_checked.h`.
> - **Memory & Error Handling**:
>   - Enable mem-limit check in TRY/CATCH macros; `ObjectPool::add` guards with `unique_ptr`.
>   - Widespread adoption of `ASSIGN_OR_RETURN` and checked allocations across codebase.
> - **Readers/Scanners**:
>   - Hive/Lake/Olap/Parquet readers and projection/aggregate/segment iterators use checked chunk creation.
>   - GroupReader `_init_read_chunk` returns `Status`.
> - **Serde/IO Updates**:
>   - Spill/protobuf serde and exchange spill paths adjusted to `StatusOr` serde.
>   - Runtime filter (de)serialize for skew/broadcast paths return `StatusOr` and propagate errors.
>   - Page IO refactored: clearer checksum/footer logic, checked buffer sizing, cache handling helpers.
> - **Storage/PK**:
>   - Lake PK writer/persistent index/rowset update state/primary key recover use `StatusOr` serde.
> - **Utils/Build**:
>   - `util/raw_container.h` enforces new CXX11 ABI; add checked resize usage in page decoders.
> - **Tests**:
>   - Update serde tests to use `ASSIGN_OR_ABORT`/`ASSERT_OK` and verify error cases (e.g., Variant).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6a60a8194c5ba5abc53fddbdb14328d2c01729f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<hr>This is an automatic backport of pull request #65131 done by [Mergify](https://mergify.com).
