### PR TITLE
[BugFix] common/proc: relax DB READ for single-table proc dirs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/EsPartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/EsPartitionsProcDir.java
@@ -81,7 +81,8 @@ public class EsPartitionsProcDir implements ProcDirInterface {
         // get info
         List<List<Comparable>> partitionInfos = new ArrayList<List<Comparable>>();
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = esTable.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             Joiner joiner = Joiner.on(", ");
             Map<String, EsShardPartitions> unPartitionedIndices =
@@ -121,7 +122,7 @@ public class EsPartitionsProcDir implements ProcDirInterface {
                 }
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
 
         // set result
@@ -145,14 +146,11 @@ public class EsPartitionsProcDir implements ProcDirInterface {
 
     @Override
     public ProcNodeInterface lookup(String indexName) throws AnalysisException {
-
-        Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
-        try {
-            return new EsShardProcDir(db, esTable, indexName);
-        } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
-        }
+        // Lock-free: this method only stashes db / esTable / indexName into a new
+        // EsShardProcDir. It does not read any mutable per-table state and does not
+        // iterate any catalog collection. The resulting EsShardProcDir takes its
+        // own per-table READ when it actually fetches data.
+        return new EsShardProcDir(db, esTable, indexName);
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/EsShardProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/EsShardProcDir.java
@@ -55,7 +55,8 @@ public class EsShardProcDir implements ProcDirInterface {
 
         List<List<Comparable>> shardInfos = new ArrayList<List<Comparable>>();
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = esTable.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             // get infos
             EsShardPartitions esShardPartitions = esTable.getEsTablePartitions().getEsShardPartitions(indexName);
@@ -78,7 +79,7 @@ public class EsShardProcDir implements ProcDirInterface {
                 }
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
 
         // sort by tabletId, replicaId

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexInfoProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexInfoProcDir.java
@@ -77,7 +77,8 @@ public class IndexInfoProcDir implements ProcDirInterface {
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = table.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             if (table.isNativeTableOrMaterializedView()) {
                 OlapTable olapTable = (OlapTable) table;
@@ -116,7 +117,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
 
             return result;
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
     }
 
@@ -137,8 +138,13 @@ public class IndexInfoProcDir implements ProcDirInterface {
             throw new AnalysisException("Invalid index meta id format: " + idxMetaIdStr);
         }
 
+        // Take per-table READ: getSchemaByIndexMetaId reads OlapTable.indexMetaIdToMeta
+        // which is a plain HashMap, so a concurrent ALTER (IX + table WRITE) can race
+        // with this get and produce undefined behavior. The lock pins the table while
+        // we resolve the schema reference.
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = table.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             List<Column> schema = null;
             Set<String> bfColumns = null;
@@ -158,7 +164,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
             }
             return node;
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
@@ -81,7 +81,8 @@ public class IndicesProcDir implements ProcDirInterface {
         // get info
         List<List<Comparable>> indexInfos = new ArrayList<List<Comparable>>();
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = olapTable.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             result.setNames(TITLE_NAMES);
             for (MaterializedIndex materializedIndex : partition.getAllMaterializedIndices(IndexExtState.ALL)) {
@@ -97,7 +98,7 @@ public class IndicesProcDir implements ProcDirInterface {
             }
 
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
 
         // sort by index id
@@ -135,8 +136,13 @@ public class IndicesProcDir implements ProcDirInterface {
             throw new AnalysisException("Invalid index id format: " + indexIdStr);
         }
 
+        // Take per-table READ: partition.getIndex reads PhysicalPartition.idToVisibleIndex
+        // / idToShadowIndex, which are plain HashMaps. A concurrent schema change
+        // (IX + table WRITE) can race with this get, so the lock pins the table while
+        // we resolve the index reference.
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = olapTable.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             MaterializedIndex materializedIndex = partition.getIndex(indexId);
             if (materializedIndex == null) {
@@ -148,7 +154,7 @@ public class IndicesProcDir implements ProcDirInterface {
                 return new LocalTabletsProcDir(db, olapTable, materializedIndex);
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
@@ -76,7 +76,8 @@ public class LakeTabletsProcDir implements ProcDirInterface {
         List<List<Comparable>> tabletInfos = Lists.newArrayList();
 
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = table.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             for (Tablet tablet : index.getTablets()) {
                 List<Comparable> tabletInfo = Lists.newArrayList();
@@ -90,7 +91,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                 tabletInfos.add(tabletInfo);
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
         return tabletInfos;
     }
@@ -136,8 +137,13 @@ public class LakeTabletsProcDir implements ProcDirInterface {
             throw new AnalysisException("Invalid tablet id format: " + tabletIdStr);
         }
 
+        // Take per-table READ: index.getTablet reads MaterializedIndex.idToTablets,
+        // which is a plain HashMap. A concurrent schema change or rebalance
+        // (IX + table WRITE) can race with this get, so the lock pins the table while
+        // we resolve the tablet reference.
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long lockTableId = table.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), lockTableId, LockType.READ);
         try {
             Tablet tablet = index.getTablet(tabletId);
             if (tablet == null) {
@@ -146,7 +152,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
             Preconditions.checkState(tablet instanceof LakeTablet);
             return new LakeTabletProcNode((LakeTablet) tablet);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), lockTableId, LockType.READ);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LocalTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LocalTabletsProcDir.java
@@ -104,7 +104,8 @@ public class LocalTabletsProcDir implements ProcDirInterface {
 
         List<List<Comparable>> tabletInfos = new ArrayList<List<Comparable>>();
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = table.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             // get infos
             for (Tablet tablet : index.getTablets()) {
@@ -170,7 +171,7 @@ public class LocalTabletsProcDir implements ProcDirInterface {
                 }
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
         return tabletInfos;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -290,7 +290,8 @@ public class PartitionsProcDir implements ProcDirInterface {
         // get info
         List<List<Comparable>> partitionInfos = new ArrayList<List<Comparable>>();
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = table.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             List<Long> partitionIds;
             PartitionInfo tblPartitionInfo = table.getPartitionInfo();
@@ -330,7 +331,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                 }
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
         return partitionInfos;
     }
@@ -451,19 +452,26 @@ public class PartitionsProcDir implements ProcDirInterface {
 
     @Override
     public ProcNodeInterface lookup(String partitionIdOrName) throws AnalysisException {
-        long partitionId = -1L;
-
+        // Take per-table READ: OlapTable.idToPartition is HashMap and
+        // nameToPartition is TreeMap (CASE_INSENSITIVE_ORDER); a concurrent
+        // ADD/DROP PARTITION (IX + table WRITE) can race with these gets, so the
+        // lock pins the table while we resolve the partition reference.
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long tableId = table.getId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             PhysicalPartition partition;
             try {
                 partition = table.getPhysicalPartition(Long.parseLong(partitionIdOrName));
             } catch (NumberFormatException e) {
-                partition = table.getPartition(partitionIdOrName, false).getDefaultPhysicalPartition();
-                if (partition == null) {
-                    partition = table.getPartition(partitionIdOrName, true).getDefaultPhysicalPartition();
+                // getPartition(name, ...) can return null if the partition does not
+                // exist; null-guard before dereferencing or this throws NPE on a
+                // legitimate "not found" or under a concurrent DROP PARTITION race.
+                Partition byName = table.getPartition(partitionIdOrName, false);
+                if (byName == null) {
+                    byName = table.getPartition(partitionIdOrName, true);
                 }
+                partition = (byName != null) ? byName.getDefaultPhysicalPartition() : null;
             }
 
             if (partition == null) {
@@ -472,7 +480,7 @@ public class PartitionsProcDir implements ProcDirInterface {
 
             return new IndicesProcDir(db, table, partition);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/TablesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/TablesProcDir.java
@@ -91,17 +91,15 @@ public class TablesProcDir implements ProcDirInterface {
             throw new AnalysisException("table id or name is null or empty");
         }
 
+        // Lock-free: idToTable / nameToTable in Database are ConcurrentHashMap, so the
+        // getTable lookup is thread-safe on its own. A concurrent DROP TABLE may make
+        // the result null or stale, both acceptable here. The returned TableProcDir
+        // takes its own table-level locks when its descendants actually fetch data.
         Table table;
-        Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
         try {
-            try {
-                table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), Long.parseLong(tableIdOrName));
-            } catch (NumberFormatException e) {
-                table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableIdOrName);
-            }
-        } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), Long.parseLong(tableIdOrName));
+        } catch (NumberFormatException e) {
+            table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableIdOrName);
         }
 
         if (table == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
@@ -70,6 +70,36 @@ public class PartitionsProcDirTest {
     }
 
     @Test
+    public void testLookupNonExistentPartitionNameThrowsAnalysisException() {
+        Database db = new Database(10000L, "PartitionsProcDirTestDB");
+
+        List<Column> col = Lists.newArrayList(new Column("province", VarcharType.VARCHAR));
+        PartitionInfo listPartition = new ListPartitionInfo(PartitionType.LIST, col);
+        long partitionId = 1025;
+        listPartition.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+        listPartition.setReplicationNum(partitionId, (short) 1);
+        OlapTable olapTable = new OlapTable(1024L, "olap_table", col, null, listPartition, null);
+        MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
+        Map<String, Long> indexNameToMetaId = olapTable.getIndexNameToMetaId();
+        indexNameToMetaId.put("index1", index.getMetaId());
+        olapTable.addPartition(new Partition(partitionId, 1035, "p1", index, new RandomDistributionInfo(10)));
+
+        db.registerTableUnlocked(olapTable);
+
+        PartitionsProcDir dir = new PartitionsProcDir(db, olapTable, false);
+
+        // Regression: lookup() previously dereferenced table.getPartition(name, ...) without
+        // a null-guard, so a missing name produced an NPE instead of the documented
+        // AnalysisException. The non-numeric name forces the catch-NumberFormatException
+        // branch that hits both getPartition(name, false) and getPartition(name, true) and
+        // resolves them as null.
+        AnalysisException ex = Assertions.assertThrows(AnalysisException.class,
+                () -> dir.lookup("no_such_partition"));
+        Assertions.assertTrue(ex.getMessage().contains("no_such_partition"),
+                "Expected message to mention the missing partition name, got: " + ex.getMessage());
+    }
+
+    @Test
     public void testFetchResultForOlapTable() throws AnalysisException {
         Database db = new Database(10000L, "PartitionsProcDirTestDB");
 


### PR DESCRIPTION
relax DB lock from READ to INTENTION_SHARE + table READ under common/proc/

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
