### PR TITLE
[Enhancement] allow hll_deserialize in HLL column load validation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -542,6 +542,7 @@ public class FunctionSet {
 
     // Other functions:
     public static final String HLL_HASH = "hll_hash";
+    public static final String HLL_DESERIALIZE = "hll_deserialize";
     public static final String HLL_CARDINALITY = "hll_cardinality";
     public static final String DEFAULT_VALUE = "default_value";
     public static final String REPLACE_VALUE = "replace_value";

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -429,17 +429,19 @@ public class FileScanNode extends LoadScanNode {
             // check hll_hash
             if (destSlotDesc.getType().getPrimitiveType() == PrimitiveType.HLL) {
                 if (!(expr instanceof FunctionCallExpr)) {
-                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + " function, like "
+                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + ", "
+                            + FunctionSet.HLL_EMPTY + ", or " + FunctionSet.HLL_DESERIALIZE + " function, like "
                             + destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH + "(xxx)");
                 }
                 FunctionCallExpr fn = (FunctionCallExpr) expr;
                 if (!fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_HASH) &&
                         !fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_EMPTY) &&
                         !fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_DESERIALIZE)) {
-                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + " function, like "
-                            + destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH + "(xxx) or " +
-                            destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_EMPTY + "() or " +
-                            destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_DESERIALIZE + "(xxx)");
+                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + ", "
+                            + FunctionSet.HLL_EMPTY + ", or " + FunctionSet.HLL_DESERIALIZE + " function, like "
+                            + destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH + "(xxx) or "
+                            + destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_EMPTY + "() or "
+                            + destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_DESERIALIZE + "(xxx)");
                 }
                 expr.setType(HLLType.HLL);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -429,15 +429,17 @@ public class FileScanNode extends LoadScanNode {
             // check hll_hash
             if (destSlotDesc.getType().getPrimitiveType() == PrimitiveType.HLL) {
                 if (!(expr instanceof FunctionCallExpr)) {
-                    throw new AnalysisException("HLL column must use hll_hash function, like "
-                            + destSlotDesc.getColumn().getName() + "=hll_hash(xxx)");
+                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + " function, like "
+                            + destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH + "(xxx)");
                 }
                 FunctionCallExpr fn = (FunctionCallExpr) expr;
                 if (!fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_HASH) &&
-                        !fn.getFunctionName().equalsIgnoreCase("hll_empty")) {
-                    throw new AnalysisException("HLL column must use hll_hash function, like "
-                            + destSlotDesc.getColumn().getName() + "=hll_hash(xxx) or " +
-                            destSlotDesc.getColumn().getName() + "=hll_empty()");
+                        !fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_EMPTY) &&
+                        !fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_DESERIALIZE)) {
+                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + " function, like "
+                            + destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH + "(xxx) or " +
+                            destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_EMPTY + "() or " +
+                            destSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_DESERIALIZE + "(xxx)");
                 }
                 expr.setType(HLLType.HLL);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -353,10 +353,12 @@ public class StreamLoadScanNode extends LoadScanNode {
                 }
                 FunctionCallExpr fn = (FunctionCallExpr) expr;
                 if (!fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_HASH)
-                        && !fn.getFunctionName().equalsIgnoreCase("hll_empty")) {
+                        && !fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_EMPTY)
+                        && !fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_DESERIALIZE)) {
                     throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + " function, like "
                             + dstSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH
-                            + "(xxx) or " + dstSlotDesc.getColumn().getName() + "=hll_empty()");
+                            + "(xxx) or " + dstSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_EMPTY
+                            + "() or " + dstSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_DESERIALIZE + "(xxx)");
                 }
                 expr.setType(HLLType.HLL);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -348,14 +348,16 @@ public class StreamLoadScanNode extends LoadScanNode {
             // check hll_hash
             if (dstSlotDesc.getType().getPrimitiveType() == PrimitiveType.HLL) {
                 if (!(expr instanceof FunctionCallExpr)) {
-                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + " function, like "
+                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + ", "
+                            + FunctionSet.HLL_EMPTY + ", or " + FunctionSet.HLL_DESERIALIZE + " function, like "
                             + dstSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH + "(xxx)");
                 }
                 FunctionCallExpr fn = (FunctionCallExpr) expr;
                 if (!fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_HASH)
                         && !fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_EMPTY)
                         && !fn.getFunctionName().equalsIgnoreCase(FunctionSet.HLL_DESERIALIZE)) {
-                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + " function, like "
+                    throw new AnalysisException("HLL column must use " + FunctionSet.HLL_HASH + ", "
+                            + FunctionSet.HLL_EMPTY + ", or " + FunctionSet.HLL_DESERIALIZE + " function, like "
                             + dstSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_HASH
                             + "(xxx) or " + dstSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_EMPTY
                             + "() or " + dstSlotDesc.getColumn().getName() + "=" + FunctionSet.HLL_DESERIALIZE + "(xxx)");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
@@ -890,7 +890,7 @@ public class FileScanNodeTest {
         scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
 
         ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
-                "HLL column must use hll_hash function",
+                "HLL column must use hll_hash, hll_empty, or hll_deserialize function",
                 () -> {
                     scanNode.init(descTable);
                     scanNode.finalizeStats();
@@ -984,7 +984,7 @@ public class FileScanNodeTest {
         scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
 
         ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
-                "HLL column must use hll_hash function",
+                "HLL column must use hll_hash, hll_empty, or hll_deserialize function",
                 () -> {
                     scanNode.init(descTable);
                     scanNode.finalizeStats();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
@@ -20,11 +20,24 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionName;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.ScalarFunction;
 import com.starrocks.load.loadv2.LoadJob;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.AggregateType;
+import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.LoadStmt;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.catalog.TableName;
+import com.starrocks.sql.parser.AstBuilder;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.common.Config;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
@@ -42,6 +55,7 @@ import com.starrocks.thrift.TBrokerRangeDesc;
 import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.type.HLLType;
 import com.starrocks.type.IntegerType;
 import mockit.Expectations;
 import mockit.Injectable;
@@ -627,6 +641,354 @@ public class FileScanNodeTest {
         ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
                 "The valid bytes length for 'row delimiter' is [1, 50]",
                 () -> scanNode.init(descTable));
+    }
+
+    @Test
+    public void testHllColumnsWithDeserialize(@Mocked GlobalStateMgr globalStateMgr,
+                                              @Mocked SystemInfoService systemInfoService,
+                                              @Mocked ConnectContext connectContext,
+                                              @Injectable Database db, @Injectable OlapTable table)
+            throws StarRocksException {
+        SqlParser sqlParser = new SqlParser(AstBuilder.getInstance());
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public SqlParser getSqlParser() {
+                return sqlParser;
+            }
+        };
+
+        List<Column> columns = Lists.newArrayList();
+        Column k1 = new Column("k1", IntegerType.BIGINT, true);
+        columns.add(k1);
+        Column v1 = new Column("v1", HLLType.HLL);
+        v1.setIsKey(false);
+        v1.setIsAllowNull(true);
+        v1.setAggregationType(AggregateType.HLL_UNION, false);
+        columns.add(v1);
+
+        new Expectations() {{
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+            result = systemInfoService;
+            systemInfoService.getIdToBackend();
+            result = idToBackend;
+            table.getBaseSchema();
+            result = columns;
+            table.getFullSchema();
+            result = columns;
+            table.getPartitions();
+            minTimes = 0;
+            result = Arrays.asList(partition);
+            partition.getId();
+            minTimes = 0;
+            result = 0;
+            table.getColumn("k1");
+            result = columns.get(0);
+            table.getColumn("k2");
+            result = null;
+            table.getColumn("v1");
+            result = columns.get(1);
+            globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+            result = new ScalarFunction(new FunctionName(FunctionSet.HLL_DESERIALIZE),
+                    Lists.newArrayList(), IntegerType.BIGINT, false);
+        }};
+
+        List<ImportColumnDesc> columnExprs = Lists.newArrayList();
+        columnExprs.add(new ImportColumnDesc("k1"));
+        columnExprs.add(new ImportColumnDesc("k2"));
+        FunctionCallExpr hllDeserializeExpr = new FunctionCallExpr(
+                FunctionSet.HLL_DESERIALIZE,
+                Lists.newArrayList((Expr) new SlotRef((TableName) null, "k2")));
+        columnExprs.add(new ImportColumnDesc("v1", hllDeserializeExpr));
+
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("hdfs://127.0.0.1:9001/file1");
+        DataDescription desc =
+                new DataDescription("testTable", null, files, Lists.newArrayList("k1", "k2"),
+                        null, null, null, false, null);
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "columnExprList", columnExprs);
+        fileGroups.add(brokerFileGroup);
+
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file1", false, 1024, true));
+        fileStatusesList.add(fileStatusList);
+
+        DescriptorTable descTable = new DescriptorTable();
+        TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
+        for (Column column : columns) {
+            SlotDescriptor slot = descTable.addSlotDescriptor(tupleDesc);
+            slot.setColumn(column);
+            slot.setIsMaterialized(true);
+            slot.setIsNullable(column.isAllowNull());
+        }
+
+        FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode",
+                fileStatusesList, 1, WarehouseManager.DEFAULT_RESOURCE);
+        scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
+        scanNode.init(descTable);
+        scanNode.finalizeStats();
+
+        List<TScanRangeLocations> locationsList = scanNode.getScanRangeLocations(0);
+        Assertions.assertFalse(locationsList.isEmpty());
+    }
+
+    @Test
+    public void testHllColumnsWithHash(@Mocked GlobalStateMgr globalStateMgr,
+                                       @Mocked SystemInfoService systemInfoService,
+                                       @Mocked ConnectContext connectContext,
+                                       @Injectable Database db, @Injectable OlapTable table)
+            throws StarRocksException {
+        SqlParser sqlParser = new SqlParser(AstBuilder.getInstance());
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public SqlParser getSqlParser() {
+                return sqlParser;
+            }
+        };
+
+        List<Column> columns = Lists.newArrayList();
+        Column k1 = new Column("k1", IntegerType.BIGINT, true);
+        columns.add(k1);
+        Column v1 = new Column("v1", HLLType.HLL);
+        v1.setIsKey(false);
+        v1.setIsAllowNull(true);
+        v1.setAggregationType(AggregateType.HLL_UNION, false);
+        columns.add(v1);
+
+        new Expectations() {{
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+            result = systemInfoService;
+            systemInfoService.getIdToBackend();
+            result = idToBackend;
+            table.getBaseSchema();
+            result = columns;
+            table.getFullSchema();
+            result = columns;
+            table.getPartitions();
+            minTimes = 0;
+            result = Arrays.asList(partition);
+            partition.getId();
+            minTimes = 0;
+            result = 0;
+            table.getColumn("k1");
+            result = columns.get(0);
+            table.getColumn("k2");
+            result = null;
+            table.getColumn("v1");
+            result = columns.get(1);
+            globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+            result = new ScalarFunction(new FunctionName(FunctionSet.HLL_HASH),
+                    Lists.newArrayList(), IntegerType.BIGINT, false);
+        }};
+
+        List<ImportColumnDesc> columnExprs = Lists.newArrayList();
+        columnExprs.add(new ImportColumnDesc("k1"));
+        columnExprs.add(new ImportColumnDesc("k2"));
+        FunctionCallExpr hllHashExpr = new FunctionCallExpr(
+                FunctionSet.HLL_HASH,
+                Lists.newArrayList((Expr) new SlotRef((TableName) null, "k2")));
+        columnExprs.add(new ImportColumnDesc("v1", hllHashExpr));
+
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("hdfs://127.0.0.1:9001/file1");
+        DataDescription desc =
+                new DataDescription("testTable", null, files, Lists.newArrayList("k1", "k2"),
+                        null, null, null, false, null);
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "columnExprList", columnExprs);
+        fileGroups.add(brokerFileGroup);
+
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file1", false, 1024, true));
+        fileStatusesList.add(fileStatusList);
+
+        DescriptorTable descTable = new DescriptorTable();
+        TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
+        for (Column column : columns) {
+            SlotDescriptor slot = descTable.addSlotDescriptor(tupleDesc);
+            slot.setColumn(column);
+            slot.setIsMaterialized(true);
+            slot.setIsNullable(column.isAllowNull());
+        }
+
+        FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode",
+                fileStatusesList, 1, WarehouseManager.DEFAULT_RESOURCE);
+        scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
+        scanNode.init(descTable);
+        scanNode.finalizeStats();
+
+        List<TScanRangeLocations> locationsList = scanNode.getScanRangeLocations(0);
+        Assertions.assertFalse(locationsList.isEmpty());
+    }
+
+    @Test
+    public void testHllColumnsNoFunction(@Mocked GlobalStateMgr globalStateMgr,
+                                         @Mocked SystemInfoService systemInfoService,
+                                         @Injectable Database db, @Injectable OlapTable table) {
+        List<Column> columns = Lists.newArrayList();
+        Column k1 = new Column("k1", IntegerType.BIGINT, true);
+        columns.add(k1);
+        Column v1 = new Column("v1", HLLType.HLL);
+        v1.setIsKey(false);
+        v1.setIsAllowNull(true);
+        v1.setAggregationType(AggregateType.HLL_UNION, false);
+        columns.add(v1);
+
+        new Expectations() {{
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+            result = systemInfoService;
+            systemInfoService.getIdToBackend();
+            result = idToBackend;
+            table.getBaseSchema();
+            result = columns;
+            table.getFullSchema();
+            result = columns;
+            table.getPartitions();
+            minTimes = 0;
+            result = Arrays.asList(partition);
+            partition.getId();
+            minTimes = 0;
+            result = 0;
+            table.getColumn("k1");
+            result = columns.get(0);
+            table.getColumn("v1");
+            result = columns.get(1);
+        }};
+
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("hdfs://127.0.0.1:9001/file1");
+        DataDescription desc =
+                new DataDescription("testTable", null, files, Lists.newArrayList("k1", "v1"),
+                        null, null, null, false, null);
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        fileGroups.add(brokerFileGroup);
+
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file1", false, 1024, true));
+        fileStatusesList.add(fileStatusList);
+
+        DescriptorTable descTable = new DescriptorTable();
+        TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
+        for (Column column : columns) {
+            SlotDescriptor slot = descTable.addSlotDescriptor(tupleDesc);
+            slot.setColumn(column);
+            slot.setIsMaterialized(true);
+            slot.setIsNullable(column.isAllowNull());
+        }
+
+        FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode",
+                fileStatusesList, 1, WarehouseManager.DEFAULT_RESOURCE);
+        scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
+
+        ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
+                "HLL column must use hll_hash function",
+                () -> {
+                    scanNode.init(descTable);
+                    scanNode.finalizeStats();
+                });
+    }
+
+    @Test
+    public void testHllColumnsWrongFunction(@Mocked GlobalStateMgr globalStateMgr,
+                                            @Mocked SystemInfoService systemInfoService,
+                                            @Mocked ConnectContext connectContext,
+                                            @Injectable Database db, @Injectable OlapTable table) {
+        SqlParser sqlParser = new SqlParser(AstBuilder.getInstance());
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public SqlParser getSqlParser() {
+                return sqlParser;
+            }
+        };
+
+        List<Column> columns = Lists.newArrayList();
+        Column k1 = new Column("k1", IntegerType.BIGINT, true);
+        columns.add(k1);
+        Column v1 = new Column("v1", HLLType.HLL);
+        v1.setIsKey(false);
+        v1.setIsAllowNull(true);
+        v1.setAggregationType(AggregateType.HLL_UNION, false);
+        columns.add(v1);
+
+        new Expectations() {{
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+            result = systemInfoService;
+            systemInfoService.getIdToBackend();
+            result = idToBackend;
+            table.getBaseSchema();
+            result = columns;
+            table.getFullSchema();
+            result = columns;
+            table.getPartitions();
+            minTimes = 0;
+            result = Arrays.asList(partition);
+            partition.getId();
+            minTimes = 0;
+            result = 0;
+            table.getColumn("k1");
+            result = columns.get(0);
+            table.getColumn("k2");
+            result = null;
+            table.getColumn("v1");
+            result = columns.get(1);
+            globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+            result = new ScalarFunction(new FunctionName("wrong_func"),
+                    Lists.newArrayList(), IntegerType.BIGINT, false);
+            minTimes = 0;
+        }};
+
+        List<ImportColumnDesc> columnExprs = Lists.newArrayList();
+        columnExprs.add(new ImportColumnDesc("k1"));
+        columnExprs.add(new ImportColumnDesc("k2"));
+        FunctionCallExpr wrongFuncExpr = new FunctionCallExpr(
+                "wrong_func",
+                Lists.newArrayList((Expr) new SlotRef((TableName) null, "k2")));
+        columnExprs.add(new ImportColumnDesc("v1", wrongFuncExpr));
+
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("hdfs://127.0.0.1:9001/file1");
+        DataDescription desc =
+                new DataDescription("testTable", null, files, Lists.newArrayList("k1", "k2"),
+                        null, null, null, false, null);
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "columnExprList", columnExprs);
+        fileGroups.add(brokerFileGroup);
+
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("hdfs://127.0.0.1:9001/file1", false, 1024, true));
+        fileStatusesList.add(fileStatusList);
+
+        DescriptorTable descTable = new DescriptorTable();
+        TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
+        for (Column column : columns) {
+            SlotDescriptor slot = descTable.addSlotDescriptor(tupleDesc);
+            slot.setColumn(column);
+            slot.setIsMaterialized(true);
+            slot.setIsNullable(column.isAllowNull());
+        }
+
+        FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode",
+                fileStatusesList, 1, WarehouseManager.DEFAULT_RESOURCE);
+        scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
+
+        ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
+                "HLL column must use hll_hash function",
+                () -> {
+                    scanNode.init(descTable);
+                    scanNode.finalizeStats();
+                });
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
@@ -465,6 +465,91 @@ public class StreamLoadScanNodeTest {
     }
 
     @Test
+    public void testHllColumnsNoFunctionExpr() {
+        assertThrows(StarRocksException.class, () -> {
+            DescriptorTable descTbl = new DescriptorTable();
+
+            List<Column> columns = getHllSchema();
+            TupleDescriptor dstDesc = descTbl.createTupleDescriptor("DstTableDesc");
+            for (Column column : columns) {
+                SlotDescriptor slot = descTbl.addSlotDescriptor(dstDesc);
+                slot.setColumn(column);
+                slot.setIsMaterialized(true);
+                if (column.isAllowNull()) {
+                    slot.setIsNullable(true);
+                } else {
+                    slot.setIsNullable(false);
+                }
+            }
+
+            new Expectations() {
+                {
+                    dstTable.getColumn("k1");
+                    result = columns.stream().filter(c -> c.getName().equals("k1")).findFirst().get();
+
+                    dstTable.getColumn("v1");
+                    result = columns.stream().filter(c -> c.getName().equals("v1")).findFirst().get();
+                }
+            };
+
+            TStreamLoadPutRequest request = getBaseRequest();
+            request.setFileType(TFileType.FILE_STREAM);
+            request.setColumns("k1, v1");
+            StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
+
+            scanNode.init(descTbl);
+            scanNode.finalizeStats();
+        });
+    }
+
+    @Test
+    public void testHllColumnsWrongFunction() {
+        assertThrows(StarRocksException.class, () -> {
+            DescriptorTable descTbl = new DescriptorTable();
+
+            List<Column> columns = getHllSchema();
+            TupleDescriptor dstDesc = descTbl.createTupleDescriptor("DstTableDesc");
+            for (Column column : columns) {
+                SlotDescriptor slot = descTbl.addSlotDescriptor(dstDesc);
+                slot.setColumn(column);
+                slot.setIsMaterialized(true);
+                if (column.isAllowNull()) {
+                    slot.setIsNullable(true);
+                } else {
+                    slot.setIsNullable(false);
+                }
+            }
+
+            new Expectations() {{
+                globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+                result = new ScalarFunction(new FunctionName("upper"), Lists.newArrayList(), IntegerType.BIGINT, false);
+                minTimes = 0;
+            }};
+
+            new Expectations() {
+                {
+                    dstTable.getColumn("k1");
+                    result = columns.stream().filter(c -> c.getName().equals("k1")).findFirst().get();
+
+                    dstTable.getColumn("k2");
+                    result = null;
+
+                    dstTable.getColumn("v1");
+                    result = columns.stream().filter(c -> c.getName().equals("v1")).findFirst().get();
+                }
+            };
+
+            TStreamLoadPutRequest request = getBaseRequest();
+            request.setFileType(TFileType.FILE_STREAM);
+            request.setColumns("k1,k2, v1=upper(k2)");
+            StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
+
+            scanNode.init(descTbl);
+            scanNode.finalizeStats();
+        });
+    }
+
+    @Test
     public void testHllColumnsNoHllHash() {
         assertThrows(StarRocksException.class, () -> {
             

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
@@ -415,6 +415,56 @@ public class StreamLoadScanNodeTest {
     }
 
     @Test
+    public void testHllColumnsWithDeserialize() throws StarRocksException {
+
+        DescriptorTable descTbl = new DescriptorTable();
+
+        List<Column> columns = getHllSchema();
+        TupleDescriptor dstDesc = descTbl.createTupleDescriptor("DstTableDesc");
+        for (Column column : columns) {
+            SlotDescriptor slot = descTbl.addSlotDescriptor(dstDesc);
+            slot.setColumn(column);
+            slot.setIsMaterialized(true);
+            if (column.isAllowNull()) {
+                slot.setIsNullable(true);
+            } else {
+                slot.setIsNullable(false);
+            }
+        }
+
+        new Expectations() {{
+            globalStateMgr.getFunction((Function) any, (Function.CompareMode) any);
+            result = new ScalarFunction(new FunctionName(FunctionSet.HLL_DESERIALIZE), Lists.newArrayList(),
+                    IntegerType.BIGINT, false);
+        }};
+
+        new Expectations() {
+            {
+                dstTable.getColumn("k1");
+                result = columns.stream().filter(c -> c.getName().equals("k1")).findFirst().get();
+
+                dstTable.getColumn("k2");
+                result = null;
+
+                dstTable.getColumn("v1");
+                result = columns.stream().filter(c -> c.getName().equals("v1")).findFirst().get();
+            }
+        };
+
+        TStreamLoadPutRequest request = getBaseRequest();
+        request.setFileType(TFileType.FILE_STREAM);
+        request.setColumns("k1,k2, v1=" + FunctionSet.HLL_DESERIALIZE + "(k2)");
+        StreamLoadInfo streamLoadInfo = StreamLoadInfo.fromTStreamLoadPutRequest(request, null);
+        StreamLoadScanNode scanNode = getStreamLoadScanNode(dstDesc, request);
+
+        scanNode.init(descTbl);
+        scanNode.finalizeStats();
+        scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
+        TPlanNode planNode = new TPlanNode();
+        scanNode.toThrift(planNode);
+    }
+
+    @Test
     public void testHllColumnsNoHllHash() {
         assertThrows(StarRocksException.class, () -> {
             


### PR DESCRIPTION
## Why I'm doing:

The FE currently validates that HLL columns in stream load and file/broker load only accept `hll_hash()` or `hll_empty()` as wrapping functions. Users who store pre-serialized HLL sketches need to load them via `hll_deserialize()`, but this function is rejected by the validation despite being a valid HLL function.

Fixes https://github.com/StarRocks/starrocks/issues/62233

## What I'm doing:

Added `hll_deserialize` to the allowed-function check in both `StreamLoadScanNode` and `FileScanNode`, and added a unit test to verify the new behavior.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
