### PR TITLE
[UT] Cover JemallocAllocator::realloc fallback for high alignment

### DIFF
--- a/be/test/runtime/memory/memory_allocator_test.cpp
+++ b/be/test/runtime/memory/memory_allocator_test.cpp
@@ -50,6 +50,27 @@ TEST(JemallocAllocatorTest, ClearAndAlignment) {
     allocator.free(grown, 32);
 }
 
+TEST(JemallocAllocatorTest, ReallocWithLargeAlignment) {
+    JemallocAllocator<true> allocator;
+    constexpr size_t alignment = 64;
+    auto* ptr = static_cast<char*>(allocator.alloc(32, alignment));
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(ptr) % alignment, 0);
+
+    std::memset(ptr, 0x5A, 32);
+    auto* grown = static_cast<char*>(allocator.realloc(ptr, 32, 96, alignment));
+    ASSERT_NE(grown, nullptr);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(grown) % alignment, 0);
+    for (int i = 0; i < 32; ++i) {
+        EXPECT_EQ(grown[i], 0x5A);
+    }
+    for (int i = 32; i < 96; ++i) {
+        EXPECT_EQ(grown[i], 0);
+    }
+
+    allocator.free(grown, 96);
+}
+
 TEST(TrackedAllocatorTest, TracksMemTrackerConsumption) {
     struct RestoreMemTrackerSource {
         ~RestoreMemTrackerSource() { starrocks::CurrentThread::set_mem_tracker_source(nullptr, nullptr); }


### PR DESCRIPTION
## Why I'm doing:

`JemallocAllocator::realloc` has two paths: an in-place try plus alloc+copy+free fallback when `alignment <= MALLOC_MIN_ALIGNMENT`, and a direct alloc+copy+free path when `alignment > MALLOC_MIN_ALIGNMENT`. The existing `JemallocAllocatorTest.ClearAndAlignment` only calls `realloc` with default alignment, so the high-alignment branch (and its `je_free` of the original buffer) is never exercised by the unit tests.

This came up while reviewing #72182 (macOS build fixes), where the BE incremental coverage gate flagged the `::je_free(ptr)` line in that branch as uncovered. The gap predates that PR — there is simply no test that drives `realloc` with a non-default alignment.

## What I'm doing:

Add `JemallocAllocatorTest.ReallocWithLargeAlignment`, which:

- allocates 32 bytes with alignment 64 and asserts the pointer is aligned,
- writes `0x5A` into the buffer, reallocs to 96 bytes (still alignment 64), and verifies:
  - the new pointer is aligned to 64,
  - the first 32 bytes preserve the `0x5A` payload,
  - bytes `[32, 96)` are zero-filled (since the test uses `JemallocAllocator<true>`).

Pure test addition; no production code change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr