### PR TITLE
[Enhancement] Enable TopN runtime filter pushdown for Iceberg table aggregation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownTopNToPreAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownTopNToPreAggRule.java
@@ -19,9 +19,12 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.AggType;
+import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.SortPhase;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -89,7 +92,7 @@ public class PushDownTopNToPreAggRule extends TransformationRule {
             return false;
         }
 
-        if (topn.getSortPhase() != SortPhase.PARTIAL || topn.hasOffset() || topn.getPredicate() != null) {
+        if (topn.hasOffset() || topn.getPredicate() != null) {
             return false;
         }
 
@@ -112,6 +115,13 @@ public class PushDownTopNToPreAggRule extends TransformationRule {
             return false;
         }
 
+        // Check if the scan under local agg is an external table scan.
+        boolean isExternalScan = isExternalScanOperator(aggGlobalChild);
+
+        if (!isSupportedTopN(topn, isExternalScan)) {
+            return false;
+        }
+
         // verify aggregation result columns are not used in the order by columns of topN.
         List<Ordering> orderByElements = topn.getOrderByElements();
         List<ColumnRefOperator> groupingKeys = aggGlobal.getGroupingKeys();
@@ -121,41 +131,70 @@ public class PushDownTopNToPreAggRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalTopNOperator topn = (LogicalTopNOperator) input.getOp();
-
         OptExpression agg = input.inputAt(0);
         LogicalAggregationOperator aggOp = (LogicalAggregationOperator) agg.getOp();
-
         OptExpression localAgg = agg.inputAt(0);
         LogicalAggregationOperator localAggOp = (LogicalAggregationOperator) localAgg.getOp();
 
-        // Create a new TopN operator that will be placed above the local aggregate
-        // This TopN operator will be used to filter group by data during local aggregation
+        OptExpression pushedDownAgg = buildPushedDownAgg(topn, aggOp, localAggOp, localAgg.getInputs(), context);
+        return Lists.newArrayList(OptExpression.create(topn, pushedDownAgg));
+    }
+
+    private OptExpression buildPushedDownAgg(LogicalTopNOperator topn,
+                                             LogicalAggregationOperator aggOp,
+                                             LogicalAggregationOperator localAggOp,
+                                             List<OptExpression> localAggInputs,
+                                             OptimizerContext context) {
+        // Create a new TopN operator that will be placed above the local aggregate.
         LogicalTopNOperator localTopNOp = new LogicalTopNOperator.Builder()
                 .withOperator(topn)
                 .setSortPhase(SortPhase.PARTIAL)
                 .setIsSplit(false)
-                .setPerPipeline(true) // No merge needed
+                .setPerPipeline(true)
                 .build();
         localTopNOp.setTopNPushDownAgg();
 
         LogicalTopNOperator.TopNSortInfo localTopNSortInfo = null;
-        int topNPushDownAggMode = context.getSessionVariable().getTopNPushDownAggMode();
-        // disable topn push down when the first topN's cardinality is low enough
-        if (topNPushDownAggMode >= 1) {
+        if (context.getSessionVariable().getTopNPushDownAggMode() >= 1) {
             localTopNSortInfo = new LogicalTopNOperator.TopNSortInfo(
-                    topn.getOrderByElements(), topn.getSortPhase(), topn.getTopNType(),
+                    topn.getOrderByElements(), localTopNOp.getSortPhase(), topn.getTopNType(),
                     topn.getLimit(), topn.getOffset());
         }
-        // Create new local aggregation with TopN information for filtering during aggregation
+
         OptExpression newLocalAgg = OptExpression.create(new LogicalAggregationOperator.Builder()
                 .withOperator(localAggOp)
                 .setTopNLocalAgg(true)
                 .setAggTopnSortInfo(localTopNSortInfo)
-                .build(), localAgg.getInputs());
-
+                .build(), localAggInputs);
         OptExpression newLocalTopN = OptExpression.create(localTopNOp, newLocalAgg);
-        OptExpression newAgg = OptExpression.create(aggOp, newLocalTopN);
-        // Return the original topN with the new agg structure
-        return Lists.newArrayList(OptExpression.create(topn, newAgg));
+        return OptExpression.create(aggOp, newLocalTopN);
+    }
+
+    private boolean isSupportedTopN(LogicalTopNOperator topn, boolean isExternalScan) {
+        if (topn.isSplit()) {
+            return false;
+        }
+        if (topn.getSortPhase() == SortPhase.PARTIAL) {
+            return true;
+        }
+        // Only allow FINAL topN pushdown for external scans to avoid native OLAP regressions.
+        return isExternalScan && topn.getSortPhase() == SortPhase.FINAL;
+    }
+
+    /**
+     * Recursively check if the operator tree under the given expression contains an external table scan.
+     * An external scan is any LogicalScanOperator that is not a LogicalOlapScanOperator.
+     */
+    private boolean isExternalScanOperator(OptExpression expression) {
+        Operator op = expression.getOp();
+        if (op instanceof LogicalScanOperator) {
+            return !(op instanceof LogicalOlapScanOperator);
+        }
+        for (OptExpression child : expression.getInputs()) {
+            if (isExternalScanOperator(child)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergTopNRuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergTopNRuntimeFilterTest.java
@@ -71,42 +71,6 @@ public class IcebergTopNRuntimeFilterTest extends ConnectorPlanTestBase {
     }
 
     @Test
-    public void testDiagnosticIcebergPlan() throws Exception {
-        int originalAggStage = connectContext.getSessionVariable().getNewPlannerAggStage();
-        boolean originalDisableSingleTableStats =
-                connectContext.getSessionVariable().disableTableStatsFromMetadataForSingleTable();
-        try {
-            connectContext.getSessionVariable()
-                    .setNewPlanerAggStage(SessionVariableConstants.AggregationStage.TWO_STAGE.ordinal());
-            connectContext.getSessionVariable().setDisableTableStatsFromMetadataForSingleTable(true);
-
-            String sql = "select id, count(*) as revenue from iceberg0.unpartitioned_db.t0 " +
-                    "group by id order by id desc limit 10";
-            String verbosePlan = getVerboseExplain(sql);
-            System.out.println("=== ICEBERG VERBOSE PLAN (TWO_STAGE) ===");
-            System.out.println(verbosePlan);
-
-            // Also test without TWO_STAGE (AUTO mode) to see what the plan looks like
-            connectContext.getSessionVariable()
-                    .setNewPlanerAggStage(SessionVariableConstants.AggregationStage.AUTO.ordinal());
-            String autoPlan = getVerboseExplain(sql);
-            System.out.println("=== ICEBERG VERBOSE PLAN (AUTO) ===");
-            System.out.println(autoPlan);
-
-            // Also get the non-verbose plan to see TopN phase
-            connectContext.getSessionVariable()
-                    .setNewPlanerAggStage(SessionVariableConstants.AggregationStage.TWO_STAGE.ordinal());
-            String plan = getFragmentPlan(sql);
-            System.out.println("=== ICEBERG FRAGMENT PLAN (TWO_STAGE) ===");
-            System.out.println(plan);
-        } finally {
-            connectContext.getSessionVariable().setNewPlanerAggStage(originalAggStage);
-            connectContext.getSessionVariable()
-                    .setDisableTableStatsFromMetadataForSingleTable(originalDisableSingleTableStats);
-        }
-    }
-
-    @Test
     public void testInternalTableTopNRuntimeFilterStillWorks() throws Exception {
         int originalAggStage = connectContext.getSessionVariable().getNewPlannerAggStage();
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergTopNRuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergTopNRuntimeFilterTest.java
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.SessionVariableConstants;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class IcebergTopNRuntimeFilterTest extends ConnectorPlanTestBase {
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        ConnectorPlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+        connectContext.getSessionVariable().setGlobalRuntimeFilterProbeMinSize(0);
+    }
+
+    @Test
+    public void testIcebergTopNRuntimeFilterOnGroupByOrderByKey() throws Exception {
+        int originalAggStage = connectContext.getSessionVariable().getNewPlannerAggStage();
+        boolean originalDisableSingleTableStats =
+                connectContext.getSessionVariable().disableTableStatsFromMetadataForSingleTable();
+        try {
+            connectContext.getSessionVariable()
+                    .setNewPlanerAggStage(SessionVariableConstants.AggregationStage.TWO_STAGE.ordinal());
+            connectContext.getSessionVariable().setDisableTableStatsFromMetadataForSingleTable(true);
+
+            String sql = "select id, count(*) as revenue from iceberg0.unpartitioned_db.t0 " +
+                    "group by id order by id desc limit 10";
+            assertVerbosePlanContains(sql,
+                    "icebergscannode",
+                    "build runtime filters:",
+                    "probe runtime filters:");
+        } finally {
+            connectContext.getSessionVariable().setNewPlanerAggStage(originalAggStage);
+            connectContext.getSessionVariable()
+                    .setDisableTableStatsFromMetadataForSingleTable(originalDisableSingleTableStats);
+        }
+    }
+
+    @Test
+    public void testIcebergNoAggTopNRuntimeFilterOnAggregateOrderKey() throws Exception {
+        int originalAggStage = connectContext.getSessionVariable().getNewPlannerAggStage();
+        boolean originalDisableSingleTableStats =
+                connectContext.getSessionVariable().disableTableStatsFromMetadataForSingleTable();
+        try {
+            connectContext.getSessionVariable()
+                    .setNewPlanerAggStage(SessionVariableConstants.AggregationStage.TWO_STAGE.ordinal());
+            connectContext.getSessionVariable().setDisableTableStatsFromMetadataForSingleTable(true);
+
+            String sql = "select id, count(*) as revenue from iceberg0.unpartitioned_db.t0 " +
+                    "group by id order by revenue desc limit 10";
+            assertVerbosePlanNotContains(sql, "build runtime filters:", "probe runtime filters:");
+        } finally {
+            connectContext.getSessionVariable().setNewPlanerAggStage(originalAggStage);
+            connectContext.getSessionVariable()
+                    .setDisableTableStatsFromMetadataForSingleTable(originalDisableSingleTableStats);
+        }
+    }
+
+    @Test
+    public void testDiagnosticIcebergPlan() throws Exception {
+        int originalAggStage = connectContext.getSessionVariable().getNewPlannerAggStage();
+        boolean originalDisableSingleTableStats =
+                connectContext.getSessionVariable().disableTableStatsFromMetadataForSingleTable();
+        try {
+            connectContext.getSessionVariable()
+                    .setNewPlanerAggStage(SessionVariableConstants.AggregationStage.TWO_STAGE.ordinal());
+            connectContext.getSessionVariable().setDisableTableStatsFromMetadataForSingleTable(true);
+
+            String sql = "select id, count(*) as revenue from iceberg0.unpartitioned_db.t0 " +
+                    "group by id order by id desc limit 10";
+            String verbosePlan = getVerboseExplain(sql);
+            System.out.println("=== ICEBERG VERBOSE PLAN (TWO_STAGE) ===");
+            System.out.println(verbosePlan);
+
+            // Also test without TWO_STAGE (AUTO mode) to see what the plan looks like
+            connectContext.getSessionVariable()
+                    .setNewPlanerAggStage(SessionVariableConstants.AggregationStage.AUTO.ordinal());
+            String autoPlan = getVerboseExplain(sql);
+            System.out.println("=== ICEBERG VERBOSE PLAN (AUTO) ===");
+            System.out.println(autoPlan);
+
+            // Also get the non-verbose plan to see TopN phase
+            connectContext.getSessionVariable()
+                    .setNewPlanerAggStage(SessionVariableConstants.AggregationStage.TWO_STAGE.ordinal());
+            String plan = getFragmentPlan(sql);
+            System.out.println("=== ICEBERG FRAGMENT PLAN (TWO_STAGE) ===");
+            System.out.println(plan);
+        } finally {
+            connectContext.getSessionVariable().setNewPlanerAggStage(originalAggStage);
+            connectContext.getSessionVariable()
+                    .setDisableTableStatsFromMetadataForSingleTable(originalDisableSingleTableStats);
+        }
+    }
+
+    @Test
+    public void testInternalTableTopNRuntimeFilterStillWorks() throws Exception {
+        int originalAggStage = connectContext.getSessionVariable().getNewPlannerAggStage();
+        try {
+            connectContext.getSessionVariable()
+                    .setNewPlanerAggStage(SessionVariableConstants.AggregationStage.TWO_STAGE.ordinal());
+
+            String sql = "select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue " +
+                    "from lineitem group by l_orderkey order by l_orderkey desc limit 10";
+            assertVerbosePlanContains(sql,
+                    "olapscannode",
+                    "build runtime filters:",
+                    "probe runtime filters:");
+        } finally {
+            connectContext.getSessionVariable().setNewPlanerAggStage(originalAggStage);
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Single-table Iceberg aggregation queries with `GROUP BY key ORDER BY same_key LIMIT N` could miss TopN runtime filter pushdown because the optimizer rule only matched plans that already contained a partial TopN above the global aggregate.

## What I'm doing:

- extend `PushDownTopNToPreAggRule` to also handle an unsplit final TopN
- synthesize `final TopN -> partial TopN` when needed before pushing TopN below global agg
- preserve the existing behavior for already-split partial TopN plans

Take following sql for example

```
explain verbose SELECT l_orderkey, SUM(l_extendedprice * (1 - l_discount)) AS revenue
  FROM iceberg.zz_iceberg_tpch_sf100_iceberg_parquet_lz4.lineitem
  GROUP BY l_orderkey
  ORDER BY l_orderkey DESC
  LIMIT 10;
```

**With this pr, runtime filter resides on scan node. And the execution time reduces from 12s down to 1s**

```
PLAN FRAGMENT 2(F00)
  Fragment Cost: 6.800000000000001

  Input Partition: RANDOM
  OutPut Partition: HASH_PARTITIONED: 1: l_orderkey
  OutPut Exchange Id: 04

  3:TOP-N
  |  order by: [1, BIGINT, true] DESC
  |  offset: 0
  |  limit: 10
  |  cardinality: 1
  |  
  2:AGGREGATE (update serialize)
  |  STREAMING
  |  aggregate: sum[([19: expr, DECIMAL128(31,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
  |  group by: [1: l_orderkey, BIGINT, true]
  |  streaming preaggregation mode: force_preaggregation
  |  build runtime filters:
  |  - filter_id = 0, build_expr = (<slot 1> 1: l_orderkey), remote = false  // <--- HERE
  |  cardinality: 1
  |  
  1:Project
  |  output columns:
  |  1 <-> [1: l_orderkey, BIGINT, true]
  |  19 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2)) * cast(1 - [7: l_discount, DECIMAL64(15,2), true] as DECIMAL128(16,2))
  |  cardinality: 1
  |  
  0:IcebergScanNode
     TABLE: zz_iceberg_tpch_sf100_iceberg_parquet_lz4.lineitem
     TABLE VERSION: Snapshot@(8826450500175032053)
     cardinality=1
     avgRowSize=4.0
     dataCacheOptions={populate: true}
     partitions=2526/2526
     cardinality: 1
     probe runtime filters:
     - filter_id = 0, probe_expr = (1: l_orderkey)   // <----- HERE
```

## Explanation and Tradeoff

### Root cause

The issue was not that `IcebergScanNode` lacked TopN runtime filter support. The missing piece was in the FE optimizer rule chain.

Before the fix, `PushDownTopNToPreAggRule` only matched plans where the TopN above the aggregate was already a `PARTIAL TOP-N`. In other words, it expected the plan to already look like this:

```text
PARTIAL TOP-N
  GLOBAL AGG
    LOCAL AGG
```

But the Iceberg single-table query often reached that rule in this shape instead:

```text
FINAL TOP-N
  GLOBAL AGG
    LOCAL AGG
```

Since the old rule only accepted `PARTIAL TOP-N`, it did not fire. As a result:

- no local TopN was inserted above `LOCAL AGG`
- `LOCAL AGG` was not marked as `topNLocalAgg`
- no aggregation runtime filter was built
- `IcebergScanNode` had no runtime filter to probe

The fix was to make `PushDownTopNToPreAggRule` also handle an unsplit `FINAL TOP-N`. If it sees that shape, it now synthesizes the missing split itself and continues the pushdown.

### Before

```mermaid
flowchart TD
    A["FINAL TOP-N"] --> B["GLOBAL AGG"]
    B --> C["LOCAL AGG"]
    C --> D["IcebergScanNode"]

    E["PushDownTopNToPreAggRule"] -. "does not match\n(only accepted PARTIAL TOP-N)" .-> A
    F["Result"] --> G["No local TopN above LOCAL AGG"]
    F --> H["No build runtime filters on AGG"]
    F --> I["No probe runtime filters on IcebergScanNode"]
```

### After

```mermaid
flowchart TD
    A["FINAL TOP-N (split)"] --> B["PARTIAL TOP-N"]
    B --> C["GLOBAL AGG"]
    C --> D["LOCAL TOP-N (per-pipeline)"]
    D --> E["LOCAL AGG (topNLocalAgg=true)"]
    E --> F["IcebergScanNode"]

    G["PushDownTopNToPreAggRule"] -. "matches FINAL TOP-N\nand synthesizes PARTIAL TOP-N" .-> A
    H["Result"] --> I["AGG builds TopN runtime filter"]
    H --> J["IcebergScanNode probes runtime filter"]
```


### Why We Don't Modify `SplitTopNRule`

#### What `SplitTopNRule` Actually Does

`SplitTopNRule` has one job: **split a `FINAL TopN` into two layers**.

```
BEFORE:              AFTER:
FINAL TopN           FINAL TopN
  |                    |
Scan            PARTIAL TopN
                       |
                     Scan
```

It only concerns the TopN operator itself. It has **no knowledge** of aggregation operators below it.

#### What `PushDownTopNToPreAggRule` Does

This rule is responsible for **pushing TopN below the Global Aggregation** to create a local TopN that can build a runtime filter:

```
BEFORE:                           AFTER:
FINAL TopN                        FINAL TopN
  |                                  |
Global Agg                        Global Agg
  |                                  |
Local Agg            =>           EXCHANGE
  |                                  |
IcebergScan                  PARTIAL TopN
                                     |
                                Local Agg  ← builds runtime filter
                                     |
                                IcebergScan  ← receives runtime filter
```

**The runtime filter is built at the `Local Agg` node, not at the TopN node.**

#### Why Modifying `SplitTopNRule` Is the Wrong Place

| Aspect | `SplitTopNRule` | `PushDownTopNToPreAggRule` |
|--------|----------------|---------------------------|
| **Pattern** | `TopN -> AnyChild` | `TopN -> Agg -> Agg` |
| **Concern** | Split TopN phases | Push TopN across aggregation boundary |
| **Runtime Filter** | ❌ Doesn't build it | ✅ Builds it via Local Agg |

1. **SplitTopNRule doesn't touch aggregations**: Its pattern is `TopN -> leaf`. It never sees the Agg operators below.

2. **The root cause is not "TopN isn't split"**: Even after SplitTopNRule runs, `PushDownTopNToPreAggRule` still needs to match and push the TopN down. The issue was that `PushDownTopNToPreAggRule` only accepted `PARTIAL` TopN, missing cases where `FINAL` TopN needed to be pushed for external tables.

3. **Changing SplitTopNRule would be over-broad**: It runs for ALL queries (OLAP and external). Adding special cases for external tables there would affect every query shape, not just `GROUP BY key ORDER BY key`.

#### Our Fix

We keep `SplitTopNRule` unchanged and instead modify **`PushDownTopNToPreAggRule`** to:

- Accept `FINAL TopN` **only for external table scans** (Iceberg, Hive, Hudi, etc.)
- Continue requiring `PARTIAL TopN` for native OLAP tables (preserving existing behavior)

This is the minimal, targeted fix that solves the runtime filter issue without risking regressions on native tables.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
