### PR TITLE
[UT] Stabilize StructCastTest against sqlMode contamination

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructCastTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructCastTest.java
@@ -25,13 +25,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class StructCastTest extends PlanTestBase {
     @Test
     public void testPositionCast() throws Exception {
-        String sql;
-        String plan;
+        final ConnectContext context = ConnectContext.get();
+        final SessionVariable sv = context.getSessionVariable();
+        final long prev = sv.getSqlMode();
+        try {
+            sv.setSqlMode(prev & ~SqlModeHelper.MODE_STRUCT_CAST_BY_NAME);
 
-        sql = "select cast(named_struct('key',1,'value',1) as struct<key1 int,value1 int>)";
-        plan = getFragmentPlan(sql);
+            String sql = "select cast(named_struct('key',1,'value',1) as struct<key1 int,value1 int>)";
+            String plan = getFragmentPlan(sql);
 
-        assertContains(plan, "CAST(named_struct('key', 1, 'value', 1) AS struct<`key1` int(11), `value1` int(11)>)");
+            assertContains(plan,
+                    "CAST(named_struct('key', 1, 'value', 1) AS struct<`key1` int(11), `value1` int(11)>)");
+        } finally {
+            sv.setSqlMode(prev);
+        }
     }
 
     @Test
@@ -40,22 +47,18 @@ public class StructCastTest extends PlanTestBase {
         final SessionVariable sv = context.getSessionVariable();
         final long prev = sv.getSqlMode();
         try {
-            sv.setSqlMode(SqlModeHelper.MODE_STRUCT_CAST_BY_NAME);
+            sv.setSqlMode(prev | SqlModeHelper.MODE_STRUCT_CAST_BY_NAME);
 
             assertThrows(SemanticException.class, () -> {
                 String sql = "select cast(named_struct('key',1,'value',1) as struct<key1 int,value1 int>)";
                 getFragmentPlan(sql);
             });
 
-            String sql;
-            String plan;
-            sql = "select cast(named_struct('k',1,'v',1) as struct<v int,`k` int>)";
-            plan = getFragmentPlan(sql);
+            String sql = "select cast(named_struct('k',1,'v',1) as struct<v int,`k` int>)";
+            String plan = getFragmentPlan(sql);
             assertContains(plan, "CAST(named_struct('k', 1, 'v', 1) AS struct<`v` int(11), `k` int(11)>)");
-
         } finally {
             sv.setSqlMode(prev);
-
         }
     }
 


### PR DESCRIPTION

## Why I'm doing:

The shared static ConnectContext in PlanTestBase makes both tests sensitive to sqlMode bits leaked from other tests:

- testPositionCast assumed MODE_STRUCT_CAST_BY_NAME was unset, so when another test left it on the cast resolved by name and threw SemanticException.
- testNamedCast called setSqlMode(MODE_STRUCT_CAST_BY_NAME), overwriting every other mode bit instead of OR-ing the flag.

Save and restore sqlMode in both tests, clearing only the relevant bit in testPositionCast and OR-ing it in testNamedCast.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
