### PR TITLE
[Enhancement] Migrate Tier-1 leader-only daemons to LeaderDaemon

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -52,7 +52,7 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -81,7 +81,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-public class ConsistencyChecker extends FrontendDaemon {
+public class ConsistencyChecker extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(ConsistencyChecker.class);
 
     private static final int MAX_JOB_NUM = 100;
@@ -334,7 +334,7 @@ public class ConsistencyChecker extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         if (System.currentTimeMillis() - lastTabletMetaCheckTime > Config.consistency_tablet_meta_check_interval_ms) {
             checkTabletMetaConsistency(creatingTableCounters);
             lastTabletMetaCheckTime = System.currentTimeMillis();
@@ -381,6 +381,32 @@ public class ConsistencyChecker extends FrontendDaemon {
         } finally {
             jobsLock.writeLock().unlock();
         }
+    }
+
+    @Override
+    protected void onStopped() {
+        // jobs holds in-flight CheckConsistencyJob instances and creatingTableCounters tracks
+        // CREATE TABLE flows that are still running on this leader. Both belong to the current
+        // leader session: in-flight create paths will fail when the editlog is sealed, so any
+        // counter increments left behind would otherwise leak across sessions and incorrectly
+        // mask tablets from future consistency checks. The watermark is reset for the same
+        // reason - the next leader should re-issue a tablet-meta scan rather than honor a
+        // timestamp captured by a different session.
+        jobsLock.writeLock().lock();
+        try {
+            for (CheckConsistencyJob job : jobs.values()) {
+                try {
+                    job.clear();
+                } catch (Throwable t) {
+                    LOG.warn("clear consistency job for tablet {} failed", job.getTabletId(), t);
+                }
+            }
+            jobs.clear();
+        } finally {
+            jobsLock.writeLock().unlock();
+        }
+        creatingTableCounters.clear();
+        lastTabletMetaCheckTime = 0;
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
@@ -26,7 +26,7 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.proc.BaseProcResult;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -46,7 +46,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-public class MetaRecoveryDaemon extends FrontendDaemon {
+public class MetaRecoveryDaemon extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(MetaRecoveryDaemon.class);
 
     private final Set<UnRecoveredPartition> unRecoveredPartitions = new HashSet<>();
@@ -57,8 +57,20 @@ public class MetaRecoveryDaemon extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         recover();
+    }
+
+    @Override
+    protected void onStopped() {
+        // unRecoveredPartitions is leader-session diagnostic state surfaced via the proc node;
+        // it should not survive demotion since the next leader rebuilds it from scratch.
+        lock.writeLock().lock();
+        try {
+            unRecoveredPartitions.clear();
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     public void recover() {

--- a/fe/fe-core/src/main/java/com/starrocks/encryption/KeyRotationDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/encryption/KeyRotationDaemon.java
@@ -13,9 +13,9 @@
 // limitations under the License.
 package com.starrocks.encryption;
 
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 
-public class KeyRotationDaemon extends FrontendDaemon {
+public class KeyRotationDaemon extends LeaderDaemon {
     private static final int KEY_ROTATION_CHECK_INTERVAL_MS = 10000;
     private final KeyMgr keyMgr;
 
@@ -25,7 +25,7 @@ public class KeyRotationDaemon extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         keyMgr.checkKeyRotation();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/healthchecker/SafeModeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/healthchecker/SafeModeChecker.java
@@ -17,7 +17,7 @@ package com.starrocks.healthchecker;
 import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.catalog.DiskInfo;
 import com.starrocks.common.Config;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import org.apache.logging.log4j.LogManager;
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-public class SafeModeChecker extends FrontendDaemon {
+public class SafeModeChecker extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(SafeModeChecker.class);
 
     public SafeModeChecker() {
@@ -33,7 +33,7 @@ public class SafeModeChecker extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         // update interval
         if (getInterval() != Config.safe_mode_checker_interval_sec * 1000) {
             setInterval(Config.safe_mode_checker_interval_sec * 1000);

--- a/fe/fe-core/src/main/java/com/starrocks/leader/TabletCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/TabletCollector.java
@@ -15,7 +15,7 @@
 package com.starrocks.leader;
 
 import com.starrocks.common.Config;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Set;
 
-public class TabletCollector extends FrontendDaemon {
+public class TabletCollector extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(TabletCollector.class);
     private static final long CHECK_INTERVAL_MS = 100;
 
@@ -47,7 +47,7 @@ public class TabletCollector extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         if (RunMode.isSharedDataMode()) {
             return;
         }
@@ -55,6 +55,14 @@ public class TabletCollector extends FrontendDaemon {
         updateQueue();
 
         collect(collectQueue.poll());
+    }
+
+    @Override
+    protected synchronized void onStopped() {
+        // Both are leader-session bookkeeping: which BEs we've already enqueued and the
+        // priority of next collection. On re-election the queue is rebuilt from updateQueue().
+        collectQueue.clear();
+        queuedBeIds.clear();
     }
 
     private void updateQueue() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadEtlChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadEtlChecker.java
@@ -18,7 +18,7 @@
 package com.starrocks.load.loadv2;
 
 import com.starrocks.common.Config;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.Logger;
  * LoadEtlChecker will update etl status for jobs that have etl state.
  * Now only for SparkLoadJob
  */
-public class LoadEtlChecker extends FrontendDaemon {
+public class LoadEtlChecker extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(LoadEtlChecker.class);
 
     private LoadMgr loadManager;
@@ -37,7 +37,7 @@ public class LoadEtlChecker extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         try {
             loadManager.processEtlStateJobs();
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingChecker.java
@@ -35,7 +35,7 @@
 package com.starrocks.load.loadv2;
 
 import com.starrocks.common.Config;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.Logger;
  * LoadLoadingChecker will update loading status for jobs that loading by PushTask.
  * Now only for SparkLoadJob
  */
-public class LoadLoadingChecker extends FrontendDaemon {
+public class LoadLoadingChecker extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(LoadLoadingChecker.class);
 
     private LoadMgr loadManager;
@@ -54,7 +54,7 @@ public class LoadLoadingChecker extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         try {
             loadManager.processLoadingStateJobs();
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTimeoutChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTimeoutChecker.java
@@ -35,7 +35,7 @@
 package com.starrocks.load.loadv2;
 
 import com.starrocks.common.Config;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -44,7 +44,7 @@ import org.apache.logging.log4j.Logger;
  * And it will not handle the job which the corresponding transaction is started.
  * For those jobs, global transaction manager cancel the corresponding job while aborting the timeout transaction.
  */
-public class LoadTimeoutChecker extends FrontendDaemon {
+public class LoadTimeoutChecker extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(LoadTimeoutChecker.class);
 
     private LoadMgr loadManager;
@@ -55,7 +55,7 @@ public class LoadTimeoutChecker extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         try {
             loadManager.processTimeoutJobs();
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -27,7 +27,7 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.MaterializedViewExceptions;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -46,7 +46,7 @@ import java.util.Set;
 /**
  * A daemon thread that check the MV active status, try to activate the MV it's inactive.
  */
-public class MVActiveChecker extends FrontendDaemon {
+public class MVActiveChecker extends LeaderDaemon {
 
     private static final Logger LOG = LogManager.getLogger(MVActiveChecker.class);
 
@@ -54,6 +54,14 @@ public class MVActiveChecker extends FrontendDaemon {
 
     public MVActiveChecker() {
         super("mv-active-checker", Config.mv_active_checker_interval_seconds * 1000);
+    }
+
+    @Override
+    protected void onStopped() {
+        // MV_ACTIVE_INFO holds per-MV failure backoff state used only by the leader's activation
+        // loop. Drop it on demotion so the next leader (or this FE on re-election) starts fresh
+        // rather than honoring backoff windows accumulated under the previous leader session.
+        MV_ACTIVE_INFO.clear();
     }
 
     public static final String MV_BACKUP_INACTIVE_REASON = "it's in backup and will be activated after restore if possible";
@@ -67,7 +75,7 @@ public class MVActiveChecker extends FrontendDaemon {
     );
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         // reset if the interval has been changed
         setInterval(Config.mv_active_checker_interval_seconds * 1000L);
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/DatabaseQuotaRefresher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/DatabaseQuotaRefresher.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import org.apache.logging.log4j.LogManager;
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-public class DatabaseQuotaRefresher extends FrontendDaemon {
+public class DatabaseQuotaRefresher extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(DatabaseQuotaRefresher.class);
 
     public DatabaseQuotaRefresher() {
@@ -36,7 +36,7 @@ public class DatabaseQuotaRefresher extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         checkAndMayUpdateInterval();
         updateAllDatabaseUsedDataQuota();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1655,10 +1655,7 @@ public class GlobalStateMgr {
      */
     void stopLeaderOnlyDaemonThreads() {
         long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
-        // Reverse of startLeaderOnlyDaemonThreads(): the most recently activated daemons
-        // wind down first, and heartbeatMgr - which was started very early and whose RPC
-        // responses are consumed by reportHandler - is stopped last so reportHandler is no
-        // longer producing/consuming when its own peers are torn down.
+        // Stop in the reverse order of startLeaderOnlyDaemonThreads().
         stopOne("tabletCollector", () -> tabletCollector.stopGracefully(timeoutMs));
         stopOne("reportHandler", () -> reportHandler.stopGracefully(timeoutMs));
         stopOne("temporaryTableCleaner", () -> temporaryTableCleaner.stopGracefully(timeoutMs));

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -98,6 +98,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.common.mv.MaterializedViewDependencyGraph;
 import com.starrocks.common.util.Daemon;
 import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.SmallFileMgr;
@@ -334,12 +335,12 @@ public class GlobalStateMgr {
     private final DatabaseQuotaRefresher updateDbUsedDataQuotaDaemon;
 
     private FrontendDaemon labelCleaner; // To clean old LabelInfo, ExportJobInfos
-    private FrontendDaemon txnTimeoutChecker; // To abort timeout txns
+    private LeaderDaemon txnTimeoutChecker; // To abort timeout txns
     private FrontendDaemon taskCleaner;   // To clean expire Task/TaskRun
     private FrontendDaemon tableKeeper;   // Maintain internal history tables
     private JournalWriter journalWriter; // leader only: write journal log
     private Daemon replayer;
-    private Daemon timePrinter;
+    private LeaderDaemon timePrinter;
     private final EsRepository esRepository;  // it is a daemon, so add it here
     private final MetastoreEventsProcessor metastoreEventsProcessor;
     private final ConnectorTableMetadataProcessor connectorTableMetadataProcessor;
@@ -1656,27 +1657,37 @@ public class GlobalStateMgr {
         long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
         // Reverse of startLeaderOnlyDaemonThreads(): stop downstream consumers first so that
         // upstream producers (heartbeat) can wind down without piling work on a draining sink.
-        try {
-            reportHandler.stopGracefully(timeoutMs);
-        } catch (Throwable t) {
-            LOG.warn("stop reportHandler failed", t);
+        stopOne("tabletCollector", () -> tabletCollector.stopGracefully(timeoutMs));
+        stopOne("reportHandler", () -> reportHandler.stopGracefully(timeoutMs));
+        stopOne("temporaryTableCleaner", () -> temporaryTableCleaner.stopGracefully(timeoutMs));
+        stopOne("metaRecoveryDaemon", () -> metaRecoveryDaemon.stopGracefully(timeoutMs));
+        stopOne("safeModeChecker", () -> safeModeChecker.stopGracefully(timeoutMs));
+        stopOne("spmAutoCapturer", () -> spmAutoCapturer.stopGracefully(timeoutMs));
+        stopOne("mvActiveChecker", () -> mvActiveChecker.stopGracefully(timeoutMs));
+        stopOne("updateDbUsedDataQuotaDaemon", () -> updateDbUsedDataQuotaDaemon.stopGracefully(timeoutMs));
+        if (timePrinter != null) {
+            stopOne("timePrinter", () -> timePrinter.stopGracefully(timeoutMs));
         }
-        try {
-            publishVersionDaemon.stopGracefully(timeoutMs);
-        } catch (Throwable t) {
-            LOG.warn("stop publishVersionDaemon failed", t);
+        stopOne("consistencyChecker", () -> consistencyChecker.stopGracefully(timeoutMs));
+        if (txnTimeoutChecker != null) {
+            stopOne("txnTimeoutChecker", () -> txnTimeoutChecker.stopGracefully(timeoutMs));
         }
+        stopOne("publishVersionDaemon", () -> publishVersionDaemon.stopGracefully(timeoutMs));
+        stopOne("loadLoadingChecker", () -> loadLoadingChecker.stopGracefully(timeoutMs));
+        stopOne("loadEtlChecker", () -> loadEtlChecker.stopGracefully(timeoutMs));
+        stopOne("loadTimeoutChecker", () -> loadTimeoutChecker.stopGracefully(timeoutMs));
         if (!RunMode.isSharedDataMode()) {
-            try {
-                tabletScheduler.stopGracefully(timeoutMs);
-            } catch (Throwable t) {
-                LOG.warn("stop tabletScheduler failed", t);
-            }
+            stopOne("tabletScheduler", () -> tabletScheduler.stopGracefully(timeoutMs));
         }
+        stopOne("heartbeatMgr", () -> heartbeatMgr.stopGracefully(timeoutMs));
+        stopOne("keyRotationDaemon", () -> keyRotationDaemon.stopGracefully(timeoutMs));
+    }
+
+    private void stopOne(String name, Runnable action) {
         try {
-            heartbeatMgr.stopGracefully(timeoutMs);
+            action.run();
         } catch (Throwable t) {
-            LOG.warn("stop heartbeatMgr failed", t);
+            LOG.warn("stop {} failed", name, t);
         }
     }
 
@@ -2115,10 +2126,10 @@ public class GlobalStateMgr {
     }
 
     public void createTxnTimeoutChecker() {
-        txnTimeoutChecker = new FrontendDaemon("txnTimeoutChecker",
+        txnTimeoutChecker = new LeaderDaemon("txnTimeoutChecker",
                 Config.transaction_clean_interval_second * 1000L) {
             @Override
-            protected void runAfterCatalogReady() {
+            protected void runAfterLeaseValid() {
                 globalTransactionMgr.abortTimeoutTxns();
 
                 try {
@@ -2408,9 +2419,9 @@ public class GlobalStateMgr {
 
     public void createTimePrinter() {
         // time printer will write timestamp edit log every 10 seconds
-        timePrinter = new FrontendDaemon("timePrinter", 10 * 1000L) {
+        timePrinter = new LeaderDaemon("timePrinter", 10 * 1000L) {
             @Override
-            protected void runAfterCatalogReady() {
+            protected void runAfterLeaseValid() {
                 Timestamp stamp = new Timestamp();
                 editLog.logTimestamp(stamp);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1655,8 +1655,10 @@ public class GlobalStateMgr {
      */
     void stopLeaderOnlyDaemonThreads() {
         long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
-        // Reverse of startLeaderOnlyDaemonThreads(): stop downstream consumers first so that
-        // upstream producers (heartbeat) can wind down without piling work on a draining sink.
+        // Reverse of startLeaderOnlyDaemonThreads(): the most recently activated daemons
+        // wind down first, and heartbeatMgr - which was started very early and whose RPC
+        // responses are consumed by reportHandler - is stopped last so reportHandler is no
+        // longer producing/consuming when its own peers are torn down.
         stopOne("tabletCollector", () -> tabletCollector.stopGracefully(timeoutMs));
         stopOne("reportHandler", () -> reportHandler.stopGracefully(timeoutMs));
         stopOne("temporaryTableCleaner", () -> temporaryTableCleaner.stopGracefully(timeoutMs));

--- a/fe/fe-core/src/main/java/com/starrocks/server/TemporaryTableCleaner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/TemporaryTableCleaner.java
@@ -17,7 +17,7 @@ package com.starrocks.server;
 import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.ThreadPoolManager;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.system.Frontend;
@@ -41,20 +41,23 @@ import java.util.concurrent.ExecutorService;
 // It is only executed on the FE leader.
 // It periodically obtains the active session IDs related to all temporary tables on all FEs and
 // automatically cleans up temporary tables that are no longer active.
-public class TemporaryTableCleaner extends FrontendDaemon  {
+public class TemporaryTableCleaner extends LeaderDaemon  {
     private static final Logger LOG = LogManager.getLogger(TemporaryTableCleaner.class);
     private static final int TEMP_TABLE_CLEANER_THREAD_NUM = 1;
     private static final int TEMP_TABLE_CLEANER_QUEUE_SIZE = 100000;
 
+    // Reserved for future async cleanup work; currently never used. Kept so a follow-up PR can
+    // dispatch table-level cleanups in parallel without changing this class' lifecycle wiring.
     private final ExecutorService executor;
 
     public TemporaryTableCleaner() {
+        super("temporary-table-cleaner");
         this.executor = ThreadPoolManager.newDaemonFixedThreadPool(TEMP_TABLE_CLEANER_THREAD_NUM, TEMP_TABLE_CLEANER_QUEUE_SIZE,
                 "temp-table-cleaner-pool", false);
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         if (FeConstants.runningUnitTest && !FeConstants.temporaryTableCleanerTest) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/TemporaryTableCleaner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/TemporaryTableCleaner.java
@@ -16,7 +16,6 @@ package com.starrocks.server;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
@@ -35,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
 
 // TemporaryTableCleaner is used to automatically clean up temporary tables.
 // It is only executed on the FE leader.
@@ -43,17 +41,9 @@ import java.util.concurrent.ExecutorService;
 // automatically cleans up temporary tables that are no longer active.
 public class TemporaryTableCleaner extends LeaderDaemon  {
     private static final Logger LOG = LogManager.getLogger(TemporaryTableCleaner.class);
-    private static final int TEMP_TABLE_CLEANER_THREAD_NUM = 1;
-    private static final int TEMP_TABLE_CLEANER_QUEUE_SIZE = 100000;
-
-    // Reserved for future async cleanup work; currently never used. Kept so a follow-up PR can
-    // dispatch table-level cleanups in parallel without changing this class' lifecycle wiring.
-    private final ExecutorService executor;
 
     public TemporaryTableCleaner() {
         super("temporary-table-cleaner");
-        this.executor = ThreadPoolManager.newDaemonFixedThreadPool(TEMP_TABLE_CLEANER_THREAD_NUM, TEMP_TABLE_CLEANER_QUEUE_SIZE,
-                "temp-table-cleaner-pool", false);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
@@ -51,7 +51,7 @@ public class SPMAutoCapturer extends LeaderDaemon {
     private ConnectContext connect;
 
     public SPMAutoCapturer() {
-        super("spm-auto-capturer", GlobalVariable.spmCaptureIntervalSeconds * 100L);
+        super("spm-auto-capturer", GlobalVariable.spmCaptureIntervalSeconds * 1000L);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class SPMAutoCapturer extends LeaderDaemon {
     protected void runAfterLeaseValid() {
         // Pick up runtime changes to spm_capture_interval_seconds so operators can retune the
         // pace without restarting the leader.
-        setInterval(GlobalVariable.spmCaptureIntervalSeconds * 100L);
+        setInterval(GlobalVariable.spmCaptureIntervalSeconds * 1000L);
         if (!GlobalVariable.enableSPMCapture) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.AuditLog;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.GlobalStateMgr;
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-public class SPMAutoCapturer extends FrontendDaemon {
+public class SPMAutoCapturer extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(SPMAutoCapturer.class);
 
     private LocalDateTime lastWorkTime =
@@ -51,16 +51,22 @@ public class SPMAutoCapturer extends FrontendDaemon {
     private ConnectContext connect;
 
     public SPMAutoCapturer() {
-        super("spm-auto-capturer");
+        super("spm-auto-capturer", GlobalVariable.spmCaptureIntervalSeconds * 100L);
     }
 
     @Override
-    public long getInterval() {
-        return GlobalVariable.spmCaptureIntervalSeconds * 100;
+    protected synchronized void onStopped() {
+        // The captured ConnectContext is leader-session-only (it carries leader-side query
+        // execution state). Drop it so the next activation rebuilds a fresh context and the
+        // demoted FE does not retain references into leader-only state.
+        connect = null;
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
+        // Pick up runtime changes to spm_capture_interval_seconds so operators can retune the
+        // pace without restarting the leader.
+        setInterval(GlobalVariable.spmCaptureIntervalSeconds * 100L);
         if (!GlobalVariable.enableSPMCapture) {
             return;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
@@ -216,4 +216,30 @@ public class ConsistencyCheckerTest {
         Assertions.assertEquals(0L, FieldUtils.readField(checker, "lastTabletMetaCheckTime", true),
                 "lastTabletMetaCheckTime watermark reset on demotion");
     }
+
+    @Test
+    public void testOnStoppedSwallowsClearException() throws Exception {
+        // A misbehaving CheckConsistencyJob.clear() must not abort the demotion drain - the
+        // remaining jobs still need to be removed and the watermark/counters still need to be
+        // reset. Exercises the per-job catch around job.clear().
+        ConsistencyChecker checker = new ConsistencyChecker();
+
+        @SuppressWarnings("unchecked")
+        Map<Long, CheckConsistencyJob> jobs =
+                (Map<Long, CheckConsistencyJob>) FieldUtils.readField(checker, "jobs", true);
+
+        CheckConsistencyJob throwingJob = new CheckConsistencyJob(201L) {
+            @Override
+            public synchronized void clear() {
+                throw new RuntimeException("simulated AgentTaskQueue failure");
+            }
+        };
+        jobs.put(201L, throwingJob);
+        jobs.put(202L, new CheckConsistencyJob(202L));
+
+        MethodUtils.invokeMethod(checker, true, "onStopped");
+
+        Assertions.assertTrue(jobs.isEmpty(),
+                "jobs map must be cleared even when an individual job's clear() throws");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
@@ -32,8 +32,13 @@ import com.starrocks.sql.ast.KeysType;
 import com.starrocks.thrift.TStorageMedium;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ConsistencyCheckerTest {
 
@@ -177,5 +182,38 @@ public class ConsistencyCheckerTest {
         tabletMeta.setToBeCleanedTime(123L);
         tabletMeta.resetToBeCleanedTime();
         Assertions.assertNull(tabletMeta.getToBeCleanedTime());
+    }
+
+    @Test
+    public void testOnStoppedClearsLeaderSessionState() throws Exception {
+        ConsistencyChecker checker = new ConsistencyChecker();
+
+        @SuppressWarnings("unchecked")
+        Map<Long, CheckConsistencyJob> jobs =
+                (Map<Long, CheckConsistencyJob>) FieldUtils.readField(checker, "jobs", true);
+        @SuppressWarnings("unchecked")
+        ConcurrentHashMap<Long, Integer> creatingTableCounters =
+                (ConcurrentHashMap<Long, Integer>) FieldUtils.readField(checker, "creatingTableCounters", true);
+
+        jobs.put(101L, new CheckConsistencyJob(101L));
+        jobs.put(102L, new CheckConsistencyJob(102L));
+        creatingTableCounters.put(7L, 1);
+        FieldUtils.writeField(checker, "lastTabletMetaCheckTime", 12345L, true);
+
+        Assertions.assertEquals(2, jobs.size(), "precondition: jobs populated");
+        Assertions.assertEquals(1, creatingTableCounters.size(), "precondition: counter populated");
+        Assertions.assertEquals(12345L, FieldUtils.readField(checker, "lastTabletMetaCheckTime", true));
+
+        // CREATE TABLE flows that bumped creatingTableCounters fail when the editlog is sealed,
+        // so leftover counters would otherwise leak across leader sessions and incorrectly mask
+        // tablets from future consistency checks. lastTabletMetaCheckTime is reset for the same
+        // reason - the next leader should re-issue a tablet-meta scan instead of honoring a
+        // watermark from a different session.
+        MethodUtils.invokeMethod(checker, true, "onStopped");
+
+        Assertions.assertTrue(jobs.isEmpty(), "jobs cleared on demotion");
+        Assertions.assertTrue(creatingTableCounters.isEmpty(), "creatingTableCounters cleared on demotion");
+        Assertions.assertEquals(0L, FieldUtils.readField(checker, "lastTabletMetaCheckTime", true),
+                "lastTabletMetaCheckTime watermark reset on demotion");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/MetaRecoveryDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/MetaRecoveryDaemonTest.java
@@ -31,10 +31,14 @@ import com.starrocks.transaction.PartitionCommitInfo;
 import com.starrocks.transaction.TableCommitInfo;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.Set;
 
 public class MetaRecoveryDaemonTest {
     @BeforeAll
@@ -181,5 +185,24 @@ public class MetaRecoveryDaemonTest {
         }
         Assertions.assertFalse(metaRecoveryDaemon.checkTabletReportCacheUp(timeMs + 1000L));
         Assertions.assertTrue(metaRecoveryDaemon.checkTabletReportCacheUp(timeMs - 1000L));
+    }
+
+    @Test
+    public void testOnStoppedClearsUnRecoveredPartitions() throws Exception {
+        // unRecoveredPartitions is leader-session diagnostic state surfaced via the proc node;
+        // the next leader rebuilds it from scratch, so it must not survive demotion.
+        MetaRecoveryDaemon recovery = new MetaRecoveryDaemon();
+        @SuppressWarnings("unchecked")
+        Set<MetaRecoveryDaemon.UnRecoveredPartition> partitions =
+                (Set<MetaRecoveryDaemon.UnRecoveredPartition>) FieldUtils.readField(
+                        recovery, "unRecoveredPartitions", true);
+        partitions.add(new MetaRecoveryDaemon.UnRecoveredPartition("d", "t", "p", 1L, "stale"));
+        partitions.add(new MetaRecoveryDaemon.UnRecoveredPartition("d", "t", "p2", 2L, "stale2"));
+        Assertions.assertEquals(2, partitions.size());
+
+        MethodUtils.invokeMethod(recovery, true, "onStopped");
+
+        Assertions.assertTrue(partitions.isEmpty(),
+                "unRecoveredPartitions must be cleared when leader-only daemon stops");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/leader/TabletCollectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/TabletCollectorTest.java
@@ -15,10 +15,13 @@
 package com.starrocks.leader;
 
 import com.starrocks.leader.TabletCollector.CollectStat;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.PriorityQueue;
+import java.util.Set;
 
 public class TabletCollectorTest {
 
@@ -31,5 +34,32 @@ public class TabletCollectorTest {
         Assertions.assertEquals(1L, queue.poll().lastCollectTime);
         Assertions.assertEquals(2L, queue.poll().lastCollectTime);
         Assertions.assertEquals(3L, queue.poll().lastCollectTime);
+    }
+
+    @Test
+    public void testOnStoppedClearsLeaderSessionState() throws Exception {
+        TabletCollector collector = new TabletCollector();
+
+        @SuppressWarnings("unchecked")
+        PriorityQueue<CollectStat> queue =
+                (PriorityQueue<CollectStat>) FieldUtils.readField(collector, "collectQueue", true);
+        @SuppressWarnings("unchecked")
+        Set<Long> queuedBeIds = (Set<Long>) FieldUtils.readField(collector, "queuedBeIds", true);
+
+        queue.add(new CollectStat(7L, 100L));
+        queue.add(new CollectStat(8L, 200L));
+        queuedBeIds.add(7L);
+        queuedBeIds.add(8L);
+
+        Assertions.assertEquals(2, queue.size(), "precondition: queue populated");
+        Assertions.assertEquals(2, queuedBeIds.size(), "precondition: queuedBeIds populated");
+
+        // Trigger LeaderDaemon's cleanup hook directly. After demotion the next leader rebuilds
+        // the queue from scratch via updateQueue(); leaving stale entries here would suppress
+        // collection from BEs whose ids stayed in queuedBeIds.
+        MethodUtils.invokeMethod(collector, true, "onStopped");
+
+        Assertions.assertTrue(queue.isEmpty(), "collectQueue should be cleared on demotion");
+        Assertions.assertTrue(queuedBeIds.isEmpty(), "queuedBeIds should be cleared on demotion");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVActiveCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVActiveCheckerTest.java
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.catalog.MvId;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class MVActiveCheckerTest {
+
+    @Test
+    public void testOnStoppedClearsActiveInfo() throws Exception {
+        MVActiveChecker checker = new MVActiveChecker();
+
+        @SuppressWarnings("unchecked")
+        Map<MvId, MVActiveChecker.MvActiveInfo> activeInfo =
+                (Map<MvId, MVActiveChecker.MvActiveInfo>) FieldUtils.readDeclaredStaticField(
+                        MVActiveChecker.class, "MV_ACTIVE_INFO", true);
+        activeInfo.clear();
+        activeInfo.put(new MvId(1L, 11L), MVActiveChecker.MvActiveInfo.firstFailure());
+        activeInfo.put(new MvId(2L, 22L), MVActiveChecker.MvActiveInfo.firstFailure());
+        Assertions.assertEquals(2, activeInfo.size(), "precondition: backoff state populated");
+
+        // MV_ACTIVE_INFO holds per-MV activation backoff windows used only by the leader's
+        // activation loop. After demotion the next leader (or this FE on re-election) must
+        // start fresh rather than honoring backoff windows from a previous leader session.
+        MethodUtils.invokeMethod(checker, true, "onStopped");
+
+        Assertions.assertTrue(activeInfo.isEmpty(),
+                "MV_ACTIVE_INFO must be cleared when leader-only daemon stops");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -483,4 +483,34 @@ public class GlobalStateMgrTest {
 
         Assertions.assertTrue(ran.get(), "action should still run");
     }
+
+    @Test
+    public void testStopLeaderOnlyDaemonThreadsDrivesEveryWiredDaemon() throws Exception {
+        // Sanity test for the demotion drain wiring: every daemon listed in
+        // stopLeaderOnlyDaemonThreads must be reachable and its stopGracefully invocation must
+        // be shielded by stopOne, so a misbehaving daemon cannot abort the drain. The lazily
+        // initialized timePrinter / txnTimeoutChecker fields are still null here, exercising the
+        // null-skip branches.
+        GlobalStateMgr mgr = new MyGlobalStateMgr(false);
+
+        Method stop = GlobalStateMgr.class.getDeclaredMethod("stopLeaderOnlyDaemonThreads");
+        stop.setAccessible(true);
+        // None of the daemons are running; every stopGracefully is effectively a state reset.
+        // Any throwable from a daemon's onStopped is contained by stopOne, so the call must
+        // complete without propagating.
+        stop.invoke(mgr);
+    }
+
+    @Test
+    public void testStopLeaderOnlyDaemonThreadsCoversLazilyInitializedDaemons() throws Exception {
+        // timePrinter and txnTimeoutChecker are created lazily after the leader has activated;
+        // exercise the non-null branch so the drain stops them too.
+        GlobalStateMgr mgr = new MyGlobalStateMgr(false);
+        mgr.createTxnTimeoutChecker();
+        mgr.createTimePrinter();
+
+        Method stop = GlobalStateMgr.class.getDeclaredMethod("stopLeaderOnlyDaemonThreads");
+        stop.setAccessible(true);
+        stop.invoke(mgr);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -71,12 +71,14 @@ import org.mockito.Mockito;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -448,5 +450,37 @@ public class GlobalStateMgrTest {
         Assertions.assertNotNull(table);
         table = newState.getLocalMetastore().getTable("db2", "t1");
         Assertions.assertEquals(1, table.getForeignKeyConstraints().size());
+    }
+
+    @Test
+    public void testStopOneInvokesAction() throws Exception {
+        GlobalStateMgr mgr = new MyGlobalStateMgr(false);
+        AtomicBoolean ran = new AtomicBoolean(false);
+        Runnable action = () -> ran.set(true);
+
+        Method stopOne = GlobalStateMgr.class.getDeclaredMethod("stopOne", String.class, Runnable.class);
+        stopOne.setAccessible(true);
+        stopOne.invoke(mgr, "fakeDaemon", action);
+
+        Assertions.assertTrue(ran.get(), "stopOne must invoke the action");
+    }
+
+    @Test
+    public void testStopOneSwallowsThrowable() throws Exception {
+        // stopOne wraps each daemon's stopGracefully so that a single misbehaving daemon
+        // does not abort the demotion drain mid-way and leave later daemons running.
+        GlobalStateMgr mgr = new MyGlobalStateMgr(false);
+        AtomicBoolean ran = new AtomicBoolean(false);
+        Runnable action = () -> {
+            ran.set(true);
+            throw new RuntimeException("boom");
+        };
+
+        Method stopOne = GlobalStateMgr.class.getDeclaredMethod("stopOne", String.class, Runnable.class);
+        stopOne.setAccessible(true);
+        // No exception expected to escape.
+        stopOne.invoke(mgr, "throwingDaemon", action);
+
+        Assertions.assertTrue(ran.get(), "action should still run");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/TemporaryTableCleanerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/TemporaryTableCleanerTest.java
@@ -58,7 +58,7 @@ public class TemporaryTableCleanerTest {
                 return result;
             }
         };
-        cleaner.runAfterCatalogReady();
+        cleaner.runAfterLeaseValid();
         Assertions.assertTrue(mgr.sessionExists(session1));
         Assertions.assertFalse(mgr.sessionExists(session2));
     }
@@ -95,11 +95,11 @@ public class TemporaryTableCleanerTest {
                 }
             }
         };
-        cleaner.runAfterCatalogReady();
+        cleaner.runAfterLeaseValid();
         Assertions.assertFalse(mgr.sessionExists(session1));
         Assertions.assertTrue(mgr.sessionExists(session2));
 
-        cleaner.runAfterCatalogReady();
+        cleaner.runAfterLeaseValid();
         Assertions.assertFalse(mgr.sessionExists(session2));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMAutoCapturerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMAutoCapturerTest.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.starrocks.qe.ConnectContext;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class SPMAutoCapturerTest {
+
+    @Test
+    public void testOnStoppedDropsCapturedConnectContext() throws Exception {
+        SPMAutoCapturer capturer = new SPMAutoCapturer();
+
+        ConnectContext captured = Mockito.mock(ConnectContext.class);
+        FieldUtils.writeField(capturer, "connect", captured, true);
+        Assertions.assertSame(captured, FieldUtils.readField(capturer, "connect", true),
+                "precondition: connect installed");
+
+        // The captured ConnectContext is leader-session-only state (carries leader-side query
+        // execution state). On demotion it must be released so the next leader rebuilds a
+        // fresh context and the demoted FE does not retain references into leader-only state.
+        MethodUtils.invokeMethod(capturer, true, "onStopped");
+
+        Assertions.assertNull(FieldUtils.readField(capturer, "connect", true),
+                "captured ConnectContext should be cleared on demotion");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #71932 (part 2 of #63357). That PR introduced `LeaderDaemon` —
a restartable, lease-aware daemon base with an `onStopped()` cleanup hook —
and migrated `HeartbeatMgr`, `ReportHandler`, `PublishVersionDaemon`, and
`TabletScheduler` so the leader can stop them safely on demotion. Many other
leader-only daemons still extend `FrontendDaemon`, so on demotion they keep
running and may hold leader-only state into the next session.

This PR migrates the Tier‑1 batch — daemons that are either stateless or
hold simple in-memory state that's trivially clearable. It does not touch
schedulers backed by static `LeaderTaskExecutor`s (Tier 2) or daemons with
heavier shared state like `BackupHandler`/`RecycleBin`/`alterJobMgr`/
`checkpointController`/lake `compactionMgr` (Tier 3); those will land in
follow-ups.

## What I'm doing:

Migrate the following daemons from `FrontendDaemon` to `LeaderDaemon`
(rename `runAfterCatalogReady()` → `runAfterLeaseValid()`, add `onStopped()`
where there is leader-session state to clear):

Stateless / simple timers (no `onStopped` body needed):

- `KeyRotationDaemon`
- `LoadTimeoutChecker`, `LoadEtlChecker`, `LoadLoadingChecker`
- `DatabaseQuotaRefresher`
- `SafeModeChecker`
- `TemporaryTableCleaner`

Stateful — clear leader-session state on demotion:

- `TabletCollector` — clear `collectQueue` and `queuedBeIds`; the next
  leader rebuilds the queue via `updateQueue()`.
- `SPMAutoCapturer` — drop the captured `ConnectContext`; rebuilt on
  re-activation. Also moved the dynamic interval from an override of the
  now-`final` `getInterval()` to `setInterval()` inside `runAfterLeaseValid()`.
- `MVActiveChecker` — clear the static `MV_ACTIVE_INFO` map.
- `MetaRecoveryDaemon` — clear `unRecoveredPartitions` under the write lock.
- `ConsistencyChecker` — clear in-flight `jobs`, `creatingTableCounters`,
  and reset `lastTabletMetaCheckTime` so the next leader re-issues a
  tablet-meta scan instead of honoring a stale watermark.

`GlobalStateMgr`:

- Switch `txnTimeoutChecker` and `timePrinter` (inline daemons) to
  `LeaderDaemon`.
- Refactor `stopLeaderOnlyDaemonThreads()` to use a `stopOne(name, action)`
  helper and stop the new daemons in reverse-of-start order.

Tests:

- `TabletCollectorTest`, `MetaRecoveryDaemonTest`, `ConsistencyCheckerTest`:
  add an `onStopped` test that seeds the relevant fields via reflection,
  invokes `onStopped()`, and asserts the state is cleared.
- `TemporaryTableCleanerTest`: rename the call to `runAfterLeaseValid()`.

Fixes #63357

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4