### PR TITLE
[BugFix] Fix Apache Parquet namespace ambiguity in ParquetScannerTest

### DIFF
--- a/be/test/exec/file_scanner/parquet_scanner_test.cpp
+++ b/be/test/exec/file_scanner/parquet_scanner_test.cpp
@@ -365,9 +365,9 @@ private:
         ASSERT_TRUE(output_res.ok()) << output_res.status().ToString();
         std::shared_ptr<arrow::io::FileOutputStream> output = output_res.ValueOrDie();
 
-        auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
-        auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
-                                                 parquet::default_writer_properties(), arrow_props);
+        auto arrow_props = ::parquet::ArrowWriterProperties::Builder().store_schema()->build();
+        auto status = ::parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
+                                                   ::parquet::default_writer_properties(), arrow_props);
         ASSERT_TRUE(status.ok()) << status.ToString();
         ASSERT_TRUE(output->Close().ok());
     }
@@ -397,9 +397,9 @@ private:
         ASSERT_TRUE(output_res.ok()) << output_res.status().ToString();
         std::shared_ptr<arrow::io::FileOutputStream> output = output_res.ValueOrDie();
 
-        auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
-        auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
-                                                 parquet::default_writer_properties(), arrow_props);
+        auto arrow_props = ::parquet::ArrowWriterProperties::Builder().store_schema()->build();
+        auto status = ::parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
+                                                   ::parquet::default_writer_properties(), arrow_props);
         ASSERT_TRUE(status.ok()) << status.ToString();
         ASSERT_TRUE(output->Close().ok());
     }
@@ -427,9 +427,9 @@ private:
         ASSERT_TRUE(output_res.ok()) << output_res.status().ToString();
         std::shared_ptr<arrow::io::FileOutputStream> output = output_res.ValueOrDie();
 
-        auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
-        auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
-                                                 parquet::default_writer_properties(), arrow_props);
+        auto arrow_props = ::parquet::ArrowWriterProperties::Builder().store_schema()->build();
+        auto status = ::parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
+                                                   ::parquet::default_writer_properties(), arrow_props);
         ASSERT_TRUE(status.ok()) << status.ToString();
         ASSERT_TRUE(output->Close().ok());
     }
@@ -461,9 +461,9 @@ private:
         ASSERT_TRUE(output_res.ok()) << output_res.status().ToString();
         std::shared_ptr<arrow::io::FileOutputStream> output = output_res.ValueOrDie();
 
-        auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
-        auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
-                                                 parquet::default_writer_properties(), arrow_props);
+        auto arrow_props = ::parquet::ArrowWriterProperties::Builder().store_schema()->build();
+        auto status = ::parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), output, table->num_rows(),
+                                                   ::parquet::default_writer_properties(), arrow_props);
         ASSERT_TRUE(status.ok()) << status.ToString();
         ASSERT_TRUE(output->Close().ok());
     }


### PR DESCRIPTION
## Why I'm doing:

Inside `namespace starrocks`, referencing `parquet::xxx` can lead to compilation
errors or incorrect symbol resolution because it may conflict with the internal 
`starrocks::parquet` namespace.

## What I'm doing:

This PR fix:
- Qualifies Apache Parquet library calls with the global scope operator `::parquet`.
- Corrects the indentation of the affected multi-line `WriteTable` calls to maintain code style consistency.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
