### PR TITLE
[Enhancement] Introduce a cache for avro schema in shadowed partitionData on partition load (backport #72215)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -38,6 +38,8 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.StarRocksIcebergTableScan;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -50,6 +52,7 @@ import org.apache.spark.util.SizeEstimator;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -72,6 +75,9 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     private static final int MEMORY_MANIFEST_SIZE = 1024; // approx memory size of one manifest object in snapshot
     private static final int MEMORY_DATA_FILE_SIZE = 1536; // approx memory size of one data file in manifest
     private static final int MEMORY_PARTITION_DATA_SIZE = 768; // approx memory size of one partition data in data file
+    // Only emit the partition-load INFO line when a refresh exceeds this many partitions, so the log
+    // remains useful for diagnosing slow loads on large tables without flooding for normal-sized ones.
+    private static final int PARTITION_LOAD_LOG_THRESHOLD = 10000;
     private final String catalogName;
     private final IcebergCatalog delegate;
     private final com.github.benmanes.caffeine.cache.LoadingCache<IcebergTableName, Table> tables;
@@ -160,7 +166,28 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                                             .setSrTableName(key.tableName)
                                             .setCatalogTableName(key.tableName)
                                             .setNativeTable(nativeTable).build();
-                            return delegate.getPartitions(icebergTable, key.snapshotId, null);
+                            Map<String, Partition> partitions =
+                                    delegate.getPartitions(icebergTable, key.snapshotId, null);
+                            if (partitions.size() > PARTITION_LOAD_LOG_THRESHOLD) {
+                                // -1 is used by callers as "use current snapshot" (see IcebergCatalog#getPartitions);
+                                // resolve it here so the summary and logged snapshot id reflect the snapshot actually scanned.
+                                Snapshot snapshot = key.snapshotId == -1
+                                        ? nativeTable.currentSnapshot() : nativeTable.snapshot(key.snapshotId);
+                                long loggedSnapshotId = snapshot != null ? snapshot.snapshotId() : key.snapshotId;
+                                Map<String, String> summary =
+                                        (snapshot != null && snapshot.summary() != null)
+                                                ? snapshot.summary() : Collections.emptyMap();
+                                LOG.info("Loaded large iceberg partition set: catalog={}, table={}.{}, snapshot={}, "
+                                                + "partitions={}, dataFiles={}, deleteFiles={}, specs={}, "
+                                                + "partitionFields={}",
+                                        catalogName, key.dbName, key.tableName, loggedSnapshotId,
+                                        partitions.size(),
+                                        summary.getOrDefault(SnapshotSummary.TOTAL_DATA_FILES_PROP, "?"),
+                                        summary.getOrDefault(SnapshotSummary.TOTAL_DELETE_FILES_PROP, "?"),
+                                        nativeTable.specs().size(),
+                                        nativeTable.spec().fields().size());
+                            }
+                            return partitions;
                         }
                     });
         long dataFileCacheSize = Math.round(Runtime.getRuntime().maxMemory() *

--- a/fe/fe-core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificData;
@@ -40,8 +42,28 @@ import java.util.stream.Stream;
 public class PartitionData
         implements IndexedRecord, StructLike, SpecificData.SchemaConstructable, Serializable {
 
+    // Avro schema is a pure function of the partition struct, so it is safe to share across
+    // instances. Bounded so an unfamiliar set of struct shapes cannot pin schemas forever; an
+    // evicted entry just rebuilds on next use.
+    private static final Cache<Types.StructType, CachedSchema> SCHEMA_CACHE =
+            Caffeine.newBuilder().maximumSize(1024).build();
+
+    private static CachedSchema cachedSchemaFor(Types.StructType partitionType) {
+        return SCHEMA_CACHE.get(partitionType, CachedSchema::new);
+    }
+
     static Schema partitionDataSchema(Types.StructType partitionType) {
-        return AvroSchemaUtil.convert(partitionType, PartitionData.class.getName());
+        return cachedSchemaFor(partitionType).schema;
+    }
+
+    private static final class CachedSchema {
+        private final Schema schema;
+        private final String stringSchema;
+
+        CachedSchema(Types.StructType partitionType) {
+            this.schema = AvroSchemaUtil.convert(partitionType, PartitionData.class.getName());
+            this.stringSchema = schema.toString();
+        }
     }
 
     private final Types.StructType partitionType;
@@ -70,8 +92,9 @@ public class PartitionData
         this.partitionType = partitionType;
         this.size = partitionType.fields().size();
         this.data = new Object[size];
-        this.schema = partitionDataSchema(partitionType);
-        this.stringSchema = schema.toString();
+        CachedSchema cached = cachedSchemaFor(partitionType);
+        this.schema = cached.schema;
+        this.stringSchema = cached.stringSchema;
     }
 
     /** Copy constructor */

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionsTable;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -692,6 +693,74 @@ public class CachingIcebergCatalogTest {
         } finally {
             es.shutdownNow();
             System.out.println("===== test reload async end =====");
+        }
+    }
+
+    @Test
+    public void testLoadLargePartitionSetTriggersDiagnosticLog(@Mocked IcebergCatalog delegate,
+                                                               @Mocked IcebergCatalogProperties props,
+                                                               @Mocked ConnectContext ctx) throws Exception {
+        // Build a partition map exceeding PARTITION_LOAD_LOG_THRESHOLD (10000) so the diagnostic
+        // INFO branch in the partition cache loader is exercised.
+        Map<String, Partition> bigPartitions = new HashMap<>();
+        for (int i = 0; i <= 10000; i++) {
+            bigPartitions.put("p" + i, new Partition(0L, 0L));
+        }
+
+        PartitionSpec spec = Mockito.mock(PartitionSpec.class);
+        Mockito.when(spec.fields()).thenReturn(java.util.Collections.emptyList());
+        Mockito.when(spec.isUnpartitioned()).thenReturn(false);
+
+        BaseTable nativeTable = (BaseTable) createBaseTableWithManifests(1, 0, spec);
+        TableMetadata meta = nativeTable.operations().current();
+        Mockito.when(meta.specsById()).thenReturn(Map.of(0, spec));
+
+        Snapshot currentSnap = meta.currentSnapshot();
+        Map<String, String> summary = new HashMap<>();
+        summary.put(SnapshotSummary.TOTAL_DATA_FILES_PROP, "5");
+        summary.put(SnapshotSummary.TOTAL_DELETE_FILES_PROP, "0");
+        Mockito.when(currentSnap.snapshotId()).thenReturn(42L);
+        Mockito.when(currentSnap.summary()).thenReturn(summary);
+
+        new Expectations() {
+            {
+                props.isEnableIcebergMetadataCache();
+                result = true;
+                props.getIcebergMetaCacheTtlSec();
+                result = 60L;
+                props.getIcebergTableCacheMemoryUsageRatio();
+                result = 1.0;
+                props.getIcebergDataFileCacheMemoryUsageRatio();
+                result = 0.0;
+                props.getIcebergDeleteFileCacheMemoryUsageRatio();
+                result = 0.0;
+
+                delegate.getTable("db", "t");
+                result = nativeTable;
+                minTimes = 0;
+
+                delegate.getPartitions((IcebergTable) any, -1L, null);
+                result = bigPartitions;
+                minTimes = 1;
+            }
+        };
+
+        ExecutorService es = Executors.newSingleThreadExecutor();
+        try {
+            CachingIcebergCatalog catalog = new CachingIcebergCatalog("c0", delegate, props, es);
+            IcebergTable icebergTable = IcebergTable.builder()
+                    .setSrTableName("t")
+                    .setCatalogDBName("db")
+                    .setCatalogTableName("t")
+                    .setNativeTable(nativeTable)
+                    .build();
+
+            // snapshotId == -1 forces the loader to fall back to nativeTable.currentSnapshot()
+            // for the logged snapshot id and summary.
+            Map<String, Partition> result = catalog.getPartitions(icebergTable, -1L, null);
+            Assertions.assertEquals(10001, result.size());
+        } finally {
+            es.shutdownNow();
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/iceberg/PartitionDataTest.java
+++ b/fe/fe-core/src/test/java/org/apache/iceberg/PartitionDataTest.java
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.apache.iceberg;
+
+import org.apache.avro.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class PartitionDataTest {
+
+    private static Types.StructType partitionType(int idOffset) {
+        return Types.StructType.of(
+                Types.NestedField.optional(1000 + idOffset, "dt", Types.StringType.get()),
+                Types.NestedField.optional(1001 + idOffset, "region", Types.IntegerType.get()));
+    }
+
+    @Test
+    public void schemaIsCachedAcrossEqualStructTypes() {
+        Types.StructType t1 = partitionType(0);
+        Types.StructType t2 = partitionType(0);
+        assertNotSame(t1, t2, "test setup should use distinct StructType instances");
+        assertEquals(t1, t2, "test setup should use structurally-equal StructType instances");
+
+        PartitionData a = new PartitionData(t1);
+        PartitionData b = new PartitionData(t2);
+        PartitionData c = new PartitionData(t1);
+
+        assertSame(a.getSchema(), b.getSchema(),
+                "Avro Schema must be shared across structurally-equal partition types");
+        assertSame(a.getSchema(), c.getSchema(),
+                "Avro Schema must be shared across calls with the same partition type");
+    }
+
+    @Test
+    public void partitionDataSchemaIsIdempotent() {
+        Types.StructType t = partitionType(50);
+        Schema first = PartitionData.partitionDataSchema(t);
+        Schema second = PartitionData.partitionDataSchema(t);
+        assertSame(first, second,
+                "partitionDataSchema must return the cached Schema for repeated calls");
+    }
+
+    @Test
+    public void differentStructTypesProduceDifferentSchemas() {
+        // Different field IDs make the StructType non-equal even though names/types match.
+        PartitionData a = new PartitionData(partitionType(0));
+        PartitionData b = new PartitionData(partitionType(100));
+        assertNotSame(a.getSchema(), b.getSchema(),
+                "structurally-distinct partition types must not share a Schema entry");
+        assertNotEquals(a.getSchema().toString(), b.getSchema().toString());
+    }
+
+    @Test
+    public void serializationRoundTripPreservesSchemaAndData() throws Exception {
+        Types.StructType t = partitionType(200);
+        PartitionData a = new PartitionData(t);
+        a.set(0, "2026-04-27");
+        a.set(1, 7);
+
+        PartitionData restored = roundTrip(a);
+        assertEquals(a, restored, "round-trip must preserve partition data values");
+        assertEquals(a.getSchema().toString(), restored.getSchema().toString(),
+                "round-trip must preserve the persisted Avro schema");
+    }
+
+    @Test
+    public void copyConstructorSharesSchemaWithSource() {
+        PartitionData a = new PartitionData(partitionType(300));
+        a.set(0, "x");
+        a.set(1, 1);
+
+        PartitionData copy = a.copy();
+        assertSame(a.getSchema(), copy.getSchema(),
+                "copy() must share Schema instance with the source");
+        assertEquals(a, copy);
+    }
+
+    @Test
+    public void copyForSharesSchemaWithSource() {
+        PartitionData a = new PartitionData(partitionType(400));
+        PartitionData replaced = a.copyFor(a);
+        assertSame(a.getSchema(), replaced.getSchema(),
+                "copyFor() must share Schema instance with the source");
+    }
+
+    @Test
+    public void avroReflectionConstructorRetainsSchemaInstance() {
+        Schema schema = PartitionData.partitionDataSchema(partitionType(500));
+        PartitionData pd = new PartitionData(schema);
+        assertSame(schema, pd.getSchema(),
+                "Avro reflection constructor must keep the supplied Schema instance");
+        assertEquals(2, pd.size());
+    }
+
+    private static PartitionData roundTrip(PartitionData input) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(bytes)) {
+            oos.writeObject(input);
+        }
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (PartitionData) ois.readObject();
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Profiling iceberg partition load (`IcebergCatalog#getPartitions` on tables with many partitions) showed ~63% of allocations in `AvroSchemaUtil.convert` — Jackson `ObjectMapper` plus `JsonNode` tree — invoked from `PartitionData(Types.StructType)`. `PartitionsTable.partitions()` constructs one `PartitionData` per partition row, so the chain runs N times and pinpoints schema construction as the dominant allocator.

The key observation is that `partitionDataSchema(Types.StructType)` is a **pure function of its `StructType` argument** — it does not depend on the the partition values, or the row count. Inside a single `PartitionsTable` scan, all N `PartitionData` instances are constructed with the *same* `StructType` (Iceberg derives it from the table's unified `Partitioning.partitionType(table)`), so, we currently rebuild the identical Avro schema once per row, this is a complete waste of CPU and memory. And that is the redundancy the cache eliminates: schema construction becomes O(1) per partition struct shape per FE lifetime, instead of O(N) per refresh.

We also considered switching the per-partition construction to a streaming model (process partitions one-by-one instead of materializing the whole `Map<String, Partition>` in memory before returning), but did not pursue it for two reasons:

- **Engineering cost is high.** The current path delegates to Iceberg's own `PartitionsTable#newScan().planFiles()`, which produces a `CloseableIterable<FileScanTask>`. Turning that into a true streaming pipeline means re-implementing partition aggregation and rewiring all downstream consumers (split assignment, stats collection, the shape of `partitionCache`'s value type, MV refresh paths, etc.). The blast radius is far larger than this localized fix.
- **Streaming does not actually fix the dominant cost.** Even in a streaming layout we would still call `new PartitionData(StructType)` per partition row and so still pay the full `AvroSchemaUtil.convert` cost N times. Caching the schema removes the per-row cost regardless of whether the outer loop materializes or streams

Also, it is currently hard to tell which (table, snapshot) is responsible when partition load is slow, because no log line records the partition count or related stats per refresh.

## What I'm doing:

1. In the project's shadowed `org.apache.iceberg.PartitionData`, memoize `(Avro Schema, schema.toString())` by partition `Types.StructType` using a Caffeine cache (`maximumSize=1024`). The Avro schema is a pure function of the partition struct, so sharing across instances is safe; the cache is bounded so unfamiliar struct shapes cannot pin schemas indefinitely.  A new JUnit5 test file (`PartitionDataTest`) covers cache hits across equal struct types, schema/stringSchema consistency, copy-constructor sharing, Avro-reflection path, and Java-serialization round-trip.

   The cache itself is small. Each entry holds an Avro `Schema.RecordSchema` tree plus its stringified JSON: ~0.6–0.8 KB for a single-field BIGINT spec, ~3–5 KB for a 5-field mixed spec (date / string / decimal / int / bigint), ~15–20 KB for very wide specs. With `maximumSize=1024` the worst-case ceiling is in the low-MB range; in practice an FE holds at most a few hundred distinct `Types.StructType`s, so the actual footprint stays in the few-hundred-KB range.

2. In `CachingIcebergCatalog`'s partition `CacheLoader.load(...)`, emit a single INFO line on every (table, snapshot) cache miss with: catalog, db.table, snapshotId, partitions count, dataFiles / deleteFiles (from snapshot summary), spec count, partition field count. Frequency is bounded by Caffeine's per-key loader contract (at most one invocation per key per absence period), so this cannot flood logs. Refresh paths (background, manual, query cold-start, MV-rewrite warm-up) all converge here, so this single log point covers them.

## Test results
During my local test for a large number of partitions, the cache can help to avoid the full gc issue and decrease the refresh time from 100s+ to ~7s.

Before:
<img width="2508" height="1163" alt="image" src="https://github.com/user-attachments/assets/72ce01de-5a8c-465c-8b78-de25072cb5af" />


After:
<img width="2508" height="1163" alt="image" src="https://github.com/user-attachments/assets/f63d2fc9-d4a0-4360-b47a-0b6f9b8cebd3" />


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

