### PR TITLE
[UT] Cover Java DECIMAL UDF data-converter and native-method paths

### DIFF
--- a/be/test/udf/java/java_data_converter_test.cpp
+++ b/be/test/udf/java/java_data_converter_test.cpp
@@ -467,8 +467,7 @@ TEST_F(DataConverterTest, convert_to_boxed_array_decimal) {
     run(TYPE_DECIMAL128, 38, 10,
         build_decimal_col<TYPE_DECIMAL128, int128_t>(38, 10, "12345678901234567890.1234567890"));
     run(TYPE_DECIMAL256, 76, 10,
-        build_decimal_col<TYPE_DECIMAL256, int256_t>(
-                76, 10, "1234567890123456789012345678901234567890.1234567890"));
+        build_decimal_col<TYPE_DECIMAL256, int256_t>(76, 10, "1234567890123456789012345678901234567890.1234567890"));
 
     // all-null shortcut path: every row null hits the create_array branch instead of
     // the decimal helper. Keep this case to exercise the early-return.

--- a/be/test/udf/java/java_data_converter_test.cpp
+++ b/be/test/udf/java/java_data_converter_test.cpp
@@ -35,6 +35,12 @@
 #include "udf/java/java_udf.h"
 
 namespace starrocks {
+// `assign_jvalue` is a free function defined in java_data_converter.cpp and only
+// declared in java_window_function.h (which pulls in heavy aggregate-fn deps).
+// Forward-declare it here so we can unit-test the DECIMAL branches directly.
+Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, int row_num, jvalue val,
+                     bool error_if_overflow);
+
 class DataConverterTest : public testing::Test {
 public:
     void SetUp() override {}
@@ -313,6 +319,206 @@ TEST_F(DataConverterTest, append_jvalue_decimal_overflow) {
         ASSERT_EQ(dst->size(), 1);
         EXPECT_TRUE(dst->is_null(0));
     }
+}
+
+// Round-trip a DECIMAL value through cast_to_jvalue -> assign_jvalue at a specified row.
+// This is the JavaWindowFunction get_values path (BigDecimal -> per-row DECIMAL slot)
+// and exercises both the DECIMAL32/64 unscaled-long branch and the DECIMAL128/256
+// LE-bytes branch.
+TEST_F(DataConverterTest, assign_jvalue_decimal_roundtrip) {
+    auto check = [](LogicalType type, int precision, int scale, const std::string& literal, const ColumnPtr& src) {
+        TypeDescriptor tdesc = TypeDescriptor::create_decimalv3_type(type, precision, scale);
+        ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(tdesc, true, src.get(), 0));
+        jobject obj = val.l;
+        LOCAL_REF_GUARD(obj);
+        ASSERT_NE(obj, nullptr) << "cast_to_jvalue returned null for " << literal;
+
+        auto dst = ColumnHelper::create_column(tdesc, true);
+        dst->resize(2);
+        ASSERT_OK(assign_jvalue(tdesc, true, dst.get(), 1, val, /*error_if_overflow=*/true));
+        EXPECT_EQ(src->debug_item(0), dst->debug_item(1))
+                << "round-trip mismatch for " << tdesc.debug_string() << " literal=" << literal;
+    };
+
+    check(TYPE_DECIMAL32, 9, 2, "12345.67", build_decimal_col<TYPE_DECIMAL32, int32_t>(9, 2, "12345.67"));
+    check(TYPE_DECIMAL64, 18, 4, "1234567890.1234",
+          build_decimal_col<TYPE_DECIMAL64, int64_t>(18, 4, "1234567890.1234"));
+    check(TYPE_DECIMAL128, 38, 10, "12345678901234567890.1234567890",
+          build_decimal_col<TYPE_DECIMAL128, int128_t>(38, 10, "12345678901234567890.1234567890"));
+    check(TYPE_DECIMAL256, 76, 10, "1234567890123456789012345678901234567890.1234567890",
+          build_decimal_col<TYPE_DECIMAL256, int256_t>(76, 10, "1234567890123456789012345678901234567890.1234567890"));
+}
+
+// `assign_jvalue` writes per-row, so a null jvalue on a nullable column must set the
+// null bit at the chosen row without touching the data slot.
+TEST_F(DataConverterTest, assign_jvalue_decimal_null) {
+    TypeDescriptor tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 38, 0);
+    auto dst = ColumnHelper::create_column(tdesc, true);
+    dst->resize(1);
+    ASSERT_OK(assign_jvalue(tdesc, true, dst.get(), 0, jvalue{.l = nullptr}, /*error_if_overflow=*/true));
+    EXPECT_TRUE(dst->is_null(0));
+}
+
+// assign_jvalue must surface the JNI ArithmeticException (REPORT_ERROR) and clear
+// it from the JVM, leaving the destination cell untouched. With OUTPUT_NULL the
+// row is nulled and Status is OK.
+TEST_F(DataConverterTest, assign_jvalue_decimal_overflow) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+    auto narrow_tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 5, 2); // narrow target
+    auto wide_tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 38, 0);
+
+    // Build a too-large BigDecimal that does not fit into DECIMAL64(5,2).
+    auto src = build_decimal_col<TYPE_DECIMAL128, int128_t>(38, 0, "1234567890");
+    ASSIGN_OR_ASSERT_FAIL(jvalue overflow_val, cast_to_jvalue(wide_tdesc, true, src.get(), 0));
+    jobject obj = overflow_val.l;
+    LOCAL_REF_GUARD(obj);
+
+    // REPORT_ERROR: returns a non-OK Status and clears the pending exception.
+    {
+        auto dst = ColumnHelper::create_column(narrow_tdesc, true);
+        dst->resize(1);
+        auto st = assign_jvalue(narrow_tdesc, true, dst.get(), 0, overflow_val, /*error_if_overflow=*/true);
+        EXPECT_FALSE(st.ok());
+        EXPECT_FALSE(env->ExceptionCheck());
+    }
+    // OUTPUT_NULL: returns OK and nullifies the row.
+    {
+        auto dst = ColumnHelper::create_column(narrow_tdesc, true);
+        dst->resize(1);
+        auto st = assign_jvalue(narrow_tdesc, true, dst.get(), 0, overflow_val, /*error_if_overflow=*/false);
+        ASSERT_OK(st);
+        EXPECT_TRUE(dst->is_null(0));
+        EXPECT_FALSE(env->ExceptionCheck());
+    }
+
+    // Same overflow check on the DECIMAL128 wide-byte path.
+    auto narrow128 = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 5, 2);
+    {
+        auto dst = ColumnHelper::create_column(narrow128, true);
+        dst->resize(1);
+        auto st = assign_jvalue(narrow128, true, dst.get(), 0, overflow_val, /*error_if_overflow=*/true);
+        EXPECT_FALSE(st.ok());
+        EXPECT_FALSE(env->ExceptionCheck());
+    }
+    {
+        auto dst = ColumnHelper::create_column(narrow128, true);
+        dst->resize(1);
+        auto st = assign_jvalue(narrow128, true, dst.get(), 0, overflow_val, /*error_if_overflow=*/false);
+        ASSERT_OK(st);
+        EXPECT_TRUE(dst->is_null(0));
+        EXPECT_FALSE(env->ExceptionCheck());
+    }
+}
+
+// `check_type_matched` rejects mismatched objects for DECIMAL columns and accepts
+// BigDecimal. Used by UDTF return-row validation, so make sure the DECIMAL branch
+// is exercised.
+TEST_F(DataConverterTest, check_type_matched_decimal) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    // BigDecimal -> DECIMAL is OK (also tests the four LogicalType variants).
+    auto src = build_decimal_col<TYPE_DECIMAL64, int64_t>(18, 4, "1234.5678");
+    auto wide_tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 18, 4);
+    ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(wide_tdesc, true, src.get(), 0));
+    jobject big_decimal_obj = val.l;
+    LOCAL_REF_GUARD(big_decimal_obj);
+
+    for (auto type : {TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128, TYPE_DECIMAL256}) {
+        auto td = TypeDescriptor::create_decimalv3_type(type, 18, 4);
+        EXPECT_OK(check_type_matched(td, big_decimal_obj));
+    }
+
+    // null val -> always OK regardless of expected type.
+    EXPECT_OK(check_type_matched(wide_tdesc, nullptr));
+
+    // String -> DECIMAL is rejected.
+    jobject jstr = helper.newString("not-a-decimal", 13);
+    LOCAL_REF_GUARD(jstr);
+    auto st = check_type_matched(wide_tdesc, jstr);
+    EXPECT_FALSE(st.ok());
+    EXPECT_FALSE(env->ExceptionCheck());
+}
+
+// convert_to_boxed_array on a DECIMAL column drives `build_decimal_boxed_array`,
+// which is the batched UDF input path for native DECIMAL columns.
+TEST_F(DataConverterTest, convert_to_boxed_array_decimal) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    auto run = [&](LogicalType type, int precision, int scale, const ColumnPtr& col) {
+        auto tdesc = TypeDescriptor::create_decimalv3_type(type, precision, scale);
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context({tdesc}, tdesc));
+
+        std::vector<jobject> res;
+        std::vector<const Column*> cols = {col.get()};
+        ASSERT_OK(JavaDataTypeConverter::convert_to_boxed_array(ctx.get(), cols.data(), 1, col->size(), &res));
+        ASSERT_EQ(res.size(), 1);
+        ASSERT_NE(res[0], nullptr);
+        env->DeleteLocalRef(res[0]);
+    };
+
+    // Build a populated nullable DECIMAL column with the given precision/scale and
+    // dispatch it through the decimal-aware boxed array helper. Covers the four
+    // DECIMAL widths via wrap_decimal_data<TYPE_DECIMAL*>.
+    run(TYPE_DECIMAL32, 9, 2, build_decimal_col<TYPE_DECIMAL32, int32_t>(9, 2, "12345.67"));
+    run(TYPE_DECIMAL64, 18, 4, build_decimal_col<TYPE_DECIMAL64, int64_t>(18, 4, "1234567890.1234"));
+    run(TYPE_DECIMAL128, 38, 10,
+        build_decimal_col<TYPE_DECIMAL128, int128_t>(38, 10, "12345678901234567890.1234567890"));
+    run(TYPE_DECIMAL256, 76, 10,
+        build_decimal_col<TYPE_DECIMAL256, int256_t>(
+                76, 10, "1234567890123456789012345678901234567890.1234567890"));
+
+    // all-null shortcut path: every row null hits the create_array branch instead of
+    // the decimal helper. Keep this case to exercise the early-return.
+    {
+        auto tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 18, 4);
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context({tdesc}, tdesc));
+
+        auto col = ColumnHelper::create_column(tdesc, true);
+        col->append_nulls(3);
+
+        std::vector<jobject> res;
+        std::vector<const Column*> cols = {col.get()};
+        ASSERT_OK(JavaDataTypeConverter::convert_to_boxed_array(ctx.get(), cols.data(), 1, 3, &res));
+        ASSERT_EQ(res.size(), 1);
+        ASSERT_NE(res[0], nullptr);
+        env->DeleteLocalRef(res[0]);
+    }
+}
+
+// ARRAY<DECIMAL> drives the DECIMAL specialization of JavaArrayConverter through the
+// elements_column accept(). The outer ARRAY routes to JavaArrayConverter (not the
+// build_decimal_boxed_array fast path) because is_decimalv3_field_type(TYPE_ARRAY)
+// is false; the elements then hit the int32/int64/int128/int256 branches.
+TEST_F(DataConverterTest, convert_to_boxed_array_array_of_decimal) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    auto run = [&](LogicalType type, int precision, int scale) {
+        TypeDescriptor element = TypeDescriptor::create_decimalv3_type(type, precision, scale);
+        TypeDescriptor array_desc = TypeDescriptor::create_array_type(element);
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context({array_desc}, array_desc));
+
+        // Non-nullable ARRAY<DECIMAL> with one empty array row. The visitor recurses
+        // into the (empty) DECIMAL elements column regardless, which is what we want
+        // to cover for JavaArrayConverter::do_visit(DecimalV3Column<T>).
+        auto col = ColumnHelper::create_column(array_desc, false);
+        col->append_default();
+
+        std::vector<jobject> res;
+        std::vector<const Column*> cols = {col.get()};
+        ASSERT_OK(JavaDataTypeConverter::convert_to_boxed_array(ctx.get(), cols.data(), 1, col->size(), &res));
+        ASSERT_EQ(res.size(), 1);
+        ASSERT_NE(res[0], nullptr);
+        env->DeleteLocalRef(res[0]);
+    };
+
+    run(TYPE_DECIMAL32, 9, 2);
+    run(TYPE_DECIMAL64, 18, 4);
+    run(TYPE_DECIMAL128, 38, 10);
+    run(TYPE_DECIMAL256, 76, 10);
 }
 
 } // namespace starrocks

--- a/be/test/udf/java/java_native_method_test.cpp
+++ b/be/test/udf/java/java_native_method_test.cpp
@@ -24,6 +24,7 @@
 #include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/column_helper.h"
+#include "column/decimalv3_column.h"
 #include "column/map_column.h"
 #include "column/nullable_column.h"
 #include "column/raw_data_visitor.h"
@@ -125,6 +126,64 @@ TEST_F(JavaNativeMethodTest, get_column_logical_type) {
         auto logical_type_2 = JavaNativeMethods::getColumnLogicalType(env, nullptr, reinterpret_cast<size_t>(c2.get()));
         ASSERT_EQ(type, logical_type_1);
         ASSERT_EQ(type, logical_type_2);
+    }
+}
+
+// DECIMAL columns are FixedLengthColumnBase but not FixedLengthColumn, so the
+// generic visitor overload doesn't match. The dedicated DECIMAL specialization
+// below has to map int32/int64/int128/int256 -> DECIMAL32/64/128/256.
+TEST_F(JavaNativeMethodTest, get_column_logical_type_decimal) {
+    auto env = getJNIEnv();
+    struct Case {
+        LogicalType type;
+        int precision;
+        int scale;
+    };
+    std::vector<Case> decimal_cases = {
+            {TYPE_DECIMAL32, 9, 2},
+            {TYPE_DECIMAL64, 18, 4},
+            {TYPE_DECIMAL128, 38, 10},
+            {TYPE_DECIMAL256, 76, 10},
+    };
+    for (const auto& c : decimal_cases) {
+        auto desc = TypeDescriptor::create_decimalv3_type(c.type, c.precision, c.scale);
+        auto c1 = ColumnHelper::create_column(desc, true);
+        auto c2 = ColumnHelper::create_column(desc, false);
+        auto logical_type_1 = JavaNativeMethods::getColumnLogicalType(env, nullptr, reinterpret_cast<size_t>(c1.get()));
+        auto logical_type_2 = JavaNativeMethods::getColumnLogicalType(env, nullptr, reinterpret_cast<size_t>(c2.get()));
+        ASSERT_EQ(c.type, logical_type_1);
+        ASSERT_EQ(c.type, logical_type_2);
+    }
+}
+
+// getAddrs on DECIMAL columns must hand back data, precision, scale (in addition to
+// the null buffer), matching the DECIMAL-aware specialization in GetColumnAddrVisitor.
+TEST_F(JavaNativeMethodTest, get_addrs_decimal) {
+    auto env = getJNIEnv();
+    struct Case {
+        LogicalType type;
+        int precision;
+        int scale;
+    };
+    std::vector<Case> decimal_cases = {
+            {TYPE_DECIMAL32, 9, 2},
+            {TYPE_DECIMAL64, 18, 4},
+            {TYPE_DECIMAL128, 38, 10},
+            {TYPE_DECIMAL256, 76, 10},
+    };
+    for (const auto& c : decimal_cases) {
+        auto desc = TypeDescriptor::create_decimalv3_type(c.type, c.precision, c.scale);
+        auto column = ColumnHelper::create_column(desc, true);
+        column->resize(4);
+        auto arr = JavaNativeMethods::getAddrs(env, nullptr, reinterpret_cast<size_t>(column.get()));
+        ASSERT_NE(arr, nullptr);
+        jlong results[4];
+        env->GetLongArrayRegion(arr, 0, 4, results);
+        const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
+        ASSERT_EQ(results[0], (jlong)nullable_column->null_column_data().data());
+        ASSERT_EQ(results[2], static_cast<jlong>(c.precision));
+        ASSERT_EQ(results[3], static_cast<jlong>(c.scale));
+        env->DeleteLocalRef(arr);
     }
 }
 TEST_F(JavaNativeMethodTest, resize) {


### PR DESCRIPTION
## Why I'm doing:

Add tests targeting the DECIMAL branches added in #72208 that the incremental BE coverage check flags as uncovered:

- assign_jvalue DECIMAL32/64 unscaled-long path and DECIMAL128/256 LE-bytes path (round-trip + null-row + overflow under both REPORT_ERROR and OUTPUT_NULL).
- check_type_matched DECIMAL accept/reject branches.
- convert_to_boxed_array drives build_decimal_boxed_array (one row per width) plus the all-null shortcut and the JavaArrayConverter::do_visit(DecimalV3Column<T>) recursion via ARRAY<DECIMAL>.
- getColumnLogicalType and getAddrs DECIMAL specializations exercising int32/int64/int128/int256 column widths.

Tests use the public FunctionContext::create_test_context API rather than poking private members.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
