### PR TITLE
[Enhancement] Add FE config: deploy_serialization_min_thread_pool_size

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4394,8 +4394,9 @@ public class Config extends ConfigBase {
     public static boolean enable_trace_historical_node = false;
 
     /**
-     * The size of the thread pool for deploy serialization.
+     * The max size of the thread pool for deploy serialization.
      * If set to -1, it means same as cpu core number.
+     * Values smaller than cpu core number are treated as cpu core number.
      */
     @ConfField(mutable = true)
     public static int deploy_serialization_thread_pool_size = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4397,8 +4397,14 @@ public class Config extends ConfigBase {
      * The size of the thread pool for deploy serialization.
      * If set to -1, it means same as cpu core number.
      */
-    @ConfField
+    @ConfField(mutable = true)
     public static int deploy_serialization_thread_pool_size = -1;
+
+    /**
+     * The min size (core pool size) of the thread pool for deploy serialization.
+     */
+    @ConfField(mutable = true)
+    public static int deploy_serialization_min_thread_pool_size = 1;
 
     /**
      * The size of the queue for deploy serialization thread pool.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
@@ -18,6 +18,7 @@ import com.google.api.client.util.Sets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Config;
+import com.starrocks.common.ConfigRefreshDaemon;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
 import com.starrocks.common.ThreadPoolManager;
@@ -38,7 +39,6 @@ import com.starrocks.qe.scheduler.slot.DeployState;
 import com.starrocks.rpc.AttachmentRequest;
 import com.starrocks.rpc.BackendServiceClient;
 import com.starrocks.rpc.RpcException;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TExecBatchPlanFragmentsParams;
 import com.starrocks.thrift.TExecPlanFragmentParams;
@@ -83,7 +83,10 @@ public class Deployer {
                 new LinkedBlockingQueue<>(threadPoolQueueSize), new ThreadPoolExecutor.AbortPolicy(),
                 "deployer", true);
         ThreadPoolManager.registerAllThreadPoolMetric();
-        GlobalStateMgr.getCurrentState().getConfigRefreshDaemon().registerListener(() -> {
+    }
+
+    public static void registerConfigListener(ConfigRefreshDaemon daemon) {
+        daemon.registerListener(() -> {
             int newMax = resolveMaxThreadPoolSize(Config.deploy_serialization_thread_pool_size);
             int newMin = clampMinThreadPoolSize(Config.deploy_serialization_min_thread_pool_size, newMax);
             resizeExecutor(EXECUTOR, newMin, newMax);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Deployer.java
@@ -38,6 +38,7 @@ import com.starrocks.qe.scheduler.slot.DeployState;
 import com.starrocks.rpc.AttachmentRequest;
 import com.starrocks.rpc.BackendServiceClient;
 import com.starrocks.rpc.RpcException;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TExecBatchPlanFragmentsParams;
 import com.starrocks.thrift.TExecPlanFragmentParams;
@@ -74,13 +75,43 @@ public class Deployer {
     private static final ThreadPoolExecutor EXECUTOR;
 
     static {
-        int threadPoolSize = Math.max(ThreadPoolManager.cpuCores(), Config.deploy_serialization_thread_pool_size);
+        int threadPoolSize = resolveMaxThreadPoolSize(Config.deploy_serialization_thread_pool_size);
+        int minThreadPoolSize = clampMinThreadPoolSize(Config.deploy_serialization_min_thread_pool_size, threadPoolSize);
         int threadPoolQueueSize = Config.deploy_serialization_queue_size > 0 ? Config.deploy_serialization_queue_size :
                 threadPoolSize * 2;
-        EXECUTOR = ThreadPoolManager.newDaemonThreadPool(1, threadPoolSize, 60, TimeUnit.SECONDS,
+        EXECUTOR = ThreadPoolManager.newDaemonThreadPool(minThreadPoolSize, threadPoolSize, 60, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<>(threadPoolQueueSize), new ThreadPoolExecutor.AbortPolicy(),
                 "deployer", true);
         ThreadPoolManager.registerAllThreadPoolMetric();
+        GlobalStateMgr.getCurrentState().getConfigRefreshDaemon().registerListener(() -> {
+            int newMax = resolveMaxThreadPoolSize(Config.deploy_serialization_thread_pool_size);
+            int newMin = clampMinThreadPoolSize(Config.deploy_serialization_min_thread_pool_size, newMax);
+            resizeExecutor(EXECUTOR, newMin, newMax);
+        });
+    }
+
+    static int resolveMaxThreadPoolSize(int configured) {
+        return Math.max(ThreadPoolManager.cpuCores(), configured);
+    }
+
+    static int clampMinThreadPoolSize(int configured, int maxPoolSize) {
+        return Math.min(Math.max(1, configured), maxPoolSize);
+    }
+
+    static void resizeExecutor(ThreadPoolExecutor executor, int newMin, int newMax) {
+        int curMax = executor.getMaximumPoolSize();
+        int curMin = executor.getCorePoolSize();
+        if (newMax == curMax && newMin == curMin) {
+            return;
+        }
+        // ThreadPoolExecutor enforces core <= max on each setter, so order matters.
+        if (newMax >= curMax) {
+            executor.setMaximumPoolSize(newMax);
+            executor.setCorePoolSize(newMin);
+        } else {
+            executor.setCorePoolSize(newMin);
+            executor.setMaximumPoolSize(newMax);
+        }
     }
 
     private final ConnectContext context;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -199,6 +199,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.qe.scheduler.Deployer;
 import com.starrocks.qe.scheduler.slot.BaseSlotManager;
 import com.starrocks.qe.scheduler.slot.GlobalSlotProvider;
 import com.starrocks.qe.scheduler.slot.LocalSlotProvider;
@@ -850,6 +851,7 @@ public class GlobalStateMgr {
                 LOG.warn("check config failed", e);
             }
         });
+        Deployer.registerConfigListener(getConfigRefreshDaemon());
 
         this.replicationMgr = new ReplicationMgr();
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -383,6 +383,7 @@ public class GlobalStateMgr {
     private CheckpointController checkpointController;
     private CheckpointWorker checkpointWorker;
     private boolean checkpointWorkerStarted = false;
+    private boolean deployerListenerRegistered = false;
 
     private HAProtocol haProtocol = null;
 
@@ -851,7 +852,6 @@ public class GlobalStateMgr {
                 LOG.warn("check config failed", e);
             }
         });
-        Deployer.registerConfigListener(getConfigRefreshDaemon());
 
         this.replicationMgr = new ReplicationMgr();
 
@@ -1699,6 +1699,12 @@ public class GlobalStateMgr {
         if (RunMode.isSharedDataMode()) {
             compactionMgr.start();
             StarMgrServer.getCurrentState().startCheckpointWorker();
+        }
+        // Register listeners that need a fully-constructed GlobalStateMgr (e.g. classes whose
+        // own static initializer transitively touches MetricRepo / getCurrentState()).
+        if (!deployerListenerRegistered) {
+            Deployer.registerConfigListener(configRefreshDaemon);
+            deployerListenerRegistered = true;
         }
         configRefreshDaemon.start();
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DeployerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DeployerTest.java
@@ -1,0 +1,111 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.common.ThreadPoolManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DeployerTest {
+
+    private ThreadPoolExecutor executor;
+
+    @AfterEach
+    public void tearDown() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testResolveMaxThreadPoolSizeFallsBackToCpuCores() {
+        // -1 means "use cpu cores"; the helper guarantees at least cpuCores threads.
+        int cpuCores = ThreadPoolManager.cpuCores();
+        assertEquals(cpuCores, Deployer.resolveMaxThreadPoolSize(-1));
+        assertEquals(cpuCores, Deployer.resolveMaxThreadPoolSize(0));
+        assertEquals(Math.max(cpuCores, 1024), Deployer.resolveMaxThreadPoolSize(1024));
+    }
+
+    @Test
+    public void testClampMinThreadPoolSize() {
+        assertEquals(1, Deployer.clampMinThreadPoolSize(-5, 8));
+        assertEquals(1, Deployer.clampMinThreadPoolSize(0, 8));
+        assertEquals(4, Deployer.clampMinThreadPoolSize(4, 8));
+        assertEquals(8, Deployer.clampMinThreadPoolSize(8, 8));
+        // Configured min above max gets clamped to max so setCorePoolSize never exceeds it.
+        assertEquals(8, Deployer.clampMinThreadPoolSize(100, 8));
+    }
+
+    @Test
+    public void testResizeExecutorExpand() {
+        executor = newExecutor(2, 4);
+
+        Deployer.resizeExecutor(executor, 6, 12);
+
+        assertEquals(12, executor.getMaximumPoolSize());
+        assertEquals(6, executor.getCorePoolSize());
+    }
+
+    @Test
+    public void testResizeExecutorShrink() {
+        executor = newExecutor(4, 8);
+
+        Deployer.resizeExecutor(executor, 1, 2);
+
+        assertEquals(2, executor.getMaximumPoolSize());
+        assertEquals(1, executor.getCorePoolSize());
+    }
+
+    @Test
+    public void testResizeExecutorShrinkBelowCurrentCore() {
+        // Current core (4) is larger than the new max (2). Must lower core first.
+        executor = newExecutor(4, 8);
+
+        Deployer.resizeExecutor(executor, 2, 2);
+
+        assertEquals(2, executor.getMaximumPoolSize());
+        assertEquals(2, executor.getCorePoolSize());
+    }
+
+    @Test
+    public void testResizeExecutorOnlyMinChanges() {
+        executor = newExecutor(2, 8);
+
+        Deployer.resizeExecutor(executor, 5, 8);
+
+        assertEquals(8, executor.getMaximumPoolSize());
+        assertEquals(5, executor.getCorePoolSize());
+    }
+
+    @Test
+    public void testResizeExecutorNoChange() {
+        executor = newExecutor(2, 8);
+
+        Deployer.resizeExecutor(executor, 2, 8);
+
+        assertEquals(8, executor.getMaximumPoolSize());
+        assertEquals(2, executor.getCorePoolSize());
+    }
+
+    private static ThreadPoolExecutor newExecutor(int core, int max) {
+        return new ThreadPoolExecutor(core, max, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>(16));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

The deploy serialization thread pool was configured as:

```
javaThreadPoolManager.newDaemonThreadPool(
    /* core */ 1,
    /* max  */ max(cpuCores, deploy_serialization_thread_pool_size),
    60s,
    new LinkedBlockingQueue<>(threadPoolQueueSize),  // default = cpuCores * 2
    AbortPolicy, "deployer", true);
```

When running a POC on concurrency point queries against a table with many columns, the performance is poor.

<img width="423" height="51" alt="image" src="https://github.com/user-attachments/assets/23ee2c6c-087a-4109-bb31-bab3f5922d7c" />

ThreadPoolExecutor only grows past corePoolSize once the queue is full — so with core=1 and an unbounded-ish LinkedBlockingQueue, the pool effectively runs single-threaded. Tasks pile up behind one worker (e.g. only deployer-0 doing work) instead of fanning out across cores, which slows down concurrent fragment deploys on busy FEs.

This PR:
* Adds deploy_serialization_min_thread_pool_size (mutable, default 1) to drive the executor's corePoolSize. Operators hitting deploy contention can raise it so multiple workers stay resident.
* Makes deploy_serialization_thread_pool_size mutable so the max can be tuned without an FE restart.
* Registers a ConfigRefreshDaemon listener that resizes the live executor. Because setCorePoolSize / setMaximumPoolSize both enforce core ≤ max, the listener applies them in expand-vs-shrink-aware order to avoid IllegalArgumentException.
* Extracts resolveMaxThreadPoolSize (-1 ⇒ cpu cores) and clampMinThreadPoolSize (clamps to [1, max]) so config interpretation lives in one place and is unit-testable.

## What I'm doing:

Add FE config: deploy_serialization_min_thread_pool_size

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
