### PR TITLE
[BugFix] Fix unexpected memory overuse in local exchange

### DIFF
--- a/be/src/exec/chunk_buffer_memory_manager.h
+++ b/be/src/exec/chunk_buffer_memory_manager.h
@@ -102,4 +102,32 @@ private:
     size_t _max_input_dop;
     std::atomic<bool> _full_events_changed{};
 };
+
+// RAII account record for a single chunk buffered in a local exchange queue.
+// Construction adds the chunk's memory/num_rows to the shared manager exactly once;
+// destruction subtracts them. By holding it via shared_ptr across all queue entries that
+// reference the same chunk, the manager's record is released only when the last
+// reference is consumed.
+class ChunkBufferMemoryEntry {
+public:
+    ChunkBufferMemoryEntry(ChunkBufferMemoryManager* manager, size_t memory_usage, size_t num_rows)
+            : _manager(manager), _memory_usage(memory_usage), _num_rows(num_rows) {
+        _manager->update_memory_usage(static_cast<int64_t>(_memory_usage), static_cast<int64_t>(_num_rows));
+    }
+
+    ~ChunkBufferMemoryEntry() {
+        _manager->update_memory_usage(-static_cast<int64_t>(_memory_usage), -static_cast<int64_t>(_num_rows));
+    }
+
+    ChunkBufferMemoryEntry(const ChunkBufferMemoryEntry&) = delete;
+    ChunkBufferMemoryEntry& operator=(const ChunkBufferMemoryEntry&) = delete;
+
+    size_t memory_usage() const { return _memory_usage; }
+    size_t num_rows() const { return _num_rows; }
+
+private:
+    ChunkBufferMemoryManager* _manager;
+    const size_t _memory_usage;
+    const size_t _num_rows;
+};
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -38,10 +38,8 @@ Status Partitioner::partition_chunk(const ChunkPtr& chunk, int32_t num_partition
     // step2: shuffle chunk into dest partitions.
     {
         _partition_row_indexes_start_points.assign(num_partitions + 1, 0);
-        _partition_memory_usage.assign(num_partitions, 0);
         for (size_t i = 0; i < num_rows; ++i) {
             _partition_row_indexes_start_points[_shuffle_channel_id[i]]++;
-            _partition_memory_usage[_shuffle_channel_id[i]] += chunk->bytes_usage(i, 1);
         }
         // We make the last item equal with number of rows of this chunk.
         for (int32_t i = 1; i <= num_partitions; ++i) {
@@ -59,6 +57,7 @@ Status Partitioner::partition_chunk(const ChunkPtr& chunk, int32_t num_partition
 Status Partitioner::send_chunk(const ChunkPtr& chunk,
                                const std::shared_ptr<std::vector<uint32_t>>& partition_row_indexes) {
     size_t num_partitions = _source->get_sources().size();
+    size_t chunk_memory_usage = chunk->memory_usage();
     for (size_t i = 0; i < num_partitions; ++i) {
         size_t from = partition_begin_offset(i);
         size_t size = partition_end_offset(i) - from;
@@ -68,7 +67,7 @@ Status Partitioner::send_chunk(const ChunkPtr& chunk,
         }
 
         RETURN_IF_ERROR(_source->get_sources()[i]->add_chunk(chunk, partition_row_indexes, from, size,
-                                                             partition_memory_usage(i)));
+                                                             chunk_memory_usage));
     }
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -70,8 +70,7 @@ Status Partitioner::send_chunk(const ChunkPtr& chunk,
             continue;
         }
 
-        RETURN_IF_ERROR(
-                _source->get_sources()[i]->add_chunk(chunk, partition_row_indexes, from, size, memory_entry));
+        RETURN_IF_ERROR(_source->get_sources()[i]->add_chunk(chunk, partition_row_indexes, from, size, memory_entry));
     }
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -57,6 +57,12 @@ Status Partitioner::partition_chunk(const ChunkPtr& chunk, int32_t num_partition
 Status Partitioner::send_chunk(const ChunkPtr& chunk,
                                const std::shared_ptr<std::vector<uint32_t>>& partition_row_indexes) {
     size_t num_partitions = _source->get_sources().size();
+    // Unpack const columns now (instead of inside each per-source add_chunk) so the
+    // accounted memory reflects the materialized post-unpack footprint. For const
+    // columns the pre-unpack memory is O(1) while the buffered, unpacked memory is
+    // O(num_rows); accounting before the unpack would let the manager undercount by
+    // orders of magnitude and weaken is_full() back-pressure.
+    chunk->unpack_and_duplicate_const_columns();
     // Account this chunk against the shared memory manager exactly once. The entry is
     // shared by every partition shard via shared_ptr, so the record is only released
     // when the last shard is consumed across all source operators.

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -57,7 +57,11 @@ Status Partitioner::partition_chunk(const ChunkPtr& chunk, int32_t num_partition
 Status Partitioner::send_chunk(const ChunkPtr& chunk,
                                const std::shared_ptr<std::vector<uint32_t>>& partition_row_indexes) {
     size_t num_partitions = _source->get_sources().size();
-    size_t chunk_memory_usage = chunk->memory_usage();
+    // Account this chunk against the shared memory manager exactly once. The entry is
+    // shared by every partition shard via shared_ptr, so the record is only released
+    // when the last shard is consumed across all source operators.
+    auto memory_entry = std::make_shared<ChunkBufferMemoryEntry>(_source->memory_manager(), chunk->memory_usage(),
+                                                                 chunk->num_rows());
     for (size_t i = 0; i < num_partitions; ++i) {
         size_t from = partition_begin_offset(i);
         size_t size = partition_end_offset(i) - from;
@@ -66,8 +70,8 @@ Status Partitioner::send_chunk(const ChunkPtr& chunk,
             continue;
         }
 
-        RETURN_IF_ERROR(_source->get_sources()[i]->add_chunk(chunk, partition_row_indexes, from, size,
-                                                             chunk_memory_usage));
+        RETURN_IF_ERROR(
+                _source->get_sources()[i]->add_chunk(chunk, partition_row_indexes, from, size, memory_entry));
     }
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -52,15 +52,6 @@ public:
 
     size_t partition_end_offset(size_t partition_id) { return _partition_row_indexes_start_points[partition_id + 1]; }
 
-    size_t partition_memory_usage(size_t partition_id) {
-        if (partition_id >= _partition_memory_usage.size() || partition_id < 0) {
-            throw std::runtime_error(fmt::format("invalid index {} to get partition memory usage, whose size = {}.",
-                                                 partition_id, _partition_memory_usage.size()));
-        } else {
-            return _partition_memory_usage[partition_id];
-        }
-    }
-
 protected:
     LocalExchangeSourceOperatorFactory* _source;
 
@@ -69,7 +60,6 @@ protected:
     // It will easy to get number of rows belong to one channel by doing
     // _partition_row_indexes_start_points[i + 1] - _partition_row_indexes_start_points[i]
     std::vector<size_t> _partition_row_indexes_start_points;
-    std::vector<size_t> _partition_memory_usage;
     std::vector<uint32_t> _shuffle_channel_id;
 };
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -29,8 +29,8 @@ void LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk) {
     if (_is_finished) {
         return;
     }
-    auto memory_entry = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), chunk->memory_usage(),
-                                                                 chunk->num_rows());
+    auto memory_entry =
+            std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), chunk->memory_usage(), chunk->num_rows());
     _full_chunk_queue.push(PassthroughChunk{std::move(chunk), std::move(memory_entry)});
 }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -31,7 +31,6 @@ void LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk) {
     }
     size_t memory_usage = chunk->memory_usage();
     size_t num_rows = chunk->num_rows();
-    _local_memory_usage += memory_usage;
     _full_chunk_queue.emplace(std::move(chunk));
     _memory_manager->update_memory_usage(memory_usage, num_rows);
 }
@@ -51,7 +50,6 @@ Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk, const std::shared_
 
     _partition_chunk_queue.emplace(std::move(chunk), indexes, from, size, memory_usage);
     _partition_rows_num += size;
-    _local_memory_usage += memory_usage;
     _memory_manager->update_memory_usage(memory_usage, size);
 
     return Status::OK();
@@ -76,19 +74,12 @@ Status LocalExchangeSourceOperator::add_chunk(const std::vector<std::optional<st
     _partition_key2partial_chunks[partition_key].memory_usage += memory_usage;
     _partition_key2partial_chunks[partition_key].partition_key_datum = partition_datum;
 
-    _local_memory_usage += memory_usage;
     _memory_manager->update_memory_usage(memory_usage, num_rows);
     return Status::OK();
 }
 
 bool LocalExchangeSourceOperator::is_finished() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
-    if (_full_chunk_queue.empty() && !_partition_rows_num && _key_partition_pending_chunk_empty()) {
-        if (UNLIKELY(_local_memory_usage != 0)) {
-            throw std::runtime_error("_local_memory_usage should be 0 as there is no rows left.");
-        }
-    }
-
     return _is_finished && _full_chunk_queue.empty() && !_partition_rows_num && _key_partition_pending_chunk_empty();
 }
 
@@ -96,7 +87,7 @@ bool LocalExchangeSourceOperator::has_output() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
     return !_full_chunk_queue.empty() || _partition_rows_num >= _factory->runtime_state()->chunk_size() ||
-           _key_partition_max_rows() > 0 || ((_is_finished || _local_buffer_almost_full()) && _partition_rows_num > 0);
+           _key_partition_max_rows() > 0 || ((_is_finished || _memory_manager->is_full()) && _partition_rows_num > 0);
 }
 
 Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
@@ -107,18 +98,31 @@ Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
     auto notify = exchanger->defer_notify_sink();
     std::lock_guard<std::mutex> l(_chunk_lock);
     _is_finished = true;
-    {
-        // clear _full_chunk_queue
-        _full_chunk_queue = {};
-        // clear _partition_chunk_queue
-        _partition_chunk_queue = {};
-        // clear _key_partition_pending_chunks
-        _partition_key2partial_chunks = std::map<std::vector<std::optional<std::string>>, PartialChunks>{};
+
+    size_t total_memory_usage = 0;
+    size_t total_num_rows = 0;
+    while (!_full_chunk_queue.empty()) {
+        const auto& chunk = _full_chunk_queue.front();
+        total_memory_usage += chunk->memory_usage();
+        total_num_rows += chunk->num_rows();
+        _full_chunk_queue.pop();
     }
-    // Subtract the number of rows of buffered chunks from row_count of _memory_manager and make it unblocked.
-    _memory_manager->update_memory_usage(-_local_memory_usage, -_partition_rows_num);
+    while (!_partition_chunk_queue.empty()) {
+        const auto& partition_chunk = _partition_chunk_queue.front();
+        total_memory_usage += partition_chunk.memory_usage;
+        total_num_rows += partition_chunk.size;
+        _partition_chunk_queue.pop();
+    }
+    for (const auto& [_, partial_chunks] : _partition_key2partial_chunks) {
+        total_memory_usage += partial_chunks.memory_usage;
+        total_num_rows += partial_chunks.num_rows;
+    }
+    _partition_key2partial_chunks.clear();
+
+    // Subtract the buffered memory and rows from _memory_manager and make it unblocked.
+    _memory_manager->update_memory_usage(-static_cast<int64_t>(total_memory_usage),
+                                         -static_cast<int64_t>(total_num_rows));
     _partition_rows_num = 0;
-    _local_memory_usage = 0;
     return Status::OK();
 }
 
@@ -144,7 +148,6 @@ const size_t min_local_memory_limit = 1LL * 1024 * 1024;
 
 void LocalExchangeSourceOperator::enter_release_memory_mode() {
     // limit the memory limit to a very small value so that the upstream will not write new data until all the data has been pushed to the downstream operators
-    _local_memory_limit = min_local_memory_limit;
     size_t max_memory_usage = min_local_memory_limit * _memory_manager->get_max_input_dop();
     _memory_manager->update_max_memory_usage(max_memory_usage);
 }
@@ -162,7 +165,6 @@ ChunkPtr LocalExchangeSourceOperator::_pull_passthrough_chunk(RuntimeState* stat
         size_t memory_usage = chunk->memory_usage();
         size_t num_rows = chunk->num_rows();
         _memory_manager->update_memory_usage(-memory_usage, -num_rows);
-        _local_memory_usage -= memory_usage;
         return chunk;
     }
 
@@ -187,7 +189,6 @@ ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
             _partition_chunk_queue.pop();
         }
         _partition_rows_num -= num_rows;
-        _local_memory_usage -= memory_usage;
         _memory_manager->update_memory_usage(-memory_usage, -num_rows);
     }
     if (selected_partition_chunks.empty()) {
@@ -228,7 +229,6 @@ ChunkPtr LocalExchangeSourceOperator::_pull_key_partition_chunk(RuntimeState* st
 
         partial_chunks.num_rows -= num_rows;
         partial_chunks.memory_usage -= memory_usage;
-        _local_memory_usage -= memory_usage;
         _memory_manager->update_memory_usage(-memory_usage, -num_rows);
     }
     Columns partition_key_columns;

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -38,7 +38,9 @@ void LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk) {
 // Only enqueue the partition chunk information here, and merge chunk in pull_chunk().
 // The shared `memory_entry` accounts for the source chunk's memory once across all
 // partition shards; it is only released back to the manager when the last shard is
-// pulled (or cleared on set_finished).
+// pulled (or cleared on set_finished). The caller (Partitioner::send_chunk) is
+// responsible for unpacking const columns BEFORE constructing the entry, so the
+// recorded memory matches the buffered post-unpack footprint.
 Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk, const std::shared_ptr<std::vector<uint32_t>>& indexes,
                                               uint32_t from, uint32_t size,
                                               std::shared_ptr<ChunkBufferMemoryEntry> memory_entry) {
@@ -47,9 +49,6 @@ Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk, const std::shared_
     if (_is_finished) {
         return Status::OK();
     }
-
-    // unpack chunk's const column, since Chunk#append_selective cannot be const column
-    chunk->unpack_and_duplicate_const_columns();
 
     _partition_chunk_queue.emplace(std::move(chunk), indexes, from, size, std::move(memory_entry));
     _partition_rows_num += size;

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -37,8 +37,12 @@ void LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk) {
 
 // Used for PartitionExchanger.
 // Only enqueue the partition chunk information here, and merge chunk in pull_chunk().
+// The shared `memory_entry` accounts for the source chunk's memory once across all
+// partition shards; it is only released back to the manager when the last shard is
+// pulled (or cleared on set_finished).
 Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk, const std::shared_ptr<std::vector<uint32_t>>& indexes,
-                                              uint32_t from, uint32_t size, size_t memory_usage) {
+                                              uint32_t from, uint32_t size,
+                                              std::shared_ptr<ChunkBufferMemoryEntry> memory_entry) {
     auto notify = defer_notify();
     std::lock_guard<std::mutex> l(_chunk_lock);
     if (_is_finished) {
@@ -48,9 +52,8 @@ Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk, const std::shared_
     // unpack chunk's const column, since Chunk#append_selective cannot be const column
     chunk->unpack_and_duplicate_const_columns();
 
-    _partition_chunk_queue.emplace(std::move(chunk), indexes, from, size, memory_usage);
+    _partition_chunk_queue.emplace(std::move(chunk), indexes, from, size, std::move(memory_entry));
     _partition_rows_num += size;
-    _memory_manager->update_memory_usage(memory_usage, size);
 
     return Status::OK();
 }
@@ -99,29 +102,28 @@ Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
     std::lock_guard<std::mutex> l(_chunk_lock);
     _is_finished = true;
 
-    size_t total_memory_usage = 0;
-    size_t total_num_rows = 0;
+    // For full and key-partition queues we own the chunk exclusively, so account each
+    // chunk's memory directly here. For the partition shuffle queue, each PartitionChunk
+    // holds a shared_ptr<ChunkBufferMemoryEntry>; clearing the queue drops references
+    // and the entry destructor refunds memory/rows to the manager when the last shard
+    // (across all sources) is released.
+    size_t direct_memory_usage = 0;
+    size_t direct_num_rows = 0;
     while (!_full_chunk_queue.empty()) {
         const auto& chunk = _full_chunk_queue.front();
-        total_memory_usage += chunk->memory_usage();
-        total_num_rows += chunk->num_rows();
+        direct_memory_usage += chunk->memory_usage();
+        direct_num_rows += chunk->num_rows();
         _full_chunk_queue.pop();
     }
-    while (!_partition_chunk_queue.empty()) {
-        const auto& partition_chunk = _partition_chunk_queue.front();
-        total_memory_usage += partition_chunk.memory_usage;
-        total_num_rows += partition_chunk.size;
-        _partition_chunk_queue.pop();
-    }
     for (const auto& [_, partial_chunks] : _partition_key2partial_chunks) {
-        total_memory_usage += partial_chunks.memory_usage;
-        total_num_rows += partial_chunks.num_rows;
+        direct_memory_usage += partial_chunks.memory_usage;
+        direct_num_rows += partial_chunks.num_rows;
     }
     _partition_key2partial_chunks.clear();
+    _partition_chunk_queue = {};
 
-    // Subtract the buffered memory and rows from _memory_manager and make it unblocked.
-    _memory_manager->update_memory_usage(-static_cast<int64_t>(total_memory_usage),
-                                         -static_cast<int64_t>(total_num_rows));
+    _memory_manager->update_memory_usage(-static_cast<int64_t>(direct_memory_usage),
+                                         -static_cast<int64_t>(direct_num_rows));
     _partition_rows_num = 0;
     return Status::OK();
 }
@@ -174,7 +176,6 @@ ChunkPtr LocalExchangeSourceOperator::_pull_passthrough_chunk(RuntimeState* stat
 ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
     std::vector<PartitionChunk> selected_partition_chunks;
     size_t num_rows = 0;
-    size_t memory_usage = 0;
     // Lock during pop partition chunks from queue.
     {
         std::lock_guard<std::mutex> l(_chunk_lock);
@@ -184,12 +185,10 @@ ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
         while (!_partition_chunk_queue.empty() &&
                num_rows + _partition_chunk_queue.front().size <= state->chunk_size()) {
             num_rows += _partition_chunk_queue.front().size;
-            memory_usage += _partition_chunk_queue.front().memory_usage;
             selected_partition_chunks.emplace_back(std::move(_partition_chunk_queue.front()));
             _partition_chunk_queue.pop();
         }
         _partition_rows_num -= num_rows;
-        _memory_manager->update_memory_usage(-memory_usage, -num_rows);
     }
     if (selected_partition_chunks.empty()) {
         throw std::runtime_error("local exchange gets empty shuffled chunk.");
@@ -202,6 +201,9 @@ ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
         chunk->append_selective(*partition_chunk.chunk, partition_chunk.indexes->data(), partition_chunk.from,
                                 partition_chunk.size);
     }
+    // selected_partition_chunks goes out of scope here. Each PartitionChunk drops its
+    // shared_ptr<ChunkBufferMemoryEntry>; once the last shard for a given source chunk is
+    // released, the entry destructor refunds its memory/rows to the manager.
     return chunk;
 }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -29,10 +29,9 @@ void LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk) {
     if (_is_finished) {
         return;
     }
-    size_t memory_usage = chunk->memory_usage();
-    size_t num_rows = chunk->num_rows();
-    _full_chunk_queue.emplace(std::move(chunk));
-    _memory_manager->update_memory_usage(memory_usage, num_rows);
+    auto memory_entry = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), chunk->memory_usage(),
+                                                                 chunk->num_rows());
+    _full_chunk_queue.push(PassthroughChunk{std::move(chunk), std::move(memory_entry)});
 }
 
 // Used for PartitionExchanger.
@@ -69,15 +68,14 @@ Status LocalExchangeSourceOperator::add_chunk(const std::vector<std::optional<st
 
     // unpack chunk's const column, since Chunk#append_selective cannot be const column
     chunk->unpack_and_duplicate_const_columns();
-    auto memory_usage = chunk->memory_usage();
     auto num_rows = chunk->num_rows();
+    auto memory_entry =
+            std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), chunk->memory_usage(), num_rows);
 
-    _partition_key2partial_chunks[partition_key].queue.push(std::move(chunk));
-    _partition_key2partial_chunks[partition_key].num_rows += num_rows;
-    _partition_key2partial_chunks[partition_key].memory_usage += memory_usage;
-    _partition_key2partial_chunks[partition_key].partition_key_datum = partition_datum;
-
-    _memory_manager->update_memory_usage(memory_usage, num_rows);
+    auto& partial = _partition_key2partial_chunks[partition_key];
+    partial.queue.push(KeyPartitionChunk{std::move(chunk), std::move(memory_entry)});
+    partial.num_rows += num_rows;
+    partial.partition_key_datum = partition_datum;
     return Status::OK();
 }
 
@@ -102,28 +100,12 @@ Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
     std::lock_guard<std::mutex> l(_chunk_lock);
     _is_finished = true;
 
-    // For full and key-partition queues we own the chunk exclusively, so account each
-    // chunk's memory directly here. For the partition shuffle queue, each PartitionChunk
-    // holds a shared_ptr<ChunkBufferMemoryEntry>; clearing the queue drops references
-    // and the entry destructor refunds memory/rows to the manager when the last shard
-    // (across all sources) is released.
-    size_t direct_memory_usage = 0;
-    size_t direct_num_rows = 0;
-    while (!_full_chunk_queue.empty()) {
-        const auto& chunk = _full_chunk_queue.front();
-        direct_memory_usage += chunk->memory_usage();
-        direct_num_rows += chunk->num_rows();
-        _full_chunk_queue.pop();
-    }
-    for (const auto& [_, partial_chunks] : _partition_key2partial_chunks) {
-        direct_memory_usage += partial_chunks.memory_usage;
-        direct_num_rows += partial_chunks.num_rows;
-    }
-    _partition_key2partial_chunks.clear();
+    // Drop all buffered chunks. Every queue entry holds a ChunkBufferMemoryEntry whose
+    // destructor refunds memory/rows back to the shared manager, so no manual accounting
+    // is needed here.
+    _full_chunk_queue = {};
     _partition_chunk_queue = {};
-
-    _memory_manager->update_memory_usage(-static_cast<int64_t>(direct_memory_usage),
-                                         -static_cast<int64_t>(direct_num_rows));
+    _partition_key2partial_chunks.clear();
     _partition_rows_num = 0;
     return Status::OK();
 }
@@ -159,18 +141,18 @@ void LocalExchangeSourceOperator::set_execute_mode(int performance_level) {
 }
 
 ChunkPtr LocalExchangeSourceOperator::_pull_passthrough_chunk(RuntimeState* state) {
-    std::lock_guard<std::mutex> l(_chunk_lock);
-
-    if (!_full_chunk_queue.empty()) {
-        ChunkPtr chunk = std::move(_full_chunk_queue.front());
+    PassthroughChunk popped;
+    {
+        std::lock_guard<std::mutex> l(_chunk_lock);
+        if (_full_chunk_queue.empty()) {
+            return nullptr;
+        }
+        popped = std::move(_full_chunk_queue.front());
         _full_chunk_queue.pop();
-        size_t memory_usage = chunk->memory_usage();
-        size_t num_rows = chunk->num_rows();
-        _memory_manager->update_memory_usage(-memory_usage, -num_rows);
-        return chunk;
     }
-
-    return nullptr;
+    // popped.memory_entry destructs at function exit and refunds memory/rows to the
+    // manager outside the lock.
+    return std::move(popped.chunk);
 }
 
 ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
@@ -208,30 +190,25 @@ ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
 }
 
 ChunkPtr LocalExchangeSourceOperator::_pull_key_partition_chunk(RuntimeState* state) {
-    std::vector<ChunkPtr> selected_partition_chunks;
+    std::vector<KeyPartitionChunk> selected_partition_chunks;
     size_t num_rows = 0;
-    size_t memory_usage = 0;
     ChunkExtraColumnsDataPtr chunk_extra_data;
     std::vector<std::pair<TypeDescriptor, ColumnPtr>> partition_key_datum;
     {
         std::lock_guard<std::mutex> l(_chunk_lock);
         auto it = _max_row_partition_chunks();
         PartialChunks& partial_chunks = it->second;
-        partition_key_datum = it->second.partition_key_datum;
+        partition_key_datum = partial_chunks.partition_key_datum;
         DCHECK(!partial_chunks.queue.empty());
 
         while (!partial_chunks.queue.empty() &&
-               num_rows + partial_chunks.queue.front()->num_rows() <= state->chunk_size()) {
-            num_rows += partial_chunks.queue.front()->num_rows();
-            memory_usage += partial_chunks.queue.front()->memory_usage();
-
+               num_rows + partial_chunks.queue.front().chunk->num_rows() <= state->chunk_size()) {
+            num_rows += partial_chunks.queue.front().chunk->num_rows();
             selected_partition_chunks.push_back(std::move(partial_chunks.queue.front()));
             partial_chunks.queue.pop();
         }
 
         partial_chunks.num_rows -= num_rows;
-        partial_chunks.memory_usage -= memory_usage;
-        _memory_manager->update_memory_usage(-memory_usage, -num_rows);
     }
     Columns partition_key_columns;
     std::vector<ChunkExtraColumnsMeta> extra_metas;
@@ -244,14 +221,15 @@ ChunkPtr LocalExchangeSourceOperator::_pull_key_partition_chunk(RuntimeState* st
     }
     chunk_extra_data = std::make_shared<ChunkExtraColumnsData>(extra_metas, std::move(partition_key_columns));
     // Unlock during merging partition chunks into a full chunk.
-    ChunkPtr chunk = selected_partition_chunks[0]->clone_empty_with_slot();
+    ChunkPtr chunk = selected_partition_chunks[0].chunk->clone_empty_with_slot();
     chunk->reserve(num_rows);
     chunk->set_extra_data(chunk_extra_data);
     for (const auto& partition_chunk : selected_partition_chunks) {
         // NOTE: unpack column if `partition_chunk.chunk` constains const column
-        chunk->append(*partition_chunk);
+        chunk->append(*partition_chunk.chunk);
     }
-
+    // selected_partition_chunks goes out of scope here; each entry destructor refunds
+    // its chunk's memory/rows to the manager outside the lock.
     return chunk;
 }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -56,9 +56,7 @@ public:
     LocalExchangeSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                                 const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager)
             : SourceOperator(factory, id, "local_exchange_source", plan_node_id, true, driver_sequence),
-              _memory_manager(memory_manager) {
-        _local_memory_limit = _memory_manager->get_memory_limit_per_driver() * 0.8;
-    }
+              _memory_manager(memory_manager) {}
 
     void add_chunk(ChunkPtr chunk);
 
@@ -102,8 +100,6 @@ private:
     std::map<std::vector<std::optional<std::string>>, LocalExchangeSourceOperator::PartialChunks>::iterator
     _max_row_partition_chunks();
 
-    bool _local_buffer_almost_full() const { return _local_memory_usage >= _local_memory_limit; }
-
     bool _key_partition_pending_chunk_empty() const {
         for (const auto& pending_chunks : _partition_key2partial_chunks) {
             if (!pending_chunks.second.queue.empty()) {
@@ -117,8 +113,6 @@ private:
     std::queue<ChunkPtr> _full_chunk_queue;
     std::queue<PartitionChunk> _partition_chunk_queue;
     size_t _partition_rows_num = 0;
-    size_t _local_memory_usage = 0;
-    size_t _local_memory_limit = 0;
 
     // TODO(KKS): make it lock free
     mutable std::mutex _chunk_lock;

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -45,10 +45,19 @@ class LocalExchangeSourceOperator final : public SourceOperator {
         std::shared_ptr<ChunkBufferMemoryEntry> memory_entry;
     };
 
+    struct PassthroughChunk {
+        ChunkPtr chunk;
+        std::shared_ptr<ChunkBufferMemoryEntry> memory_entry;
+    };
+
+    struct KeyPartitionChunk {
+        ChunkUniquePtr chunk;
+        std::shared_ptr<ChunkBufferMemoryEntry> memory_entry;
+    };
+
     struct PartialChunks {
-        std::queue<ChunkUniquePtr> queue;
+        std::queue<KeyPartitionChunk> queue;
         int64_t num_rows{0};
-        size_t memory_usage{0};
         std::vector<std::pair<TypeDescriptor, ColumnPtr>> partition_key_datum;
     };
 
@@ -110,7 +119,7 @@ private:
     }
 
     bool _is_finished = false;
-    std::queue<ChunkPtr> _full_chunk_queue;
+    std::queue<PassthroughChunk> _full_chunk_queue;
     std::queue<PartitionChunk> _partition_chunk_queue;
     size_t _partition_rows_num = 0;
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -27,12 +27,12 @@ class LocalExchangeSourceOperator final : public SourceOperator {
     class PartitionChunk {
     public:
         PartitionChunk(ChunkPtr chunk, std::shared_ptr<std::vector<uint32_t>> indexes, const uint32_t from,
-                       const uint32_t size, const size_t memory_usage)
+                       const uint32_t size, std::shared_ptr<ChunkBufferMemoryEntry> memory_entry)
                 : chunk(std::move(chunk)),
                   indexes(std::move(indexes)),
                   from(from),
                   size(size),
-                  memory_usage(memory_usage) {}
+                  memory_entry(std::move(memory_entry)) {}
 
         PartitionChunk(const PartitionChunk&) = delete;
 
@@ -42,7 +42,7 @@ class LocalExchangeSourceOperator final : public SourceOperator {
         std::shared_ptr<std::vector<uint32_t>> indexes;
         const uint32_t from;
         const uint32_t size;
-        const size_t memory_usage;
+        std::shared_ptr<ChunkBufferMemoryEntry> memory_entry;
     };
 
     struct PartialChunks {
@@ -61,7 +61,7 @@ public:
     void add_chunk(ChunkPtr chunk);
 
     Status add_chunk(ChunkPtr chunk, const std::shared_ptr<std::vector<uint32_t>>& indexes, uint32_t from,
-                     uint32_t size, size_t memory_bytes);
+                     uint32_t size, std::shared_ptr<ChunkBufferMemoryEntry> memory_entry);
 
     Status add_chunk(const std::vector<std::optional<std::string>>& partition_key,
                      const std::vector<std::pair<TypeDescriptor, ColumnPtr>>& partition_datum, ChunkUniquePtr chunk);
@@ -140,6 +140,8 @@ public:
 
     void set_exchanger(LocalExchanger* exchanger) { _exchanger = exchanger; }
     LocalExchanger* exchanger() { return _exchanger; }
+
+    ChunkBufferMemoryManager* memory_manager() { return _memory_manager.get(); }
 
     std::vector<LocalExchangeSourceOperator*>& get_sources() { return _sources; }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -74,6 +74,7 @@ set(EXEC_FILES
         ./exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
         ./exec/pipeline/limit_operator_test.cpp
         ./exec/pipeline/local_bucket_shuffle_test.cpp
+        ./exec/pipeline/local_exchange_memory_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/pipeline/exec_group_test.cpp
         ./exec/pipeline/glm_manager_tablet_adaptor_test.cpp

--- a/be/test/exec/pipeline/local_exchange_memory_test.cpp
+++ b/be/test/exec/pipeline/local_exchange_memory_test.cpp
@@ -1,0 +1,278 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <numeric>
+
+#include "base/testutil/assert.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "exec/chunk_buffer_memory_manager.h"
+#include "exec/pipeline/exchange/local_exchange.h"
+#include "exec/pipeline/exchange/local_exchange_source_operator.h"
+#include "exec/pipeline/query_context.h"
+#include "gutil/casts.h"
+#include "runtime/exec_env.h"
+#include "types/logical_type.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks::pipeline {
+
+class LocalExchangeMemoryTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _exec_env = ExecEnv::GetInstance();
+
+        _query_context = std::make_shared<QueryContext>();
+        _query_context->set_query_execution_services(&_exec_env->query_execution_services());
+        _query_context->init_mem_tracker(-1, GlobalEnv::GetInstance()->process_mem_tracker());
+
+        TQueryOptions query_options;
+        query_options.batch_size = 4096;
+        TQueryGlobals query_globals;
+        _runtime_state = std::make_shared<RuntimeState>(_fragment_id, query_options, query_globals,
+                                                        &_exec_env->query_execution_services(), _exec_env);
+        _runtime_state->set_query_ctx(_query_context.get());
+        _runtime_state->init_instance_mem_tracker();
+
+        _memory_manager = std::make_shared<ChunkBufferMemoryManager>(_dop, 1024 * 1024);
+        _source_op_factory = std::make_unique<LocalExchangeSourceOperatorFactory>(0, 1, _memory_manager);
+        _source_op_factory->set_runtime_state(_runtime_state.get());
+        for (size_t i = 0; i < _dop; i++) {
+            _sources.emplace_back(_source_op_factory->create(_dop, i));
+        }
+        // Wire up an exchanger so pull_chunk / set_finished have a valid factory exchanger.
+        _exchanger = std::make_unique<PassthroughExchanger>(_memory_manager, _source_op_factory.get());
+    }
+
+protected:
+    LocalExchangeSourceOperator* _source(size_t i) {
+        return down_cast<LocalExchangeSourceOperator*>(_sources[i].get());
+    }
+
+    static ChunkPtr _make_int_chunk(size_t num_rows) {
+        auto chunk = std::make_shared<Chunk>();
+        auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        for (size_t i = 0; i < num_rows; i++) {
+            col->append_datum(Datum(static_cast<int32_t>(i)));
+        }
+        chunk->append_column(std::move(col), 1);
+        return chunk;
+    }
+
+    std::shared_ptr<ChunkBufferMemoryManager> _memory_manager;
+    std::unique_ptr<LocalExchangeSourceOperatorFactory> _source_op_factory;
+    std::unique_ptr<PassthroughExchanger> _exchanger;
+    TUniqueId _fragment_id;
+    ExecEnv* _exec_env;
+    std::shared_ptr<QueryContext> _query_context;
+    std::shared_ptr<RuntimeState> _runtime_state;
+    std::vector<OperatorPtr> _sources;
+    size_t _dop = 3;
+};
+
+// ChunkBufferMemoryEntry should add memory/rows to the manager on construction and
+// refund them exactly once on destruction.
+TEST_F(LocalExchangeMemoryTest, chunk_buffer_memory_entry_raii) {
+    constexpr size_t kMemory = 1024;
+    constexpr size_t kRows = 32;
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+    {
+        auto entry = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), kMemory, kRows);
+        EXPECT_EQ(kMemory, _memory_manager->get_memory_usage());
+        EXPECT_EQ(kMemory, entry->memory_usage());
+        EXPECT_EQ(kRows, entry->num_rows());
+
+        // A second shared_ptr to the same entry must NOT double-account.
+        auto alias = entry;
+        EXPECT_EQ(kMemory, _memory_manager->get_memory_usage());
+    }
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+}
+
+// Passthrough: a chunk added to the queue accounts its memory once, and pulling it
+// refunds the manager.
+TEST_F(LocalExchangeMemoryTest, passthrough_add_pull_accounting) {
+    auto chunk = _make_int_chunk(100);
+    const size_t mem = chunk->memory_usage();
+    const size_t rows = chunk->num_rows();
+    ASSERT_GT(mem, 0);
+
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+    _source(0)->add_chunk(chunk);
+    EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+
+    auto pulled = _source(0)->pull_chunk(_runtime_state.get());
+    ASSERT_OK(pulled);
+    ASSERT_TRUE(pulled.value() != nullptr);
+    EXPECT_EQ(rows, pulled.value()->num_rows());
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+}
+
+// Partition shuffle fan-out: a chunk shared across N source shards must add its memory
+// to the manager exactly once, not N times.
+TEST_F(LocalExchangeMemoryTest, partition_fanout_accounts_chunk_once) {
+    auto chunk = _make_int_chunk(_dop * 4);
+    const size_t mem = chunk->memory_usage();
+    const size_t rows = chunk->num_rows();
+    ASSERT_GT(mem, 0);
+
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+    auto entry = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), mem, rows);
+    EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+
+    auto indexes = std::make_shared<std::vector<uint32_t>>(rows);
+    std::iota(indexes->begin(), indexes->end(), 0);
+
+    const size_t per_shard = rows / _dop;
+    for (size_t i = 0; i < _dop; ++i) {
+        ASSERT_OK(_source(i)->add_chunk(chunk, indexes, i * per_shard, per_shard, entry));
+        // Memory must remain at exactly the chunk's memory regardless of how many
+        // shards have been enqueued.
+        EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+    }
+
+    // Drop the local reference; sources still hold the entry, so the record stays.
+    entry.reset();
+    EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+}
+
+// The manager record for a fanned-out chunk must persist until the LAST source shard
+// is consumed; pulling from earlier sources should not refund anything.
+TEST_F(LocalExchangeMemoryTest, partition_memory_released_on_last_pull) {
+    auto chunk = _make_int_chunk(_dop * 4);
+    const size_t mem = chunk->memory_usage();
+    const size_t rows = chunk->num_rows();
+    ASSERT_GT(mem, 0);
+
+    auto entry = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), mem, rows);
+    auto indexes = std::make_shared<std::vector<uint32_t>>(rows);
+    std::iota(indexes->begin(), indexes->end(), 0);
+
+    const size_t per_shard = rows / _dop;
+    for (size_t i = 0; i < _dop; ++i) {
+        ASSERT_OK(_source(i)->add_chunk(chunk, indexes, i * per_shard, per_shard, entry));
+    }
+    entry.reset();
+    EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+
+    // Pull from every source except the last; memory must still be charged because
+    // the final source still holds a reference to the shared entry.
+    for (size_t i = 0; i + 1 < _dop; ++i) {
+        auto pulled = _source(i)->pull_chunk(_runtime_state.get());
+        ASSERT_OK(pulled);
+        ASSERT_TRUE(pulled.value() != nullptr);
+        EXPECT_EQ(per_shard, pulled.value()->num_rows());
+        EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+    }
+
+    // Pulling from the last source releases the entry and refunds memory.
+    auto pulled = _source(_dop - 1)->pull_chunk(_runtime_state.get());
+    ASSERT_OK(pulled);
+    ASSERT_TRUE(pulled.value() != nullptr);
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+}
+
+// Two distinct fanned-out chunks should be accounted independently — each should add
+// its own memory exactly once and be refunded only when fully consumed.
+TEST_F(LocalExchangeMemoryTest, multiple_partition_chunks_independent) {
+    auto chunk_a = _make_int_chunk(_dop * 4);
+    auto chunk_b = _make_int_chunk(_dop * 4);
+    const size_t mem_a = chunk_a->memory_usage();
+    const size_t mem_b = chunk_b->memory_usage();
+    ASSERT_GT(mem_a, 0);
+    ASSERT_GT(mem_b, 0);
+
+    auto entry_a = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), mem_a, chunk_a->num_rows());
+    auto entry_b = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), mem_b, chunk_b->num_rows());
+
+    auto indexes_a = std::make_shared<std::vector<uint32_t>>(chunk_a->num_rows());
+    auto indexes_b = std::make_shared<std::vector<uint32_t>>(chunk_b->num_rows());
+    std::iota(indexes_a->begin(), indexes_a->end(), 0);
+    std::iota(indexes_b->begin(), indexes_b->end(), 0);
+
+    const size_t per_shard = chunk_a->num_rows() / _dop;
+    for (size_t i = 0; i < _dop; ++i) {
+        ASSERT_OK(_source(i)->add_chunk(chunk_a, indexes_a, i * per_shard, per_shard, entry_a));
+        ASSERT_OK(_source(i)->add_chunk(chunk_b, indexes_b, i * per_shard, per_shard, entry_b));
+    }
+    entry_a.reset();
+    entry_b.reset();
+    EXPECT_EQ(mem_a + mem_b, _memory_manager->get_memory_usage());
+
+    // Each pull merges all enqueued shards for that source up to chunk_size, so a
+    // single pull releases this source's contribution to BOTH entries.
+    for (size_t i = 0; i + 1 < _dop; ++i) {
+        auto pulled = _source(i)->pull_chunk(_runtime_state.get());
+        ASSERT_OK(pulled);
+        EXPECT_EQ(mem_a + mem_b, _memory_manager->get_memory_usage());
+    }
+    auto pulled = _source(_dop - 1)->pull_chunk(_runtime_state.get());
+    ASSERT_OK(pulled);
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+}
+
+// set_finished must refund every byte/row buffered across passthrough, partition, and
+// key-partition queues.
+TEST_F(LocalExchangeMemoryTest, set_finished_refunds_all_queues) {
+    auto chunk_pass = _make_int_chunk(50);
+    auto chunk_part = _make_int_chunk(_dop * 4);
+
+    _source(0)->add_chunk(chunk_pass);
+
+    auto entry = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), chunk_part->memory_usage(),
+                                                          chunk_part->num_rows());
+    auto indexes = std::make_shared<std::vector<uint32_t>>(chunk_part->num_rows());
+    std::iota(indexes->begin(), indexes->end(), 0);
+    const size_t per_shard = chunk_part->num_rows() / _dop;
+    for (size_t i = 0; i < _dop; ++i) {
+        ASSERT_OK(_source(i)->add_chunk(chunk_part, indexes, i * per_shard, per_shard, entry));
+    }
+    entry.reset();
+
+    EXPECT_GT(_memory_manager->get_memory_usage(), 0);
+
+    for (auto& source : _sources) {
+        ASSERT_OK(source->set_finished(_runtime_state.get()));
+    }
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+}
+
+// is_full() must reflect actual chunk memory, not an N-times-inflated value. With a
+// chunk whose true memory fits inside the manager limit but whose Nx-inflated value
+// would exceed it, single-count accounting must keep the manager not-full.
+TEST_F(LocalExchangeMemoryTest, fanout_does_not_falsely_trip_is_full) {
+    // per-driver limit = 1MB, dop = 3 → manager max = 3MB. Use a "claimed" chunk
+    // memory of 1.5MB: real single-count = 1.5MB < 3MB (not full); a broken N=3
+    // accounting would be 4.5MB ≥ 3MB (full).
+    auto chunk = _make_int_chunk(_dop * 4);
+    constexpr size_t kClaimedChunkMemory = 1500UL * 1024;
+
+    auto entry = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), kClaimedChunkMemory,
+                                                          chunk->num_rows());
+    auto indexes = std::make_shared<std::vector<uint32_t>>(chunk->num_rows());
+    std::iota(indexes->begin(), indexes->end(), 0);
+    const size_t per_shard = chunk->num_rows() / _dop;
+    for (size_t i = 0; i < _dop; ++i) {
+        ASSERT_OK(_source(i)->add_chunk(chunk, indexes, i * per_shard, per_shard, entry));
+    }
+    entry.reset();
+
+    EXPECT_EQ(kClaimedChunkMemory, _memory_manager->get_memory_usage());
+    EXPECT_FALSE(_memory_manager->is_full());
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/local_exchange_memory_test.cpp
+++ b/be/test/exec/pipeline/local_exchange_memory_test.cpp
@@ -20,6 +20,7 @@
 #include "base/testutil/assert.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
+#include "column/const_column.h"
 #include "exec/chunk_buffer_memory_manager.h"
 #include "exec/pipeline/exchange/local_exchange.h"
 #include "exec/pipeline/exchange/local_exchange_source_operator.h"
@@ -249,6 +250,40 @@ TEST_F(LocalExchangeMemoryTest, set_finished_refunds_all_queues) {
         ASSERT_OK(source->set_finished(_runtime_state.get()));
     }
     EXPECT_EQ(0, _memory_manager->get_memory_usage());
+}
+
+// Regression: a chunk built from const columns has tiny pre-unpack memory_usage
+// (O(1) per column) but is materialized to O(num_rows) by Partitioner::send_chunk
+// before being buffered. The memory manager must record the post-unpack footprint,
+// otherwise back-pressure under-counts buffered memory by orders of magnitude.
+TEST_F(LocalExchangeMemoryTest, const_column_accounted_after_unpack) {
+    constexpr size_t kNumRows = 4096;
+
+    // Chunk with a single const-INT column over kNumRows virtual rows.
+    auto inner = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+    inner->append_datum(Datum(static_cast<int32_t>(42)));
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(ConstColumn::create(std::move(inner), kNumRows), 1);
+    ASSERT_EQ(kNumRows, chunk->num_rows());
+
+    const size_t pre_unpack_mem = chunk->memory_usage();
+
+    // Partition + send a copy of the chunk. RandomPartitioner needs no expr context.
+    auto partitioner = std::make_unique<RandomPartitioner>(_source_op_factory.get());
+    auto partition_row_indexes = std::make_shared<std::vector<uint32_t>>(kNumRows);
+    ASSERT_OK(partitioner->partition_chunk(chunk, _dop, *partition_row_indexes));
+    ASSERT_OK(partitioner->send_chunk(chunk, partition_row_indexes));
+
+    // After send_chunk, the const column has been materialized into a regular column
+    // of kNumRows datums; the per-shard buffered memory is therefore much larger than
+    // what chunk->memory_usage() would have reported pre-unpack.
+    const size_t post_unpack_mem = chunk->memory_usage();
+    EXPECT_GT(post_unpack_mem, pre_unpack_mem)
+            << "const-column unpack should grow chunk memory_usage";
+
+    // The manager must record the post-unpack footprint, not the tiny pre-unpack
+    // value. Equality (rather than >=) ensures we accounted exactly once.
+    EXPECT_EQ(post_unpack_mem, _memory_manager->get_memory_usage());
 }
 
 // is_full() must reflect actual chunk memory, not an N-times-inflated value. With a

--- a/be/test/exec/pipeline/local_exchange_memory_test.cpp
+++ b/be/test/exec/pipeline/local_exchange_memory_test.cpp
@@ -278,8 +278,7 @@ TEST_F(LocalExchangeMemoryTest, const_column_accounted_after_unpack) {
     // of kNumRows datums; the per-shard buffered memory is therefore much larger than
     // what chunk->memory_usage() would have reported pre-unpack.
     const size_t post_unpack_mem = chunk->memory_usage();
-    EXPECT_GT(post_unpack_mem, pre_unpack_mem)
-            << "const-column unpack should grow chunk memory_usage";
+    EXPECT_GT(post_unpack_mem, pre_unpack_mem) << "const-column unpack should grow chunk memory_usage";
 
     // The manager must record the post-unpack footprint, not the tiny pre-unpack
     // value. Equality (rather than >=) ensures we accounted exactly once.

--- a/be/test/exec/pipeline/local_exchange_memory_test.cpp
+++ b/be/test/exec/pipeline/local_exchange_memory_test.cpp
@@ -309,4 +309,89 @@ TEST_F(LocalExchangeMemoryTest, fanout_does_not_falsely_trip_is_full) {
     EXPECT_FALSE(_memory_manager->is_full());
 }
 
+// Early-finish on one source must release ONLY that source's contribution to a
+// shared fan-out entry; the chunk's memory record must persist while at least one
+// other source still holds a reference. After the remaining sources drain, memory
+// drops to zero — i.e. early finish does not leak nor pile up memory.
+TEST_F(LocalExchangeMemoryTest, early_finish_one_source_keeps_other_refs) {
+    auto chunk = _make_int_chunk(_dop * 4);
+    const size_t mem = chunk->memory_usage();
+    ASSERT_GT(mem, 0);
+
+    auto entry = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), mem, chunk->num_rows());
+    auto indexes = std::make_shared<std::vector<uint32_t>>(chunk->num_rows());
+    std::iota(indexes->begin(), indexes->end(), 0);
+    const size_t per_shard = chunk->num_rows() / _dop;
+    for (size_t i = 0; i < _dop; ++i) {
+        ASSERT_OK(_source(i)->add_chunk(chunk, indexes, i * per_shard, per_shard, entry));
+    }
+    entry.reset();
+    EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+
+    // Source 0 finishes early. Its queue clears and its ref to the shared entry drops,
+    // but sources 1..N-1 still hold the entry, so the chunk's memory stays accounted.
+    ASSERT_OK(_source(0)->set_finished(_runtime_state.get()));
+    EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+
+    // Drain the remaining sources; memory only returns to zero after the last ref drops.
+    for (size_t i = 1; i + 1 < _dop; ++i) {
+        auto pulled = _source(i)->pull_chunk(_runtime_state.get());
+        ASSERT_OK(pulled);
+        EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+    }
+    auto pulled = _source(_dop - 1)->pull_chunk(_runtime_state.get());
+    ASSERT_OK(pulled);
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+}
+
+// After one source has finished, subsequent send_chunk fan-outs must only accumulate
+// references in the remaining active sources — memory still scales as 1x per chunk,
+// not by the (already-dead) finished sources.
+TEST_F(LocalExchangeMemoryTest, send_after_partial_finish_only_charges_active_sources) {
+    // Source 0 finishes before any chunk arrives.
+    ASSERT_OK(_source(0)->set_finished(_runtime_state.get()));
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+
+    // Fan a chunk out via the partitioner. The finished source's add_chunk no-ops,
+    // and add_chunk takes the entry by value, so its parameter copy is dropped on
+    // return — the entry ends up held only by the active sources.
+    auto chunk = _make_int_chunk(_dop * 4);
+    auto partitioner = std::make_unique<RandomPartitioner>(_source_op_factory.get());
+    auto partition_row_indexes = std::make_shared<std::vector<uint32_t>>(chunk->num_rows());
+    ASSERT_OK(partitioner->partition_chunk(chunk, _dop, *partition_row_indexes));
+    ASSERT_OK(partitioner->send_chunk(chunk, partition_row_indexes));
+
+    const size_t mem = chunk->memory_usage();
+    EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+
+    // Drain the active sources; memory drops to zero after the last one pulls.
+    for (size_t i = 1; i + 1 < _dop; ++i) {
+        auto pulled = _source(i)->pull_chunk(_runtime_state.get());
+        ASSERT_OK(pulled);
+        EXPECT_EQ(mem, _memory_manager->get_memory_usage());
+    }
+    auto pulled = _source(_dop - 1)->pull_chunk(_runtime_state.get());
+    ASSERT_OK(pulled);
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+}
+
+// When ALL sources have already finished, send_chunk briefly registers the entry
+// (constructor side-effect) but every per-source add_chunk no-ops, so the entry has
+// no holders by the time send_chunk returns and the manager goes back to zero.
+// Verifies that finishing all consumers does not strand chunks in the manager.
+TEST_F(LocalExchangeMemoryTest, send_after_all_sources_finished_refunds_immediately) {
+    for (auto& source : _sources) {
+        ASSERT_OK(source->set_finished(_runtime_state.get()));
+    }
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+
+    auto chunk = _make_int_chunk(_dop * 4);
+    auto partitioner = std::make_unique<RandomPartitioner>(_source_op_factory.get());
+    auto partition_row_indexes = std::make_shared<std::vector<uint32_t>>(chunk->num_rows());
+    ASSERT_OK(partitioner->partition_chunk(chunk, _dop, *partition_row_indexes));
+    ASSERT_OK(partitioner->send_chunk(chunk, partition_row_indexes));
+
+    EXPECT_EQ(0, _memory_manager->get_memory_usage());
+}
+
 } // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/local_exchange_memory_test.cpp
+++ b/be/test/exec/pipeline/local_exchange_memory_test.cpp
@@ -261,8 +261,8 @@ TEST_F(LocalExchangeMemoryTest, fanout_does_not_falsely_trip_is_full) {
     auto chunk = _make_int_chunk(_dop * 4);
     constexpr size_t kClaimedChunkMemory = 1500UL * 1024;
 
-    auto entry = std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), kClaimedChunkMemory,
-                                                          chunk->num_rows());
+    auto entry =
+            std::make_shared<ChunkBufferMemoryEntry>(_memory_manager.get(), kClaimedChunkMemory, chunk->num_rows());
     auto indexes = std::make_shared<std::vector<uint32_t>>(chunk->num_rows());
     std::iota(indexes->begin(), indexes->end(), 0);
     const size_t per_shard = chunk->num_rows() / _dop;


### PR DESCRIPTION
## Why I'm doing:

Local exchange retains chunks until all referencing sources have consumed them. In scenarios with heavy data skew, some chunks stay referenced much longer than others, delaying their release and resulting in higher-than-expected memory consumption.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
