### PR TITLE
[BugFix] fix mem leak when caching mv plan context

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -305,6 +305,11 @@ public class CachingMvPlanContextBuilder {
         return MV_PLAN_CONTEXT_CACHE.asMap().containsKey(mv);
     }
 
+    @VisibleForTesting
+    public boolean isPending(MaterializedView mv) {
+        return MV_PLAN_CACHE_PENDING.containsKey(mv.getId());
+    }
+
     /**
      * Cache materialized view, this will put the mv into ast cache and load plan context asynchronously.
      * @param mv: the materialized view to cache.
@@ -328,6 +333,9 @@ public class CachingMvPlanContextBuilder {
         try {
             // invalidate mv from plan cache
             MV_PLAN_CONTEXT_CACHE.synchronous().invalidate(mv);
+
+            // invalidate mv from pending cache
+            MV_PLAN_CACHE_PENDING.remove(mv.getId());
 
             // invalidate mv from mv level cache
             MV_GLOBAL_CONTEXT_CACHE_MAP.remove(mv);
@@ -401,7 +409,15 @@ public class CachingMvPlanContextBuilder {
         }
         long startTime = System.currentTimeMillis();
         LOG.info("Trigger loading {} pending mv plan caches", MV_PLAN_CACHE_PENDING.size());
-        MV_PLAN_CACHE_PENDING.values().forEach(this::triggerLoadMVPlanCacheAsync);
+        MV_PLAN_CACHE_PENDING.values().forEach(mv -> {
+            // Re-fetch from metastore to skip MVs that were dropped during replay.
+            MaterializedView curMV = GlobalStateMgr.getCurrentState().getLocalMetastore().getMaterializedView(mv.getMvId());
+            if (curMV == null) {
+                LOG.warn("Skip pending mv plan cache load, mv not found in metastore: {}", mv.getName());
+                return;
+            }
+            triggerLoadMVPlanCacheAsync(curMV);
+        });
         MV_PLAN_CACHE_PENDING.clear();
         LOG.info("Finish triggering pending mv plan caches, costs: {}ms",
                 System.currentTimeMillis() - startTime);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
@@ -15,17 +15,22 @@
 package com.starrocks.planner;
 
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ParseNode;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.plan.PlanTestBase;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.util.Map;
 import java.util.Set;
 
 @TestMethodOrder(MethodOrderer.MethodName.class)
@@ -428,5 +433,92 @@ public class MaterializedViewTextBasedRewriteTest extends MaterializedViewTestBa
             MaterializedView expectedMV = getMv(MATERIALIZED_DB_NAME, "test_mv0");
             Assertions.assertEquals(expectedMV, actualMV);
         }
+    }
+
+    /**
+     * Regression test for the bug where a dropped MV still remains in MV_PLAN_CACHE_PENDING.
+     *
+     * Scenario (mirrors replay order during FE startup when isReady=false):
+     *   1. MV is created  → mv set active → cacheMaterializedView() → triggerLoadMVPlanCacheAsync() → enters pending
+     *   2. MV is dropped  → evictMaterializedViewCache() must also remove it from pending
+     *
+     * Without the fix, the dropped MV is remained in MV_PLAN_CACHE_PENDING.
+     */
+    @Test
+    public void testEvictRemovesMvFromPendingCache() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isReady() {
+                return false;
+            }
+        };
+        String mvName = "test_mv_evict_pending";
+        String createMvSql = "create materialized view " + mvName + " distributed by random refresh manual " +
+                "as select user_id, time, sum(tag_id) from user_tags group by user_id, time";
+
+        starRocksAssert.withMaterializedView(createMvSql);
+        MaterializedView mv = getMv(MATERIALIZED_DB_NAME, mvName);
+        mv.setActive();
+
+        Assertions.assertTrue(CachingMvPlanContextBuilder.getInstance().isPending(mv),
+                "MV should be in pending after triggerLoadMVPlanCacheAsync with isReady=false");
+
+        starRocksAssert.dropMaterializedView(mvName);
+
+        Assertions.assertFalse(CachingMvPlanContextBuilder.getInstance().isPending(mv),
+                "MV should be removed from pending after evictMaterializedViewCache");
+    }
+
+    /**
+     * Regression test for the bug where a dropped MV still remains in MV_PLAN_CACHE_PENDING.
+     *
+     * Scenario (mirrors replay order during FE startup when isReady=false):
+     *   1. MV is created  → mv set active → cacheMaterializedView() → triggerLoadMVPlanCacheAsync() → enters pending
+     *   2. MV is dropped  → evictMaterializedViewCache() must also remove it from pending
+     *   3. After FE ready → triggerPendingMVPlanCacheLoads() must not re-insert the dropped MV
+     *
+     * Without the fix, step 3 would load the stale MV object into MV_PLAN_CONTEXT_CACHE.
+     */
+    @Test
+    public void testEvictRemovesMvFromPendingCache2() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isReady() {
+                return false;
+            }
+        };
+        String mvName = "test_mv_evict_pending";
+        String createMvSql = "create materialized view " + mvName + " distributed by random refresh manual " +
+                "as select user_id, time, sum(tag_id) from user_tags group by user_id, time";
+
+        starRocksAssert.withMaterializedView(createMvSql);
+        MaterializedView mv = getMv(MATERIALIZED_DB_NAME, mvName);
+        mv.setActive();
+
+        // MV should now be in pending.
+        Assertions.assertTrue(CachingMvPlanContextBuilder.getInstance().isPending(mv),
+                "MV should be in pending after triggerLoadMVPlanCacheAsync with isReady=false");
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isReady() {
+                return true;
+            }
+        };
+        starRocksAssert.dropMaterializedView(mvName);
+
+        // Simulate the racing condition: MV was dropped during replay, but its stale entry is still
+        // present in MV_PLAN_CACHE_PENDING
+        Map<Long, MaterializedView> pendingMap =
+                Deencapsulation.getField(CachingMvPlanContextBuilder.getInstance(), "MV_PLAN_CACHE_PENDING");
+        pendingMap.put(mv.getId(), mv);
+
+        CachingMvPlanContextBuilder.getInstance().triggerPendingMVPlanCacheLoads();
+
+        Assertions.assertFalse(CachingMvPlanContextBuilder.getInstance().isPending(mv),
+                "MV should be removed from pending after triggerPendingMVPlanCacheLoads");
+
+        Assertions.assertFalse(CachingMvPlanContextBuilder.getInstance().contains(mv),
+                "MV should not be cached triggerPendingMVPlanCacheLoads");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTest.java
@@ -442,7 +442,7 @@ public class MaterializedViewTextBasedRewriteTest extends MaterializedViewTestBa
      *   1. MV is created  → mv set active → cacheMaterializedView() → triggerLoadMVPlanCacheAsync() → enters pending
      *   2. MV is dropped  → evictMaterializedViewCache() must also remove it from pending
      *
-     * Without the fix, the dropped MV is remained in MV_PLAN_CACHE_PENDING.
+     * Without the fix, the dropped MV remains in MV_PLAN_CACHE_PENDING.
      */
     @Test
     public void testEvictRemovesMvFromPendingCache() throws Exception {
@@ -458,15 +458,17 @@ public class MaterializedViewTextBasedRewriteTest extends MaterializedViewTestBa
 
         starRocksAssert.withMaterializedView(createMvSql);
         MaterializedView mv = getMv(MATERIALIZED_DB_NAME, mvName);
-        mv.setActive();
+        try {
+            mv.setActive();
 
-        Assertions.assertTrue(CachingMvPlanContextBuilder.getInstance().isPending(mv),
-                "MV should be in pending after triggerLoadMVPlanCacheAsync with isReady=false");
+            Assertions.assertTrue(CachingMvPlanContextBuilder.getInstance().isPending(mv),
+                    "MV should be in pending after triggerLoadMVPlanCacheAsync with isReady=false");
+        } finally {
+            starRocksAssert.dropMaterializedView(mvName);
 
-        starRocksAssert.dropMaterializedView(mvName);
-
-        Assertions.assertFalse(CachingMvPlanContextBuilder.getInstance().isPending(mv),
-                "MV should be removed from pending after evictMaterializedViewCache");
+            Assertions.assertFalse(CachingMvPlanContextBuilder.getInstance().isPending(mv),
+                    "MV should be removed from pending after evictMaterializedViewCache");
+        }
     }
 
     /**
@@ -493,32 +495,79 @@ public class MaterializedViewTextBasedRewriteTest extends MaterializedViewTestBa
 
         starRocksAssert.withMaterializedView(createMvSql);
         MaterializedView mv = getMv(MATERIALIZED_DB_NAME, mvName);
-        mv.setActive();
+        try {
+            mv.setActive();
 
-        // MV should now be in pending.
-        Assertions.assertTrue(CachingMvPlanContextBuilder.getInstance().isPending(mv),
-                "MV should be in pending after triggerLoadMVPlanCacheAsync with isReady=false");
+            // MV should now be in pending.
+            Assertions.assertTrue(CachingMvPlanContextBuilder.getInstance().isPending(mv),
+                    "MV should be in pending after triggerLoadMVPlanCacheAsync with isReady=false");
+        } finally {
+            new MockUp<GlobalStateMgr>() {
+                @Mock
+                public boolean isReady() {
+                    return true;
+                }
+            };
+            starRocksAssert.dropMaterializedView(mvName);
 
+            // Simulate the racing condition: MV was dropped during replay, but its stale entry is still
+            // present in MV_PLAN_CACHE_PENDING
+            Map<Long, MaterializedView> pendingMap =
+                    Deencapsulation.getField(CachingMvPlanContextBuilder.getInstance(), "MV_PLAN_CACHE_PENDING");
+            pendingMap.put(mv.getId(), mv);
+
+            CachingMvPlanContextBuilder.getInstance().triggerPendingMVPlanCacheLoads();
+
+            Assertions.assertFalse(CachingMvPlanContextBuilder.getInstance().isPending(mv),
+                    "MV should be removed from pending after triggerPendingMVPlanCacheLoads");
+
+            Assertions.assertFalse(CachingMvPlanContextBuilder.getInstance().contains(mv),
+                    "MV should not be cached after triggerPendingMVPlanCacheLoads");
+        }
+    }
+
+    /**
+     * Normal path
+     *
+     * Scenario (mirrors replay order during FE startup when isReady=false):
+     *   1. MV is created  → mv set active → cacheMaterializedView() → triggerLoadMVPlanCacheAsync() → enters pending
+     *   2. After FE ready → triggerPendingMVPlanCacheLoads() must re-insert the MV
+     *
+     */
+    @Test
+    public void testEvictRemovesMvFromPendingCache3() throws Exception {
         new MockUp<GlobalStateMgr>() {
             @Mock
             public boolean isReady() {
-                return true;
+                return false;
             }
         };
-        starRocksAssert.dropMaterializedView(mvName);
+        String mvName = "test_mv_evict_pending";
+        String createMvSql = "create materialized view " + mvName + " distributed by random refresh manual " +
+                "as select user_id, time, sum(tag_id) from user_tags group by user_id, time";
 
-        // Simulate the racing condition: MV was dropped during replay, but its stale entry is still
-        // present in MV_PLAN_CACHE_PENDING
-        Map<Long, MaterializedView> pendingMap =
-                Deencapsulation.getField(CachingMvPlanContextBuilder.getInstance(), "MV_PLAN_CACHE_PENDING");
-        pendingMap.put(mv.getId(), mv);
+        starRocksAssert.withMaterializedView(createMvSql, name -> {
+            MaterializedView mv = getMv(MATERIALIZED_DB_NAME, mvName);
+            mv.setActive();
 
-        CachingMvPlanContextBuilder.getInstance().triggerPendingMVPlanCacheLoads();
+            // MV should now be in pending.
+            Assertions.assertTrue(CachingMvPlanContextBuilder.getInstance().isPending(mv),
+                    "MV should be in pending after triggerLoadMVPlanCacheAsync with isReady=false");
 
-        Assertions.assertFalse(CachingMvPlanContextBuilder.getInstance().isPending(mv),
-                "MV should be removed from pending after triggerPendingMVPlanCacheLoads");
+            new MockUp<GlobalStateMgr>() {
+                @Mock
+                public boolean isReady() {
+                    return true;
+                }
+            };
 
-        Assertions.assertFalse(CachingMvPlanContextBuilder.getInstance().contains(mv),
-                "MV should not be cached triggerPendingMVPlanCacheLoads");
+            CachingMvPlanContextBuilder.getInstance().triggerPendingMVPlanCacheLoads();
+
+            Assertions.assertFalse(CachingMvPlanContextBuilder.getInstance().isPending(mv),
+                    "MV should be removed from pending after triggerPendingMVPlanCacheLoads");
+
+            Assertions.assertTrue(CachingMvPlanContextBuilder.getInstance().contains(mv),
+                    "MV should be cached after triggerPendingMVPlanCacheLoads");
+        });
     }
 }


### PR DESCRIPTION
## Why I'm doing:

There are lots of `LakeTablet` object on FOLLOWER after frequently drop&create same materialized view.
And objects can't be releazed after fe transfers to LEADER.

```
 num     #instances         #bytes  class name (module)
-------------------------------------------------------
   1:      24469095     1080226352  [B (java.base@17.0.2)
   2:      13197226     1055778080  com.starrocks.lake.LakeTablet
```
## What I'm doing:

Removed dropped materialized view object from pending cache and double check materialized view still exists before be added to context cache.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
