### PR TITLE
[Enhancement] Introduce SCHEDULE keyword as ASYNC synonym for MV refresh

### DIFF
--- a/docs/en/sql-reference/sql-statements/materialized_view/ALTER_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/ALTER_MATERIALIZED_VIEW.md
@@ -70,7 +70,7 @@ ALTER MATERIALIZED VIEW lo_mv1 RENAME lo_mv1_new_name;
 Example 2: Alter the refresh interval of the materialized view.
 
 ```SQL
-ALTER MATERIALIZED VIEW lo_mv2 REFRESH ASYNC EVERY(INTERVAL 1 DAY);
+ALTER MATERIALIZED VIEW lo_mv2 REFRESH SCHEDULE EVERY(INTERVAL 1 DAY);
 ```
 
 Example 3: Alter the timeout duration for the materialized view refresh tasks to 1 hour (default).

--- a/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -164,7 +164,7 @@ CREATE MATERIALIZED VIEW [IF NOT EXISTS] [database.]<mv_name>
 -- refresh_moment
     [IMMEDIATE | DEFERRED]
 -- refresh_scheme
-    [ASYNC | ASYNC [START (<start_time>)] EVERY (INTERVAL <refresh_interval>) | MANUAL]
+    [ASYNC | SCHEDULE [START (<start_time>)] EVERY (INTERVAL <refresh_interval>) | MANUAL]
 ]
 -- partition_expression
 [PARTITION BY 
@@ -250,7 +250,7 @@ The refresh moment of the materialized view. Default value: `IMMEDIATE`. Valid v
 The refresh strategy of the asynchronous materialized view. Valid values:
 
 - `ASYNC`: Automatic refresh mode. Each time the base table data changes, the materialized view is automatically refreshed.
-- `ASYNC [START (<start_time>)] EVERY(INTERVAL <interval>)`: Regular refresh mode. The materialized view is refreshed regularly at the interval defined. You can specify the interval as `EVERY (interval n day/hour/minute/second)` using the following units: `DAY`, `HOUR`, `MINUTE`, and `SECOND`. The default value is `10 MINUTE`. You can further specify the refresh start time as `START('yyyy-MM-dd hh:mm:ss')`. If the start time is not specified, the current time is used. Example: `ASYNC START ('2023-09-12 16:30:25') EVERY (INTERVAL 5 MINUTE)`.
+- `SCHEDULE [START (<start_time>)] EVERY(INTERVAL <interval>)`: Regular refresh mode. The materialized view is refreshed regularly at the interval defined. You can specify the interval as `EVERY (interval n day/hour/minute/second)` using the following units: `DAY`, `HOUR`, `MINUTE`, and `SECOND`. The default value is `10 MINUTE`. You can further specify the refresh start time as `START('yyyy-MM-dd hh:mm:ss')`. If the start time is not specified, the current time is used. Example: `SCHEDULE START ('2023-09-12 16:30:25') EVERY (INTERVAL 5 MINUTE)`. The legacy form `ASYNC [START (...)] EVERY (...)` is still accepted for backward compatibility but `SHOW CREATE MATERIALIZED VIEW` always renders the scheduled form with `SCHEDULE`.
 - `MANUAL`: Manual refresh mode. The materialized view will not be refreshed unless you trigger a refresh task manually.
 
 If this parameter is not specified, the default value `MANUAL` is used.

--- a/docs/ja/sql-reference/sql-statements/materialized_view/ALTER_MATERIALIZED_VIEW.md
+++ b/docs/ja/sql-reference/sql-statements/materialized_view/ALTER_MATERIALIZED_VIEW.md
@@ -72,7 +72,7 @@ ALTER MATERIALIZED VIEW lo_mv1 RENAME lo_mv1_new_name;
 例2: マテリアライズドビューのリフレッシュ間隔を変更します。
 
 ```SQL
-ALTER MATERIALIZED VIEW lo_mv2 REFRESH ASYNC EVERY(INTERVAL 1 DAY);
+ALTER MATERIALIZED VIEW lo_mv2 REFRESH SCHEDULE EVERY(INTERVAL 1 DAY);
 ```
 
 例3: マテリアライズドビューのリフレッシュタスクのタイムアウト期間を1時間（デフォルト）に変更します。

--- a/docs/ja/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/ja/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -166,7 +166,7 @@ CREATE MATERIALIZED VIEW [IF NOT EXISTS] [database.]<mv_name>
 -- refresh_moment
     [IMMEDIATE | DEFERRED]
 -- refresh_scheme
-    [ASYNC | ASYNC [START (<start_time>)] EVERY (INTERVAL <refresh_interval>) | MANUAL]
+    [ASYNC | SCHEDULE [START (<start_time>)] EVERY (INTERVAL <refresh_interval>) | MANUAL]
 ]
 -- partition_expression
 [PARTITION BY 
@@ -252,7 +252,7 @@ AS
 非同期マテリアライズドビューのリフレッシュ戦略。有効な値:
 
 - `ASYNC`: 自動リフレッシュモード。ベーステーブルデータが変更されるたびに、マテリアライズドビューが自動的にリフレッシュされます。
-- `ASYNC [START (<start_time>)] EVERY(INTERVAL <interval>)`: 定期リフレッシュモード。定義された間隔でマテリアライズドビューが定期的にリフレッシュされます。間隔は`EVERY (interval n day/hour/minute/second)`として指定できます。使用可能な単位は`DAY`、`HOUR`、`MINUTE`、`SECOND`です。デフォルト値は`10 MINUTE`です。リフレッシュ開始時間を`START('yyyy-MM-dd hh:mm:ss')`としてさらに指定できます。開始時間が指定されていない場合、現在の時間が使用されます。例: `ASYNC START ('2023-09-12 16:30:25') EVERY (INTERVAL 5 MINUTE)`。
+- `SCHEDULE [START (<start_time>)] EVERY(INTERVAL <interval>)`: 定期リフレッシュモード。定義された間隔でマテリアライズドビューが定期的にリフレッシュされます。間隔は`EVERY (interval n day/hour/minute/second)`として指定できます。使用可能な単位は`DAY`、`HOUR`、`MINUTE`、`SECOND`です。デフォルト値は`10 MINUTE`です。リフレッシュ開始時間を`START('yyyy-MM-dd hh:mm:ss')`としてさらに指定できます。開始時間が指定されていない場合、現在の時間が使用されます。例: `SCHEDULE START ('2023-09-12 16:30:25') EVERY (INTERVAL 5 MINUTE)`。互換性のため `ASYNC [START (...)] EVERY (...)` も引き続き受け付けますが、`SHOW CREATE MATERIALIZED VIEW` の出力は常に `SCHEDULE` で表示されます。
 - `MANUAL`: 手動リフレッシュモード。リフレッシュタスクを手動でトリガーしない限り、マテリアライズドビューはリフレッシュされません。
 
 このパラメータが指定されていない場合、デフォルト値`MANUAL`が使用されます。

--- a/docs/zh/sql-reference/sql-statements/materialized_view/ALTER_MATERIALIZED_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/materialized_view/ALTER_MATERIALIZED_VIEW.md
@@ -71,7 +71,7 @@ ALTER MATERIALIZED VIEW lo_mv1 RENAME lo_mv1_new_name;
 示例二：修改物化视图刷新间隔
 
 ```SQL
-ALTER MATERIALIZED VIEW lo_mv2 REFRESH ASYNC EVERY(INTERVAL 1 DAY);
+ALTER MATERIALIZED VIEW lo_mv2 REFRESH SCHEDULE EVERY(INTERVAL 1 DAY);
 ```
 
 示例三：修改物化视图属性，调整物化视图刷新 Timeout 为一小时（默认）。

--- a/docs/zh/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -164,7 +164,7 @@ CREATE MATERIALIZED VIEW [IF NOT EXISTS] [database.]<mv_name>
 -- refresh_moment
     [IMMEDIATE | DEFERRED]
 -- refresh_scheme
-    [ASYNC | ASYNC [START (<start_time>)] EVERY (INTERVAL <refresh_interval>) | MANUAL]
+    [ASYNC | SCHEDULE [START (<start_time>)] EVERY (INTERVAL <refresh_interval>) | MANUAL]
 ]
 -- partition_expression
 [PARTITION BY 
@@ -248,7 +248,7 @@ AS
 物化视图的刷新方式。该参数支持如下值：
 
 - `ASYNC`: 自动刷新模式。每当基表数据发生变化时，物化视图会自动刷新。
-- `ASYNC [START (<start_time>)] EVERY(INTERVAL <interval>)`: 定时刷新模式。物化视图将按照定义的间隔定时刷新。您可以使用 `DAY`（天）、`HOUR`（小时）、`MINUTE`（分钟）和 `SECOND`（秒）作为单位指定间隔，格式为 `EVERY (interval n day/hour/minute/second)`。默认值为 `10 MINUTE`（10 分钟）。您还可以进一步指定刷新起始时间，格式为 `START('yyyy-MM-dd hh:mm:ss')`。如未指定起始时间，默认使用当前时间。示例：`ASYNC START ('2023-09-12 16:30:25') EVERY (INTERVAL 5 MINUTE)`。
+- `SCHEDULE [START (<start_time>)] EVERY(INTERVAL <interval>)`: 定时刷新模式。物化视图将按照定义的间隔定时刷新。您可以使用 `DAY`（天）、`HOUR`（小时）、`MINUTE`（分钟）和 `SECOND`（秒）作为单位指定间隔，格式为 `EVERY (interval n day/hour/minute/second)`。默认值为 `10 MINUTE`（10 分钟）。您还可以进一步指定刷新起始时间，格式为 `START('yyyy-MM-dd hh:mm:ss')`。如未指定起始时间，默认使用当前时间。示例：`SCHEDULE START ('2023-09-12 16:30:25') EVERY (INTERVAL 5 MINUTE)`。为兼容旧版本，`ASYNC [START (...)] EVERY (...)` 仍然被接受，但 `SHOW CREATE MATERIALIZED VIEW` 输出的定时刷新部分始终使用 `SCHEDULE`。
 - `MANUAL`: 手动刷新模式。除非手动触发刷新任务，否则物化视图不会刷新。
 
 如果不指定该参数，则默认使用 MANUAL 方式。

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1904,10 +1904,18 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         if (refreshScheme == null) {
             sb.append("\nREFRESH ").append("UNKNOWN");
         } else {
+            // Prefer the SCHEDULE keyword for scheduled refresh (ASYNC + EVERY). ASYNC is kept
+            // as the legacy synonym in the parser; for bare ASYNC (no EVERY) we still emit
+            // ASYNC because bare SCHEDULE is not a valid form.
+            String typeName = refreshScheme.getType().name();
+            if (refreshScheme.getType() == MaterializedViewRefreshType.ASYNC
+                    && refreshScheme.getAsyncRefreshContext().getTimeUnit() != null) {
+                typeName = "SCHEDULE";
+            }
             if (refreshScheme.getMoment().equals(RefreshMoment.DEFERRED)) {
-                sb.append(String.format("\nREFRESH %s %s", refreshScheme.getMoment(), refreshScheme.getType()));
+                sb.append(String.format("\nREFRESH %s %s", refreshScheme.getMoment(), typeName));
             } else {
-                sb.append("\nREFRESH ").append(refreshScheme.getType());
+                sb.append("\nREFRESH ").append(typeName);
             }
         }
         if (refreshScheme != null && refreshScheme.getType() == MaterializedViewRefreshType.ASYNC) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -9308,7 +9308,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         } else if (context.IMMEDIATE() != null) {
             refreshMoment = RefreshSchemeClause.RefreshMoment.IMMEDIATE;
         }
-        if (context.ASYNC() != null) {
+        // SCHEDULE is the preferred keyword; ASYNC is kept as a synonym for compatibility.
+        if (context.ASYNC() != null || context.SCHEDULE() != null) {
             boolean defineStartTime = false;
             if (context.START() != null) {
                 NodePosition timePos = createPos(context.string());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -140,14 +140,19 @@ public class AlterMaterializedViewTest extends MVTestBase  {
         MaterializedView mv = starRocksAssert.getMv("test", mvName);
         String taskDefinition = mv.getTaskDefinition();
         for (String refresh : refreshSchemes) {
-            // alter
+            // alter — ASYNC is kept as a legacy synonym; SCHEDULE is the preferred keyword
+            // for the EVERY form and is what SHOW CREATE displays.
             String sql = String.format("alter materialized view %s refresh %s", mvName, refresh);
             starRocksAssert.ddl(sql);
 
-            // verify
             mv = starRocksAssert.getMv("test", mvName);
             String showCreateStmt = mv.getMaterializedViewDdlStmt(false);
-            Assertions.assertTrue(showCreateStmt.contains(refresh),
+            // SHOW CREATE rewrites "ASYNC ... EVERY ..." to "SCHEDULE ... EVERY ..." but leaves
+            // bare ASYNC (no EVERY) unchanged.
+            String expected = refresh.contains("EVERY")
+                    ? refresh.replaceFirst("^ASYNC", "SCHEDULE")
+                    : refresh;
+            Assertions.assertTrue(showCreateStmt.contains(expected),
                     String.format("alter to %s \nbut got \n%s", refresh, showCreateStmt));
             Assertions.assertEquals(taskDefinition, mv.getTaskDefinition());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
@@ -237,13 +237,46 @@ public class ShowCreateMaterializedViewStmtTest {
         Assertions.assertThrows(SemanticException.class, () -> table.getUniqueConstraints().get(0).getUniqueColumnNames(table));
     }
 
+    @Test
+    public void testAsyncIsSynonymForScheduleAndShowCreatePrefersSchedule() throws Exception {
+        final String mvName = "test_mv_async_synonym";
+        starRocksAssert.ddl("drop materialized view if exists " + mvName);
+        // ASYNC must remain accepted as a synonym.
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW " + mvName +
+                " DISTRIBUTED BY HASH(`k1`) BUCKETS 3" +
+                " REFRESH ASYNC EVERY(INTERVAL 1 HOUR)" +
+                " AS SELECT k1, k2 FROM test.tbl1");
+        MaterializedView mv = starRocksAssert.getMv(starRocksAssert.getCtx().getDatabase(), mvName);
+        List<String> ddl = Lists.newArrayList();
+        AstToStringBuilder.getDdlStmt(mv, ddl, null, null, false, true);
+        Assertions.assertTrue(ddl.get(0).contains("REFRESH SCHEDULE EVERY(INTERVAL 1 HOUR)"),
+                "SHOW CREATE should display SCHEDULE, got: " + ddl.get(0));
+        Assertions.assertFalse(ddl.get(0).contains("REFRESH ASYNC"),
+                "SHOW CREATE should not display ASYNC, got: " + ddl.get(0));
+        starRocksAssert.dropMaterializedView(mvName);
+
+        // SCHEDULE should also parse and produce the same display.
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW " + mvName +
+                " DISTRIBUTED BY HASH(`k1`) BUCKETS 3" +
+                " REFRESH SCHEDULE EVERY(INTERVAL 1 HOUR)" +
+                " AS SELECT k1, k2 FROM test.tbl1");
+        mv = starRocksAssert.getMv(starRocksAssert.getCtx().getDatabase(), mvName);
+        ddl.clear();
+        AstToStringBuilder.getDdlStmt(mv, ddl, null, null, false, true);
+        Assertions.assertTrue(ddl.get(0).contains("REFRESH SCHEDULE EVERY(INTERVAL 1 HOUR)"),
+                "SHOW CREATE should display SCHEDULE, got: " + ddl.get(0));
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
     public static Stream<Arguments> genTestArguments() {
+        // Bare ASYNC (without EVERY) is the legacy form retained for backward compatibility;
+        // SCHEDULE is the preferred keyword for scheduled refresh and requires EVERY.
         List<String> refreshArgumentsList = Lists.newArrayList(
                 "REFRESH MANUAL",
                 "REFRESH DEFERRED MANUAL",
                 "REFRESH ASYNC",
-                "REFRESH ASYNC EVERY(INTERVAL 1 HOUR)",
-                "REFRESH ASYNC START(\"1998-01-01 00:00:00\") EVERY(INTERVAL 1 HOUR)"
+                "REFRESH SCHEDULE EVERY(INTERVAL 1 HOUR)",
+                "REFRESH SCHEDULE START(\"1998-01-01 00:00:00\") EVERY(INTERVAL 1 HOUR)"
         );
         List<String> orderByList = Lists.newArrayList("", "ORDER BY (k3)");
         List<String> propertiesList = Lists.newArrayList(

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -3048,7 +3048,7 @@ alterModifyDefaultBuckets
 
 refreshSchemeDesc
     : REFRESH (IMMEDIATE | DEFERRED)? (ASYNC
-    | ASYNC (START '(' string ')')? EVERY '(' interval ')'
+    | (ASYNC | SCHEDULE) (START '(' string ')')? EVERY '(' interval ')'
     | MANUAL)
     ;
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
the trigger framework keyword for scheduled refresh is renamed to SCHEDULE. ASYNC is preserved as a parser-level synonym so existing scripts continue to work; SHOW CREATE displays the new SCHEDULE keyword.

Production:
- Grammar: refreshSchemeDesc now accepts (ASYNC | SCHEDULE) as equivalent tokens for the scheduled refresh form. Both keywords are already declared in the lexer and listed as non-reserved.
- AstBuilder.visitRefreshSchemeDesc: branch on ASYNC || SCHEDULE; both produce the same AsyncRefreshSchemeDesc.
- MaterializedView.getMaterializedViewDdlStmt: emit "SCHEDULE" in place of "ASYNC" for MaterializedViewRefreshType.ASYNC. The persisted enum is unchanged; only the user-facing display is updated.

Tests:
- Add a synonym test (testAsyncIsSynonymForScheduleAndShowCreatePrefers Schedule) covering both keywords in CREATE and asserting SHOW CREATE output uses SCHEDULE.
- Update the parameterized refreshArgumentsList in ShowCreateMaterializedViewStmtTest from REFRESH ASYNC to REFRESH SCHEDULE so the SHOW CREATE round-trip assertion matches the new display.
- Update testAlterRefreshScheme to translate ASYNC→SCHEDULE when comparing the SHOW CREATE output of an ALTER REFRESH ASYNC ... statement.
- Update SQL integration R files where SHOW CREATE output appears (test_enable_mv, test_random_distribution) to expect SCHEDULE.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4