### PR TITLE
[Refactor] Hide AUTO refresh mode from user surface

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -278,7 +278,11 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         }
 
         MaterializedView.RefreshMode finalCurrentRefreshMode = currentRefreshMode;
-        if (!tableProperty.getMvRefreshMode().equals(mvRefreshMode)) {
+        // Trigger applier when either the persisted property or the in-memory current mode
+        // would change. Comparing only the persisted string would miss cases where the two
+        // are out of sync (e.g. mode promoted internally without rewriting the property).
+        if (!tableProperty.getMvRefreshMode().equals(mvRefreshMode)
+                || materializedView.getCurrentRefreshMode() != finalCurrentRefreshMode) {
             appliers.add(() -> {
                 tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_MV_REFRESH_MODE, mvRefreshMode);
                 tableProperty.setMvRefreshMode(mvRefreshMode);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -102,7 +102,6 @@ import com.starrocks.type.Type;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang3.EnumUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -724,14 +723,18 @@ public class PropertyAnalyzer {
         String refreshMode = null;
         if (properties != null && properties.containsKey(PROPERTIES_MV_REFRESH_MODE)) {
             refreshMode = properties.get(PROPERTIES_MV_REFRESH_MODE);
+            MaterializedView.RefreshMode parsed;
             try {
-                MaterializedView.RefreshMode.valueOf(refreshMode.toUpperCase());
+                parsed = MaterializedView.RefreshMode.valueOf(refreshMode.toUpperCase());
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Invalid refresh_mode: " + refreshMode + ". Only " +
-                        EnumUtils.getEnumList(MaterializedView.RefreshMode.class).stream()
-                                .map(MaterializedView.RefreshMode::name)
-                                .collect(Collectors.joining(", ")) +
-                        " are supported.");
+                throw new IllegalArgumentException("Invalid refresh_mode: " + refreshMode +
+                        ". Only INCREMENTAL, PCT are supported.");
+            }
+            // AUTO is intentionally not exposed to users; the implementation is preserved
+            // internally for future revival.
+            if (parsed == MaterializedView.RefreshMode.AUTO) {
+                throw new IllegalArgumentException("Invalid refresh_mode: " + refreshMode +
+                        ". Only INCREMENTAL, PCT are supported.");
             }
             properties.remove(PROPERTIES_MV_REFRESH_MODE);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -341,9 +341,21 @@ public class IVMAnalyzer {
         }
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_MV_REFRESH_MODE)) {
             String mode = properties.get(PropertyAnalyzer.PROPERTIES_MV_REFRESH_MODE);
-            return MaterializedView.RefreshMode.valueOf(mode.toUpperCase());
+            MaterializedView.RefreshMode parsed;
+            try {
+                parsed = MaterializedView.RefreshMode.valueOf(mode.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new SemanticException("Invalid refresh_mode: " + mode +
+                        ". Only INCREMENTAL, PCT are supported.");
+            }
+            // AUTO is intentionally not exposed to users; the implementation is preserved
+            // internally for future revival.
+            if (parsed == MaterializedView.RefreshMode.AUTO) {
+                throw new SemanticException("Invalid refresh_mode: " + mode +
+                        ". Only INCREMENTAL, PCT are supported.");
+            }
+            return parsed;
         } else {
-            // Default to INCREMENTAL
             return MaterializedView.RefreshMode.PCT;
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewTest.java
@@ -60,11 +60,11 @@ public class AlterMaterializedViewTest extends MVTestBase {
             alterMaterializedView(alterStmt, false);
             Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
         }
-        // change refresh mode from incremental to auto
+        // change refresh mode from incremental to auto: rejected (AUTO is hidden from users)
         {
             String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
-            alterMaterializedView(alterStmt, false);
-            Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
         }
         // change refresh mode from auto to full
         {
@@ -106,17 +106,17 @@ public class AlterMaterializedViewTest extends MVTestBase {
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
         Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
 
-        // change refresh mode from auto to incremental
+        // alter incremental -> incremental: no-op success
         {
             String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"incremental\")";
             alterMaterializedView(alterStmt, false);
             Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
         }
-        // change refresh mode from incremental to auto
+        // alter incremental -> auto: rejected (AUTO is hidden from users)
         {
             String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
-            alterMaterializedView(alterStmt, false);
-            Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
         }
         // change refresh mode from auto to full
         {
@@ -288,6 +288,28 @@ public class AlterMaterializedViewTest extends MVTestBase {
             alterMaterializedView(alterStmt, false);
             Assertions.assertEquals(MaterializedView.RefreshMode.PCT, mv.getCurrentRefreshMode());
         }
+    }
+
+    @Test
+    public void testCreateMVWithAutoRefreshModeRejected() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW `auto_rejected_mv` REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\"refresh_mode\" = \"auto\") " +
+                "AS SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        Exception ex = Assertions.assertThrows(Exception.class,
+                () -> starRocksAssert.withMaterializedView(ddl));
+        Assertions.assertTrue(ex.getMessage().contains("refresh_mode"),
+                "expected refresh_mode error, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testAlterMVRefreshModeToAutoRejected() throws Exception {
+        String query = "SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+
+        String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
+        alterMaterializedView(alterStmt, true);
+        Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -318,28 +318,6 @@ public class RefreshMaterializedViewTest extends MVTestBase {
     }
 
     @Test
-    public void testAutoRefreshModeRejectsPartitionRefresh() throws Exception {
-        starRocksAssert.withMaterializedView("create materialized view test.mv_auto_to_refresh\n" +
-                "PARTITION BY k1\n" +
-                "distributed by hash(k2) buckets 3\n" +
-                "refresh manual\n" +
-                "properties (\n" +
-                "\"refresh_mode\" = \"auto\"\n" +
-                ")\n" +
-                "as select k1, k2, v1 from test.tbl_with_mv;");
-        try {
-            String sql = "REFRESH MATERIALIZED VIEW test.mv_auto_to_refresh " +
-                    "PARTITION START('2022-02-03') END ('2022-02-25') FORCE;";
-            Exception e = Assertions.assertThrows(Exception.class,
-                    () -> UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
-            Assertions.assertTrue(e.getMessage().contains(
-                    "Partition refresh is not supported for materialized views with refresh_mode=AUTO."));
-        } finally {
-            starRocksAssert.dropMaterializedView("test.mv_auto_to_refresh");
-        }
-    }
-
-    @Test
     public void testIncrementalRefreshModeRejectsPartitionRefresh() throws Exception {
         ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
         starRocksAssert.withMaterializedView("create materialized view test.mv_incremental_to_refresh\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -886,6 +886,36 @@ public abstract class MVTestBase extends StarRocksTestBase {
             String refreshMode,
             String partitionBy,
             Map<String, String> extraProperties) throws Exception {
+        // AUTO is rejected at the user-input boundary. Test-only bypass: substitute INCREMENTAL
+        // through the SQL path (which exercises the IVMAnalyzer the same way), then promote
+        // currentRefreshMode to AUTO. If the query is not IVM-eligible, INCREMENTAL throws;
+        // fall back to PCT, mirroring AUTO's real create-time fallback.
+        boolean wantAuto = "auto".equalsIgnoreCase(refreshMode);
+        String effectiveMode = wantAuto ? "incremental" : refreshMode;
+
+        MaterializedView mv;
+        try {
+            mv = createMaterializedViewViaSql(query, effectiveMode, partitionBy, extraProperties);
+        } catch (Exception e) {
+            if (!wantAuto) {
+                throw e;
+            }
+            mv = createMaterializedViewViaSql(query, "pct", partitionBy, extraProperties);
+        }
+        if (wantAuto && mv.getCurrentRefreshMode() == MaterializedView.RefreshMode.INCREMENTAL) {
+            mv.setCurrentRefreshMode(MaterializedView.RefreshMode.AUTO);
+            // Persisted refresh_mode property remains "incremental" so DDL regeneration during
+            // ALTER ACTIVE does not feed "auto" back through IVMAnalyzer (which now rejects it).
+            // The in-memory currentRefreshMode is what drives processor selection.
+        }
+        return mv;
+    }
+
+    private MaterializedView createMaterializedViewViaSql(
+            String query,
+            String refreshMode,
+            String partitionBy,
+            Map<String, String> extraProperties) throws Exception {
         StringBuilder ddl = new StringBuilder();
         ddl.append("CREATE MATERIALIZED VIEW `test_mv1` ");
         if (partitionBy != null) {

--- a/test/lib/skip.py
+++ b/test/lib/skip.py
@@ -69,4 +69,9 @@ skip_res_cmd = [
 skip_files = set([
     'test_window_skew_rewrite_with_mcv',
     # 'test_parquet_dict_null_predicate'
+    # refresh_mode=auto is not exposed to users; these tests exercise the AUTO path via
+    # SQL and are kept on disk for future revival when AUTO is re-introduced.
+    'test_ivm_with_iceberg_auto',
+    'test_ivm_with_iceberg_delete',
+    'test_ivm_with_iceberg_expire_snapshots',
 ])


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
AUTO is intentionally not exposed to users; the implementation is preserved internally and will be revived in a later phase. This change rejects user-facing input of refresh_mode = "auto" on both CREATE and ALTER paths, while leaving the internal AUTO machinery (RefreshMode.AUTO enum, MVHybridRefreshProcessor, etc.) fully intact.

Production:
- IVMAnalyzer.getRefreshMode (CREATE path): reject "auto" with a clear SemanticException. Tighten error reporting for any invalid refresh_mode value.
- PropertyAnalyzer.analyzeRefreshMode (ALTER path): reject "auto" with the same message. Update the error to list only the supported values (INCREMENTAL, PCT) instead of the full enum.
- AlterMVJobExecutor.alterMVRefreshMode: idempotency check now also considers the in-memory currentRefreshMode, not just the persisted property. Without this, an ALTER could no-op when the two are out of sync, leaving the in-memory mode stale.

Tests:
- MVTestBase.createMaterializedViewWithRefreshMode: add a test-only bypass for "auto" — create through the SQL path with INCREMENTAL (which exercises the IVMAnalyzer the same way), then promote the in-memory currentRefreshMode to AUTO. If the query is not IVM-eligible, fall back to PCT, mirroring real AUTO behavior. The persisted property remains "incremental" so DDL regeneration during ALTER ACTIVE does not feed "auto" back through the analyzer.
- Update unit tests where ALTER to "auto" was expected to succeed; they now expect failure with the mode unchanged.
- Add explicit rejection tests for CREATE and ALTER.
- Skip 3 SQL integration tests that exercise AUTO end-to-end through SQL (test_ivm_with_iceberg_{auto,delete,expire_snapshots}). Files remain on disk so they can be revived when AUTO ships in a later phase.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
