### PR TITLE
[Enhancement] Add getTabletMetadata RPC for cn-free tablet creation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -53,10 +53,12 @@ import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -65,6 +67,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.Tablet;
@@ -199,10 +202,13 @@ import com.starrocks.thrift.TAuthInfo;
 import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TBatchGetTableSchemaRequest;
 import com.starrocks.thrift.TBatchGetTableSchemaResponse;
+import com.starrocks.thrift.TBatchGetTabletMetadataRequest;
+import com.starrocks.thrift.TBatchGetTabletMetadataResponse;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TBeginRemoteTxnRequest;
 import com.starrocks.thrift.TBeginRemoteTxnResponse;
+import com.starrocks.thrift.TCloudTabletMeta;
 import com.starrocks.thrift.TClusterSnapshotJobsRequest;
 import com.starrocks.thrift.TClusterSnapshotJobsResponse;
 import com.starrocks.thrift.TClusterSnapshotsRequest;
@@ -274,6 +280,8 @@ import com.starrocks.thrift.TGetTablesInfoRequest;
 import com.starrocks.thrift.TGetTablesInfoResponse;
 import com.starrocks.thrift.TGetTablesParams;
 import com.starrocks.thrift.TGetTablesResult;
+import com.starrocks.thrift.TGetTabletMetadataRequest;
+import com.starrocks.thrift.TGetTabletMetadataResponse;
 import com.starrocks.thrift.TGetTabletScheduleRequest;
 import com.starrocks.thrift.TGetTabletScheduleResponse;
 import com.starrocks.thrift.TGetTaskInfoResult;
@@ -373,6 +381,7 @@ import com.starrocks.thrift.TTablePrivDesc;
 import com.starrocks.thrift.TTableReplicationRequest;
 import com.starrocks.thrift.TTableReplicationResponse;
 import com.starrocks.thrift.TTabletLocation;
+import com.starrocks.thrift.TTabletRange;
 import com.starrocks.thrift.TTabletReshardJobsRequest;
 import com.starrocks.thrift.TTabletReshardJobsResponse;
 import com.starrocks.thrift.TTaskInfo;
@@ -3585,6 +3594,133 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
         }
         return batchResponse;
+    }
+
+    @Override
+    public TBatchGetTabletMetadataResponse getTabletMetadata(
+            TBatchGetTabletMetadataRequest batchRequest) {
+        TBatchGetTabletMetadataResponse batchResponse = new TBatchGetTabletMetadataResponse();
+        batchResponse.setStatus(new TStatus(OK));
+        if (batchRequest.isSetRequests()) {
+            for (TGetTabletMetadataRequest request : batchRequest.getRequests()) {
+                batchResponse.addToResponses(handleGetTabletMetadata(request));
+            }
+        }
+        return batchResponse;
+    }
+
+    private TGetTabletMetadataResponse handleGetTabletMetadata(TGetTabletMetadataRequest request) {
+        TGetTabletMetadataResponse response = new TGetTabletMetadataResponse();
+        // Only version 1 (initial empty metadata) is supported today. Higher versions
+        // would require returning rowsets and historical schemas, which are not yet
+        // wired through this RPC.
+        long version = request.isSetVersion() ? request.getVersion() : 1;
+        if (version != 1) {
+            TStatus status = new TStatus(TStatusCode.NOT_IMPLEMENTED_ERROR);
+            status.addToError_msgs("only version 1 is supported, requested version: " + version);
+            response.setStatus(status);
+            return response;
+        }
+        long tableId = request.getTable_id();
+        long partitionId = request.getPartition_id();
+        long indexId = request.getIndex_id();
+
+        long tabletId = request.getTablet_id();
+        TabletMeta tabletMeta = GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getTabletMeta(tabletId);
+        if (tabletMeta == null) {
+            TStatus status = new TStatus(TStatusCode.NOT_FOUND);
+            status.addToError_msgs("tablet not found: " + tabletId);
+            response.setStatus(status);
+            return response;
+        }
+        long dbId = tabletMeta.getDbId();
+
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, tableId);
+        if (table == null) {
+            TStatus status = new TStatus(TStatusCode.NOT_FOUND);
+            status.addToError_msgs("table not found, db_id: " + dbId + ", table_id: " + tableId);
+            response.setStatus(status);
+            return response;
+        }
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs("not a cloud native table, table_id: " + tableId);
+            response.setStatus(status);
+            return response;
+        }
+        OlapTable olapTable = (OlapTable) table;
+        try (AutoCloseableLock ignore = new AutoCloseableLock(
+                new Locker(), dbId, Collections.singletonList(tableId), LockType.READ)) {
+            PhysicalPartition partition = olapTable.getPhysicalPartition(partitionId);
+            if (partition == null) {
+                TStatus status = new TStatus(TStatusCode.NOT_FOUND);
+                status.addToError_msgs("partition not found: " + partitionId);
+                response.setStatus(status);
+                return response;
+            }
+
+            MaterializedIndex index = partition.getIndex(indexId);
+            if (index == null) {
+                TStatus status = new TStatus(TStatusCode.NOT_FOUND);
+                status.addToError_msgs("index not found: " + indexId);
+                response.setStatus(status);
+                return response;
+            }
+
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(index.getMetaId());
+            if (indexMeta == null) {
+                TStatus status = new TStatus(TStatusCode.NOT_FOUND);
+                status.addToError_msgs("index meta not found for metaId: " + index.getMetaId());
+                response.setStatus(status);
+                return response;
+            }
+
+            TCloudTabletMeta meta = new TCloudTabletMeta();
+            meta.setTablet_id(tabletId);
+
+            long indexMetaId = index.getMetaId();
+            SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(olapTable, indexMetaId, indexMeta);
+            meta.setSchema(schemaInfo.toTabletSchema());
+
+            meta.setEnable_persistent_index(olapTable.enablePersistentIndex());
+            if (olapTable.getPersistentIndexType() != null) {
+                meta.setPersistent_index_type(olapTable.getPersistentIndexType());
+            }
+            meta.setCompaction_strategy(olapTable.getCompactionStrategy());
+            FlatJsonConfig flatJsonConfig = olapTable.getFlatJsonConfig();
+            if (flatJsonConfig != null) {
+                meta.setFlat_json_config(flatJsonConfig.toTFlatJsonConfig());
+            }
+            if (olapTable.getCompressionType() != null) {
+                meta.setCompression_type(olapTable.getCompressionType());
+            }
+            meta.setCompression_level(olapTable.getCompressionLevel());
+
+            // tablet_ranges holds all tablets' ranges in this index, only for range distribution
+            if (olapTable.isRangeDistribution()) {
+                Map<Long, TTabletRange> tabletRanges = new java.util.HashMap<>();
+                for (Tablet tablet : index.getTablets()) {
+                    if (tablet.getRange() != null) {
+                        tabletRanges.put(tablet.getId(), tablet.getRange().toThrift());
+                    }
+                }
+                if (!tabletRanges.isEmpty()) {
+                    meta.setTablet_ranges(tabletRanges);
+                }
+            }
+
+            meta.setGtid(0);
+
+            response.setMeta(meta);
+            response.setStatus(new TStatus(TStatusCode.OK));
+        } catch (Exception e) {
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs("failed to get tablet metadata, table_id: " + tableId
+                    + ", partition_id: " + partitionId + ", index_id: " + indexId
+                    + ", error: " + e.getMessage());
+            response.setStatus(status);
+        }
+        return response;
     }
 
     private static class CreatePartitionMetrics {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
@@ -33,10 +34,17 @@ import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.service.FrontendServiceImpl;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.storagevolume.StorageVolume;
+import com.starrocks.thrift.TBatchGetTabletMetadataRequest;
+import com.starrocks.thrift.TBatchGetTabletMetadataResponse;
+import com.starrocks.thrift.TGetTabletMetadataRequest;
+import com.starrocks.thrift.TGetTabletMetadataResponse;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TTabletRange;
 import com.starrocks.utframe.UtFrameUtils;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
@@ -580,5 +588,191 @@ public class CreateLakeTableTest {
                 snapshot, engine, metastore);
         LightWeightDeltaLakeTable light = new LightWeightDeltaLakeTable(table);
         Assertions.assertThrows(UnsupportedOperationException.class, light::getDeltaSnapshot);
+    }
+
+    @Test
+    public void testGetTabletMetadata() throws Exception {
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.tablet_metadata_rpc_test\n" +
+                        "(c0 int, c1 string)\n" +
+                        "duplicate key(c0)\n" +
+                        "distributed by hash(c0) buckets 2"));
+        LakeTable lakeTable = getLakeTable("lake_test", "tablet_metadata_rpc_test");
+        Partition partition = lakeTable.getPartitions().stream().findFirst().get();
+        MaterializedIndex index = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
+        long tabletId = index.getTablets().get(0).getId();
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(null);
+
+        // hash distribution tablet: returns OK with schema, no range
+        {
+            TGetTabletMetadataRequest req = new TGetTabletMetadataRequest();
+            req.setTable_id(lakeTable.getId());
+            req.setPartition_id(partition.getDefaultPhysicalPartition().getId());
+            req.setIndex_id(index.getId());
+            req.setTablet_id(tabletId);
+            req.setVersion(1);
+            TBatchGetTabletMetadataRequest batchReq = new TBatchGetTabletMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
+
+            Assertions.assertEquals(TStatusCode.OK, batchResp.getStatus().getStatus_code());
+            Assertions.assertEquals(1, batchResp.getResponsesSize());
+            TGetTabletMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.OK, resp.getStatus().getStatus_code());
+            Assertions.assertTrue(resp.isSetMeta());
+            Assertions.assertEquals(tabletId, resp.getMeta().getTablet_id());
+            Assertions.assertTrue(resp.getMeta().isSetSchema());
+            Assertions.assertTrue(resp.getMeta().isSetCompression_type());
+            // hash distribution table should not have tablet_ranges set
+            Assertions.assertFalse(resp.getMeta().isSetTablet_ranges());
+        }
+
+        // version unset: defaults to 1, behaves identically
+        {
+            TGetTabletMetadataRequest req = new TGetTabletMetadataRequest();
+            req.setTable_id(lakeTable.getId());
+            req.setPartition_id(partition.getDefaultPhysicalPartition().getId());
+            req.setIndex_id(index.getId());
+            req.setTablet_id(tabletId);
+            TBatchGetTabletMetadataRequest batchReq = new TBatchGetTabletMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
+            TGetTabletMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.OK, resp.getStatus().getStatus_code());
+            Assertions.assertTrue(resp.isSetMeta());
+            Assertions.assertTrue(resp.getMeta().isSetSchema());
+        }
+
+        // unsupported version: returns NOT_IMPLEMENTED_ERROR
+        {
+            TGetTabletMetadataRequest req = new TGetTabletMetadataRequest();
+            req.setTable_id(lakeTable.getId());
+            req.setPartition_id(partition.getDefaultPhysicalPartition().getId());
+            req.setIndex_id(index.getId());
+            req.setTablet_id(tabletId);
+            req.setVersion(2);
+            TBatchGetTabletMetadataRequest batchReq = new TBatchGetTabletMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
+            TGetTabletMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.NOT_IMPLEMENTED_ERROR, resp.getStatus().getStatus_code());
+        }
+
+        // range distribution tablet: tablet_ranges should contain all tablets' ranges
+        {
+            boolean savedRangeDistribution = Config.enable_range_distribution;
+            try {
+                Config.enable_range_distribution = true;
+                connectContext.getSessionVariable().setEnableRangeDistribution(true);
+                ExceptionChecker.expectThrowsNoException(() -> createTable(
+                        "create table lake_test.tablet_metadata_range_test\n" +
+                                "(c0 int, c1 string)\n" +
+                                "PRIMARY KEY(c0)"));
+                LakeTable rangeTable = getLakeTable("lake_test", "tablet_metadata_range_test");
+                Assertions.assertTrue(rangeTable.isRangeDistribution());
+
+                Partition rangePart = rangeTable.getPartitions().stream().findFirst().get();
+                MaterializedIndex rangeIndex = rangePart.getDefaultPhysicalPartition().getLatestBaseIndex();
+                int numTablets = rangeIndex.getTablets().size();
+                long rangeTabletId = rangeIndex.getTablets().get(0).getId();
+                TGetTabletMetadataRequest req = new TGetTabletMetadataRequest();
+                req.setTable_id(rangeTable.getId());
+                req.setPartition_id(rangePart.getDefaultPhysicalPartition().getId());
+                req.setIndex_id(rangeIndex.getId());
+                req.setTablet_id(rangeTabletId);
+                req.setVersion(1);
+                TBatchGetTabletMetadataRequest batchReq = new TBatchGetTabletMetadataRequest();
+                batchReq.addToRequests(req);
+                TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
+
+                TGetTabletMetadataResponse resp = batchResp.getResponses().get(0);
+                Assertions.assertEquals(TStatusCode.OK, resp.getStatus().getStatus_code());
+                Assertions.assertTrue(resp.isSetMeta());
+                Assertions.assertTrue(resp.getMeta().isSetTablet_ranges());
+                Assertions.assertEquals(numTablets, resp.getMeta().getTablet_ranges().size());
+                Assertions.assertTrue(resp.getMeta().getTablet_ranges().containsKey(rangeTabletId));
+                // initial range is Range.all(), so bounds are not set
+                TTabletRange tabletRange = resp.getMeta().getTablet_ranges().get(rangeTabletId);
+                Assertions.assertFalse(tabletRange.isSetLower_bound());
+                Assertions.assertFalse(tabletRange.isSetUpper_bound());
+            } finally {
+                Config.enable_range_distribution = savedRangeDistribution;
+                connectContext.getSessionVariable().setEnableRangeDistribution(false);
+            }
+        }
+
+        // non-existent tablet: returns NOT_FOUND
+        {
+            TGetTabletMetadataRequest req = new TGetTabletMetadataRequest();
+            req.setTable_id(999999999L);
+            req.setPartition_id(1L);
+            req.setIndex_id(1L);
+            req.setTablet_id(999999999L);
+            req.setVersion(1);
+            TBatchGetTabletMetadataRequest batchReq = new TBatchGetTabletMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
+
+            Assertions.assertEquals(TStatusCode.OK, batchResp.getStatus().getStatus_code());
+            TGetTabletMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.NOT_FOUND, resp.getStatus().getStatus_code());
+        }
+
+        // table_id not exist (tablet_id valid but table dropped): returns NOT_FOUND
+        {
+            TGetTabletMetadataRequest req = new TGetTabletMetadataRequest();
+            req.setTable_id(999999999L);
+            req.setPartition_id(partition.getDefaultPhysicalPartition().getId());
+            req.setIndex_id(index.getId());
+            req.setTablet_id(tabletId);
+            req.setVersion(1);
+            TBatchGetTabletMetadataRequest batchReq = new TBatchGetTabletMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
+
+            TGetTabletMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.NOT_FOUND, resp.getStatus().getStatus_code());
+        }
+
+        // partition_id not exist: returns NOT_FOUND
+        {
+            TGetTabletMetadataRequest req = new TGetTabletMetadataRequest();
+            req.setTable_id(lakeTable.getId());
+            req.setPartition_id(999999999L);
+            req.setIndex_id(index.getId());
+            req.setTablet_id(tabletId);
+            req.setVersion(1);
+            TBatchGetTabletMetadataRequest batchReq = new TBatchGetTabletMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
+
+            TGetTabletMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.NOT_FOUND, resp.getStatus().getStatus_code());
+        }
+
+        // index_id not exist: returns NOT_FOUND
+        {
+            TGetTabletMetadataRequest req = new TGetTabletMetadataRequest();
+            req.setTable_id(lakeTable.getId());
+            req.setPartition_id(partition.getDefaultPhysicalPartition().getId());
+            req.setIndex_id(999999999L);
+            req.setTablet_id(tabletId);
+            req.setVersion(1);
+            TBatchGetTabletMetadataRequest batchReq = new TBatchGetTabletMetadataRequest();
+            batchReq.addToRequests(req);
+            TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
+
+            TGetTabletMetadataResponse resp = batchResp.getResponses().get(0);
+            Assertions.assertEquals(TStatusCode.NOT_FOUND, resp.getStatus().getStatus_code());
+        }
+
+        // empty batch
+        {
+            TBatchGetTabletMetadataRequest batchReq = new TBatchGetTabletMetadataRequest();
+            TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
+            Assertions.assertEquals(TStatusCode.OK, batchResp.getStatus().getStatus_code());
+            Assertions.assertFalse(batchResp.isSetResponses());
+        }
     }
 }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -140,6 +140,10 @@ struct TCreateTabletReq {
     25: optional TFlatJsonConfig flat_json_config;
     26: optional TCompactionStrategy compaction_strategy;
     27: optional Types.TTabletRange range;
+
+    // New fields should be added above this comment.
+    // NOTE: If you add a new field here that ends up in tablet metadata,
+    // also update TCloudTabletMeta in FrontendService.thrift to keep the two paths in sync.
 }
 
 struct TDropTabletReq {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2295,6 +2295,51 @@ struct TBatchGetTableSchemaResponse {
     2: optional list<TGetTableSchemaResponse> responses;
 }
 
+struct TGetTabletMetadataRequest {
+    1: optional i64 tablet_id;
+    2: optional i64 table_id;
+    3: optional i64 partition_id;
+    4: optional i64 index_id;
+    // The metadata version to fetch. Defaults to 1 when unset.
+    // The current implementation only serves version 1 (the initial empty metadata
+    // produced by tablet creation). Other versions return NOT_IMPLEMENTED until a
+    // future change extends the response with the fields needed for higher versions
+    // (rowsets, historical schemas, etc.).
+    5: optional i64 version;
+}
+
+// Subset of tablet metadata fields needed to construct a version-1 TabletMetadataPB
+// on CN. The shape currently overlaps with AgentService.TCreateTabletReq; the two
+// must be kept in sync per the NOTE on TCreateTabletReq. Higher versions will need
+// additional fields (rowsets, sstable meta, historical schemas, etc.) which can be
+// added without breaking compatibility since all fields are optional.
+struct TCloudTabletMeta {
+    1: optional i64 tablet_id;
+    2: optional AgentService.TTabletSchema schema;
+    3: optional bool enable_persistent_index;
+    4: optional AgentService.TPersistentIndexType persistent_index_type;
+    5: optional AgentService.TCompactionStrategy compaction_strategy;
+    6: optional AgentService.TFlatJsonConfig flat_json_config;
+    7: optional map<i64, Types.TTabletRange> tablet_ranges;
+    8: optional i64 gtid;
+    9: optional Types.TCompressionType compression_type;
+    10: optional i32 compression_level;
+}
+
+struct TGetTabletMetadataResponse {
+    1: optional Status.TStatus status;
+    2: optional TCloudTabletMeta meta;
+}
+
+struct TBatchGetTabletMetadataRequest {
+    1: optional list<TGetTabletMetadataRequest> requests;
+}
+
+struct TBatchGetTabletMetadataResponse {
+    1: optional Status.TStatus status;
+    2: optional list<TGetTabletMetadataResponse> responses;
+}
+
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)
     TGetTablesResult getTableNames(1:TGetTablesParams params)
@@ -2446,4 +2491,6 @@ service FrontendService {
     TRefreshConnectionsResponse refreshConnections(1: TRefreshConnectionsRequest request)
 
     TBatchGetTableSchemaResponse getTableSchema(1: TBatchGetTableSchemaRequest request)
+
+    TBatchGetTabletMetadataResponse getTabletMetadata(1: optional TBatchGetTabletMetadataRequest request)
 }


### PR DESCRIPTION
Introduce the FE-side RPC that an upcoming CN-Free Tablet Creation feature will call to fetch tablet metadata when DDL skips writing version 1 metadata to object storage.

This change is FE infrastructure only and changes no existing behavior:
  * No caller of the new RPC ships in this PR. The CN-side consumer and fallback wire-up land in a follow-up.
  * The user-visible switch (table property cn_free_tablet_creation and DDL skip in TabletTaskExecutor) lands in a later PR.

The request includes a version field so callers can ask for any tablet metadata version, but only version 1 (the initial empty metadata produced by tablet creation) is implemented. Other versions return NOT_IMPLEMENTED_ERROR; they will be supported when a future change extends the response with the fields needed (rowsets, historical schemas, etc.).

For version 1 the handler resolves the tablet via TabletInvertedIndex and returns the schema and configuration needed to construct the initial TabletMetadataPB on CN: compression type/level, persistent index settings, flat-json config, compaction strategy, GTID, and per-tablet ranges.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
