### PR TITLE
[UT] Fix wrong conjunct used for TestEmptyNullCountsInColumnIndex (backport #68701)

### DIFF
--- a/be/test/formats/parquet/page_index_test.cpp
+++ b/be/test/formats/parquet/page_index_test.cpp
@@ -694,5 +694,4 @@ TEST_F(PageIndexTest, TestEmptyNullCountsInColumnIndex) {
     }
     EXPECT_GT(total_row_nums, 0);
 }
-
 } // namespace starrocks::parquet


### PR DESCRIPTION
Backport of #68701 to `branch-3.5-cc`.

Original commit: 6079cebc27da73bf2c5ba084400e643da4c0dd45
Original PR: https://github.com/StarRocks/starrocks/pull/68701

---

<!-- Original PR description below -->

## Why I'm doing:
During https://github.com/StarRocks/starrocks/pull/68463 test TestEmptyNullCountsInColumnIndex uses `append_int_conjunct` used, but the correct one is ` append_bigint_conjunct`
## What I'm doing:
Fixing the inconsistency

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
<hr>This is an automatic backport of pull request #68513 done by [Mergify](https://mergify.com).
