### PR TITLE
[BugFix] Cast COALESCE children to common type in JOIN USING transformer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -1441,14 +1441,19 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
             commonType = leftType;
         }
 
-        Type[] argTypes = new Type[] {leftType, rightType};
+        ScalarOperator leftCasted = leftType.equals(commonType)
+                ? leftOp : foldCast(new CastOperator(commonType, leftOp, true));
+        ScalarOperator rightCasted = rightType.equals(commonType)
+                ? rightOp : foldCast(new CastOperator(commonType, rightOp, true));
+
+        Type[] argTypes = new Type[] {commonType, commonType};
         com.starrocks.catalog.Function coalesceFunction =
                 com.starrocks.sql.ast.expression.ExprUtils.getBuiltinFunction(
                         FunctionSet.COALESCE, argTypes,
                         com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
 
         return new CallOperator(FunctionSet.COALESCE, commonType,
-                Lists.newArrayList(leftOp, rightOp), coalesceFunction);
+                Lists.newArrayList(leftCasted, rightCasted), coalesceFunction);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -496,6 +496,22 @@ public class JoinTest extends PlanTestBase {
     }
 
     @Test
+    public void testFullOuterJoinUsingWithMismatchedTypes() throws Exception {
+        // Two USING columns with the same name but different types (DATETIME vs VARCHAR).
+        // The synthesized COALESCE must wrap the side whose type does not equal the
+        // resolved common type in an explicit CAST, so that arg types match the function
+        // signature.
+        String sql = "select v from " +
+                "  (select id_datetime as v from test_all_type) a " +
+                "  full outer join " +
+                "  (select t1a as v from test_all_type) b using(v)";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "join op: FULL OUTER JOIN");
+        // The DATETIME side must be cast to the common (string) type inside the coalesce.
+        assertContains(plan, "coalesce(CAST");
+    }
+
+    @Test
     public void testJoinAssociativityConst() throws Exception {
         String sql = "SELECT x0.*\n" +
                 "FROM (\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -508,7 +508,7 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "join op: FULL OUTER JOIN");
         // The DATETIME side must be cast to the common (string) type inside the coalesce.
-        assertContains(plan, "coalesce(CAST");
+        assertContains(plan, "coalesce(8: id_datetime, CAST(11: t1a AS DATETIME))");
     }
 
     @Test

--- a/test/sql/test_join/R/test_full_outer_join_using_mismatched_types.sql
+++ b/test/sql/test_join/R/test_full_outer_join_using_mismatched_types.sql
@@ -1,0 +1,62 @@
+-- name: test_full_outer_join_using_mismatched_types
+DROP DATABASE IF EXISTS test_full_outer_join_using_mismatched_types_${uuid0};
+-- result:
+-- !result
+CREATE DATABASE test_full_outer_join_using_mismatched_types_${uuid0};
+-- result:
+-- !result
+USE test_full_outer_join_using_mismatched_types_${uuid0};
+-- result:
+-- !result
+CREATE TABLE left_t (
+    k INT,
+    dt DATETIME,
+    region VARCHAR(255),
+    city VARCHAR(255)
+) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE right_t (
+    k INT,
+    dt VARCHAR(255),
+    region VARCHAR(255),
+    city VARCHAR(255)
+) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO left_t VALUES
+    (1, '2024-01-01 00:00:00', 'us-east', 'NYC'),
+    (2, '2024-02-01 00:00:00', 'us-west', 'SFO'),
+    (3, NULL, 'eu', 'LON');
+-- result:
+-- !result
+INSERT INTO right_t VALUES
+    (1, '2024-01-01 00:00:00', 'us-east', 'NYC'),
+    (4, '2024-03-01 00:00:00', 'apac', 'TYO'),
+    (5, NULL, NULL, 'BER');
+-- result:
+-- !result
+SELECT count(*) FROM left_t FULL OUTER JOIN right_t USING(dt, region, city);
+-- result:
+5
+-- !result
+SELECT count(*) FROM left_t FULL OUTER JOIN right_t USING(dt);
+-- result:
+5
+-- !result
+SELECT
+    coalesce(left_t.k, right_t.k) AS k,
+    region,
+    city
+FROM left_t FULL OUTER JOIN right_t USING(region, city)
+ORDER BY k, region, city;
+-- result:
+1	us-east	NYC
+2	us-west	SFO
+3	eu	LON
+4	apac	TYO
+5	None	BER
+-- !result
+DROP DATABASE test_full_outer_join_using_mismatched_types_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_join/T/test_full_outer_join_using_mismatched_types.sql
+++ b/test/sql/test_join/T/test_full_outer_join_using_mismatched_types.sql
@@ -1,0 +1,53 @@
+-- name: test_full_outer_join_using_mismatched_types
+-- Regression test: FULL OUTER JOIN ... USING(col) where the same-named
+-- column has a different type on each side (e.g. DATETIME vs VARCHAR).
+-- The planner must wrap the side whose type differs from the resolved
+-- common type in an explicit CAST so that the synthesized COALESCE has
+-- children matching its function signature.
+DROP DATABASE IF EXISTS test_full_outer_join_using_mismatched_types_${uuid0};
+CREATE DATABASE test_full_outer_join_using_mismatched_types_${uuid0};
+USE test_full_outer_join_using_mismatched_types_${uuid0};
+
+CREATE TABLE left_t (
+    k INT,
+    dt DATETIME,
+    region VARCHAR(255),
+    city VARCHAR(255)
+) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+CREATE TABLE right_t (
+    k INT,
+    dt VARCHAR(255),
+    region VARCHAR(255),
+    city VARCHAR(255)
+) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+INSERT INTO left_t VALUES
+    (1, '2024-01-01 00:00:00', 'us-east', 'NYC'),
+    (2, '2024-02-01 00:00:00', 'us-west', 'SFO'),
+    (3, NULL, 'eu', 'LON');
+
+INSERT INTO right_t VALUES
+    (1, '2024-01-01 00:00:00', 'us-east', 'NYC'),
+    (4, '2024-03-01 00:00:00', 'apac', 'TYO'),
+    (5, NULL, NULL, 'BER');
+
+-- The query must not error out: USING(dt, region, city) requires the
+-- planner to coalesce a DATETIME with a VARCHAR for the `dt` column.
+SELECT count(*) FROM left_t FULL OUTER JOIN right_t USING(dt, region, city);
+
+-- Single-key cross-typed USING: dt is DATETIME on the left, VARCHAR on
+-- the right.  Only the row whose datetime/string round-trip matches
+-- joins; the rest become outer rows.
+SELECT count(*) FROM left_t FULL OUTER JOIN right_t USING(dt);
+
+-- Verify the synthesized COALESCE column has well-typed values for the
+-- matched / outer rows.  Order by the deterministic key column.
+SELECT
+    coalesce(left_t.k, right_t.k) AS k,
+    region,
+    city
+FROM left_t FULL OUTER JOIN right_t USING(region, city)
+ORDER BY k, region, city;
+
+DROP DATABASE test_full_outer_join_using_mismatched_types_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

createCoalesceOperator resolved a common result type for the synthesized USING-projection COALESCE but passed the original left/right operands as children without casting, so the call's actual child types could disagree with the resolved function signature (e.g. DATETIME child under a coalesce(VARCHAR) signature). Wrap children whose type differs from the common type in an implicit CAST and look up the function with {commonType, commonType} so the signature is consistent.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
