### PR TITLE
[Enhancement] Allow unpartitioned MVs on evolved Iceberg tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -50,6 +50,7 @@ import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.View;
 import com.starrocks.catalog.constraint.GlobalConstraintManager;
@@ -88,6 +89,7 @@ import com.starrocks.scheduler.TaskRunManager;
 import com.starrocks.scheduler.mv.MVTimelinessMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterMaterializedViewStatusClause;
@@ -247,10 +249,12 @@ public class AlterJobMgr {
             }
 
             // Skip checks to maintain eventual consistency when replay
-            Set<BaseTableInfo> baseTableInfos = MaterializedViewAnalyzer.getBaseTableInfos(mvQueryStatement);
+            Map<TableName, Table> tableNameTableMap =
+                    AnalyzerUtils.collectAllConnectorTableAndViewWithViewDefinition(mvQueryStatement);
+            Set<BaseTableInfo> baseTableInfos = MaterializedViewAnalyzer.getBaseTableInfos(tableNameTableMap);
             if (!isReplay) {
                 MaterializedViewAnalyzer.checkBaseTables(
-                        baseTableInfos, materializedView.getPartitionInfo().isUnPartitioned());
+                        tableNameTableMap, materializedView.getPartitionInfo().isUnPartitioned());
             }
             TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
             Task task = taskManager.getTask(materializedView);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -247,15 +247,18 @@ public class AlterJobMgr {
             }
 
             // Skip checks to maintain eventual consistency when replay
-            List<BaseTableInfo> baseTableInfos =
-                    Lists.newArrayList(MaterializedViewAnalyzer.getBaseTableInfos(mvQueryStatement, !isReplay));
+            Set<BaseTableInfo> baseTableInfos = MaterializedViewAnalyzer.getBaseTableInfos(mvQueryStatement);
+            if (!isReplay) {
+                MaterializedViewAnalyzer.checkBaseTables(
+                        baseTableInfos, materializedView.getPartitionInfo().isUnPartitioned());
+            }
             TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
             Task task = taskManager.getTask(materializedView);
             if (task == null) {
                 throw new SemanticException("Can not find running task for materialized view [%s]",
                         materializedView.getName());
             }
-            return new AlterMaterializedViewStatusContext(status, reason, baseTableInfos, task);
+            return new AlterMaterializedViewStatusContext(status, reason, Lists.newArrayList(baseTableInfos), task);
         } else if (AlterMaterializedViewStatusClause.INACTIVE.equalsIgnoreCase(status)) {
             TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
             Task currentTask = taskManager.getTask(TaskBuilder.getMvTaskName(materializedView.getId()));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -712,8 +712,8 @@ public abstract class MVRefreshProcessor {
                 // TODO: Implement a `SnapshotTable` later which can use the copied table or transfer to the real table.
                 final Table table = tableOpt.get();
 
-                // Check if the table is an Iceberg table with partition evolution
-                if (table instanceof IcebergTable) {
+                // Non-partitioned MVs do full refresh without base partition mapping.
+                if (table instanceof IcebergTable && !mv.getPartitionInfo().isUnPartitioned()) {
                     IcebergTable icebergTable = (IcebergTable) table;
                     if (icebergTable.getNativeTable().specs().size() > 1) {
                         throw new DmlException("Materialized view %s.%s refresh failed: base Iceberg table %s " +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -934,6 +934,31 @@ public class AnalyzerUtils {
         return tables;
     }
 
+    public static Map<TableName, Table> collectAllConnectorTableAndViewWithViewDefinition(
+            QueryStatement queryStatement) {
+        Map<TableName, Table> tables = Maps.newHashMap();
+        collectAllConnectorTableAndViewWithViewDefinition(queryStatement, tables);
+        return tables;
+    }
+
+    private static void collectAllConnectorTableAndViewWithViewDefinition(
+            QueryStatement queryStatement, Map<TableName, Table> tables) {
+        Map<TableName, Table> tableNameTableMap = collectAllConnectorTableAndView(queryStatement);
+        for (Map.Entry<TableName, Table> entry : tableNameTableMap.entrySet()) {
+            Table table = entry.getValue();
+            if (table == null || table.isView()) {
+                continue;
+            }
+            tables.put(entry.getKey(), table);
+        }
+
+        Set<ViewRelation> viewRelationSet = Sets.newHashSet(collectViewRelations(queryStatement));
+        for (ViewRelation viewRelation : viewRelationSet) {
+            collectAllConnectorTableAndViewWithViewDefinition(viewRelation.getQueryStatement(), tables);
+            tables.put(viewRelation.getName(), viewRelation.getView());
+        }
+    }
+
     private static class TableAndViewCollector extends TableCollector {
         public TableAndViewCollector(Map<TableName, Table> dbs) {
             super(dbs);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -170,9 +170,11 @@ public class MaterializedViewAnalyzer {
     }
 
     public static Set<BaseTableInfo> getBaseTableInfos(QueryStatement queryStatement) {
+        return getBaseTableInfos(AnalyzerUtils.collectAllConnectorTableAndViewWithViewDefinition(queryStatement));
+    }
+
+    public static Set<BaseTableInfo> getBaseTableInfos(Map<TableName, Table> tableNameTableMap) {
         Set<BaseTableInfo> baseTableInfos = Sets.newHashSet();
-        Map<TableName, Table> tableNameTableMap =
-                AnalyzerUtils.collectAllConnectorTableAndViewWithViewDefinition(queryStatement);
         for (Map.Entry<TableName, Table> entry : tableNameTableMap.entrySet()) {
             TableName tableName = entry.getKey();
             Table table = entry.getValue();
@@ -228,16 +230,19 @@ public class MaterializedViewAnalyzer {
         return false;
     }
 
-    public static void checkBaseTables(Set<BaseTableInfo> baseTableInfos, boolean allowIcebergPartitionEvolution) {
-        for (BaseTableInfo baseTableInfo : baseTableInfos) {
-            Table table = MvUtils.getTableChecked(baseTableInfo);
+    public static void checkBaseTables(Map<TableName, Table> tableNameTableMap, boolean allowIcebergPartitionEvolution) {
+        for (Map.Entry<TableName, Table> entry : tableNameTableMap.entrySet()) {
+            TableName tableName = entry.getKey();
+            Table table = entry.getValue();
+            Preconditions.checkState(table != null, "Materialized view base table is null");
             if (!isSupportBasedOnTable(table)) {
                 throw new SemanticException("Create/Rebuild materialized view do not support the table type: " +
-                        table.getType());
+                        table.getType(), tableName.getPos());
             }
             if (table instanceof MaterializedView && !((MaterializedView) table).isActive()) {
                 throw new SemanticException(
-                        "Create/Rebuild materialized view from inactive materialized view: " + table.getName());
+                        "Create/Rebuild materialized view from inactive materialized view: " + table.getName(),
+                        tableName.getPos());
             }
 
             // The view itself is recorded as an MV dependency, but its underlying base tables
@@ -250,13 +255,13 @@ public class MaterializedViewAnalyzer {
                 IcebergTable icebergTable = (IcebergTable) table;
                 if (icebergTable.getNativeTable().specs().size() > 1) {
                     throw new SemanticException("Do not support create materialized view when base iceberg table " +
-                            table.getName() + " has done partition evolution");
+                            table.getName() + " has done partition evolution", tableName.getPos());
                 }
             }
             if (!FeConstants.isReplayFromQueryDump && !isSupportedExternalTables(table)) {
                 throw new SemanticException(
                         "Only supports creating materialized views based on the external table " +
-                                "which created by catalog");
+                                "which created by catalog", tableName.getPos());
             }
         }
     }
@@ -400,8 +405,10 @@ public class MaterializedViewAnalyzer {
                 throw new SemanticException(errMsg, statement.getTableRef().getPos());
             }
             boolean allowIcebergPartitionEvolution = CollectionUtils.isEmpty(statement.getPartitionByExprs());
-            Set<BaseTableInfo> baseTableInfos = getBaseTableInfos(queryStatement);
-            checkBaseTables(baseTableInfos, allowIcebergPartitionEvolution);
+            Map<TableName, Table> tableNameTableMap =
+                    AnalyzerUtils.collectAllConnectorTableAndViewWithViewDefinition(queryStatement);
+            Set<BaseTableInfo> baseTableInfos = getBaseTableInfos(tableNameTableMap);
+            checkBaseTables(tableNameTableMap, allowIcebergPartitionEvolution);
             // now do not support empty base tables
             // will be relaxed after test
             if (baseTableInfos.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -169,52 +169,24 @@ public class MaterializedViewAnalyzer {
         new MaterializedViewAnalyzerVisitor().visit(stmt, session);
     }
 
-    public static Set<BaseTableInfo> getBaseTableInfos(QueryStatement queryStatement, boolean withCheck) {
+    public static Set<BaseTableInfo> getBaseTableInfos(QueryStatement queryStatement) {
         Set<BaseTableInfo> baseTableInfos = Sets.newHashSet();
-        processBaseTables(queryStatement, baseTableInfos, withCheck);
-        return baseTableInfos;
-    }
-
-    private static void processBaseTables(QueryStatement queryStatement, Set<BaseTableInfo> baseTableInfos,
-                                          boolean withCheck) {
-        Map<TableName, Table> tableNameTableMap = AnalyzerUtils.collectAllConnectorTableAndView(queryStatement);
+        Map<TableName, Table> tableNameTableMap =
+                AnalyzerUtils.collectAllConnectorTableAndViewWithViewDefinition(queryStatement);
         for (Map.Entry<TableName, Table> entry : tableNameTableMap.entrySet()) {
-            TableName tableNameInfo = entry.getKey();
+            TableName tableName = entry.getKey();
             Table table = entry.getValue();
-            if (withCheck) {
-                Preconditions.checkState(table != null, "Materialized view base table is null");
-                if (!isSupportBasedOnTable(table)) {
-                    throw new SemanticException("Create/Rebuild materialized view do not support the table type: " +
-                            table.getType(), tableNameInfo.getPos());
-                }
-                if (table instanceof MaterializedView && !((MaterializedView) table).isActive()) {
-                    throw new SemanticException(
-                            "Create/Rebuild materialized view from inactive materialized view: " + table.getName(),
-                            tableNameInfo.getPos());
-                }
+            Preconditions.checkState(table != null, "Materialized view base table is null");
+            if (isInternalCatalog(tableName.getCatalog())) {
+                Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tableName.getDb());
+                baseTableInfos.add(new BaseTableInfo(database.getId(), database.getFullName(),
+                        table.getName(), table.getId()));
+            } else {
+                baseTableInfos.add(new BaseTableInfo(tableName.getCatalog(), tableName.getDb(),
+                        table.getName(), table.getTableIdentifier()));
             }
-
-            if (table.isView()) {
-                continue;
-            }
-
-            // Check if the table is an Iceberg table with partition evolution
-            if (table instanceof IcebergTable) {
-                IcebergTable icebergTable = (IcebergTable) table;
-                if (icebergTable.getNativeTable().specs().size() > 1) {
-                    throw new SemanticException("Do not support create materialized view when base iceberg table " +
-                            table.getName() + " has done partition evolution", tableNameInfo.getPos());
-                }
-            }
-
-            if (!FeConstants.isReplayFromQueryDump && !isSupportedExternalTables(table)) {
-                throw new SemanticException(
-                        "Only supports creating materialized views based on the external table " +
-                                "which created by catalog", tableNameInfo.getPos());
-            }
-            baseTableInfos.add(fromTableName(tableNameInfo, table));
         }
-        processViews(queryStatement, baseTableInfos, withCheck);
+        return baseTableInfos;
     }
 
     private static boolean isSupportBasedOnTable(Table table) {
@@ -256,28 +228,36 @@ public class MaterializedViewAnalyzer {
         return false;
     }
 
-    private static void processViews(QueryStatement queryStatement, Set<BaseTableInfo> baseTableInfos,
-                                     boolean withCheck) {
-        List<ViewRelation> viewRelations = AnalyzerUtils.collectViewRelations(queryStatement);
-        if (viewRelations.isEmpty()) {
-            return;
-        }
-        Set<ViewRelation> viewRelationSet = Sets.newHashSet(viewRelations);
-        for (ViewRelation viewRelation : viewRelationSet) {
-            // base tables of view
-            processBaseTables(viewRelation.getQueryStatement(), baseTableInfos, withCheck);
+    public static void checkBaseTables(Set<BaseTableInfo> baseTableInfos, boolean allowIcebergPartitionEvolution) {
+        for (BaseTableInfo baseTableInfo : baseTableInfos) {
+            Table table = MvUtils.getTableChecked(baseTableInfo);
+            if (!isSupportBasedOnTable(table)) {
+                throw new SemanticException("Create/Rebuild materialized view do not support the table type: " +
+                        table.getType());
+            }
+            if (table instanceof MaterializedView && !((MaterializedView) table).isActive()) {
+                throw new SemanticException(
+                        "Create/Rebuild materialized view from inactive materialized view: " + table.getName());
+            }
 
-            // view itself is considered as base-table
-            baseTableInfos.add(fromTableName(viewRelation.getName(), viewRelation.getView()));
-        }
-    }
+            // The view itself is recorded as an MV dependency, but its underlying base tables
+            // have already been expanded and will be checked separately.
+            if (table.isView()) {
+                continue;
+            }
 
-    private static BaseTableInfo fromTableName(TableName name, Table table) {
-        if (isInternalCatalog(name.getCatalog())) {
-            Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(name.getDb());
-            return new BaseTableInfo(database.getId(), database.getFullName(), table.getName(), table.getId());
-        } else {
-            return new BaseTableInfo(name.getCatalog(), name.getDb(), table.getName(), table.getTableIdentifier());
+            if (!allowIcebergPartitionEvolution && table instanceof IcebergTable) {
+                IcebergTable icebergTable = (IcebergTable) table;
+                if (icebergTable.getNativeTable().specs().size() > 1) {
+                    throw new SemanticException("Do not support create materialized view when base iceberg table " +
+                            table.getName() + " has done partition evolution");
+                }
+            }
+            if (!FeConstants.isReplayFromQueryDump && !isSupportedExternalTables(table)) {
+                throw new SemanticException(
+                        "Only supports creating materialized views based on the external table " +
+                                "which created by catalog");
+            }
         }
     }
 
@@ -419,7 +399,9 @@ public class MaterializedViewAnalyzer {
                 String errMsg = String.format("Can not find database:%s in %s", dbName, catalog);
                 throw new SemanticException(errMsg, statement.getTableRef().getPos());
             }
-            Set<BaseTableInfo> baseTableInfos = getBaseTableInfos(queryStatement, true);
+            boolean allowIcebergPartitionEvolution = CollectionUtils.isEmpty(statement.getPartitionByExprs());
+            Set<BaseTableInfo> baseTableInfos = getBaseTableInfos(queryStatement);
+            checkBaseTables(baseTableInfos, allowIcebergPartitionEvolution);
             // now do not support empty base tables
             // will be relaxed after test
             if (baseTableInfos.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -672,32 +672,25 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
 
     @Test
     public void testRefreshMvWithIcebergPartitionEvolution() throws Exception {
-        // Create MV on Iceberg table without partition evolution
-        String mvName = "iceberg_refresh_evolution_mv";
+        String mvName = "iceberg_refresh_evolution_unpartitioned_mv";
         starRocksAssert.useDatabase("test")
                 .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`" + mvName + "`\n" +
-                        "PARTITION BY date_trunc('month', ts)\n" +
                         "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                         "REFRESH DEFERRED MANUAL\n" +
                         "PROPERTIES (\n" +
                         "\"replication_num\" = \"1\"\n" +
                         ")\n" +
-                        "AS SELECT id, data, ts FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` as a;");
+                        "AS SELECT id, data, ts FROM `iceberg0`.`partitioned_transforms_db`."
+                        + "`t0_date_month_identity_evolution` as a;");
 
         Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getTable(testDb.getFullName(), mvName));
+        Assertions.assertTrue(mv.getPartitionInfo().isUnPartitioned());
 
-        // First refresh should succeed
         triggerRefreshMv(testDb, mv);
 
-        // Now simulate partition evolution by changing the base table to one with evolution
-        // This simulates the scenario where the base table has done partition evolution after MV creation
-        // We do this by altering the MV's base table info to point to the evolution table
-        // Note: This is a test-only approach to verify the check works
-
-        // Create a new MV directly on the evolution table - should fail during creation
-        String mvName2 = "iceberg_evolution_mv2";
+        String mvName2 = "iceberg_evolution_partitioned_mv";
         try {
             starRocksAssert.useDatabase("test")
                     .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`" + mvName2 + "`\n" +
@@ -711,9 +704,7 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
                             + "`t0_date_month_identity_evolution` as a;");
             Assertions.fail("Should fail because Iceberg table has partition evolution");
         } catch (Exception e) {
-            Assertions.assertTrue(e.getMessage().contains(
-                    "Do not support create materialized view when base iceberg table"));
-            Assertions.assertTrue(e.getMessage().contains("has done partition evolution"));
+            Assertions.assertTrue(e.getMessage().contains("partition evolution"));
         }
 
         starRocksAssert.dropMaterializedView(mvName);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.analyzer;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.lake.LakeMaterializedView;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class AnalyzerUtilsTest {
 
@@ -156,6 +158,24 @@ public class AnalyzerUtilsTest {
         Assertions.assertEquals(Arrays.asList(qualifiedRelationName("test", "relation_src"),
                         qualifiedRelationName("test", "relation_view")),
                 AnalyzerUtils.collectAllTableAndViewRelationNamesForAudit(cteStmt));
+    }
+
+    @Test
+    public void testCollectAllConnectorTableAndViewWithViewDefinitions() throws Exception {
+        starRocksAssert.withView("CREATE VIEW relation_nested_view AS SELECT k1 FROM relation_view;");
+        try {
+            QueryStatement queryStatement = (QueryStatement) UtFrameUtils.parseStmtWithNewParser(
+                    "SELECT k1 FROM relation_nested_view", starRocksAssert.getCtx());
+            Set<String> tableNames = AnalyzerUtils.collectAllConnectorTableAndViewWithViewDefinition(queryStatement)
+                    .values().stream()
+                    .map(Table::getName)
+                    .collect(Collectors.toSet());
+
+            Assertions.assertEquals(Sets.newHashSet("relation_src", "relation_view", "relation_nested_view"),
+                    tableNames);
+        } finally {
+            starRocksAssert.dropView("relation_nested_view");
+        }
     }
 
     private String qualifiedRelationName(String dbName, String tableName) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -571,12 +571,27 @@ public class MaterializedViewAnalyzerTest {
     }
 
     @Test
-    public void testCreateMvOnIcebergTableWithPartitionEvolution() {
-        // Test creating MV on Iceberg table with partition evolution should fail
-        String mvName = "iceberg_evolution_mv";
+    public void testCreateMvOnIcebergTableWithPartitionEvolution() throws Exception {
+        String unpartitionedMvName = "iceberg_evolution_unpartitioned_mv";
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`" + unpartitionedMvName + "`\n" +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, ts FROM `iceberg0`.`partitioned_transforms_db`."
+                        + "`t0_date_month_identity_evolution` as a;");
+        Table unpartitionedMv = starRocksAssert.getTable("test", unpartitionedMvName);
+        Assertions.assertTrue(unpartitionedMv instanceof MaterializedView);
+        Assertions.assertTrue(((MaterializedView) unpartitionedMv).getPartitionInfo().isUnPartitioned());
+        starRocksAssert.dropMaterializedView(unpartitionedMvName);
+
+        String partitionedMvName = "iceberg_evolution_partitioned_mv";
         try {
             starRocksAssert.useDatabase("test")
-                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`" + mvName + "`\n" +
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`" + partitionedMvName + "`\n" +
                             "COMMENT \"MATERIALIZED_VIEW\"\n" +
                             "PARTITION BY date_trunc('month', ts)\n" +
                             "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
@@ -588,9 +603,7 @@ public class MaterializedViewAnalyzerTest {
                             + "`t0_date_month_identity_evolution` as a;");
             Assertions.fail("Should fail because Iceberg table has partition evolution");
         } catch (Exception e) {
-            Assertions.assertTrue(e.getMessage().contains(
-                    "Do not support create materialized view when base iceberg table"));
-            Assertions.assertTrue(e.getMessage().contains("has done partition evolution"));
+            Assertions.assertTrue(e.getMessage().contains("partition evolution"));
         }
     }
 

--- a/test/sql/test_mv_on_iceberg/R/test_mv_iceberg_drop_partition_field.result
+++ b/test/sql/test_mv_on_iceberg/R/test_mv_iceberg_drop_partition_field.result
@@ -1,0 +1,116 @@
+-- name: test_mv_iceberg_drop_partition_field
+function: create_iceberg_catalog("mv_iceberg_${uuid0}", "${iceberg_sql_test_catalog_type}")
+-- result:
+None
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (id int, dt date, val int)
+PARTITION BY month(dt), bucket(id, 4);
+-- result:
+-- !result
+INSERT INTO t1 VALUES
+  (1, '2024-01-03', 10),
+  (2, '2024-01-15', 20),
+  (3, '2024-02-05', 30);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY (date_trunc('month', dt))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019da5e7-c006-7c83-a453-594a6f443de5
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views
+  WHERE table_name = 'test_mv1' AND table_schema = 'db_${uuid0}';
+-- result:
+true
+-- !result
+SELECT count(*) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT id, dt, val FROM test_mv1 ORDER BY id;
+-- result:
+1	2024-01-03	10
+2	2024-01-15	20
+3	2024-02-05	30
+-- !result
+function: print_hit_materialized_view("SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY id", "test_mv1")
+-- result:
+True
+-- !result
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 drop partition column bucket(id, 4);
+-- result:
+-- !result
+show create table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+[REGEX](?s)t1\s+CREATE TABLE `t1` \(.*\)\s*PARTITION BY month\(`dt`\).*
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 VALUES
+  (4, '2024-03-10', 40),
+  (5, '2024-03-25', 50);
+-- result:
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views
+  WHERE table_name = 'test_mv1' AND table_schema = 'db_${uuid0}';
+-- result:
+true
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+[REGEX]E: \(1064, '.*base Iceberg table t1 has undergone partition evolution \(2 partition specs\), which is not supported.*'\)
+-- !result
+SELECT count(*) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT id, dt, val FROM test_mv1 ORDER BY id;
+-- result:
+1	2024-01-03	10
+2	2024-01-15	20
+3	2024-02-05	30
+-- !result
+function: print_hit_materialized_view("SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY id", "test_mv1")
+-- result:
+True
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database default_catalog.db_${uuid0} force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_mv_on_iceberg/R/test_mv_iceberg_replace_partition_field.result
+++ b/test/sql/test_mv_on_iceberg/R/test_mv_iceberg_replace_partition_field.result
@@ -1,0 +1,116 @@
+-- name: test_mv_iceberg_replace_partition_field
+function: create_iceberg_catalog("mv_iceberg_${uuid0}", "${iceberg_sql_test_catalog_type}")
+-- result:
+None
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (id int, dt date, val int)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO t1 VALUES
+  (1, '2024-01-03', 10),
+  (2, '2024-01-15', 20),
+  (3, '2024-02-05', 30);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+[REGEX].+
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views
+  WHERE table_name = 'test_mv1' AND table_schema = 'db_${uuid0}';
+-- result:
+true
+-- !result
+SELECT count(*) FROM test_mv1;
+-- result:
+3
+-- !result
+SELECT id, dt, val FROM test_mv1 ORDER BY id;
+-- result:
+1	2024-01-03	10
+2	2024-01-15	20
+3	2024-02-05	30
+-- !result
+function: print_hit_materialized_view("SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY id", "test_mv1")
+-- result:
+True
+-- !result
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 replace partition column dt with month(dt);
+-- result:
+-- !result
+show create table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+[REGEX](?s)t1\s+CREATE TABLE `t1` \(.*\)\s*PARTITION BY month\(`dt`\).*
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 VALUES
+  (4, '2024-03-10', 40),
+  (5, '2024-03-25', 50);
+-- result:
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views
+  WHERE table_name = 'test_mv1' AND table_schema = 'db_${uuid0}';
+-- result:
+true
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+[REGEX]E: \(1064, '.*base Iceberg table t1 has undergone partition evolution \(2 partition specs\), which is not supported.*'\)
+-- !result
+[UC]SELECT count(*) FROM test_mv1;
+-- result:
+3
+-- !result
+[UC]SELECT id, dt, val FROM test_mv1 ORDER BY id;
+-- result:
+1	2024-01-03	10
+2	2024-01-15	20
+3	2024-02-05	30
+-- !result
+function: print_hit_materialized_view("SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY id", "test_mv1")
+-- result:
+False
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database default_catalog.db_${uuid0} force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_mv_on_iceberg/T/test_mv_iceberg_drop_partition_field.sql
+++ b/test/sql/test_mv_on_iceberg/T/test_mv_iceberg_drop_partition_field.sql
@@ -1,0 +1,64 @@
+-- name: test_mv_iceberg_drop_partition_field
+-- Test Point: ALTER TABLE ... DROP PARTITION COLUMN on an Iceberg base
+--             with a composite partition spec — verify the drop itself
+--             succeeds, SHOW CREATE reflects the new spec, and the
+--             downstream MV's IS_ACTIVE + refresh correctness after the
+--             partition-spec evolution.
+-- Method: build Iceberg base with month(dt) + bucket(id, 4); create MV
+--         aligned on month(dt); refresh; DROP partition column
+--         bucket(id, 4); insert new rows; refresh; assert correctness.
+-- Scope: Iceberg partition evolution (DROP) × MV (M3-2).
+function: create_iceberg_catalog("mv_iceberg_${uuid0}", "${iceberg_sql_test_catalog_type}")
+
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+CREATE TABLE t1 (id int, dt date, val int)
+PARTITION BY month(dt), bucket(id, 4);
+INSERT INTO t1 VALUES
+  (1, '2024-01-03', 10),
+  (2, '2024-01-15', 20),
+  (3, '2024-02-05', 30);
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+set new_planner_optimize_timeout=10000;
+
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY (date_trunc('month', dt))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+SELECT IS_ACTIVE FROM information_schema.materialized_views
+  WHERE table_name = 'test_mv1' AND table_schema = 'db_${uuid0}';
+SELECT count(*) FROM test_mv1;
+SELECT id, dt, val FROM test_mv1 ORDER BY id;
+function: print_hit_materialized_view("SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY id", "test_mv1")
+
+-- DROP the bucket partition field; month stays
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 drop partition column bucket(id, 4);
+
+-- Verify SHOW CREATE TABLE reflects the drop
+show create table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+-- Insert new data after drop
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 VALUES
+  (4, '2024-03-10', 40),
+  (5, '2024-03-25', 50);
+
+-- Lock IS_ACTIVE + refresh behavior
+SELECT IS_ACTIVE FROM information_schema.materialized_views
+  WHERE table_name = 'test_mv1' AND table_schema = 'db_${uuid0}';
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT count(*) FROM test_mv1;
+SELECT id, dt, val FROM test_mv1 ORDER BY id;
+function: print_hit_materialized_view("SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY id", "test_mv1")
+
+drop materialized view test_mv1;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database default_catalog.db_${uuid0} force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};

--- a/test/sql/test_mv_on_iceberg/T/test_mv_iceberg_replace_partition_field.sql
+++ b/test/sql/test_mv_on_iceberg/T/test_mv_iceberg_replace_partition_field.sql
@@ -1,0 +1,64 @@
+-- name: test_mv_iceberg_replace_partition_field
+-- Test Point: ALTER TABLE ... REPLACE PARTITION COLUMN on an Iceberg base
+--             under an MV — lock FE behavior on MV IS_ACTIVE, refresh, and
+--             rewrite after the partition-spec replacement.
+-- Method: build Iceberg base partitioned by identity(dt); create MV aligned
+--         on dt; refresh; REPLACE the identity dt with month(dt); insert new
+--         rows; refresh MV; assert.
+-- Scope: Iceberg partition evolution (REPLACE) × MV (M3-3).
+function: create_iceberg_catalog("mv_iceberg_${uuid0}", "${iceberg_sql_test_catalog_type}")
+
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+CREATE TABLE t1 (id int, dt date, val int)
+PARTITION BY (dt);
+INSERT INTO t1 VALUES
+  (1, '2024-01-03', 10),
+  (2, '2024-01-15', 20),
+  (3, '2024-02-05', 30);
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+set new_planner_optimize_timeout=10000;
+
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+-- Baseline
+SELECT IS_ACTIVE FROM information_schema.materialized_views
+  WHERE table_name = 'test_mv1' AND table_schema = 'db_${uuid0}';
+SELECT count(*) FROM test_mv1;
+SELECT id, dt, val FROM test_mv1 ORDER BY id;
+function: print_hit_materialized_view("SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY id", "test_mv1")
+
+-- REPLACE: identity(dt) -> month(dt)
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 replace partition column dt with month(dt);
+
+-- Verify SHOW CREATE TABLE reflects new spec
+show create table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+-- Post-evolution inserts
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 VALUES
+  (4, '2024-03-10', 40),
+  (5, '2024-03-25', 50);
+
+SELECT IS_ACTIVE FROM information_schema.materialized_views
+  WHERE table_name = 'test_mv1' AND table_schema = 'db_${uuid0}';
+
+-- [UC] on refresh because FE may reject with "undergone partition evolution" error
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]SELECT count(*) FROM test_mv1;
+[UC]SELECT id, dt, val FROM test_mv1 ORDER BY id;
+function: print_hit_materialized_view("SELECT id, dt, val FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY id", "test_mv1")
+
+drop materialized view test_mv1;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database default_catalog.db_${uuid0} force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

StarRocks currently rejects creating materialized views when an Iceberg base table has partition evolution before distinguishing partitioned and unpartitioned MVs. The partition-evolution restriction is needed for partition-mapped MVs, but unpartitioned MVs do not rely on base-table partition mapping and should be allowed.

## What I'm doing:

- Allow unpartitioned MVs on Iceberg tables with partition evolution while keeping partitioned MVs blocked.
- Extract recursive table/view collection into `AnalyzerUtils` as a generic `TableName -> Table` helper, while keeping MV-specific `BaseTableInfo` conversion and validation in `MaterializedViewAnalyzer`.
- Reuse collected base table info for MV activation checks.
- Add FE unit coverage and SQL test coverage for Iceberg partition-field drop/replace evolution cases.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4