### PR TITLE
[auto-perf-opt] Reuse IndexValuesWithVerPB in KeyValueMerger merge/flush loop

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -485,6 +485,12 @@ CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 CONF_mInt64(pk_index_size_tiered_min_level_size, "131072");
 CONF_mInt64(pk_index_size_tiered_level_multiplier, "10");
 CONF_mInt64(pk_index_size_tiered_max_level, "5");
+// Defer merge_base_level=true compactions when the selected size-tiered level has
+// at least this many non-base filesets — picks just the non-base filesets instead,
+// forcing merge_base_level=false. Avoids 100-300 s base rewrites on hot/oversized
+// PK-index tablets that block publish_version. Set to 0 to disable. Default 2 means
+// any selected level with >=2 non-base filesets will skip the base.
+CONF_mInt64(pk_index_size_tiered_defer_base_merge_min_non_base_filesets, "2");
 // Used to control the sampling interval size for SSTable files.
 CONF_mInt64(pk_index_sstable_sample_interval_bytes, "16777216");
 // Controls merge condition evaluation behavior within the same transaction for primary key tables.

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -40,7 +40,10 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
     const std::string& value = iter_ptr->value().to_string();
     uint64_t max_rss_rowid = iter_ptr->max_rss_rowid();
 
-    IndexValuesWithVerPB index_value_ver;
+    // Reuse the per-merger protobuf instance: ParseFromString resets it before
+    // populating, and RepeatedPtrField retains its element backing across calls,
+    // so we avoid a heap alloc + free of the message and its values list per key.
+    IndexValuesWithVerPB& index_value_ver = _scratch_value_pb;
     if (!index_value_ver.ParseFromString(value)) {
         return Status::InternalError("Failed to parse index value ver");
     }
@@ -145,7 +148,11 @@ Status KeyValueMerger::flush() {
         return Status::OK();
     }
 
-    IndexValuesWithVerPB index_value_pb;
+    // Reuse the per-merger protobuf instance: Clear() retains the values'
+    // RepeatedPtrField backing memory, so the add_values() loop below can
+    // reuse the slot allocations across flushes for the same merger.
+    IndexValuesWithVerPB& index_value_pb = _scratch_flush_pb;
+    index_value_pb.Clear();
     for (const auto& index_value_with_ver : _index_value_vers) {
         if (_merge_base_level && index_value_with_ver.second == IndexValue(NullIndexValue)) {
             // deleted

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.h
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.h
@@ -83,6 +83,12 @@ private:
     // data volume larger than pk_index_target_file_size.
     bool _enable_multiple_output_files = false;
     std::vector<TableBuilderWrapper> _output_builders;
+    // Reused across merge() calls to avoid per-key heap alloc/free of the
+    // protobuf message and its repeated-field storage. ParseFromString resets
+    // the message; RepeatedPtrField::Clear retains element backing memory.
+    IndexValuesWithVerPB _scratch_value_pb;
+    // Reused across flush() calls for the same reason.
+    IndexValuesWithVerPB _scratch_flush_pb;
 };
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
+++ b/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
@@ -179,11 +179,40 @@ StatusOr<CompactionCandidateResult> LakePersistentIndexSizeTieredCompactionStrat
         return result;
     }
 
+    // Defer base-level merges when the selected level has enough non-base filesets to compact
+    // on their own. merge_base_level=true rewrites the largest tier and, on hot/oversized PK-index
+    // tablets, can take 100-300 s while holding the per-tablet PK-index lock that publish_version
+    // serializes against — producing multi-second LoadTime tails via FE publish retries. By
+    // skipping the base fileset in this iteration, we keep doing useful compaction (the non-base
+    // filesets still merge into one) while letting the base wait for a quieter moment when no
+    // non-base alternative is available. The base will still be merged eventually, just less often.
+    const int64_t min_non_base_to_defer =
+            config::pk_index_size_tiered_defer_base_merge_min_non_base_filesets;
+    bool defer_base_merge = false;
+    if (min_non_base_to_defer > 0) {
+        size_t non_base_in_level = 0;
+        bool level_includes_base = false;
+        for (size_t fileset_idx : selected_level->fileset_indexes) {
+            if (filesets[fileset_idx].fileset_id == base_level_fileset_id) {
+                level_includes_base = true;
+            } else {
+                ++non_base_in_level;
+            }
+        }
+        defer_base_merge = level_includes_base && non_base_in_level >= static_cast<size_t>(min_non_base_to_defer);
+    }
+
     // Build result: for each selected fileset, add all its sstables
     uint64_t max_max_rss_rowid = 0;
     bool merge_base_level = false;
     for (size_t fileset_idx : selected_level->fileset_indexes) {
         const FilesetInfo& fileset = filesets[fileset_idx];
+        if (defer_base_merge && fileset.fileset_id == base_level_fileset_id) {
+            // Skip the base fileset; keep merge_base_level=false so tombstones are preserved.
+            // Note: candidate filesets remain consecutive among themselves — the base is the
+            // first index and we only drop that single element.
+            continue;
+        }
         std::vector<PersistentIndexSstablePB> fileset_sstables;
 
         for (int sstable_idx : fileset.sstable_indices) {

--- a/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
+++ b/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
@@ -186,8 +186,7 @@ StatusOr<CompactionCandidateResult> LakePersistentIndexSizeTieredCompactionStrat
     // skipping the base fileset in this iteration, we keep doing useful compaction (the non-base
     // filesets still merge into one) while letting the base wait for a quieter moment when no
     // non-base alternative is available. The base will still be merged eventually, just less often.
-    const int64_t min_non_base_to_defer =
-            config::pk_index_size_tiered_defer_base_merge_min_non_base_filesets;
+    const int64_t min_non_base_to_defer = config::pk_index_size_tiered_defer_base_merge_min_non_base_filesets;
     bool defer_base_merge = false;
     if (min_non_base_to_defer > 0) {
         size_t non_base_in_level = 0;


### PR DESCRIPTION
## Bottleneck (from iter-001 baseline + out-of-band perf record on `branch-4.1-51e81ff`)

Single dominant CPU stack on the hottest CN at 99 % busy, ~270 async-delta-writer tasks/s:

```
29.83 %  cloud_native_pk_* → LakePersistentIndexParallelCompactTask::run
 └ 27.67 %  ::do_run
   └ 20.99 %  starrocks::lake::KeyValueMerger::merge
     ├ 10.59 %  ::flush  (3.86 % new + 3.72 % free)
     ├  4.29 %  protobuf::MessageLite::ParseFromString
     │           └ IndexValuesWithVerPB::_InternalParse
     └  1.83 %  ~IndexValuesWithVerPB → free
```

Self time: `my_malloc` 15.9 % + `my_free` 15.5 % = ~31 % of all real CPU work spent in the allocator. The PK-index merge/flush loop is the dominant caller. Source: `be/src/storage/lake/lake_persistent_index_key_value_merger.cpp:43, 148`.

## What this PR changes

`KeyValueMerger::merge` constructs a fresh `IndexValuesWithVerPB` on every input key and destroys it at scope exit; same in `flush()` per output key. With millions of keys flowing through PK-index parallel compaction during ingest, that's a heap alloc + free of the message and its `RepeatedPtrField` storage per key.

Hoist both to `KeyValueMerger` members (`_scratch_value_pb`, `_scratch_flush_pb`):

- `merge()` relies on `ParseFromString` resetting the message before populating.
- `flush()` calls `Clear()` explicitly because it builds the message via `add_values()`.

Protobuf's `RepeatedPtrField::Clear()` retains the underlying element storage, so the second and subsequent calls reuse the same slot allocations — eliminating the per-key new/free pair.

No behavioural change. The message lifetime in both functions is local to a single call, the message is fully consumed before the next call starts, and there is no concurrent access (each `KeyValueMerger` instance runs on a single compaction worker thread).

## Expected impact

Removes the dominant allocator/parse cost in the merge loop; the merge-side ~21 % inclusive CPU share should drop substantially. Direct effect on publish/apply tail latency depends on how much the freed CPU unblocks the contended PK-index lock — to be measured in iter-002.

Reversible by reverting the diff.

## Iter chain (auto-perf-opt run my-rt)

This branch stacks `bd356ebfb8 "Defer PK-index base-level merges"` (already deployed as `branch-4.1-51e81ff`) plus this iter's new commit `b538db5cbc`. The previous title of this PR ("Defer PK-index base-level merges") referred to `bd356ebfb8`; that commit is unchanged. Reviewers of the *new* optimization should focus on `b538db5cbc`.