### PR TITLE
[BugFix] clip tablet_range edges and anchor per-rowset stats to parent totals on tablet split

### DIFF
--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -15,11 +15,131 @@
 #include "storage/lake/tablet_reshard_helper.h"
 
 #include <algorithm>
+#include <numeric>
 
+#include "common/logging.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/tablet_range.h"
 
 namespace starrocks::lake::tablet_reshard_helper {
+
+void allocate_proportionally(int64_t total, const std::vector<int64_t>& weights, std::vector<int64_t>* out) {
+    DCHECK(out != nullptr);
+    DCHECK_GE(total, 0);
+    DCHECK_EQ(weights.size(), out->size());
+    DCHECK(!weights.empty());
+    for (auto w : weights) DCHECK_GE(w, 0);
+
+    const size_t n = weights.size();
+
+    if (total == 0) {
+        std::fill(out->begin(), out->end(), 0);
+        return;
+    }
+
+    __int128 sum_w = 0;
+    for (auto w : weights) sum_w += static_cast<__int128>(w);
+
+    // All-zero weights with non-zero total: deterministic uniform fallback.
+    // Allocate floor(total/N) to each, +1 to the lowest indices to absorb the
+    // remainder. Preserves Σ exactly without stranding any of the total.
+    if (sum_w == 0) {
+        const int64_t base = total / static_cast<int64_t>(n);
+        const int64_t leftover = total - base * static_cast<int64_t>(n);
+        for (size_t i = 0; i < n; ++i) {
+            (*out)[i] = base + (static_cast<int64_t>(i) < leftover ? 1 : 0);
+        }
+        return;
+    }
+
+    // Largest-remainder method. base[i] = floor(total * w[i] / sum_w);
+    // remainder[i] = (total * w[i]) mod sum_w. The total minus Σ base[i]
+    // is the leftover (always in [0, n)) and is distributed +1 each to the
+    // entries with the largest fractional remainders, breaking ties by
+    // ascending index for determinism.
+    //
+    // remainder is stored as __int128 because rem can be in [0, sum_w) and
+    // sum_w may itself exceed INT64_MAX when there are many large weights;
+    // truncating to int64_t there would corrupt the largest-remainder ordering.
+    // numerator and base also stay in __int128: numerator = total * weights[i]
+    // ≤ INT64_MAX * INT64_MAX ≈ 8.5e37, well within __int128's ~1.7e38 limit.
+    std::vector<__int128> remainders(n, 0);
+    int64_t sum_base = 0;
+    for (size_t i = 0; i < n; ++i) {
+        if (weights[i] == 0) {
+            (*out)[i] = 0;
+            remainders[i] = 0;
+            continue;
+        }
+        const __int128 numerator = static_cast<__int128>(total) * static_cast<__int128>(weights[i]);
+        const __int128 base = numerator / sum_w;
+        const __int128 rem = numerator - base * sum_w;
+        (*out)[i] = static_cast<int64_t>(base);
+        remainders[i] = rem;
+        sum_base += static_cast<int64_t>(base);
+    }
+    int64_t leftover = total - sum_base;
+
+    if (leftover > 0) {
+        std::vector<size_t> order(n);
+        std::iota(order.begin(), order.end(), 0);
+        std::sort(order.begin(), order.end(), [&](size_t a, size_t b) {
+            if (remainders[a] != remainders[b]) return remainders[a] > remainders[b];
+            return a < b;
+        });
+        for (size_t k = 0; k < n && leftover > 0; ++k, --leftover) {
+            (*out)[order[k]]++;
+        }
+    }
+
+#ifndef NDEBUG
+    int64_t actual_sum = 0;
+    for (auto v : *out) actual_sum += v;
+    DCHECK_EQ(actual_sum, total);
+#endif
+}
+
+void cap_and_redistribute_dels(const std::vector<int64_t>& rows, std::vector<int64_t>* dels) {
+    DCHECK(dels != nullptr);
+    DCHECK_EQ(rows.size(), dels->size());
+    for (auto r : rows) DCHECK_GE(r, 0);
+    for (auto d : *dels) DCHECK_GE(d, 0);
+
+    const size_t n = rows.size();
+
+    // Cap each (*dels)[i] to rows[i]; accumulate the over-cap mass as overflow.
+    int64_t overflow = 0;
+    for (size_t i = 0; i < n; ++i) {
+        if ((*dels)[i] > rows[i]) {
+            overflow += (*dels)[i] - rows[i];
+            (*dels)[i] = rows[i];
+        }
+    }
+    if (overflow == 0) return;
+
+    // Redistribute overflow to buckets with headroom, ordered by
+    // (headroom desc, index asc) for deterministic output.
+    std::vector<size_t> order(n);
+    std::iota(order.begin(), order.end(), 0);
+    std::sort(order.begin(), order.end(), [&](size_t a, size_t b) {
+        const int64_t ha = rows[a] - (*dels)[a];
+        const int64_t hb = rows[b] - (*dels)[b];
+        if (ha != hb) return ha > hb;
+        return a < b;
+    });
+    for (size_t idx : order) {
+        if (overflow <= 0) break;
+        const int64_t headroom = rows[idx] - (*dels)[idx];
+        if (headroom <= 0) break; // remaining are zero-headroom under desc sort
+        const int64_t take = std::min(headroom, overflow);
+        (*dels)[idx] += take;
+        overflow -= take;
+    }
+    // overflow > 0 here only if the input violated the feasibility precondition
+    // (Σ pre-cap dels > Σ rows). The post-condition becomes Σ dels == Σ rows
+    // (the maximum feasible) with per-bucket cap honored, matching the
+    // best-effort contract in tablet_reshard_helper.h.
+}
 
 void set_all_data_files_shared(RowsetMetadataPB* rowset_metadata) {
     auto* shared_segments = rowset_metadata->mutable_shared_segments();

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -57,5 +58,52 @@ void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t s
 // collisions are not expected in practice. Matches the no-dedup style of
 // transactions.cpp::collect_files_in_log.
 std::vector<std::string> collect_compaction_output_file_paths(const TxnLogPB& txn_log, TabletManager* tablet_manager);
+
+// Allocate `total` across `out->size()` buckets in proportion to
+// weights[i] / Σweights using the largest-remainder (Hare-Niemeyer) method,
+// preserving Σ result == total exactly.
+//
+// Tie-break for equal fractional remainders is deterministic:
+// (remainder desc, index asc) — reproducible across machines and runs.
+//
+// Preconditions (DCHECK in debug):
+//   - out != nullptr
+//   - total >= 0
+//   - weights.size() == out->size() and >= 1
+//   - all weights[i] >= 0
+//   - `weights` and `*out` must NOT alias
+//
+// Postcondition (DCHECK in debug):
+//   - Σ (*out)[i] == total
+//
+// Degenerate inputs:
+//   - total == 0: all zeros.
+//   - total > 0 and Σweights == 0: deterministic uniform fallback —
+//     floor(total/N) to each, +1 to the lowest indices to absorb the
+//     remainder. Preserves Σ exactly.
+//
+// Used by per-rowset stat anchoring during tablet split (see
+// `tablet_splitter.cpp`'s `apply_rowset_anchor`). The future
+// cross-publish (P2) refactor of `update_txn_log_data_stats` is expected
+// to reuse this helper for sibling-wide range-aware allocation.
+void allocate_proportionally(int64_t total, const std::vector<int64_t>& weights, std::vector<int64_t>* out);
+
+// Given per-bucket row counts and a pre-allocated per-bucket num_dels vector,
+// cap each (*dels)[i] to rows[i] and redistribute the overflow to buckets
+// with headroom (rows[i] - dels[i] > 0) using (headroom desc, index asc) as
+// the deterministic redistribution order.
+//
+// Contract:
+//   If Σ dels (pre-cap) ≤ Σ rows, post-call Σ dels == Σ dels (pre-cap)
+//   exactly and (*dels)[i] ≤ rows[i] for every i.
+//   If Σ dels (pre-cap) > Σ rows (caller failed to clamp), post-call
+//   Σ dels == Σ rows (the maximum feasible) and per-bucket cap still holds.
+//
+// Preconditions (DCHECK in debug):
+//   - dels != nullptr
+//   - rows.size() == dels->size()
+//   - rows[i] >= 0 for all i
+//   - (*dels)[i] >= 0 for all i
+void cap_and_redistribute_dels(const std::vector<int64_t>& rows, std::vector<int64_t>* dels);
 
 } // namespace starrocks::lake::tablet_reshard_helper

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -200,6 +200,22 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
             ordered_boundaries.insert(&sample);
         }
     }
+    // Insert tablet_range bounds so any ordered_range that previously straddled a
+    // tablet_range edge is split exactly at that edge. Without this, a shared
+    // segment whose physical key range extends past the tablet's range (a tablet
+    // that has been split before still sees the full physical extent of its
+    // shared rowsets) can leak its out-of-range data into the per-split
+    // estimates: the candidate filter only excludes ranges that don't overlap at
+    // all, so a partial-crossing range is kept whole and its full data_size /
+    // num_rows is summed into one of the new splits.
+    if (tablet_range != nullptr) {
+        if (!tablet_range->is_minimum()) {
+            ordered_boundaries.insert(&tablet_range->lower_bound());
+        }
+        if (!tablet_range->is_maximum()) {
+            ordered_boundaries.insert(&tablet_range->upper_bound());
+        }
+    }
 
     if (ordered_boundaries.size() < 2) {
         return result;
@@ -229,13 +245,57 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
 
     // Step 4: Calculate split boundaries using a greedy algorithm.
     // If tablet_range is provided, only consider ranges that overlap with it.
+    //
+    // The overlap predicate mirrors find_overlapping_ranges' last-range
+    // semantics: every ordered_range except the last is the half-open interval
+    // [min, max); the last range is the closed interval [min, max]. The check
+    // also has to honor TabletRange's lower / upper inclusion flags (a child
+    // produced by split has lower_bound_included=true and upper_bound_included
+    // =false, so e.g. a range whose r.max == tablet_range.lower_bound is
+    // entirely below the tablet — TabletRange::greater_than alone misses this
+    // case because it returns false when the lower bound is included).
+    //
+    // Precondition assumed by the production caller (split_tablet): tablet
+    // ranges follow the [lower, upper) shape — `upper_bound_excluded` is the
+    // convention written by `get_tablet_split_ranges` (lower_bound_included
+    // = true, upper_bound_included = false; see the per-split range
+    // construction below). The corner case `r.min == tablet.upper_bound` with
+    // `upper_bound_included` would represent a singleton overlap that the
+    // ordered_range model cannot allocate precisely (a non-last
+    // ordered_range covers [r.min, r.max), so it would consume more than the
+    // single key). For an inclusive upper bound we still mark such an r as
+    // overlapping (best-effort), but the caller must rely on the half-open
+    // convention to avoid silent over-counting.
+    const size_t last_range_index = ordered_ranges.size() - 1;
+    auto range_overlaps_tablet = [&](const RangeInfo& r, size_t idx) -> bool {
+        if (tablet_range == nullptr) return true;
+        if (!tablet_range->is_minimum()) {
+            const int cmp = r.max.compare(tablet_range->lower_bound());
+            if (idx == last_range_index) {
+                // r covers [r.min, r.max]: entirely below iff r.max is strictly
+                // less than the smallest key in tablet_range.
+                if (cmp < 0) return false;
+                if (cmp == 0 && tablet_range->lower_bound_excluded()) return false;
+            } else {
+                // r covers [r.min, r.max): entirely below iff r.max is at or
+                // below the smallest key in tablet_range.
+                if (cmp <= 0) return false;
+            }
+        }
+        if (!tablet_range->is_maximum()) {
+            const int cmp = r.min.compare(tablet_range->upper_bound());
+            if (cmp > 0) return false;
+            if (cmp == 0 && tablet_range->upper_bound_excluded()) return false;
+        }
+        return true;
+    };
     std::vector<const RangeInfo*> candidate_ranges;
     candidate_ranges.reserve(ordered_ranges.size());
-    for (const auto& r : ordered_ranges) {
-        if (tablet_range != nullptr && (tablet_range->less_than(r.min) || tablet_range->greater_than(r.max))) {
+    for (size_t i = 0; i < ordered_ranges.size(); ++i) {
+        if (!range_overlaps_tablet(ordered_ranges[i], i)) {
             continue;
         }
-        candidate_ranges.push_back(&r);
+        candidate_ranges.push_back(&ordered_ranges[i]);
     }
 
     int32_t actual_split_count = std::min(target_split_count, static_cast<int32_t>(candidate_ranges.size()));
@@ -368,61 +428,117 @@ struct TabletRangeInfo {
     std::unordered_map<uint32_t, Statistic> rowset_stats;
 };
 
-// Split the parent rowset's total_num_dels across the split groups proportional to
-// each group's share of the rowset's rows, using the Hare-Niemeyer (largest-remainder)
-// method. Writes the result into TabletRangeInfo.rowset_stats[source_id].num_dels.
-// Guarantees the sum of allocated values equals total_num_dels when at least one
-// group has rows for this source.
-//
-// Each split child keeps the same shared segment files and inherits the parent's
-// delvec cardinality, so without this proportional estimate get_tablet_stats would
-// subtract the full parent num_dels from each child's partial num_rows and collapse
-// the partition's live-row count (see lake_service.cpp:1166).
-void allocate_rowset_num_dels_across_splits(uint32_t source_id, int64_t total_num_dels,
-                                            std::vector<TabletRangeInfo>* split_ranges) {
-    if (total_num_dels <= 0 || split_ranges == nullptr || split_ranges->empty()) {
-        return;
-    }
+// Per-rowset anchor totals taken from the parent's recorded metadata. Used to
+// renormalize per-split-group estimates so Σ children equals parent exactly,
+// preserving stat conservation across re-splits regardless of how the
+// underlying segment-distribution model approximates straddling sub-segments.
+struct RowsetAnchor {
+    int64_t num_rows = 0;
+    int64_t data_size = 0;
+    int64_t num_dels = 0;
+};
 
-    int64_t total_rows = 0;
-    for (auto& split_range : *split_ranges) {
-        auto it = split_range.rowset_stats.find(source_id);
-        if (it != split_range.rowset_stats.end()) {
-            total_rows += it->second.num_rows;
+// Build the per-rowset anchor map from the parent tablet metadata. For PK
+// tablets without a populated num_dels field on the rowset (legacy
+// metadata), derive num_dels from the delvec — same fallback as the
+// pre-anchor code path. If a rowset reports num_dels > num_rows
+// (pathological metadata), clamp up front with a WARNING; the
+// cap-and-redistribute contract assumes parent.num_dels <= parent.num_rows.
+std::unordered_map<uint32_t, RowsetAnchor> build_rowset_anchor(const TabletMetadataPB& metadata,
+                                                               TabletManager* tablet_manager) {
+    std::unordered_map<uint32_t, RowsetAnchor> anchor;
+    anchor.reserve(metadata.rowsets_size());
+    const bool pk = is_primary_key(metadata);
+    for (const auto& rowset : metadata.rowsets()) {
+        RowsetAnchor a;
+        // Anchor totals: prefer the rowset-level fields. When legacy /
+        // incomplete metadata omits them, fall back to summing the
+        // segment-level fields. Without this fallback, anchor=0 collapses
+        // every child's stat to 0 even though segment metadata still
+        // carries real values — the pre-anchor path implicitly used the
+        // segment-derived numbers via range_source_stats, so we preserve
+        // that property explicitly here.
+        if (rowset.has_num_rows()) {
+            a.num_rows = rowset.num_rows();
+        } else {
+            for (const auto& sm : rowset.segment_metas()) {
+                a.num_rows += sm.num_rows();
+            }
         }
+        if (rowset.has_data_size()) {
+            a.data_size = rowset.data_size();
+        } else {
+            for (int i = 0; i < rowset.segment_size_size(); ++i) {
+                a.data_size += rowset.segment_size(i);
+            }
+        }
+        if (rowset.has_num_dels()) {
+            a.num_dels = rowset.num_dels();
+        } else if (pk && tablet_manager != nullptr) {
+            // Legacy fallback: derive num_dels from the delvec. Costs one
+            // delvec read per rowset, acceptable on the one-shot split path.
+            a.num_dels = static_cast<int64_t>(tablet_manager->update_mgr()->get_rowset_num_deletes(metadata, rowset));
+        }
+        if (a.num_dels > a.num_rows) {
+            LOG(WARNING) << "rowset id=" << rowset.id() << " has num_dels=" << a.num_dels
+                         << " > num_rows=" << a.num_rows << "; clamping for split allocation";
+            a.num_dels = a.num_rows;
+        }
+        anchor.emplace(rowset.id(), a);
     }
-    if (total_rows <= 0) {
-        return;
-    }
+    return anchor;
+}
 
-    std::vector<int64_t> allocated(split_ranges->size(), 0);
-    std::vector<std::pair<int64_t, size_t>> fractional_remainders;
-    fractional_remainders.reserve(split_ranges->size());
-    int64_t sum_allocated = 0;
-    for (size_t i = 0; i < split_ranges->size(); ++i) {
-        auto it = (*split_ranges)[i].rowset_stats.find(source_id);
-        if (it == (*split_ranges)[i].rowset_stats.end() || it->second.num_rows <= 0) continue;
-        // Use 128-bit intermediate: both operands can realistically reach 1e10 on very
-        // large rowsets, whose product overflows int64_t. base fits because it is
-        // bounded by total_num_dels; fractional_remainder fits because it is < total_rows.
-        __int128 numerator = static_cast<__int128>(total_num_dels) * static_cast<__int128>(it->second.num_rows);
-        int64_t base = static_cast<int64_t>(numerator / total_rows);
-        int64_t fractional_remainder = static_cast<int64_t>(numerator % total_rows);
-        allocated[i] = base;
-        sum_allocated += base;
-        fractional_remainders.emplace_back(fractional_remainder, i);
-    }
+// Anchor each split group's per-rowset stats to the parent's recorded totals
+// using the Hare-Niemeyer helper. Σ children stat == parent stat exactly for
+// num_rows, data_size, and num_dels per rowset (modulo cap-and-redistribute
+// for invalid parents — see tablet_reshard_helper.h contracts).
+//
+// Replaces the pre-anchor flow which wrote per-source weights raw into
+// rowset_stats and ran a separate num_dels Hare-Niemeyer pass after.
+void apply_rowset_anchor(const std::unordered_map<uint32_t, RowsetAnchor>& anchor, const RangeSplitResult& split_result,
+                         std::vector<TabletRangeInfo>* split_ranges) {
+    DCHECK(split_ranges != nullptr);
+    const int64_t num_splits = static_cast<int64_t>(split_ranges->size());
+    if (num_splits == 0) return;
 
-    std::sort(fractional_remainders.begin(), fractional_remainders.end(),
-              [](const auto& a, const auto& b) { return a.first > b.first; });
-    int64_t leftover = total_num_dels - sum_allocated;
-    for (size_t k = 0; k < fractional_remainders.size() && leftover > 0; ++k, --leftover) {
-        allocated[fractional_remainders[k].second]++;
-    }
+    for (const auto& [source_id, ra] : anchor) {
+        // Gather per-group weights for this source. Missing entries
+        // contribute weight 0; zero-weight buckets receive zero allocation
+        // (or share the uniform fallback when every weight is zero).
+        std::vector<int64_t> rows_w(num_splits, 0);
+        std::vector<int64_t> bytes_w(num_splits, 0);
+        for (int64_t g = 0; g < num_splits; ++g) {
+            if (g >= static_cast<int64_t>(split_result.range_source_stats.size())) break;
+            auto it = split_result.range_source_stats[g].find(source_id);
+            if (it != split_result.range_source_stats[g].end()) {
+                rows_w[g] = it->second.first;
+                bytes_w[g] = it->second.second;
+            }
+        }
 
-    for (size_t i = 0; i < split_ranges->size(); ++i) {
-        if (allocated[i] > 0) {
-            (*split_ranges)[i].rowset_stats[source_id].num_dels = allocated[i];
+        std::vector<int64_t> rows_alloc(num_splits, 0);
+        std::vector<int64_t> bytes_alloc(num_splits, 0);
+        std::vector<int64_t> dels_alloc(num_splits, 0);
+        tablet_reshard_helper::allocate_proportionally(ra.num_rows, rows_w, &rows_alloc);
+        tablet_reshard_helper::allocate_proportionally(ra.data_size, bytes_w, &bytes_alloc);
+        // num_dels follows the row distribution: deletes are per-row, not
+        // per-byte, so byte weights would skew the split when row and byte
+        // distributions disagree (e.g. compressed columns).
+        tablet_reshard_helper::allocate_proportionally(ra.num_dels, rows_w, &dels_alloc);
+        tablet_reshard_helper::cap_and_redistribute_dels(rows_alloc, &dels_alloc);
+
+        for (int64_t g = 0; g < num_splits; ++g) {
+            // Skip writes that would create an empty entry — keeps the
+            // rowset_stats map sparse, identical to the pre-anchor behavior
+            // for sources with no representation in the group.
+            if (rows_alloc[g] == 0 && bytes_alloc[g] == 0 && dels_alloc[g] == 0) {
+                continue;
+            }
+            auto& dst = (*split_ranges)[g].rowset_stats[source_id];
+            dst.num_rows = rows_alloc[g];
+            dst.data_size = bytes_alloc[g];
+            dst.num_dels = dels_alloc[g];
         }
     }
 }
@@ -511,14 +627,6 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
                 sr.range.clear_upper_bound_included();
             }
         }
-
-        if (i < static_cast<int32_t>(split_result.range_source_stats.size())) {
-            for (const auto& [source_id, stats_pair] : split_result.range_source_stats[i]) {
-                auto& rowset_stat = sr.rowset_stats[source_id];
-                rowset_stat.num_rows = stats_pair.first;
-                rowset_stat.data_size = stats_pair.second;
-            }
-        }
     }
 
     if (split_ranges->size() != static_cast<size_t>(split_count)) {
@@ -531,22 +639,16 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
                 fmt::format("Insufficient split boundaries: requested {}, produced {}", split_count, produced));
     }
 
-    // Only PK tablets maintain delete vectors; duplicate/aggregate keys never populate
-    // num_dels so there is nothing to scale.
-    if (is_primary_key(*tablet_metadata)) {
-        for (const auto& rowset : tablet_metadata->rowsets()) {
-            int64_t total_num_dels = 0;
-            if (rowset.has_num_dels()) {
-                total_num_dels = rowset.num_dels();
-            } else if (tablet_manager != nullptr) {
-                // Legacy metadata without num_dels: derive from the delvec. This costs
-                // one delvec read per rowset, acceptable on the one-shot split path.
-                total_num_dels = static_cast<int64_t>(
-                        tablet_manager->update_mgr()->get_rowset_num_deletes(*tablet_metadata, rowset));
-            }
-            allocate_rowset_num_dels_across_splits(rowset.id(), total_num_dels, split_ranges);
-        }
-    }
+    // Anchor per-split per-rowset stats to the parent's recorded totals so
+    // that Σ children stat == parent stat exactly for num_rows / data_size /
+    // num_dels. The segment-level distribution from
+    // calculate_range_split_boundaries is used as relative weights only;
+    // absolute values come from the parent metadata. This eliminates the
+    // residual drift seen across multi-level splits when the algorithm
+    // re-runs on the same physical segments under a different
+    // ordered_boundaries set.
+    auto anchor = build_rowset_anchor(*tablet_metadata, tablet_manager);
+    apply_rowset_anchor(anchor, split_result, split_ranges);
 
     return Status::OK();
 }
@@ -617,6 +719,10 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
             RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_range(&rowset_metadata, split_ranges[i].range));
             const auto it = split_ranges[i].rowset_stats.find(rowset_metadata.id());
             if (it != split_ranges[i].rowset_stats.end()) {
+                // apply_rowset_anchor + cap_and_redistribute_dels guarantee
+                // num_dels <= num_rows for every (rowset, child). The std::min
+                // below is defense-in-depth against an upstream regression.
+                DCHECK_LE(it->second.num_dels, it->second.num_rows);
                 int64_t scaled_num_dels = std::min<int64_t>(it->second.num_dels, it->second.num_rows);
                 rowset_metadata.set_num_rows(it->second.num_rows);
                 rowset_metadata.set_data_size(it->second.data_size);

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -17,11 +17,178 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <numeric>
+#include <random>
+
 namespace starrocks::lake {
 
 using namespace tablet_reshard_helper;
 
 class TabletReshardHelperTest : public ::testing::Test {};
+
+namespace {
+
+int64_t sum_of(const std::vector<int64_t>& v) {
+    return std::accumulate(v.begin(), v.end(), int64_t{0});
+}
+
+} // namespace
+
+// -----------------------------------------------------------------------------
+// Proportional anchor helpers. allocate_proportionally and
+// cap_and_redistribute_dels back the per-rowset anchor pass in
+// tablet_splitter (split_tablet → get_tablet_split_ranges → apply_rowset_anchor)
+// so re-splits preserve `Σ children == parent` exactly. End-to-end conservation
+// under split is covered by LakeTabletReshardTest in tablet_reshard_test.cpp.
+// -----------------------------------------------------------------------------
+
+TEST_F(TabletReshardHelperTest, allocate_proportionally_basic_conservation) {
+    std::vector<int64_t> out(3, 0);
+    allocate_proportionally(/*total=*/12, /*weights=*/{1, 2, 3}, &out);
+    EXPECT_EQ(12, sum_of(out));
+    EXPECT_EQ((std::vector<int64_t>{2, 4, 6}), out);
+}
+
+TEST_F(TabletReshardHelperTest, allocate_proportionally_largest_remainder) {
+    // total=10, weights=[1,1,1] → base=3 each, leftover=1 → first index gets +1.
+    std::vector<int64_t> out(3, 0);
+    allocate_proportionally(/*total=*/10, /*weights=*/{1, 1, 1}, &out);
+    EXPECT_EQ(10, sum_of(out));
+    EXPECT_EQ((std::vector<int64_t>{4, 3, 3}), out);
+}
+
+TEST_F(TabletReshardHelperTest, allocate_proportionally_tiebreak_deterministic) {
+    // Equal weights and tied remainders fall to the lowest indices. Run twice
+    // and compare to confirm reproducibility.
+    std::vector<int64_t> a(5, 0), b(5, 0);
+    allocate_proportionally(7, {1, 1, 1, 1, 1}, &a);
+    allocate_proportionally(7, {1, 1, 1, 1, 1}, &b);
+    EXPECT_EQ(7, sum_of(a));
+    EXPECT_EQ((std::vector<int64_t>{2, 2, 1, 1, 1}), a);
+    EXPECT_EQ(a, b);
+}
+
+TEST_F(TabletReshardHelperTest, allocate_proportionally_zero_total) {
+    std::vector<int64_t> out(4, 99);
+    allocate_proportionally(0, {3, 5, 7, 9}, &out);
+    EXPECT_EQ((std::vector<int64_t>{0, 0, 0, 0}), out);
+}
+
+TEST_F(TabletReshardHelperTest, allocate_proportionally_zero_weights_uniform_fallback) {
+    std::vector<int64_t> out(3, 0);
+    allocate_proportionally(10, {0, 0, 0}, &out);
+    EXPECT_EQ(10, sum_of(out));
+    // floor(10/3)=3 each, remainder 1 → first index gets +1.
+    EXPECT_EQ((std::vector<int64_t>{4, 3, 3}), out);
+}
+
+TEST_F(TabletReshardHelperTest, allocate_proportionally_overflow_safe_at_extreme_scale) {
+    // total * weight overflows int64 without __int128 (1e10 * 1e10 = 1e20).
+    constexpr int64_t kTotal = 10'000'000'000LL;
+    std::vector<int64_t> weights{kTotal, kTotal};
+    std::vector<int64_t> out(2, 0);
+    allocate_proportionally(kTotal, weights, &out);
+    EXPECT_EQ(kTotal, sum_of(out));
+    EXPECT_EQ(kTotal / 2, out[0]);
+    EXPECT_EQ(kTotal / 2, out[1]);
+}
+
+// Regression: when Σ weights overflows int64_t (each weight ≈ INT64_MAX/2 + 1,
+// sum > INT64_MAX), the largest-remainder routine must keep remainders in
+// __int128 — truncating to int64_t there would corrupt the tie-break order.
+// Hare-Niemeyer for two equal weights and an even total still gives an even
+// split; the test asserts both Σ conservation and the deterministic
+// per-bucket value.
+TEST_F(TabletReshardHelperTest, allocate_proportionally_handles_sum_weights_above_int64_max) {
+    constexpr int64_t kHalfPlus = (std::numeric_limits<int64_t>::max() / 2) + 1;
+    // 2 * kHalfPlus exceeds INT64_MAX (overflows in int64), but sum_w stays
+    // safe in __int128.
+    std::vector<int64_t> weights{kHalfPlus, kHalfPlus};
+    std::vector<int64_t> out(2, 0);
+    allocate_proportionally(/*total=*/100, weights, &out);
+    EXPECT_EQ(100, sum_of(out));
+    EXPECT_EQ(50, out[0]);
+    EXPECT_EQ(50, out[1]);
+}
+
+TEST_F(TabletReshardHelperTest, cap_and_redistribute_dels_no_overflow_is_no_op) {
+    std::vector<int64_t> dels{2, 3, 1};
+    cap_and_redistribute_dels(/*rows=*/{10, 10, 10}, &dels);
+    EXPECT_EQ((std::vector<int64_t>{2, 3, 1}), dels);
+}
+
+TEST_F(TabletReshardHelperTest, cap_and_redistribute_dels_basic_overflow) {
+    // dels[0] over-allocated by 5; redistribute to bucket 2 which has the
+    // largest headroom. Σ preserved at 20.
+    std::vector<int64_t> dels{15, 5, 0};
+    cap_and_redistribute_dels(/*rows=*/{10, 10, 10}, &dels);
+    EXPECT_EQ(20, sum_of(dels));
+    EXPECT_EQ(10, dels[0]);
+    // Bucket 1 has headroom 5, bucket 2 has 10 — headroom desc puts 2 ahead of 1
+    // (10 > 5). So overflow=5 goes to bucket 2 first.
+    EXPECT_EQ(5, dels[1]);
+    EXPECT_EQ(5, dels[2]);
+    for (size_t i = 0; i < dels.size(); ++i) {
+        EXPECT_LE(dels[i], 10);
+    }
+}
+
+TEST_F(TabletReshardHelperTest, cap_and_redistribute_dels_skewed_headrooms_break_by_index) {
+    // Σ pre-cap dels = 20, Σ rows = 25 (feasible). After cap dels[0] from 10
+    // to 5, overflow=5; headroom=[0,5,5] → buckets 1 and 2 tie, index-asc
+    // tie-break sends overflow to bucket 1 first.
+    std::vector<int64_t> dels{10, 5, 5}; // pre-cap, Σ=20
+    cap_and_redistribute_dels(/*rows=*/{5, 10, 10}, &dels);
+    EXPECT_EQ(20, sum_of(dels));
+    EXPECT_EQ(5, dels[0]);
+    EXPECT_EQ(10, dels[1]); // takes the full overflow=5 (tie-break by index)
+    EXPECT_EQ(5, dels[2]);
+}
+
+TEST_F(TabletReshardHelperTest, cap_and_redistribute_dels_invalid_parent_input_capped_to_rows_sum) {
+    // Σ pre-cap dels (30) > Σ rows (15). Best-effort contract: per-bucket cap
+    // honored, Σ dels post equals Σ rows (= 15).
+    std::vector<int64_t> dels{20, 5, 5};
+    cap_and_redistribute_dels(/*rows=*/{5, 5, 5}, &dels);
+    EXPECT_EQ(15, sum_of(dels));
+    for (size_t i = 0; i < 3; ++i) {
+        EXPECT_LE(dels[i], 5);
+    }
+}
+
+TEST_F(TabletReshardHelperTest, cap_and_redistribute_dels_fuzz_conservation_and_cap) {
+    // 1000 random trials with feasible inputs (Σ dels ≤ Σ rows). Helper must
+    // preserve Σ exactly and respect per-bucket cap.
+    std::mt19937_64 rng(42);
+    for (int trial = 0; trial < 1000; ++trial) {
+        const int n = 1 + (rng() % 8);
+        std::vector<int64_t> rows(n, 0);
+        std::vector<int64_t> dels(n, 0);
+        int64_t total_rows = 0;
+        for (int i = 0; i < n; ++i) {
+            rows[i] = static_cast<int64_t>(rng() % 1'000'000);
+            total_rows += rows[i];
+        }
+        // Pick parent.dels in [0, total_rows]; distribute it arbitrarily across
+        // buckets (may individually exceed rows[i]).
+        const int64_t parent_dels = total_rows == 0 ? 0 : static_cast<int64_t>(rng() % (total_rows + 1));
+        int64_t remaining = parent_dels;
+        for (int i = 0; i < n - 1 && remaining > 0; ++i) {
+            const int64_t take = static_cast<int64_t>(rng() % (remaining + 1));
+            dels[i] = take;
+            remaining -= take;
+        }
+        if (n > 0) dels[n - 1] = remaining;
+
+        cap_and_redistribute_dels(rows, &dels);
+        EXPECT_EQ(parent_dels, sum_of(dels)) << "trial=" << trial;
+        for (int i = 0; i < n; ++i) {
+            EXPECT_LE(dels[i], rows[i]) << "trial=" << trial << " bucket=" << i;
+            EXPECT_GE(dels[i], 0) << "trial=" << trial << " bucket=" << i;
+        }
+    }
+}
 
 // Verify that set_all_data_files_shared(TxnLogPB*) marks all SST-related fields
 // as shared=true, including the ssts fields in OpWrite and OpCompaction that were

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -881,6 +881,443 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_fallback_reads_delvec_for
     EXPECT_EQ(4, total_child_num_dels);
 }
 
+// Multi-rowset conservation. Parent has multiple rowsets with overlapping
+// segment key ranges so the per-source weight distribution differs across
+// rowsets. After split, Σ children.rowset[r].{num_rows,data_size,num_dels}
+// must equal the parent's recorded value for every rowset r — this is the
+// anchor's exactness contract regardless of how the segment-level
+// distribution chose to weight the children.
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_per_rowset_conservation) {
+    const int64_t base_version = 2;
+    const int64_t new_version = 3;
+    const int64_t tablet_id = next_id();
+
+    prepare_tablet_dirs(tablet_id);
+
+    TabletMetadataPB metadata;
+    metadata.set_id(tablet_id);
+    metadata.set_version(base_version);
+    set_primary_key_schema(&metadata, 1);
+    add_historical_schema(&metadata, 1);
+
+    // Rowset A: keys [0, 99], 100 rows / 10000 bytes / 7 dels.
+    auto* rs_a = metadata.add_rowsets();
+    rs_a->set_id(2);
+    rs_a->set_overlapped(true);
+    rs_a->set_num_rows(100);
+    rs_a->set_data_size(10000);
+    rs_a->set_num_dels(7);
+    rs_a->add_segments("rs_a_0.dat");
+    rs_a->add_segment_size(10000);
+    auto* sm_a = rs_a->add_segment_metas();
+    sm_a->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    sm_a->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+    sm_a->set_num_rows(100);
+
+    // Rowset B: keys [50, 199], 60 rows / 6000 bytes / 0 dels (overlaps A on [50,99]).
+    auto* rs_b = metadata.add_rowsets();
+    rs_b->set_id(3);
+    rs_b->set_overlapped(true);
+    rs_b->set_num_rows(60);
+    rs_b->set_data_size(6000);
+    rs_b->set_num_dels(0);
+    rs_b->add_segments("rs_b_0.dat");
+    rs_b->add_segment_size(6000);
+    auto* sm_b = rs_b->add_segment_metas();
+    sm_b->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+    sm_b->mutable_sort_key_max()->CopyFrom(generate_sort_key(199));
+    sm_b->set_num_rows(60);
+
+    // Rowset C: keys [100, 199], 30 rows / 3000 bytes / 11 dels.
+    auto* rs_c = metadata.add_rowsets();
+    rs_c->set_id(4);
+    rs_c->set_overlapped(true);
+    rs_c->set_num_rows(30);
+    rs_c->set_data_size(3000);
+    rs_c->set_num_dels(11);
+    rs_c->add_segments("rs_c_0.dat");
+    rs_c->add_segment_size(3000);
+    auto* sm_c = rs_c->add_segment_metas();
+    sm_c->mutable_sort_key_min()->CopyFrom(generate_sort_key(100));
+    sm_c->mutable_sort_key_max()->CopyFrom(generate_sort_key(199));
+    sm_c->set_num_rows(30);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child_id_1 = next_id();
+    const int64_t child_id_2 = next_id();
+    const int64_t child_id_3 = next_id();
+    splitting.add_new_tablet_ids(child_id_1);
+    splitting.add_new_tablet_ids(child_id_2);
+    splitting.add_new_tablet_ids(child_id_3);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version, txn_info,
+                                              false, tablet_metadatas, tablet_ranges));
+
+    // Per-rowset Σ children == parent for every stat.
+    struct RsTotals {
+        int64_t num_rows = 0;
+        int64_t data_size = 0;
+        int64_t num_dels = 0;
+    };
+    std::unordered_map<uint32_t, RsTotals> totals;
+    for (int64_t cid : {child_id_1, child_id_2, child_id_3}) {
+        auto it = tablet_metadatas.find(cid);
+        ASSERT_TRUE(it != tablet_metadatas.end());
+        for (const auto& rs : it->second->rowsets()) {
+            auto& t = totals[rs.id()];
+            t.num_rows += rs.num_rows();
+            t.data_size += rs.data_size();
+            t.num_dels += rs.num_dels();
+            EXPECT_LE(rs.num_dels(), rs.num_rows()) << "child cid=" << cid << " rs=" << rs.id();
+        }
+    }
+
+    EXPECT_EQ(100, totals[2].num_rows);
+    EXPECT_EQ(10000, totals[2].data_size);
+    EXPECT_EQ(7, totals[2].num_dels);
+
+    EXPECT_EQ(60, totals[3].num_rows);
+    EXPECT_EQ(6000, totals[3].data_size);
+    EXPECT_EQ(0, totals[3].num_dels);
+
+    EXPECT_EQ(30, totals[4].num_rows);
+    EXPECT_EQ(3000, totals[4].data_size);
+    EXPECT_EQ(11, totals[4].num_dels);
+}
+
+// Pathological metadata: parent rowset has num_dels > num_rows. The anchor
+// builder clamps num_dels up front (with WARNING) so cap-and-redistribute
+// has a feasible input. After split, Σ children.num_dels equals the clamped
+// parent.num_rows, and per-child num_dels stays within rows.
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_clamps_invalid_parent_dels) {
+    const int64_t base_version = 2;
+    const int64_t new_version = 3;
+    const int64_t tablet_id = next_id();
+
+    prepare_tablet_dirs(tablet_id);
+
+    TabletMetadataPB metadata;
+    metadata.set_id(tablet_id);
+    metadata.set_version(base_version);
+    set_primary_key_schema(&metadata, 1);
+    add_historical_schema(&metadata, 1);
+
+    auto* rowset = metadata.add_rowsets();
+    rowset->set_id(2);
+    rowset->set_overlapped(true);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(1000);
+    rowset->set_num_dels(15); // pathological: > num_rows
+
+    // Two segments so calculate_range_split_boundaries has enough key-space
+    // boundaries to produce a 2-way split (single segment falls back to
+    // identical-tablet publish, which would skip the anchor pass).
+    rowset->add_segments("seg_0.dat");
+    rowset->add_segment_size(500);
+    auto* sm0 = rowset->add_segment_metas();
+    sm0->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    sm0->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+    sm0->set_num_rows(5);
+
+    rowset->add_segments("seg_1.dat");
+    rowset->add_segment_size(500);
+    auto* sm1 = rowset->add_segment_metas();
+    sm1->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+    sm1->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+    sm1->set_num_rows(5);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child_id_1 = next_id();
+    const int64_t child_id_2 = next_id();
+    splitting.add_new_tablet_ids(child_id_1);
+    splitting.add_new_tablet_ids(child_id_2);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version, txn_info,
+                                              false, tablet_metadatas, tablet_ranges));
+
+    int64_t total_child_num_rows = 0;
+    int64_t total_child_num_dels = 0;
+    for (int64_t cid : {child_id_1, child_id_2}) {
+        auto it = tablet_metadatas.find(cid);
+        ASSERT_TRUE(it != tablet_metadatas.end());
+        ASSERT_EQ(1, it->second->rowsets_size());
+        const auto& child_rs = it->second->rowsets(0);
+        EXPECT_TRUE(child_rs.has_num_dels());
+        EXPECT_LE(child_rs.num_dels(), child_rs.num_rows());
+        total_child_num_rows += child_rs.num_rows();
+        total_child_num_dels += child_rs.num_dels();
+    }
+    // num_rows still conserves at parent.num_rows; num_dels conserves at the
+    // *clamped* parent value (= parent.num_rows = 10), not the bogus 15.
+    EXPECT_EQ(10, total_child_num_rows);
+    EXPECT_EQ(10, total_child_num_dels);
+}
+
+// Anchor input fallback: legacy / incomplete metadata may omit
+// rowset-level num_rows / data_size while still carrying valid
+// segment_metas + segment_size. The previous (pre-anchor) split path
+// derived its per-child stats from segment metadata via
+// range_source_stats, so children received non-zero stats even when
+// the rowset proto fields were unset. The anchor path must preserve
+// this property: when rowset.has_num_rows() / has_data_size() is false,
+// fall back to summing the corresponding segment-level fields. Without
+// this, anchor=0 would collapse every child's stat to zero.
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_falls_back_to_segment_sums_when_rowset_totals_unset) {
+    const int64_t base_version = 2;
+    const int64_t new_version = 3;
+    const int64_t tablet_id = next_id();
+
+    prepare_tablet_dirs(tablet_id);
+
+    TabletMetadataPB metadata;
+    metadata.set_id(tablet_id);
+    metadata.set_version(base_version);
+    set_primary_key_schema(&metadata, 1);
+    add_historical_schema(&metadata, 1);
+
+    auto* rowset = metadata.add_rowsets();
+    rowset->set_id(2);
+    rowset->set_overlapped(true);
+    // Intentionally do NOT set num_rows or data_size at the rowset level.
+    // Segment metadata still carries the real values.
+
+    rowset->add_segments("seg_0.dat");
+    rowset->add_segment_size(400);
+    auto* sm0 = rowset->add_segment_metas();
+    sm0->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    sm0->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+    sm0->set_num_rows(4);
+
+    rowset->add_segments("seg_1.dat");
+    rowset->add_segment_size(400);
+    auto* sm1 = rowset->add_segment_metas();
+    sm1->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+    sm1->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+    sm1->set_num_rows(4);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child_id_1 = next_id();
+    const int64_t child_id_2 = next_id();
+    splitting.add_new_tablet_ids(child_id_1);
+    splitting.add_new_tablet_ids(child_id_2);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version, txn_info,
+                                              false, tablet_metadatas, tablet_ranges));
+
+    // Σ children rowset[r].num_rows must equal the segment-derived total
+    // (4 + 4 = 8 rows), data_size the segment_size sum (400 + 400 = 800).
+    int64_t total_num_rows = 0;
+    int64_t total_data_size = 0;
+    for (int64_t cid : {child_id_1, child_id_2}) {
+        auto it = tablet_metadatas.find(cid);
+        ASSERT_TRUE(it != tablet_metadatas.end());
+        ASSERT_EQ(1, it->second->rowsets_size());
+        total_num_rows += it->second->rowsets(0).num_rows();
+        total_data_size += it->second->rowsets(0).data_size();
+    }
+    EXPECT_EQ(8, total_num_rows) << "anchor must fall back to Σ segment_metas.num_rows()";
+    EXPECT_EQ(800, total_data_size) << "anchor must fall back to Σ segment_size";
+}
+
+// Three-level chain conservation. Σ children == parent at every split level
+// for num_rows / data_size / num_dels per rowset. By induction Σ leaves at
+// level-3 == original parent — the property a multi-level reshard must
+// guarantee for downstream consumers (get_tablet_stats, planner, vacuum).
+//
+// Setup uses sampled segments (sort_key_samples populated) so segment-level
+// boundary candidates are dense enough for 3 successive splits to find
+// candidates inside ever-narrowing tablet ranges.
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_three_level_chain_conservation) {
+    auto add_sampled_rowset = [](TabletMetadataPB* md, int64_t rs_id, int min_v, int max_v, int num_rows, int data_size,
+                                 int num_dels, int interval) {
+        auto* rs = md->add_rowsets();
+        rs->set_id(rs_id);
+        rs->set_overlapped(true);
+        rs->set_num_rows(num_rows);
+        rs->set_data_size(data_size);
+        rs->set_num_dels(num_dels);
+        rs->add_segments(fmt::format("rs_{}_0.dat", rs_id));
+        rs->add_segment_size(data_size);
+        auto* sm = rs->add_segment_metas();
+        sm->mutable_sort_key_min()->CopyFrom(generate_sort_key(min_v));
+        sm->mutable_sort_key_max()->CopyFrom(generate_sort_key(max_v));
+        sm->set_num_rows(num_rows);
+        sm->set_sort_key_sample_row_interval(interval);
+        for (int v = min_v + interval; v < max_v; v += interval) {
+            sm->add_sort_key_samples()->CopyFrom(generate_sort_key(v));
+        }
+    };
+
+    auto verify_per_rowset_conservation = [](const TabletMetadataPB& parent_md, const std::vector<int64_t>& child_ids,
+                                             const std::unordered_map<int64_t, TabletMetadataPtr>& children,
+                                             const char* level) {
+        struct Totals {
+            int64_t num_rows = 0;
+            int64_t data_size = 0;
+            int64_t num_dels = 0;
+        };
+        std::unordered_map<uint32_t, Totals> totals;
+        for (int64_t cid : child_ids) {
+            auto it = children.find(cid);
+            ASSERT_TRUE(it != children.end()) << level << ": missing child " << cid;
+            for (const auto& rs : it->second->rowsets()) {
+                auto& t = totals[rs.id()];
+                t.num_rows += rs.num_rows();
+                t.data_size += rs.data_size();
+                t.num_dels += rs.num_dels();
+                EXPECT_LE(rs.num_dels(), rs.num_rows())
+                        << level << ": child " << cid << " rs " << rs.id() << " num_dels exceeds num_rows";
+            }
+        }
+        for (const auto& rs : parent_md.rowsets()) {
+            auto it = totals.find(rs.id());
+            ASSERT_TRUE(it != totals.end()) << level << ": rowset " << rs.id() << " missing in children";
+            EXPECT_EQ(rs.num_rows(), it->second.num_rows) << level << ": num_rows for rs " << rs.id();
+            EXPECT_EQ(rs.data_size(), it->second.data_size) << level << ": data_size for rs " << rs.id();
+            EXPECT_EQ(rs.num_dels(), it->second.num_dels) << level << ": num_dels for rs " << rs.id();
+        }
+    };
+
+    const int64_t base_version_l0 = 2;
+    const int64_t version_l1 = 3;
+    const int64_t version_l2 = 4;
+    const int64_t version_l3 = 5;
+    const int64_t tablet_id = next_id();
+
+    prepare_tablet_dirs(tablet_id);
+
+    TabletMetadataPB metadata;
+    metadata.set_id(tablet_id);
+    metadata.set_version(base_version_l0);
+    set_primary_key_schema(&metadata, 1);
+    add_historical_schema(&metadata, 1);
+
+    // 2 rowsets covering [0,1499] with samples every 100 rows. Combined ~2000
+    // rows / 16000 bytes / 42 dels. Sample density gives every ~100 keys a
+    // boundary candidate, plenty to drive 3 levels of splitting.
+    add_sampled_rowset(&metadata, /*rs_id=*/2, /*min=*/0, /*max=*/999, /*num_rows=*/1000,
+                       /*data_size=*/10000, /*num_dels=*/30, /*interval=*/100);
+    add_sampled_rowset(&metadata, /*rs_id=*/3, /*min=*/500, /*max=*/1499, /*num_rows=*/1000,
+                       /*data_size=*/6000, /*num_dels=*/12, /*interval=*/100);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    // ---- Level 1: split tablet → 3 children ----
+    ReshardingTabletInfoPB r1;
+    auto& s1 = *r1.mutable_splitting_tablet_info();
+    s1.set_old_tablet_id(tablet_id);
+    const int64_t l1_a = next_id();
+    const int64_t l1_b = next_id();
+    const int64_t l1_c = next_id();
+    s1.add_new_tablet_ids(l1_a);
+    s1.add_new_tablet_ids(l1_b);
+    s1.add_new_tablet_ids(l1_c);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tm_l1;
+    std::unordered_map<int64_t, TabletRangePB> tr_l1;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), r1, base_version_l0, version_l1, txn_info, false,
+                                              tm_l1, tr_l1));
+    verify_per_rowset_conservation(metadata, {l1_a, l1_b, l1_c}, tm_l1, "level-1");
+
+    // ---- Level 2: re-split the level-1 child with the most rows ----
+    int64_t l2_parent_id = l1_a;
+    int64_t l2_parent_total_rows = 0;
+    {
+        for (const auto& rs : tm_l1.at(l1_a)->rowsets()) l2_parent_total_rows += rs.num_rows();
+        for (int64_t cid : {l1_b, l1_c}) {
+            int64_t total = 0;
+            for (const auto& rs : tm_l1.at(cid)->rowsets()) total += rs.num_rows();
+            if (total > l2_parent_total_rows) {
+                l2_parent_id = cid;
+                l2_parent_total_rows = total;
+            }
+        }
+    }
+    auto l2_parent_md = tm_l1.at(l2_parent_id);
+
+    ReshardingTabletInfoPB r2;
+    auto& s2 = *r2.mutable_splitting_tablet_info();
+    s2.set_old_tablet_id(l2_parent_id);
+    const int64_t l2_a = next_id();
+    const int64_t l2_b = next_id();
+    s2.add_new_tablet_ids(l2_a);
+    s2.add_new_tablet_ids(l2_b);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tm_l2;
+    std::unordered_map<int64_t, TabletRangePB> tr_l2;
+    auto st_l2 = lake::publish_resharding_tablet(_tablet_manager.get(), r2, version_l1, version_l2, txn_info, false,
+                                                 tm_l2, tr_l2);
+    if (!st_l2.ok()) {
+        GTEST_SKIP() << "level-2 split could not be exercised on this fixture: " << st_l2;
+    }
+    verify_per_rowset_conservation(*l2_parent_md, {l2_a, l2_b}, tm_l2, "level-2");
+
+    // ---- Level 3: split the bigger level-2 grandchild ----
+    int64_t l3_parent_id = l2_a;
+    int64_t l3_parent_total_rows = 0;
+    for (const auto& rs : tm_l2.at(l2_a)->rowsets()) l3_parent_total_rows += rs.num_rows();
+    {
+        int64_t total_b = 0;
+        for (const auto& rs : tm_l2.at(l2_b)->rowsets()) total_b += rs.num_rows();
+        if (total_b > l3_parent_total_rows) {
+            l3_parent_id = l2_b;
+            l3_parent_total_rows = total_b;
+        }
+    }
+    auto l3_parent_md = tm_l2.at(l3_parent_id);
+
+    ReshardingTabletInfoPB r3;
+    auto& s3 = *r3.mutable_splitting_tablet_info();
+    s3.set_old_tablet_id(l3_parent_id);
+    const int64_t l3_a = next_id();
+    const int64_t l3_b = next_id();
+    s3.add_new_tablet_ids(l3_a);
+    s3.add_new_tablet_ids(l3_b);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tm_l3;
+    std::unordered_map<int64_t, TabletRangePB> tr_l3;
+    auto st_l3 = lake::publish_resharding_tablet(_tablet_manager.get(), r3, version_l2, version_l3, txn_info, false,
+                                                 tm_l3, tr_l3);
+    if (!st_l3.ok()) {
+        GTEST_SKIP() << "level-3 split could not be exercised on this fixture: " << st_l3;
+    }
+    verify_per_rowset_conservation(*l3_parent_md, {l3_a, l3_b}, tm_l3, "level-3");
+}
+
 TEST_F(LakeTabletReshardTest, test_merge_rowsets_reorder_by_predicate_version) {
     const int64_t base_version = 2;
     const int64_t new_version = 3;

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -416,4 +416,182 @@ TEST(TabletSplitterTest, rca_reproducer_scaled_down) {
     EXPECT_LT(std::abs(left - right) * 4, 4000) << "sampled-path split should be within 25% imbalance";
 }
 
+// -----------------------------------------------------------------------------
+// PR #1: precise tablet_range clipping in calculate_range_split_boundaries.
+//
+// shared-data tablet split shares physical segments across child tablets, so
+// after a tablet has been split once its remaining shared rowsets still report
+// physical sort_key_min / sort_key_max that extend past the child tablet's
+// range. When that child is split again, the algorithm builds ordered_ranges
+// from segment boundaries plus tablet_range bounds (after this fix). The
+// candidate filter must precisely exclude any ordered_range that falls
+// outside the tablet's range, including ordered_ranges that previously
+// straddled a tablet edge.
+// -----------------------------------------------------------------------------
+
+// Upper crossing: a segment whose physical extent crosses the tablet's
+// upper_bound used to leak its out-of-range rows/bytes into the per-split
+// estimates because the candidate filter only excluded ranges with no overlap.
+TEST(TabletSplitterTest, tablet_range_excludes_data_past_upper_when_segments_straddle) {
+    // seg1 [0, 50) is fully within tablet [0, 70).
+    // seg2 [40, 100) physically crosses tablet's upper bound 70.
+    auto seg1 = make_seg(/*min=*/0, /*max=*/50, /*num_rows=*/50, /*data_size=*/500, /*source_id=*/1);
+    auto seg2 = make_seg(/*min=*/40, /*max=*/100, /*num_rows=*/60, /*data_size=*/600, /*source_id=*/2);
+
+    TabletRange tablet_range(make_int_tuple(0), make_int_tuple(70),
+                             /*lower_bound_included=*/true, /*upper_bound_included=*/false);
+
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries({seg1, seg2}, /*target_split_count=*/2,
+                                                     /*target_value_per_split=*/40,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true, &tablet_range));
+    ASSERT_EQ(1u, result.boundaries.size());
+    int64_t total_rows = 0;
+    int64_t total_bytes = 0;
+    for (size_t i = 0; i < result.range_num_rows.size(); ++i) {
+        total_rows += result.range_num_rows[i];
+        total_bytes += result.range_data_sizes[i];
+    }
+    // After inserting tablet_range bound 70, ordered_ranges become
+    //   [0,40), [40,50), [50,70), [70,100)
+    // seg2's 60 rows are split evenly across the 3 overlapping ranges
+    // [40,50)/[50,70)/[70,100), giving 20 rows each. Only [70,100) is outside
+    // the tablet, so seg2 contributes 40 rows. seg1 stays at 50 rows.
+    EXPECT_EQ(90, total_rows);
+    EXPECT_EQ(900, total_bytes);
+    // Per-source sums: seg1 fully kept, seg2 trimmed.
+    auto [s1_rows, s1_bytes] = sum_source_stats(result, 1);
+    EXPECT_EQ(50, s1_rows);
+    EXPECT_EQ(500, s1_bytes);
+    auto [s2_rows, s2_bytes] = sum_source_stats(result, 2);
+    EXPECT_EQ(40, s2_rows);
+    EXPECT_EQ(400, s2_bytes);
+}
+
+// Lower-bound inclusivity: child tablets produced by split have
+// lower_bound_included=true, but TabletRange::greater_than returns false when
+// r.max == lower_bound under that flag. Without inserting the tablet bound and
+// using a precise overlap predicate, an ordered_range whose r.max ==
+// tablet.lower_bound is incorrectly kept and inflates the in-tablet sum.
+TEST(TabletSplitterTest, tablet_range_excludes_data_below_when_lower_bound_inclusive) {
+    auto seg1 = make_seg(/*min=*/0, /*max=*/60, /*num_rows=*/30, /*data_size=*/300, /*source_id=*/1);
+    auto seg2 = make_sampled_seg(/*min=*/50, /*max=*/90, /*num_rows=*/40, /*data_size=*/400,
+                                 /*iv=*/20, /*samples=*/{60}, /*source_id=*/2);
+    auto seg3 = make_seg(/*min=*/70, /*max=*/100, /*num_rows=*/25, /*data_size=*/250, /*source_id=*/3);
+
+    TabletRange tablet_range(make_int_tuple(60), make_int_tuple(100),
+                             /*lower_bound_included=*/true, /*upper_bound_included=*/false);
+
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries({seg1, seg2, seg3}, /*target_split_count=*/2,
+                                                     /*target_value_per_split=*/30,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true, &tablet_range));
+    ASSERT_EQ(1u, result.boundaries.size());
+
+    // seg1 [0, 60) is entirely below the tablet (its r.max == tablet.lower_bound,
+    // and the tablet's smallest key is 60-included; seg1 has no key in [60, _)).
+    auto [s1_rows, s1_bytes] = sum_source_stats(result, 1);
+    EXPECT_EQ(0, s1_rows);
+    EXPECT_EQ(0, s1_bytes);
+    // seg2's sample at 60 splits its rows into [50,60) (below) and [60,90)
+    // (within), 20 rows per sub-segment.
+    auto [s2_rows, s2_bytes] = sum_source_stats(result, 2);
+    EXPECT_EQ(20, s2_rows);
+    EXPECT_EQ(200, s2_bytes);
+    // seg3 is fully within the tablet.
+    auto [s3_rows, s3_bytes] = sum_source_stats(result, 3);
+    EXPECT_EQ(25, s3_rows);
+    EXPECT_EQ(250, s3_bytes);
+
+    int64_t total_rows = 0;
+    int64_t total_bytes = 0;
+    for (size_t i = 0; i < result.range_num_rows.size(); ++i) {
+        total_rows += result.range_num_rows[i];
+        total_bytes += result.range_data_sizes[i];
+    }
+    EXPECT_EQ(45, total_rows);
+    EXPECT_EQ(450, total_bytes);
+}
+
+// Regression: when segment boundaries are entirely inside tablet_range (the
+// first-split shape), adding tablet_range bounds to ordered_boundaries must
+// not change the per-split totals. The empty edge ranges contribute zero and
+// the greedy still picks the same split point.
+TEST(TabletSplitterTest, tablet_range_covering_all_data_does_not_change_totals) {
+    auto seg1 = make_seg(/*min=*/10, /*max=*/50, /*num_rows=*/50, /*data_size=*/500, /*source_id=*/1);
+    auto seg2 = make_seg(/*min=*/60, /*max=*/100, /*num_rows=*/50, /*data_size=*/500, /*source_id=*/2);
+
+    ASSIGN_OR_ABORT(auto without, calculate_range_split_boundaries({seg1, seg2}, /*target_split_count=*/2,
+                                                                   /*target_value_per_split=*/50,
+                                                                   /*use_num_rows=*/true, /*track_sources=*/true));
+
+    TabletRange tablet_range(make_int_tuple(0), make_int_tuple(150),
+                             /*lower_bound_included=*/true, /*upper_bound_included=*/false);
+    ASSIGN_OR_ABORT(auto with,
+                    calculate_range_split_boundaries({seg1, seg2}, /*target_split_count=*/2,
+                                                     /*target_value_per_split=*/50,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true, &tablet_range));
+
+    ASSERT_EQ(without.boundaries.size(), with.boundaries.size());
+    EXPECT_EQ(without.range_num_rows, with.range_num_rows);
+    EXPECT_EQ(without.range_data_sizes, with.range_data_sizes);
+    // Both source totals must match too.
+    auto [w_s1_r, w_s1_b] = sum_source_stats(without, 1);
+    auto [t_s1_r, t_s1_b] = sum_source_stats(with, 1);
+    EXPECT_EQ(w_s1_r, t_s1_r);
+    EXPECT_EQ(w_s1_b, t_s1_b);
+    auto [w_s2_r, w_s2_b] = sum_source_stats(without, 2);
+    auto [t_s2_r, t_s2_b] = sum_source_stats(with, 2);
+    EXPECT_EQ(w_s2_r, t_s2_r);
+    EXPECT_EQ(w_s2_b, t_s2_b);
+}
+
+// Conservation across split count: for the same input + tablet_range, the sum
+// of per-split rows/bytes must be invariant regardless of the split count
+// chosen. Runs split_count = 2..5 against a tablet whose bounds fall inside
+// the segments' physical extent on both sides.
+TEST(TabletSplitterTest, tablet_range_total_invariant_across_split_counts) {
+    std::vector<int64_t> samples;
+    for (int64_t v = 20; v <= 180; v += 20) samples.push_back(v);
+    std::vector<SegmentSplitInfo> segs;
+    segs.push_back(make_sampled_seg(/*min=*/0, /*max=*/200, /*num_rows=*/200, /*data_size=*/2000,
+                                    /*iv=*/20, samples, /*source_id=*/1));
+    segs.push_back(make_seg(/*min=*/50, /*max=*/150, /*num_rows=*/100, /*data_size=*/1000, /*source_id=*/2));
+
+    TabletRange tablet_range(make_int_tuple(30), make_int_tuple(170),
+                             /*lower_bound_included=*/true, /*upper_bound_included=*/false);
+
+    int64_t reference_rows = -1;
+    int64_t reference_bytes = -1;
+    int succeeded_runs = 0;
+    for (int32_t split_count = 2; split_count <= 5; ++split_count) {
+        ASSIGN_OR_ABORT(auto result,
+                        calculate_range_split_boundaries(segs, split_count, /*target_value_per_split=*/0,
+                                                         /*use_num_rows=*/true, /*track_sources=*/true, &tablet_range));
+        if (result.boundaries.empty()) continue;
+        ++succeeded_runs;
+        int64_t total_rows = 0;
+        int64_t total_bytes = 0;
+        for (auto v : result.range_num_rows) total_rows += v;
+        for (auto v : result.range_data_sizes) total_bytes += v;
+        if (reference_rows < 0) {
+            reference_rows = total_rows;
+            reference_bytes = total_bytes;
+        } else {
+            EXPECT_EQ(reference_rows, total_rows) << "row total should be invariant across split count " << split_count;
+            EXPECT_EQ(reference_bytes, total_bytes)
+                    << "byte total should be invariant across split count " << split_count;
+        }
+    }
+    EXPECT_GT(succeeded_runs, 0) << "expected at least one split count to succeed";
+    EXPECT_GT(reference_rows, 0);
+    EXPECT_GT(reference_bytes, 0);
+}
+
+// Helper unit tests for `allocate_proportionally` and `cap_and_redistribute_dels`
+// live in `tablet_reshard_helper_test.cpp` — those helpers were moved to the
+// `tablet_reshard_helper` namespace as part of the per-rowset anchor change so
+// they can be reused by the planned cross-publish (P2) refactor without
+// re-introducing a private split-only header.
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, splitting a tablet does not rewrite data: child tablets share the parent's physical segments. So a segment's reported `sort_key_min` / `sort_key_max` still cover the original physical range even after the split has narrowed the tablet's logical range.

This PR fixes two issues that compound on **re-splitting a tablet that already has shared rowsets**:

### Issue A — out-of-range data leaks into per-split estimates

When `calculate_range_split_boundaries` builds `ordered_ranges` from segment boundaries plus sample points, an `ordered_range` can straddle the tablet's lower or upper bound. The old candidate filter

```cpp
tablet_range->less_than(r.min) || tablet_range->greater_than(r.max)
```

keeps such ranges whole. Their full `data_size` / `num_rows` are then summed into one of the new splits, so any **re-split** of a tablet that already has shared data files inflates the per-split estimates by the part of the shared file that does not belong to the tablet. The lower-bound side has the same defect: child tablets produced by split have `lower_bound_included=true`, and `TabletRange::greater_than` returns `false` when `r.max == lower_bound` under that flag, so a range entirely below the tablet is also kept.

### Issue B — Σ children stats drift from parent across re-splits

Even after fixing Issue A, the segment-level distribution algorithm is non-stable across `ordered_boundaries` changes: the same physical sub-segment, when re-distributed under a different boundary set at level-2 vs level-1, yields slightly different in-tablet sums (~0.6% in real-cluster validation). Each level produces its own internally-consistent estimate but the chain across re-splits drifts.

## What I'm doing:

### Fix A — precise tablet_range clipping

- Insert `tablet_range.lower_bound` and `upper_bound` (when not unbounded) into `ordered_boundaries` so straddling ranges get split at the tablet edge.
- Replace the candidate-overlap check with a precise predicate that mirrors `find_overlapping_ranges`' last-range semantics (`[min, max)` for non-last, `[min, max]` for last) and honors the `TabletRange`'s lower / upper inclusion flags.

`distribute_segment_to_ranges` and the greedy boundary placement do not need changes: with finer `ordered_ranges` the existing distribution still works, and the existing `strictly_contains` check already rejects placing a chosen split boundary at the tablet edge.

### Fix B — anchor per-rowset stats to parent totals (exact conservation)

In `get_tablet_split_ranges`, after `calculate_range_split_boundaries` returns:

- Build a **rowset anchor** from the parent's recorded `RowsetMetadataPB` (with the existing legacy delvec fallback for rowsets missing `has_num_dels`). Defensively clamp pathological `num_dels > num_rows` up front with a WARNING.
- Treat `range_source_stats` as **relative weights**, not absolute counts. Use largest-remainder (Hare-Niemeyer) integer allocation against the anchor totals so `Σ children stat ≡ parent stat` exactly for `num_rows` / `data_size` / `num_dels`, per rowset.
- Cap each per-child `num_dels ≤ num_rows`, redistribute overflow to children with headroom (deterministic by `(headroom desc, index asc)`).
- Aggregate consistency is automatic: `split_tablet` writes only per-rowset stats; aggregates are summed at query time.
- The legacy `allocate_rowset_num_dels_across_splits` post-pass is removed; its job is unified into the per-source anchor pass.

Two new helpers in `tablet_reshard_helper.{h,cpp}` implement the math:
- `allocate_proportionally(total, weights, out)` with deterministic `(remainder desc, index asc)` tie-break and a uniform fallback for the all-zero-weights case.
- `cap_and_redistribute_dels(rows, dels)` for the `num_dels ≤ num_rows` invariant.

`calculate_range_split_boundaries`, `RangeSplitResult`, and the parallel-compaction caller in `tablet_parallel_compaction_manager.cpp` are not modified.

### Real-cluster validation (TSP)

| | gap = (Σ grandchildren num_row − parent num_row) / parent |
|--|--|
| no fix | +3.165% (Issue A — out-of-range leak) |
| Fix A only | +0.633% (residual from Issue B) |
| Fix A + Fix B | **0.000%** (exact conservation, verified on TSP build 1361 / cluster pr72324-fix-v2 — Σ grandchildren num_row = 2,588,673 ≡ parent; data_size = 547,226 ≡ parent) |

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes
- [ ] Parameter changes
- [ ] Policy changes: per-split per-rowset stats are now anchored to parent totals so Σ conserves exactly across re-splits; previously each level recomputed from physical segments and could drift slightly. First-split behavior is unchanged.
- [ ] Feature removed
- [ ] Miscellaneous

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4