### PR TITLE
[Enhancement] Reject FORCE refresh on INCREMENTAL/AUTO materialized views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -1519,6 +1519,12 @@ public class MaterializedViewAnalyzer {
                         "refresh_mode=" + refreshMode.name() + ". Please refresh the whole materialized view instead.",
                         tableRef.getPos());
             }
+            if (statement.isForceRefresh() && refreshMode.isIncrementalOrAuto()) {
+                throw new SemanticException("FORCE refresh is not supported for materialized views with " +
+                        "refresh_mode=" + refreshMode.name() +
+                        ". Please drop and re-create the materialized view instead.",
+                        tableRef.getPos());
+            }
             PartitionInfo partitionInfo = mv.getPartitionInfo();
             if (statement.getPartitionRangeDesc() != null) {
                 if (partitionInfo.isUnPartitioned()) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -33,6 +33,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.clone.DynamicPartitionScheduler;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MaterializedViewExceptions;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.schema.MTable;
@@ -359,6 +360,53 @@ public class RefreshMaterializedViewTest extends MVTestBase {
                     "Partition refresh is not supported for materialized views with refresh_mode=INCREMENTAL."));
         } finally {
             starRocksAssert.dropMaterializedView("test.mv_incremental_to_refresh");
+        }
+    }
+
+    @Test
+    public void testIncrementalRefreshModeRejectsForceRefresh() throws Exception {
+        // Create a MV with PCT mode (no Iceberg required), then flip the persisted refresh_mode
+        // to "incremental" so the FORCE-rejection branch in the analyzer fires. This isolates the
+        // analyzer check from the IVM eligibility constraints of the CREATE path.
+        starRocksAssert.withMaterializedView("create materialized view test.mv_incremental_force_refresh\n" +
+                "distributed by hash(k2) buckets 3\n" +
+                "refresh manual\n" +
+                "properties (\n" +
+                "\"refresh_mode\" = \"pct\"\n" +
+                ")\n" +
+                "as select k1, k2, v1 from test.tbl_with_mv;");
+        try {
+            MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState()
+                    .getLocalMetastore().getTable("test", "mv_incremental_force_refresh");
+            mv.getTableProperty().setMvRefreshMode("incremental");
+            mv.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_MV_REFRESH_MODE, "incremental");
+
+            String sql = "REFRESH MATERIALIZED VIEW test.mv_incremental_force_refresh FORCE;";
+            Exception e = Assertions.assertThrows(Exception.class,
+                    () -> UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
+            Assertions.assertTrue(e.getMessage().contains(
+                    "FORCE refresh is not supported for materialized views with refresh_mode=INCREMENTAL."),
+                    "expected FORCE rejection error, got: " + e.getMessage());
+        } finally {
+            starRocksAssert.dropMaterializedView("test.mv_incremental_force_refresh");
+        }
+    }
+
+    @Test
+    public void testPctRefreshModeAllowsForceRefresh() throws Exception {
+        starRocksAssert.withMaterializedView("create materialized view test.mv_pct_force_refresh\n" +
+                "distributed by hash(k2) buckets 3\n" +
+                "refresh manual\n" +
+                "properties (\n" +
+                "\"refresh_mode\" = \"pct\"\n" +
+                ")\n" +
+                "as select k1, k2, v1 from test.tbl_with_mv;");
+        try {
+            String sql = "REFRESH MATERIALIZED VIEW test.mv_pct_force_refresh FORCE;";
+            // Should parse without error: FORCE is only blocked on INCREMENTAL/AUTO MVs.
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        } finally {
+            starRocksAssert.dropMaterializedView("test.mv_pct_force_refresh");
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
the FORCE clause on REFRESH MATERIALIZED VIEW must be rejected for materialized views with refresh_mode=INCREMENTAL (and refresh_mode=AUTO, which shares the same code path via isIncrementalOrAuto()). FORCE is only meaningful for the legacy PCT mode where it triggers a full re-materialization; for incremental MVs the recovery path is drop-and-recreate.

Production:
- MaterializedViewAnalyzer.visitRefreshMaterializedViewStatement: in the same block that already rejects partition-level refresh on INCREMENTAL/AUTO MVs, add a FORCE rejection with a clear error message that points users at the drop-and-recreate workflow.

Tests:
- testIncrementalRefreshModeRejectsForceRefresh: create a PCT MV via the SQL path (no Iceberg dependency), flip the persisted refresh_mode to "incremental", then assert that REFRESH ... FORCE is rejected with the expected message.
- testPctRefreshModeAllowsForceRefresh: regression guard that PCT MVs still accept the FORCE clause.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
