### PR TITLE
[Enhancement] Align range-colocate scan-range dispatch by ColocateRange index

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
@@ -66,13 +66,39 @@ public class ColocateRangeMgr {
      * @return the ColocateRange containing the value, or null if not found
      */
     public ColocateRange getColocateRange(long colocateGroupId, Tuple colocateValue) {
+        int index = getColocateRangeIndex(colocateGroupId, colocateValue);
+        if (index < 0) {
+            return null;
+        }
+        return colocateGroupToRanges.get(colocateGroupId).get(index);
+    }
+
+    /**
+     * Returns the index of the ColocateRange that contains the given colocate value.
+     *
+     * <p>The index is stable across all tables sharing this colocate group: the i-th
+     * range in {@link #getColocateRanges(long)} corresponds to the same PACK shard group
+     * across every partition/table/database in the group. Coordinator-side scan-range
+     * dispatch uses this index as the bucket sequence so that scan ranges from joined
+     * tables that share a colocate range are routed to the same fragment instance.
+     *
+     * @param colocateGroupId the colocate group id
+     * @param colocateValue the colocate prefix to look up; null means the global lower
+     *                      bound (-inf), which always lands in the first range
+     * @return the index in {@code [0, getColocateRanges(grpId).size())}, or -1 if the
+     *         group does not exist or the value is not covered
+     */
+    public int getColocateRangeIndex(long colocateGroupId, Tuple colocateValue) {
         List<ColocateRange> colocateRanges = colocateGroupToRanges.get(colocateGroupId);
         if (colocateRanges == null || colocateRanges.isEmpty()) {
-            return null;
+            return -1;
+        }
+        if (colocateValue == null) {
+            return 0;
         }
         Range<Tuple> pointRange = Range.gele(colocateValue, colocateValue);
         int index = Collections.binarySearch(colocateRanges, pointRange);
-        return index >= 0 ? colocateRanges.get(index) : null;
+        return index >= 0 ? index : -1;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeUtils.java
@@ -83,4 +83,43 @@ public class ColocateRangeUtils {
         }
         return new Tuple(values);
     }
+
+    /**
+     * Extracts the colocate column prefix from a tablet's full sort-key range.
+     *
+     * <p>Inverse of {@link #expandToFullSortKey}: a tablet whose range was produced by
+     * expansion stores a full sort-key tuple in its lower bound, but the colocate-range
+     * lookup keys on the colocate prefix only.
+     *
+     * <p>If the tablet range is unbounded below (lower bound is -inf), this returns
+     * {@code null}, signaling the caller to fall back to the first colocate range
+     * (which always begins at -inf by the {@link ColocateRangeMgr} invariant).
+     *
+     * <p>Unlike {@link #expandToFullSortKey}, this method requires
+     * {@code colocateColumnCount > 0}: a colocate group with zero colocate columns
+     * is not a meaningful concept on the lookup side (every value would map to the
+     * same range, which is just the no-colocate case).
+     *
+     * @param tabletRange the tablet's full sort-key range
+     * @param colocateColumnCount the number of colocate columns (sort key prefix length),
+     *                            must be positive
+     * @return the colocate prefix Tuple, or {@code null} if the range is unbounded below
+     */
+    public static Tuple extractColocatePrefix(Range<Tuple> tabletRange, int colocateColumnCount) {
+        Preconditions.checkArgument(colocateColumnCount > 0,
+                "colocateColumnCount must be positive, got %s", colocateColumnCount);
+        if (tabletRange.isMinimum()) {
+            return null;
+        }
+        List<Variant> values = tabletRange.getLowerBound().getValues();
+        Preconditions.checkArgument(values.size() >= colocateColumnCount,
+                "tablet lower bound has %s values, fewer than colocateColumnCount %s",
+                values.size(), colocateColumnCount);
+        if (values.size() == colocateColumnCount) {
+            return tabletRange.getLowerBound();
+        }
+        // subList returns a view backed by the original list; copy so that the
+        // returned Tuple does not retain a reference to the tablet's bound.
+        return new Tuple(new ArrayList<>(values.subList(0, colocateColumnCount)));
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Range.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Range.java
@@ -347,6 +347,53 @@ public abstract class Range<T extends Comparable<T>> implements Comparable<Range
     }
 
     /**
+     * Checks if this range contains every value of another range.
+     *
+     * <p>Handles {@code -∞} / {@code +∞} bounds and inclusive/exclusive edges
+     * explicitly. Unlike {@link #compareTo(Range)}, which returns 0 for any
+     * overlapping pair, this returns true only when {@code other} is a subset
+     * of {@code this}.
+     *
+     * @param other the candidate sub-range, must not be null
+     * @return true if every value in {@code other} is also in this range
+     * @throws NullPointerException if other is null
+     */
+    public boolean contains(Range<T> other) {
+        Objects.requireNonNull(other, "Range must not be null");
+        return lowerBoundContainsLowerOf(other) && upperBoundContainsUpperOf(other);
+    }
+
+    private boolean lowerBoundContainsLowerOf(Range<T> other) {
+        if (isMinimum()) {
+            return true;
+        }
+        if (other.isMinimum()) {
+            return false;
+        }
+        int cmp = getLowerBound().compareTo(other.getLowerBound());
+        if (cmp != 0) {
+            return cmp < 0;
+        }
+        // Equal lower bound values: this range must include the bound, or
+        // other must also exclude it.
+        return isLowerBoundIncluded() || !other.isLowerBoundIncluded();
+    }
+
+    private boolean upperBoundContainsUpperOf(Range<T> other) {
+        if (isMaximum()) {
+            return true;
+        }
+        if (other.isMaximum()) {
+            return false;
+        }
+        int cmp = other.getUpperBound().compareTo(getUpperBound());
+        if (cmp != 0) {
+            return cmp < 0;
+        }
+        return isUpperBoundIncluded() || !other.isUpperBoundIncluded();
+    }
+
+    /**
      * Compares this range with another for ordering.
      *
      * <p>Note: This method may return 0 for overlapping ranges that are not equal.

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -132,6 +132,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javax.annotation.Nullable;
+
 public class OlapScanNode extends AbstractOlapTableScanNode {
     private static final Logger LOG = LogManager.getLogger(OlapScanNode.class);
 
@@ -327,13 +329,66 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
 
     @Override
     public int getBucketNums() {
-        int bucketNum = olapTable.getDefaultDistributionInfo().getBucketNum();
+        DistributionInfo distInfo = olapTable.getDefaultDistributionInfo();
+        if (distInfo.getType() == DistributionInfo.DistributionInfoType.RANGE) {
+            return getRangeDistributionBucketNums(distInfo);
+        }
+        // HASH path.
+        int bucketNum = distInfo.getBucketNum();
         if (getSelectedPartitionIds().size() <= 1) {
             for (Long pid : getSelectedPartitionIds()) {
                 bucketNum = olapTable.getPartition(pid).getDistributionInfo().getBucketNum();
             }
         }
         return bucketNum;
+    }
+
+    private int getRangeDistributionBucketNums(DistributionInfo distInfo) {
+        RangeColocateScanDispatch dispatch = RangeColocateScanDispatch.forTable(olapTable);
+        if (dispatch != null) {
+            // getBucketNums() is invoked from ExecutionFragment.getOrCreateColocatedAssignment
+            // only when BackendSelectorFactory has chosen a colocate-dispatch path. Verify
+            // alignment HERE, after the dispatch decision: a misaligned ColocateRangeMgr
+            // would silently produce wrong join results under colocate dispatch.
+            // Non-colocate scans go through NormalBackendSelector and never reach this point.
+            dispatch.requireAligned(getSelectedPhysicalPartitions(), index.indexMetaId);
+            return dispatch.bucketCount();
+        }
+        // Range distribution without a colocate group: RangeDistributionInfo always
+        // reports 1 (one tablet per partition by design).
+        return distInfo.getBucketNum();
+    }
+
+    /**
+     * Returns the physical partitions that actually contribute scan tablets.
+     * Optimizer path: derived from {@link #partitionToScanTabletMap} (skip
+     * empty entries — those were pruned out). Legacy path: every sub-partition
+     * of every selected logical partition.
+     */
+    private List<PhysicalPartition> getSelectedPhysicalPartitions() {
+        List<PhysicalPartition> result = new ArrayList<>();
+        if (partitionToScanTabletMap != null) {
+            for (Map.Entry<Long, List<Long>> entry : partitionToScanTabletMap.entrySet()) {
+                if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                    continue;
+                }
+                PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(entry.getKey());
+                if (physicalPartition != null) {
+                    result.add(physicalPartition);
+                }
+            }
+            return result;
+        }
+        for (Long partitionId : selectedPartitionIds) {
+            Partition partition = olapTable.getPartition(partitionId);
+            if (partition == null) {
+                continue;
+            }
+            for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                result.add(physicalPartition);
+            }
+        }
+        return result;
     }
 
     @Override
@@ -776,6 +831,11 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
          */
         Preconditions.checkState(scanBackendIds.size() == 0);
         Preconditions.checkState(scanTabletIds.size() == 0);
+        DistributionInfo distInfo = olapTable.getDefaultDistributionInfo();
+        RangeColocateScanDispatch dispatch = null;
+        if (distInfo.getType() == DistributionInfo.DistributionInfoType.RANGE) {
+            dispatch = RangeColocateScanDispatch.forTable(olapTable);
+        }
         for (Long partitionId : selectedPartitionIds) {
             final Partition partition = olapTable.getPartition(partitionId);
 
@@ -796,13 +856,34 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                     scanTabletIds.addAll(allTabletIds);
                 }
 
-                for (int i = 0; i < allTabletIds.size(); i++) {
-                    tabletId2BucketSeq.put(allTabletIds.get(i), i);
-                }
+                fillTabletId2BucketSeq(dispatch, selectedIndex, allTabletIds);
                 totalTabletsNum += selectedIndex.getTablets().size();
                 selectedTabletsNum += tablets.size();
                 addScanRangeLocations(partition, physicalPartition, selectedIndex, tablets, List.of(), localBeId);
             }
+        }
+    }
+
+    /**
+     * Populates {@link #tabletId2BucketSeq} for one {@link MaterializedIndex}.
+     * Range-colocate scans use the bucket sequence supplied by the dispatch
+     * facade when alignment holds; everything else (HASH, range non-colocate,
+     * or transiently unaligned range colocate) falls back to position-based
+     * bucketSeq. The dispatch-time alignment guard fires later in
+     * {@link #getBucketNums()} for the colocate-dispatch path.
+     */
+    private void fillTabletId2BucketSeq(@Nullable RangeColocateScanDispatch dispatch,
+                                          MaterializedIndex selectedIndex,
+                                          List<Long> allTabletIds) {
+        if (dispatch != null) {
+            Map<Long, Integer> rangeColocateMap = dispatch.computeBucketSeq(selectedIndex);
+            if (rangeColocateMap != null) {
+                tabletId2BucketSeq.putAll(rangeColocateMap);
+                return;
+            }
+        }
+        for (int i = 0; i < allTabletIds.size(); i++) {
+            tabletId2BucketSeq.put(allTabletIds.get(i), i);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
@@ -1,0 +1,194 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.catalog.ColocateGroupSchema;
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateRangeMgr;
+import com.starrocks.catalog.ColocateRangeUtils;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.common.Range;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.MetaUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+/**
+ * Scan-time dispatch facade for range distribution colocate tables.
+ *
+ * <p>Encapsulates the policy that lets {@link OlapScanNode} and
+ * {@link com.starrocks.sql.plan.PlanFragmentBuilder} produce range-aware
+ * bucket sequences and verify that the colocate group is aligned with the
+ * actual tablet layout. The catalog layer ({@link ColocateRangeUtils}) keeps
+ * only the pure range-geometry primitives (range expansion / prefix
+ * extraction); this class composes those with {@link ColocateRangeMgr} state
+ * to drive scan-time decisions.
+ *
+ * <p>Lifecycle: callers obtain an instance per call via {@link #forTable},
+ * which returns {@code null} for tables that are not range colocate
+ * participants. Do not cache the instance across phases — the alignment
+ * guard must observe the current {@code ColocateRangeMgr} at dispatch time.
+ */
+public final class RangeColocateScanDispatch {
+
+    private final OlapTable olapTable;
+    private final ColocateTableIndex colocateTableIndex;
+    private final long colocateGroupId;
+    private final int colocateColumnCount;
+
+    private RangeColocateScanDispatch(OlapTable olapTable,
+                                       ColocateTableIndex colocateTableIndex,
+                                       long colocateGroupId,
+                                       int colocateColumnCount) {
+        this.olapTable = olapTable;
+        this.colocateTableIndex = colocateTableIndex;
+        this.colocateGroupId = colocateGroupId;
+        this.colocateColumnCount = colocateColumnCount;
+    }
+
+    /**
+     * Returns a dispatch instance iff {@code olapTable} is a range distribution
+     * lake table that participates in a range colocate group, otherwise
+     * {@code null}.
+     *
+     * <p>Resolves {@link ColocateTableIndex} from {@link GlobalStateMgr} once
+     * at construction; the same instance is reused by subsequent
+     * {@link #bucketCount}, {@link #requireAligned}, and
+     * {@link #computeBucketSeq} calls.
+     */
+    @Nullable
+    public static RangeColocateScanDispatch forTable(OlapTable olapTable) {
+        if (olapTable.getDefaultDistributionInfo().getType() != DistributionInfo.DistributionInfoType.RANGE) {
+            return null;
+        }
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        if (!colocateTableIndex.isColocateTable(olapTable.getId())) {
+            return null;
+        }
+        ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(olapTable.getId());
+        if (groupId == null || !colocateTableIndex.isRangeColocateGroup(groupId)) {
+            return null;
+        }
+        ColocateGroupSchema schema = colocateTableIndex.getGroupSchema(groupId);
+        return new RangeColocateScanDispatch(
+                olapTable, colocateTableIndex, groupId.grpId, schema.getColocateColumnCount());
+    }
+
+    /**
+     * Returns the colocate range count, used as the bucket bound that
+     * {@link com.starrocks.qe.ColocatedBackendSelector}'s
+     * {@code bucketSeq < bucketNum} invariant requires.
+     */
+    public int bucketCount() {
+        int count = colocateTableIndex.getColocateRangeMgr().getColocateRanges(colocateGroupId).size();
+        // ColocateRangeMgr always seeds a group with the [MIN, MAX) range,
+        // so a registered group has at least one entry.
+        Preconditions.checkState(count > 0,
+                "range colocate group %s has no colocate ranges", colocateGroupId);
+        return count;
+    }
+
+    /**
+     * Verifies every {@link MaterializedIndex} actually scanned in the supplied
+     * physical partitions is aligned with the colocate group. Throws
+     * {@link IllegalStateException} on the first misaligned one.
+     *
+     * <p>Caller invariant: {@code physicalPartitions} must be the partitions
+     * that actually contributed scan tablets — sibling sub-partitions that
+     * were pruned out must not be passed in.
+     */
+    public void requireAligned(Iterable<PhysicalPartition> physicalPartitions, long indexMetaId) {
+        for (PhysicalPartition physicalPartition : physicalPartitions) {
+            MaterializedIndex selectedIndex = physicalPartition.getLatestIndex(indexMetaId);
+            if (computeBucketSeq(selectedIndex) == null) {
+                throw new IllegalStateException(String.format(
+                        "range colocate group %d is in an unaligned state in physical partition %d; "
+                                + "cannot dispatch colocate join until alignment is restored",
+                        colocateGroupId, physicalPartition.getId()));
+            }
+        }
+    }
+
+    /**
+     * Returns the tablet-id → bucket-sequence mapping for {@code selectedIndex}
+     * when every tablet's range is contained in exactly one ColocateRange and
+     * every ColocateRange has at least one covering tablet (the colocate group
+     * is fully aligned).
+     *
+     * <p>Returns {@code null} when the colocate group is in a transient
+     * unaligned state — a spanning tablet, or a missing range. The caller
+     * falls back to position-based bucketSeq; {@link #requireAligned} is the
+     * dispatch-time correctness guard.
+     *
+     * <p>Throws {@link IllegalStateException} when a tablet has no
+     * {@link com.starrocks.catalog.TabletRange} despite being in a range
+     * colocate group — this is a P0/P1 invariant violation, not a transient
+     * state.
+     */
+    @Nullable
+    public Map<Long, Integer> computeBucketSeq(MaterializedIndex selectedIndex) {
+        ColocateRangeMgr colocateRangeMgr = colocateTableIndex.getColocateRangeMgr();
+        List<ColocateRange> colocateRanges = colocateRangeMgr.getColocateRanges(colocateGroupId);
+        Preconditions.checkState(!colocateRanges.isEmpty(),
+                "range colocate group %s has no colocate ranges", colocateGroupId);
+        List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(olapTable);
+
+        // Pre-expand each ColocateRange once.
+        List<Range<Tuple>> expandedRanges = new ArrayList<>(colocateRanges.size());
+        for (ColocateRange colocateRange : colocateRanges) {
+            expandedRanges.add(ColocateRangeUtils.expandToFullSortKey(
+                    colocateRange.getRange(), sortKeyColumns, colocateColumnCount));
+        }
+
+        Map<Long, Integer> output = new HashMap<>();
+        Set<Integer> coveredBucketSeqs = new HashSet<>();
+        for (Long tabletId : selectedIndex.getTabletIdsInOrder()) {
+            Tablet tablet = selectedIndex.getTablet(tabletId);
+            Preconditions.checkState(tablet.getRange() != null,
+                    "tablet %s in range colocate group %s has no TabletRange",
+                    tabletId, colocateGroupId);
+            Range<Tuple> tabletRange = tablet.getRange().getRange();
+            Tuple prefix = ColocateRangeUtils.extractColocatePrefix(tabletRange, colocateColumnCount);
+            int bucketSeq = colocateRangeMgr.getColocateRangeIndex(colocateGroupId, prefix);
+            if (bucketSeq < 0) {
+                return null; // tablet prefix does not match any ColocateRange
+            }
+            if (!expandedRanges.get(bucketSeq).contains(tabletRange)) {
+                return null; // spanning tablet — colocate group is unaligned
+            }
+            output.put(tabletId, bucketSeq);
+            coveredBucketSeqs.add(bucketSeq);
+        }
+        if (coveredBucketSeqs.size() != colocateRanges.size()) {
+            return null; // missing-range — some ColocateRange has no covering tablet
+        }
+        return output;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
+import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.IcebergTable;
@@ -100,6 +101,7 @@ import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.ProjectNode;
+import com.starrocks.planner.RangeColocateScanDispatch;
 import com.starrocks.planner.RawValuesNode;
 import com.starrocks.planner.RepeatNode;
 import com.starrocks.planner.RuntimeFilterId;
@@ -965,6 +967,12 @@ public class PlanFragmentBuilder {
                             .getBackendIdByHost(FrontendOptions.getLocalHostAddress());
                 }
 
+                DistributionInfo distInfo = referenceTable.getDefaultDistributionInfo();
+                RangeColocateScanDispatch dispatch = null;
+                if (distInfo.getType() == DistributionInfo.DistributionInfoType.RANGE) {
+                    dispatch = RangeColocateScanDispatch.forTable(referenceTable);
+                }
+
                 // Filter out empty partitions from all selected partitions, original selected partition ids may be
                 // only parent partition ids if table contains subpartitions, use the real sub partition ids instead.
                 // eg:
@@ -996,8 +1004,25 @@ public class PlanFragmentBuilder {
                         final MaterializedIndex selectedIndex = physicalPartition.getLatestIndex(selectedIndexMetaId);
                         totalTabletsNum += selectedIndex.getTablets().size();
                         List<Long> allTabletIds = selectedIndex.getTabletIdsInOrder();
-                        for (int i = 0; i < allTabletIds.size(); i++) {
-                            tabletId2BucketSeq.put(allTabletIds.get(i), i);
+                        // Range-colocate scans use the dispatch facade when alignment
+                        // holds; if alignment is transiently broken the same scan still
+                        // needs a bucketSeq for non-colocate consumers, so fall back to
+                        // position-based and let the dispatch-time alignment guard in
+                        // OlapScanNode.getBucketNums() handle the colocate-dispatch path.
+                        if (dispatch != null) {
+                            Map<Long, Integer> rangeColocateMap = dispatch.computeBucketSeq(selectedIndex);
+                            if (rangeColocateMap != null) {
+                                tabletId2BucketSeq.putAll(rangeColocateMap);
+                            } else {
+                                for (int i = 0; i < allTabletIds.size(); i++) {
+                                    tabletId2BucketSeq.put(allTabletIds.get(i), i);
+                                }
+                            }
+                        } else {
+                            // HASH or range non-colocate: position-based bucketSeq.
+                            for (int i = 0; i < allTabletIds.size(); i++) {
+                                tabletId2BucketSeq.put(allTabletIds.get(i), i);
+                            }
                         }
                         scanNode.setTabletId2BucketSeq(tabletId2BucketSeq);
                         List<Tablet> tablets =

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrTest.java
@@ -226,6 +226,58 @@ public class ColocateRangeMgrTest {
         Assertions.assertEquals(1990L, found99999.getShardGroupId());
     }
 
+    // ---- getColocateRangeIndex ----
+
+    @Test
+    public void testGetColocateRangeIndexNonExistentGroup() {
+        Assertions.assertEquals(-1, colocateRangeMgr.getColocateRangeIndex(999L, makeTuple(100)));
+    }
+
+    @Test
+    public void testGetColocateRangeIndexAllRange() {
+        colocateRangeMgr.initColocateGroup(COLOCATE_GROUP_ID, 1001L);
+        // Any value falls in the single (-inf, +inf) range at index 0.
+        Assertions.assertEquals(0, colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, makeTuple(-9999)));
+        Assertions.assertEquals(0, colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, makeTuple(0)));
+        Assertions.assertEquals(0, colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, makeTuple(9999)));
+        // Null value (tablet lower bound is -inf) maps to the first range.
+        Assertions.assertEquals(0, colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, null));
+    }
+
+    @Test
+    public void testGetColocateRangeIndexThreeRanges() {
+        // (-inf, 100), [100, 200), [200, +inf)
+        List<ColocateRange> ranges = Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 1001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 1002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 1003L));
+        colocateRangeMgr.setColocateRanges(COLOCATE_GROUP_ID, ranges);
+
+        Assertions.assertEquals(0, colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, null));
+        Assertions.assertEquals(0, colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, makeTuple(50)));
+        Assertions.assertEquals(1, colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, makeTuple(100)));
+        Assertions.assertEquals(1, colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, makeTuple(150)));
+        Assertions.assertEquals(2, colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, makeTuple(200)));
+        Assertions.assertEquals(2, colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, makeTuple(99999)));
+    }
+
+    @Test
+    public void testGetColocateRangeIndexMatchesLookup() {
+        // The index must point to the same ColocateRange that getColocateRange returns.
+        List<ColocateRange> ranges = Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(50)), 1001L),
+                new ColocateRange(Range.gelt(makeTuple(50), makeTuple(150)), 1002L),
+                new ColocateRange(Range.gelt(makeTuple(150), makeTuple(250)), 1003L),
+                new ColocateRange(Range.ge(makeTuple(250)), 1004L));
+        colocateRangeMgr.setColocateRanges(COLOCATE_GROUP_ID, ranges);
+
+        for (int probe : new int[] {-1, 49, 50, 100, 149, 150, 249, 250, 9999}) {
+            ColocateRange found = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(probe));
+            int index = colocateRangeMgr.getColocateRangeIndex(COLOCATE_GROUP_ID, makeTuple(probe));
+            Assertions.assertEquals(ranges.indexOf(found), index, "probe=" + probe);
+        }
+    }
+
     // ---- Multiple colocate groups ----
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeUtilsTest.java
@@ -140,4 +140,80 @@ public class ColocateRangeUtilsTest {
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> ColocateRangeUtils.expandToFullSortKey(colocateRange, SORT_KEY_COLUMNS, 4));
     }
+
+    // ---- extractColocatePrefix ----
+
+    @Test
+    public void testExtractPrefixFromAllRange() {
+        // Range.all() has -inf lower bound: caller must fall back to first colocate range.
+        Assertions.assertNull(ColocateRangeUtils.extractColocatePrefix(Range.all(), 1));
+    }
+
+    @Test
+    public void testExtractPrefixFromLowerUnbounded() {
+        // (-inf, (200, NULL, NULL)) -> still unbounded below.
+        Range<Tuple> expanded = ColocateRangeUtils.expandToFullSortKey(
+                Range.lt(makeTuple(200)), SORT_KEY_COLUMNS, 1);
+        Assertions.assertNull(ColocateRangeUtils.extractColocatePrefix(expanded, 1));
+    }
+
+    @Test
+    public void testExtractPrefixTruncatesFullSortKeyTuple() {
+        // [(100, NULL, NULL), (200, NULL, NULL)) with 1 colocate column -> (100,)
+        Range<Tuple> expanded = ColocateRangeUtils.expandToFullSortKey(
+                Range.gelt(makeTuple(100), makeTuple(200)), SORT_KEY_COLUMNS, 1);
+        Tuple prefix = ColocateRangeUtils.extractColocatePrefix(expanded, 1);
+        Assertions.assertNotNull(prefix);
+        Assertions.assertEquals(1, prefix.getValues().size());
+        Assertions.assertEquals("100", prefix.getValues().get(0).getStringValue());
+    }
+
+    @Test
+    public void testExtractPrefixReturnsLowerBoundWhenSizesMatch() {
+        // Tablet whose range was created with colocateColumnCount == sort key count:
+        // expansion is a no-op, lower bound itself IS the colocate prefix.
+        List<Column> singleColumnSortKey = Arrays.asList(new Column("k1", IntegerType.INT));
+        Range<Tuple> expanded = ColocateRangeUtils.expandToFullSortKey(
+                Range.gelt(makeTuple(100), makeTuple(200)), singleColumnSortKey, 1);
+        Tuple prefix = ColocateRangeUtils.extractColocatePrefix(expanded, 1);
+        Assertions.assertSame(expanded.getLowerBound(), prefix);
+    }
+
+    @Test
+    public void testExtractPrefixWithIntraColocateSplit() {
+        // After P3 intra-colocate split, a tablet may be [(100, "a", 1), (100, "z", 9)).
+        Tuple lower = new Tuple(Arrays.asList(
+                Variant.of(IntegerType.INT, "100"),
+                Variant.of(VarcharType.VARCHAR, "a"),
+                Variant.of(IntegerType.BIGINT, "1")));
+        Tuple upper = new Tuple(Arrays.asList(
+                Variant.of(IntegerType.INT, "100"),
+                Variant.of(VarcharType.VARCHAR, "z"),
+                Variant.of(IntegerType.BIGINT, "9")));
+        Range<Tuple> tabletRange = Range.gelt(lower, upper);
+        Tuple prefix = ColocateRangeUtils.extractColocatePrefix(tabletRange, 1);
+        Assertions.assertNotNull(prefix);
+        Assertions.assertEquals(1, prefix.getValues().size());
+        Assertions.assertEquals("100", prefix.getValues().get(0).getStringValue());
+    }
+
+    @Test
+    public void testExtractPrefixRejectsZeroOrNegativeCount() {
+        Range<Tuple> tabletRange = ColocateRangeUtils.expandToFullSortKey(
+                Range.gelt(makeTuple(100), makeTuple(200)), SORT_KEY_COLUMNS, 1);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ColocateRangeUtils.extractColocatePrefix(tabletRange, 0));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ColocateRangeUtils.extractColocatePrefix(tabletRange, -1));
+    }
+
+    @Test
+    public void testExtractPrefixRejectsLowerBoundShorterThanColocateCount() {
+        Tuple lower = new Tuple(Arrays.asList(Variant.of(IntegerType.INT, "100")));
+        Tuple upper = new Tuple(Arrays.asList(Variant.of(IntegerType.INT, "200")));
+        Range<Tuple> tabletRange = Range.gelt(lower, upper);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ColocateRangeUtils.extractColocatePrefix(tabletRange, 2));
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/RangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/RangeTest.java
@@ -569,7 +569,7 @@ public class RangeTest {
     @Test
     public void testNullParameterInContains() {
         Range<Integer> range = Range.of(1, 10, true, true);
-        Assertions.assertThrows(NullPointerException.class, () -> range.contains(null));
+        Assertions.assertThrows(NullPointerException.class, () -> range.contains((Integer) null));
     }
 
     @Test
@@ -953,5 +953,64 @@ public class RangeTest {
         Assertions.assertTrue(!r1.isOverlapping(target1));
         Assertions.assertTrue(r2.isOverlapping(target1));
         Assertions.assertTrue(!r3.isOverlapping(target1));
+    }
+
+    // ---- contains(Range) ----
+
+    @Test
+    public void testContainsRangeAllContainsAnything() {
+        Range<Integer> all = Range.all();
+        Assertions.assertTrue(all.contains(all));
+        Assertions.assertTrue(all.contains(Range.lt(100)));
+        Assertions.assertTrue(all.contains(Range.gelt(100, 200)));
+        Assertions.assertTrue(all.contains(Range.ge(200)));
+    }
+
+    @Test
+    public void testContainsRangeFiniteRangeDoesNotContainAll() {
+        Range<Integer> all = Range.all();
+        Assertions.assertFalse(Range.lt(100).contains(all));
+        Assertions.assertFalse(Range.gelt(100, 200).contains(all));
+        Assertions.assertFalse(Range.ge(100).contains(all));
+    }
+
+    @Test
+    public void testContainsRangeHalfBoundedContainsBounded() {
+        Assertions.assertTrue(Range.lt(200).contains(Range.gelt(100, 150)));
+        Assertions.assertTrue(Range.ge(100).contains(Range.gelt(150, 200)));
+    }
+
+    @Test
+    public void testContainsRangeBoundedContainsSubrange() {
+        Range<Integer> outer = Range.gelt(100, 200);
+        Assertions.assertTrue(outer.contains(Range.gelt(100, 150)));
+        Assertions.assertTrue(outer.contains(Range.gelt(150, 200)));
+        Assertions.assertTrue(outer.contains(outer));
+    }
+
+    @Test
+    public void testContainsRangeRejectsSpanning() {
+        Range<Integer> outer = Range.gelt(100, 200);
+        Assertions.assertFalse(outer.contains(Range.gelt(50, 150)));   // spans below
+        Assertions.assertFalse(outer.contains(Range.gelt(150, 300))); // spans above
+    }
+
+    @Test
+    public void testContainsRangeInclusivityAtEqualBounds() {
+        // Outer (100, 200), inner [100, 200): inner is more inclusive on lower
+        // bound — outer does not contain it.
+        Assertions.assertFalse(Range.gtlt(100, 200).contains(Range.gelt(100, 200)));
+        // Outer [100, 200], inner [100, 200): outer is more inclusive on upper
+        // bound — outer contains inner.
+        Assertions.assertTrue(Range.gele(100, 200).contains(Range.gelt(100, 200)));
+        // Outer [100, 200), inner [150, 200]: inner extends to inclusive 200,
+        // outer ends at exclusive 200 — outer does not contain inner.
+        Assertions.assertFalse(Range.gelt(100, 200).contains(Range.gele(150, 200)));
+    }
+
+    @Test
+    public void testContainsRangeRejectsNull() {
+        Range<Integer> all = Range.all();
+        Assertions.assertThrows(NullPointerException.class, () -> all.contains((Range<Integer>) null));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanDispatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanDispatchTest.java
@@ -1,0 +1,327 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateRangeUtils;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Config;
+import com.starrocks.common.Range;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Unit tests for {@link RangeColocateScanDispatch} — the scan-time facade that
+ * encapsulates range-colocate dispatch policy. Higher-level tests that exercise
+ * {@code OlapScanNode.getBucketNums()} and the optimizer-built
+ * {@code PlanFragmentBuilder} path live in
+ * {@link RangeColocateScanRangeDispatchTest}.
+ */
+public class RangeColocateScanDispatchTest {
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static Database db;
+
+    private static final int COLOCATE_COL_COUNT = 1;
+    private static final List<Column> SORT_KEY = Arrays.asList(
+            new Column("k1", IntegerType.INT),
+            new Column("k2", IntegerType.INT));
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        Config.enable_range_distribution = true;
+
+        starRocksAssert.withDatabase("p4_dispatch_facade").useDatabase("p4_dispatch_facade");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("p4_dispatch_facade");
+    }
+
+    private static Tuple makeTuple(int value) {
+        return new Tuple(Arrays.asList(Variant.of(IntegerType.INT, String.valueOf(value))));
+    }
+
+    private static MaterializedIndex baseIndexOf(OlapTable table) {
+        PhysicalPartition partition = table.getPartitions().iterator().next()
+                .getDefaultPhysicalPartition();
+        return partition.getLatestBaseIndex();
+    }
+
+    private static LakeTablet makeLakeTabletWithRange(long tabletId, Range<Tuple> colocateRange) {
+        Range<Tuple> fullRange = ColocateRangeUtils.expandToFullSortKey(
+                colocateRange, SORT_KEY, COLOCATE_COL_COUNT);
+        return new LakeTablet(tabletId, new TabletRange(fullRange));
+    }
+
+    /**
+     * Adds a tablet to the index without touching the inverted index. The shard ids
+     * we synthesize do not exist in StarOS, so we must skip the inverted-index path
+     * to avoid leaking them across tests.
+     */
+    private static void addSyntheticTablet(MaterializedIndex index, Tablet tablet) {
+        index.addTablet(tablet, null, false);
+    }
+
+    // ---- forTable() gate ----
+
+    @Test
+    public void testForTableReturnsEmptyForNonRangeTable() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_facade_hash (k1 int, k2 int)\n"
+                        + "distributed by hash(k1) buckets 4\n"
+                        + "properties('replication_num' = '1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_facade_hash");
+
+        Assertions.assertNull(RangeColocateScanDispatch.forTable(table));
+    }
+
+    @Test
+    public void testForTableReturnsEmptyForRangeNonColocateTable() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_facade_nonloc (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_facade_nonloc");
+
+        Assertions.assertNull(RangeColocateScanDispatch.forTable(table));
+    }
+
+    @Test
+    public void testForTableReturnsDispatchForRangeColocateTable() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_facade_colo (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_facade_colo:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_facade_colo");
+
+        RangeColocateScanDispatch dispatch = RangeColocateScanDispatch.forTable(table);
+        Assertions.assertNotNull(dispatch);
+        // Initial state: one ColocateRange = (-inf, +inf).
+        Assertions.assertEquals(1, dispatch.bucketCount());
+    }
+
+    // ---- bucketCount + computeBucketSeq for the aligned path ----
+
+    @Test
+    public void testComputeBucketSeqSingleRangeAligned() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_facade_single (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_facade_single:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_facade_single");
+        MaterializedIndex index = baseIndexOf(table);
+
+        RangeColocateScanDispatch dispatch =
+                Objects.requireNonNull(RangeColocateScanDispatch.forTable(table));
+        Map<Long, Integer> bucketSeq = dispatch.computeBucketSeq(index);
+        Assertions.assertNotNull(bucketSeq);
+        Assertions.assertEquals(1, bucketSeq.size());
+        long tabletId = index.getTabletIdsInOrder().get(0);
+        Assertions.assertEquals(0, bucketSeq.get(tabletId));
+    }
+
+    @Test
+    public void testComputeBucketSeqIntraColocateSplitMapsToSameBucket() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_facade_intra (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_facade_intra:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_facade_intra");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long groupId = colocateTableIndex.getGroup(table.getId()).grpId;
+
+        // Three ColocateRanges. Range 1 ([100, 200)) holds two intra-colocate
+        // sub-range tablets; ranges 0 and 2 each hold a tablet that exactly
+        // covers the range. This mirrors the post-P3 intra-colocate split state.
+        colocateTableIndex.getColocateRangeMgr().setColocateRanges(groupId, Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 9001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 9002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 9003L)));
+
+        // Insert in non-range order — bucketSeq must come from ColocateRange index,
+        // not insertion position.
+        MaterializedIndex index = new MaterializedIndex(99L);
+        addSyntheticTablet(index, makeLakeTabletWithRange(902L, Range.ge(makeTuple(200))));
+        Tuple lower1 = new Tuple(Arrays.asList(
+                Variant.of(IntegerType.INT, "150"), Variant.of(IntegerType.INT, "1")));
+        Tuple upper1 = new Tuple(Arrays.asList(
+                Variant.of(IntegerType.INT, "150"), Variant.of(IntegerType.INT, "5000")));
+        Tuple lower2 = new Tuple(Arrays.asList(
+                Variant.of(IntegerType.INT, "150"), Variant.of(IntegerType.INT, "5000")));
+        Tuple upper2 = new Tuple(Arrays.asList(
+                Variant.of(IntegerType.INT, "150"), Variant.of(IntegerType.INT, "9999")));
+        addSyntheticTablet(index, new LakeTablet(911L, new TabletRange(Range.gelt(lower1, upper1))));
+        addSyntheticTablet(index, new LakeTablet(912L, new TabletRange(Range.gelt(lower2, upper2))));
+        addSyntheticTablet(index, makeLakeTabletWithRange(900L, Range.lt(makeTuple(100))));
+
+        RangeColocateScanDispatch dispatch =
+                Objects.requireNonNull(RangeColocateScanDispatch.forTable(table));
+        Map<Long, Integer> bucketSeq = dispatch.computeBucketSeq(index);
+        Assertions.assertEquals(Map.of(900L, 0, 911L, 1, 912L, 1, 902L, 2), bucketSeq);
+    }
+
+    // ---- Unaligned states return empty ----
+
+    @Test
+    public void testComputeBucketSeqEmptyOnSpanningTablet() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_facade_span (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_facade_span:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_facade_span");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long groupId = colocateTableIndex.getGroup(table.getId()).grpId;
+
+        // Inject 3 ranges without re-aligning the underlying single tablet that
+        // still covers Range.all() — the spanning-tablet case.
+        colocateTableIndex.getColocateRangeMgr().setColocateRanges(groupId, Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 9001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 9002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 9003L)));
+
+        RangeColocateScanDispatch dispatch =
+                Objects.requireNonNull(RangeColocateScanDispatch.forTable(table));
+        Assertions.assertNull(dispatch.computeBucketSeq(baseIndexOf(table)));
+    }
+
+    @Test
+    public void testComputeBucketSeqEmptyOnMissingRange() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_facade_missing (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_facade_missing:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_facade_missing");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long groupId = colocateTableIndex.getGroup(table.getId()).grpId;
+
+        // Three ColocateRanges, but the synthetic index only has a tablet for range 0.
+        colocateTableIndex.getColocateRangeMgr().setColocateRanges(groupId, Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 9001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 9002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 9003L)));
+
+        MaterializedIndex index = new MaterializedIndex(98L);
+        addSyntheticTablet(index, makeLakeTabletWithRange(800L, Range.lt(makeTuple(100))));
+
+        RangeColocateScanDispatch dispatch =
+                Objects.requireNonNull(RangeColocateScanDispatch.forTable(table));
+        Assertions.assertNull(dispatch.computeBucketSeq(index));
+    }
+
+    @Test
+    public void testComputeBucketSeqRejectsTabletWithoutRange() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_facade_norange (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_facade_norange:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_facade_norange");
+
+        MaterializedIndex index = new MaterializedIndex(97L);
+        addSyntheticTablet(index, new LakeTablet(701L)); // no TabletRange
+
+        RangeColocateScanDispatch dispatch =
+                Objects.requireNonNull(RangeColocateScanDispatch.forTable(table));
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class,
+                () -> dispatch.computeBucketSeq(index));
+        Assertions.assertTrue(exception.getMessage().contains("no TabletRange"),
+                "actual: " + exception.getMessage());
+    }
+
+    // ---- requireAligned ----
+
+    @Test
+    public void testRequireAlignedOnAlignedGroupSucceeds() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_facade_req_ok (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_facade_req_ok:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_facade_req_ok");
+
+        RangeColocateScanDispatch dispatch =
+                Objects.requireNonNull(RangeColocateScanDispatch.forTable(table));
+        Assertions.assertDoesNotThrow(() -> dispatch.requireAligned(
+                List.of(table.getPartitions().iterator().next().getDefaultPhysicalPartition()),
+                table.getBaseIndexMetaId()));
+    }
+
+    @Test
+    public void testRequireAlignedOnUnalignedGroupThrows() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_facade_req_bad (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_facade_req_bad:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_facade_req_bad");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long groupId = colocateTableIndex.getGroup(table.getId()).grpId;
+
+        colocateTableIndex.getColocateRangeMgr().setColocateRanges(groupId, Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 9001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 9002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 9003L)));
+
+        RangeColocateScanDispatch dispatch =
+                Objects.requireNonNull(RangeColocateScanDispatch.forTable(table));
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class,
+                () -> dispatch.requireAligned(
+                        List.of(table.getPartitions().iterator().next().getDefaultPhysicalPartition()),
+                        table.getBaseIndexMetaId()));
+        Assertions.assertTrue(exception.getMessage().contains("unaligned state"),
+                "actual: " + exception.getMessage());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanRangeDispatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanRangeDispatchTest.java
@@ -1,0 +1,212 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.RangeDistributionInfo;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Config;
+import com.starrocks.common.Range;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * End-to-end coordinator-side scan-range dispatch tests for range-distribution
+ * colocate tables (P4). Exercises the observable behavior of
+ * {@link OlapScanNode#getBucketNums()} and the optimizer-built
+ * {@link com.starrocks.sql.plan.PlanFragmentBuilder} path against real
+ * shared-data tables.
+ *
+ * <p>Lower-level tests for the {@link RangeColocateScanDispatch} facade
+ * (forTable / bucketCount / requireAligned / computeBucketSeq) live in
+ * {@link RangeColocateScanDispatchTest}.
+ */
+public class RangeColocateScanRangeDispatchTest {
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static Database db;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        Config.enable_range_distribution = true;
+
+        starRocksAssert.withDatabase("p4_dispatch_test").useDatabase("p4_dispatch_test");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("p4_dispatch_test");
+    }
+
+    private static Tuple makeTuple(int value) {
+        return new Tuple(Arrays.asList(Variant.of(IntegerType.INT, String.valueOf(value))));
+    }
+
+    private static OlapScanNode newOlapScanNode(OlapTable table, int planNodeIdSeq) {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(planNodeIdSeq));
+        desc.setTable(table);
+        return new OlapScanNode(new PlanNodeId(planNodeIdSeq), desc,
+                "OlapScanNode", table.getBaseIndexMetaId());
+    }
+
+    // ---- OlapScanNode.getBucketNums against a real range colocate table ----
+
+    @Test
+    public void testGetBucketNumsSingleRange() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_dispatch_single (k1 int, k2 int, v1 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_dispatch_single:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_dispatch_single");
+        Assertions.assertInstanceOf(RangeDistributionInfo.class, table.getDefaultDistributionInfo());
+
+        OlapScanNode scanNode = newOlapScanNode(table, 1);
+        scanNode.setSelectedPartitionIds(new ArrayList<>(table.getAllPartitionIds()));
+
+        // Initial state: ColocateRangeMgr seeded with [MIN, MAX) -> 1 PACK shard group,
+        // and createRangeColocateLakeTablets created exactly 1 tablet per partition.
+        Assertions.assertEquals(1, scanNode.getBucketNums());
+    }
+
+    @Test
+    public void testGetBucketNumsForNonColocateRangeTable() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_dispatch_nonloc (k1 int, k2 int, v1 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_dispatch_nonloc");
+        Assertions.assertFalse(GlobalStateMgr.getCurrentState().getColocateTableIndex()
+                .isColocateTable(table.getId()));
+
+        OlapScanNode scanNode = newOlapScanNode(table, 3);
+        scanNode.setSelectedPartitionIds(new ArrayList<>(table.getAllPartitionIds()));
+
+        // Range-distribution non-colocate falls through and returns
+        // RangeDistributionInfo.getBucketNum() == 1.
+        Assertions.assertEquals(1, scanNode.getBucketNums());
+    }
+
+    @Test
+    public void testGetBucketNumsThrowsWhenColocateGroupIsUnaligned() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_dispatch_throw (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_dispatch_throw:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_dispatch_throw");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long groupId = colocateTableIndex.getGroup(table.getId()).grpId;
+
+        colocateTableIndex.getColocateRangeMgr().setColocateRanges(groupId, Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 9001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 9002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 9003L)));
+
+        OlapScanNode scanNode = newOlapScanNode(table, 9);
+        scanNode.setSelectedPartitionIds(new ArrayList<>(table.getAllPartitionIds()));
+
+        // getBucketNums() is invoked from ExecutionFragment.getOrCreateColocatedAssignment,
+        // which BackendSelectorFactory only calls on the colocate-dispatch path. The
+        // throw therefore fires only there, not on single-table reads.
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class,
+                scanNode::getBucketNums);
+        Assertions.assertTrue(exception.getMessage().contains("unaligned state"),
+                "actual: " + exception.getMessage());
+    }
+
+    // ---- PlanFragmentBuilder end-to-end + availability regression ----
+
+    @Test
+    public void testPlanFragmentBuilderAlignsBucketSeqToColocateRange() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_e2e_left (k1 int, k2 int, v1 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_e2e:k1');");
+        starRocksAssert.withTable(
+                "create table t_e2e_right (k1 int, k2 int, v2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_e2e:k1');");
+
+        // Drive the real PlanFragmentBuilder path. The query is unfiltered so every
+        // ColocateRange should appear as a key in bucketSeq2locations.
+        com.starrocks.sql.plan.ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(connectContext,
+                "select l.v1, r.v2 from t_e2e_left l "
+                        + "join t_e2e_right r on l.k1 = r.k1 and l.k2 = r.k2").second;
+
+        List<OlapScanNode> olapScans = new ArrayList<>();
+        for (ScanNode scanNode : execPlan.getScanNodes()) {
+            if (scanNode instanceof OlapScanNode) {
+                olapScans.add((OlapScanNode) scanNode);
+            }
+        }
+        Assertions.assertEquals(2, olapScans.size(), "expected two OlapScanNodes for the join");
+
+        for (OlapScanNode scan : olapScans) {
+            ArrayListMultimap<Integer, TScanRangeLocations> bucketSeq2Locations = scan.bucketSeq2locations;
+            Assertions.assertFalse(bucketSeq2Locations.isEmpty(),
+                    "scan node " + scan.getTableName() + " has no bucketSeq2locations entries");
+            Assertions.assertEquals(1, bucketSeq2Locations.keySet().size(),
+                    "bucketSeq2locations should have one bucket key for a single-range colocate group");
+            Assertions.assertTrue(bucketSeq2Locations.containsKey(0),
+                    "bucketSeq 0 missing from " + bucketSeq2Locations.keySet());
+        }
+    }
+
+    @Test
+    public void testSingleTableSelectDuringUnalignedStatePlansSuccessfully() throws Exception {
+        starRocksAssert.withTable(
+                "create table t_avail (k1 int, k2 int, v1 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_avail:k1');");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_avail");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long groupId = colocateTableIndex.getGroup(table.getId()).grpId;
+
+        // 3-range ColocateRangeMgr without aligning the underlying tablet — single-table
+        // SELECT must still plan because it does not need colocate dispatch
+        // (NormalBackendSelector is chosen, getBucketNums() is not invoked).
+        colocateTableIndex.getColocateRangeMgr().setColocateRanges(groupId, Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 9001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 9002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 9003L)));
+
+        Assertions.assertDoesNotThrow(() -> UtFrameUtils.getPlanAndFragment(connectContext,
+                "select v1 from t_avail"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Range-distribution colocate joins emit no-exchange plans (introduced in #71860), but the FE coordinator still dispatched scan ranges by **tablet position** within a partition (in both `OlapScanNode.computeTabletInfo` and `PlanFragmentBuilder.visitPhysicalOlapScan`). Position-based bucketSeq only aligns left/right tablets when both sides preserve identical tablet ordering — and `AlterTableClauseAnalyzer.visitSplitTabletClause` (no colocate guard) plus auto-reshard can already produce sub-range tablets on range distribution colocate tables, breaking that invariant. Without this fix, range-colocate joins can silently mis-route scan ranges and return wrong results.

This is the runtime-correctness prerequisite for using #71860's plans in production.

## What I'm doing:

Source the bucket sequence from the **`ColocateRange` index in `ColocateRangeMgr`** instead of tablet position whenever an `OlapScanNode` reads a range-distribution lake table that participates in a colocate group. The index is stable across all tables in the colocate group (the i-th range corresponds to the same PACK shard group across every partition/table/database), so left and right scan ranges sharing a colocate range now land on the same fragment instance regardless of tablet insertion order.

- `ColocateRangeMgr.getColocateRangeIndex(grpId, Tuple)` — stable bucket-sequence lookup; `null` value (lower bound `-inf`) maps to the first range. `getColocateRange` is reworded to delegate.
- `ColocateRangeUtils.extractColocatePrefix(Range<Tuple>, int)` — inverse of `expandToFullSortKey`; truncates a tablet's full sort-key lower bound to the colocate prefix; returns `null` if the lower bound is `-inf`.
- `ColocateRangeUtils.computeRangeColocateBucketSeq(OlapTable, MaterializedIndex, allTabletIdsInOrder, ColocateTableIndex)` — the shared utility called from BOTH `OlapScanNode.computeTabletInfo` and `PlanFragmentBuilder.visitPhysicalOlapScan` so the legacy and optimizer-built scan paths cannot drift. Returns `null` for non-range-colocate scans (caller falls back to position-based bucketSeq).
- `ColocateRangeUtils` package-private `rangeContains` helper — bound-aware containment that handles `-∞`/`+∞` and inclusive/exclusive edges (avoids `Range.compareTo`'s overlap semantics).
- `OlapScanNode.getBucketNums()` overridden to return the colocate range count for range colocate tables, so `ColocatedBackendSelector`'s `bucketSeq < bucketNum` invariant holds (`RangeDistributionInfo.getBucketNum()` is hard-coded to 1).

**Fail-closed alignment guard inside the utility**: throws `IllegalStateException` when the colocate group is in an unaligned state — either a tablet whose range is not contained in any single ColocateRange (the spanning-tablet case), or a ColocateRange with no covering tablet in the partition's index (the missing-range case). This is critical because a `Range.all()` tablet co-existing with a multi-range `ColocateRangeMgr` would otherwise silently misroute scan ranges.

The check uses **containment** rather than strict equality so that legitimate intra-colocate splits (which produce sub-range tablets within a single ColocateRange) keep working. When P3's range-aware split + alignment daemon ship, both alignment states (inter-colocate and intra-colocate) are handled by the existing utility without further change.

### Test coverage

- **Helper tests**: 4 new cases on `ColocateRangeMgrTest` (index lookup), 6 new cases on `ColocateRangeUtilsTest` for `extractColocatePrefix`, 5 new cases for `rangeContains`.
- **`RangeColocateScanRangeDispatchTest`** (new, 10 cases) using `UtFrameUtils.createMinStarRocksCluster(SHARED_DATA)`:
  - `getBucketNums()` against real range colocate tables (single-range default, after multi-range injection, non-colocate fallback).
  - `computeRangeColocateBucketSeq` against real tables (single range, non-colocate returns `null`, spanning-tablet throws "unaligned").
  - `computeRangeColocateBucketSeq` against synthetic fixtures (intra-colocate split sub-range tablets share a bucket; missing-range throws "no covering tablet"; missing-`TabletRange` throws).
  - End-to-end `PlanFragmentBuilder` test that drives a real range-colocate join via `UtFrameUtils.getPlanAndFragment`, walks `ExecPlan.getScanNodes()`, and asserts `bucketSeq2locations` aligns by ColocateRange.

### Follow-up dependency note

P5 (edit-log persistence for `ColocateRangeMgr`) must precede multi-FE production enablement of P3 (range-aware splits). Without P5, follower FEs in a multi-FE cluster will plan with stale `ColocateRangeMgr` after splits and produce wrong join results — the new alignment guard catches the leader's view, not divergence between leader and follower.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4