### PR TITLE
[Enhancement] Skip colocate cleanup warn when no invalid tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -1078,9 +1078,12 @@ public class ColocateTableIndex implements Writable {
             }
             badTableIds.add(tableId);
         }
-        LOG.warn("remove {} invalid tableid: {}", badTableIds.size(), badTableIds);
-        for (Long tableId : badTableIds) {
-            removeTable(tableId, null, false /* isReplay */);
+        
+        if (badTableIds.size() > 0) {
+            LOG.warn("remove {} invalid tableid: {}", badTableIds.size(), badTableIds);
+            for (Long tableId : badTableIds) {
+                removeTable(tableId, null, false /* isReplay */);
+            }
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

Avoids a useless `WARN (remove 0 invalid tableid: [])` when colocate cleanup has nothing to do; only log and remove when there are invalid tables.

## What I'm doing:

In `ColocateTableIndex.cleanupInvalidDbOrTable()`, skip the summary WARN and the `removeTable` loop when `badTableIds` is empty. (`fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java`)

Fixes #<issue-number>

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

*(Metadata/scheduling behavior is unchanged; only log WARN output when there are zero invalid tables.)*

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4