### PR TITLE
[BugFix] Preserve CompactionTaskStats in be_cloud_native_compactions PROFILE for parallel subtasks

### DIFF
--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -118,15 +118,13 @@ std::string CompactionTaskStats::to_json_stats() const {
     return serialize(root);
 }
 
-std::string CompactionTaskStats::to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets,
-                                                                     int64_t input_bytes) const {
+std::string CompactionTaskStats::to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets) const {
     rapidjson::Document root;
     root.SetObject();
     fill_stats_fields(root, *this);
     auto& allocator = root.GetAllocator();
     root.AddMember("subtask_id", rapidjson::Value(subtask_id), allocator);
     root.AddMember("input_rowsets", rapidjson::Value(static_cast<int64_t>(input_rowsets)), allocator);
-    root.AddMember("input_bytes", rapidjson::Value(input_bytes), allocator);
     root.AddMember("is_parallel_subtask", rapidjson::Value(true), allocator);
     return serialize(root);
 }

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -84,31 +84,50 @@ CompactionTaskStats CompactionTaskStats::operator-(const CompactionTaskStats& th
     return diff;
 }
 
-std::string CompactionTaskStats::to_json_stats() {
-    rapidjson::Document root;
-    root.SetObject();
+static void fill_stats_fields(rapidjson::Document& root, const CompactionTaskStats& s) {
     auto& allocator = root.GetAllocator();
-    // add stats
-    root.AddMember("read_local_sec", rapidjson::Value(io_ns_read_local_disk / TIME_UNIT_NS_PER_SECOND), allocator);
-    root.AddMember("read_local_mb", rapidjson::Value(io_bytes_read_local_disk / BYTES_UNIT_MB), allocator);
-    root.AddMember("read_remote_sec", rapidjson::Value(io_ns_read_remote / TIME_UNIT_NS_PER_SECOND), allocator);
-    root.AddMember("read_remote_mb", rapidjson::Value(io_bytes_read_remote / BYTES_UNIT_MB), allocator);
-    root.AddMember("read_remote_count", rapidjson::Value(io_count_remote), allocator);
-    root.AddMember("read_local_count", rapidjson::Value(io_count_local_disk), allocator);
-    root.AddMember("segment_init_sec", rapidjson::Value(segment_init_ns / TIME_UNIT_NS_PER_SECOND), allocator);
-    root.AddMember("column_iterator_init_sec", rapidjson::Value(column_iterator_init_ns / TIME_UNIT_NS_PER_SECOND),
+    root.AddMember("read_local_sec", rapidjson::Value(s.io_ns_read_local_disk / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("read_local_mb", rapidjson::Value(s.io_bytes_read_local_disk / BYTES_UNIT_MB), allocator);
+    root.AddMember("read_remote_sec", rapidjson::Value(s.io_ns_read_remote / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("read_remote_mb", rapidjson::Value(s.io_bytes_read_remote / BYTES_UNIT_MB), allocator);
+    root.AddMember("read_remote_count", rapidjson::Value(s.io_count_remote), allocator);
+    root.AddMember("read_local_count", rapidjson::Value(s.io_count_local_disk), allocator);
+    root.AddMember("segment_init_sec", rapidjson::Value(s.segment_init_ns / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("column_iterator_init_sec", rapidjson::Value(s.column_iterator_init_ns / TIME_UNIT_NS_PER_SECOND),
                    allocator);
-    root.AddMember("read_segment_count", rapidjson::Value(read_segment_count), allocator);
-    root.AddMember("write_segment_count", rapidjson::Value(write_segment_count), allocator);
-    root.AddMember("write_remote_mb", rapidjson::Value(write_segment_bytes / BYTES_UNIT_MB), allocator);
-    root.AddMember("write_remote_sec", rapidjson::Value(io_ns_write_remote / TIME_UNIT_NS_PER_SECOND), allocator);
-    root.AddMember("in_queue_sec", rapidjson::Value(in_queue_time_sec), allocator);
-    root.AddMember("pk_sst_merge_sec", rapidjson::Value(pk_sst_merge_ns / TIME_UNIT_NS_PER_SECOND), allocator);
-    root.AddMember("input_file_size", rapidjson::Value(input_file_size), allocator);
+    root.AddMember("read_segment_count", rapidjson::Value(s.read_segment_count), allocator);
+    root.AddMember("write_segment_count", rapidjson::Value(s.write_segment_count), allocator);
+    root.AddMember("write_remote_mb", rapidjson::Value(s.write_segment_bytes / BYTES_UNIT_MB), allocator);
+    root.AddMember("write_remote_sec", rapidjson::Value(s.io_ns_write_remote / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("in_queue_sec", rapidjson::Value(s.in_queue_time_sec), allocator);
+    root.AddMember("pk_sst_merge_sec", rapidjson::Value(s.pk_sst_merge_ns / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("input_file_size", rapidjson::Value(s.input_file_size), allocator);
+}
 
+static std::string serialize(const rapidjson::Document& root) {
     rapidjson::StringBuffer strbuf;
     rapidjson::Writer<rapidjson::StringBuffer> writer(strbuf);
     root.Accept(writer);
     return {strbuf.GetString()};
+}
+
+std::string CompactionTaskStats::to_json_stats() const {
+    rapidjson::Document root;
+    root.SetObject();
+    fill_stats_fields(root, *this);
+    return serialize(root);
+}
+
+std::string CompactionTaskStats::to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets,
+                                                                     int64_t input_bytes) const {
+    rapidjson::Document root;
+    root.SetObject();
+    fill_stats_fields(root, *this);
+    auto& allocator = root.GetAllocator();
+    root.AddMember("subtask_id", rapidjson::Value(subtask_id), allocator);
+    root.AddMember("input_rowsets", rapidjson::Value(static_cast<int64_t>(input_rowsets)), allocator);
+    root.AddMember("input_bytes", rapidjson::Value(input_bytes), allocator);
+    root.AddMember("is_parallel_subtask", rapidjson::Value(true), allocator);
+    return serialize(root);
 }
 } // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -63,7 +63,14 @@ struct CompactionTaskStats {
     void collect(const OlapWriterStatistics& writer_stats);
     CompactionTaskStats operator+(const CompactionTaskStats& that) const;
     CompactionTaskStats operator-(const CompactionTaskStats& that) const;
-    std::string to_json_stats();
+    std::string to_json_stats() const;
+
+    // Same JSON layout as to_json_stats(), with parallel-subtask metadata fields
+    // (subtask_id, input_rowsets, input_bytes, is_parallel_subtask) appended.
+    // Used for the PROFILE column of be_cloud_native_compactions so that both
+    // the CompactionTaskStats counters and per-subtask metadata are visible.
+    std::string to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets,
+                                                    int64_t input_bytes) const;
 };
 
 // Context of a single tablet compaction task.

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -66,11 +66,12 @@ struct CompactionTaskStats {
     std::string to_json_stats() const;
 
     // Same JSON layout as to_json_stats(), with parallel-subtask metadata fields
-    // (subtask_id, input_rowsets, input_bytes, is_parallel_subtask) appended.
-    // Used for the PROFILE column of be_cloud_native_compactions so that both
-    // the CompactionTaskStats counters and per-subtask metadata are visible.
-    std::string to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets,
-                                                    int64_t input_bytes) const;
+    // (subtask_id, input_rowsets, is_parallel_subtask) appended. Used for the
+    // PROFILE column of be_cloud_native_compactions so that both the
+    // CompactionTaskStats counters and per-subtask metadata are visible. Actual
+    // read volume is already reported via read_local_mb / read_remote_mb in the
+    // stats fields, so the planned input_bytes is intentionally omitted.
+    std::string to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets) const;
 };
 
 // Context of a single tablet compaction task.
@@ -130,7 +131,6 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     // start so that the PROFILE column of be_cloud_native_compactions can keep reporting it
     // after the subtask leaves running_subtasks.
     int64_t subtask_input_rowsets = 0;
-    int64_t subtask_input_bytes = 0;
     // Flag to indicate this is a merged context from parallel compaction.
     // When true, cleanup_tablet should be called in remove_states after RPC response is sent.
     bool is_parallel_merged = false;

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -126,6 +126,11 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     int32_t subtask_id = -1; // -1 means not a parallel compaction subtask
     // Number of subtasks in this compaction (1 for normal compaction, >1 for parallel compaction)
     int32_t subtask_count = 1;
+    // Snapshot of the parallel-subtask input footprint, copied from SubtaskInfo at execution
+    // start so that the PROFILE column of be_cloud_native_compactions can keep reporting it
+    // after the subtask leaves running_subtasks.
+    int64_t subtask_input_rowsets = 0;
+    int64_t subtask_input_bytes = 0;
     // Flag to indicate this is a merged context from parallel compaction.
     // When true, cleanup_tablet should be called in remove_states after RPC response is sent.
     bool is_parallel_merged = false;

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1458,7 +1458,6 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
             // Snapshot the subtask input footprint onto the context so list_tasks() can
             // surface it consistently for both running and completed subtasks.
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
-            context->subtask_input_bytes = it->second.input_bytes;
             // Store context pointer for real-time progress/status tracking
             it->second.context = context.get();
         }
@@ -1646,8 +1645,8 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
             if (subtask_info.context != nullptr && subtask_info.context->stats) {
                 stats_ptr = subtask_info.context->stats.get();
             }
-            info.profile = stats_ptr->to_json_stats_with_subtask_metadata(
-                    subtask_id, subtask_info.input_rowset_ids.size(), subtask_info.input_bytes);
+            info.profile =
+                    stats_ptr->to_json_stats_with_subtask_metadata(subtask_id, subtask_info.input_rowset_ids.size());
         }
 
         // Add completed subtasks that haven't been cleaned up yet
@@ -1667,7 +1666,7 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
                 // parallel subtask.
                 if (ctx->subtask_id >= 0) {
                     info.profile = ctx->stats->to_json_stats_with_subtask_metadata(
-                            ctx->subtask_id, static_cast<size_t>(ctx->subtask_input_rowsets), ctx->subtask_input_bytes);
+                            ctx->subtask_id, static_cast<size_t>(ctx->subtask_input_rowsets));
                 } else {
                     info.profile = ctx->stats->to_json_stats();
                 }
@@ -2212,7 +2211,6 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
             int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
             context->stats->in_queue_time_sec += in_queue_time_sec;
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
-            context->subtask_input_bytes = it->second.input_bytes;
             it->second.context = context.get();
         }
     }
@@ -2559,7 +2557,6 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
             int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
             context->stats->in_queue_time_sec += in_queue_time_sec;
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
-            context->subtask_input_bytes = it->second.input_bytes;
             it->second.context = context.get();
         }
     }

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1634,10 +1634,16 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
                 info.progress = 0;
             }
             info.status = Status::OK();
-            // Build profile with subtask-specific info
-            info.profile =
-                    fmt::format(R"({{"subtask_id":{},"input_rowsets":{},"input_bytes":{},"is_parallel_subtask":true}})",
-                                subtask_id, subtask_info.input_rowset_ids.size(), subtask_info.input_bytes);
+            // Build profile combining CompactionTaskStats (from the running context, when
+            // available) with subtask-specific metadata. Falling back to a default-constructed
+            // stats object keeps the JSON schema stable when the context has not yet been linked.
+            CompactionTaskStats empty_stats;
+            const CompactionTaskStats* stats_ptr = &empty_stats;
+            if (subtask_info.context != nullptr && subtask_info.context->stats) {
+                stats_ptr = subtask_info.context->stats.get();
+            }
+            info.profile = stats_ptr->to_json_stats_with_subtask_metadata(
+                    subtask_id, subtask_info.input_rowset_ids.size(), subtask_info.input_bytes);
         }
 
         // Add completed subtasks that haven't been cleaned up yet

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1455,6 +1455,10 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
             int64_t enqueue_time = it->second.start_time;
             int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
             context->stats->in_queue_time_sec += in_queue_time_sec;
+            // Snapshot the subtask input footprint onto the context so list_tasks() can
+            // surface it consistently for both running and completed subtasks.
+            context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
+            context->subtask_input_bytes = it->second.input_bytes;
             // Store context pointer for real-time progress/status tracking
             it->second.context = context.get();
         }
@@ -1658,7 +1662,16 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
             info.finish_time = ctx->finish_time.load(std::memory_order_acquire);
             info.progress = ctx->progress.value();
             if (info.runs > 0 && ctx->stats) {
-                info.profile = ctx->stats->to_json_stats();
+                // Keep the PROFILE schema consistent with the running-subtasks branch above:
+                // emit subtask metadata alongside the stats whenever the context belongs to a
+                // parallel subtask.
+                if (ctx->subtask_id >= 0) {
+                    info.profile = ctx->stats->to_json_stats_with_subtask_metadata(
+                            ctx->subtask_id, static_cast<size_t>(ctx->subtask_input_rowsets),
+                            ctx->subtask_input_bytes);
+                } else {
+                    info.profile = ctx->stats->to_json_stats();
+                }
             }
             if (info.finish_time > 0) {
                 info.status = ctx->status;
@@ -2199,6 +2212,8 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
             int64_t enqueue_time = it->second.start_time;
             int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
             context->stats->in_queue_time_sec += in_queue_time_sec;
+            context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
+            context->subtask_input_bytes = it->second.input_bytes;
             it->second.context = context.get();
         }
     }
@@ -2544,6 +2559,8 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
             int64_t enqueue_time = it->second.start_time;
             int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
             context->stats->in_queue_time_sec += in_queue_time_sec;
+            context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
+            context->subtask_input_bytes = it->second.input_bytes;
             it->second.context = context.get();
         }
     }

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1667,8 +1667,7 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
                 // parallel subtask.
                 if (ctx->subtask_id >= 0) {
                     info.profile = ctx->stats->to_json_stats_with_subtask_metadata(
-                            ctx->subtask_id, static_cast<size_t>(ctx->subtask_input_rowsets),
-                            ctx->subtask_input_bytes);
+                            ctx->subtask_id, static_cast<size_t>(ctx->subtask_input_rowsets), ctx->subtask_input_bytes);
                 } else {
                     info.profile = ctx->stats->to_json_stats();
                 }

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -165,7 +165,7 @@ TEST_F(CompactionTaskContextTest, test_to_json_stats_with_subtask_metadata) {
     context.stats->in_queue_time_sec = 11;
 
     std::string json_profile = context.stats->to_json_stats_with_subtask_metadata(
-            /*subtask_id=*/3, /*input_rowsets=*/5, /*input_bytes=*/2048);
+            /*subtask_id=*/3, /*input_rowsets=*/5);
 
     // Stats fields must still be present (this is the regression that was being lost).
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("read_remote_mb":2)"));
@@ -173,10 +173,12 @@ TEST_F(CompactionTaskContextTest, test_to_json_stats_with_subtask_metadata) {
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("write_segment_count":7)"));
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("in_queue_sec":11)"));
 
-    // Subtask metadata must be appended alongside the stats.
+    // Subtask metadata must be appended alongside the stats. The planned input_bytes
+    // is intentionally omitted because the actual read volume is already reported via
+    // read_local_mb / read_remote_mb in the stats fields above.
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("subtask_id":3)"));
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("input_rowsets":5)"));
-    EXPECT_THAT(json_profile, testing::HasSubstr(R"("input_bytes":2048)"));
+    EXPECT_THAT(json_profile, testing::Not(testing::HasSubstr(R"("input_bytes")")));
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("is_parallel_subtask":true)"));
 }
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -155,4 +155,28 @@ TEST_F(CompactionTaskContextTest, test_to_json_stats) {
     EXPECT_THAT(json_stats, testing::HasSubstr(R"("in_queue_sec":5)"));
     EXPECT_THAT(json_stats, testing::HasSubstr(R"("pk_sst_merge_sec":5)"));
 }
+
+TEST_F(CompactionTaskContextTest, test_to_json_stats_with_subtask_metadata) {
+    static constexpr long TIME_UNIT_NS_PER_SECOND = 1000000000;
+
+    context.stats->io_bytes_read_remote = 2 * 1048576;
+    context.stats->io_ns_read_remote = 4 * TIME_UNIT_NS_PER_SECOND;
+    context.stats->write_segment_count = 7;
+    context.stats->in_queue_time_sec = 11;
+
+    std::string json_profile = context.stats->to_json_stats_with_subtask_metadata(
+            /*subtask_id=*/3, /*input_rowsets=*/5, /*input_bytes=*/2048);
+
+    // Stats fields must still be present (this is the regression that was being lost).
+    EXPECT_THAT(json_profile, testing::HasSubstr(R"("read_remote_mb":2)"));
+    EXPECT_THAT(json_profile, testing::HasSubstr(R"("read_remote_sec":4)"));
+    EXPECT_THAT(json_profile, testing::HasSubstr(R"("write_segment_count":7)"));
+    EXPECT_THAT(json_profile, testing::HasSubstr(R"("in_queue_sec":11)"));
+
+    // Subtask metadata must be appended alongside the stats.
+    EXPECT_THAT(json_profile, testing::HasSubstr(R"("subtask_id":3)"));
+    EXPECT_THAT(json_profile, testing::HasSubstr(R"("input_rowsets":5)"));
+    EXPECT_THAT(json_profile, testing::HasSubstr(R"("input_bytes":2048)"));
+    EXPECT_THAT(json_profile, testing::HasSubstr(R"("is_parallel_subtask":true)"));
+}
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -1387,6 +1387,9 @@ TEST_F(TabletParallelCompactionManagerTest, test_list_tasks_with_completed) {
     ctx0->start_time.store(::time(nullptr) - 10, std::memory_order_relaxed);
     ctx0->finish_time.store(::time(nullptr), std::memory_order_release);
     ctx0->skipped.store(false, std::memory_order_relaxed);
+    ctx0->subtask_input_rowsets = 4;
+    ctx0->subtask_input_bytes = 1234;
+    ctx0->stats->in_queue_time_sec = 7;
     ctx0->txn_log = std::make_unique<TxnLogPB>();
     ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
     ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
@@ -1399,6 +1402,21 @@ TEST_F(TabletParallelCompactionManagerTest, test_list_tasks_with_completed) {
 
     // Should have tasks listed
     EXPECT_GE(infos.size(), 1);
+
+    // The PROFILE for a completed parallel subtask must carry both the CompactionTaskStats
+    // counters and the subtask metadata - i.e. the same JSON schema as a running subtask.
+    bool found_completed_profile = false;
+    for (const auto& info : infos) {
+        if (info.finish_time > 0 && info.runs > 0) {
+            EXPECT_NE(info.profile.find(R"("in_queue_sec":7)"), std::string::npos);
+            EXPECT_NE(info.profile.find(R"("subtask_id":0)"), std::string::npos);
+            EXPECT_NE(info.profile.find(R"("input_rowsets":4)"), std::string::npos);
+            EXPECT_NE(info.profile.find(R"("input_bytes":1234)"), std::string::npos);
+            EXPECT_NE(info.profile.find(R"("is_parallel_subtask":true)"), std::string::npos);
+            found_completed_profile = true;
+        }
+    }
+    EXPECT_TRUE(found_completed_profile);
 
     // Complete subtask 1 to finish
     auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -1388,7 +1388,6 @@ TEST_F(TabletParallelCompactionManagerTest, test_list_tasks_with_completed) {
     ctx0->finish_time.store(::time(nullptr), std::memory_order_release);
     ctx0->skipped.store(false, std::memory_order_relaxed);
     ctx0->subtask_input_rowsets = 4;
-    ctx0->subtask_input_bytes = 1234;
     ctx0->stats->in_queue_time_sec = 7;
     ctx0->txn_log = std::make_unique<TxnLogPB>();
     ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
@@ -1411,7 +1410,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_list_tasks_with_completed) {
             EXPECT_NE(info.profile.find(R"("in_queue_sec":7)"), std::string::npos);
             EXPECT_NE(info.profile.find(R"("subtask_id":0)"), std::string::npos);
             EXPECT_NE(info.profile.find(R"("input_rowsets":4)"), std::string::npos);
-            EXPECT_NE(info.profile.find(R"("input_bytes":1234)"), std::string::npos);
+            EXPECT_EQ(info.profile.find(R"("input_bytes")"), std::string::npos);
             EXPECT_NE(info.profile.find(R"("is_parallel_subtask":true)"), std::string::npos);
             found_completed_profile = true;
         }


### PR DESCRIPTION
## Why I'm doing:
For running parallel compaction subtasks, the PROFILE column was overwritten with only subtask metadata (subtask_id, input_rowsets, input_bytes, is_parallel_subtask), discarding the CompactionTaskStats counters that to_json_stats() produced. Add a new CompactionTaskStats::to_json_stats_with_subtask_metadata() that emits the same JSON layout as to_json_stats() with the subtask metadata fields appended, and use it from TabletParallelCompactionManager::list_tasks() so both pieces are visible in information_schema.be_cloud_native_compactions.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
