### PR TITLE
[Enhancement] support DATE and DATETIME types in Java UDF

### DIFF
--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -31,9 +31,11 @@
 #include "column/vectorized_fwd.h"
 #include "common/compiler_util.h"
 #include "common/status.h"
+#include "types/date_value.h"
 #include "types/datum.h"
 #include "types/decimalv3.h"
 #include "types/logical_type.h"
+#include "types/timestamp_value.h"
 #include "types/type_descriptor.h"
 #include "udf/java/java_udf.h"
 #include "udf/java/type_traits.h"
@@ -269,6 +271,8 @@ DEFINE_CAST_TO_JVALUE(TYPE_BIGINT, helper.newLong(data_value));
 DEFINE_CAST_TO_JVALUE(TYPE_FLOAT, helper.newFloat(data_value));
 DEFINE_CAST_TO_JVALUE(TYPE_DOUBLE, helper.newDouble(data_value));
 DEFINE_CAST_TO_JVALUE(TYPE_VARCHAR, helper.newString(data_value.get_data(), data_value.get_size()));
+DEFINE_CAST_TO_JVALUE(TYPE_DATE, helper.newLocalDate(data_value._julian));
+DEFINE_CAST_TO_JVALUE(TYPE_DATETIME, helper.newLocalDateTime(data_value.timestamp()));
 
 void release_jvalue(bool is_box, jvalue val) {
     if (is_box && val.l) {
@@ -331,6 +335,16 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
         auto spec_col = down_cast<const BinaryColumn*>(col);
         Slice slice = spec_col->get_slice(row_num);
         v.l = helper.newString(slice.get_data(), slice.get_size());
+        break;
+    }
+    case TYPE_DATE: {
+        auto spec_col = down_cast<const RunTimeColumnType<TYPE_DATE>*>(col);
+        v.l = helper.newLocalDate(spec_col->immutable_data()[row_num]._julian);
+        break;
+    }
+    case TYPE_DATETIME: {
+        auto spec_col = down_cast<const RunTimeColumnType<TYPE_DATETIME>*>(col);
+        v.l = helper.newLocalDateTime(spec_col->immutable_data()[row_num].timestamp());
         break;
     }
     case TYPE_DECIMAL32:
@@ -446,6 +460,18 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         ASSIGN_BOX_TYPE(TYPE_BIGINT, int64_t)
         ASSIGN_BOX_TYPE(TYPE_FLOAT, float)
         ASSIGN_BOX_TYPE(TYPE_DOUBLE, double)
+    case TYPE_DATE: {
+        DateValue dv;
+        dv._julian = helper.valLocalDate(val.l);
+        down_cast<RunTimeColumnType<TYPE_DATE>*>(data_col)->get_data()[row_num] = dv;
+        break;
+    }
+    case TYPE_DATETIME: {
+        TimestampValue tv;
+        tv.set_timestamp(helper.valLocalDateTime(val.l));
+        down_cast<RunTimeColumnType<TYPE_DATETIME>*>(data_col)->get_data()[row_num] = tv;
+        break;
+    }
     case TYPE_VARCHAR: {
         if (val.l == nullptr) {
             col->append_nulls(1);
@@ -542,6 +568,18 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
             APPEND_BOX_TYPE(TYPE_FLOAT, float)
             APPEND_BOX_TYPE(TYPE_DOUBLE, double)
 
+        case TYPE_DATE: {
+            DateValue dv;
+            dv._julian = helper.valLocalDate(val.l);
+            col->append_datum(Datum(dv));
+            break;
+        }
+        case TYPE_DATETIME: {
+            TimestampValue tv;
+            tv.set_timestamp(helper.valLocalDateTime(val.l));
+            col->append_datum(Datum(tv));
+            break;
+        }
         case TYPE_VARCHAR: {
             std::string buffer;
             auto slice = helper.sliceVal((jstring)val.l, &buffer);
@@ -657,6 +695,24 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val) {
             LOCAL_REF_GUARD(clazz);
             return Status::InternalError(
                     fmt::format("Type not matched, expect java.math.BigDecimal, but got {}", helper.to_string(clazz)));
+        }
+        break;
+    }
+    case TYPE_DATE: {
+        if (!env->IsInstanceOf(val, helper.local_date_class())) {
+            auto clazz = env->GetObjectClass(val);
+            LOCAL_REF_GUARD(clazz);
+            return Status::InternalError(
+                    fmt::format("Type not matched, expect java.time.LocalDate, but got {}", helper.to_string(clazz)));
+        }
+        break;
+    }
+    case TYPE_DATETIME: {
+        if (!env->IsInstanceOf(val, helper.local_datetime_class())) {
+            auto clazz = env->GetObjectClass(val);
+            LOCAL_REF_GUARD(clazz);
+            return Status::InternalError(fmt::format("Type not matched, expect java.time.LocalDateTime, but got {}",
+                                                     helper.to_string(clazz)));
         }
         break;
     }

--- a/be/src/udf/java/java_native_method.cpp
+++ b/be/src/udf/java/java_native_method.cpp
@@ -26,7 +26,9 @@
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "gutil/casts.h"
+#include "types/date_value.h"
 #include "types/logical_type.h"
+#include "types/timestamp_value.h"
 
 namespace starrocks {
 
@@ -137,6 +139,12 @@ public:
             return Status::OK();
         } else if constexpr (std::is_same_v<T, double>) {
             *_result = TYPE_DOUBLE;
+            return Status::OK();
+        } else if constexpr (std::is_same_v<T, DateValue>) {
+            *_result = TYPE_DATE;
+            return Status::OK();
+        } else if constexpr (std::is_same_v<T, TimestampValue>) {
+            *_result = TYPE_DATETIME;
             return Status::OK();
         }
         return Status::NotSupported("unsupported UDF type");

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -26,7 +26,9 @@
 #include "exprs/function_context.h"
 #include "fmt/core.h"
 #include "jni.h"
+#include "types/date_value.h"
 #include "types/logical_type.h"
+#include "types/timestamp_value.h"
 #include "udf/java/java_native_method.h"
 #include "udf/java/type_traits.h"
 #include "udf/java/utils.h"
@@ -190,6 +192,16 @@ void JVMFunctionHelper::_init() {
     _big_decimal_value_of_ll = _env->GetStaticMethodID(_big_decimal_class, "valueOf", "(JI)Ljava/math/BigDecimal;");
     CHECK(_big_decimal_value_of_ll);
 
+    _local_date_class = JNI_FIND_CLASS("java/time/LocalDate");
+    CHECK(_local_date_class);
+    _local_date_of_epoch_day = _env->GetStaticMethodID(_local_date_class, "ofEpochDay", "(J)Ljava/time/LocalDate;");
+    CHECK(_local_date_of_epoch_day);
+    _local_date_to_epoch_day = _env->GetMethodID(_local_date_class, "toEpochDay", "()J");
+    CHECK(_local_date_to_epoch_day);
+
+    _local_datetime_class = JNI_FIND_CLASS("java/time/LocalDateTime");
+    CHECK(_local_datetime_class);
+
     ADD_NUMBERIC_CLASS(boolean, Boolean, Z);
     ADD_NUMBERIC_CLASS(byte, Byte, B);
     ADD_NUMBERIC_CLASS(short, Short, S);
@@ -262,6 +274,15 @@ void JVMFunctionHelper::_init() {
     _method_map.emplace(TYPE_ARRAY_METHOD_ID, tmp);
     INIT_HELPER_METHOD(tmp, "createBoxedMapArray", CREATE_BOXED_MAP_SIGNATURE);
     _method_map.emplace(TYPE_MAP_METHOD_ID, tmp);
+    INIT_HELPER_METHOD(tmp, "createBoxedLocalDateArray", CREATE_BOXED_PRIMI_SIGNATURE);
+    _method_map.emplace(JNIPrimTypeId<DateValue>::id, tmp);
+    INIT_HELPER_METHOD(tmp, "createBoxedLocalDateTimeArray", CREATE_BOXED_PRIMI_SIGNATURE);
+    _method_map.emplace(JNIPrimTypeId<TimestampValue>::id, tmp);
+
+    // LocalDateTime <-> packed int64 conversion stays in UDFHelper because the
+    // packing is StarRocks-specific.
+    INIT_HELPER_METHOD(_local_datetime_from_packed, "localDateTimeFromPackedTimestamp", "(J)Ljava/time/LocalDateTime;");
+    INIT_HELPER_METHOD(_local_datetime_to_packed, "packedTimestampFromLocalDateTime", "(Ljava/time/LocalDateTime;)J");
 
     // init bytebuffer
     _direct_buffer_class = JNI_FIND_CLASS("java/nio/ByteBuffer");
@@ -604,6 +625,33 @@ jbyteArray JVMFunctionHelper::unscaled_le_bytes(jobject big_decimal, int precisi
     return (jbyteArray)_env->CallStaticObjectMethod(_udf_helper_class, _bd_unscaled_le_bytes, big_decimal,
                                                     static_cast<jint>(precision), static_cast<jint>(scale),
                                                     static_cast<jint>(byte_width));
+}
+
+// DateValue stores days as Julian day; LocalDate exposes them as days-since-1970-01-01.
+// 2440588 is the Julian day number of the Unix epoch.
+static constexpr jlong UNIX_EPOCH_JULIAN_DAYS = 2440588;
+
+jobject JVMFunctionHelper::newLocalDate(int32_t julian) {
+    jobject ld = _env->CallStaticObjectMethod(_local_date_class, _local_date_of_epoch_day,
+                                              static_cast<jlong>(julian) - UNIX_EPOCH_JULIAN_DAYS);
+    RETURN_IF_JNI_EXCEPTION(_env, "newLocalDate: ofEpochDay failed", nullptr);
+    return ld;
+}
+
+int32_t JVMFunctionHelper::valLocalDate(jobject obj) {
+    jlong epoch_day = _env->CallLongMethod(obj, _local_date_to_epoch_day);
+    return static_cast<int32_t>(epoch_day + UNIX_EPOCH_JULIAN_DAYS);
+}
+
+jobject JVMFunctionHelper::newLocalDateTime(int64_t packed_timestamp) {
+    jobject ldt = _env->CallStaticObjectMethod(_udf_helper_class, _local_datetime_from_packed,
+                                               static_cast<jlong>(packed_timestamp));
+    RETURN_IF_JNI_EXCEPTION(_env, "newLocalDateTime: localDateTimeFromPackedTimestamp failed", nullptr);
+    return ldt;
+}
+
+int64_t JVMFunctionHelper::valLocalDateTime(jobject obj) {
+    return _env->CallStaticLongMethod(_udf_helper_class, _local_datetime_to_packed, obj);
 }
 
 Slice JVMFunctionHelper::sliceVal(jstring jstr, std::string* buffer) {
@@ -1104,6 +1152,15 @@ Status ClassAnalyzer::get_udaf_method_desc(const std::string& sign, std::vector<
                 // BigDecimal params. The actual DECIMAL precision/scale is resolved from
                 // ctx->get_arg_type() / ctx->get_return_type() at the call site.
                 desc->emplace_back(MethodTypeDescriptor{TYPE_DECIMAL128, true});
+            } else if (type == "java/time/LocalDate") {
+                desc->emplace_back(MethodTypeDescriptor{TYPE_DATE, true});
+            } else if (type == "java/time/LocalDateTime") {
+                desc->emplace_back(MethodTypeDescriptor{TYPE_DATETIME, true});
+            } else {
+                // Unrecognized object class. Surface as TYPE_UNKNOWN so get_method_desc()
+                // validation produces a clear error instead of leaving method_desc short
+                // and crashing on a later method_desc[0].is_box access.
+                desc->emplace_back(MethodTypeDescriptor{TYPE_UNKNOWN, true});
             }
             continue;
         }

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -196,6 +196,18 @@ public:
     Slice sliceVal(jstring jstr, std::string* buffer);
     jclass string_clazz() { return _string_class; }
     jclass big_decimal_class() { return _big_decimal_class; }
+    jclass local_date_class() { return _local_date_class; }
+    jclass local_datetime_class() { return _local_datetime_class; }
+
+    // Box/unbox a StarRocks DateValue (int32 Julian day) as a java.time.LocalDate.
+    // Round-trips StarRocks's internal Julian-day encoding.
+    jobject newLocalDate(int32_t julian);
+    int32_t valLocalDate(jobject obj);
+
+    // Box/unbox a StarRocks TimestampValue (packed int64: julian << 40 | usOfDay)
+    // as a java.time.LocalDateTime.
+    jobject newLocalDateTime(int64_t packed_timestamp);
+    int64_t valLocalDateTime(jobject obj);
     // replace '.' as '/'
     // eg: java.lang.Integer -> java/lang/Integer
     static std::string to_jni_class_name(const std::string& name);
@@ -232,10 +244,18 @@ private:
     jclass _jarrays_class;
     jclass _exception_util_class;
     jclass _big_decimal_class;
+    jclass _local_date_class;
+    jclass _local_datetime_class;
 
     jmethodID _string_construct_with_bytes;
     jmethodID _big_decimal_ctor_string;
     jmethodID _big_decimal_value_of_ll;
+    // java.time.LocalDate.ofEpochDay(long) / java.time.LocalDate.toEpochDay()
+    jmethodID _local_date_of_epoch_day;
+    jmethodID _local_date_to_epoch_day;
+    // UDFHelper.localDateTimeFromPackedTimestamp(long) / packedTimestampFromLocalDateTime(LocalDateTime)
+    jmethodID _local_datetime_from_packed;
+    jmethodID _local_datetime_to_packed;
 
     ListMeta _list_meta;
     MapMeta _map_meta;

--- a/be/src/udf/java/type_traits.h
+++ b/be/src/udf/java/type_traits.h
@@ -19,6 +19,9 @@
 #include "base/string/slice.h"
 
 namespace starrocks {
+class DateValue;
+class TimestampValue;
+
 template <class Type>
 struct JNIPrimTypeId {
     static constexpr bool supported = false;
@@ -42,5 +45,9 @@ DEFINE_TYPE(double, 8);
 DEFINE_TYPE(Slice, 9);
 static constexpr int TYPE_ARRAY_METHOD_ID = 10;
 static constexpr int TYPE_MAP_METHOD_ID = 11;
+// DateValue/TimestampValue are PODs whose storage IS the wire format
+// (int32 Julian day / packed int64). Java UDFHelper decodes inline.
+DEFINE_TYPE(DateValue, 12);
+DEFINE_TYPE(TimestampValue, 13);
 
 } // namespace starrocks

--- a/be/test/udf/java/java_data_converter_test.cpp
+++ b/be/test/udf/java/java_data_converter_test.cpp
@@ -29,9 +29,11 @@
 #include "column/runtime_type_traits.h"
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
+#include "types/date_value.h"
 #include "types/datum.h"
 #include "types/decimalv3.h"
 #include "types/logical_type.h"
+#include "types/timestamp_value.h"
 #include "udf/java/java_udf.h"
 
 namespace starrocks {
@@ -482,6 +484,242 @@ TEST_F(DataConverterTest, convert_to_boxed_array_decimal) {
         std::vector<const Column*> cols = {col.get()};
         ASSERT_OK(JavaDataTypeConverter::convert_to_boxed_array(ctx.get(), cols.data(), 1, 3, &res));
         ASSERT_EQ(res.size(), 1);
+        ASSERT_NE(res[0], nullptr);
+        env->DeleteLocalRef(res[0]);
+    }
+}
+
+// ============================================================================
+// DATE / DATETIME tests. Wire format mirrors BE column storage:
+//   - DATE     : int32 Julian day (DateValue::_julian)
+//   - DATETIME : packed int64 (julian << 40 | microseconds_of_day)
+// Round-trips exercise cast_to_jvalue (BE -> LocalDate/LocalDateTime) and
+// assign_jvalue / append_jvalue (LocalDate/LocalDateTime -> BE).
+// ============================================================================
+
+namespace {
+ColumnPtr make_date_column(std::initializer_list<DateValue> rows) {
+    auto data = DateColumn::create();
+    for (auto v : rows) {
+        data->append(v);
+    }
+    auto nulls = NullColumn::create(rows.size(), 0);
+    return NullableColumn::create(std::move(data), std::move(nulls));
+}
+
+ColumnPtr make_datetime_column(std::initializer_list<TimestampValue> rows) {
+    auto data = TimestampColumn::create();
+    for (auto v : rows) {
+        data->append(v);
+    }
+    auto nulls = NullColumn::create(rows.size(), 0);
+    return NullableColumn::create(std::move(data), std::move(nulls));
+}
+} // namespace
+
+// cast_to_jvalue must produce a LocalDate / LocalDateTime whose Java value
+// matches the BE-side row, validated via the corresponding val{LocalDate,
+// LocalDateTime} accessor.
+TEST_F(DataConverterTest, cast_to_jvalue_date_datetime) {
+    auto& helper = JVMFunctionHelper::getInstance();
+
+    {
+        TypeDescriptor td(TYPE_DATE);
+        DateValue dv = DateValue::create(2024, 1, 15);
+        auto src = make_date_column({dv});
+        ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(td, true, src.get(), 0));
+        jobject obj = val.l;
+        LOCAL_REF_GUARD(obj);
+        ASSERT_NE(obj, nullptr);
+        EXPECT_EQ(dv._julian, helper.valLocalDate(obj));
+    }
+    {
+        TypeDescriptor td(TYPE_DATETIME);
+        TimestampValue tv = TimestampValue::create(2024, 1, 15, 12, 34, 56, 789000);
+        auto src = make_datetime_column({tv});
+        ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(td, true, src.get(), 0));
+        jobject obj = val.l;
+        LOCAL_REF_GUARD(obj);
+        ASSERT_NE(obj, nullptr);
+        EXPECT_EQ(tv.timestamp(), helper.valLocalDateTime(obj));
+    }
+}
+
+// Null cells short-circuit cast_to_jvalue to a null jobject (no JNI call), so
+// the resulting jvalue.l must be nullptr without throwing.
+TEST_F(DataConverterTest, cast_to_jvalue_date_datetime_null) {
+    {
+        TypeDescriptor td(TYPE_DATE);
+        auto col = ColumnHelper::create_column(td, true);
+        col->append_nulls(1);
+        ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(td, true, col.get(), 0));
+        EXPECT_EQ(val.l, nullptr);
+    }
+    {
+        TypeDescriptor td(TYPE_DATETIME);
+        auto col = ColumnHelper::create_column(td, true);
+        col->append_nulls(1);
+        ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(td, true, col.get(), 0));
+        EXPECT_EQ(val.l, nullptr);
+    }
+}
+
+// Round-trip a DATE / DATETIME value through cast_to_jvalue -> append_jvalue
+// (the UDAF finalize / UDTF emit path).
+TEST_F(DataConverterTest, append_jvalue_date_datetime_roundtrip) {
+    {
+        TypeDescriptor td(TYPE_DATE);
+        DateValue values[] = {
+                DateValue::create(1970, 1, 1),
+                DateValue::create(2024, 12, 31),
+                DateValue::create(1, 1, 1),
+        };
+        for (auto v : values) {
+            auto src = make_date_column({v});
+            ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(td, true, src.get(), 0));
+            jobject obj = val.l;
+            LOCAL_REF_GUARD(obj);
+            auto dst = ColumnHelper::create_column(td, true);
+            ASSERT_OK(append_jvalue(td, true, dst.get(), val));
+            EXPECT_EQ(src->debug_item(0), dst->debug_item(0));
+        }
+    }
+    {
+        TypeDescriptor td(TYPE_DATETIME);
+        TimestampValue values[] = {
+                TimestampValue::create(1970, 1, 1, 0, 0, 0, 0),
+                TimestampValue::create(2024, 1, 15, 12, 34, 56, 789000),
+                TimestampValue::create(9999, 12, 31, 23, 59, 59, 999999),
+        };
+        for (auto v : values) {
+            auto src = make_datetime_column({v});
+            ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(td, true, src.get(), 0));
+            jobject obj = val.l;
+            LOCAL_REF_GUARD(obj);
+            auto dst = ColumnHelper::create_column(td, true);
+            ASSERT_OK(append_jvalue(td, true, dst.get(), val));
+            EXPECT_EQ(src->debug_item(0), dst->debug_item(0));
+        }
+    }
+}
+
+// append_jvalue with a null jvalue on a nullable column appends a null row.
+TEST_F(DataConverterTest, append_jvalue_date_datetime_null) {
+    for (auto type : {TYPE_DATE, TYPE_DATETIME}) {
+        TypeDescriptor td(type);
+        auto dst = ColumnHelper::create_column(td, true);
+        ASSERT_OK(append_jvalue(td, true, dst.get(), jvalue{.l = nullptr}));
+        ASSERT_EQ(dst->size(), 1);
+        EXPECT_TRUE(dst->is_null(0));
+    }
+}
+
+// Round-trip via assign_jvalue at a specified row (Java window function path).
+TEST_F(DataConverterTest, assign_jvalue_date_datetime_roundtrip) {
+    {
+        TypeDescriptor td(TYPE_DATE);
+        DateValue dv = DateValue::create(2024, 1, 15);
+        auto src = make_date_column({dv});
+        ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(td, true, src.get(), 0));
+        jobject obj = val.l;
+        LOCAL_REF_GUARD(obj);
+        auto dst = ColumnHelper::create_column(td, true);
+        dst->resize(2);
+        ASSERT_OK(assign_jvalue(td, true, dst.get(), 1, val, /*error_if_overflow=*/true));
+        EXPECT_EQ(src->debug_item(0), dst->debug_item(1));
+    }
+    {
+        TypeDescriptor td(TYPE_DATETIME);
+        TimestampValue tv = TimestampValue::create(2024, 1, 15, 12, 34, 56, 789000);
+        auto src = make_datetime_column({tv});
+        ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(td, true, src.get(), 0));
+        jobject obj = val.l;
+        LOCAL_REF_GUARD(obj);
+        auto dst = ColumnHelper::create_column(td, true);
+        dst->resize(2);
+        ASSERT_OK(assign_jvalue(td, true, dst.get(), 1, val, /*error_if_overflow=*/true));
+        EXPECT_EQ(src->debug_item(0), dst->debug_item(1));
+    }
+}
+
+// assign_jvalue with a null jvalue on a nullable column sets the null bit at
+// the chosen row without touching the data slot.
+TEST_F(DataConverterTest, assign_jvalue_date_datetime_null) {
+    for (auto type : {TYPE_DATE, TYPE_DATETIME}) {
+        TypeDescriptor td(type);
+        auto dst = ColumnHelper::create_column(td, true);
+        dst->resize(1);
+        ASSERT_OK(assign_jvalue(td, true, dst.get(), 0, jvalue{.l = nullptr}, /*error_if_overflow=*/true));
+        EXPECT_TRUE(dst->is_null(0));
+    }
+}
+
+// check_type_matched accepts LocalDate/LocalDateTime for their respective types
+// and rejects mismatches (e.g. swapping the two, or passing a String).
+TEST_F(DataConverterTest, check_type_matched_date_datetime) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    TypeDescriptor date_td(TYPE_DATE);
+    TypeDescriptor dt_td(TYPE_DATETIME);
+
+    auto date_src = make_date_column({DateValue::create(2024, 1, 15)});
+    ASSIGN_OR_ASSERT_FAIL(jvalue date_val, cast_to_jvalue(date_td, true, date_src.get(), 0));
+    jobject date_obj = date_val.l;
+    LOCAL_REF_GUARD(date_obj);
+
+    auto dt_src = make_datetime_column({TimestampValue::create(2024, 1, 15, 12, 0, 0, 0)});
+    ASSIGN_OR_ASSERT_FAIL(jvalue dt_val, cast_to_jvalue(dt_td, true, dt_src.get(), 0));
+    jobject dt_obj = dt_val.l;
+    LOCAL_REF_GUARD(dt_obj);
+
+    EXPECT_OK(check_type_matched(date_td, date_obj));
+    EXPECT_OK(check_type_matched(dt_td, dt_obj));
+    // null val is always OK.
+    EXPECT_OK(check_type_matched(date_td, nullptr));
+    EXPECT_OK(check_type_matched(dt_td, nullptr));
+
+    // Cross-type: LocalDate vs DATETIME and LocalDateTime vs DATE both fail.
+    EXPECT_FALSE(check_type_matched(date_td, dt_obj).ok());
+    EXPECT_FALSE(check_type_matched(dt_td, date_obj).ok());
+
+    // String against DATE / DATETIME is rejected.
+    jobject jstr = helper.newString("not-a-date", 10);
+    LOCAL_REF_GUARD(jstr);
+    EXPECT_FALSE(check_type_matched(date_td, jstr).ok());
+    EXPECT_FALSE(check_type_matched(dt_td, jstr).ok());
+}
+
+// convert_to_boxed_array drives the batch input path via JavaArrayConverter.
+// For DATE / DATETIME this routes through the FixedLengthColumn<T> overload
+// using the JNIPrimTypeId<DateValue> / JNIPrimTypeId<TimestampValue> id, which
+// must be registered against createBoxedLocalDate{,Time}Array in _method_map.
+TEST_F(DataConverterTest, convert_to_boxed_array_date_datetime) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    auto run = [&](LogicalType type, const ColumnPtr& col) {
+        TypeDescriptor td(type);
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context({td}, td));
+        std::vector<jobject> res;
+        std::vector<const Column*> cols = {col.get()};
+        ASSERT_OK(JavaDataTypeConverter::convert_to_boxed_array(ctx.get(), cols.data(), 1, col->size(), &res));
+        ASSERT_EQ(res.size(), 1);
+        ASSERT_NE(res[0], nullptr);
+        env->DeleteLocalRef(res[0]);
+    };
+
+    run(TYPE_DATE, make_date_column({DateValue::create(2024, 1, 15), DateValue::create(1970, 1, 1)}));
+    run(TYPE_DATETIME, make_datetime_column({TimestampValue::create(2024, 1, 15, 12, 34, 56, 0),
+                                             TimestampValue::create(1970, 1, 1, 0, 0, 0, 0)}));
+
+    // all-null short-circuit
+    {
+        TypeDescriptor td(TYPE_DATE);
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context({td}, td));
+        auto col = ColumnHelper::create_column(td, true);
+        col->append_nulls(3);
+        std::vector<jobject> res;
+        std::vector<const Column*> cols = {col.get()};
+        ASSERT_OK(JavaDataTypeConverter::convert_to_boxed_array(ctx.get(), cols.data(), 1, 3, &res));
         ASSERT_NE(res[0], nullptr);
         env->DeleteLocalRef(res[0]);
     }

--- a/be/test/udf/java/java_native_method_test.cpp
+++ b/be/test/udf/java/java_native_method_test.cpp
@@ -30,7 +30,9 @@
 #include "column/raw_data_visitor.h"
 #include "column/vectorized_fwd.h"
 #include "exprs/base64.h"
+#include "types/date_value.h"
 #include "types/logical_type.h"
+#include "types/timestamp_value.h"
 #include "types/type_descriptor.h"
 #include "udf/java/java_udf.h"
 
@@ -169,6 +171,73 @@ TEST_F(JavaNativeMethodTest, get_column_logical_type_decimal) {
         auto logical_type_2 = JavaNativeMethods::getColumnLogicalType(env, nullptr, reinterpret_cast<size_t>(c2.get()));
         ASSERT_EQ(c.type, logical_type_1);
         ASSERT_EQ(c.type, logical_type_2);
+    }
+}
+
+// DateColumn / TimestampColumn are FixedLengthColumn<DateValue> and
+// FixedLengthColumn<TimestampValue>. Without explicit handling in the visitor's
+// FixedLengthColumn<T> template, the call falls through to "unsupported UDF
+// type", which is the bug fixed in this commit. Make sure both shapes resolve.
+TEST_F(JavaNativeMethodTest, get_column_logical_type_date_datetime) {
+    auto env = getJNIEnv();
+    for (auto type : {TYPE_DATE, TYPE_DATETIME}) {
+        for (bool nullable : {true, false}) {
+            auto col = ColumnHelper::create_column(TypeDescriptor(type), nullable);
+            auto t = JavaNativeMethods::getColumnLogicalType(env, nullptr, reinterpret_cast<size_t>(col.get()));
+            EXPECT_EQ(type, t) << "type=" << type << " nullable=" << nullable;
+        }
+    }
+}
+
+// ARRAY<DATE> / ARRAY<DATETIME>: the Java side recurses into the element column
+// to dispatch the per-row write, so the element column must also resolve.
+TEST_F(JavaNativeMethodTest, get_column_logical_type_array_of_date_datetime) {
+    auto env = getJNIEnv();
+    for (auto type : {TYPE_DATE, TYPE_DATETIME}) {
+        TypeDescriptor array_type(TYPE_ARRAY);
+        array_type.children.emplace_back(type);
+        auto col = ColumnHelper::create_column(array_type, true);
+        EXPECT_EQ(TYPE_ARRAY,
+                  JavaNativeMethods::getColumnLogicalType(env, nullptr, reinterpret_cast<size_t>(col.get())));
+
+        const auto* nullable = down_cast<const NullableColumn*>(col.get());
+        const auto* array_col = down_cast<const ArrayColumn*>(nullable->data_column().get());
+        const auto* elements = array_col->elements_column().get();
+        EXPECT_EQ(type, JavaNativeMethods::getColumnLogicalType(env, nullptr, reinterpret_cast<size_t>(elements)))
+                << "elements of ARRAY<" << type << ">";
+    }
+}
+
+// getAddrs on a DATE / DATETIME column returns the underlying int32 / int64 raw
+// buffer that the Java helper memcpys into. Verify the data pointer matches the
+// FixedLengthColumn raw storage.
+TEST_F(JavaNativeMethodTest, get_addrs_date_datetime) {
+    auto env = getJNIEnv();
+    {
+        auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_DATE), true);
+        col->resize(8);
+        auto arr = JavaNativeMethods::getAddrs(env, nullptr, reinterpret_cast<size_t>(col.get()));
+        ASSERT_NE(arr, nullptr);
+        jlong results[4];
+        env->GetLongArrayRegion(arr, 0, 4, results);
+        const auto* nullable = down_cast<const NullableColumn*>(col.get());
+        const auto* date_col = down_cast<const DateColumn*>(nullable->data_column().get());
+        EXPECT_EQ(results[0], (jlong)nullable->null_column_data().data());
+        EXPECT_EQ(results[1], (jlong)date_col->immutable_data().data());
+        env->DeleteLocalRef(arr);
+    }
+    {
+        auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_DATETIME), true);
+        col->resize(8);
+        auto arr = JavaNativeMethods::getAddrs(env, nullptr, reinterpret_cast<size_t>(col.get()));
+        ASSERT_NE(arr, nullptr);
+        jlong results[4];
+        env->GetLongArrayRegion(arr, 0, 4, results);
+        const auto* nullable = down_cast<const NullableColumn*>(col.get());
+        const auto* ts_col = down_cast<const TimestampColumn*>(nullable->data_column().get());
+        EXPECT_EQ(results[0], (jlong)nullable->null_column_data().data());
+        EXPECT_EQ(results[1], (jlong)ts_col->immutable_data().data());
+        env->DeleteLocalRef(arr);
     }
 }
 

--- a/be/test/udf/java/java_udf_test.cpp
+++ b/be/test/udf/java/java_udf_test.cpp
@@ -17,8 +17,13 @@
 #include <gtest/gtest.h>
 
 #include "base/testutil/assert.h"
+#include "base/utility/defer_op.h"
 #include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "gutil/casts.h"
+#include "types/date_value.h"
 #include "types/logical_type.h"
+#include "types/timestamp_value.h"
 
 namespace starrocks {
 class JavaUDFTest : public testing::Test {
@@ -115,6 +120,113 @@ TEST_F(JavaUDFTest, test_time_convert) {
     _env->DeleteLocalRef(time_obj);
     _env->DeleteLocalRef(time_array);
     _env->DeleteLocalRef(time_class);
+}
+
+// ============================================================================
+// LocalDate / LocalDateTime helper round-trips and end-to-end batch output.
+// Wire format mirrors BE column storage:
+//   DATE     -> int32 Julian day (DateValue::_julian)
+//   DATETIME -> packed int64 (julian << 40 | microseconds_of_day)
+// ============================================================================
+
+// newLocalDate(julian) -> LocalDate -> valLocalDate(...) must round-trip the
+// underlying int32 Julian day exactly across the JNI boundary.
+TEST_F(JavaUDFTest, local_date_helper_roundtrip) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    DateValue cases[] = {
+            DateValue::create(1970, 1, 1),
+            DateValue::create(1, 1, 1),
+            DateValue::create(2024, 1, 15),
+            DateValue::create(9999, 12, 31),
+    };
+    for (auto v : cases) {
+        jobject ld = helper.newLocalDate(v._julian);
+        ASSERT_NE(ld, nullptr);
+        LOCAL_REF_GUARD(ld);
+        EXPECT_EQ(v._julian, helper.valLocalDate(ld));
+        EXPECT_TRUE(_env->IsInstanceOf(ld, helper.local_date_class()));
+    }
+}
+
+// newLocalDateTime(packed) -> LocalDateTime -> valLocalDateTime(...) round-trip.
+// The packed encoding bridges the BE Julian-time format and Java LocalDateTime
+// via UDFHelper's packedTimestampFromLocalDateTime / localDateTimeFromPackedTimestamp.
+TEST_F(JavaUDFTest, local_datetime_helper_roundtrip) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    TimestampValue cases[] = {
+            TimestampValue::create(1970, 1, 1, 0, 0, 0, 0),
+            TimestampValue::create(1970, 1, 1, 0, 0, 0, 1), // 1 microsecond
+            TimestampValue::create(2024, 1, 15, 12, 34, 56, 789000),
+            TimestampValue::create(9999, 12, 31, 23, 59, 59, 999999),
+    };
+    for (auto v : cases) {
+        jobject ldt = helper.newLocalDateTime(v.timestamp());
+        ASSERT_NE(ldt, nullptr);
+        LOCAL_REF_GUARD(ldt);
+        EXPECT_EQ(v.timestamp(), helper.valLocalDateTime(ldt));
+        EXPECT_TRUE(_env->IsInstanceOf(ldt, helper.local_datetime_class()));
+    }
+}
+
+// End-to-end batch output for DATE: build a Java LocalDate[] (with one null)
+// and let UDFHelper.getResultFromBoxedArray write into a native DateColumn.
+// Mirrors the path a UDF returning DATE goes through.
+TEST_F(JavaUDFTest, get_result_from_boxed_array_date) {
+    auto& helper = JVMFunctionHelper::getInstance();
+
+    DateValue d0 = DateValue::create(2024, 1, 15);
+    DateValue d2 = DateValue::create(1970, 1, 1);
+    jobject ld0 = helper.newLocalDate(d0._julian);
+    jobject ld2 = helper.newLocalDate(d2._julian);
+    LOCAL_REF_GUARD(ld0);
+    LOCAL_REF_GUARD(ld2);
+
+    jobjectArray arr = _env->NewObjectArray(3, helper.local_date_class(), nullptr);
+    ASSERT_NE(arr, nullptr);
+    LOCAL_REF_GUARD(arr);
+    _env->SetObjectArrayElement(arr, 0, ld0);
+    // index 1 stays null
+    _env->SetObjectArrayElement(arr, 2, ld2);
+
+    auto result = ColumnHelper::create_column(TypeDescriptor(TYPE_DATE), true);
+    ASSERT_OK(helper.get_result_from_boxed_array(TYPE_DATE, result.get(), arr, 3));
+    // Java memcpys the null buffer directly; mirror the production path
+    // (java_function_call_expr.cpp::get_boxed_result) and refresh _has_null.
+    down_cast<NullableColumn*>(result.get())->update_has_null();
+    ASSERT_EQ(result->size(), 3);
+    EXPECT_FALSE(result->is_null(0));
+    EXPECT_EQ(result->debug_item(0), d0.to_string());
+    EXPECT_TRUE(result->is_null(1));
+    EXPECT_FALSE(result->is_null(2));
+    EXPECT_EQ(result->debug_item(2), d2.to_string());
+}
+
+// End-to-end batch output for DATETIME, mirroring the DATE test.
+TEST_F(JavaUDFTest, get_result_from_boxed_array_datetime) {
+    auto& helper = JVMFunctionHelper::getInstance();
+
+    TimestampValue t0 = TimestampValue::create(2024, 1, 15, 12, 34, 56, 789000);
+    TimestampValue t2 = TimestampValue::create(1970, 1, 1, 0, 0, 0, 0);
+    jobject ldt0 = helper.newLocalDateTime(t0.timestamp());
+    jobject ldt2 = helper.newLocalDateTime(t2.timestamp());
+    LOCAL_REF_GUARD(ldt0);
+    LOCAL_REF_GUARD(ldt2);
+
+    jobjectArray arr = _env->NewObjectArray(3, helper.local_datetime_class(), nullptr);
+    ASSERT_NE(arr, nullptr);
+    LOCAL_REF_GUARD(arr);
+    _env->SetObjectArrayElement(arr, 0, ldt0);
+    _env->SetObjectArrayElement(arr, 2, ldt2);
+
+    auto result = ColumnHelper::create_column(TypeDescriptor(TYPE_DATETIME), true);
+    ASSERT_OK(helper.get_result_from_boxed_array(TYPE_DATETIME, result.get(), arr, 3));
+    down_cast<NullableColumn*>(result.get())->update_has_null();
+    ASSERT_EQ(result->size(), 3);
+    EXPECT_FALSE(result->is_null(0));
+    EXPECT_EQ(result->debug_item(0), t0.to_string());
+    EXPECT_TRUE(result->is_null(1));
+    EXPECT_FALSE(result->is_null(2));
+    EXPECT_EQ(result->debug_item(2), t2.to_string());
 }
 
 // ============================================================================
@@ -229,6 +341,40 @@ TEST(GetUdafMethodDescTest, MultiDimensionalPrimitiveArray) {
     ASSERT_EQ(desc.size(), 2);
     EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
     EXPECT_EQ(desc[1].type, TYPE_UNKNOWN); // param long[][] (array)
+}
+
+// Test: java.time.LocalDate / LocalDateTime must map to TYPE_DATE / TYPE_DATETIME.
+// Before the fix, the L-type parser silently skipped these classes, leaving
+// method_desc empty and producing a SIGSEGV at method_desc[0].is_box.
+TEST(GetUdafMethodDescTest, LocalDateAndLocalDateTime) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    // Signature: evaluate(LocalDate, LocalDateTime) -> LocalDateTime
+    std::string sign = "(Ljava/time/LocalDate;Ljava/time/LocalDateTime;)Ljava/time/LocalDateTime;";
+    ASSERT_OK(analyzer.get_udaf_method_desc(sign, &desc));
+    ASSERT_EQ(desc.size(), 3);
+    EXPECT_EQ(desc[0].type, TYPE_DATETIME); // return LocalDateTime
+    EXPECT_TRUE(desc[0].is_box);
+    EXPECT_EQ(desc[1].type, TYPE_DATE); // param LocalDate
+    EXPECT_TRUE(desc[1].is_box);
+    EXPECT_EQ(desc[2].type, TYPE_DATETIME); // param LocalDateTime
+    EXPECT_TRUE(desc[2].is_box);
+}
+
+// Test: unrecognized object class surfaces as TYPE_UNKNOWN (rejected by
+// get_method_desc validation) instead of being silently skipped.
+TEST(GetUdafMethodDescTest, UnknownObjectClassRejected) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    // process(String, com/example/Mystery) -> void
+    ASSERT_OK(analyzer.get_udaf_method_desc("(Ljava/lang/String;Lcom/example/Mystery;)V", &desc));
+    ASSERT_EQ(desc.size(), 3);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
+    EXPECT_EQ(desc[1].type, TYPE_VARCHAR); // String
+    EXPECT_EQ(desc[2].type, TYPE_UNKNOWN); // unknown class
+    // get_method_desc validation must reject the parameter TYPE_UNKNOWN.
+    desc.clear();
+    EXPECT_FALSE(analyzer.get_method_desc("(Ljava/lang/String;Lcom/example/Mystery;)V", &desc).ok());
 }
 
 } // namespace starrocks

--- a/docs/en/sql-reference/sql-functions/JAVA_UDF.md
+++ b/docs/en/sql-reference/sql-functions/JAVA_UDF.md
@@ -556,6 +556,8 @@ For more information, see [DROP FUNCTION](../sql-statements/Function/DROP_FUNCTI
 | DOUBLE                                         | java.lang.Double      |
 | STRING/VARCHAR                                 | java.lang.String      |
 | DECIMAL(p, s) (DECIMAL32 / 64 / 128 / 256)     | java.math.BigDecimal  |
+| DATE                                           | java.time.LocalDate   |
+| DATETIME                                       | java.time.LocalDateTime |
 | ARRAY                                          | java.util.List        |
 | Map                                            | java.util.Map         |
 

--- a/docs/ja/sql-reference/sql-functions/JAVA_UDF.md
+++ b/docs/ja/sql-reference/sql-functions/JAVA_UDF.md
@@ -557,6 +557,10 @@ DROP [GLOBAL] FUNCTION <function_name>(arg_type [, ...]);
 | DOUBLE                                         | java.lang.Double      |
 | STRING/VARCHAR                                 | java.lang.String      |
 | DECIMAL(p, s) (DECIMAL32 / 64 / 128 / 256)     | java.math.BigDecimal  |
+| DATE                                           | java.time.LocalDate   |
+| DATETIME                                       | java.time.LocalDateTime |
+| ARRAY                                          | java.util.List        |
+| Map                                            | java.util.Map         |
 
 > **NOTE**
 >

--- a/docs/zh/sql-reference/sql-functions/JAVA_UDF.md
+++ b/docs/zh/sql-reference/sql-functions/JAVA_UDF.md
@@ -563,6 +563,8 @@ DROP [GLOBAL] FUNCTION <function_name>(arg_type [, ...]);
 | DOUBLE                                         | java.lang.Double      |
 | STRING/VARCHAR                                 | java.lang.String      |
 | DECIMAL(p, s) (DECIMAL32 / 64 / 128 / 256)     | java.math.BigDecimal  |
+| DATE                                           | java.time.LocalDate   |
+| DATETIME                                       | java.time.LocalDateTime |
 | ARRAY                                          | java.util.List        |
 | Map                                            | java.util.Map         |
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -463,6 +463,8 @@ public class CreateFunctionAnalyzer {
                     .put(PrimitiveType.DECIMAL64, java.math.BigDecimal.class)
                     .put(PrimitiveType.DECIMAL128, java.math.BigDecimal.class)
                     .put(PrimitiveType.DECIMAL256, java.math.BigDecimal.class)
+                    .put(PrimitiveType.DATE, java.time.LocalDate.class)
+                    .put(PrimitiveType.DATETIME, java.time.LocalDateTime.class)
                     .build();
     private static final Class<?> JAVA_ARRAY_CLASS_TYPE = List.class;
     private static final Class<?> JAVA_MAP_CLASS_TYPE = Map.class;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
@@ -1115,4 +1115,42 @@ public class CreateFunctionStmtAnalyzerTest {
             }
         });
     }
+
+    public static class DateEval {
+        public java.time.LocalDateTime evaluate(java.time.LocalDate d, java.time.LocalDateTime ts) {
+            return ts;
+        }
+    }
+
+    @Test
+    public void testJScalarUDFDateDateTime() {
+        try {
+            Config.enable_udf = true;
+            mockClazz(DateEval.class);
+            String createFunctionSql = buildFunction("datetime", "date, datetime");
+            CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                    createFunctionSql, 32).get(0);
+            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+        } finally {
+            Config.enable_udf = false;
+        }
+    }
+
+    @Test
+    public void testJScalarUDFDateMismatchedJavaType() {
+        // Java method takes LocalDate but SQL declares STRING; analyzer must reject the mismatch.
+        assertThrows(SemanticException.class, () -> {
+            try {
+                Config.enable_udf = true;
+                mockClazz(DateEval.class);
+                String createFunctionSql = buildFunction("datetime", "string, datetime");
+                CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                        createFunctionSql, 32).get(0);
+                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+            } finally {
+                Config.enable_udf = false;
+            }
+        });
+    }
 }

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
@@ -35,6 +35,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -85,8 +86,16 @@ public class UDFHelper {
             put(TYPE_DECIMAL64, BigDecimal.class);
             put(TYPE_DECIMAL128, BigDecimal.class);
             put(TYPE_DECIMAL256, BigDecimal.class);
+            put(TYPE_DATE, LocalDate.class);
+            put(TYPE_DATETIME, LocalDateTime.class);
         }
     };
+
+    // StarRocks DateValue stores the int32 Julian-day. DateValue '1970-01-01' -> 2440588.
+    private static final int UNIX_EPOCH_JULIAN = 2440588;
+    // StarRocks TimestampValue packs (julian_days << 40) | microseconds_of_day.
+    private static final int TIMESTAMP_BITS = 40;
+    private static final long TIMESTAMP_MICROS_OF_DAY_MASK = (1L << TIMESTAMP_BITS) - 1L;
 
     private static final byte[] emptyBytes = new byte[0];
 
@@ -314,6 +323,64 @@ public class UDFHelper {
             }
         }
         getStringBoxedResult(numRows, results, columnAddr);
+    }
+
+    // Decode StarRocks DateValue (int32 Julian day) into a LocalDate.
+    private static LocalDate localDateFromJulian(int julian) {
+        return LocalDate.ofEpochDay((long) julian - UNIX_EPOCH_JULIAN);
+    }
+
+    // Encode a LocalDate as StarRocks DateValue (int32 Julian day).
+    private static int julianFromLocalDate(LocalDate ld) {
+        return (int) (ld.toEpochDay() + UNIX_EPOCH_JULIAN);
+    }
+
+    // Decode StarRocks TimestampValue (packed int64) into a LocalDateTime.
+    // Layout: high 24 bits = Julian day, low 40 bits = microseconds-of-day.
+    public static LocalDateTime localDateTimeFromPackedTimestamp(long packed) {
+        long julian = packed >>> TIMESTAMP_BITS;
+        long microsOfDay = packed & TIMESTAMP_MICROS_OF_DAY_MASK;
+        return LocalDateTime.of(LocalDate.ofEpochDay(julian - UNIX_EPOCH_JULIAN),
+                LocalTime.ofNanoOfDay(microsOfDay * 1000L));
+    }
+
+    // Encode a LocalDateTime as StarRocks TimestampValue (packed int64).
+    public static long packedTimestampFromLocalDateTime(LocalDateTime ldt) {
+        long julian = ldt.toLocalDate().toEpochDay() + UNIX_EPOCH_JULIAN;
+        long microsOfDay = ldt.toLocalTime().toNanoOfDay() / 1000L;
+        return (julian << TIMESTAMP_BITS) | microsOfDay;
+    }
+
+    // Output batch: write LocalDate[] into a TYPE_DATE column as int32 Julian days.
+    private static void getLocalDateBoxedResult(int numRows, LocalDate[] column, long columnAddr) {
+        byte[] nulls = new byte[numRows];
+        int[] dataArr = new int[numRows];
+        for (int i = 0; i < numRows; i++) {
+            if (column[i] == null) {
+                nulls[i] = 1;
+            } else {
+                dataArr[i] = julianFromLocalDate(column[i]);
+            }
+        }
+        final long[] addrs = getAddrs(columnAddr);
+        Platform.copyMemory(nulls, Platform.BYTE_ARRAY_OFFSET, null, addrs[0], numRows);
+        Platform.copyMemory(dataArr, Platform.INT_ARRAY_OFFSET, null, addrs[1], numRows * 4L);
+    }
+
+    // Output batch: write LocalDateTime[] into a TYPE_DATETIME column as packed int64.
+    private static void getLocalDateTimeBoxedResult(int numRows, LocalDateTime[] column, long columnAddr) {
+        byte[] nulls = new byte[numRows];
+        long[] dataArr = new long[numRows];
+        for (int i = 0; i < numRows; i++) {
+            if (column[i] == null) {
+                nulls[i] = 1;
+            } else {
+                dataArr[i] = packedTimestampFromLocalDateTime(column[i]);
+            }
+        }
+        final long[] addrs = getAddrs(columnAddr);
+        Platform.copyMemory(nulls, Platform.BYTE_ARRAY_OFFSET, null, addrs[0], numRows);
+        Platform.copyMemory(dataArr, Platform.LONG_ARRAY_OFFSET, null, addrs[1], numRows * 8L);
     }
 
     public static void getStringDecimalResult(int numRows, BigDecimal[] column, long columnAddr) {
@@ -704,6 +771,14 @@ public class UDFHelper {
                 getBigIntBoxedResult(numRows, (Long[]) boxedResult, columnAddr);
                 break;
             }
+            case TYPE_DATE: {
+                getLocalDateBoxedResult(numRows, (LocalDate[]) boxedResult, columnAddr);
+                break;
+            }
+            case TYPE_DATETIME: {
+                getLocalDateTimeBoxedResult(numRows, (LocalDateTime[]) boxedResult, columnAddr);
+                break;
+            }
             case TYPE_TIME: {
                 getDoubleTimeResult(numRows, (Time[]) boxedResult, columnAddr);
                 break;
@@ -813,6 +888,20 @@ public class UDFHelper {
                     return createBoxedStringArray(numRows, null, buffer[0], buffer[1]);
                 } else {
                     return createBoxedStringArray(numRows, buffer[0], buffer[1], buffer[2]);
+                }
+            }
+            case TYPE_DATE: {
+                if (!nullable) {
+                    return createBoxedLocalDateArray(numRows, null, buffer[0]);
+                } else {
+                    return createBoxedLocalDateArray(numRows, buffer[0], buffer[1]);
+                }
+            }
+            case TYPE_DATETIME: {
+                if (!nullable) {
+                    return createBoxedLocalDateTimeArray(numRows, null, buffer[0]);
+                } else {
+                    return createBoxedLocalDateTimeArray(numRows, buffer[0], buffer[1]);
                 }
             }
             default:
@@ -946,6 +1035,46 @@ public class UDFHelper {
             }
             return res;
         }
+    }
+
+    // Read a TYPE_DATE column (int32 Julian-day per row) into a LocalDate[].
+    public static Object[] createBoxedLocalDateArray(int numRows, ByteBuffer nullBuffer, ByteBuffer dataBuffer) {
+        int[] dataArr = new int[numRows];
+        dataBuffer.order(ByteOrder.LITTLE_ENDIAN).asIntBuffer().get(dataArr);
+        LocalDate[] res = new LocalDate[numRows];
+        if (nullBuffer != null) {
+            byte[] nullArr = getNullData(nullBuffer, numRows);
+            for (int i = 0; i < numRows; i++) {
+                if (nullArr[i] == 0) {
+                    res[i] = localDateFromJulian(dataArr[i]);
+                }
+            }
+        } else {
+            for (int i = 0; i < numRows; i++) {
+                res[i] = localDateFromJulian(dataArr[i]);
+            }
+        }
+        return res;
+    }
+
+    // Read a TYPE_DATETIME column (packed int64 per row) into a LocalDateTime[].
+    public static Object[] createBoxedLocalDateTimeArray(int numRows, ByteBuffer nullBuffer, ByteBuffer dataBuffer) {
+        long[] dataArr = new long[numRows];
+        dataBuffer.order(ByteOrder.LITTLE_ENDIAN).asLongBuffer().get(dataArr);
+        LocalDateTime[] res = new LocalDateTime[numRows];
+        if (nullBuffer != null) {
+            byte[] nullArr = getNullData(nullBuffer, numRows);
+            for (int i = 0; i < numRows; i++) {
+                if (nullArr[i] == 0) {
+                    res[i] = localDateTimeFromPackedTimestamp(dataArr[i]);
+                }
+            }
+        } else {
+            for (int i = 0; i < numRows; i++) {
+                res[i] = localDateTimeFromPackedTimestamp(dataArr[i]);
+            }
+        }
+        return res;
     }
 
     public static Object[] createBoxedDoubleArray(int numRows, ByteBuffer nullBuffer, ByteBuffer dataBuffer) {

--- a/java-extensions/udf-extensions/src/test/java/com/starrocks/udf/UDFHelperDateTest.java
+++ b/java-extensions/udf-extensions/src/test/java/com/starrocks/udf/UDFHelperDateTest.java
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.udf;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class UDFHelperDateTest {
+
+    // 1970-01-01 in StarRocks Julian-day encoding. Anchor for the round-trip checks.
+    private static final int JULIAN_UNIX_EPOCH = 2440588;
+
+    private static ByteBuffer littleEndian(int capacity) {
+        return ByteBuffer.allocate(capacity).order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    private static ByteBuffer nullFlags(byte... flags) {
+        ByteBuffer buf = ByteBuffer.allocate(flags.length);
+        buf.put(flags);
+        buf.flip();
+        return buf;
+    }
+
+    @Test
+    public void testCreateBoxedLocalDateArrayNonNullable() {
+        // 2024-01-15 -> 19737 days since unix epoch -> julian = 19737 + 2440588.
+        long epoch20240115 = LocalDate.of(2024, 1, 15).toEpochDay();
+        ByteBuffer data = littleEndian(3 * 4);
+        data.putInt(JULIAN_UNIX_EPOCH);                          // 1970-01-01
+        data.putInt((int) (epoch20240115 + JULIAN_UNIX_EPOCH));  // 2024-01-15
+        data.putInt(JULIAN_UNIX_EPOCH - 1);                      // 1969-12-31
+        data.flip();
+
+        Object[] result = UDFHelper.createBoxedLocalDateArray(3, null, data);
+        Assertions.assertEquals(3, result.length);
+        Assertions.assertEquals(LocalDate.of(1970, 1, 1), result[0]);
+        Assertions.assertEquals(LocalDate.of(2024, 1, 15), result[1]);
+        Assertions.assertEquals(LocalDate.of(1969, 12, 31), result[2]);
+    }
+
+    @Test
+    public void testCreateBoxedLocalDateArrayNullable() {
+        ByteBuffer data = littleEndian(2 * 4);
+        data.putInt(JULIAN_UNIX_EPOCH);
+        data.putInt(0); // ignored, masked by null flag
+        data.flip();
+        ByteBuffer nulls = nullFlags((byte) 0, (byte) 1);
+
+        Object[] result = UDFHelper.createBoxedLocalDateArray(2, nulls, data);
+        Assertions.assertEquals(LocalDate.of(1970, 1, 1), result[0]);
+        Assertions.assertNull(result[1]);
+    }
+
+    @Test
+    public void testCreateBoxedLocalDateTimeArrayNonNullable() {
+        ByteBuffer data = littleEndian(2 * 8);
+        data.putLong(packed(LocalDateTime.of(1970, 1, 1, 0, 0, 0)));
+        data.putLong(packed(LocalDateTime.of(2024, 1, 15, 12, 34, 56, 789_000_000)));
+        data.flip();
+
+        Object[] result = UDFHelper.createBoxedLocalDateTimeArray(2, null, data);
+        Assertions.assertEquals(LocalDateTime.of(1970, 1, 1, 0, 0, 0), result[0]);
+        Assertions.assertEquals(LocalDateTime.of(2024, 1, 15, 12, 34, 56, 789_000_000), result[1]);
+    }
+
+    @Test
+    public void testCreateBoxedLocalDateTimeArrayNullable() {
+        ByteBuffer data = littleEndian(2 * 8);
+        data.putLong(packed(LocalDateTime.of(2025, 6, 30, 23, 59, 59, 999_000)));
+        data.putLong(0L);
+        data.flip();
+        ByteBuffer nulls = nullFlags((byte) 0, (byte) 1);
+
+        Object[] result = UDFHelper.createBoxedLocalDateTimeArray(2, nulls, data);
+        Assertions.assertEquals(LocalDateTime.of(2025, 6, 30, 23, 59, 59, 999_000), result[0]);
+        Assertions.assertNull(result[1]);
+    }
+
+    // packedTimestampFromLocalDateTime / localDateTimeFromPackedTimestamp must round-trip.
+    @Test
+    public void testLocalDateTimePackedRoundTrip() {
+        LocalDateTime[] cases = {
+                LocalDateTime.of(1, 1, 1, 0, 0, 0),
+                LocalDateTime.of(1970, 1, 1, 0, 0, 0),
+                LocalDateTime.of(1970, 1, 1, 0, 0, 0, 1_000), // 1 microsecond
+                LocalDateTime.of(2024, 1, 15, 12, 34, 56, 789_000),
+                LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999_999_000),
+        };
+        for (LocalDateTime input : cases) {
+            long packed = UDFHelper.packedTimestampFromLocalDateTime(input);
+            LocalDateTime decoded = UDFHelper.localDateTimeFromPackedTimestamp(packed);
+            Assertions.assertEquals(input, decoded, "round-trip failed for " + input);
+        }
+    }
+
+    // Layout of the StarRocks TimestampValue:
+    //   high 24 bits = Julian day, low 40 bits = microseconds-of-day.
+    private static long packed(LocalDateTime ldt) {
+        long julian = ldt.toLocalDate().toEpochDay() + JULIAN_UNIX_EPOCH;
+        long microsOfDay = ldt.toLocalTime().toNanoOfDay() / 1000L;
+        return (julian << 40) | microsOfDay;
+    }
+}

--- a/test/sql/test_udf/R/test_jvm_date_udf
+++ b/test/sql/test_udf/R/test_jvm_date_udf
@@ -1,0 +1,99 @@
+-- name: test_jvm_date_udf @no_arrow_flight_sql
+CREATE FUNCTION echo_date(date)
+RETURNS date
+PROPERTIES (
+    "symbol" = "EchoDate",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/date.jar"
+);
+-- result:
+-- !result
+CREATE FUNCTION echo_datetime(datetime)
+RETURNS datetime
+PROPERTIES (
+    "symbol" = "EchoDateTime",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/date.jar"
+);
+-- result:
+-- !result
+CREATE FUNCTION date_gt(datetime, date)
+RETURNS datetime
+PROPERTIES (
+    "symbol" = "GreaterTime",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/date.jar"
+);
+-- result:
+-- !result
+CREATE FUNCTION echo_date_array(array<date>)
+RETURNS array<date>
+PROPERTIES (
+    "symbol" = "EchoDateArray",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/date.jar"
+);
+-- result:
+-- !result
+CREATE FUNCTION echo_date_map(map<date, date>)
+RETURNS map<date, date>
+PROPERTIES (
+    "symbol" = "EchoDateMap",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/date.jar"
+);
+-- result:
+-- !result
+CREATE TABLE t_dt (
+    id INT,
+    dt1 date,
+    dt2 datetime,
+    dt3 array<date>,
+    dt4 map<date, date>
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_dt VALUES
+    (1, '2020-02-02', '2020-02-02 20:22:02', ['2020-02-02', '2020-02-03'], map('2020-02-02', '2020-02-21')),
+    (2, '2020-01-22', '2020-01-02 20:22:02', ['2021-02-02', '2026-02-03'], map('2023-02-02', '2024-02-21'));
+-- result:
+-- !result
+select echo_date(dt1) from t_dt;
+-- result:
+2020-02-02
+2020-01-22
+-- !result
+select echo_datetime(dt2) from t_dt;
+-- result:
+2020-02-02 20:22:02
+2020-01-02 20:22:02
+-- !result
+select echo_date_array(dt3) from t_dt;
+-- result:
+["2020-02-02","2020-02-03"]
+["2021-02-02","2026-02-03"]
+-- !result
+select echo_date_map(dt4) from t_dt;
+-- result:
+{"2020-02-02":"2020-02-21"}
+{"2023-02-02":"2024-02-21"}
+-- !result
+select echo_date('2020-02-02');
+-- result:
+2020-02-02
+-- !result
+select echo_datetime('2020-02-02 19:22:02');
+-- result:
+2020-02-02 19:22:02
+-- !result
+select echo_date_array(['2020-02-02']);
+-- result:
+["2020-02-02"]
+-- !result
+select echo_date_map(map('2020-02-02', '2020-01-01'));
+-- result:
+{"2020-02-02":"2020-01-01"}
+-- !result

--- a/test/sql/test_udf/T/test_jvm_date_udf
+++ b/test/sql/test_udf/T/test_jvm_date_udf
@@ -1,0 +1,66 @@
+-- name: test_jvm_date_udf @no_arrow_flight_sql
+
+CREATE FUNCTION echo_date(date)
+RETURNS date
+PROPERTIES (
+    "symbol" = "EchoDate",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/date.jar"
+);
+
+CREATE FUNCTION echo_datetime(datetime)
+RETURNS datetime
+PROPERTIES (
+    "symbol" = "EchoDateTime",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/date.jar"
+);
+
+CREATE FUNCTION date_gt(datetime, date)
+RETURNS datetime
+PROPERTIES (
+    "symbol" = "GreaterTime",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/date.jar"
+);
+
+CREATE FUNCTION echo_date_array(array<date>)
+RETURNS array<date>
+PROPERTIES (
+    "symbol" = "EchoDateArray",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/date.jar"
+);
+
+CREATE FUNCTION echo_date_map(map<date, date>)
+RETURNS map<date, date>
+PROPERTIES (
+    "symbol" = "EchoDateMap",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/date.jar"
+);
+
+CREATE TABLE t_dt (
+    id INT,
+    dt1 date,
+    dt2 datetime,
+    dt3 array<date>,
+    dt4 map<date, date>
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_dt VALUES
+    (1, '2020-02-02', '2020-02-02 20:22:02', ['2020-02-02', '2020-02-03'], map('2020-02-02', '2020-02-21')),
+    (2, '2020-01-22', '2020-01-02 20:22:02', ['2021-02-02', '2026-02-03'], map('2023-02-02', '2024-02-21'));
+
+select echo_date(dt1) from t_dt;
+select echo_datetime(dt2) from t_dt;
+select echo_date_array(dt3) from t_dt;
+select echo_date_map(dt4) from t_dt;
+
+select echo_date('2020-02-02');
+select echo_datetime('2020-02-02 19:22:02');
+select echo_date_array(['2020-02-02']);
+select echo_date_map(map('2020-02-02', '2020-01-01'));


### PR DESCRIPTION
## Why I'm doing:

Map SQL DATE to java.time.LocalDate and DATETIME to java.time.LocalDateTime across the FE analyzer, the udf-extensions JNI runtime, and the BE Java function call path. Wire format mirrors the StarRocks column storage:

- DATE: int32 Julian day. Java decodes via LocalDate.ofEpochDay(julian - UNIX_EPOCH_JULIAN), encodes the inverse.
- DATETIME: packed int64 (julian << 40 | microseconds_of_day). Encoding lives in UDFHelper since the layout is StarRocks-specific.

The batch path (input + output) zero-copies the column buffer through DirectByteBuffer; the per-row path (cast_to_jvalue / assign_jvalue / append_jvalue / check_type_matched) routes through new JVMFunctionHelper::newLocalDate{,Time} / valLocalDate{,Time} so const-column inputs and UDAF/UDTF returns also work.

Also wires DATE/DATETIME into the BE-side JNI signature parser (ClassAnalyzer::get_udaf_method_desc) and the GetColumnLogicalTypeVistor so ARRAY<DATE>/ARRAY<DATETIME> elements resolve correctly. The previous silent-skip on unrecognized object classes is hardened to a TYPE_UNKNOWN entry that surfaces a clear "unknown type sign" error from get_method_desc instead of segfaulting at method_desc[0].is_box.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
 
https://claude.ai/code/session_013eanvS6pP87BHRE865hig8