### PR TITLE
[BugFix] Fix tablet merge correctness for split→compaction→merge

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -209,6 +209,7 @@ set(STORAGE_FILES
     lake/tablet_reshard_helper.cpp
     lake/tablet_splitter.cpp
     lake/tablet_merger.cpp
+    lake/tablet_merger_split_family.cpp
     lake/tablet_reshard.cpp
     lake/replication_txn_manager.cpp
     lake/lake_replication_txn_manager.cpp

--- a/be/src/storage/del_vector.cpp
+++ b/be/src/storage/del_vector.cpp
@@ -82,6 +82,17 @@ void DelVector::init(int64_t version, const uint32_t* data, size_t length) {
     _update_stats();
 }
 
+void DelVector::union_with(int64_t version, const Roaring& src) {
+    _loaded = true;
+    _version = version;
+    if (_roaring) {
+        *_roaring |= src;
+    } else if (!src.isEmpty()) {
+        _roaring = std::make_unique<Roaring>(src);
+    }
+    _update_stats();
+}
+
 string DelVector::save() const {
     string ret;
     auto roaring_size = _roaring ? _roaring->getSizeInBytes() : 0;

--- a/be/src/storage/del_vector.h
+++ b/be/src/storage/del_vector.h
@@ -51,6 +51,13 @@ public:
 
     void init(int64_t version, const uint32_t* data, size_t length);
 
+    // OR-in |src| with this delvec's bitmap. If this delvec is empty, becomes a
+    // copy of |src|. Updates version + stats. Skips the rowid-vector
+    // round-trip that init(uint32_t*, size) requires; meaningful when |src|
+    // covers a large run of rowids (e.g. a synthesized gap delvec from tablet
+    // merge across compacted children).
+    void union_with(int64_t version, const Roaring& src);
+
     std::string save() const;
 
     void save_to(std::string* str) const;

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -70,14 +70,21 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
     }
     if (iter_ptr->rssid_offset() != 0) {
         const int32_t rssid_offset = iter_ptr->rssid_offset();
+        // Per-entry projection: stored bytes are in pre-projection space, so
+        // each entry's rssid must be lifted by rssid_offset to land in the
+        // current child's effective id space.
         for (size_t i = 0; i < index_value_ver.values_size(); ++i) {
             if (is_index_tombstone(index_value_ver.values(i))) continue;
             const int64_t rssid = static_cast<int64_t>(index_value_ver.values(i).rssid()) + rssid_offset;
             index_value_ver.mutable_values(i)->set_rssid(static_cast<uint32_t>(rssid));
         }
-        const uint64_t low = max_rss_rowid & 0xffffffffULL;
-        const int64_t high = static_cast<int64_t>(max_rss_rowid >> 32) + rssid_offset;
-        max_rss_rowid = (static_cast<uint64_t>(high) << 32) | low;
+        // `max_rss_rowid` already lives in the source sstable's effective id
+        // space (per the canonical convention documented at
+        // tablet_merger.cpp::project_source_max_rss_rowid). It must NOT be
+        // shifted by rssid_offset again — doing so double-counts the offset
+        // and inflates the apparent watermark above the true effective max,
+        // which can flip the same-version tie-break below to pick the wrong
+        // input sstable.
     }
 
     auto version = index_value_ver.values(0).version();

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -923,6 +923,32 @@ Status merge_delvec_files(TabletManager* tablet_mgr, const std::vector<DelvecFil
     return Status::OK();
 }
 
+Status write_delvec_file_from_buffer(TabletManager* tablet_mgr, int64_t new_tablet_id, int64_t txn_id,
+                                     const Slice& buffer, FileMetaPB* new_delvec_file) {
+    DCHECK(new_delvec_file != nullptr);
+    if (buffer.empty()) {
+        return Status::InvalidArgument("write_delvec_file_from_buffer called with empty buffer");
+    }
+
+    const std::string new_file_name = gen_delvec_filename(txn_id);
+    const std::string new_file_path = tablet_mgr->delvec_location(new_tablet_id, new_file_name);
+    WritableFileOptions wopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    // No encryption: merge_delvec_files only encrypts when at least one
+    // source file carried encryption_meta, and there are no source files
+    // here. A future caller wanting encrypted output should pass the
+    // encryption metadata in explicitly rather than implicitly fetching the
+    // KEK (which is not configured in unit tests).
+    ASSIGN_OR_RETURN(auto writer, fs::new_writable_file(wopts, new_file_path));
+    RETURN_IF_ERROR(writer->append(buffer));
+    RETURN_IF_ERROR(writer->close());
+
+    new_delvec_file->set_name(new_file_name);
+    new_delvec_file->set_size(buffer.size);
+    new_delvec_file->clear_encryption_meta();
+    new_delvec_file->set_shared(false);
+    return Status::OK();
+}
+
 bool is_primary_key(TabletMetadata* metadata) {
     return metadata->schema().keys_type() == KeysType::PRIMARY_KEYS;
 }

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -154,6 +154,16 @@ Status merge_delvec_files(TabletManager* tablet_mgr, const std::vector<DelvecFil
                           std::vector<uint64_t>* offsets, const Slice& extra_data = {},
                           uint64_t* extra_data_offset = nullptr);
 
+// Write a brand-new delvec file containing only |buffer|. Used by tablet merge
+// when the only contributor is a synthesized gap delvec and there are no
+// existing source delvec files to concatenate with — sidesteps
+// merge_delvec_files's DCHECK on (empty old_files + non-empty extra_data) and
+// avoids generating an empty file by mistake. Buffer is written at offset 0;
+// the resulting FileMetaPB is shared=false, encryption is per-call when
+// |buffer| is non-empty.
+Status write_delvec_file_from_buffer(TabletManager* tablet_mgr, int64_t new_tablet_id, int64_t txn_id,
+                                     const Slice& buffer, FileMetaPB* new_delvec_file);
+
 Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, const DelvecPagePB& delvec_page,
                    bool fill_cache, const LakeIOOptions& lake_io_opts, DelVector* delvec);
 Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, uint32_t segment_id, bool fill_cache,

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -26,20 +26,26 @@
 
 #include "base/hash/crc32c.h"
 #include "base/testutil/sync_point.h"
+#include "base/uid_util.h"
+#include "base/utility/defer_op.h"
 #include "column/column_helper.h"
 #include "common/config_rowset_fwd.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"
+#include "gutil/stl_util.h"
 #include "storage/chunk_helper.h"
 #include "storage/del_vector.h"
 #include "storage/delta_column_group.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/persistent_index_sstable.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_merger_split_family.h"
 #include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/update_manager.h"
+#include "storage/lake/utils.h"
 #include "storage/olap_common.h"
 #include "storage/options.h"
 #include "storage/rowset/column_iterator.h"
@@ -47,6 +53,10 @@
 #include "storage/rowset/segment_iterator.h"
 #include "storage/rowset/segment_options.h"
 #include "storage/rowset/segment_writer.h"
+#include "storage/sstable/comparator.h"
+#include "storage/sstable/iterator.h"
+#include "storage/sstable/options.h"
+#include "storage/sstable/table_builder.h"
 #include "storage/tablet_schema.h"
 
 namespace {
@@ -54,6 +64,38 @@ namespace {
 bvar::Adder<int64_t> g_tablet_merge_dcg_rebuild_total("tablet_merge_dcg_rebuild_total");
 bvar::Adder<int64_t> g_tablet_merge_dcg_rebuild_fallback_not_supported_total(
         "tablet_merge_dcg_rebuild_fallback_not_supported_total");
+
+bvar::Adder<int64_t> g_tablet_merge_gap_delvec_total("tablet_merge_gap_delvec_total");
+bvar::Adder<int64_t> g_tablet_merge_non_pk_skip_dedup_total("tablet_merge_non_pk_skip_dedup_total");
+bvar::Adder<int64_t> g_tablet_merge_synthesized_only_delvec_total("tablet_merge_synthesized_only_delvec_total");
+
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_rebuild_total("tablet_merge_legacy_sstable_rebuild_total");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_rebuild_dropped_entries(
+        "tablet_merge_legacy_sstable_rebuild_dropped_entries");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_total("tablet_merge_legacy_sstable_fastpath_total");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_to_rebuild_total(
+        "tablet_merge_legacy_sstable_fastpath_fallback_to_rebuild_total");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_source_offset_nonzero(
+        "tablet_merge_legacy_sstable_fastpath_fallback_source_offset_nonzero");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_canonical_offset_nonzero(
+        "tablet_merge_legacy_sstable_fastpath_fallback_canonical_offset_nonzero");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_invalid_form(
+        "tablet_merge_legacy_sstable_fastpath_fallback_invalid_form");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_merged_no_range(
+        "tablet_merge_legacy_sstable_fastpath_fallback_merged_no_range");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_ranged_no_fileset_id(
+        "tablet_merge_legacy_sstable_fastpath_fallback_ranged_no_fileset_id");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_partial_compaction(
+        "tablet_merge_legacy_sstable_fastpath_fallback_partial_compaction");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_merged_delvec_nonempty(
+        "tablet_merge_legacy_sstable_fastpath_fallback_merged_delvec_nonempty");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid(
+        "tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_no_family(
+        "tablet_merge_legacy_sstable_fastpath_fallback_no_family");
+bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_fastpath_fallback_unsafe_family(
+        "tablet_merge_legacy_sstable_fastpath_fallback_unsafe_family");
+bvar::Adder<int64_t> g_tablet_merge_non_shared_sstable_rebuild_total("tablet_merge_non_shared_sstable_rebuild_total");
 
 } // namespace
 
@@ -74,10 +116,28 @@ public:
     int64_t rssid_offset() const { return _rssid_offset; }
     void set_rssid_offset(int64_t offset) { _rssid_offset = offset; }
 
-    // Maps an original rssid to the final output rssid.
-    // If the rssid was deduped, returns the canonical rssid from shared_rssid_map;
-    // otherwise applies the default offset mapping with overflow check.
+    uint32_t child_index() const { return _child_index; }
+    void set_child_index(uint32_t child_index) { _child_index = child_index; }
+
+    // The plan must outlive this ctx (typically a stack local in
+    // merge_tablet). Null on non-PK merges; map_rssid then degenerates to
+    // the shared_rssid_map → natural offset path.
+    void set_projection_plan(const detail::RssidProjectionPlan* plan) { _projection_plan = plan; }
+    const detail::RssidProjectionPlan* projection_plan() const { return _projection_plan; }
+
+    // Maps an original rssid to the final output rssid. Lookup priority:
+    //   (1) RssidProjectionPlan.explicit_rssid_map keyed by (child_index,
+    //       rssid). Hit only for shared-ancestor rowsets in safe families
+    //       (PK + cloud-native gate at plan-build time).
+    //   (2) shared_rssid_map for runtime-deduped child-local mappings.
+    //   (3) natural offset (rssid + ctx.rssid_offset).
     StatusOr<uint32_t> map_rssid(uint32_t rssid) const {
+        if (_projection_plan != nullptr) {
+            auto plan_it = _projection_plan->explicit_rssid_map.find({_child_index, rssid});
+            if (plan_it != _projection_plan->explicit_rssid_map.end()) {
+                return plan_it->second;
+            }
+        }
         auto it = _shared_rssid_map.find(rssid);
         if (it != _shared_rssid_map.end()) {
             return it->second;
@@ -89,6 +149,58 @@ public:
         return static_cast<uint32_t>(mapped);
     }
 
+    // Precomputes the sorted set of source-effective rssids whose
+    // map_rssid would return a value DIFFERENT from
+    // rssid + this->_rssid_offset under the plan/shared_rssid priority.
+    // merge_sstables calls this once per ctx, then uses
+    // mapping_disagrees_with_natural_in_range below to range-test each
+    // non-shared sstable in O(log N) instead of re-scanning the plan +
+    // shared_rssid_map per sstable.
+    //
+    // Conservative: arithmetic overflow on natural-offset projection is
+    // treated as a disagreement so the rebuild path runs and rejects
+    // out-of-range entries explicitly. False-positives only cost an
+    // extra rebuild; false-negatives would silently mis-map PK lookups.
+    std::vector<uint32_t> compute_disagreement_keys() const {
+        auto disagrees = [&](uint32_t key, uint32_t value) -> bool {
+            const int64_t natural = static_cast<int64_t>(key) + _rssid_offset;
+            if (natural < 0 || natural > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+                return true; // arithmetic overflow → force rebuild
+            }
+            return value != static_cast<uint32_t>(natural);
+        };
+
+        const size_t plan_size = (_projection_plan != nullptr) ? _projection_plan->explicit_rssid_map.size() : 0;
+        std::vector<uint32_t> keys;
+        keys.reserve(plan_size + _shared_rssid_map.size());
+
+        if (_projection_plan != nullptr) {
+            for (const auto& [source_key, final_rssid] : _projection_plan->explicit_rssid_map) {
+                if (source_key.child_index != _child_index) continue;
+                if (disagrees(source_key.source_rssid, final_rssid)) {
+                    keys.push_back(source_key.source_rssid);
+                }
+            }
+        }
+        for (const auto& [source_rssid, final_rssid] : _shared_rssid_map) {
+            if (disagrees(source_rssid, final_rssid)) {
+                keys.push_back(source_rssid);
+            }
+        }
+        STLSortAndRemoveDuplicates(&keys);
+        return keys;
+    }
+
+    // True iff the precomputed sorted disagreement-keys vector contains
+    // any key in [lifted_lower, lifted_upper] (inclusive). O(log N) via
+    // binary search; the caller is expected to compute the keys vector
+    // once per ctx outside the inner sstable loop.
+    static bool mapping_disagrees_with_natural_in_range(const std::vector<uint32_t>& sorted_disagreement_keys,
+                                                        uint32_t lifted_lower, uint32_t lifted_upper) {
+        auto it = std::lower_bound(sorted_disagreement_keys.begin(), sorted_disagreement_keys.end(), lifted_lower);
+        return it != sorted_disagreement_keys.end() && *it <= lifted_upper;
+    }
+
     bool has_shared_rssid_mapping() const { return !_shared_rssid_map.empty(); }
 
     // Fills shared_rssid_map so that all rssids occupied by |rowset| map to
@@ -96,10 +208,10 @@ public:
     void update_shared_rssid_map(const RowsetMetadataPB& rowset, const RowsetMetadataPB& canonical_rowset) {
         uint32_t canonical_rssid = canonical_rowset.id();
         _shared_rssid_map[rowset.id()] = canonical_rssid;
-        for (int seg_pos = 0; seg_pos < rowset.segments_size(); ++seg_pos) {
-            uint32_t rssid = get_rssid(rowset, seg_pos);
-            uint32_t seg_offset = rssid - rowset.id();
-            _shared_rssid_map[rssid] = canonical_rssid + seg_offset;
+        for (int segment_pos = 0; segment_pos < rowset.segments_size(); ++segment_pos) {
+            uint32_t rssid = get_rssid(rowset, segment_pos);
+            uint32_t segment_offset_within_rowset = rssid - rowset.id();
+            _shared_rssid_map[rssid] = canonical_rssid + segment_offset_within_rowset;
         }
     }
 
@@ -111,12 +223,44 @@ private:
     TabletMetadataPtr _metadata;
     int64_t _rssid_offset = 0;
     int _current_rowset_index = 0;
+    uint32_t _child_index = 0;
+    // Non-owning. Lifetime guaranteed by merge_tablet's stack frame.
+    const detail::RssidProjectionPlan* _projection_plan = nullptr;
     // Dedup-produced rssid remap table.
     // key: original rssid in this child metadata
     // value: canonical rowset's actual rssid in the final output
     // rssid not in this map uses the default offset mapping.
     std::unordered_map<uint32_t, uint32_t> _shared_rssid_map;
 };
+
+// PersistentIndexSstablePB::max_rss_rowid encodes (rssid << 32) | rowid.
+// Helpers below name that encoding so callers don't open-code the shift
+// or mask. The "rss_rowid" naming matches the PB field; "high" / "low"
+// disambiguate which 32-bit half is being referenced.
+constexpr int kRssRowidHighShift = 32;
+constexpr uint64_t kRssRowidLowMask = 0xFFFFFFFFULL;
+
+inline uint32_t extract_rss_rowid_high(uint64_t encoded) {
+    return static_cast<uint32_t>(encoded >> kRssRowidHighShift);
+}
+inline uint64_t extract_rss_rowid_low(uint64_t encoded) {
+    return encoded & kRssRowidLowMask;
+}
+inline uint64_t encode_rss_rowid(uint32_t rssid_high, uint64_t rowid_low) {
+    return (static_cast<uint64_t>(rssid_high) << kRssRowidHighShift) | rowid_low;
+}
+
+// Tracks the contributing children's child-local ranges per canonical rowset
+// in new_metadata. Used by the post-merge_rowsets PK coverage check and by
+// gap-delvec synthesis.
+//
+// Key: index of the canonical rowset in new_metadata->rowsets().
+// Value: each entry is the contributing child's effective_child_local_range
+// (rowset.range, fallback ctx.metadata.range, fallback unbounded), captured
+// BEFORE update_canonical's union_range mutates the canonical's stored range
+// — otherwise the convex hull would swallow gaps and the coverage / gap
+// detection would fail.
+using CanonicalContribMap = std::unordered_map<int, std::vector<TabletRangePB>>;
 
 struct DelvecSourceRef {
     const TabletMergeContext* ctx;
@@ -209,11 +353,22 @@ Status add_rowset(TabletMergeContext& ctx, const RowsetMetadataPB& rowset, Table
     return Status::OK();
 }
 
-Status update_canonical(RowsetMetadataPB* canonical_rowset, const RowsetMetadataPB& duplicate_rowset) {
-    if (canonical_rowset->has_range() && duplicate_rowset.has_range()) {
+Status update_canonical(RowsetMetadataPB* canonical_rowset, const TabletRangePB& duplicate_effective_range,
+                        const RowsetMetadataPB& duplicate_rowset) {
+    // Always extend the canonical range with the duplicate's *effective* range
+    // (rowset.range, fallback ctx.metadata.range, fallback unbounded — same chain
+    // as Rowset::get_seek_range()). The previous gate of
+    // `canonical_rowset->has_range() && duplicate_rowset.has_range()` silently
+    // dropped contributors whose rowset.range was unset but whose ctx tablet
+    // range filled the slice; the post-dedup canonical.range would then reflect
+    // only the first contributor and readers (which prefer rowset.range over
+    // tablet.range) would miss rows from later contributors.
+    if (canonical_rowset->has_range()) {
         ASSIGN_OR_RETURN(auto merged_range,
-                         tablet_reshard_helper::union_range(canonical_rowset->range(), duplicate_rowset.range()));
+                         tablet_reshard_helper::union_range(canonical_rowset->range(), duplicate_effective_range));
         canonical_rowset->mutable_range()->CopyFrom(merged_range);
+    } else {
+        canonical_rowset->mutable_range()->CopyFrom(duplicate_effective_range);
     }
     // Each merge input carries a proportional num_dels slice written by
     // tablet_splitter.cpp / tablet_reshard_helper.cpp with num_dels <= num_rows.
@@ -228,7 +383,9 @@ Status update_canonical(RowsetMetadataPB* canonical_rowset, const RowsetMetadata
     return Status::OK();
 }
 
-Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata) {
+Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata,
+                     CanonicalContribMap* canonical_contribs) {
+    const bool is_pk = is_primary_key(*new_metadata);
     int version_start_index = 0;
     int64_t current_version = -1;
 
@@ -248,6 +405,7 @@ Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMeta
         if (min_child_index < 0) break;
 
         const auto& rowset = merge_contexts[min_child_index].current_rowset();
+        const auto& ctx_meta = *merge_contexts[min_child_index].metadata();
 
         // Version change: update version_start_index
         if (rowset.version() != current_version) {
@@ -255,13 +413,42 @@ Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMeta
             version_start_index = new_metadata->rowsets_size();
         }
 
-        // Check for duplicate in [version_start_index, end)
+        // Search [version_start_index, end) for a dedup candidate. Decision:
+        //   - Delete-predicate dups: keep original unconditional skip path.
+        //   - Shared-segment / shared-del_file dups (the only other case
+        //     is_duplicate_rowset returns true on): PK always dedups; non-PK
+        //     dedups only when ranges are contiguous so that the convex-hull
+        //     range stored on the canonical does not span a gap left by a
+        //     compacted sibling.
         int canonical_index = -1;
+        bool non_pk_skip_dedup_fired = false;
         for (int i = version_start_index; i < new_metadata->rowsets_size(); ++i) {
-            if (is_duplicate_rowset(rowset, new_metadata->rowsets(i))) {
+            if (!is_duplicate_rowset(rowset, new_metadata->rowsets(i))) continue;
+
+            if (rowset.has_delete_predicate()) {
                 canonical_index = i;
                 break;
             }
+            if (is_pk) {
+                canonical_index = i;
+                break;
+            }
+            const auto& candidate_range = new_metadata->rowsets(i).range();
+            const auto& incoming_range = tablet_reshard_helper::effective_child_local_range(rowset, ctx_meta);
+            if (tablet_reshard_helper::ranges_are_contiguous(candidate_range, incoming_range)) {
+                canonical_index = i;
+                break;
+            }
+            // Non-PK + non-contiguous: keep scanning. If no other candidate
+            // matches, fall through to add_rowset and treat as a separate
+            // shared rowset — each retains its own contiguous range.
+            non_pk_skip_dedup_fired = true;
+        }
+        if (canonical_index < 0 && non_pk_skip_dedup_fired) {
+            // At least one is_duplicate_rowset hit was rejected due to
+            // non-contiguous ranges and no later candidate accepted it →
+            // the rowset is added as a sibling of an existing shared rowset.
+            g_tablet_merge_non_pk_skip_dedup_total << 1;
         }
 
         if (canonical_index >= 0) {
@@ -274,12 +461,32 @@ Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMeta
                     << canonical.del_files_size() << ")";
             if (!rowset.has_delete_predicate()) {
                 merge_contexts[min_child_index].update_shared_rssid_map(rowset, canonical);
-                RETURN_IF_ERROR(update_canonical(new_metadata->mutable_rowsets(canonical_index), rowset));
+                // Capture the duplicate's child-local effective range BEFORE
+                // update_canonical mutates canonical.range via union_range. The
+                // same effective range is also passed into update_canonical so
+                // that a rowset without its own .range() but with a ctx tablet
+                // range still extends the canonical range.
+                const auto& duplicate_effective_range =
+                        tablet_reshard_helper::effective_child_local_range(rowset, ctx_meta);
+                if (canonical_contribs != nullptr) {
+                    (*canonical_contribs)[canonical_index].push_back(duplicate_effective_range);
+                }
+                RETURN_IF_ERROR(update_canonical(new_metadata->mutable_rowsets(canonical_index),
+                                                 duplicate_effective_range, rowset));
             }
             // predicate: just skip
         } else {
-            // First occurrence: output
+            // First occurrence: output. Capture child-local range first so that
+            // we record the pre-clip view (add_rowset clips to ctx tablet range).
+            TabletRangePB initial_child_range;
+            if (canonical_contribs != nullptr && !rowset.has_delete_predicate()) {
+                initial_child_range = tablet_reshard_helper::effective_child_local_range(rowset, ctx_meta);
+            }
+            const int new_index = new_metadata->rowsets_size();
             RETURN_IF_ERROR(add_rowset(merge_contexts[min_child_index], rowset, new_metadata));
+            if (canonical_contribs != nullptr && !rowset.has_delete_predicate()) {
+                (*canonical_contribs)[new_index].push_back(std::move(initial_child_range));
+            }
         }
 
         merge_contexts[min_child_index].advance_rowset();
@@ -379,6 +586,37 @@ struct DcgSurvivingEntry {
     // bookkeeping and downstream emission uniform.
     DeltaColumnGroupVerPB single_entry;
 };
+
+// True iff the entry's column_ids list contains |unique_id|. The
+// underlying PB shape is `entry.single_entry.unique_column_ids(0)
+// .column_ids()` (a single-entry-normalized DCG keeps all column ids
+// at slot 0); this helper hides the indirection.
+inline bool entry_claims_column_uid(const DcgSurvivingEntry& entry, uint32_t unique_id) {
+    for (auto claimed : entry.single_entry.unique_column_ids(0).column_ids()) {
+        if (claimed == unique_id) return true;
+    }
+    return false;
+}
+
+// Mark every DCG entry that shares any column UID with another entry
+// in |entries|. Two entries that both claim the same UID conflict —
+// merge_dcg_meta routes those through the rebuild path; non-conflicting
+// entries can be emitted as-is.
+inline std::vector<bool> mark_conflicting_dcg_entries(const std::vector<DcgSurvivingEntry>& entries) {
+    std::unordered_map<uint32_t, std::vector<size_t>> entry_indices_by_unique_id;
+    for (size_t entry_index = 0; entry_index < entries.size(); ++entry_index) {
+        for (auto unique_id : entries[entry_index].single_entry.unique_column_ids(0).column_ids()) {
+            entry_indices_by_unique_id[unique_id].push_back(entry_index);
+        }
+    }
+    std::vector<bool> entry_is_conflicting(entries.size(), false);
+    for (const auto& [unique_id, entry_indices] : entry_indices_by_unique_id) {
+        if (entry_indices.size() > 1) {
+            for (size_t entry_index : entry_indices) entry_is_conflicting[entry_index] = true;
+        }
+    }
+    return entry_is_conflicting;
+}
 
 struct DcgSourceRowsetReference {
     size_t child_index;
@@ -601,6 +839,14 @@ Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int
     *out_windows = std::move(deduped_windows);
 
     // Coverage validation: windows must be contiguous and cover [0, num_rows_in_target).
+    //
+    // Known limitation: the synthesized gap delvec from
+    // compute_synthesized_gap_specs masks rowids that no contributing child
+    // claims, but DCG rebuild does not yet consult that bitmap. A
+    // (compacted-child gap) × (DCG conflict on canonical R0) combination
+    // therefore returns NotSupported here. FE scheduling currently avoids
+    // the combo by requiring all children compacted before merge for any
+    // tablet with active partial-update DCGs.
     if ((*out_windows)[0].range.begin() != 0) {
         return Status::NotSupported(
                 fmt::format("DCG rebuild: row window coverage gap at the start (first.begin={}, expect 0)",
@@ -741,14 +987,7 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
     std::unordered_map<uint32_t, ColumnSourceInfo> column_source_info_by_unique_id;
     for (uint32_t unique_id : rebuild_columns) {
         for (const DcgSurvivingEntry* entry : conflicting_entries) {
-            bool entry_claims_this_column = false;
-            for (auto claimed_unique_id : entry->single_entry.unique_column_ids(0).column_ids()) {
-                if (claimed_unique_id == unique_id) {
-                    entry_claims_this_column = true;
-                    break;
-                }
-            }
-            if (!entry_claims_this_column) continue;
+            if (!entry_claims_column_uid(*entry, unique_id)) continue;
             auto& info = column_source_info_by_unique_id[unique_id];
             if (info.default_donor == nullptr) info.default_donor = entry;
             info.override_by_child_index[entry->child_index] = entry;
@@ -898,21 +1137,10 @@ Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMer
     for (auto& [target_rssid, target_work] : work_by_target) {
         if (target_work.entries.empty()) continue;
 
-        // Build column UID -> entries index (stable indices, not pointers).
-        std::unordered_map<uint32_t, std::vector<size_t>> entry_indices_by_unique_id;
-        for (size_t entry_index = 0; entry_index < target_work.entries.size(); ++entry_index) {
-            for (auto unique_id : target_work.entries[entry_index].single_entry.unique_column_ids(0).column_ids()) {
-                entry_indices_by_unique_id[unique_id].push_back(entry_index);
-            }
-        }
-
-        // Identify conflicting entries: any entry claiming a UID shared with another entry.
-        std::vector<bool> entry_is_conflicting(target_work.entries.size(), false);
-        for (auto& [unique_id, entry_indices] : entry_indices_by_unique_id) {
-            if (entry_indices.size() > 1) {
-                for (size_t entry_index : entry_indices) entry_is_conflicting[entry_index] = true;
-            }
-        }
+        // Identify conflicting entries: any entry claiming a UID shared
+        // with another entry. Conflict-free entries are emitted as-is;
+        // conflicting entries are rebuilt below.
+        const std::vector<bool> entry_is_conflicting = mark_conflicting_dcg_entries(target_work.entries);
 
         DeltaColumnGroupVerPB final_dcg;
 
@@ -979,8 +1207,160 @@ Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMer
     return Status::OK();
 }
 
+// Phase 0 output: per-target rowid bitmaps representing keys in the
+// shared physical segment that no contributing child claims. Read-path
+// consumers:
+//   - canonical R0's segment iterator already filters by canonical.range, so
+//     gap rowids outside the convex hull are no-ops for scans.
+//   - PersistentIndexSstable::multi_get filters by the projected delvec on
+//     the sstable PB regardless of LSM block-sort order, which keeps the
+//     first-child-compacts case safe.
+struct CanonicalGapSpec {
+    uint32_t target_rssid;
+    Roaring gap_bits;
+};
+
+// Phase 0: for every PK canonical rowset that owns at least one shared
+// segment, mask the rowids whose key falls outside ⋃ contributors but inside
+// the merged tablet range.
+//
+// Bound = merged tablet range, not unbounded `(-∞, +∞)`. The plan's original
+// motivation for unbounded was to surface keys outside canonical.range (left
+// or right edges); but since each child's tablet.range is a sub-range of the
+// pre-split tablet, and merged_tablet.range = union of children's tablet
+// ranges, the shared physical segment never carries keys outside the merged
+// tablet range. The unbounded helper would just generate edge complements
+// that seek to empty rowid windows. Bounded-by-merged-tablet-range is both
+// correct and lets us skip the segment open entirely when contributors fully
+// cover the merged tablet range (the no-compaction common case).
+StatusOr<std::vector<CanonicalGapSpec>> compute_synthesized_gap_specs(TabletManager* tablet_manager,
+                                                                      const TabletMetadataPB& new_metadata,
+                                                                      const CanonicalContribMap& canonical_contribs) {
+    std::vector<CanonicalGapSpec> result;
+    for (const auto& [canonical_index, contrib] : canonical_contribs) {
+        if (canonical_index < 0 || canonical_index >= new_metadata.rowsets_size()) {
+            return Status::InternalError(
+                    fmt::format("compute_synthesized_gap_specs: invalid canonical_index {}", canonical_index));
+        }
+        const auto& canonical = new_metadata.rowsets(canonical_index);
+        // shared_segments_size() alone is insufficient because metadata
+        // transforms can leave an all-false vector behind. Only synthesize
+        // gap bits when at least one segment is actually shared.
+        bool has_shared = false;
+        for (int i = 0; i < canonical.shared_segments_size(); ++i) {
+            if (canonical.shared_segments(i)) {
+                has_shared = true;
+                break;
+            }
+        }
+        if (!has_shared) continue;
+
+        ASSIGN_OR_RETURN(auto sorted_disjoint, tablet_reshard_helper::sort_and_merge_adjacent_ranges(contrib));
+        ASSIGN_OR_RETURN(auto non_contributed,
+                         tablet_reshard_helper::compute_disjoint_gaps_within(new_metadata.range(), sorted_disjoint));
+        if (non_contributed.empty()) continue;
+
+        const TabletSchemaPB* schema_pb = resolve_rowset_schema_pb(new_metadata, canonical);
+        if (schema_pb == nullptr) {
+            return Status::Corruption("compute_synthesized_gap_specs: schema not found for canonical rowset");
+        }
+        TabletSchemaCSPtr schema = TabletSchema::create(*schema_pb);
+
+        for (int seg_pos = 0; seg_pos < canonical.shared_segments_size(); ++seg_pos) {
+            if (!canonical.shared_segments(seg_pos)) continue;
+            uint32_t target_rssid = get_rssid(canonical, seg_pos);
+
+            FileInfo seg_file_info;
+            seg_file_info.path = tablet_manager->segment_location(new_metadata.id(), canonical.segments(seg_pos));
+            if (canonical.segment_size_size() > seg_pos) {
+                seg_file_info.size = canonical.segment_size(seg_pos);
+            }
+            if (canonical.bundle_file_offsets_size() > seg_pos) {
+                seg_file_info.bundle_file_offset = canonical.bundle_file_offsets(seg_pos);
+            }
+            if (canonical.segment_encryption_metas_size() > seg_pos) {
+                seg_file_info.encryption_meta = canonical.segment_encryption_metas(seg_pos);
+            }
+            ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(seg_file_info.path));
+            ASSIGN_OR_RETURN(auto base_segment,
+                             Segment::open(fs, seg_file_info, /*segment_id=*/0, schema,
+                                           /*footer_length_hint=*/nullptr, /*partial_rowset_footer=*/nullptr,
+                                           /*lake_io_opts=*/LakeIOOptions{}, tablet_manager));
+            const rowid_t num_rows = static_cast<rowid_t>(base_segment->num_rows());
+            if (num_rows == 0) continue;
+
+            Roaring gap_bits;
+            for (const auto& gap_range : non_contributed) {
+                ASSIGN_OR_RETURN(auto seek_range,
+                                 TabletRangeHelper::create_seek_range_from(gap_range, schema, /*mem_pool=*/nullptr));
+                LakeIOOptions io_opts{.fill_data_cache = false};
+                ASSIGN_OR_RETURN(auto rowid_range_opt,
+                                 segment_seek_range_to_rowid_range(base_segment, seek_range, io_opts));
+                if (!rowid_range_opt.has_value()) continue;
+                rowid_t lo = std::max<rowid_t>(rowid_range_opt->begin(), 0);
+                rowid_t hi = std::min<rowid_t>(rowid_range_opt->end(), num_rows);
+                if (lo >= hi) continue;
+                gap_bits.addRange(static_cast<uint64_t>(lo), static_cast<uint64_t>(hi));
+            }
+            if (!gap_bits.isEmpty()) {
+                result.push_back(CanonicalGapSpec{target_rssid, std::move(gap_bits)});
+            }
+        }
+    }
+    return result;
+}
+
+// Phase 2.5 of merge_delvecs: union each synthesized gap bitmap into the
+// corresponding target state. Mirrors the Phase 2 transitions but the source
+// is a synthesized Roaring rather than a child delvec page — so no
+// (file_name, offset) entry goes into seen_sources.
+//
+// Uses DelVector::union_with(Roaring) directly (no rowid-vector round-trip):
+// a compacted-away child's gap can span millions of rowids, and the legacy
+// path through std::vector<uint32_t> + DelVector::init(uint32_t*, size) +
+// union_delvec would re-enumerate every rowid into a vector twice.
+Status inject_synthesized_gaps_into_target_states(TabletManager* tablet_manager,
+                                                  const std::vector<CanonicalGapSpec>& specs, int64_t new_version,
+                                                  std::map<uint32_t, TargetDelvecState>* target_states) {
+    for (const auto& spec : specs) {
+        if (spec.gap_bits.isEmpty()) continue;
+        auto& state = (*target_states)[spec.target_rssid];
+
+        if (state.single_source.has_value() && !state.merged) {
+            // Promote single_source → merged: load the source delvec, OR in gap_bits.
+            DelVector dv_prev;
+            const auto& ref = *state.single_source;
+            LakeIOOptions io_opts;
+            RETURN_IF_ERROR(get_del_vec(tablet_manager, *ref.ctx->metadata(), ref.page, false, io_opts, &dv_prev));
+            auto merged_dv = std::make_unique<DelVector>();
+            if (dv_prev.roaring()) {
+                merged_dv->union_with(new_version, *dv_prev.roaring());
+            }
+            merged_dv->union_with(new_version, spec.gap_bits);
+            state.merged = std::move(merged_dv);
+            state.single_source.reset();
+        } else if (state.merged) {
+            state.merged->union_with(new_version, spec.gap_bits);
+        } else {
+            // Empty state: construct merged directly from gap_bits.
+            auto merged_dv = std::make_unique<DelVector>();
+            merged_dv->union_with(new_version, spec.gap_bits);
+            state.merged = std::move(merged_dv);
+        }
+    }
+    return Status::OK();
+}
+
 Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMergeContext>& merge_contexts,
-                     int64_t new_version, int64_t txn_id, TabletMetadataPB* new_metadata) {
+                     const CanonicalContribMap& canonical_contribs, int64_t new_version, int64_t txn_id,
+                     TabletMetadataPB* new_metadata) {
+    // Phase 0: synthesize gap delvec bits from canonical_contribs.
+    ASSIGN_OR_RETURN(auto synthesized_gap_specs,
+                     compute_synthesized_gap_specs(tablet_manager, *new_metadata, canonical_contribs));
+    if (!synthesized_gap_specs.empty()) {
+        g_tablet_merge_gap_delvec_total << 1;
+    }
+
     // Phase 1: Collect unique delvec files across all children
     std::vector<DelvecFileInfo> unique_delvec_files;
     std::unordered_map<std::string, size_t> file_name_to_index;
@@ -1008,7 +1388,10 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
         }
     }
 
-    if (unique_delvec_files.empty()) {
+    // Early-return only when there is no work at all: no source delvec files
+    // AND no synthesized gaps. A clean PK table with no prior deletes can
+    // still need a synthesized gap delvec to mask compacted-away child rowids.
+    if (unique_delvec_files.empty() && synthesized_gap_specs.empty()) {
         return Status::OK();
     }
 
@@ -1090,6 +1473,14 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
         }
     }
 
+    // Phase 2.5: inject synthesized gap delvecs into target_states. Each spec's
+    // bitmap masks rowids in the shared physical segment whose key was
+    // contributed by no surviving child (e.g., a child that compacted away
+    // its copy of the shared rowset). Promotes any single_source state to
+    // merged so the bitmap can be unioned in.
+    RETURN_IF_ERROR(inject_synthesized_gaps_into_target_states(tablet_manager, synthesized_gap_specs, new_version,
+                                                               &target_states));
+
     // Phase 3: Serialize union results into union_buffer
     std::string union_buffer;
     std::map<uint32_t, UnionPageInfo> union_page_infos;
@@ -1104,14 +1495,34 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
         }
     }
 
-    // Phase 4: Write one file (old files concatenated + union_buffer appended)
+    // Phase 4: Write one file. Three routes depending on what contributed:
+    //   1. only synthesized (no source delvec files) → write_delvec_file_from_buffer
+    //      with the union_buffer at offset 0; sidesteps merge_delvec_files's
+    //      DCHECK on (empty old_files + non-empty extra_data).
+    //   2. only source files (no synthesized + empty union_buffer) → existing
+    //      merge_delvec_files with empty extra_data.
+    //   3. both → existing merge_delvec_files with extra_data populated.
     FileMetaPB new_delvec_file;
     std::vector<uint64_t> offsets;
     uint64_t union_base_offset = 0;
-    RETURN_IF_ERROR(merge_delvec_files(tablet_manager, unique_delvec_files, new_metadata->id(), txn_id,
-                                       &new_delvec_file, &offsets, Slice(union_buffer), &union_base_offset));
+    if (unique_delvec_files.empty()) {
+        // Route 1: synthesized-only. Phase 1's early-return guarantees that
+        // synthesized_gap_specs (and therefore union_buffer) is non-empty
+        // here.
+        DCHECK(!union_buffer.empty()) << "synthesized-only path with empty union_buffer";
+        RETURN_IF_ERROR(write_delvec_file_from_buffer(tablet_manager, new_metadata->id(), txn_id, Slice(union_buffer),
+                                                      &new_delvec_file));
+        union_base_offset = 0;
+        g_tablet_merge_synthesized_only_delvec_total << 1;
+    } else {
+        // Routes 2 & 3.
+        RETURN_IF_ERROR(merge_delvec_files(tablet_manager, unique_delvec_files, new_metadata->id(), txn_id,
+                                           &new_delvec_file, &offsets, Slice(union_buffer), &union_base_offset));
+    }
 
-    // Build base_offset_by_file_name
+    // Build base_offset_by_file_name. Empty for synthesized-only route since
+    // there are no source files to reference; merged-state targets always go
+    // through union_page_infos which is keyed by target rssid, not file name.
     std::unordered_map<std::string, uint64_t> base_offset_by_file_name;
     for (size_t i = 0; i < unique_delvec_files.size(); ++i) {
         base_offset_by_file_name[unique_delvec_files[i].delvec_file.name()] = offsets[i];
@@ -1159,14 +1570,1061 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
     return Status::OK();
 }
 
+// Lookup maps from a child-id-space rssid to the merged tablet's final
+// rssid. Built once per rebuild from the merge_contexts, scoped per
+// inferred family (or per orphan child for kNoFamily ctxs) so a multi-
+// family merge with overlapping source rssids never returns another
+// family's mapping. Each PerFamilyMaps half follows first-emitter-wins:
+//
+//   data_rssid_map      — keyed by per-segment lifted rssid via
+//                         get_rssid(rs, seg_pos). Honors sparse segment_idx
+//                         (e.g. {0,2} after middle-segment removal). Excludes
+//                         delete-only rowsets so a data entry pointing at
+//                         their rssid is dropped as a ghost.
+//   watermark_rssid_map — superset that ALSO records rs.id() for
+//                         delete-only rowsets. Used only for projecting
+//                         src_pb.max_rss_rowid (memtable flush sets it to
+//                         the current rowset id, which may be delete-only).
+//                         Must NOT be used for data-entry remap.
+struct LegacyRssidLookupMaps {
+    struct PerFamilyMaps {
+        std::unordered_map<uint32_t, uint32_t> data_rssid_map;
+        std::unordered_map<uint32_t, uint32_t> watermark_rssid_map;
+    };
+
+    // family_id → maps populated from that family's member ctxs only.
+    std::unordered_map<uint32_t, PerFamilyMaps> per_family;
+    // child_index → maps populated from THAT specific orphan ctx only.
+    // Each orphan ctx (kNoFamily) gets its own scoped entry so two
+    // unrelated orphan children with overlapping source rssids do not
+    // pollute each other — orphan ctxs each have an independent
+    // child-local id space, so a global orphan map would be susceptible
+    // to the same first-emitter-wins pollution that the per-family
+    // structure was designed to prevent for family ctxs.
+    std::unordered_map<size_t, PerFamilyMaps> orphan_by_child;
+};
+
+// Locate the PerFamilyMaps slot for (family_id, child_index): a family ctx
+// shares its family map; an orphan ctx (kNoFamily) has its own child-scoped
+// map so unrelated orphan children with overlapping source rssids stay
+// isolated. Returns nullptr on miss; callers wrap the result in either an
+// InternalError or a DCHECK depending on whether they're building or reading.
+template <typename Maps>
+auto* find_per_family_maps_slot(Maps& maps, uint32_t family_id, size_t child_index) {
+    if (family_id != detail::InferredSplitFamilies::kNoFamily) {
+        auto iter = maps.per_family.find(family_id);
+        return iter == maps.per_family.end() ? nullptr : &iter->second;
+    }
+    auto iter = maps.orphan_by_child.find(child_index);
+    return iter == maps.orphan_by_child.end() ? nullptr : &iter->second;
+}
+
+// Read-side accessor: missing entry surfaces as InternalError so the merge
+// fails loudly. build_legacy_rssid_lookup_maps pre-creates every entry, so a
+// miss is a programmer bug; falling back to an empty map would silently drop
+// every PK entry and manifest as data loss.
+StatusOr<const LegacyRssidLookupMaps::PerFamilyMaps*> lookup_maps_for_ctx(const LegacyRssidLookupMaps& maps,
+                                                                          uint32_t family_id, size_t child_index) {
+    if (const auto* slot = find_per_family_maps_slot(maps, family_id, child_index); slot != nullptr) {
+        return slot;
+    }
+    return Status::InternalError(
+            fmt::format("LegacyRssidLookupMaps: missing slot (family_id={}, child_index={})", family_id, child_index));
+}
+
+// Build-phase accessor: same lookup, but DCHECK on miss since
+// build_legacy_rssid_lookup_maps just pre-created the entry it's about to
+// populate.
+LegacyRssidLookupMaps::PerFamilyMaps& mutable_per_family_maps_for_ctx(LegacyRssidLookupMaps& maps, uint32_t family_id,
+                                                                      size_t child_index) {
+    auto* slot = find_per_family_maps_slot(maps, family_id, child_index);
+    DCHECK(slot != nullptr) << "PerFamilyMaps not pre-created (family_id=" << family_id
+                            << ", child_index=" << child_index << ")";
+    return *slot;
+}
+
+StatusOr<LegacyRssidLookupMaps> build_legacy_rssid_lookup_maps(const std::vector<TabletMergeContext>& merge_contexts,
+                                                               const detail::InferredSplitFamilies& families) {
+    if (families.child_to_family.size() != merge_contexts.size()) {
+        return Status::InvalidArgument(fmt::format(
+                "InferredSplitFamilies.child_to_family size {} != merge_contexts size {}; the families must be built "
+                "from the same contexts",
+                families.child_to_family.size(), merge_contexts.size()));
+    }
+    // Validate every child_to_family entry is either kNoFamily or a real
+    // family id so the population loop's find()-based lookups can rely on
+    // pre-created entries (and the lookup helper never silently skips a
+    // bad family id by treating it as orphan).
+    for (size_t child_index = 0; child_index < families.child_to_family.size(); ++child_index) {
+        const uint32_t family_id = families.child_to_family[child_index];
+        if (family_id != detail::InferredSplitFamilies::kNoFamily && family_id >= families.families.size()) {
+            return Status::InvalidArgument(
+                    fmt::format("InferredSplitFamilies.child_to_family[{}]={} is out of range (families.size={})",
+                                child_index, family_id, families.families.size()));
+        }
+    }
+
+    LegacyRssidLookupMaps lookup_maps;
+    // Pre-create one PerFamilyMaps per inferred family so consumers can
+    // assume the entry exists when they look up a non-orphan family.
+    lookup_maps.per_family.reserve(families.families.size());
+    for (uint32_t family_id = 0; family_id < families.families.size(); ++family_id) {
+        lookup_maps.per_family.emplace(family_id, LegacyRssidLookupMaps::PerFamilyMaps{});
+    }
+    // Pre-create one PerFamilyMaps per orphan child_index so consumers
+    // can assume the entry exists for every kNoFamily ctx.
+    for (size_t child_index = 0; child_index < merge_contexts.size(); ++child_index) {
+        if (families.child_to_family[child_index] == detail::InferredSplitFamilies::kNoFamily) {
+            lookup_maps.orphan_by_child.emplace(child_index, LegacyRssidLookupMaps::PerFamilyMaps{});
+        }
+    }
+
+    for (size_t child_index = 0; child_index < merge_contexts.size(); ++child_index) {
+        const auto& ctx = merge_contexts[child_index];
+        const uint32_t family_id = families.child_to_family[child_index];
+        auto& target = mutable_per_family_maps_for_ctx(lookup_maps, family_id, child_index);
+
+        for (const auto& rowset : ctx.metadata()->rowsets()) {
+            // Watermark map: rowset id (catches delete-only rowsets).
+            if (auto [it, inserted] = target.watermark_rssid_map.try_emplace(rowset.id(), 0); inserted) {
+                ASSIGN_OR_RETURN(it->second, ctx.map_rssid(rowset.id()));
+            }
+            // Data + watermark maps: per-segment rssids.
+            for (int segment_position = 0; segment_position < rowset.segments_size(); ++segment_position) {
+                const uint32_t lifted_rssid = get_rssid(rowset, segment_position);
+                auto [it, inserted] = target.data_rssid_map.try_emplace(lifted_rssid, 0);
+                if (!inserted) continue;
+                ASSIGN_OR_RETURN(it->second, ctx.map_rssid(lifted_rssid));
+                // Watermark map: only record if not already present (first
+                // emitter wins, matching merge_rowsets canonical-id semantics).
+                target.watermark_rssid_map.try_emplace(lifted_rssid, it->second);
+            }
+        }
+    }
+    return lookup_maps;
+}
+
+// True iff two PB instances of the same-filename shared sstable describe the
+// same physical file AND have identical projection-affecting fields. The
+// projection fields (rssid_offset, shared_rssid, shared_version) are included
+// because they change how stored bytes are interpreted at read time —
+// keeping the first sibling's PB on a mismatch would silently mis-map the
+// rebuilt or projected output. SPLIT today copies metadata as-is so siblings
+// agree on every field; this is defense-in-depth against future MERGE input
+// topologies. fileset_id is intentionally excluded: it can be synthesized
+// per-load by PersistentIndexSstableFileset::init when the source has none
+// (PR #72031).
+bool shared_sstable_metadata_matches(const PersistentIndexSstablePB& a, const PersistentIndexSstablePB& b) {
+    if (a.filesize() != b.filesize() || a.encryption_meta() != b.encryption_meta()) return false;
+    if (a.has_range() != b.has_range()) return false;
+    if (a.has_range() &&
+        (a.range().start_key() != b.range().start_key() || a.range().end_key() != b.range().end_key())) {
+        return false;
+    }
+    if (a.rssid_offset() != b.rssid_offset()) return false;
+    if (a.has_shared_rssid() != b.has_shared_rssid()) return false;
+    if (a.has_shared_rssid() && a.shared_rssid() != b.shared_rssid()) return false;
+    if (a.has_shared_version() != b.has_shared_version()) return false;
+    if (a.has_shared_version() && a.shared_version() != b.shared_version()) return false;
+    return true;
+}
+
+// Defense-in-depth invariants for the legacy-shared form. The merge_sstables
+// caller branch already gates on (shared && !has_shared_rssid), but rebuild
+// may be entered through other paths in the future.
+Status validate_legacy_shared_sstable_form(const PersistentIndexSstablePB& src_pb) {
+    if (src_pb.has_shared_rssid()) {
+        return Status::Corruption("rebuild_legacy_shared_sstable called on a non-legacy sstable (has_shared_rssid)");
+    }
+    if (src_pb.has_shared_version() && src_pb.shared_version() > 0) {
+        // multi_get DCHECKs has_shared_rssid when shared_version > 0
+        // (persistent_index_sstable.cpp:211). A legacy file with shared_version > 0
+        // is malformed and cannot be safely rebuilt without materializing that
+        // version into every entry.
+        return Status::Corruption("Legacy shared sstable has shared_version > 0 without has_shared_rssid");
+    }
+    if (src_pb.has_delvec() && src_pb.delvec().size() > 0) {
+        return Status::Corruption("Legacy shared sstable carries a delvec; cannot rebuild without shared_rssid");
+    }
+    return Status::OK();
+}
+
+// Project src_pb.max_rss_rowid through the rebuild. Returns the initial
+// encoded watermark for the rebuilt sstable, or std::nullopt when projection
+// cannot be done (out-of-range lifted high, or watermark map miss). Lets the
+// rebuilt file inherit a sensible max even when it ends up tombstone-only or
+// when its source max points at a delete-only rowset.
+// Convention: PersistentIndexSstablePB.max_rss_rowid.high is the EFFECTIVE
+// (post-projection) max rssid in the SOURCE child's id space — i.e. it
+// already includes any accumulated src_pb.rssid_offset. Cross-sstable
+// invariants in lake_persistent_index.cpp (the I1 ordering check at
+// apply_opcompaction line 875-886, the _memtable seed at line 146-160,
+// the post-compaction validation at line 686-689) all read max_rss_rowid
+// as effective rssid, and project_non_shared_legacy_sstable already shifts
+// max_rss_rowid.high by ctx.rssid_offset to maintain that convention.
+//
+// Therefore the source rssid offset must NOT be added again here; doing
+// so would double-shift for any stacked-offset src (anything that has
+// gone through one round of project_non_shared). The lookup key is just
+// source_max_rssid_high directly — it is the source child's effective
+// max rssid, exactly the key shape watermark_rssid_map records.
+std::optional<uint64_t> project_source_max_rss_rowid(
+        const PersistentIndexSstablePB& src_pb, int32_t /*source_rssid_offset*/,
+        const std::unordered_map<uint32_t, uint32_t>& watermark_rssid_map) {
+    const uint64_t source_max_rowid_low = extract_rss_rowid_low(src_pb.max_rss_rowid());
+    const uint32_t source_max_rssid_high = extract_rss_rowid_high(src_pb.max_rss_rowid());
+    auto entry = watermark_rssid_map.find(source_max_rssid_high);
+    if (entry == watermark_rssid_map.end()) {
+        return std::nullopt;
+    }
+    return encode_rss_rowid(entry->second, source_max_rowid_low);
+}
+
+// Walk |values_pb|'s non-tombstone entries and update |*max_encoded| /
+// |*initialized| with the encoded `(rssid<<32)|rowid` if larger.
+void update_max_encoded_rss_rowid_from(const IndexValuesWithVerPB& values_pb, uint64_t* max_encoded,
+                                       bool* initialized) {
+    for (int i = 0; i < values_pb.values_size(); ++i) {
+        const auto& index_value = values_pb.values(i);
+        if (is_index_tombstone(index_value)) continue;
+        const uint64_t encoded = encode_rss_rowid(index_value.rssid(), index_value.rowid());
+        if (!*initialized || encoded > *max_encoded) {
+            *max_encoded = encoded;
+            *initialized = true;
+        }
+    }
+}
+
+// Remap stored rssids on each non-tombstone value via the data map (lifted by
+// |source_rssid_offset|) and, on the first non-tombstone, check the rowid
+// against the per-final-rssid delvec via |load_del_vector|. The rowid is
+// shared across versions within an IndexValuesWithVerPB (same row, multiple
+// versions) — see KeyValueMerger and PersistentIndexSstable::multi_get for
+// the same invariant.
+//
+// Tombstones (sentinel rssid/rowid = UINT32_MAX) are preserved as-is.
+//
+// Returns:
+//   true  → keep this entry; rssids in |*values_pb| have been rewritten.
+//   false → drop this entry (dead source rowset or rowid in delvec).
+//   error → corruption (out-of-range stored rssid) or delvec load failure.
+// Owns the mutable resources used while writing a rebuilt PK sstable. The
+// caller arms a DeferOp that calls delete_partial_legacy_rebuild_output() on
+// any path that doesn't go through finalize_legacy_rebuild_output().
+struct LegacyRebuildOutputWriter {
+    std::string filename;
+    std::string location;
+    std::string encryption_meta;
+    std::unique_ptr<WritableFile> writable_file;
+    std::unique_ptr<sstable::FilterPolicy> filter_policy;
+    std::unique_ptr<sstable::TableBuilder> table_builder;
+};
+
+StatusOr<LegacyRebuildOutputWriter> open_legacy_rebuild_output(TabletManager* tablet_manager,
+                                                               int64_t merged_tablet_id) {
+    LegacyRebuildOutputWriter writer;
+    writer.filename = gen_sst_filename();
+    writer.location = tablet_manager->sst_location(merged_tablet_id, writer.filename);
+    WritableFileOptions write_options;
+    if (config::enable_transparent_data_encryption) {
+        ASSIGN_OR_RETURN(auto encryption_pair, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+        write_options.encryption_info = encryption_pair.info;
+        writer.encryption_meta = std::move(encryption_pair.encryption_meta);
+    }
+    ASSIGN_OR_RETURN(writer.writable_file, fs::new_writable_file(write_options, writer.location));
+    sstable::Options builder_options;
+    writer.filter_policy.reset(const_cast<sstable::FilterPolicy*>(sstable::NewBloomFilterPolicy(10)));
+    builder_options.filter_policy = writer.filter_policy.get();
+    writer.table_builder = std::make_unique<sstable::TableBuilder>(builder_options, writer.writable_file.get());
+    return writer;
+}
+
+// Finalize the table builder, close the writer, and populate |out_pb| with a
+// non-shared sstable PB pointing at the just-written physical file. A fresh
+// fileset_id is assigned because PersistentIndexSstableFileset::init(vector)
+// DCHECKs has_fileset_id() for any sstable with a range
+// (persistent_index_sstable_fileset.cpp:30-31), and the rebuilt PB carries a
+// real key range from builder.KeyRange().
+Status finalize_legacy_rebuild_output(LegacyRebuildOutputWriter& writer, uint64_t max_rss_rowid,
+                                      PersistentIndexSstablePB* out_pb) {
+    RETURN_IF_ERROR(writer.table_builder->Finish());
+    auto [start_key, end_key] = writer.table_builder->KeyRange();
+    const uint64_t filesize = writer.table_builder->FileSize();
+    RETURN_IF_ERROR(writer.writable_file->close());
+
+    out_pb->set_filename(writer.filename);
+    out_pb->set_filesize(filesize);
+    out_pb->set_encryption_meta(writer.encryption_meta);
+    out_pb->mutable_range()->set_start_key(start_key.to_string());
+    out_pb->mutable_range()->set_end_key(end_key.to_string());
+    out_pb->set_shared(false);
+    out_pb->set_rssid_offset(0);
+    out_pb->set_max_rss_rowid(max_rss_rowid);
+    out_pb->mutable_fileset_id()->CopyFrom(UniqueId::gen_uid().to_proto());
+    return Status::OK();
+}
+
+// Best-effort cleanup of an unfinalized partial output: close any writer
+// handle and delete the file at the recorded location. Used by the rebuild
+// cleanup guard so failure paths and "every entry dropped" don't leak OSS
+// orphans.
+void delete_partial_legacy_rebuild_output(LegacyRebuildOutputWriter& writer) {
+    if (writer.writable_file) {
+        (void)writer.writable_file->close();
+    }
+    auto filesystem_or = FileSystemFactory::CreateSharedFromString(writer.location);
+    if (filesystem_or.ok()) {
+        (void)(*filesystem_or)->delete_file(writer.location);
+    }
+}
+
+StatusOr<bool> remap_legacy_entry_or_drop(IndexValuesWithVerPB* values_pb, int32_t source_rssid_offset,
+                                          const std::unordered_map<uint32_t, uint32_t>& data_rssid_map,
+                                          const std::function<StatusOr<DelVectorPtr>(uint32_t)>& load_del_vector) {
+    bool delvec_already_checked = false;
+    for (int i = 0; i < values_pb->values_size(); ++i) {
+        auto* index_value = values_pb->mutable_values(i);
+        if (is_index_tombstone(*index_value)) continue;
+        const int64_t lifted_rssid = static_cast<int64_t>(index_value->rssid()) + source_rssid_offset;
+        if (lifted_rssid < 0 || lifted_rssid > std::numeric_limits<uint32_t>::max()) {
+            return Status::Corruption(fmt::format(
+                    "legacy sstable stored rssid out of range after applying source offset: stored={} offset={}",
+                    index_value->rssid(), source_rssid_offset));
+        }
+        auto mapped_entry = data_rssid_map.find(static_cast<uint32_t>(lifted_rssid));
+        if (mapped_entry == data_rssid_map.end()) {
+            return false; // dead source rowset
+        }
+        index_value->set_rssid(mapped_entry->second);
+        if (!delvec_already_checked) {
+            ASSIGN_OR_RETURN(auto del_vector, load_del_vector(mapped_entry->second));
+            if (del_vector && del_vector->roaring() && del_vector->roaring()->contains(index_value->rowid())) {
+                return false; // rowid filtered by merged delvec
+            }
+            delvec_already_checked = true;
+        }
+    }
+    return true;
+}
+
+// Try to project an ancestor-inherited shared PK sstable (shared=true,
+// !has_shared_rssid) without reading the source file. canonical_offset is
+// read from plan.family_legacy_sstable_offset; the dense walk verifies
+// data_rssid_map[lifted_rssid] == lifted_rssid + canonical_offset and that
+// the merged delvec at the final rssid is empty. Emit accumulates:
+//   out_pb.rssid_offset       = src_pb.rssid_offset + canonical_offset
+//   out_pb.max_rss_rowid.high = source_lifted_max + canonical_offset
+//
+// Returns true with out_pb filled when every safety check passes. On any
+// miss returns false and the caller falls back to
+// rebuild_legacy_shared_sstable; each fallback path increments a dedicated
+// counter so production can break down why fast-path missed.
+StatusOr<bool> try_fastpath_project_legacy_shared_sstable(const PersistentIndexSstablePB& src_pb, uint32_t family_id,
+                                                          const detail::RssidProjectionPlan& plan,
+                                                          const TabletMetadataPB& new_metadata,
+                                                          const LegacyRssidLookupMaps::PerFamilyMaps& rssid_lookup_maps,
+                                                          PersistentIndexSstablePB* out_pb) {
+    constexpr uint32_t kFastPathMaxRssidSpan = 8192;
+
+    if (family_id == detail::InferredSplitFamilies::kNoFamily) {
+        g_tablet_merge_legacy_sstable_fastpath_fallback_no_family << 1;
+        return false;
+    }
+    if (plan.unsafe_families.count(family_id) > 0) {
+        g_tablet_merge_legacy_sstable_fastpath_fallback_unsafe_family << 1;
+        return false;
+    }
+    auto family_offset_it = plan.family_legacy_sstable_offset.find(family_id);
+    if (family_offset_it == plan.family_legacy_sstable_offset.end()) {
+        g_tablet_merge_legacy_sstable_fastpath_fallback_no_family << 1;
+        return false;
+    }
+    const int64_t canonical_offset = family_offset_it->second;
+
+    // Form / range / fileset_id gates: identical legality contract to v1.
+    // Rebuild's PersistentIndexSstableFileset::init(vector) DCHECK requires
+    // a fileset_id on any ranged sstable, so the fast-path must too.
+    if (!validate_legacy_shared_sstable_form(src_pb).ok()) {
+        g_tablet_merge_legacy_sstable_fastpath_fallback_invalid_form << 1;
+        return false;
+    }
+    if (!new_metadata.has_range()) {
+        g_tablet_merge_legacy_sstable_fastpath_fallback_merged_no_range << 1;
+        return false;
+    }
+    if (src_pb.has_range() && !src_pb.has_fileset_id()) {
+        g_tablet_merge_legacy_sstable_fastpath_fallback_ranged_no_fileset_id << 1;
+        return false;
+    }
+
+    // Boundary / overflow checks. accumulated_offset must fit in int32 so
+    // it can be written back to the PB; new_lifted_max must fit in uint32
+    // so the high word is well-defined.
+    const int64_t accumulated_offset = static_cast<int64_t>(src_pb.rssid_offset()) + canonical_offset;
+    if (accumulated_offset < std::numeric_limits<int32_t>::min() ||
+        accumulated_offset > std::numeric_limits<int32_t>::max()) {
+        g_tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid << 1;
+        return false;
+    }
+    // max_rss_rowid.high is already in source-effective space (post-PR0).
+    const int64_t source_lifted_max = static_cast<int64_t>(extract_rss_rowid_high(src_pb.max_rss_rowid()));
+    const int64_t source_lifted_lower = static_cast<int64_t>(src_pb.rssid_offset()) + 1; // skip stored rssid 0
+    if (source_lifted_max < source_lifted_lower) {
+        g_tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid << 1;
+        return false;
+    }
+    if (source_lifted_max - source_lifted_lower + 1 > kFastPathMaxRssidSpan) {
+        g_tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid << 1;
+        return false;
+    }
+    const int64_t new_lifted_max = source_lifted_max + canonical_offset;
+    if (new_lifted_max < 0 || new_lifted_max > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+        g_tablet_merge_legacy_sstable_fastpath_fallback_coverage_span_invalid << 1;
+        return false;
+    }
+
+    // Dense walk of [source_lifted_lower, source_lifted_max] in source-
+    // effective (canonical_ctx-local) space. For each lifted_rssid, expect:
+    //   data_rssid_map[lifted_rssid] == lifted_rssid + canonical_offset
+    // and the merged delvec at the FINAL rssid is empty (fast-path can't
+    // physically drop entries).
+    const auto& family_data_rssid_map = rssid_lookup_maps.data_rssid_map;
+    const auto& merged_delvecs = new_metadata.delvec_meta().delvecs();
+    for (int64_t lifted_rssid_64 = source_lifted_lower; lifted_rssid_64 <= source_lifted_max; ++lifted_rssid_64) {
+        const auto lifted_rssid = static_cast<uint32_t>(lifted_rssid_64);
+        const auto expected_final = static_cast<uint32_t>(lifted_rssid_64 + canonical_offset);
+        auto data_entry = family_data_rssid_map.find(lifted_rssid);
+        if (data_entry == family_data_rssid_map.end() || data_entry->second != expected_final) {
+            g_tablet_merge_legacy_sstable_fastpath_fallback_partial_compaction << 1;
+            return false;
+        }
+        auto delvec_entry = merged_delvecs.find(expected_final);
+        if (delvec_entry != merged_delvecs.end() && delvec_entry->second.size() > 0) {
+            g_tablet_merge_legacy_sstable_fastpath_fallback_merged_delvec_nonempty << 1;
+            return false;
+        }
+    }
+
+    // Emit projected PB. PB.rssid_offset accumulates; max_rss_rowid.high
+    // (in effective space) shifts by canonical_offset. low word and every
+    // other field copy through unchanged.
+    out_pb->CopyFrom(src_pb);
+    out_pb->set_rssid_offset(static_cast<int32_t>(accumulated_offset));
+    out_pb->set_max_rss_rowid(
+            encode_rss_rowid(static_cast<uint32_t>(new_lifted_max), extract_rss_rowid_low(src_pb.max_rss_rowid())));
+    return true;
+}
+
+// Rebuilds an ancestor-inherited shared PK sstable (shared=true,
+// !has_shared_rssid) by reading every entry, remapping stored rssids to the
+// merged tablet's final rssid space via merge_contexts, applying the merged
+// tablet's range filter and per-rssid delvec, and writing a fresh non-shared
+// sstable.
+//
+// Why this is needed (run4 ghost-rssid bug): the legacy projection path only
+// accumulates a single rssid_offset per PB, but a single PK sstable file holds
+// entries for many ancestor rowsets. After multi-cycle split/merge with partial
+// child compaction, a surviving rowset can be assigned a NEW id by add_rowset
+// in some merge while the inherited sstable still stores the OLD id. PK lookup
+// then returns a stored rssid that no longer corresponds to any live rowset
+// in the merged tablet — `unexpected segment id` at publish time.
+//
+// Five filtering layers (all needed to match modern shared_rssid path semantics
+// once we emit a non-shared file):
+//   (1) Tablet-range filter via TabletRangeHelper::create_sst_seek_range_from
+//       — drops ancestor keys outside the merged tablet range. The modern
+//       shared path gets this at PK index init via the contain_shared_sstables
+//       gate (lake_persistent_index.cpp:624-635). A non-shared rebuilt output
+//       must apply it inline.
+//   (2) Per-entry rssid remap via the precomputed data_rssid_map (built once
+//       by build_legacy_rssid_lookup_maps) — drops entries whose source rowset
+//       is dead in every child.
+//   (3) Per-entry delvec filter via new_metadata.delvec_meta() — drops entries
+//       whose rowid is in the merged delvec, which by Phase 5 of merge_delvecs
+//       includes both real deletes and synthesized gap-bits for shared segments
+//       not covered by any contributing child's range.
+//   (4) Watermark projection via the watermark_rssid_map (superset of the data
+//       map; also covers delete-only rowsets) — sets max_rss_rowid even when
+//       the file is tombstone-only or its source max points at a delete-only
+//       rowset.
+//   (5) Tombstones preserved as-is (rssid/rowid sentinel; never remapped or
+//       delvec-filtered) — same invariant as multi_get and KeyValueMerger.
+//
+// On success out_pb is filled with a non-shared sstable PB pointing at a new
+// physical file. If every entry was dropped (dead rowset / out-of-range / in
+// delvec), out_pb is left empty and the caller should drop the sstable entirely
+// from the merged metadata; the cleanup guard deletes the partial output file
+// before this function returns so we don't leave OSS orphans for vacuum.
+Status rebuild_legacy_shared_sstable(TabletManager* tablet_manager, int64_t merged_tablet_id,
+                                     const PersistentIndexSstablePB& src_pb, const TabletMetadataPtr& src_metadata,
+                                     const TabletMetadataPB& new_metadata,
+                                     const LegacyRssidLookupMaps::PerFamilyMaps& rssid_lookup_maps,
+                                     PersistentIndexSstablePB* out_pb) {
+    out_pb->Clear();
+    RETURN_IF_ERROR(validate_legacy_shared_sstable_form(src_pb));
+
+    // The merged tablet must carry a range for shared-data range distribution.
+    // Without it the (1) tablet-range filter below cannot be applied; refuse
+    // rather than silently dropping it.
+    if (!new_metadata.has_range()) {
+        return Status::InternalError("merged tablet has no range; cannot apply range filter to legacy rebuild");
+    }
+
+    // Open the source iterator and Seek to the merged tablet range start.
+    // (1) Tablet-range filter — mirrors the contain_shared_sstables gate at
+    // lake_persistent_index.cpp:624-635. Modern shared sstables get this at PK
+    // index init; the rebuilt output is shared=false, so we apply it inline.
+    ASSIGN_OR_RETURN(auto source_sstable,
+                     PersistentIndexSstable::new_sstable(
+                             src_pb, tablet_manager->sst_location(src_metadata->id(), src_pb.filename()),
+                             /*cache=*/nullptr, /*need_filter=*/false,
+                             /*delvec=*/nullptr, src_metadata, tablet_manager));
+    sstable::ReadOptions source_read_options;
+    source_read_options.fill_cache = false;
+    std::unique_ptr<sstable::Iterator> source_iterator(source_sstable->new_iterator(source_read_options));
+    auto merged_tablet_schema = TabletSchema::create(new_metadata.schema());
+    ASSIGN_OR_RETURN(auto seek_range,
+                     TabletRangeHelper::create_sst_seek_range_from(new_metadata.range(), merged_tablet_schema));
+    if (seek_range.seek_key.empty()) {
+        source_iterator->SeekToFirst();
+    } else {
+        source_iterator->Seek(seek_range.seek_key);
+    }
+    const sstable::Comparator* bytewise_comparator = sstable::BytewiseComparator();
+
+    // Maps are built once per merge_sstables() call and shared with the fast-path
+    // helper; both paths consult the same data + watermark mappings, so building
+    // them at the merge_sstables top avoids the quadratic walk that would
+    // otherwise scan merge_contexts × rowsets × segments per stored entry.
+
+    // Open the output writer and arm a cleanup guard so any failure path —
+    // parse error, delvec load, builder Add, builder Finish, close — and the
+    // "every entry dropped" path leave no OSS orphan. cancel() is called only
+    // after the output PB is fully built and ready to swap into the merged
+    // metadata.
+    ASSIGN_OR_RETURN(auto output_writer, open_legacy_rebuild_output(tablet_manager, merged_tablet_id));
+    CancelableDefer cleanup_partial_output([&] { delete_partial_legacy_rebuild_output(output_writer); });
+
+    // Stored rssids in the file are in pre-projection space. The read path at
+    // persistent_index_sstable.cpp:222-225 shifts them by src_pb.rssid_offset()
+    // to derive the effective rssid in the current child's id space. Apply the
+    // same shift before lookup so a stacked-offset legacy sstable still
+    // resolves correctly.
+    const int32_t source_rssid_offset = src_pb.rssid_offset();
+
+    // (4) Project src.max_rss_rowid through the rebuild before the scan so
+    // tombstone-only files and files whose source max points at a delete-only
+    // rowset still get a stable watermark.
+    uint64_t max_encoded_rss_rowid = 0;
+    bool max_encoded_initialized = false;
+    if (auto initial_max =
+                project_source_max_rss_rowid(src_pb, source_rssid_offset, rssid_lookup_maps.watermark_rssid_map)) {
+        max_encoded_rss_rowid = *initial_max;
+        max_encoded_initialized = true;
+    }
+
+    // (3) Per-rssid delvec cache. fill_cache=false / fill_data_cache=false so
+    // a one-shot bulk merge scan doesn't pollute long-lived block / delvec
+    // caches; the local cache here already deduplicates per-rssid loads.
+    std::unordered_map<uint32_t, DelVectorPtr> del_vector_cache;
+    auto load_del_vector = [&](uint32_t final_rssid) -> StatusOr<DelVectorPtr> {
+        auto cached_entry = del_vector_cache.find(final_rssid);
+        if (cached_entry != del_vector_cache.end()) return cached_entry->second;
+        const auto& delvecs_by_rssid = new_metadata.delvec_meta().delvecs();
+        auto delvec_page_entry = delvecs_by_rssid.find(final_rssid);
+        if (delvec_page_entry == delvecs_by_rssid.end() || delvec_page_entry->second.size() == 0) {
+            del_vector_cache.emplace(final_rssid, DelVectorPtr{});
+            return DelVectorPtr{};
+        }
+        DelVectorPtr del_vector = std::make_shared<DelVector>();
+        LakeIOOptions lake_io_options{.fill_data_cache = false, .skip_disk_cache = false};
+        RETURN_IF_ERROR(lake::get_del_vec(tablet_manager, new_metadata, delvec_page_entry->second,
+                                          /*fill_cache=*/false, lake_io_options, del_vector.get()));
+        del_vector_cache.emplace(final_rssid, del_vector);
+        return del_vector;
+    };
+
+    uint64_t kept_entry_count = 0;
+    uint64_t dropped_entry_count = 0;
+    for (; source_iterator->Valid(); source_iterator->Next()) {
+        const Slice entry_key = source_iterator->key();
+        if (!seek_range.stop_key.empty() && bytewise_comparator->Compare(entry_key, Slice(seek_range.stop_key)) >= 0) {
+            break; // (1) past merged tablet range upper bound
+        }
+        const Slice entry_raw_value = source_iterator->value();
+        IndexValuesWithVerPB values_pb;
+        if (!values_pb.ParseFromArray(entry_raw_value.data, static_cast<int>(entry_raw_value.size))) {
+            return Status::InternalError("Failed to parse legacy sstable value during rebuild");
+        }
+        // (2) + (3) per-entry remap and delvec filter, packed into one helper.
+        ASSIGN_OR_RETURN(bool keep_entry,
+                         remap_legacy_entry_or_drop(&values_pb, source_rssid_offset, rssid_lookup_maps.data_rssid_map,
+                                                    load_del_vector));
+        if (!keep_entry) {
+            ++dropped_entry_count;
+            continue;
+        }
+        update_max_encoded_rss_rowid_from(values_pb, &max_encoded_rss_rowid, &max_encoded_initialized);
+        const std::string serialized_entry = values_pb.SerializeAsString();
+        RETURN_IF_ERROR(output_writer.table_builder->Add(entry_key, Slice(serialized_entry)));
+        ++kept_entry_count;
+    }
+    RETURN_IF_ERROR(source_iterator->status());
+
+    if (dropped_entry_count > 0) {
+        g_tablet_merge_legacy_sstable_rebuild_dropped_entries << static_cast<int64_t>(dropped_entry_count);
+    }
+
+    if (kept_entry_count == 0) {
+        // Every entry was dropped (dead rowset / out-of-range / in delvec).
+        // The cleanup guard deletes the partial output file; signal to the
+        // caller that the sstable should be dropped from the merged metadata
+        // entirely.
+        return Status::OK();
+    }
+
+    RETURN_IF_ERROR(
+            finalize_legacy_rebuild_output(output_writer, max_encoded_initialized ? max_encoded_rss_rowid : 0, out_pb));
+    cleanup_partial_output.cancel(); // file is now referenced; keep it
+    g_tablet_merge_legacy_sstable_rebuild_total << 1;
+    return Status::OK();
+}
+
+// Emit the projected PB for one ancestor-inherited shared PK sstable into
+// |out_pb|. Tries the metadata-only fast-path first; on any safety miss
+// falls back to rebuild_legacy_shared_sstable. An empty out_pb after this
+// call means rebuild dropped every entry — the caller should NOT emit it
+// to the merged sstable_meta.
+Status emit_legacy_shared_sstable_via_fastpath_or_rebuild(TabletManager* tablet_manager, int64_t merged_tablet_id,
+                                                          const PersistentIndexSstablePB& src_pb,
+                                                          const TabletMetadataPtr& src_metadata,
+                                                          const TabletMetadataPB& new_metadata, uint32_t family_id,
+                                                          const detail::RssidProjectionPlan& plan,
+                                                          const LegacyRssidLookupMaps::PerFamilyMaps& rssid_lookup_maps,
+                                                          PersistentIndexSstablePB* out_pb) {
+    ASSIGN_OR_RETURN(bool fastpath_succeeded,
+                     try_fastpath_project_legacy_shared_sstable(src_pb, family_id, plan, new_metadata,
+                                                                rssid_lookup_maps, out_pb));
+    if (fastpath_succeeded) {
+        g_tablet_merge_legacy_sstable_fastpath_total << 1;
+        return Status::OK();
+    }
+    g_tablet_merge_legacy_sstable_fastpath_fallback_to_rebuild_total << 1;
+    return rebuild_legacy_shared_sstable(tablet_manager, merged_tablet_id, src_pb, src_metadata, new_metadata,
+                                         rssid_lookup_maps, out_pb);
+}
+
+// Rebuild a non-shared legacy sstable (shared=false, !has_shared_rssid)
+// by reading every entry, remapping stored rssid via ctx.map_rssid (which
+// honors the family-canonical projection), and writing a fresh non-shared
+// sstable. Used when the source sstable contains entries referencing both
+// shared-ancestor and child-local rowsets — typically a post-split PK-index
+// compaction output that crossed the shared-ancestor boundary — which a
+// single PB-level rssid_offset shift cannot translate uniformly.
+//
+// Differences from rebuild_legacy_shared_sstable:
+//   - SeekToFirst (non-shared sstable was written within this child's
+//     range, which is a subset of the merged range; no tablet-range
+//     filter needed).
+//   - No per-rssid delvec filter (matches v1 project_non_shared_legacy_-
+//     sstable; merged delvec is applied by the read path at lookup
+//     time, not pre-baked into the projected PB).
+//   - Per-entry remap via ctx.map_rssid instead of a family-scoped
+//     data_rssid_map (covers both shared-ancestor and child-local
+//     rowsets in a single funnel).
+//
+// On success out_pb carries a non-shared PB pointing at a new file with
+// rssid_offset=0 (entries are pre-remapped) and a fresh fileset_id. If
+// the source iterator is empty, out_pb stays empty and the caller drops
+// the sstable from merged metadata; the cleanup guard removes the
+// partial output on every error path.
+Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t merged_tablet_id,
+                                         const PersistentIndexSstablePB& src_pb, const TabletMergeContext& ctx,
+                                         const TabletMetadataPtr& src_metadata, PersistentIndexSstablePB* out_pb) {
+    out_pb->Clear();
+    // Mirror project_non_shared_legacy_sstable's existing corruption
+    // guard: a non-shared sstable must not carry an embedded delvec —
+    // the embedded delvec format only applies to shared_rssid=true PBs.
+    if (src_pb.has_delvec() && src_pb.delvec().size() > 0) {
+        return Status::Corruption(
+                "non-shared sstable has delvec but no shared_rssid, cannot rebuild during tablet merge");
+    }
+
+    // Open source iterator FIRST; emptiness must reach the drop-output
+    // path without going through map_rssid arithmetic that could error
+    // on an unrelated edge case (negative ctx offset + max_rss_rowid==0).
+    ASSIGN_OR_RETURN(auto source_sstable,
+                     PersistentIndexSstable::new_sstable(
+                             src_pb, tablet_manager->sst_location(src_metadata->id(), src_pb.filename()),
+                             /*cache=*/nullptr, /*need_filter=*/false,
+                             /*delvec=*/nullptr, src_metadata, tablet_manager));
+    sstable::ReadOptions source_read_options;
+    source_read_options.fill_cache = false;
+    std::unique_ptr<sstable::Iterator> source_iterator(source_sstable->new_iterator(source_read_options));
+    source_iterator->SeekToFirst();
+    if (!source_iterator->Valid()) {
+        RETURN_IF_ERROR(source_iterator->status());
+        // Zero-entry sstable: leave out_pb empty, caller drops it.
+        return Status::OK();
+    }
+
+    // Now safe to open the writer + project initial watermark.
+    ASSIGN_OR_RETURN(auto output_writer, open_legacy_rebuild_output(tablet_manager, merged_tablet_id));
+    CancelableDefer cleanup_partial_output([&] { delete_partial_legacy_rebuild_output(output_writer); });
+
+    const int32_t source_rssid_offset = src_pb.rssid_offset();
+    // Initial watermark: project the source max_rss_rowid.high through
+    // ctx.map_rssid so tombstone-only files still emit a stable
+    // post-merge watermark. Per-entry update_max_encoded_rss_rowid_from
+    // only widens this initial value as non-tombstone entries are
+    // written.
+    const uint32_t source_max_high = extract_rss_rowid_high(src_pb.max_rss_rowid());
+    ASSIGN_OR_RETURN(uint32_t projected_max_high, ctx.map_rssid(source_max_high));
+    uint64_t max_encoded_rss_rowid =
+            encode_rss_rowid(projected_max_high, extract_rss_rowid_low(src_pb.max_rss_rowid()));
+    bool max_encoded_initialized = true;
+
+    uint64_t kept_entry_count = 0;
+    for (; source_iterator->Valid(); source_iterator->Next()) {
+        const Slice entry_key = source_iterator->key();
+        const Slice entry_raw_value = source_iterator->value();
+        IndexValuesWithVerPB values_pb;
+        if (!values_pb.ParseFromArray(entry_raw_value.data, static_cast<int>(entry_raw_value.size))) {
+            return Status::InternalError("Failed to parse non-shared sstable value during rebuild");
+        }
+        for (int j = 0; j < values_pb.values_size(); ++j) {
+            auto* index_value = values_pb.mutable_values(j);
+            if (is_index_tombstone(*index_value)) continue; // preserve sentinel as-is
+            const int64_t lifted_rssid =
+                    static_cast<int64_t>(index_value->rssid()) + static_cast<int64_t>(source_rssid_offset);
+            if (lifted_rssid < 0 || lifted_rssid > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+                return Status::Corruption(fmt::format(
+                        "non-shared rebuild: lifted rssid out of uint32 range: stored={} src_offset={} lifted={}",
+                        index_value->rssid(), source_rssid_offset, lifted_rssid));
+            }
+            ASSIGN_OR_RETURN(uint32_t final_rssid, ctx.map_rssid(static_cast<uint32_t>(lifted_rssid)));
+            index_value->set_rssid(final_rssid);
+        }
+        update_max_encoded_rss_rowid_from(values_pb, &max_encoded_rss_rowid, &max_encoded_initialized);
+        const std::string serialized_entry = values_pb.SerializeAsString();
+        RETURN_IF_ERROR(output_writer.table_builder->Add(entry_key, Slice(serialized_entry)));
+        ++kept_entry_count;
+    }
+    RETURN_IF_ERROR(source_iterator->status());
+
+    if (kept_entry_count == 0) {
+        // Defensive: SeekToFirst returned Valid() above, so this should
+        // be unreachable, but covers the case where every Add() somehow
+        // got skipped without an error.
+        return Status::OK();
+    }
+
+    RETURN_IF_ERROR(finalize_legacy_rebuild_output(output_writer, max_encoded_rss_rowid, out_pb));
+    cleanup_partial_output.cancel();
+    g_tablet_merge_non_shared_sstable_rebuild_total << 1;
+    return Status::OK();
+}
+
+// Project a sstable that has shared_rssid set (modern shared or
+// `ingest_sst()` output). |out| was already CopyFrom'd from |sst|; this
+// function rewrites the projection-affected fields in place.
+//
+// Always re-attaches the merged delvec from |new_metadata->delvec_meta()|
+// regardless of whether the source carried one — this is what lets a
+// synthesized gap-delvec (created by merge_delvecs Phase 0 for keys covered
+// by no contributing child) reach the rebuilt sstable PB. Without it,
+// PersistentIndexSstable::multi_get could return stale rssids when the LSM
+// block-sort order is inverted.
+Status project_modern_shared_rssid_sstable(const PersistentIndexSstablePB& sst, TabletMergeContext& ctx,
+                                           const TabletMetadataPB* new_metadata, PersistentIndexSstablePB* out) {
+    ASSIGN_OR_RETURN(auto mapped_rssid, ctx.map_rssid(sst.shared_rssid()));
+    out->set_shared_rssid(mapped_rssid);
+    out->set_rssid_offset(0); // shared_rssid is post-projection; clear to avoid double-transform on read
+    out->set_max_rss_rowid(encode_rss_rowid(mapped_rssid, extract_rss_rowid_low(sst.max_rss_rowid())));
+
+    auto delvec_entry = new_metadata->delvec_meta().delvecs().find(mapped_rssid);
+    if (delvec_entry != new_metadata->delvec_meta().delvecs().end() && delvec_entry->second.size() > 0) {
+        out->mutable_delvec()->CopyFrom(delvec_entry->second);
+    } else if (sst.has_delvec() && sst.delvec().size() > 0) {
+        return Status::Corruption("Delvec page not found for sstable after merge");
+    }
+    return Status::OK();
+}
+
+// Project a non-shared sstable without shared_rssid: a child-local file
+// produced by flush_pk_memtable for THIS merge round, or a rebuilt legacy
+// file from a prior merge. Stored rssids already live in the child's id
+// space, so a single ctx.rssid_offset() shift suffices. The accumulation
+// preserves correctness when the file already carries a non-zero
+// rssid_offset (stacked merge case).
+Status project_non_shared_legacy_sstable(const PersistentIndexSstablePB& sst, const TabletMergeContext& ctx,
+                                         PersistentIndexSstablePB* out) {
+    if (sst.has_delvec() && sst.delvec().size() > 0) {
+        return Status::Corruption("Sstable has delvec but no shared_rssid, cannot project delvec");
+    }
+    const int64_t accumulated_offset = static_cast<int64_t>(sst.rssid_offset()) + ctx.rssid_offset();
+    if (accumulated_offset < std::numeric_limits<int32_t>::min() ||
+        accumulated_offset > std::numeric_limits<int32_t>::max()) {
+        return Status::Corruption(
+                fmt::format("accumulated rssid_offset exceeds int32 range: sst_offset={} ctx_offset={} sum={}",
+                            sst.rssid_offset(), ctx.rssid_offset(), accumulated_offset));
+    }
+    out->set_rssid_offset(static_cast<int32_t>(accumulated_offset));
+    const int64_t high = static_cast<int64_t>(extract_rss_rowid_high(sst.max_rss_rowid()));
+    const int64_t new_high = high + ctx.rssid_offset();
+    if (new_high < 0 || new_high > std::numeric_limits<uint32_t>::max()) {
+        return Status::Corruption(
+                fmt::format("rssid high overflow in merge projection: high={} ctx_offset={} new_high={}", high,
+                            ctx.rssid_offset(), new_high));
+    }
+    out->set_max_rss_rowid(
+            encode_rss_rowid(static_cast<uint32_t>(new_high), extract_rss_rowid_low(sst.max_rss_rowid())));
+    out->clear_delvec();
+    return Status::OK();
+}
+
+// Two invariants must hold on the emitted sstable_meta after merge_sstables's
+// per-ctx projection:
+//
+//   (I1) Global signed-monotone non-decreasing max_rss_rowid.
+//        LakePersistentIndex::commit (lake_persistent_index.cpp:907-911)
+//        fetches max_rss_rowid into an int64_t and rejects last > cur with
+//        "sstables are not ordered". The signed comparison matters when the
+//        encoded (rssid<<32|rowid) sets the high bit (rssid >= 2^31 or
+//        memtable_max set to (rowset_id<<32|UINT32_MAX) per
+//        persistent_index_memtable.cpp:110) — unsigned ordering would be
+//        the reverse of signed against any low-rssid sibling.
+//
+//   (I2) Same fileset_id sstables are contiguous in metadata order.
+//        LakePersistentIndex::init (lake_persistent_index.cpp:131-145) groups
+//        sstables into PersistentIndexSstableFileset by consecutive equal
+//        fileset_id. lake_persistent_index_size_tiered_compaction_strategy
+//        .cpp:83-87 rejects non-contiguous reuse with "inconsistent
+//        fileset_id in sstables", and apply_opcompaction's contiguous-range
+//        find_if (lake_persistent_index.cpp:865-885) erases the wrong span
+//        otherwise.
+//
+// Source of conflict between I1 and I2: PersistentIndexSstableFileset::
+// append() (persistent_index_sstable_fileset.cpp:96-115) lets a freshly-
+// flushed sstable inherit an existing fileset's _fileset_id whenever the
+// new sstable's key range strictly extends the existing range. In a
+// multi-cycle SPLIT/MERGE flow, flush_pk_memtable on each merge context can
+// add a per-child sstable that inherits the same source FID-X from a long-
+// lived shared sstable. After projection these per-child flushes spread
+// across a wide max_rss_rowid range intermixed with other-FID compaction
+// outputs, so a single sort by max_rss_rowid necessarily produces multiple
+// non-contiguous runs of FID-X.
+//
+// Resolution: stable_sort by signed max_rss_rowid (satisfies I1), then walk
+// the sorted output and detect when a fileset_id reappears after at least
+// one other-FID sstable has closed its earlier run. Any such later run
+// cannot share a logical fileset with the earlier one — there is at least
+// one foreign sstable physically between them in metadata, so init() /
+// pick_compaction_candidates / apply_opcompaction would have to treat them
+// as separate filesets anyway. Assign a fresh fileset_id (UniqueId::
+// gen_uid) to each later run so I2 is satisfied without sacrificing I1.
+// Sstables with no fileset_id remain singletons and close any open run;
+// they are not grouped with anything.
+void reassign_fileset_ids_for_ordered_runs(google::protobuf::RepeatedPtrField<PersistentIndexSstablePB>* dest) {
+    std::vector<PersistentIndexSstablePB> sorted;
+    sorted.reserve(dest->size());
+    for (const auto& sst : *dest) {
+        sorted.emplace_back(sst);
+    }
+    std::stable_sort(sorted.begin(), sorted.end(),
+                     [](const PersistentIndexSstablePB& a, const PersistentIndexSstablePB& b) {
+                         return static_cast<int64_t>(a.max_rss_rowid()) < static_cast<int64_t>(b.max_rss_rowid());
+                     });
+
+    std::unordered_set<UniqueId> closed_orig_fids;
+    UniqueId current_run_orig;
+    UniqueId current_run_emitted;
+    bool has_run = false;
+    for (auto& sst : sorted) {
+        if (!sst.has_fileset_id()) {
+            // No fileset_id (legacy / standalone): cannot be grouped. Close
+            // any open run so a same-FID sstable after this one will be
+            // treated as a non-contiguous reuse.
+            if (has_run) {
+                closed_orig_fids.insert(current_run_orig);
+                has_run = false;
+            }
+            continue;
+        }
+        UniqueId orig(sst.fileset_id());
+        if (has_run && orig == current_run_orig) {
+            // Continuation of the current run: emit with this run's FID
+            // (which may be the original or a freshly-assigned one).
+            sst.mutable_fileset_id()->CopyFrom(current_run_emitted.to_proto());
+            continue;
+        }
+        // Run boundary.
+        if (has_run) {
+            closed_orig_fids.insert(current_run_orig);
+        }
+        UniqueId emitted = (closed_orig_fids.count(orig) > 0) ? UniqueId::gen_uid() : orig;
+        sst.mutable_fileset_id()->CopyFrom(emitted.to_proto());
+        current_run_orig = orig;
+        current_run_emitted = emitted;
+        has_run = true;
+    }
+
+    dest->Clear();
+    for (auto& sst : sorted) {
+        *dest->Add() = std::move(sst);
+    }
+}
+
+// Source-effective rssid range that a sstable's stored entries could
+// reference, clamped to the uint32_t key space the per-ctx
+// disagreement-key vector indexes by. Both bounds are inclusive.
+//
+// The signed arithmetic matters because compute_rssid_offset can
+// produce a negative ctx.rssid_offset() when ctx[N>0]'s input rowset
+// ids exceed ctx[0]'s next_rowset_id (legal — exercised by
+// test_tablet_merging_accumulates_stacked_rssid_offset). Casting a
+// negative low to uint32_t directly would wrap to a huge value and
+// silently miss in-range disagreement keys.
+struct ClampedLiftedRange {
+    uint32_t lower = 0;
+    uint32_t upper = 0;
+    bool valid() const { return lower <= upper; }
+};
+
+ClampedLiftedRange clamp_lifted_range_to_uint32(int32_t source_rssid_offset, uint64_t source_max_rss_rowid_high) {
+    constexpr int64_t kUint32Max = std::numeric_limits<uint32_t>::max();
+    const int64_t low_signed = static_cast<int64_t>(source_rssid_offset) + 1;
+    const int64_t high_signed = static_cast<int64_t>(source_max_rss_rowid_high);
+    ClampedLiftedRange range;
+    range.lower = static_cast<uint32_t>(std::max<int64_t>(0, low_signed));
+    range.upper = (high_signed < 0) ? 0u : static_cast<uint32_t>(std::min(high_signed, kUint32Max));
+    return range;
+}
+
+// Resolve the family-canonical projection plan for a ctx. Non-PK merges
+// leave the plan pointer null; the fast-path emit still wants a plan
+// reference, so an empty static instance acts as a safe identity.
+const detail::RssidProjectionPlan& projection_plan_or_empty(const TabletMergeContext& ctx) {
+    static const detail::RssidProjectionPlan kEmptyPlan{};
+    const auto* plan = ctx.projection_plan();
+    return (plan != nullptr) ? *plan : kEmptyPlan;
+}
+
+// Returns the highest (rowset.id + step + ctx.rssid_offset) seen across
+// merge_contexts[0..upper_exclusive), or |base_next_rowset_id| if higher.
+// Phase 1 in merge_tablet uses this as the watermark for ctx[i]'s
+// rssid_offset assignment so each child's projected rowset ids land
+// strictly above every earlier child's projected ids.
+//
+// Each uint32_t addend is widened to int64_t before the addition to avoid
+// uint32_t wrap when rowset.id() approaches UINT32_MAX — wrap there would
+// under-estimate the watermark and let later children reuse occupied rssids.
+uint32_t compute_cumulative_rowset_id_ceiling(const std::vector<TabletMergeContext>& merge_contexts,
+                                              size_t upper_exclusive, uint32_t base_next_rowset_id) {
+    uint32_t ceiling = base_next_rowset_id;
+    for (size_t j = 0; j < upper_exclusive; ++j) {
+        for (const auto& rowset : merge_contexts[j].metadata()->rowsets()) {
+            const int64_t end_wide = static_cast<int64_t>(rowset.id()) +
+                                     static_cast<int64_t>(get_rowset_id_step(rowset)) +
+                                     merge_contexts[j].rssid_offset();
+            const uint32_t end =
+                    static_cast<uint32_t>(std::clamp<int64_t>(end_wide, 0, std::numeric_limits<uint32_t>::max()));
+            ceiling = std::max(ceiling, end);
+        }
+    }
+    return ceiling;
+}
+
+// Emit one ancestor-inherited shared PK sstable (shared=true,
+// !has_shared_rssid) into dest via the fast-path or its rebuild fallback.
+// Resolves family_id, the family's PerFamilyMaps, and the projection plan
+// from ctx. Drops sstables whose rebuild emitted no entries (matches the
+// cleanup contract documented on rebuild_legacy_shared_sstable).
+Status emit_legacy_shared_sstable_into_dest(TabletManager* tablet_manager, const TabletMergeContext& ctx,
+                                            size_t child_index, const PersistentIndexSstablePB& src_pb,
+                                            const TabletMetadataPB& new_metadata,
+                                            const detail::InferredSplitFamilies& families,
+                                            const LegacyRssidLookupMaps& rssid_lookup_maps,
+                                            ::google::protobuf::RepeatedPtrField<PersistentIndexSstablePB>* dest) {
+    const uint32_t family_id = families.child_to_family[child_index];
+    ASSIGN_OR_RETURN(const auto* family_maps_ptr, lookup_maps_for_ctx(rssid_lookup_maps, family_id, child_index));
+    PersistentIndexSstablePB projected_pb;
+    RETURN_IF_ERROR(emit_legacy_shared_sstable_via_fastpath_or_rebuild(
+            tablet_manager, new_metadata.id(), src_pb, ctx.metadata(), new_metadata, family_id,
+            projection_plan_or_empty(ctx), *family_maps_ptr, &projected_pb));
+    if (!projected_pb.filename().empty()) {
+        dest->Add()->Swap(&projected_pb);
+    }
+    return Status::OK();
+}
+
+// Emit one non-shared legacy PK sstable (shared=false, !has_shared_rssid)
+// into dest. Routes through the per-entry rebuild path when the projection
+// plan would map some referenced rssid to a value that disagrees with the
+// natural ctx.rssid_offset shift; otherwise the metadata-only
+// project_non_shared_legacy_sstable path applies.
+Status emit_non_shared_legacy_sstable_into_dest(TabletManager* tablet_manager, const TabletMergeContext& ctx,
+                                                const PersistentIndexSstablePB& src_pb,
+                                                const TabletMetadataPB& new_metadata,
+                                                const std::vector<uint32_t>& ctx_disagreement_keys,
+                                                ::google::protobuf::RepeatedPtrField<PersistentIndexSstablePB>* dest) {
+    const auto lifted_range =
+            clamp_lifted_range_to_uint32(src_pb.rssid_offset(), extract_rss_rowid_high(src_pb.max_rss_rowid()));
+    const bool needs_rebuild = lifted_range.valid() && !ctx_disagreement_keys.empty() &&
+                               TabletMergeContext::mapping_disagrees_with_natural_in_range(
+                                       ctx_disagreement_keys, lifted_range.lower, lifted_range.upper);
+    if (needs_rebuild) {
+        PersistentIndexSstablePB rebuilt_pb;
+        RETURN_IF_ERROR(rebuild_non_shared_legacy_sstable(tablet_manager, new_metadata.id(), src_pb, ctx,
+                                                          ctx.metadata(), &rebuilt_pb));
+        if (!rebuilt_pb.filename().empty()) {
+            dest->Add()->Swap(&rebuilt_pb);
+        }
+        return Status::OK();
+    }
+    auto* out = dest->Add();
+    out->CopyFrom(src_pb);
+    return project_non_shared_legacy_sstable(src_pb, ctx, out);
+}
+
 Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeContext>& merge_contexts,
                       TabletMetadataPB* new_metadata) {
     auto* dest = new_metadata->mutable_sstable_meta()->mutable_sstables();
-    // key: filename -> index in dest, for shared dedup + consistency check
-    std::unordered_map<std::string, int> shared_dedup;
+    // Tracks shared sstables by filename so subsequent occurrences across child
+    // contexts are deduped + consistency-checked against the original source PB.
+    // We cache the SOURCE PB (not an index into dest) because the legacy-shared
+    // rebuild path can either replace the emitted PB with one that has a
+    // different filename/filesize, or drop it from dest entirely — either of
+    // which would invalidate an index-based cache.
+    std::unordered_map<std::string, PersistentIndexSstablePB> shared_dedup_sources;
 
     auto* update_manager = tablet_manager->update_mgr();
-    for (auto& ctx : merge_contexts) {
+
+    // PK-index memtable flush has to run first (below) before the lookup maps
+    // can be built — flushed metadata may add new rowsets the legacy path needs
+    // to remap into. Build the maps lazily once after the flush phase, and
+    // reuse them for both the fast-path and the rebuild fallback.
+    bool rssid_lookup_maps_initialized = false;
+    LegacyRssidLookupMaps rssid_lookup_maps;
+    detail::InferredSplitFamilies inferred_families;
+    auto ensure_rssid_lookup_maps = [&]() -> Status {
+        if (rssid_lookup_maps_initialized) return Status::OK();
+        // Family inference and lookup-map population must consume the same
+        // merge_contexts snapshot so per-ctx child_index → family_id mapping
+        // remains in lockstep with per-ctx contributions to the per-family
+        // PerFamilyMaps.
+        std::vector<detail::SplitFamilyInferenceInput> inference_inputs;
+        inference_inputs.reserve(merge_contexts.size());
+        for (const auto& ctx : merge_contexts) {
+            inference_inputs.push_back({ctx.metadata(), ctx.rssid_offset()});
+        }
+        ASSIGN_OR_RETURN(inferred_families, detail::infer_split_families(inference_inputs));
+        ASSIGN_OR_RETURN(rssid_lookup_maps, build_legacy_rssid_lookup_maps(merge_contexts, inferred_families));
+        rssid_lookup_maps_initialized = true;
+        return Status::OK();
+    };
+    for (size_t child_index = 0; child_index < merge_contexts.size(); ++child_index) {
+        auto& ctx = merge_contexts[child_index];
         // Flush the tablet's PK-index memtable into sstables so that the
         // inherited sstable_meta covers all live data of its rowsets. Covers
         // the case where a child accumulated post-split DML that never
@@ -1176,153 +2634,63 @@ Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeCont
         ctx.set_metadata(std::move(flushed_metadata));
         if (!ctx.metadata()->has_sstable_meta()) continue;
 
+        // Compute the per-ctx disagreement-keys cache ONCE outside the
+        // sstable loop. Each non-shared sstable then range-tests this
+        // cache via binary search instead of re-walking the projection
+        // plan + shared_rssid_map. Empty when ctx has no plan-driven
+        // disagreement (= ctx is canonical, ctx is non-PK, or no rowsets
+        // disagree with natural offset).
+        const std::vector<uint32_t> ctx_disagreement_keys = ctx.compute_disagreement_keys();
+
         for (const auto& sst : ctx.metadata()->sstable_meta().sstables()) {
-            // Dedup: only shared sstables can be duplicates
+            // (1) Dedup: only shared sstables can be duplicates across ctxs.
+            // The dedup map caches the SOURCE PB (not a dest index)
+            // because the rebuild path may replace or drop the projected
+            // PB, which would invalidate an index-based cache.
             if (sst.shared()) {
-                auto [it, inserted] = shared_dedup.emplace(sst.filename(), dest->size());
+                auto [it, inserted] = shared_dedup_sources.emplace(sst.filename(), sst);
                 if (!inserted) {
-                    // Dedup hit: check the fields that identify the physical file.
-                    // fileset_id is intentionally excluded: it is a grouping hint that
-                    // PersistentIndexSstableFileset::init may synthesize per-load when
-                    // the source sstable has no persisted id, so two ctxs sharing the
-                    // same legacy file can legitimately hold different ids. The merged
-                    // tablet re-derives grouping from whatever id the dedup keeps.
-                    const auto& existing = dest->Get(it->second);
-                    if (existing.filesize() != sst.filesize() || existing.encryption_meta() != sst.encryption_meta() ||
-                        existing.range().start_key() != sst.range().start_key() ||
-                        existing.range().end_key() != sst.range().end_key()) {
+                    if (!shared_sstable_metadata_matches(it->second, sst)) {
                         return Status::Corruption("Shared sstable metadata mismatch for same filename");
                     }
-                    continue; // skip duplicate
+                    continue; // duplicate, already projected/rebuilt
                 }
             }
 
-            // Projection: branch on has_shared_rssid, not on shared flag
-            auto* out = dest->Add();
-            out->CopyFrom(sst);
+            // (2) Ancestor-inherited shared PK sstable (shared=true,
+            // !has_shared_rssid): legacy form, may need rebuild after
+            // multi-cycle split/merge with partial-child compaction.
+            // The current ctx is the dedup-winner by construction:
+            // shared_dedup_sources only emplaces on first sighting.
+            if (sst.shared() && !sst.has_shared_rssid()) {
+                RETURN_IF_ERROR(ensure_rssid_lookup_maps());
+                RETURN_IF_ERROR(emit_legacy_shared_sstable_into_dest(tablet_manager, ctx, child_index, sst,
+                                                                     *new_metadata, inferred_families,
+                                                                     rssid_lookup_maps, dest));
+                continue;
+            }
 
+            // (3) Modern projection: shared sstable with has_shared_rssid
+            // (split-derived single-rowset slice).
             if (sst.has_shared_rssid()) {
-                // shared_rssid path: project rssid, clear offset, project delvec
-                ASSIGN_OR_RETURN(auto mapped_rssid, ctx.map_rssid(sst.shared_rssid()));
-                out->set_shared_rssid(mapped_rssid);
-                out->set_rssid_offset(0); // clear to avoid double-transform in read path
-
-                // max_rss_rowid: replace high part with mapped rssid
-                uint64_t low = sst.max_rss_rowid() & 0xffffffffULL;
-                out->set_max_rss_rowid((static_cast<uint64_t>(mapped_rssid) << 32) | low);
-
-                // delvec projection via new_metadata->delvec_meta()
-                if (sst.has_delvec() && sst.delvec().size() > 0) {
-                    auto dv_it = new_metadata->delvec_meta().delvecs().find(mapped_rssid);
-                    if (dv_it == new_metadata->delvec_meta().delvecs().end()) {
-                        return Status::Corruption("Delvec page not found for sstable after merge");
-                    }
-                    out->mutable_delvec()->CopyFrom(dv_it->second);
-                }
-            } else {
-                // No shared_rssid (legacy format): accumulate rssid_offset so that a
-                // stacked merge (parent sstable already has an offset from a prior
-                // merge) composes correctly. The read path at
-                // persistent_index_sstable.cpp:214 adds the sstable's rssid_offset
-                // once to each stored rssid, so the stored offset must be the total
-                // cumulative shift from the original rowset-id to the current tablet.
-                if (sst.has_delvec() && sst.delvec().size() > 0) {
-                    return Status::Corruption("Sstable has delvec but no shared_rssid, cannot project delvec");
-                }
-                const int64_t accumulated_offset = static_cast<int64_t>(sst.rssid_offset()) + ctx.rssid_offset();
-                if (accumulated_offset < std::numeric_limits<int32_t>::min() ||
-                    accumulated_offset > std::numeric_limits<int32_t>::max()) {
-                    return Status::Corruption(fmt::format(
-                            "accumulated rssid_offset exceeds int32 range: sst_offset={} ctx_offset={} sum={}",
-                            sst.rssid_offset(), ctx.rssid_offset(), accumulated_offset));
-                }
-                out->set_rssid_offset(static_cast<int32_t>(accumulated_offset));
-                uint64_t low = sst.max_rss_rowid() & 0xffffffffULL;
-                int64_t high = static_cast<int64_t>(sst.max_rss_rowid() >> 32);
-                const int64_t new_high = high + ctx.rssid_offset();
-                if (new_high < 0 || new_high > std::numeric_limits<uint32_t>::max()) {
-                    return Status::Corruption(
-                            fmt::format("rssid high overflow in merge projection: high={} ctx_offset={} new_high={}",
-                                        high, ctx.rssid_offset(), new_high));
-                }
-                out->set_max_rss_rowid((static_cast<uint64_t>(new_high) << 32) | low);
-                out->clear_delvec();
+                auto* out = dest->Add();
+                out->CopyFrom(sst);
+                RETURN_IF_ERROR(project_modern_shared_rssid_sstable(sst, ctx, new_metadata, out));
+                continue;
             }
+
+            // (4) Non-shared, non-modern: child-local PK sstable.
+            RETURN_IF_ERROR(emit_non_shared_legacy_sstable_into_dest(tablet_manager, ctx, sst, *new_metadata,
+                                                                     ctx_disagreement_keys, dest));
         }
     }
 
-    // The merge above appends sstables in source-child iteration order. The post-projection
-    // max_rss_rowid is what LakePersistentIndex::commit() and the size-tiered compaction
-    // strategy use to enforce the index-wide ordering invariant. If different children
-    // contributed sstables whose projected (rssid<<32|rowid) values interleave — for
-    // example, when a tombstone-bearing delete-only sstable in one child has its low
-    // word saturated near UINT32_MAX and a freshly-written sstable in the next child
-    // has a smaller projected high word — the source-order output would carry the
-    // disorder forward and any later commit/compaction on the merged tablet would
-    // refuse to publish with "sstables are not ordered". Reorder defensively here so
-    // the merged metadata always satisfies the invariant.
-    //
-    // Constraint: a single naive sort by max_rss_rowid alone breaks a separate invariant
-    // that LakePersistentIndex::init() and apply_opcompaction rely on — sstables sharing
-    // the same fileset_id must be contiguous in metadata order. Same fileset_id sstables
-    // can span a wide max_rss_rowid range (a fileset accretes via append() across
-    // multiple memtable flushes, persistent_index_sstable_fileset.cpp:96), and other
-    // fileset_ids' sstables can fall within that range. A flat sort by max_rss_rowid
-    // would interleave them, splitting one logical fileset into multiple physical
-    // filesets in init()'s grouping (which keys on adjacent fileset_id) and confusing
-    // apply_opcompaction's contiguous-range find_if (lake_persistent_index.cpp:838).
-    //
-    // Approach: bucket source-order entries into contiguous-fileset_id blocks, sort
-    // blocks by their first element's max_rss_rowid, and emit. This:
-    //   * Keeps same-fileset_id sstables together (init / apply_opcompaction invariant).
-    //   * Within a block, preserves source order — already monotonic in max_rss_rowid
-    //     per source child since the projection paths preserve relative order
-    //     (rssid_offset path adds a constant; shared_rssid path collapses to a single
-    //     mapped_rssid with low word in range order).
-    //   * Across blocks, orders by first-element max_rss_rowid — the sort key the flat
-    //     sort would have used. Cross-block monotonicity matches the original PR's
-    //     intent for cross-source ordering.
-    //
-    // Compare as `int64_t` rather than `uint64_t` to match the downstream check:
-    // LakePersistentIndex::commit() (lake_persistent_index.cpp:880-881) fetches
-    // max_rss_rowid into an `int64_t` and does a signed `>` comparison. When the
-    // encoded (rssid<<32|rowid) sets the high bit — e.g. an ingest_sst entry with
-    // rssid >= 2^31, or a delete-only sstable whose memtable max_rss_rowid was set to
-    // (rowset_id<<32|UINT32_MAX) (persistent_index_memtable.cpp:110, 131) — unsigned
-    // ordering is the reverse of signed ordering against any low-rssid sibling.
-    // Sstables without an explicit fileset_id are not part of any logical fileset
-    // group (they predate fileset_id, or are test fixtures). Treat each as its own
-    // singleton block so block-sort orders them by max_rss_rowid like the original
-    // flat sort would. When both sides have a fileset_id, only consider them in the
-    // same block if the ids match.
-    auto same_block_as_predecessor = [](const PersistentIndexSstablePB& prev, const PersistentIndexSstablePB& cur) {
-        if (!prev.has_fileset_id() || !cur.has_fileset_id()) return false;
-        return prev.fileset_id().hi() == cur.fileset_id().hi() && prev.fileset_id().lo() == cur.fileset_id().lo();
-    };
-
-    struct SstableBlock {
-        std::vector<PersistentIndexSstablePB> sstables;
-        int64_t sort_key = 0;
-    };
-    std::vector<SstableBlock> blocks;
-    blocks.reserve(dest->size());
-    for (const auto& sst : *dest) {
-        if (blocks.empty() || !same_block_as_predecessor(blocks.back().sstables.back(), sst)) {
-            blocks.emplace_back();
-            blocks.back().sort_key = static_cast<int64_t>(sst.max_rss_rowid());
-        }
-        blocks.back().sstables.push_back(sst);
-    }
-    std::stable_sort(blocks.begin(), blocks.end(),
-                     [](const SstableBlock& a, const SstableBlock& b) { return a.sort_key < b.sort_key; });
-
-    dest->Clear();
-    for (const auto& block : blocks) {
-        for (const auto& sst : block.sstables) {
-            *dest->Add() = sst;
-        }
-    }
-
+    // The merge above appended projected sstables in source-child iteration
+    // order. Re-sort by signed max_rss_rowid and reassign fileset_ids on
+    // non-contiguous reuse so the emitted sstable_meta satisfies both the
+    // signed-monotone (I1) and contiguous-fileset (I2) invariants. See the
+    // helper for the full reasoning.
+    reassign_fileset_ids_for_ordered_runs(dest);
     return Status::OK();
 }
 
@@ -1348,11 +2716,11 @@ void update_next_rowset_id(TabletMetadataPB* metadata) {
     // is strictly greater than every projected sstable rssid.
     if (metadata->has_sstable_meta()) {
         for (const auto& sst : metadata->sstable_meta().sstables()) {
-            uint64_t projected_high = sst.max_rss_rowid() >> 32;
-            // Clamp the projected high to uint32 range; rssids are uint32 elsewhere
-            // and any saturated high word would already break the rssid encoding.
+            const uint32_t projected_high = extract_rss_rowid_high(sst.max_rss_rowid());
+            // Saturated UINT32_MAX would already break the rssid encoding, so
+            // bumping past it is meaningless — leave max_end alone there.
             if (projected_high < std::numeric_limits<uint32_t>::max()) {
-                max_end = std::max(max_end, static_cast<uint32_t>(projected_high) + 1);
+                max_end = std::max(max_end, projected_high + 1);
             }
         }
     }
@@ -1439,18 +2807,15 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     new_tablet_metadata->clear_prev_garbage_version();
     new_tablet_metadata->set_cumulative_point(0);
 
-    // Phase 1: Prepare rssid offsets and merged range
+    // Phase 1: Prepare rssid offsets and merged range. For each ctx[i],
+    // set new_tablet_metadata.next_rowset_id to the watermark of all
+    // earlier ctxs[0..i-1]'s projected rowset ids; compute_rssid_offset
+    // then derives ctx[i].rssid_offset against that watermark so its
+    // projected ids land strictly above every earlier ctx's.
     for (size_t i = 1; i < merge_contexts.size(); ++i) {
-        // Temporarily set next_rowset_id for compute_rssid_offset
-        uint32_t temp_next = merge_contexts.front().metadata()->next_rowset_id();
-        for (size_t j = 0; j < i; ++j) {
-            for (const auto& rowset : merge_contexts[j].metadata()->rowsets()) {
-                uint32_t end = static_cast<uint32_t>(static_cast<int64_t>(rowset.id() + get_rowset_id_step(rowset)) +
-                                                     merge_contexts[j].rssid_offset());
-                temp_next = std::max(temp_next, end);
-            }
-        }
-        new_tablet_metadata->set_next_rowset_id(temp_next);
+        const uint32_t cumulative_ceiling = compute_cumulative_rowset_id_ceiling(
+                merge_contexts, /*upper_exclusive=*/i, merge_contexts.front().metadata()->next_rowset_id());
+        new_tablet_metadata->set_next_rowset_id(cumulative_ceiling);
         merge_contexts[i].set_rssid_offset(compute_rssid_offset(*new_tablet_metadata, *merge_contexts[i].metadata()));
     }
 
@@ -1462,8 +2827,41 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     }
     new_tablet_metadata->mutable_range()->CopyFrom(merged_range);
 
-    // Phase 2: Merge rowsets (version-driven k-way merge with dedup)
-    RETURN_IF_ERROR(merge_rowsets(merge_contexts, new_tablet_metadata.get()));
+    // Phase 1.5: build the family-canonical projection plan once Phase 1
+    // has populated rssid_offset, and wire (_child_index, _projection_plan)
+    // onto every TabletMergeContext. The plan drives three consumers:
+    //   - TabletMergeContext::map_rssid (priority 1 lookup);
+    //   - the legacy-sstable fast-path (plan.family_legacy_sstable_offset
+    //     + per-family LegacyRssidLookupMaps);
+    //   - merge_sstables's non-shared dispatch via
+    //     mapping_disagrees_with_natural_in_range, which routes mixed-
+    //     reference sstables to rebuild_non_shared_legacy_sstable.
+    //
+    // PK gate only — non-PK tables skip the build and leave the plan
+    // pointer null; map_rssid then degenerates to the
+    // shared_rssid_map → natural offset path.
+    detail::InferredSplitFamilies inferred_families;
+    detail::RssidProjectionPlan projection_plan;
+    if (is_primary_key(*new_tablet_metadata)) {
+        std::vector<detail::SplitFamilyInferenceInput> inference_inputs;
+        inference_inputs.reserve(merge_contexts.size());
+        for (const auto& ctx : merge_contexts) {
+            inference_inputs.push_back({ctx.metadata(), ctx.rssid_offset()});
+        }
+        ASSIGN_OR_RETURN(inferred_families, detail::infer_split_families(inference_inputs));
+        ASSIGN_OR_RETURN(projection_plan, detail::build_rssid_projection_plan(inference_inputs, inferred_families));
+        for (size_t i = 0; i < merge_contexts.size(); ++i) {
+            merge_contexts[i].set_child_index(static_cast<uint32_t>(i));
+            merge_contexts[i].set_projection_plan(&projection_plan);
+        }
+    }
+
+    // Phase 2: Merge rowsets (version-driven k-way merge with dedup).
+    // canonical_contribs collects each canonical rowset's contributing
+    // children's child-local ranges; consumed by the PK fail-fast coverage
+    // check below and by gap-delvec synthesis.
+    CanonicalContribMap canonical_contribs;
+    RETURN_IF_ERROR(merge_rowsets(merge_contexts, new_tablet_metadata.get(), &canonical_contribs));
 
     // Phase 2.5: Merge schemas (must run before merge_dcg_meta, which needs
     // historical_schemas to locate rebuild schemas for shared-segment rebuild).
@@ -1474,8 +2872,8 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
                                    txn_info.txn_id(), new_tablet_metadata.get()));
 
     if (is_primary_key(*new_tablet_metadata)) {
-        RETURN_IF_ERROR(merge_delvecs(tablet_manager, merge_contexts, new_version, txn_info.txn_id(),
-                                      new_tablet_metadata.get()));
+        RETURN_IF_ERROR(merge_delvecs(tablet_manager, merge_contexts, canonical_contribs, new_version,
+                                      txn_info.txn_id(), new_tablet_metadata.get()));
     }
 
     RETURN_IF_ERROR(merge_sstables(tablet_manager, merge_contexts, new_tablet_metadata.get()));

--- a/be/src/storage/lake/tablet_merger_split_family.cpp
+++ b/be/src/storage/lake/tablet_merger_split_family.cpp
@@ -1,0 +1,379 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_merger_split_family.h"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+
+#include "base/hash/hash_util.hpp"
+#include "common/logging.h"
+#include "common/status.h"
+#include "storage/lake/meta_file.h"
+
+namespace starrocks::lake::detail {
+
+namespace {
+
+// Compute a rowset's lifted rssid for a given segment position WITHOUT
+// risking uint32_t wraparound that get_rssid()'s native return type would
+// silently allow. Returns std::nullopt when rowset.id() + segment_idx
+// would overflow uint32; the caller must mark the affected family unsafe
+// in that case.
+std::optional<uint32_t> safe_lifted_segment_rssid(const RowsetMetadataPB& rowset_meta, int32_t segment_pos) {
+    const uint64_t lifted =
+            static_cast<uint64_t>(rowset_meta.id()) + static_cast<uint64_t>(get_segment_idx(rowset_meta, segment_pos));
+    if (lifted > std::numeric_limits<uint32_t>::max()) {
+        return std::nullopt;
+    }
+    return static_cast<uint32_t>(lifted);
+}
+
+template <typename T>
+inline void fold_into_hash(size_t& hash, const T& value) {
+    HashUtil::hash_combine(hash, value);
+}
+
+// Standard union-find with the smallest member always rising to the root.
+// This makes find(x) deterministically return the minimum child_index in
+// x's family, which is exactly what canonical_child_index needs.
+class UnionFind {
+public:
+    explicit UnionFind(uint32_t n) : _parent(n) {
+        for (uint32_t i = 0; i < n; ++i) _parent[i] = i;
+    }
+
+    uint32_t find(uint32_t x) {
+        while (_parent[x] != x) {
+            _parent[x] = _parent[_parent[x]]; // path compression
+            x = _parent[x];
+        }
+        return x;
+    }
+
+    void unite(uint32_t x, uint32_t y) {
+        const uint32_t root_x = find(x);
+        const uint32_t root_y = find(y);
+        if (root_x == root_y) return;
+        // The smaller root absorbs the larger root, so the canonical
+        // (smallest) child stays at the family's root after every union.
+        if (root_x < root_y) {
+            _parent[root_y] = root_x;
+        } else {
+            _parent[root_x] = root_y;
+        }
+    }
+
+private:
+    std::vector<uint32_t> _parent;
+};
+
+} // namespace
+
+size_t RowsetPhysicalKeyHash::operator()(const RowsetPhysicalKey& key) const noexcept {
+    size_t hash = std::hash<int64_t>{}(key.version);
+    for (const auto& segment : key.segments) {
+        fold_into_hash(hash, segment);
+    }
+    for (const auto offset : key.bundle_file_offsets) {
+        fold_into_hash(hash, offset);
+    }
+    for (const auto flag : key.shared_segments_flags) {
+        // std::hash<bool> exists but is trivial; cast to int8 first so
+        // false / true don't collide with adjacent integer fields.
+        fold_into_hash(hash, static_cast<int8_t>(flag));
+    }
+    for (const auto idx : key.segment_idx_layout) {
+        fold_into_hash(hash, idx);
+    }
+    return hash;
+}
+
+RowsetPhysicalKey make_rowset_physical_key(const RowsetMetadataPB& rowset_meta) {
+    RowsetPhysicalKey key;
+    key.version = rowset_meta.version();
+    key.segments.assign(rowset_meta.segments().begin(), rowset_meta.segments().end());
+    key.shared_segments_flags.assign(rowset_meta.shared_segments().begin(), rowset_meta.shared_segments().end());
+
+    // Normalize bundle_file_offsets and segment_idx_layout to ALWAYS have one
+    // entry per segment, falling back to documented defaults when the PB
+    // omits them. Without this, two physically-equivalent rowsets where one
+    // copy has the field populated (e.g., `bundle_file_offsets = [0, 0]`)
+    // and the other has it absent (`bundle_file_offsets = []`) would hash
+    // and compare unequal — a false-negative family inference that loses the
+    // canonical projection. PB defaults match production read semantics:
+    // bundle_file_offsets default to 0 per segment, and segment_idx falls
+    // back to positional index per get_segment_idx() in meta_file.cpp.
+    const int segments_count = rowset_meta.segments_size();
+    key.bundle_file_offsets.reserve(segments_count);
+    key.segment_idx_layout.reserve(segments_count);
+    for (int segment_pos = 0; segment_pos < segments_count; ++segment_pos) {
+        const int64_t bundle_offset =
+                segment_pos < rowset_meta.bundle_file_offsets_size() ? rowset_meta.bundle_file_offsets(segment_pos) : 0;
+        key.bundle_file_offsets.push_back(bundle_offset);
+        key.segment_idx_layout.push_back(static_cast<int32_t>(get_segment_idx(rowset_meta, segment_pos)));
+    }
+    return key;
+}
+
+bool is_shared_ancestor_rowset(const RowsetMetadataPB& rowset_meta) {
+    if (rowset_meta.segments_size() == 0) return false;
+    if (rowset_meta.shared_segments_size() != rowset_meta.segments_size()) return false;
+    return std::all_of(rowset_meta.shared_segments().begin(), rowset_meta.shared_segments().end(),
+                       [](bool flag) { return flag; });
+}
+
+StatusOr<InferredSplitFamilies> infer_split_families(const std::vector<SplitFamilyInferenceInput>& inputs) {
+    InferredSplitFamilies result;
+    const auto child_count = static_cast<uint32_t>(inputs.size());
+    result.child_to_family.assign(child_count, InferredSplitFamilies::kNoFamily);
+    if (child_count == 0) {
+        return result;
+    }
+
+    UnionFind union_find(child_count);
+
+    // Edge (1): legacy `shared && !has_shared_rssid` sstable filename.
+    // Two children that reference the same legacy file must come from the
+    // same SPLIT family (the file is bytes-immutable; SPLIT marks shared
+    // copies but doesn't rewrite anything).
+    std::unordered_map<std::string, uint32_t> filename_to_first_child;
+    for (uint32_t child_index = 0; child_index < child_count; ++child_index) {
+        const auto& metadata = inputs[child_index].metadata;
+        if (metadata == nullptr || !metadata->has_sstable_meta()) continue;
+        for (const auto& sstable : metadata->sstable_meta().sstables()) {
+            if (!sstable.shared() || sstable.has_shared_rssid()) continue;
+            auto [iter, inserted] = filename_to_first_child.emplace(sstable.filename(), child_index);
+            if (!inserted) {
+                union_find.unite(iter->second, child_index);
+            }
+        }
+    }
+
+    // Edge (2): full physical identity of a shared-ancestor rowset. Both
+    // children must satisfy is_shared_ancestor_rowset() — delete-only and
+    // child-local rowsets are filtered out so two physically-matching but
+    // unrelated rowsets cannot create a false union.
+    std::unordered_map<RowsetPhysicalKey, uint32_t, RowsetPhysicalKeyHash> rowset_key_to_first_child;
+    for (uint32_t child_index = 0; child_index < child_count; ++child_index) {
+        const auto& metadata = inputs[child_index].metadata;
+        if (metadata == nullptr) continue;
+        for (const auto& rowset : metadata->rowsets()) {
+            if (!is_shared_ancestor_rowset(rowset)) continue;
+            auto key = make_rowset_physical_key(rowset);
+            auto [iter, inserted] = rowset_key_to_first_child.emplace(std::move(key), child_index);
+            if (!inserted) {
+                union_find.unite(iter->second, child_index);
+            }
+        }
+    }
+
+    // Materialize families. members_by_root[r] ends up holding every child
+    // whose union-find root is r. Because UnionFind always promotes the
+    // smaller index to the root, members_by_root[r] is non-empty only when
+    // r is the smallest member of its family — which is exactly the
+    // canonical child.
+    std::vector<std::vector<uint32_t>> members_by_root(child_count);
+    for (uint32_t child_index = 0; child_index < child_count; ++child_index) {
+        members_by_root[union_find.find(child_index)].push_back(child_index);
+    }
+    for (uint32_t root_child_index = 0; root_child_index < child_count; ++root_child_index) {
+        auto& members = members_by_root[root_child_index];
+        if (members.size() < 2) {
+            // size 0 → not a root (its members were absorbed into a smaller root).
+            // size 1 → standalone child with no edges; leave as kNoFamily.
+            continue;
+        }
+        InferredSplitFamilies::Family family;
+        family.member_child_indexes = std::move(members);
+        // member_child_indexes is already in ascending order because we
+        // pushed children in iteration order (child_index 0..N-1).
+        family.canonical_child_index = family.member_child_indexes.front();
+        family.canonical_rssid_offset = inputs[family.canonical_child_index].rssid_offset;
+        const auto family_id = static_cast<uint32_t>(result.families.size());
+        for (const auto member : family.member_child_indexes) {
+            result.child_to_family[member] = family_id;
+        }
+        result.families.push_back(std::move(family));
+    }
+    return result;
+}
+
+namespace {
+
+// Lift one occupancy candidate into the plan. On a clash with a prior
+// occupant carrying a different physical key, mark both involved families
+// unsafe so merge_rowsets + the fast-path fall back to natural-offset
+// behavior.
+void record_occupancy(uint32_t final_rssid, const RowsetPhysicalKey& key, uint32_t family_id,
+                      RssidProjectionPlan& plan) {
+    auto [iter, inserted] = plan.occupied_rssids.emplace(final_rssid, RssidProjectionPlan::Occupancy{key, family_id});
+    if (inserted) return;
+    if (iter->second.key == key) return; // dedup across family members; no-op
+    // Two physically-distinct rowsets want the same final rssid. Orphan ctx
+    // entries carry kNoFamily and are filtered — orphans use natural offset
+    // and don't go through the canonical projection.
+    if (family_id != InferredSplitFamilies::kNoFamily) {
+        plan.unsafe_families.insert(family_id);
+    }
+    if (iter->second.family_id != InferredSplitFamilies::kNoFamily) {
+        plan.unsafe_families.insert(iter->second.family_id);
+    }
+}
+
+// Try to project a single source rssid through the plan-building pass.
+// Returns false if the projection arithmetic overflows uint32_t (and
+// records the family as unsafe), so the outer loop can skip the
+// unprojectable entry without poisoning the plan.
+bool try_record_projection(uint32_t source_rssid, int64_t offset, const RowsetPhysicalKey& key, uint32_t family_id,
+                           RssidProjectionPlan& plan) {
+    const int64_t final_rssid = static_cast<int64_t>(source_rssid) + offset;
+    if (final_rssid < 0 || final_rssid > std::numeric_limits<uint32_t>::max()) {
+        if (family_id != InferredSplitFamilies::kNoFamily) {
+            plan.unsafe_families.insert(family_id);
+        }
+        return false;
+    }
+    record_occupancy(static_cast<uint32_t>(final_rssid), key, family_id, plan);
+    return true;
+}
+
+} // namespace
+
+StatusOr<RssidProjectionPlan> build_rssid_projection_plan(const std::vector<SplitFamilyInferenceInput>& inputs,
+                                                          const InferredSplitFamilies& families) {
+    // The plan must be built from the same (inputs, families) pair: a
+    // future caller diverging them would produce out-of-bounds accesses
+    // below, so validate in release as well as debug.
+    if (families.child_to_family.size() != inputs.size()) {
+        return Status::InvalidArgument(
+                "child_to_family size mismatches inputs size — InferredSplitFamilies must be built from these inputs");
+    }
+    for (uint32_t child_index = 0; child_index < families.child_to_family.size(); ++child_index) {
+        const uint32_t family_id = families.child_to_family[child_index];
+        if (family_id == InferredSplitFamilies::kNoFamily) continue;
+        if (family_id >= families.families.size()) {
+            return Status::InvalidArgument(fmt::format("child_to_family[{}] = {} but only {} families exist",
+                                                       child_index, family_id, families.families.size()));
+        }
+    }
+    for (uint32_t family_id = 0; family_id < families.families.size(); ++family_id) {
+        const auto& family = families.families[family_id];
+        for (const uint32_t member : family.member_child_indexes) {
+            if (member >= inputs.size()) {
+                return Status::InvalidArgument(
+                        fmt::format("InferredSplitFamilies references child_index {} but only {} inputs were provided",
+                                    member, inputs.size()));
+            }
+            // child_to_family must round-trip: a Family's member must map
+            // back to that family_id. Otherwise step 1 (which reads
+            // child_to_family) and step 2 (which iterates families) operate
+            // on inconsistent assumptions.
+            if (families.child_to_family[member] != family_id) {
+                return Status::InvalidArgument(
+                        fmt::format("InferredSplitFamilies inconsistency: families[{}] lists child {} as member but "
+                                    "child_to_family[{}] = {}",
+                                    family_id, member, member, families.child_to_family[member]));
+            }
+        }
+    }
+
+    RssidProjectionPlan plan;
+
+    // Step 1: walk every rowset in every ctx, claim its final rssids, and
+    // detect cross-family / orphan-vs-family collisions. A rowset's
+    // projection offset depends on whether it is a shared-ancestor inside
+    // a family (canonical offset) or otherwise (natural offset = the ctx's
+    // own rssid_offset, same as v1's add_rowset path).
+    for (uint32_t child_index = 0; child_index < inputs.size(); ++child_index) {
+        const auto& metadata = inputs[child_index].metadata;
+        if (metadata == nullptr) continue;
+        const uint32_t family_id = families.child_to_family[child_index];
+        DCHECK(family_id == InferredSplitFamilies::kNoFamily || family_id < families.families.size());
+        const int64_t natural_offset = inputs[child_index].rssid_offset;
+        const int64_t canonical_offset = (family_id != InferredSplitFamilies::kNoFamily)
+                                                 ? families.families[family_id].canonical_rssid_offset
+                                                 : natural_offset;
+
+        for (const auto& rowset : metadata->rowsets()) {
+            const bool use_canonical =
+                    family_id != InferredSplitFamilies::kNoFamily && is_shared_ancestor_rowset(rowset);
+            const int64_t offset = use_canonical ? canonical_offset : natural_offset;
+            const auto key = make_rowset_physical_key(rowset);
+
+            // Always claim rowset.id() — covers add_rowset's first
+            // map_rssid call AND rowset-level metadata (delvec keys, DCG
+            // keys) that use rowset.id() rather than a segment-position
+            // rssid.
+            try_record_projection(rowset.id(), offset, key, family_id, plan);
+
+            // Also claim every segment position. safe_lifted_segment_rssid
+            // checks for rowset.id() + segment_idx wraparound BEFORE
+            // narrowing to uint32_t; on overflow it returns nullopt and
+            // we mark the family unsafe (matches the wraparound treatment
+            // of the int64 overflow check inside try_record_projection).
+            for (int segment_pos = 0; segment_pos < rowset.segments_size(); ++segment_pos) {
+                const auto lifted_or = safe_lifted_segment_rssid(rowset, segment_pos);
+                if (!lifted_or.has_value()) {
+                    if (family_id != InferredSplitFamilies::kNoFamily) {
+                        plan.unsafe_families.insert(family_id);
+                    }
+                    continue;
+                }
+                try_record_projection(*lifted_or, offset, key, family_id, plan);
+            }
+        }
+    }
+
+    // Step 2: populate explicit_rssid_map and family_legacy_sstable_offset
+    // for SAFE families only. For unsafe families the plan stays silent so
+    // map_rssid falls through to the natural-offset path automatically.
+    for (uint32_t family_id = 0; family_id < families.families.size(); ++family_id) {
+        if (plan.unsafe_families.count(family_id) > 0) continue;
+        const auto& family = families.families[family_id];
+        plan.family_legacy_sstable_offset.emplace(family_id, family.canonical_rssid_offset);
+
+        for (const uint32_t child_index : family.member_child_indexes) {
+            const auto& metadata = inputs[child_index].metadata;
+            if (metadata == nullptr) continue;
+            for (const auto& rowset : metadata->rowsets()) {
+                if (!is_shared_ancestor_rowset(rowset)) continue;
+
+                const int64_t rs_id_final = static_cast<int64_t>(rowset.id()) + family.canonical_rssid_offset;
+                // Step 1 already would have marked the family unsafe on
+                // overflow, but defensively skip the entry here too.
+                if (rs_id_final >= 0 && rs_id_final <= std::numeric_limits<uint32_t>::max()) {
+                    plan.explicit_rssid_map.emplace(SourceRssidKey{child_index, rowset.id()},
+                                                    static_cast<uint32_t>(rs_id_final));
+                }
+                for (int segment_pos = 0; segment_pos < rowset.segments_size(); ++segment_pos) {
+                    const auto lifted_or = safe_lifted_segment_rssid(rowset, segment_pos);
+                    if (!lifted_or.has_value()) continue;
+                    const int64_t segment_final = static_cast<int64_t>(*lifted_or) + family.canonical_rssid_offset;
+                    if (segment_final < 0 || segment_final > std::numeric_limits<uint32_t>::max()) continue;
+                    plan.explicit_rssid_map.emplace(SourceRssidKey{child_index, *lifted_or},
+                                                    static_cast<uint32_t>(segment_final));
+                }
+            }
+        }
+    }
+
+    return plan;
+}
+
+} // namespace starrocks::lake::detail

--- a/be/src/storage/lake/tablet_merger_split_family.h
+++ b/be/src/storage/lake/tablet_merger_split_family.h
@@ -1,0 +1,190 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "common/statusor.h"
+#include "gen_cpp/lake_types.pb.h"
+#include "storage/lake/tablet_metadata.h"
+
+namespace starrocks::lake {
+
+// Internal helpers for the legacy shared PK sstable fast-path. Infers split
+// families across merge_contexts, then uses the canonical child's rssid
+// offset to project shared-ancestor rowsets and their referencing legacy
+// sstables onto matching final rssids in the merged tablet — so partial-
+// compaction across siblings can be remapped via metadata instead of
+// rebuilt entry-by-entry.
+namespace detail {
+
+// Full physical identity for a rowset, used by family inference's rowset-
+// identity edge to decide whether two rowsets in different merge_contexts
+// are the same physical rowset (i.e. inherited from the same SPLIT). Must
+// be an exact match — partial signals (first segment only) can falsely
+// union unrelated rowsets across families.
+struct RowsetPhysicalKey {
+    int64_t version = 0;
+    std::vector<std::string> segments;
+    std::vector<int64_t> bundle_file_offsets;
+    std::vector<bool> shared_segments_flags;
+    std::vector<int32_t> segment_idx_layout;
+
+    bool operator==(const RowsetPhysicalKey& other) const = default;
+};
+
+struct RowsetPhysicalKeyHash {
+    size_t operator()(const RowsetPhysicalKey& key) const noexcept;
+};
+
+// Construct a RowsetPhysicalKey by copying every identifying field from a
+// rowset's metadata.
+RowsetPhysicalKey make_rowset_physical_key(const RowsetMetadataPB& rowset_meta);
+
+// Returns true iff the rowset is a candidate for the rowset-identity edge:
+// it has at least one segment, every segment is marked shared (inherited
+// from SPLIT, not produced by post-split DML or compaction), and the
+// shared_segments vector covers every segment position. Delete-only
+// rowsets (no segments) and child-local rowsets are excluded.
+bool is_shared_ancestor_rowset(const RowsetMetadataPB& rowset_meta);
+
+// Pure-data input for split family inference. Decoupled from
+// TabletMergeContext (which lives in tablet_merger.cpp's anonymous
+// namespace and cannot cross the TU boundary), so tests can construct
+// inputs directly without spinning up a full merge context.
+struct SplitFamilyInferenceInput {
+    TabletMetadataPtr metadata;
+    // Already-computed rssid_offset for this child (Phase 1 of merge_tablet
+    // sets ctx[i].rssid_offset before any merge_rowsets work; the inference
+    // helper just records it on the canonical entry of each family).
+    int64_t rssid_offset = 0;
+};
+
+// Inferred split families across a set of merge contexts. Each input
+// (= one child of the merge) belongs to AT MOST one family (or kNoFamily
+// for orphan / standalone children).
+struct InferredSplitFamilies {
+    static constexpr uint32_t kNoFamily = std::numeric_limits<uint32_t>::max();
+
+    struct Family {
+        // member child_indexes in ascending order. The smallest member is
+        // the canonical child for this family.
+        std::vector<uint32_t> member_child_indexes;
+        // == member_child_indexes.front(). Stored explicitly so callers
+        // don't have to peek into the vector.
+        uint32_t canonical_child_index = 0;
+        // == inputs[canonical_child_index].rssid_offset at the moment of
+        // inference. Recorded once so subsequent consumers don't re-fetch
+        // it from the merge contexts.
+        int64_t canonical_rssid_offset = 0;
+    };
+
+    // child_index → family_id (kNoFamily for orphan).
+    std::vector<uint32_t> child_to_family;
+    // Indexed by family_id. Emitted in ascending canonical_child_index
+    // order (so the iteration is deterministic and matches the dedup
+    // order in merge_sstables).
+    std::vector<Family> families;
+};
+
+// Infer split families from a vector of merge inputs. Edges:
+//   (1) two children share a legacy `shared && !has_shared_rssid` sstable
+//       filename (catches the case where rowset duplication is incomplete
+//       across children but the shared sstable file is still common);
+//   (2) two children carry a rowset that satisfies is_shared_ancestor_
+//       rowset() AND has identical RowsetPhysicalKey. The shared-ancestor
+//       filter excludes delete-only and child-local rowsets that could
+//       otherwise produce false unions when their physical keys happen
+//       to match.
+//
+// Children with no edges to any other child get kNoFamily. Family ids are
+// assigned in ascending canonical_child_index order; canonical_child_index
+// is always the smallest child_index in the family.
+StatusOr<InferredSplitFamilies> infer_split_families(const std::vector<SplitFamilyInferenceInput>& inputs);
+
+// Composite key for RssidProjectionPlan::explicit_rssid_map. Named fields
+// prevent positional swaps at call sites.
+struct SourceRssidKey {
+    uint32_t child_index = 0;
+    uint32_t source_rssid = 0;
+
+    bool operator==(const SourceRssidKey& other) const = default;
+};
+
+struct SourceRssidKeyHash {
+    size_t operator()(const SourceRssidKey& key) const noexcept {
+        return std::hash<uint64_t>{}((static_cast<uint64_t>(key.child_index) << 32) | key.source_rssid);
+    }
+};
+
+// Concrete projection plan: for each (child_index, source_rssid) the plan
+// records the final rssid the merge will assign in the merged tablet's id
+// space. Consumed by ctx.map_rssid() and the legacy-sstable fast-path.
+struct RssidProjectionPlan {
+    // (child_index, source_rssid) → final_rssid for shared-ancestor rowsets
+    // in safe families. Populated for both the rowset.id() key (covers
+    // add_rowset's first map_rssid call and rowset-level metadata such as
+    // delvec keys) and every get_rssid(rowset, segment_position) key
+    // (covers data-entry remap with sparse segment_idx layouts).
+    std::unordered_map<SourceRssidKey, uint32_t, SourceRssidKeyHash> explicit_rssid_map;
+
+    // family_id → accumulated rssid_offset to write into emitted legacy
+    // sstable PBs by the fast-path. Recorded only for safe families.
+    std::unordered_map<uint32_t, int64_t> family_legacy_sstable_offset;
+
+    // Occupancy table for collision detection during plan build. Each
+    // entry records which physical rowset claimed a given final rssid AND
+    // which family that rowset belonged to (or kNoFamily if it came from
+    // an orphan ctx). The plan's consumers do NOT read this map at runtime;
+    // it is exposed for tests and diagnostics.
+    struct Occupancy {
+        RowsetPhysicalKey key;
+        uint32_t family_id; // == InferredSplitFamilies::kNoFamily for orphan
+    };
+    std::unordered_map<uint32_t, Occupancy> occupied_rssids;
+
+    // family_ids that hit a collision during plan build. The fast-path
+    // treats every sstable in an unsafe family as a fallback rebuild;
+    // merge_rowsets skips the explicit projection for member rowsets and
+    // lets first-emitter natural assignment take over.
+    std::unordered_set<uint32_t> unsafe_families;
+};
+
+// Build the projection plan from the merge inputs and the inferred families.
+//
+// Step 1: for every (ctx, rowset, key_position) — where key_position is
+// rowset.id() or each get_rssid(rowset, segment_position) — record an
+// occupancy at key_position + offset, where offset is the family's
+// canonical_rssid_offset for shared-ancestor rowsets and ctx.rssid_offset
+// otherwise. A second claim on the same final rssid by a different physical
+// rowset marks both involved families unsafe.
+//
+// Step 2: for every safe family, populate explicit_rssid_map for every
+// shared-ancestor rowset's rowset.id() and every segment position, and
+// record family_legacy_sstable_offset[family_id].
+//
+// Any final-rssid arithmetic that overflows uint32_t marks the family unsafe.
+StatusOr<RssidProjectionPlan> build_rssid_projection_plan(const std::vector<SplitFamilyInferenceInput>& inputs,
+                                                          const InferredSplitFamilies& families);
+
+} // namespace detail
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -283,6 +283,161 @@ StatusOr<TabletRangePB> union_range(const TabletRangePB& lhs_pb, const TabletRan
     return result_pb;
 }
 
+// Compare lower-bound positions between two ranges. Unbounded lower (-∞) is
+// smallest; otherwise compare values, then prefer included over excluded as
+// the smaller (it covers the boundary point).
+static int compare_lower_position(const TabletRange& a, const TabletRange& b) {
+    if (a.is_minimum() && b.is_minimum()) return 0;
+    if (a.is_minimum()) return -1;
+    if (b.is_minimum()) return 1;
+    int c = a.lower_bound().compare(b.lower_bound());
+    if (c != 0) return c;
+    if (a.lower_bound_included() == b.lower_bound_included()) return 0;
+    return a.lower_bound_included() ? -1 : 1;
+}
+
+// True iff |first| (with first.lower <= second.lower) extends to or past
+// |second|.lower without leaving a gap. Caller guarantees the ordering.
+static bool first_meets_second(const TabletRange& first, const TabletRange& second) {
+    if (first.is_maximum()) return true; // first covers everything to the right
+    if (second.is_minimum())
+        return true; // second covers everything to the left,
+                     //   which forces first.lower == -∞ too
+    int c = first.upper_bound().compare(second.lower_bound());
+    if (c < 0) return false; // strict gap
+    if (c > 0) return true;  // overlap
+    return first.upper_bound_included() || second.lower_bound_included();
+}
+
+bool ranges_are_contiguous(const TabletRangePB& lhs_pb, const TabletRangePB& rhs_pb) {
+    TabletRange lhs;
+    if (!lhs.from_proto(lhs_pb).ok()) return false;
+    TabletRange rhs;
+    if (!rhs.from_proto(rhs_pb).ok()) return false;
+    if (lhs.is_empty() || rhs.is_empty()) return false;
+
+    const TabletRange* first = &lhs;
+    const TabletRange* second = &rhs;
+    if (compare_lower_position(lhs, rhs) > 0) std::swap(first, second);
+    return first_meets_second(*first, *second);
+}
+
+StatusOr<std::vector<TabletRangePB>> sort_and_merge_adjacent_ranges(std::vector<TabletRangePB> ranges) {
+    std::vector<TabletRange> tr;
+    tr.reserve(ranges.size());
+    for (const auto& r : ranges) {
+        TabletRange tmp;
+        RETURN_IF_ERROR(tmp.from_proto(r));
+        if (!tmp.is_empty()) {
+            tr.push_back(std::move(tmp));
+        }
+    }
+
+    std::sort(tr.begin(), tr.end(),
+              [](const TabletRange& a, const TabletRange& b) { return compare_lower_position(a, b) < 0; });
+
+    std::vector<TabletRange> merged;
+    for (auto& cur : tr) {
+        if (merged.empty()) {
+            merged.push_back(std::move(cur));
+            continue;
+        }
+        auto& last = merged.back();
+        if (first_meets_second(last, cur)) {
+            // Overlap or touch with compatible included → merge via union.
+            last = last.union_with(cur);
+        } else {
+            merged.push_back(std::move(cur));
+        }
+    }
+
+    std::vector<TabletRangePB> result;
+    result.reserve(merged.size());
+    for (const auto& r : merged) {
+        result.emplace_back();
+        r.to_proto(&result.back());
+    }
+    return result;
+}
+
+StatusOr<std::vector<TabletRangePB>> compute_disjoint_gaps_within(
+        const TabletRangePB& bound_pb, const std::vector<TabletRangePB>& sorted_disjoint_children) {
+    TabletRange bound;
+    RETURN_IF_ERROR(bound.from_proto(bound_pb));
+    if (bound.is_empty()) return std::vector<TabletRangePB>{};
+
+    // Clip each child to within bound; drop empty post-clip.
+    std::vector<TabletRange> children;
+    children.reserve(sorted_disjoint_children.size());
+    for (const auto& c_pb : sorted_disjoint_children) {
+        TabletRange c;
+        RETURN_IF_ERROR(c.from_proto(c_pb));
+        if (c.is_empty()) continue;
+        ASSIGN_OR_RETURN(auto clipped, c.intersect(bound));
+        if (!clipped.is_empty()) {
+            children.push_back(std::move(clipped));
+        }
+    }
+
+    std::vector<TabletRangePB> result;
+
+    // Walk gap = [running_lower, child.lower); after last child, gap to bound.upper.
+    // running_* tracks the next-gap left edge. Initial value = bound's lower.
+    VariantTuple running_lower = bound.lower_bound();
+    bool running_lower_included = bound.is_minimum() ? false : bound.lower_bound_included();
+    bool running_lower_unbounded = bound.is_minimum();
+
+    auto emit_gap = [&](const VariantTuple& upper, bool upper_included, bool upper_unbounded) -> Status {
+        TabletRangePB pb;
+        if (!running_lower_unbounded) {
+            running_lower.to_proto(pb.mutable_lower_bound());
+            pb.set_lower_bound_included(running_lower_included);
+        }
+        if (!upper_unbounded) {
+            upper.to_proto(pb.mutable_upper_bound());
+            pb.set_upper_bound_included(upper_included);
+        }
+        TabletRange tr;
+        RETURN_IF_ERROR(tr.from_proto(pb));
+        if (!tr.is_empty()) {
+            result.push_back(std::move(pb));
+        }
+        return Status::OK();
+    };
+
+    for (const auto& child : children) {
+        // Left side of gap: [running_lower, child.lower) with flipped included.
+        if (!child.is_minimum()) {
+            RETURN_IF_ERROR(emit_gap(child.lower_bound(), !child.lower_bound_included(), false));
+        }
+        // Advance: if child reaches +∞, no further gap is possible.
+        if (child.is_maximum()) {
+            return result;
+        }
+        running_lower = child.upper_bound();
+        running_lower_included = !child.upper_bound_included();
+        running_lower_unbounded = false;
+    }
+
+    // Final gap: [running_lower, bound.upper].
+    RETURN_IF_ERROR(emit_gap(bound.upper_bound(), bound.is_maximum() ? false : bound.upper_bound_included(),
+                             bound.is_maximum()));
+    return result;
+}
+
+StatusOr<std::vector<TabletRangePB>> compute_non_contributed_ranges(
+        const std::vector<TabletRangePB>& sorted_disjoint_children) {
+    TabletRangePB unbounded; // empty PB is treated as (-∞, +∞)
+    return compute_disjoint_gaps_within(unbounded, sorted_disjoint_children);
+}
+
+const TabletRangePB& effective_child_local_range(const RowsetMetadataPB& rowset, const TabletMetadataPB& ctx_metadata) {
+    static const TabletRangePB kUnbounded;
+    if (rowset.has_range()) return rowset.range();
+    if (ctx_metadata.has_range()) return ctx_metadata.range();
+    return kUnbounded;
+}
+
 Status update_rowset_range(RowsetMetadataPB* rowset, const TabletRangePB& range) {
     DCHECK(rowset != nullptr);
     if (!rowset->has_range()) {

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -38,6 +38,37 @@ StatusOr<TabletRangePB> union_range(const TabletRangePB& lhs_pb, const TabletRan
 Status update_rowset_range(RowsetMetadataPB* rowset, const TabletRangePB& range);
 Status update_rowset_ranges(TxnLogPB* txn_log, const TabletRangePB& range);
 
+// True iff |lhs ∪ rhs| has no gap. Touching at a boundary counts as
+// contiguous iff at least one side is included at the touching point.
+// Same-direction unbounded sides always extend without forming a gap.
+// Empty input ranges return false.
+bool ranges_are_contiguous(const TabletRangePB& lhs_pb, const TabletRangePB& rhs_pb);
+
+// Sort+merge a list of ranges into a disjoint, ascending-by-lower list. Adjacent
+// (touching with compatible included flags) and overlapping intervals are
+// merged. Empty inputs are dropped.
+StatusOr<std::vector<TabletRangePB>> sort_and_merge_adjacent_ranges(std::vector<TabletRangePB> ranges);
+
+// Complement of |sorted_disjoint_children| within |bound|. The children list
+// must already be sorted ascending by lower bound and pairwise disjoint
+// (callers can use sort_and_merge_adjacent_ranges first). Children outside
+// |bound| are clipped. Returns empty list iff children fully cover |bound|.
+StatusOr<std::vector<TabletRangePB>> compute_disjoint_gaps_within(
+        const TabletRangePB& bound, const std::vector<TabletRangePB>& sorted_disjoint_children);
+
+// Complement of |sorted_disjoint_children| over an unbounded (-∞, +∞) universe.
+// Equivalent to compute_disjoint_gaps_within with an unbounded bound. Used when
+// callers need to mask everything not covered by contributors, including keys
+// outside any specific bounded range (e.g., PK-index sstable indexes from a
+// pre-split tablet that extend beyond the merged tablet range).
+StatusOr<std::vector<TabletRangePB>> compute_non_contributed_ranges(
+        const std::vector<TabletRangePB>& sorted_disjoint_children);
+
+// Mirrors Rowset::get_seek_range() fallback chain:
+//   rowset.range if has_range, else ctx_metadata.range if has_range,
+//   else an unbounded singleton owned by this function.
+const TabletRangePB& effective_child_local_range(const RowsetMetadataPB& rowset, const TabletMetadataPB& ctx_metadata);
+
 void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int32_t split_index);
 void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t split_index);
 

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -19,7 +19,12 @@
 
 #include <limits>
 #include <numeric>
+#include <optional>
 #include <random>
+
+#include "storage/datum_variant.h"
+#include "storage/types.h"
+#include "storage/variant_tuple.h"
 
 namespace starrocks::lake {
 
@@ -502,6 +507,260 @@ TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_skips_when_num_del
 
     update_rowset_data_stats(&rowset, /*split_count=*/2, /*split_index=*/0);
     EXPECT_FALSE(rowset.has_num_dels());
+}
+
+// ---------------------------------------------------------------------------
+// Range-helper tests (PR-1).
+// ---------------------------------------------------------------------------
+
+// Build a TabletRangePB from optional int32 lower/upper bounds. nullopt means
+// unbounded on that side. Callers pass int values for the sort-key value
+// component; this matches the existing generate_sort_key style in
+// tablet_reshard_test.cpp without pulling in the heavy fixture.
+namespace {
+
+TabletRangePB make_range(std::optional<int> lower, bool lower_included, std::optional<int> upper, bool upper_included) {
+    TabletRangePB pb;
+    auto write_int = [](TuplePB* tuple_pb, int v) {
+        DatumVariant variant(get_type_info(LogicalType::TYPE_INT), Datum(v));
+        VariantTuple t;
+        t.append(variant);
+        t.to_proto(tuple_pb);
+    };
+    if (lower) {
+        write_int(pb.mutable_lower_bound(), *lower);
+        pb.set_lower_bound_included(lower_included);
+    }
+    if (upper) {
+        write_int(pb.mutable_upper_bound(), *upper);
+        pb.set_upper_bound_included(upper_included);
+    }
+    return pb;
+}
+
+// Convenience: closed-open [lower, upper).
+TabletRangePB co_range(std::optional<int> lower, std::optional<int> upper) {
+    return make_range(lower, /*lower_included=*/true, upper, /*upper_included=*/false);
+}
+
+bool ranges_pb_equal(const TabletRangePB& a, const TabletRangePB& b) {
+    if (a.has_lower_bound() != b.has_lower_bound()) return false;
+    if (a.has_upper_bound() != b.has_upper_bound()) return false;
+    if (a.has_lower_bound() && a.lower_bound().DebugString() != b.lower_bound().DebugString()) return false;
+    if (a.has_upper_bound() && a.upper_bound().DebugString() != b.upper_bound().DebugString()) return false;
+    if (a.lower_bound_included() != b.lower_bound_included()) return false;
+    if (a.upper_bound_included() != b.upper_bound_included()) return false;
+    return true;
+}
+
+} // namespace
+
+// ranges_are_contiguous --------------------------------------------------------
+
+TEST_F(TabletReshardHelperTest, test_ranges_are_contiguous_overlap) {
+    EXPECT_TRUE(ranges_are_contiguous(co_range(0, 15), co_range(10, 20)));
+    EXPECT_TRUE(ranges_are_contiguous(co_range(10, 20), co_range(0, 15)));
+}
+
+TEST_F(TabletReshardHelperTest, test_ranges_are_contiguous_touching_included) {
+    // [0, 10] + [10, 20) → contiguous (10 is in left side).
+    EXPECT_TRUE(ranges_are_contiguous(make_range(0, true, 10, true), make_range(10, false, 20, false)));
+    // [0, 10) + [10, 20) → contiguous (10 is in right side, lower_included).
+    EXPECT_TRUE(ranges_are_contiguous(co_range(0, 10), co_range(10, 20)));
+    // Reverse argument order.
+    EXPECT_TRUE(ranges_are_contiguous(co_range(10, 20), co_range(0, 10)));
+}
+
+TEST_F(TabletReshardHelperTest, test_ranges_are_contiguous_touching_excluded) {
+    // [0, 10) + (10, 20) → gap at value 10 (excluded both sides).
+    EXPECT_FALSE(ranges_are_contiguous(co_range(0, 10), make_range(10, false, 20, false)));
+}
+
+TEST_F(TabletReshardHelperTest, test_ranges_are_contiguous_gap) {
+    EXPECT_FALSE(ranges_are_contiguous(co_range(0, 10), co_range(20, 30)));
+    EXPECT_FALSE(ranges_are_contiguous(co_range(20, 30), co_range(0, 10)));
+}
+
+TEST_F(TabletReshardHelperTest, test_ranges_are_contiguous_unbounded_same_side) {
+    // (-∞, 10) + (-∞, 20) → both reach -∞, overlap → contiguous.
+    EXPECT_TRUE(ranges_are_contiguous(co_range(std::nullopt, 10), co_range(std::nullopt, 20)));
+    // [10, +∞) + [20, +∞) → both reach +∞, overlap → contiguous.
+    EXPECT_TRUE(ranges_are_contiguous(make_range(10, true, std::nullopt, false),
+                                      make_range(20, true, std::nullopt, false)));
+}
+
+TEST_F(TabletReshardHelperTest, test_ranges_are_contiguous_unbounded_inner) {
+    // (-∞, +∞) covers everything, contiguous with anything non-empty.
+    EXPECT_TRUE(ranges_are_contiguous(make_range(std::nullopt, false, std::nullopt, false), co_range(0, 10)));
+    // (-∞, 10) + [20, +∞) → strict gap [10, 20).
+    EXPECT_FALSE(ranges_are_contiguous(co_range(std::nullopt, 10), make_range(20, true, std::nullopt, false)));
+    // (-∞, 10) + [10, +∞) → touch at 10, contiguous.
+    EXPECT_TRUE(ranges_are_contiguous(make_range(std::nullopt, false, 10, false),
+                                      make_range(10, true, std::nullopt, false)));
+}
+
+// sort_and_merge_adjacent_ranges -----------------------------------------------
+
+TEST_F(TabletReshardHelperTest, test_sort_and_merge_adjacent_basic) {
+    auto result = sort_and_merge_adjacent_ranges({co_range(20, 30), co_range(0, 10)});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(2u, result.value().size());
+    EXPECT_TRUE(ranges_pb_equal(co_range(0, 10), result.value()[0]));
+    EXPECT_TRUE(ranges_pb_equal(co_range(20, 30), result.value()[1]));
+}
+
+TEST_F(TabletReshardHelperTest, test_sort_and_merge_adjacent_overlapping) {
+    auto result = sort_and_merge_adjacent_ranges({co_range(5, 15), co_range(0, 10), co_range(12, 20)});
+    ASSERT_TRUE(result.ok());
+    // [0,15) ∪ [12,20) merge to [0,20). [5,15) overlaps with [0,15) → [0,15).
+    ASSERT_EQ(1u, result.value().size());
+    EXPECT_TRUE(ranges_pb_equal(co_range(0, 20), result.value()[0]));
+}
+
+TEST_F(TabletReshardHelperTest, test_sort_and_merge_adjacent_touching) {
+    // [0,10) and [10,20) touch at 10 with right side included → merge.
+    auto result = sort_and_merge_adjacent_ranges({co_range(10, 20), co_range(0, 10)});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(1u, result.value().size());
+    EXPECT_TRUE(ranges_pb_equal(co_range(0, 20), result.value()[0]));
+}
+
+TEST_F(TabletReshardHelperTest, test_sort_and_merge_adjacent_unbounded) {
+    auto result =
+            sort_and_merge_adjacent_ranges({co_range(std::nullopt, 10), make_range(10, true, std::nullopt, false)});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(1u, result.value().size());
+    EXPECT_FALSE(result.value()[0].has_lower_bound());
+    EXPECT_FALSE(result.value()[0].has_upper_bound());
+}
+
+// compute_disjoint_gaps_within --------------------------------------------------
+
+TEST_F(TabletReshardHelperTest, test_compute_disjoint_gaps_within_full_coverage) {
+    auto result = compute_disjoint_gaps_within(co_range(0, 30), {co_range(0, 30)});
+    ASSERT_TRUE(result.ok());
+    EXPECT_TRUE(result.value().empty());
+}
+
+TEST_F(TabletReshardHelperTest, test_compute_disjoint_gaps_within_internal_gap) {
+    auto result = compute_disjoint_gaps_within(co_range(0, 30), {co_range(0, 10), co_range(20, 30)});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(1u, result.value().size());
+    EXPECT_TRUE(ranges_pb_equal(co_range(10, 20), result.value()[0]));
+}
+
+TEST_F(TabletReshardHelperTest, test_compute_disjoint_gaps_within_left_edge) {
+    // bound=[0,30), children=[10,30). Gap = [0,10).
+    auto result = compute_disjoint_gaps_within(co_range(0, 30), {co_range(10, 30)});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(1u, result.value().size());
+    EXPECT_TRUE(ranges_pb_equal(co_range(0, 10), result.value()[0]));
+}
+
+TEST_F(TabletReshardHelperTest, test_compute_disjoint_gaps_within_right_edge) {
+    auto result = compute_disjoint_gaps_within(co_range(0, 30), {co_range(0, 20)});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(1u, result.value().size());
+    EXPECT_TRUE(ranges_pb_equal(co_range(20, 30), result.value()[0]));
+}
+
+TEST_F(TabletReshardHelperTest, test_compute_disjoint_gaps_within_outside_clipped) {
+    // bound=[0,30), children include a slice extending below bound → clip.
+    auto result = compute_disjoint_gaps_within(co_range(0, 30), {co_range(-5, 10), co_range(10, 30)});
+    ASSERT_TRUE(result.ok());
+    EXPECT_TRUE(result.value().empty()); // children fully cover bound after clipping.
+}
+
+TEST_F(TabletReshardHelperTest, test_compute_disjoint_gaps_within_no_children) {
+    auto result = compute_disjoint_gaps_within(co_range(0, 30), {});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(1u, result.value().size());
+    EXPECT_TRUE(ranges_pb_equal(co_range(0, 30), result.value()[0]));
+}
+
+// compute_non_contributed_ranges (unbounded universe) --------------------------
+
+TEST_F(TabletReshardHelperTest, test_compute_non_contributed_ranges_full_coverage) {
+    // Children = (-∞, +∞). Result empty.
+    auto result = compute_non_contributed_ranges({make_range(std::nullopt, false, std::nullopt, false)});
+    ASSERT_TRUE(result.ok());
+    EXPECT_TRUE(result.value().empty());
+}
+
+TEST_F(TabletReshardHelperTest, test_compute_non_contributed_ranges_internal_gap) {
+    auto result = compute_non_contributed_ranges({co_range(0, 10), co_range(20, 30)});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(3u, result.value().size());
+    // (-∞, 0)
+    EXPECT_FALSE(result.value()[0].has_lower_bound());
+    EXPECT_TRUE(ranges_pb_equal(co_range(std::nullopt, 0), result.value()[0]));
+    // [10, 20)
+    EXPECT_TRUE(ranges_pb_equal(co_range(10, 20), result.value()[1]));
+    // [30, +∞)
+    EXPECT_TRUE(ranges_pb_equal(make_range(30, true, std::nullopt, false), result.value()[2]));
+}
+
+TEST_F(TabletReshardHelperTest, test_compute_non_contributed_ranges_left_edge_only) {
+    // First-child-compaction case: children = [K1, +∞). Result = (-∞, K1).
+    auto result = compute_non_contributed_ranges({make_range(10, true, std::nullopt, false)});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(1u, result.value().size());
+    EXPECT_TRUE(ranges_pb_equal(co_range(std::nullopt, 10), result.value()[0]));
+}
+
+TEST_F(TabletReshardHelperTest, test_compute_non_contributed_ranges_right_edge_only) {
+    // Last-child-compaction case: children = (-∞, K2). Result = [K2, +∞).
+    auto result = compute_non_contributed_ranges({co_range(std::nullopt, 20)});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(1u, result.value().size());
+    EXPECT_TRUE(ranges_pb_equal(make_range(20, true, std::nullopt, false), result.value()[0]));
+}
+
+TEST_F(TabletReshardHelperTest, test_compute_non_contributed_ranges_both_edges) {
+    auto result = compute_non_contributed_ranges({co_range(10, 20)});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(2u, result.value().size());
+    EXPECT_TRUE(ranges_pb_equal(co_range(std::nullopt, 10), result.value()[0]));
+    EXPECT_TRUE(ranges_pb_equal(make_range(20, true, std::nullopt, false), result.value()[1]));
+}
+
+TEST_F(TabletReshardHelperTest, test_compute_non_contributed_ranges_empty_children) {
+    auto result = compute_non_contributed_ranges({});
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(1u, result.value().size());
+    // (-∞, +∞)
+    EXPECT_FALSE(result.value()[0].has_lower_bound());
+    EXPECT_FALSE(result.value()[0].has_upper_bound());
+}
+
+// effective_child_local_range --------------------------------------------------
+
+TEST_F(TabletReshardHelperTest, test_effective_child_local_range_rowset_present) {
+    RowsetMetadataPB rowset;
+    *rowset.mutable_range() = co_range(0, 10);
+    TabletMetadataPB ctx;
+    *ctx.mutable_range() = co_range(0, 30);
+
+    const auto& result = effective_child_local_range(rowset, ctx);
+    EXPECT_TRUE(ranges_pb_equal(co_range(0, 10), result));
+}
+
+TEST_F(TabletReshardHelperTest, test_effective_child_local_range_rowset_absent_ctx_present) {
+    RowsetMetadataPB rowset; // no range
+    TabletMetadataPB ctx;
+    *ctx.mutable_range() = co_range(0, 30);
+
+    const auto& result = effective_child_local_range(rowset, ctx);
+    EXPECT_TRUE(ranges_pb_equal(co_range(0, 30), result));
+}
+
+TEST_F(TabletReshardHelperTest, test_effective_child_local_range_both_absent) {
+    RowsetMetadataPB rowset;
+    TabletMetadataPB ctx;
+
+    const auto& result = effective_child_local_range(rowset, ctx);
+    EXPECT_FALSE(result.has_lower_bound());
+    EXPECT_FALSE(result.has_upper_bound());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <set>
 
 #include "base/path/filesystem_util.h"
 #include "base/testutil/assert.h"
@@ -38,7 +39,9 @@
 #include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/persistent_index_sstable.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_merger_split_family.h"
 #include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/transactions.h"
@@ -48,6 +51,8 @@
 #include "storage/rowset/segment_options.h"
 #include "storage/rowset/segment_writer.h"
 #include "storage/seek_range.h"
+#include "storage/sstable/iterator.h"
+#include "storage/sstable/options.h"
 #include "storage/tablet_schema.h"
 #include "storage/variant_tuple.h"
 
@@ -175,6 +180,29 @@ protected:
         if (with_delvec) {
             sstable->mutable_delvec()->set_version(1);
         }
+    }
+
+    // Write a real PK-index sstable file for tests that need to exercise the
+    // legacy-shared-sstable rebuild path (which opens the source file). Each
+    // entry maps a key to (rssid, rowid, version=1). Returns the file size,
+    // so callers can populate sst.set_filesize() consistently.
+    uint64_t write_legacy_pk_sstable(const std::string& path,
+                                     const std::vector<std::tuple<std::string, uint32_t, uint32_t>>& entries) {
+        WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        auto wf_or = fs::new_writable_file(opts, path);
+        CHECK_OK(wf_or.status());
+        auto wf = std::move(wf_or.value());
+
+        phmap::btree_map<std::string, lake::IndexValueWithVer, std::less<>> map;
+        for (const auto& [key, rssid, rowid] : entries) {
+            uint64_t packed = (static_cast<uint64_t>(rssid) << 32) | rowid;
+            map.emplace(key, std::make_pair(int64_t{1}, IndexValue(packed)));
+        }
+        uint64_t filesz = 0;
+        PersistentIndexSstableRangePB range_pb;
+        CHECK_OK(lake::PersistentIndexSstable::build_sstable(map, wf.get(), &filesz, &range_pb));
+        CHECK_OK(wf->close());
+        return filesz;
     }
 
     void add_dcg(TabletMetadataPB* metadata, uint32_t segment_id, const std::string& file_name) {
@@ -3938,7 +3966,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_duplicate_column_uid) {
 // --- sstable merge tests ---
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_shared_without_shared_rssid) {
-    // Legacy shared sstable without shared_rssid: uses rssid_offset path.
+    // Legacy shared sstable (shared=true && !has_shared_rssid). With the
+    // metadata-only fast-path on top of PR #72219's rebuild, a clean family
+    // (no partial compaction, no delvec) is projected without reading or
+    // writing a new file: output PB is byte-identical to the source PB.
+    // PR #72219's rebuild remains as a fallback for non-clean cases (covered
+    // by the test_tablet_merging_legacy_sstable_rebuild_* tests).
     const int64_t base_version = 1;
     const int64_t new_version = 2;
     const int64_t child_a = next_id();
@@ -3948,6 +3981,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_shared_without_shared_
     prepare_tablet_dirs(child_a);
     prepare_tablet_dirs(child_b);
     prepare_tablet_dirs(merged_tablet);
+
+    // Write a real PK sstable shared by both children. Stored rssid 1 must
+    // match a live child rowset for the rebuild to keep the entries; rowset
+    // id 1 below satisfies that.
+    const std::string legacy_filename = "legacy_sst.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/1, /*rowid=*/1}});
 
     auto make_child = [&](int64_t tablet_id) {
         auto meta = std::make_shared<TabletMetadataPB>();
@@ -3965,8 +4006,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_shared_without_shared_
         rowset->add_shared_segments(true);
         // Legacy shared sstable: no shared_rssid, no delvec
         auto* sst = meta->mutable_sstable_meta()->add_sstables();
-        sst->set_filename("legacy_sst.sst");
-        sst->set_filesize(256);
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
         sst->set_shared(true);
         sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 50);
         return meta;
@@ -3995,14 +4036,18 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_shared_without_shared_
                                               txn_info, false, tablet_metadatas, tablet_ranges));
 
     auto merged = tablet_metadatas.at(merged_tablet);
-    // Deduped to 1 sstable
+    // Deduped to a single sstable. Both children kept rowset id=1 alive and
+    // there is no merged delvec → fast-path safety conditions hold; output is
+    // a byte-for-byte copy of the source PB (same filename, shared=true).
     ASSERT_EQ(1, merged->sstable_meta().sstables_size());
     const auto& out_sst = merged->sstable_meta().sstables(0);
-    EXPECT_EQ("legacy_sst.sst", out_sst.filename());
-    // No shared_rssid: should use rssid_offset (first child offset = 0)
+    EXPECT_EQ(legacy_filename, out_sst.filename());
+    EXPECT_TRUE(out_sst.shared());
     EXPECT_FALSE(out_sst.has_shared_rssid());
     EXPECT_EQ(0, out_sst.rssid_offset());
     EXPECT_FALSE(out_sst.has_delvec());
+    EXPECT_EQ(static_cast<uint32_t>(1), static_cast<uint32_t>(out_sst.max_rss_rowid() >> 32));
+    EXPECT_EQ(legacy_filesize, out_sst.filesize());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_mixed_shared_and_local) {
@@ -5054,6 +5099,16 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_sort_uses_signed_comp
 // on multi-cycle SPLIT/MERGE: a single fileset's sstables can span a wide
 // max_rss_rowid range because filesets accumulate via append() across
 // multiple memtable flushes (persistent_index_sstable_fileset.cpp:96-115).
+//
+// Long-term contract: the merged metadata must satisfy BOTH (I1)
+// signed-monotone non-decreasing max_rss_rowid AND (I2) every output
+// fileset_id appears in exactly one contiguous run. When a single source
+// fileset_id's sstables would have to interleave with foreign-fileset_id
+// sstables to satisfy I1, merge_sstables splits the source FID into multiple
+// output FIDs by re-assigning fresh fileset_id (UniqueId::gen_uid) to each
+// run that comes after a foreign-FID interruption — the later run is by
+// physical layout already a separate logical fileset and cannot share
+// PersistentIndexSstableFileset state with the earlier run.
 TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_keep_same_fileset_id_contiguous) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
@@ -5144,7 +5199,15 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_keep_same_fileset_id_
     auto merged = tablet_metadatas.at(merged_tablet);
     ASSERT_EQ(5, merged->sstable_meta().sstables_size());
 
-    // Build a list of (fileset_id_bytes, position) and verify same-id is contiguous.
+    // I1: signed-monotone non-decreasing max_rss_rowid across the merged metadata.
+    int64_t prev_max = std::numeric_limits<int64_t>::min();
+    for (const auto& sst : merged->sstable_meta().sstables()) {
+        const int64_t cur = static_cast<int64_t>(sst.max_rss_rowid());
+        EXPECT_LE(prev_max, cur) << "post-merge sstables must be in non-decreasing int64 max_rss_rowid order";
+        prev_max = cur;
+    }
+
+    // I2: every output fileset_id appears in exactly one contiguous run.
     std::vector<std::pair<std::string, int>> id_runs; // <fileset_id_bytes, run_idx>
     int run_idx = -1;
     std::string last_id;
@@ -5161,8 +5224,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_keep_same_fileset_id_
         }
         id_runs.emplace_back(id_bytes, run_idx);
     }
-
-    // Each fileset_id should appear in exactly one contiguous run.
     std::map<std::string, std::set<int>> id_to_runs;
     for (const auto& [id, run] : id_runs) {
         id_to_runs[id].insert(run);
@@ -5172,20 +5233,196 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_keep_same_fileset_id_
                                    << " non-contiguous runs in merged metadata — Bug F regression";
     }
 
-    // Block-sort by min(max_rss_rowid) means F_X (min=100) precedes F_A (min=200).
+    // child_b's lone F_A sstable carries fa_high200.sst. Because child_b is the
+    // SECOND merge context, its rssid_offset = compute_rssid_offset(base_after_A,
+    // child_b) = 500 - 2 = 498, so the projection lifts F_A's max_rss high from
+    // 200 to 698. After the signed-monotone sort, F_A lands AFTER all four F_X
+    // sstables (whose projection is a no-op since child_a is first → offset=0):
+    //   pos 0..3 : F_X high=100/250/300/400 (contiguous, retains original FID-X)
+    //   pos 4    : F_A high=698 (post-projection)
+    // F_X stays contiguous in this layout without any FID reassignment.
     EXPECT_EQ("fx_high100.sst", merged->sstable_meta().sstables(0).filename());
+    EXPECT_EQ("fx_high250.sst", merged->sstable_meta().sstables(1).filename());
+    EXPECT_EQ("fx_high300.sst", merged->sstable_meta().sstables(2).filename());
     EXPECT_EQ("fx_high400.sst", merged->sstable_meta().sstables(3).filename());
     EXPECT_EQ("fa_high200.sst", merged->sstable_meta().sstables(4).filename());
+
+    // F_X kept the original fileset_id (its run was uninterrupted in the
+    // sorted layout), and F_A kept its original id too (single sstable run).
+    auto fid_pair = [](const PUniqueId& f) { return std::make_pair(f.hi(), f.lo()); };
+    EXPECT_EQ(std::make_pair(static_cast<int64_t>(0x1111111111111111LL), static_cast<int64_t>(0x2222222222222222LL)),
+              fid_pair(merged->sstable_meta().sstables(0).fileset_id()));
+    EXPECT_EQ(std::make_pair(static_cast<int64_t>(0x3333333333333333LL), static_cast<int64_t>(0x4444444444444444LL)),
+              fid_pair(merged->sstable_meta().sstables(4).fileset_id()));
+}
+
+// Reproduces the run3 11306 fact pattern observed on tablet reshard: a single
+// inherited fileset_id (FID-X) carried by the cycle-2 MERGE flush sstable
+// (low max_rss), plus several per-child flush_pk_memtable outputs that
+// inherited FID-X via PersistentIndexSstableFileset::append() (high max_rss),
+// with foreign-FID compaction outputs interleaved at intermediate max_rss.
+// The fix must keep each output fileset_id contiguous AND keep the global
+// max_rss_rowid sequence signed-monotone non-decreasing.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_sstables_split_inherited_fileset_on_interleave) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // FID-X carries one early sstable (high=225) and three late per-child-flush
+    // sstables (high=724/725/726) that inherited FID-X via append(). FID-A,
+    // FID-B, FID-C, FID-D each carry one foreign sstable at high=226/393/570/715
+    // — exactly the run3 11306 layout.
+    PUniqueId fid_x;
+    fid_x.set_hi(0x5111111111111111LL);
+    fid_x.set_lo(0x5222222222222222LL);
+    PUniqueId fid_a;
+    fid_a.set_hi(0x6111111111111111LL);
+    fid_a.set_lo(0x6222222222222222LL);
+    PUniqueId fid_b;
+    fid_b.set_hi(0x7111111111111111LL);
+    fid_b.set_lo(0x7222222222222222LL);
+    PUniqueId fid_c;
+    fid_c.set_hi(0x4111111111111111LL);
+    fid_c.set_lo(0x4222222222222222LL);
+    PUniqueId fid_d;
+    fid_d.set_hi(0x3111111111111111LL);
+    fid_d.set_lo(0x3222222222222222LL);
+
+    auto add_sst = [](TabletMetadataPB* meta, const std::string& filename, uint64_t high, uint64_t low,
+                      const PUniqueId& fid) {
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(filename);
+        sst->set_filesize(128);
+        sst->set_max_rss_rowid((high << 32) | low);
+        sst->mutable_fileset_id()->CopyFrom(fid);
+    };
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(800);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* rowset_a = meta_a->add_rowsets();
+    rowset_a->set_id(1);
+    rowset_a->set_version(1);
+    rowset_a->set_num_rows(10);
+    rowset_a->set_data_size(100);
+    rowset_a->add_segments("seg_a.dat");
+    rowset_a->add_segment_size(100);
+    // Source-iteration order in child_a: the early FID-X sstable, then foreign
+    // compaction outputs and the per-child flush sstables also tagged FID-X.
+    add_sst(meta_a.get(), "fx_high225.sst", 225, 0, fid_x);
+    add_sst(meta_a.get(), "fa_high226.sst", 226, 0, fid_a);
+    add_sst(meta_a.get(), "fb_high393.sst", 393, 0, fid_b);
+    add_sst(meta_a.get(), "fc_high570.sst", 570, 0, fid_c);
+    add_sst(meta_a.get(), "fd_high715.sst", 715, 0, fid_d);
+    add_sst(meta_a.get(), "fx_high724.sst", 724, 0, fid_x);
+    add_sst(meta_a.get(), "fx_high725.sst", 725, 0, fid_x);
+    add_sst(meta_a.get(), "fx_high726.sst", 726, 0, fid_x);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(800);
+    set_primary_key_schema(meta_b.get(), 1001);
+    auto* rowset_b = meta_b->add_rowsets();
+    rowset_b->set_id(2);
+    rowset_b->set_version(1);
+    rowset_b->set_num_rows(10);
+    rowset_b->set_data_size(100);
+    rowset_b->add_segments("seg_b.dat");
+    rowset_b->add_segment_size(100);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(8, merged->sstable_meta().sstables_size());
+
+    // I1: signed-monotone non-decreasing max_rss_rowid across the merged metadata.
+    int64_t prev_max = std::numeric_limits<int64_t>::min();
+    for (const auto& sst : merged->sstable_meta().sstables()) {
+        const int64_t cur = static_cast<int64_t>(sst.max_rss_rowid());
+        EXPECT_LE(prev_max, cur);
+        prev_max = cur;
+    }
+
+    // Sort by max_rss_rowid produces the layout:
+    //   0: fx_high225  (FID-X, kept)
+    //   1: fa_high226  (FID-A, kept)
+    //   2: fb_high393  (FID-B, kept)
+    //   3: fc_high570  (FID-C, kept)
+    //   4: fd_high715  (FID-D, kept)
+    //   5: fx_high724  (FID-X re-encounter — fresh FID)
+    //   6: fx_high725  (continues fresh-FID run)
+    //   7: fx_high726  (continues fresh-FID run)
+    EXPECT_EQ("fx_high225.sst", merged->sstable_meta().sstables(0).filename());
+    EXPECT_EQ("fa_high226.sst", merged->sstable_meta().sstables(1).filename());
+    EXPECT_EQ("fb_high393.sst", merged->sstable_meta().sstables(2).filename());
+    EXPECT_EQ("fc_high570.sst", merged->sstable_meta().sstables(3).filename());
+    EXPECT_EQ("fd_high715.sst", merged->sstable_meta().sstables(4).filename());
+    EXPECT_EQ("fx_high724.sst", merged->sstable_meta().sstables(5).filename());
+    EXPECT_EQ("fx_high725.sst", merged->sstable_meta().sstables(6).filename());
+    EXPECT_EQ("fx_high726.sst", merged->sstable_meta().sstables(7).filename());
+
+    // I2: every output fileset_id appears in exactly one contiguous run.
+    std::map<std::pair<int64_t, int64_t>, std::vector<int>> fid_to_positions;
+    for (int i = 0; i < merged->sstable_meta().sstables_size(); ++i) {
+        const auto& f = merged->sstable_meta().sstables(i).fileset_id();
+        fid_to_positions[{f.hi(), f.lo()}].push_back(i);
+    }
+    for (const auto& [fid, positions] : fid_to_positions) {
+        for (size_t k = 1; k < positions.size(); ++k) {
+            EXPECT_EQ(positions[k - 1] + 1, positions[k])
+                    << "fileset_id non-contiguous in merged metadata — Bug F regression";
+        }
+    }
+
+    // The early FID-X (pos 0) keeps its original id; the late re-encounter run
+    // (pos 5..7) must have been re-assigned to a fresh id distinct from FID-X
+    // and from any of the foreign FIDs.
+    auto fid_pair = [](const PUniqueId& f) { return std::make_pair(f.hi(), f.lo()); };
+    const auto pos0_fid = fid_pair(merged->sstable_meta().sstables(0).fileset_id());
+    const auto pos5_fid = fid_pair(merged->sstable_meta().sstables(5).fileset_id());
+    EXPECT_EQ(std::make_pair(fid_x.hi(), fid_x.lo()), pos0_fid);
+    EXPECT_NE(pos0_fid, pos5_fid) << "non-contiguous re-encounter must be reassigned";
+    EXPECT_NE(std::make_pair(fid_a.hi(), fid_a.lo()), pos5_fid);
+    EXPECT_NE(std::make_pair(fid_b.hi(), fid_b.lo()), pos5_fid);
+    EXPECT_NE(std::make_pair(fid_c.hi(), fid_c.lo()), pos5_fid);
+    EXPECT_NE(std::make_pair(fid_d.hi(), fid_d.lo()), pos5_fid);
+    EXPECT_EQ(pos5_fid, fid_pair(merged->sstable_meta().sstables(6).fileset_id()));
+    EXPECT_EQ(pos5_fid, fid_pair(merged->sstable_meta().sstables(7).fileset_id()));
 }
 
 // Two PK parents (not cloud-native, so flush_parent_for_merge is a pass-through)
 // each carry a shared legacy standalone sstable with the same filename but
 // different `fileset_id` values (as would happen when PersistentIndexSstableFileset
-// init synthesizes a random id per load). Without excluding fileset_id from the
-// shared-sstable consistency check in merge_sstables dedup, this would return
-// Status::Corruption. With fileset_id excluded (identity is pinned by filename
-// + filesize + encryption_meta + range), the merge succeeds and the output
-// sstable_meta deduplicates to a single entry.
+// init synthesizes a random id per load). The shared-sstable consistency check
+// must exclude fileset_id (identity is pinned by filename + filesize +
+// encryption_meta + range), so the dedup keeps a single source PB and the
+// rebuild path emits exactly one rebuilt sstable for the merged tablet.
 TEST_F(LakeTabletReshardTest, test_tablet_merging_dedup_legacy_standalone_sstable) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
@@ -5197,8 +5434,16 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dedup_legacy_standalone_sstabl
     prepare_tablet_dirs(child_b);
     prepare_tablet_dirs(merged_tablet);
 
-    // Both children share the same legacy standalone sstable (no range, no
-    // shared_rssid) but carry different synthesized fileset_id values.
+    // Both children share the SAME physical legacy sstable file. We write it
+    // once into the test FS — the FixedLocationProvider routes any tablet_id's
+    // sst_location to the same shared segments dir.
+    const std::string legacy_filename = "legacy_shared.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/1, /*rowid=*/1}});
+
+    // Both children reference the same legacy standalone sstable but carry
+    // different synthesized fileset_id values.
     auto make_child = [&](int64_t tablet_id, uint64_t fileset_hi, uint64_t fileset_lo) {
         auto meta = std::make_shared<TabletMetadataPB>();
         meta->set_id(tablet_id);
@@ -5214,11 +5459,11 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dedup_legacy_standalone_sstabl
         rowset->add_segment_size(100);
         rowset->add_shared_segments(true);
         auto* sst = meta->mutable_sstable_meta()->add_sstables();
-        sst->set_filename("legacy_shared.sst");
-        sst->set_filesize(512);
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
         sst->set_shared(true);
-        // Legacy standalone: no range, no shared_rssid. Simulated per-parent
-        // synthesized fileset_id (differs across parents).
+        // Legacy standalone: no shared_rssid. Simulated per-parent synthesized
+        // fileset_id (differs across parents).
         sst->mutable_fileset_id()->set_hi(fileset_hi);
         sst->mutable_fileset_id()->set_lo(fileset_lo);
         sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 99);
@@ -5251,13 +5496,1641 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dedup_legacy_standalone_sstabl
     ASSERT_TRUE(it != tablet_metadatas.end());
     const auto& merged = it->second;
 
-    // Legacy standalone sstable should dedup to a single entry despite
-    // differing fileset_ids across parents.
+    // Differing fileset_ids do not block dedup; the merge produces exactly one
+    // sstable. With the fast-path on a clean family the output PB is a
+    // byte-for-byte copy of the source PB (the dedup-winner ctx[0]'s PB),
+    // including its fileset_id; the C2' check is vacuous here because the
+    // source PB has no range field.
     ASSERT_EQ(1, merged->sstable_meta().sstables_size());
-    EXPECT_EQ("legacy_shared.sst", merged->sstable_meta().sstables(0).filename());
-    EXPECT_TRUE(merged->sstable_meta().sstables(0).shared());
-    EXPECT_FALSE(merged->sstable_meta().sstables(0).has_range());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    EXPECT_EQ(legacy_filename, out_sst.filename());
+    EXPECT_TRUE(out_sst.shared());
+    EXPECT_FALSE(out_sst.has_shared_rssid());
+    EXPECT_EQ(0, out_sst.rssid_offset());
+    // Fast-path keeps the ctx[0] (dedup-winner) source PB's fileset_id.
+    ASSERT_TRUE(out_sst.has_fileset_id());
+    EXPECT_EQ(static_cast<uint64_t>(0x1111), out_sst.fileset_id().hi());
+    EXPECT_EQ(static_cast<uint64_t>(0x2222), out_sst.fileset_id().lo());
 }
+
+// Reproduces run4 cycle-3 ghost-rssid shape at the metadata level: the legacy
+// shared sstable inherited from an ancestor still stores entries for rowsets
+// that have been compacted out of every surviving child. The bug-fix rebuild
+// path walks merge_contexts to find a live rowset that owns each stored rssid
+// and drops entries whose source rowset is dead in every child.
+//
+// Setup:
+//   - Children A and B both inherit one shared PK sstable with three entries:
+//       k1 -> rssid 1, k2 -> rssid 2, k3 -> rssid 3
+//   - A keeps rowset id=1 alive (shared_segments=true).
+//   - B keeps rowset id=2 alive (shared_segments=true).
+//   - Neither child has rowset id=3 — that ancestor rowset has been compacted
+//     out everywhere, but the legacy sstable cannot be rewritten by the old
+//     metadata-only projection so its entry for k3 is the run4 ghost.
+// Expected post-fix:
+//   - The merged tablet has exactly one PK sstable (the rebuilt file).
+//   - The rebuilt PB is non-shared with no shared_rssid and rssid_offset==0.
+//   - Iterating the rebuilt file yields exactly k1 (mapped to 1) and k2
+//     (mapped to 2). The dead k3 entry is dropped.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_drops_dead_rssids) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string legacy_filename = "ghost_rssid.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize = write_legacy_pk_sstable(
+            legacy_path,
+            {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}, {"k3", /*rssid=*/3, /*rowid=*/0}});
+
+    auto make_child = [&](int64_t tablet_id, uint32_t live_rowset_id, const std::string& seg_filename) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(live_rowset_id + 1);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(live_rowset_id);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments(seg_filename);
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(3) << 32) | 0);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a, /*live_rowset_id=*/1, "seg_a.dat");
+    auto meta_b = make_child(child_b, /*live_rowset_id=*/2, "seg_b.dat");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    EXPECT_NE(legacy_filename, out_sst.filename());
+    EXPECT_FALSE(out_sst.shared());
+    EXPECT_FALSE(out_sst.has_shared_rssid());
+    EXPECT_EQ(0, out_sst.rssid_offset());
+    // Rebuilt PB carries a fresh fileset_id. PersistentIndexSstableFileset::
+    // init(vector) DCHECKs has_fileset_id() for ranged sstables, so missing
+    // it here would crash debug builds and leave release builds with a
+    // default identity that breaks compaction matching.
+    EXPECT_TRUE(out_sst.has_fileset_id());
+    EXPECT_TRUE(out_sst.has_range());
+
+    // Read the rebuilt sstable directly and verify the dead-rssid entry was
+    // dropped while the live entries were remapped to the merged tablet's
+    // surviving rowset ids.
+    ASSIGN_OR_ABORT(auto sstable, lake::PersistentIndexSstable::new_sstable(
+                                          out_sst, _tablet_manager->sst_location(merged_tablet, out_sst.filename()),
+                                          /*cache=*/nullptr, /*need_filter=*/false, /*delvec=*/nullptr, merged,
+                                          _tablet_manager.get()));
+    sstable::ReadOptions read_options;
+    read_options.fill_cache = false;
+    std::unique_ptr<sstable::Iterator> iter(sstable->new_iterator(read_options));
+    std::map<std::string, uint32_t> rebuilt_entries;
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+        IndexValuesWithVerPB index_values_pb;
+        ASSERT_TRUE(index_values_pb.ParseFromArray(iter->value().data, static_cast<int>(iter->value().size)));
+        ASSERT_GT(index_values_pb.values_size(), 0);
+        rebuilt_entries.emplace(iter->key().to_string(), index_values_pb.values(0).rssid());
+    }
+    ASSERT_OK(iter->status());
+
+    EXPECT_EQ(2u, rebuilt_entries.size()) << "k3 (dead rssid 3) should have been dropped";
+    ASSERT_TRUE(rebuilt_entries.count("k1"));
+    ASSERT_TRUE(rebuilt_entries.count("k2"));
+    EXPECT_EQ(0u, rebuilt_entries.count("k3"));
+    // Both children get rssid_offset=0 in this layout (compute_rssid_offset
+    // returns base.next_rowset_id - append.min_id), so the rebuilt entries
+    // keep their original rssids.
+    EXPECT_EQ(1u, rebuilt_entries["k1"]);
+    EXPECT_EQ(2u, rebuilt_entries["k2"]);
+}
+
+// Round-2 (Codex high #1): the rebuild must filter entries whose rowid is in
+// the merged delvec — the same protection the modern shared_rssid path gets
+// via its post-merge delvec PB attachment. merge_delvecs Phase 5 writes the
+// per-rssid pages into new_metadata.delvec_meta.delvecs, including any real
+// deletes the children carried (and synthesized gap-bits, which require
+// real segment files to exercise — covered conceptually here via real
+// deletes that flow through the same rebuild filter).
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_filters_via_delvec) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Both children mark rowid 8 of segment rssid=1 as deleted via independent
+    // delvec entries on the shared rowset. merge_delvecs unions them onto the
+    // canonical's final rssid; the rebuilt sstable's per-entry filter must
+    // drop k2 (rowid 8) and keep k1 (rowid 0).
+    DelVector shared_delvec;
+    const uint32_t deleted_rowids[] = {8};
+    shared_delvec.init(1, deleted_rowids, 1);
+    std::string shared_delvec_data = shared_delvec.save();
+
+    const std::string legacy_filename = "delvec_filter.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/1, /*rowid=*/8}});
+
+    auto make_child = [&](int64_t tablet_id, const std::string& delvec_filename) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(2);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        add_delvec(meta.get(), tablet_id, 1, /*segment_id=*/1, delvec_filename, shared_delvec_data);
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 8);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a, "delvec_a.dv");
+    auto meta_b = make_child(child_b, "delvec_b.dv");
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+
+    ASSIGN_OR_ABORT(auto sstable, lake::PersistentIndexSstable::new_sstable(
+                                          out_sst, _tablet_manager->sst_location(merged_tablet, out_sst.filename()),
+                                          /*cache=*/nullptr, /*need_filter=*/false, /*delvec=*/nullptr, merged,
+                                          _tablet_manager.get()));
+    sstable::ReadOptions read_options;
+    read_options.fill_cache = false;
+    std::unique_ptr<sstable::Iterator> iter(sstable->new_iterator(read_options));
+    std::set<std::string> rebuilt_keys;
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+        rebuilt_keys.insert(iter->key().to_string());
+    }
+    ASSERT_OK(iter->status());
+    EXPECT_EQ(1u, rebuilt_keys.size());
+    EXPECT_TRUE(rebuilt_keys.count("k1")) << "k1 (rowid 0, not deleted) should survive";
+    EXPECT_FALSE(rebuilt_keys.count("k2")) << "k2 (rowid 8, in merged delvec) should be filtered out";
+}
+
+// Round-2 (Codex high #2): the data-entry rssid lookup must use
+// get_rssid(rs, seg_pos) so that a sparse segment_idx ({0, 2} after a
+// middle-segment compaction) resolves correctly. A naive id+segments_size
+// span check would (a) drop the live segment at id+2 and (b) keep a ghost
+// at id+1 — both wrong.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_sparse_segment_idx) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string legacy_filename = "sparse_seg.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize = write_legacy_pk_sstable(
+            legacy_path,
+            {{"k0", /*rssid=*/10, /*rowid=*/0}, {"k1", /*rssid=*/11, /*rowid=*/0}, {"k2", /*rssid=*/12, /*rowid=*/0}});
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(13);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(10);
+        rowset->set_version(1);
+        rowset->set_num_rows(20);
+        rowset->set_data_size(200);
+        // Two segments at sparse segment_idx {0, 2} — the {0,1,2} dense span
+        // is broken because the middle segment was compacted away.
+        rowset->add_segments("sparse_seg_0.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        auto* segment_meta_at_idx_0 = rowset->add_segment_metas();
+        segment_meta_at_idx_0->set_segment_idx(0);
+        rowset->add_segments("sparse_seg_2.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        auto* segment_meta_at_idx_2 = rowset->add_segment_metas();
+        segment_meta_at_idx_2->set_segment_idx(2);
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(12) << 32) | 0);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    auto meta_b = make_child(child_b);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+
+    ASSIGN_OR_ABORT(auto sstable, lake::PersistentIndexSstable::new_sstable(
+                                          out_sst, _tablet_manager->sst_location(merged_tablet, out_sst.filename()),
+                                          /*cache=*/nullptr, /*need_filter=*/false, /*delvec=*/nullptr, merged,
+                                          _tablet_manager.get()));
+    sstable::ReadOptions read_options;
+    read_options.fill_cache = false;
+    std::unique_ptr<sstable::Iterator> iter(sstable->new_iterator(read_options));
+    std::map<std::string, uint32_t> rebuilt_entries;
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+        IndexValuesWithVerPB index_values_pb;
+        ASSERT_TRUE(index_values_pb.ParseFromArray(iter->value().data, static_cast<int>(iter->value().size)));
+        ASSERT_GT(index_values_pb.values_size(), 0);
+        rebuilt_entries.emplace(iter->key().to_string(), index_values_pb.values(0).rssid());
+    }
+    ASSERT_OK(iter->status());
+
+    EXPECT_EQ(2u, rebuilt_entries.size()) << "k1 (rssid 11, no segment_idx=1) should be dropped";
+    EXPECT_TRUE(rebuilt_entries.count("k0"));
+    EXPECT_TRUE(rebuilt_entries.count("k2"));
+    EXPECT_FALSE(rebuilt_entries.count("k1"));
+    EXPECT_EQ(10u, rebuilt_entries["k0"]);
+    EXPECT_EQ(12u, rebuilt_entries["k2"]);
+}
+
+// Round-2 (Codex risk #2): a stacked-merge legacy sstable whose source PB
+// already carries a non-zero rssid_offset must lift stored rssids by that
+// offset BEFORE looking them up in merge_contexts. Otherwise the rebuild
+// would search for a rowset id in the wrong space and either drop a live
+// entry or pick the wrong owner.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_with_source_offset) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Source bytes encode stored rssid 2; src.rssid_offset = 3; lifted = 5.
+    // Both children have rowset id=5 alive on the shared sstable.
+    const std::string legacy_filename = "stacked_offset.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize = write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/2, /*rowid=*/0}});
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(6);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(5);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_rssid_offset(3); // stacked: prior merge already shifted by 3
+        sst->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    auto meta_b = make_child(child_b);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    EXPECT_EQ(0, out_sst.rssid_offset()) << "rebuilt sstable must have offset reset to 0";
+
+    ASSIGN_OR_ABORT(auto sstable, lake::PersistentIndexSstable::new_sstable(
+                                          out_sst, _tablet_manager->sst_location(merged_tablet, out_sst.filename()),
+                                          /*cache=*/nullptr, /*need_filter=*/false, /*delvec=*/nullptr, merged,
+                                          _tablet_manager.get()));
+    sstable::ReadOptions read_options;
+    read_options.fill_cache = false;
+    std::unique_ptr<sstable::Iterator> iter(sstable->new_iterator(read_options));
+    int entries_seen = 0;
+    uint32_t k1_rssid = 0;
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+        IndexValuesWithVerPB index_values_pb;
+        ASSERT_TRUE(index_values_pb.ParseFromArray(iter->value().data, static_cast<int>(iter->value().size)));
+        ASSERT_GT(index_values_pb.values_size(), 0);
+        if (iter->key().to_string() == "k1") {
+            k1_rssid = index_values_pb.values(0).rssid();
+        }
+        ++entries_seen;
+    }
+    ASSERT_OK(iter->status());
+    EXPECT_EQ(1, entries_seen);
+    EXPECT_EQ(5u, k1_rssid) << "stored=2, lifted by source offset 3 → 5; remap to merged rowset 5";
+}
+
+// Round-2 (Codex high #3): tombstone-only sstable max_rss_rowid must come
+// from projecting the source PB's max_rss_rowid through the rebuild — not
+// from per-entry max over non-tombstone values (which would yield 0 and
+// corrupt the post-merge sort).
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_tombstone_only_watermark) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // All entries are tombstones (rssid=UINT32_MAX, rowid=UINT32_MAX). Source
+    // max_rss_rowid.high = 5 (the rowset id at memtable flush time).
+    const uint32_t kTombstoneSentinel = std::numeric_limits<uint32_t>::max();
+    const std::string legacy_filename = "tombstone_only.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k_dead_a", kTombstoneSentinel, kTombstoneSentinel},
+                                                  {"k_dead_b", kTombstoneSentinel, kTombstoneSentinel}});
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(6);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(5);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(5) << 32) | kTombstoneSentinel);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    auto meta_b = make_child(child_b);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    const uint32_t out_high = static_cast<uint32_t>(out_sst.max_rss_rowid() >> 32);
+    EXPECT_EQ(5u, out_high) << "tombstone-only file must inherit projected source watermark, not 0";
+}
+
+// Stacked-offset tombstone-only watermark.
+//
+// Convention: PersistentIndexSstablePB.max_rss_rowid.high is the EFFECTIVE
+// max rssid in the source child's id space (post-projection — already
+// includes any accumulated src_pb.rssid_offset). project_non_shared_legacy_
+// sstable + cross-sstable invariants in lake_persistent_index.cpp all read
+// max_rss_rowid as effective.
+//
+// The previous implementation of project_source_max_rss_rowid added
+// src_pb.rssid_offset() AGAIN to max_rss_rowid.high, which works for
+// fresh sstables (rssid_offset == 0) but double-shifts for any stacked-
+// offset src. Per-entry update_max_encoded_rss_rowid_from masked the
+// resulting watermark miss for non-tombstone files, but tombstone-only
+// files (no per-entry override) emitted max_rss_rowid.high == 0,
+// breaking the cross-sstable ordering invariant on subsequent merges.
+//
+// This test pins the fixed convention: a tombstone-only sstable carrying
+// a stacked rssid_offset still gets its source watermark mapped through
+// to the merged tablet's effective max — without the spurious second
+// shift.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_stacked_offset_tombstone_only_watermark) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // All entries are tombstones. Source sstable has rssid_offset = 3 (a
+    // prior projection had stacked it) and max_rss_rowid.high = 5 (= the
+    // effective max in source child's id space). Both children expose
+    // rowset id=5 alive on the shared sstable so the merged tablet's
+    // watermark map records key 5 → final 5.
+    const uint32_t kTombstoneSentinel = std::numeric_limits<uint32_t>::max();
+    const std::string legacy_filename = "stacked_tombstone_only.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k_dead_a", kTombstoneSentinel, kTombstoneSentinel},
+                                                  {"k_dead_b", kTombstoneSentinel, kTombstoneSentinel}});
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(6);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(5);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_rssid_offset(3); // stacked: a prior projection accumulated 3.
+        // Effective max in source child's id space. 5 is also the merged
+        // tablet's watermark key — pre-fix code looked up watermark[5+3=8]
+        // and missed; post-fix looks up watermark[5] directly and hits.
+        sst->set_max_rss_rowid((static_cast<uint64_t>(5) << 32) | kTombstoneSentinel);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    auto meta_b = make_child(child_b);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    const uint32_t out_high = static_cast<uint32_t>(out_sst.max_rss_rowid() >> 32);
+    EXPECT_EQ(5u, out_high) << "stacked-offset tombstone-only file: source effective max 5 → merged final 5; "
+                               "double-shift bug would have produced 0 here";
+}
+
+// Round-3 (Codex high #2 follow-up): the watermark helper must resolve a
+// delete-only rowset id (segments_size==0) — memtable's flush watermark
+// embeds the live rowset id at flush time, which can be a delete-only
+// rowset. The data-entry helper must NOT match such ids; a data entry
+// stored with that rssid is a ghost and gets dropped.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_tombstone_watermark_delete_only_rowset) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const uint32_t kTombstoneSentinel = std::numeric_limits<uint32_t>::max();
+    // Source has one tombstone (preserved) and one ghost data entry pointing
+    // at the delete-only rowset id 10. Source max_rss_rowid.high = 10 — the
+    // delete-only rowset's id.
+    const std::string legacy_filename = "del_only_watermark.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize = write_legacy_pk_sstable(
+            legacy_path, {{"k_tomb", kTombstoneSentinel, kTombstoneSentinel}, {"k_ghost", /*rssid=*/10, /*rowid=*/0}});
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(11);
+        set_primary_key_schema(meta.get(), 1001);
+        // Data rowset id=5 with one segment (live).
+        auto* data_rowset = meta->add_rowsets();
+        data_rowset->set_id(5);
+        data_rowset->set_version(1);
+        data_rowset->set_num_rows(10);
+        data_rowset->set_data_size(100);
+        data_rowset->add_segments("data_seg.dat");
+        data_rowset->add_segment_size(100);
+        data_rowset->add_shared_segments(true);
+        // Delete-only rowset id=10 (segments_size==0): owns no PK index entries.
+        auto* delete_only_rowset = meta->add_rowsets();
+        delete_only_rowset->set_id(10);
+        delete_only_rowset->set_version(2);
+        delete_only_rowset->set_num_rows(0);
+        delete_only_rowset->set_data_size(0);
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(10) << 32) | kTombstoneSentinel);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    auto meta_b = make_child(child_b);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+
+    // Watermark projection succeeds via the watermark helper (matches
+    // delete-only rowset 10 by rs.id()): rebuilt PB high == 10.
+    const uint32_t out_high = static_cast<uint32_t>(out_sst.max_rss_rowid() >> 32);
+    EXPECT_EQ(10u, out_high) << "watermark helper should resolve delete-only rowset id";
+
+    // The ghost data entry pointing at rssid=10 must have been dropped
+    // (data-entry helper skips segments_size==0). Only the tombstone survives.
+    ASSIGN_OR_ABORT(auto sstable, lake::PersistentIndexSstable::new_sstable(
+                                          out_sst, _tablet_manager->sst_location(merged_tablet, out_sst.filename()),
+                                          /*cache=*/nullptr, /*need_filter=*/false, /*delvec=*/nullptr, merged,
+                                          _tablet_manager.get()));
+    sstable::ReadOptions read_options;
+    read_options.fill_cache = false;
+    std::unique_ptr<sstable::Iterator> iter(sstable->new_iterator(read_options));
+    std::set<std::string> rebuilt_keys;
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+        rebuilt_keys.insert(iter->key().to_string());
+    }
+    ASSERT_OK(iter->status());
+    EXPECT_TRUE(rebuilt_keys.count("k_tomb")) << "tombstone must be preserved";
+    EXPECT_FALSE(rebuilt_keys.count("k_ghost")) << "ghost data on delete-only rowset must be dropped";
+}
+
+// =============================================================================
+// Fast-path metadata-only projection tests (PR following PR #72219)
+// =============================================================================
+//
+// These tests verify try_fastpath_project_legacy_shared_sstable's behavior
+// through the merge end-to-end. Distinguishing the two paths via output PB
+// shape:
+//   * Fast-path hit  → output filename == source, shared==true,
+//                      rssid_offset == 0 (= source), no new file written.
+//   * Fallback       → output filename != source (rebuild wrote a new UUID),
+//                      shared==false, has fileset_id (rebuild assigned).
+
+// Clean family: both children share the legacy sstable and both contribute the
+// full set of ancestor rowsets. data_rssid_map == identity over [1, M], no
+// merged delvec → all of C0, C0', C2, C3, C5, C6, C7 hold → fast-path emits
+// the source PB byte-for-byte.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_clean_family) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string legacy_filename = "fastpath_clean.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize = write_legacy_pk_sstable(
+            legacy_path,
+            {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}, {"k3", /*rssid=*/3, /*rowid=*/0}});
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(4);
+        set_primary_key_schema(meta.get(), 1001);
+        // Rowsets 1, 2, 3 are all shared between children → dedup at
+        // merge_rowsets, canonical = ctx[0]'s mapping (offset 0).
+        for (uint32_t rs_id : {1u, 2u, 3u}) {
+            auto* rowset = meta->add_rowsets();
+            rowset->set_id(rs_id);
+            rowset->set_version(1);
+            rowset->set_num_rows(10);
+            rowset->set_data_size(100);
+            rowset->add_segments(fmt::format("shared_seg_{}.dat", rs_id));
+            rowset->add_segment_size(100);
+            rowset->add_shared_segments(true);
+        }
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        // No has_shared_rssid: this is the legacy ancestor-inherited form.
+        // No rssid_offset (C0). max_rss_rowid.high == 3 == |rowsets|.
+        sst->set_max_rss_rowid((static_cast<uint64_t>(3) << 32) | 0);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    auto meta_b = make_child(child_b);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+
+    // Fast-path signature: output PB is byte-identical to source PB.
+    EXPECT_EQ(legacy_filename, out_sst.filename()) << "fast-path keeps source filename, no new UUID written";
+    EXPECT_TRUE(out_sst.shared()) << "fast-path keeps shared=true";
+    EXPECT_FALSE(out_sst.has_shared_rssid()) << "fast-path keeps !has_shared_rssid";
+    EXPECT_EQ(0, out_sst.rssid_offset()) << "C0+C0' force zero offset";
+    EXPECT_EQ(legacy_filesize, out_sst.filesize());
+    EXPECT_EQ((static_cast<uint64_t>(3) << 32) | 0, out_sst.max_rss_rowid());
+}
+
+// Inverse of clean-family: child_a (= ctx[0]) does NOT carry the legacy
+// sstable, only child_b (= ctx[1]) does. Phase 1 makes ctx[1].rssid_offset
+// non-zero whenever ctx[0]'s rowset id-space pushes ctx[1]'s ids upward, so
+// canonical_offset != 0 → C0' fails → fallback to rebuild. Required by the
+// plan as defense-in-depth against a fast-path output with non-zero
+// rssid_offset that would later get double-shifted by another rebuild.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_nonzero_canonical_offset_falls_back) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string legacy_filename = "fastpath_nonzero_canonical.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_b, legacy_filename);
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}});
+
+    // child_a uses high rowset ids; ctx[1].rssid_offset = base.next_rowset_id -
+    // min(child_b.rowsets) = 11 - 1 = 10, so canonical_ctx (= ctx[1]) carries
+    // a non-zero offset.
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(11);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* rs_a = meta_a->add_rowsets();
+    rs_a->set_id(10);
+    rs_a->set_version(1);
+    rs_a->set_num_rows(10);
+    rs_a->set_data_size(100);
+    rs_a->add_segments("seg_a10.dat");
+    rs_a->add_segment_size(100);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    set_primary_key_schema(meta_b.get(), 1001);
+    for (uint32_t rs_id : {1u, 2u}) {
+        auto* rs = meta_b->add_rowsets();
+        rs->set_id(rs_id);
+        rs->set_version(1);
+        rs->set_num_rows(10);
+        rs->set_data_size(100);
+        rs->add_segments(fmt::format("seg_b{}.dat", rs_id));
+        rs->add_segment_size(100);
+    }
+    auto* sst = meta_b->mutable_sstable_meta()->add_sstables();
+    sst->set_filename(legacy_filename);
+    sst->set_filesize(legacy_filesize);
+    sst->set_shared(true);
+    sst->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    // Rebuild signature: new filename, !shared, fresh fileset_id, has_range.
+    EXPECT_NE(legacy_filename, out_sst.filename()) << "fallback rebuild wrote a new file";
+    EXPECT_FALSE(out_sst.shared());
+    EXPECT_TRUE(out_sst.has_fileset_id());
+}
+
+// C0: source PB carries a non-zero rssid_offset (a stacked-merge legacy
+// sstable). Even if everything else is clean, fast-path falls back unconditionally
+// to avoid an emitted PB whose accumulated offset would later get double-shifted
+// by a subsequent rebuild.
+// v2 update: source PB carrying a non-zero rssid_offset (= a stacked-merge
+// legacy sstable) used to fall back to rebuild under v1's C0 zero-offset
+// gate. v2 drops C0, so the fast-path now accumulates the source offset
+// into the emitted PB (out.rssid_offset = src.rssid_offset +
+// canonical_offset) and shifts max_rss_rowid.high accordingly.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_v2_src_offset_hit) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string legacy_filename = "fastpath_nonzero_src.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    // Stored rssids must be >= 1 (rs.id >= 1 invariant). The dense walk
+    // skips effective rssid below src.rssid_offset+1 because there is no
+    // valid stored rssid 0 in production sstables.
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}});
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(4);
+        set_primary_key_schema(meta.get(), 1001);
+        for (uint32_t rs_id : {1u, 2u, 3u}) {
+            auto* rs = meta->add_rowsets();
+            rs->set_id(rs_id);
+            rs->set_version(1);
+            rs->set_num_rows(10);
+            rs->set_data_size(100);
+            rs->add_segments(fmt::format("nzs_seg_{}.dat", rs_id));
+            rs->add_segment_size(100);
+            rs->add_shared_segments(true);
+        }
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        // Non-zero src rssid_offset: prior merge already shifted stored ids
+        // by 1, so stored 1/2 lift to effective 2/3 in this child's space.
+        sst->set_rssid_offset(1);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(3) << 32) | 0);
+        return meta;
+    };
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_child(child_a)));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_child(child_b)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(3);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    // Fast-path signature: original filename preserved, shared=true, no
+    // new fileset_id minted. canonical_offset is 0 (canonical = ctx[0],
+    // rssid_offset = 0) so accumulated == 1, and max_rss_rowid.high
+    // shifts from 3 to 3 + 0 = 3.
+    EXPECT_EQ(legacy_filename, out_sst.filename())
+            << "v2 fast-path keeps source filename even with non-zero src offset";
+    EXPECT_TRUE(out_sst.shared());
+    EXPECT_FALSE(out_sst.has_shared_rssid());
+    EXPECT_EQ(1, out_sst.rssid_offset()) << "accumulated = src.rssid_offset(1) + canonical_offset(0)";
+    EXPECT_EQ((static_cast<uint64_t>(3) << 32) | 0, out_sst.max_rss_rowid())
+            << "max_rss_rowid.high shifts by canonical_offset (0 here)";
+}
+
+// C2': source PB has range but no fileset_id. PersistentIndexSstableFileset::
+// init(vector) DCHECKs has_fileset_id() for ranged sstables; the fast-path
+// preserves the source PB so we cannot mint a new fileset_id without losing
+// the no-write-no-read guarantee. Fallback to rebuild, which assigns a fresh
+// fileset_id explicitly.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_range_without_fileset_id_falls_back) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string legacy_filename = "fastpath_range_no_fid.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}});
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        set_primary_key_schema(meta.get(), 1001);
+        for (uint32_t rs_id : {1u, 2u}) {
+            auto* rs = meta->add_rowsets();
+            rs->set_id(rs_id);
+            rs->set_version(1);
+            rs->set_num_rows(10);
+            rs->set_data_size(100);
+            rs->add_segments(fmt::format("rfid_seg_{}.dat", rs_id));
+            rs->add_segment_size(100);
+            rs->add_shared_segments(true);
+        }
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
+        // Set has_range but NOT has_fileset_id → C2' fail.
+        sst->mutable_range()->set_start_key("a");
+        sst->mutable_range()->set_end_key("z");
+        // sst->mutable_fileset_id() is intentionally unset.
+        return meta;
+    };
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_child(child_a)));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_child(child_b)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(4);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    EXPECT_NE(legacy_filename, out_sst.filename()) << "C2' fail → fallback rebuild";
+    EXPECT_FALSE(out_sst.shared());
+    EXPECT_TRUE(out_sst.has_fileset_id()) << "rebuild always assigns a fresh fileset_id";
+}
+
+// Regression for fast-path v2 commit 3 (per-child orphan scoping): two
+// children that family inference classifies as kNoFamily — their legacy
+// shared sstables have distinct filenames (no filename edge) and their
+// rowsets are child-local (shared_segments=false → not shared-ancestor,
+// no rowset edge). Both children's source rssid space overlaps at
+// rssid=1.
+//
+// Without per-child orphan scoping, the single shared orphan map's
+// first-emitter rule lets ctx_a's mapping {1 → 1} survive into ctx_b's
+// rebuild lookup. ctx_b's entries would then translate to rssid=1
+// (ctx_a's rowset) instead of rssid=2 (ctx_b's rowset, post-Phase-1
+// id space lift) — silent PK corruption.
+//
+// With per-child orphan scoping (orphan_by_child), ctx_b's rebuild
+// consumes orphan_by_child[1] which contains only ctx_b.map_rssid(1) = 2.
+// The rebuilt sstable's max_rss_rowid (projected via watermark map)
+// reflects this isolation directly, so the test asserts on the emitted
+// PB's high word.
+//
+// Note: v2 commit 5's fast-path requires a resolved family_id !=
+// kNoFamily, so orphan ctxs always fall through to rebuild here — that
+// is what exercises the per-child orphan map fix from commit 3.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_orphan_per_child_lookup_isolation) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string legacy_a_filename = "orphan_legacy_a.sst";
+    const std::string legacy_b_filename = "orphan_legacy_b.sst";
+    const auto legacy_a_path = _tablet_manager->sst_location(child_a, legacy_a_filename);
+    const auto legacy_b_path = _tablet_manager->sst_location(child_b, legacy_b_filename);
+    const uint64_t legacy_a_filesize = write_legacy_pk_sstable(legacy_a_path, {{"ka", /*rssid=*/1, /*rowid=*/0}});
+    const uint64_t legacy_b_filesize = write_legacy_pk_sstable(legacy_b_path, {{"kb", /*rssid=*/1, /*rowid=*/0}});
+
+    auto make_child = [&](int64_t tablet_id, const std::string& seg_name, const std::string& legacy_filename,
+                          uint64_t legacy_filesize) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(2);
+        set_primary_key_schema(meta.get(), 1001);
+        // Child-local rowset (shared_segments=false): not a shared-ancestor,
+        // so the rowset edge in family inference does not fire across
+        // children.
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments(seg_name);
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(false);
+        // Legacy ancestor-inherited sstable. Distinct filenames across
+        // children → filename edge does not fire either, so both ctxs
+        // remain kNoFamily.
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 0);
+        return meta;
+    };
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(
+            make_child(child_a, "a_local_seg.dat", legacy_a_filename, legacy_a_filesize)));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(
+            make_child(child_b, "b_local_seg.dat", legacy_b_filename, legacy_b_filesize)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(7);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Two child-local rowsets, no dedup expected.
+    ASSERT_EQ(2, merged->rowsets_size());
+    ASSERT_EQ(2, merged->sstable_meta().sstables_size());
+    const auto& sstables = merged->sstable_meta().sstables();
+
+    // Both ctxs are kNoFamily (no edges), so v2 fast-path falls through to
+    // rebuild for both legacy sstables. Each rebuild consults its own
+    // per-child orphan PerFamilyMaps (orphan_by_child[child_index]). Both
+    // emitted PBs therefore wear the rebuild signature: !shared, fresh
+    // fileset_id, new (UUID) filename. They differ in max_rss_rowid.high:
+    //   ctx_a (rssid_offset=0): orphan_by_child[0][1] = 1, high = 1.
+    //   ctx_b (rssid_offset=1): orphan_by_child[1][1] = 2, high = 2.
+    EXPECT_FALSE(sstables.Get(0).shared());
+    EXPECT_FALSE(sstables.Get(1).shared());
+    EXPECT_TRUE(sstables.Get(0).has_fileset_id());
+    EXPECT_TRUE(sstables.Get(1).has_fileset_id());
+    EXPECT_NE(legacy_a_filename, sstables.Get(0).filename());
+    EXPECT_NE(legacy_a_filename, sstables.Get(1).filename());
+    EXPECT_NE(legacy_b_filename, sstables.Get(0).filename());
+    EXPECT_NE(legacy_b_filename, sstables.Get(1).filename());
+
+    // The pollution-bug regression assertion: collect the high words of
+    // both rebuilt PBs and verify they are {1, 2}, not {1, 1}. The latter
+    // would mean ctx_a's first-emitter mapping {rssid=1 → final=1}
+    // polluted ctx_b's rebuild lookup; per-child orphan scoping prevents
+    // that.
+    std::set<uint64_t> rebuilt_highs{sstables.Get(0).max_rss_rowid() >> 32, sstables.Get(1).max_rss_rowid() >> 32};
+    EXPECT_EQ((std::set<uint64_t>{1, 2}), rebuilt_highs)
+            << "ctx_b's rebuild must consult orphan_by_child[1], not a polluted shared orphan map";
+}
+
+// v2 fast-path headline win: canonical_ctx for the family carries a
+// non-zero rssid_offset (it is NOT ctx[0]) yet the family-canonical
+// projection still produces a byte-mappable shift. Under v1 this hit the
+// C0' canonical-offset-nonzero gate and fell back to rebuild. Under v2
+// the family's safe canonical_offset accumulates into the emitted PB.
+//
+// Setup:
+//   ctx_a (= ctx[0]): unrelated child-local rowset, no edge to b/c.
+//   ctx_b (= ctx[1]): shared-ancestor rowsets {1, 2} + legacy sstable.
+//   ctx_c (= ctx[2]): same shared-ancestor rowsets + same legacy sstable.
+// Family inference unions ctx_b + ctx_c via either edge; ctx_a stays
+// kNoFamily. canonical_child_index = 1 (smallest member of {1, 2}), so
+// canonical_rssid_offset = ctx_b.rssid_offset = 1 (Phase 1 lifts ctx_b's
+// id space by ctx_a's contribution of 1 rowset).
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_fastpath_v2_canonical_offset_hit) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t child_c = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(child_c);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string legacy_filename = "fastpath_v2_canonical.sst";
+    // The legacy sstable file lives only on ctx_b's storage; ctx_c's PB
+    // points at the same logical filename (shared sstable file). For the
+    // fast-path that is byte-mapped, the source file isn't actually read,
+    // so single-side write is fine.
+    const auto legacy_path = _tablet_manager->sst_location(child_b, legacy_filename);
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}});
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(2);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* rs_a = meta_a->add_rowsets();
+    rs_a->set_id(1);
+    rs_a->set_version(1);
+    rs_a->set_num_rows(10);
+    rs_a->set_data_size(100);
+    rs_a->add_segments("seg_a_local.dat");
+    rs_a->add_segment_size(100);
+    rs_a->add_shared_segments(false);
+
+    auto make_family_member = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        set_primary_key_schema(meta.get(), 1001);
+        for (uint32_t rs_id : {1u, 2u}) {
+            auto* rs = meta->add_rowsets();
+            rs->set_id(rs_id);
+            rs->set_version(1);
+            rs->set_num_rows(10);
+            rs->set_data_size(100);
+            // Family-shared segment: same filename across ctx_b and ctx_c
+            // gives them identical RowsetPhysicalKey for the rowset edge.
+            rs->add_segments(fmt::format("family_seg_{}.dat", rs_id));
+            rs->add_segment_size(100);
+            rs->add_shared_segments(true);
+        }
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
+        return meta;
+    };
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_family_member(child_b)));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_family_member(child_c)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.add_old_tablet_ids(child_c);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // dedup'd to one legacy sstable PB.
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    // v2 fast-path signature: original filename preserved (byte-mapped),
+    // shared=true, no fileset_id minted. canonical_offset = ctx_b's
+    // rssid_offset = 1, accumulating into the emitted PB.
+    EXPECT_EQ(legacy_filename, out_sst.filename())
+            << "v2 fast-path keeps source filename even with non-zero canonical offset";
+    EXPECT_TRUE(out_sst.shared());
+    EXPECT_FALSE(out_sst.has_shared_rssid());
+    EXPECT_EQ(1, out_sst.rssid_offset()) << "accumulated = src.rssid_offset(0) + canonical_offset(1)";
+    EXPECT_EQ((static_cast<uint64_t>(3) << 32) | 0, out_sst.max_rss_rowid())
+            << "max_rss_rowid.high shifts by canonical_offset (=1)";
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// v2 follow-up: per-entry rebuild for non-shared sstables with mixed plan refs
+// ─────────────────────────────────────────────────────────────────────
+//
+// Companion tests for the rewired map_rssid + non-shared rebuild path.
+// These cover the partial-compaction win that v2 commit 5 alone could not
+// deliver: when a non-canonical ctx's non-shared sstable references both
+// safe-family shared-ancestor rowsets AND child-local rowsets (the
+// "post-split PK-index compaction crossed the boundary" case), the
+// dispatch routes to rebuild_non_shared_legacy_sstable for a per-entry
+// remap via ctx.map_rssid (plan id for shared-ancestor, natural offset
+// for child-local).
+
+// T1: a non-shared sstable whose rssid range is DISJOINT from the family's
+// shared-ancestor rowset ids stays on the metadata-only fast path. Setup:
+// shared-ancestor at high id (10), child-local at low id (1), sstable
+// references only the child-local. The predicate's conservative range
+// scan correctly skips the high-id plan entry.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_pure_child_local_uses_fast_path) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // ctx_b non-shared sstable references only stored rssid=1 (= ctx_b
+    // child-local rowset id 1). Sstable's lifted range = [1, 1], does
+    // NOT overlap shared-ancestor rowset id 10's plan entry.
+    const std::string ns_filename = "ns_pure_local.sst";
+    const auto ns_path = _tablet_manager->sst_location(child_b, ns_filename);
+    const uint64_t ns_filesize = write_legacy_pk_sstable(ns_path, {{"k_local", /*rssid=*/1, /*rowid=*/0}});
+
+    auto make_meta = [&](int64_t tablet_id, bool include_local_and_sstable) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(11);
+        set_primary_key_schema(meta.get(), 1001);
+        // Shared-ancestor rowset at HIGH id 10. Both ctxs carry it →
+        // family unions them, plan covers id=10.
+        auto* shared_rs = meta->add_rowsets();
+        shared_rs->set_id(10);
+        shared_rs->set_version(1);
+        shared_rs->set_num_rows(10);
+        shared_rs->set_data_size(100);
+        shared_rs->add_segments("shared.dat");
+        shared_rs->add_segment_size(100);
+        shared_rs->add_shared_segments(true);
+        if (include_local_and_sstable) {
+            // Child-local rowset at LOW id 1, in a "gap" beneath the
+            // shared-ancestor (legal: rs.id ≥ 1, ids need not be
+            // contiguous).
+            auto* local_rs = meta->add_rowsets();
+            local_rs->set_id(1);
+            local_rs->set_version(1);
+            local_rs->set_num_rows(5);
+            local_rs->set_data_size(50);
+            local_rs->add_segments("ctx_b_local.dat");
+            local_rs->add_segment_size(50);
+            local_rs->add_shared_segments(false);
+            auto* sst = meta->mutable_sstable_meta()->add_sstables();
+            sst->set_filename(ns_filename);
+            sst->set_filesize(ns_filesize);
+            sst->set_shared(false);
+            sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 0);
+        }
+        return meta;
+    };
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_a, /*include_local_and_sstable=*/false)));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_b, /*include_local_and_sstable=*/true)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(91);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    // Metadata-only path was taken (predicate returned false because
+    // stored rssid=1 lifts to lifted=1, plan/shared_rssid disagreement
+    // keys all live at lifted=10 — outside the [1,1] sstable range, so
+    // the binary-search range test misses).
+    EXPECT_EQ(ns_filename, out_sst.filename()) << "metadata-only path keeps source filename";
+    EXPECT_FALSE(out_sst.shared());
+    EXPECT_FALSE(out_sst.has_fileset_id()) << "metadata-only does not mint a new fileset_id";
+}
+
+// T2: mixed-reference non-shared sstable on non-canonical ctx → rebuild
+// route taken; per-entry remap honors plan (shared-ancestor) AND natural
+// offset (child-local) simultaneously, output PB has fresh fileset_id
+// and rssid_offset=0.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_mixed_refs_routes_to_rebuild) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // ctx_a (canonical, ctx[0], rssid_offset=0): rowset 1, shared-ancestor.
+    // ctx_b (ctx[1], rssid_offset=1): rowset 1 shared-ancestor + rowset 2
+    // child-local + non-shared sstable that mixes refs to BOTH (= post-
+    // split PK-index compaction's signature output).
+    const std::string ns_filename = "ns_mixed.sst";
+    const auto ns_path = _tablet_manager->sst_location(child_b, ns_filename);
+    const uint64_t ns_filesize = write_legacy_pk_sstable(
+            ns_path, {{"k_shared", /*rssid=*/1, /*rowid=*/0}, {"k_local", /*rssid=*/2, /*rowid=*/0}});
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(2);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* rs_a1 = meta_a->add_rowsets();
+    rs_a1->set_id(1);
+    rs_a1->set_version(1);
+    rs_a1->set_num_rows(10);
+    rs_a1->set_data_size(100);
+    rs_a1->add_segments("shared.dat");
+    rs_a1->add_segment_size(100);
+    rs_a1->add_shared_segments(true);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    set_primary_key_schema(meta_b.get(), 1001);
+    auto* rs_b1 = meta_b->add_rowsets();
+    rs_b1->set_id(1);
+    rs_b1->set_version(1);
+    rs_b1->set_num_rows(10);
+    rs_b1->set_data_size(100);
+    rs_b1->add_segments("shared.dat");
+    rs_b1->add_segment_size(100);
+    rs_b1->add_shared_segments(true);
+    auto* rs_b2 = meta_b->add_rowsets();
+    rs_b2->set_id(2);
+    rs_b2->set_version(1);
+    rs_b2->set_num_rows(5);
+    rs_b2->set_data_size(50);
+    rs_b2->add_segments("ctx_b_local.dat");
+    rs_b2->add_segment_size(50);
+    rs_b2->add_shared_segments(false);
+    auto* sst_b = meta_b->mutable_sstable_meta()->add_sstables();
+    sst_b->set_filename(ns_filename);
+    sst_b->set_filesize(ns_filesize);
+    sst_b->set_shared(false);
+    sst_b->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(92);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    // ctx_b's rowset_1 (shared-ancestor) dedups to id=1. ctx_b's rowset_2
+    // (child-local, no plan entry, ctx_b shared_rssid_map covers rowset_1
+    // dedup but not rowset_2) gets natural offset id=2+1=3. Mapping
+    // rowset_1's lifted=1 → plan id 1, but ctx_b's natural would be
+    // 1+1=2 — predicate fires (1 != 2 in [1,2]) → rebuild taken.
+    EXPECT_NE(ns_filename, out_sst.filename()) << "rebuild emits a new file";
+    EXPECT_FALSE(out_sst.shared());
+    EXPECT_TRUE(out_sst.has_fileset_id()) << "rebuild mints a fresh fileset_id";
+    EXPECT_EQ(0, out_sst.rssid_offset()) << "rebuild output is pre-remapped (rssid_offset=0)";
+    // max_rss_rowid.high after rebuild equals the maximum final rssid
+    // among emitted entries: rowset_1 entry → 1, rowset_2 entry → 3.
+    EXPECT_EQ((static_cast<uint64_t>(3) << 32) | 0, out_sst.max_rss_rowid());
+}
+
+// T3: when ctx is the family canonical (smallest child_index member of
+// a multi-ctx family), plan id == natural offset by construction
+// (canonical_rssid_offset == ctx.rssid_offset == 0 for ctx[0]). The
+// predicate must NOT fire even when the sstable references shared-
+// ancestor rowsets covered by an actual plan family.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_canonical_ctx_skips_rebuild) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Non-shared sstable on canonical ctx_a, references shared-ancestor
+    // rowset id=1.
+    const std::string ns_filename = "ns_canonical.sst";
+    const auto ns_path = _tablet_manager->sst_location(child_a, ns_filename);
+    const uint64_t ns_filesize = write_legacy_pk_sstable(ns_path, {{"k", /*rssid=*/1, /*rowid=*/0}});
+
+    auto make_meta = [&](int64_t tablet_id, bool include_sstable) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(2);
+        set_primary_key_schema(meta.get(), 1001);
+        // Same shared-ancestor rowset on both ctxs → family inference
+        // unions them via the rowset edge; canonical_child_index = 0.
+        auto* rs = meta->add_rowsets();
+        rs->set_id(1);
+        rs->set_version(1);
+        rs->set_num_rows(10);
+        rs->set_data_size(100);
+        rs->add_segments("shared.dat");
+        rs->add_segment_size(100);
+        rs->add_shared_segments(true);
+        if (include_sstable) {
+            auto* sst = meta->mutable_sstable_meta()->add_sstables();
+            sst->set_filename(ns_filename);
+            sst->set_filesize(ns_filesize);
+            sst->set_shared(false);
+            sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 0);
+        }
+        return meta;
+    };
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_a, /*include_sstable=*/true)));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_b, /*include_sstable=*/false)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(93);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    // ctx_a is family canonical: plan entry for rowset 1 has value
+    // 1 + canonical_rssid_offset(0) = 1, natural = 1 + ctx_a.rssid_offset(0)
+    // = 1. They match → ctx_a's compute_disagreement_keys returns empty
+    // → predicate returns false → metadata-only path keeps source filename.
+    EXPECT_EQ(ns_filename, out_sst.filename());
+    EXPECT_FALSE(out_sst.has_fileset_id());
+}
+
+// T8 (delvec guard): a non-shared sstable PB that carries an embedded
+// delvec is corrupt for the !has_shared_rssid form, regardless of
+// whether the rebuild route or the metadata-only route is taken. Both
+// must surface Status::Corruption with a descriptive message rather
+// than silently emitting a misformed PB.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_with_delvec_corruption_guard) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Construct a malformed non-shared sstable: shared=false +
+    // !has_shared_rssid + non-empty embedded delvec. The combination is
+    // illegal per the v1 corruption guard at project_non_shared_legacy_-
+    // sstable; the rebuild path must reject it identically.
+    const std::string ns_filename = "ns_with_delvec.sst";
+    const auto ns_path = _tablet_manager->sst_location(child_b, ns_filename);
+    const uint64_t ns_filesize = write_legacy_pk_sstable(ns_path, {{"k", /*rssid=*/1, /*rowid=*/0}});
+
+    // ctx_a + ctx_b form a safe family via shared rowset id=10. ctx_b's
+    // non-shared sstable references rowset_10 (= predicate fires →
+    // rebuild route is taken → delvec guard inside rebuild fires).
+    auto make_meta = [&](int64_t tablet_id, bool include_sstable) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(11);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* shared_rs = meta->add_rowsets();
+        shared_rs->set_id(10);
+        shared_rs->set_version(1);
+        shared_rs->set_num_rows(10);
+        shared_rs->set_data_size(100);
+        shared_rs->add_segments("shared.dat");
+        shared_rs->add_segment_size(100);
+        shared_rs->add_shared_segments(true);
+        if (include_sstable) {
+            auto* sst = meta->mutable_sstable_meta()->add_sstables();
+            sst->set_filename(ns_filename);
+            sst->set_filesize(ns_filesize);
+            sst->set_shared(false);
+            sst->set_max_rss_rowid((static_cast<uint64_t>(10) << 32) | 0);
+            // Inject a non-empty embedded delvec to trip the guard.
+            // sst.has_delvec() && sst.delvec().size() > 0 == illegal
+            // for !has_shared_rssid form.
+            sst->mutable_delvec()->set_version(1);
+            sst->mutable_delvec()->set_size(123);
+        }
+        return meta;
+    };
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_a, /*include_sstable=*/false)));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(make_meta(child_b, /*include_sstable=*/true)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(98);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto status = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                                  txn_info, false, tablet_metadatas, tablet_ranges);
+    ASSERT_FALSE(status.ok()) << "non-shared sstable with embedded delvec must trigger corruption guard";
+    EXPECT_TRUE(status.is_corruption()) << "expected Corruption, got: " << status.to_string();
+}
+
+// TODO(round-3 follow-up): test_tablet_merging_legacy_sstable_rebuild_filters_outside_tablet_range
+// This test would set up real INT-typed PK columns + tablet ranges with
+// PrimaryKeyEncoder-encoded sstable keys to verify the rebuild's tablet-range
+// Seek/stop filter (TabletRangeHelper::create_sst_seek_range_from). The filter
+// is wired in rebuild_legacy_shared_sstable; verifying its behavior end-to-end
+// requires PK encoding scaffolding that's not currently in this fixture. The
+// existing tests above all use set_primary_key_schema (no columns), which makes
+// merged_range bound-less, so the range filter degenerates to an unbounded
+// scan — the filter code path is exercised but its filtering behavior on a
+// bounded range is not directly asserted yet. Track for follow-up once the
+// fixture grows a helper for PK-encoded test sstables.
 
 // Stacked merge: parent's legacy sstable already has a non-zero rssid_offset
 // (from a prior merge). Merging this parent as ctx[N>=1] with an additional
@@ -6325,6 +8198,1387 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_cleanup_on_failure
         if (pre_files.count(file) > 0) continue; // pre-existing
         EXPECT_EQ(std::string::npos, file.find(".cols")) << "leftover .cols file after cleanup: " << file;
     }
+}
+
+// ---------------------------------------------------------------------------
+// PR-1: PK fail-fast + non-PK skip-dedup tests for split → partial-children
+// compaction → merge correctness fix.
+// ---------------------------------------------------------------------------
+
+namespace pr1_helpers {
+
+// Populate range = [lower, upper) on a TabletRangePB using INT sort key.
+inline void set_int_range(TabletRangePB* range, int lower, int upper) {
+    LakeTabletReshardTest::generate_sort_key(lower).Swap(range->mutable_lower_bound());
+    range->set_lower_bound_included(true);
+    LakeTabletReshardTest::generate_sort_key(upper).Swap(range->mutable_upper_bound());
+    range->set_upper_bound_included(false);
+}
+
+// Build a child metadata that retains a shared rowset (no compaction).
+// Range conventions:
+//   - tablet range = [tablet_lower, tablet_upper)
+//   - rowset range = same as tablet (split clip semantics)
+inline std::shared_ptr<TabletMetadataPB> make_shared_child(int64_t tablet_id, int64_t base_version, uint32_t shared_id,
+                                                           KeysType keys_type, int tablet_lower, int tablet_upper) {
+    auto meta = std::make_shared<TabletMetadataPB>();
+    meta->set_id(tablet_id);
+    meta->set_version(base_version);
+    meta->set_next_rowset_id(shared_id + 1);
+    auto* schema = meta->mutable_schema();
+    schema->set_keys_type(keys_type);
+    schema->set_id(7777);
+    set_int_range(meta->mutable_range(), tablet_lower, tablet_upper);
+
+    auto* rowset = meta->add_rowsets();
+    rowset->set_id(shared_id);
+    rowset->set_version(base_version);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(100);
+    rowset->add_segments("shared_seg.dat");
+    rowset->add_segment_size(100);
+    rowset->add_shared_segments(true);
+    set_int_range(rowset->mutable_range(), tablet_lower, tablet_upper);
+    return meta;
+}
+
+// Build a child metadata where the shared rowset has been compacted into a
+// fresh non-shared output rowset.
+inline std::shared_ptr<TabletMetadataPB> make_compacted_child(int64_t tablet_id, int64_t base_version,
+                                                              uint32_t compacted_id, KeysType keys_type,
+                                                              int tablet_lower, int tablet_upper,
+                                                              const std::string& compacted_seg_name) {
+    auto meta = std::make_shared<TabletMetadataPB>();
+    meta->set_id(tablet_id);
+    meta->set_version(base_version);
+    meta->set_next_rowset_id(compacted_id + 1);
+    auto* schema = meta->mutable_schema();
+    schema->set_keys_type(keys_type);
+    schema->set_id(7777);
+    set_int_range(meta->mutable_range(), tablet_lower, tablet_upper);
+
+    auto* rowset = meta->add_rowsets();
+    rowset->set_id(compacted_id);
+    rowset->set_version(base_version + 1); // compaction bumps version
+    rowset->set_num_rows(10);
+    rowset->set_data_size(100);
+    rowset->add_segments(compacted_seg_name);
+    rowset->add_segment_size(100);
+    // Not shared: this is the local compaction output.
+    set_int_range(rowset->mutable_range(), tablet_lower, tablet_upper);
+    return meta;
+}
+
+// PR-2: 1-column PK schema with c0:INT key, mirroring the column layout used
+// by write_two_column_segment for the shared physical segment. Phase 0 only
+// needs the key column; we omit c1 so the schema matches the segment's
+// expected column ordering for the seek-range to rowid-range translation.
+inline void set_pk_int_key_schema(TabletMetadataPB* metadata, int64_t schema_id) {
+    auto* schema = metadata->mutable_schema();
+    schema->set_keys_type(PRIMARY_KEYS);
+    schema->set_id(schema_id);
+    schema->set_num_short_key_columns(1);
+    schema->set_num_rows_per_row_block(65535);
+    auto* c0 = schema->add_column();
+    c0->set_unique_id(1001);
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+    auto* c1 = schema->add_column();
+    c1->set_unique_id(1002);
+    c1->set_name("c1");
+    c1->set_type("INT");
+    c1->set_is_key(false);
+    c1->set_is_nullable(false);
+    c1->set_aggregation("REPLACE");
+}
+
+inline std::shared_ptr<TabletMetadataPB> make_pk_shared_child_with_real_segment(int64_t tablet_id, int64_t base_version,
+                                                                                uint32_t shared_id, int tablet_lower,
+                                                                                int tablet_upper,
+                                                                                uint64_t segment_size) {
+    auto meta = std::make_shared<TabletMetadataPB>();
+    meta->set_id(tablet_id);
+    meta->set_version(base_version);
+    meta->set_next_rowset_id(shared_id + 1);
+    set_pk_int_key_schema(meta.get(), 9001);
+    set_int_range(meta->mutable_range(), tablet_lower, tablet_upper);
+
+    auto* rowset = meta->add_rowsets();
+    rowset->set_id(shared_id);
+    rowset->set_version(base_version);
+    rowset->set_num_rows(static_cast<int64_t>(tablet_upper - tablet_lower));
+    rowset->set_data_size(static_cast<int64_t>(segment_size));
+    rowset->add_segments("shared_seg.dat");
+    rowset->add_segment_size(segment_size);
+    rowset->add_shared_segments(true);
+    set_int_range(rowset->mutable_range(), tablet_lower, tablet_upper);
+    return meta;
+}
+
+inline std::shared_ptr<TabletMetadataPB> make_pk_compacted_child(int64_t tablet_id, int64_t base_version,
+                                                                 uint32_t compacted_id, int tablet_lower,
+                                                                 int tablet_upper,
+                                                                 const std::string& compacted_seg_name) {
+    auto meta = std::make_shared<TabletMetadataPB>();
+    meta->set_id(tablet_id);
+    meta->set_version(base_version);
+    meta->set_next_rowset_id(compacted_id + 1);
+    set_pk_int_key_schema(meta.get(), 9001);
+    set_int_range(meta->mutable_range(), tablet_lower, tablet_upper);
+
+    auto* rowset = meta->add_rowsets();
+    rowset->set_id(compacted_id);
+    rowset->set_version(base_version + 1);
+    rowset->set_num_rows(tablet_upper - tablet_lower);
+    rowset->set_data_size(100);
+    rowset->add_segments(compacted_seg_name);
+    rowset->add_segment_size(100);
+    set_int_range(rowset->mutable_range(), tablet_lower, tablet_upper);
+    return meta;
+}
+
+} // namespace pr1_helpers
+
+// PR-2 helper: build a 3-way split with one compacted child + 2 children
+// retaining a shared rowset that points to a real on-disk segment, and
+// publish the merge. The macro returns the merged metadata bound to |MERGED|
+// and the canonical R0's segment rssid bound to |CANONICAL_RSSID|. Use a
+// macro because the helper needs access to the fixture's protected
+// |_tablet_manager| / |next_id| / |prepare_tablet_dirs| /
+// |write_two_column_segment|.
+#define BUILD_THREE_WAY_PK_GAP_MERGE(MERGED, CANONICAL_RSSID, MERGED_TABLET, COMPACTED_INDEX, TXN_ID)                  \
+    TabletMetadataPtr MERGED;                                                                                          \
+    int64_t MERGED_TABLET = 0;                                                                                         \
+    uint32_t CANONICAL_RSSID = 0;                                                                                      \
+    do {                                                                                                               \
+        using namespace pr1_helpers;                                                                                   \
+        const int64_t base_version = 1;                                                                                \
+        const int64_t new_version = 2;                                                                                 \
+        const int64_t child_ids[3] = {next_id(), next_id(), next_id()};                                                \
+        MERGED_TABLET = next_id();                                                                                     \
+        prepare_tablet_dirs(child_ids[0]);                                                                             \
+        prepare_tablet_dirs(child_ids[1]);                                                                             \
+        prepare_tablet_dirs(child_ids[2]);                                                                             \
+        prepare_tablet_dirs(MERGED_TABLET);                                                                            \
+        constexpr int kNumRows = 30;                                                                                   \
+        constexpr int kRangeBoundaries[4] = {0, 10, 20, 30};                                                           \
+        uint64_t segment_size =                                                                                        \
+                write_two_column_segment(MERGED_TABLET, "shared_seg.dat", kNumRows, [](int i) { return i * 10; });     \
+        std::shared_ptr<TabletMetadataPB> metas[3];                                                                    \
+        for (int i = 0; i < 3; ++i) {                                                                                  \
+            const int lower = kRangeBoundaries[i];                                                                     \
+            const int upper = kRangeBoundaries[i + 1];                                                                 \
+            if (i == (COMPACTED_INDEX)) {                                                                              \
+                metas[i] = make_pk_compacted_child(child_ids[i], base_version, /*compacted_id=*/11, lower, upper,      \
+                                                   fmt::format("compacted_{}.dat", i));                                \
+            } else {                                                                                                   \
+                metas[i] = make_pk_shared_child_with_real_segment(child_ids[i], base_version, /*shared_id=*/10, lower, \
+                                                                  upper, segment_size);                                \
+            }                                                                                                          \
+            EXPECT_OK(_tablet_manager->put_tablet_metadata(metas[i]));                                                 \
+        }                                                                                                              \
+        ReshardingTabletInfoPB resharding_tablet;                                                                      \
+        auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();                                         \
+        merging_info.add_old_tablet_ids(child_ids[0]);                                                                 \
+        merging_info.add_old_tablet_ids(child_ids[1]);                                                                 \
+        merging_info.add_old_tablet_ids(child_ids[2]);                                                                 \
+        merging_info.set_new_tablet_id(MERGED_TABLET);                                                                 \
+        TxnInfoPB txn_info;                                                                                            \
+        txn_info.set_txn_id(TXN_ID);                                                                                   \
+        txn_info.set_commit_time(1);                                                                                   \
+        txn_info.set_gtid(1);                                                                                          \
+        std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;                                               \
+        std::unordered_map<int64_t, TabletRangePB> tablet_ranges;                                                      \
+        ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version, \
+                                                  txn_info, false, tablet_metadatas, tablet_ranges));                  \
+        MERGED = tablet_metadatas.at(MERGED_TABLET);                                                                   \
+        ASSERT_NE(MERGED, nullptr);                                                                                    \
+        for (const auto& r : MERGED->rowsets()) {                                                                      \
+            bool has_shared = false;                                                                                   \
+            for (int i = 0; i < r.shared_segments_size(); ++i) {                                                       \
+                if (r.shared_segments(i)) {                                                                            \
+                    has_shared = true;                                                                                 \
+                    break;                                                                                             \
+                }                                                                                                      \
+            }                                                                                                          \
+            if (has_shared) {                                                                                          \
+                CANONICAL_RSSID = r.id();                                                                              \
+                break;                                                                                                 \
+            }                                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+#define ASSERT_SYNTHESIZED_GAP_DELVEC(MERGED, CANONICAL_RSSID)                                                     \
+    do {                                                                                                           \
+        ASSERT_TRUE((MERGED)->has_delvec_meta()) << "delvec_meta missing — Phase 0 did not synthesize gap delvec"; \
+        ASSERT_EQ(1, (MERGED)->delvec_meta().version_to_file_size())                                               \
+                << "expected exactly one delvec file written by merge_delvecs";                                    \
+        auto delvec_it = (MERGED)->delvec_meta().delvecs().find(CANONICAL_RSSID);                                  \
+        ASSERT_NE(delvec_it, (MERGED)->delvec_meta().delvecs().end())                                              \
+                << "delvec_meta has no entry for canonical rssid " << (CANONICAL_RSSID);                           \
+        EXPECT_GT(delvec_it->second.size(), 0u) << "synthesized delvec page is empty";                             \
+        EXPECT_EQ(2, (MERGED)->version()) << "merged tablet version mismatch";                                     \
+    } while (0)
+
+// PR-2 §5.2.4: merge_sstables's shared_rssid path must project a delvec from
+// new_metadata->delvec_meta()[mapped_rssid] regardless of whether the SOURCE
+// sstable had has_delvec set. Without this change, a synthesized gap delvec
+// (created in Phase 0 because a sibling child compacted away its share)
+// would never reach the PK-index sstable PB and PersistentIndexSstable::
+// multi_get could return stale rssids.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_pk_sstable_pb_delvec_projection_when_source_has_no_delvec) {
+    using namespace pr1_helpers;
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Real shared segment under merged_tablet/segments/. c0 = [0..20).
+    const uint64_t segment_size =
+            write_two_column_segment(merged_tablet, "shared_seg.dat", 20, [](int i) { return i * 10; });
+
+    // Child A retains the shared rowset for tablet range [0, 10). Its
+    // sstable_meta carries a shared sstable with shared_rssid=10 (A's R0
+    // namespace) and NO has_delvec on source — exercising the §5.2.4 path.
+    auto meta_a = make_pk_shared_child_with_real_segment(child_a, base_version, /*shared_id=*/10, /*lower=*/0,
+                                                         /*upper=*/10, segment_size);
+    auto* sst_a = meta_a->mutable_sstable_meta()->add_sstables();
+    sst_a->set_filename("shared.sst");
+    sst_a->set_filesize(512);
+    sst_a->set_shared(true);
+    sst_a->set_shared_rssid(10);
+    sst_a->set_shared_version(2);
+    sst_a->set_max_rss_rowid((static_cast<uint64_t>(10) << 32) | 99);
+    // intentionally NO sst_a->set_delvec(...): source has no delvec.
+
+    // Child B has compacted away its share — non-shared compaction output for
+    // tablet range [10, 20). Without B's contribution, canonical R0's
+    // contributors only cover [0,10); compute_disjoint_gaps_within emits
+    // [10, 20) within the merged tablet range.
+    auto meta_b = make_pk_compacted_child(child_b, base_version, /*compacted_id=*/11, /*lower=*/10, /*upper=*/20,
+                                          "compacted_b.dat");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2010);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_NE(merged, nullptr);
+
+    // Locate canonical R0 (the rowset with at least one shared_segments(i)==true).
+    uint32_t canonical_rssid = 0;
+    for (const auto& r : merged->rowsets()) {
+        bool has_shared = false;
+        for (int i = 0; i < r.shared_segments_size(); ++i) {
+            if (r.shared_segments(i)) {
+                has_shared = true;
+                break;
+            }
+        }
+        if (has_shared) {
+            canonical_rssid = r.id();
+            break;
+        }
+    }
+    ASSERT_NE(canonical_rssid, 0u);
+
+    // delvec_meta should have a synthesized entry for canonical_rssid.
+    auto delvec_it = merged->delvec_meta().delvecs().find(canonical_rssid);
+    ASSERT_NE(delvec_it, merged->delvec_meta().delvecs().end());
+    EXPECT_GT(delvec_it->second.size(), 0u);
+
+    // sstable_meta should have one shared sstable; its delvec PB must be
+    // populated by §5.2.4's projection even though the source had no delvec.
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    EXPECT_EQ("shared.sst", out_sst.filename());
+    EXPECT_EQ(canonical_rssid, out_sst.shared_rssid());
+    ASSERT_TRUE(out_sst.has_delvec()) << "merged sstable PB missing projected delvec";
+    EXPECT_GT(out_sst.delvec().size(), 0u) << "merged sstable PB delvec is empty";
+}
+
+// PR-2: first child compacted. canonical_contribs covers [10,30) inside the
+// merged tablet range [0,30); compute_disjoint_gaps_within emits [0,10),
+// translated into rowid window [0,10) on the shared 30-row segment, which
+// must end up in the synthesized delvec on canonical R0.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_pk_gap_delvec_first_child_compacts) {
+    BUILD_THREE_WAY_PK_GAP_MERGE(merged, canonical_rssid, merged_tablet, /*compacted_index=*/0, /*txn_id=*/1001);
+    ASSERT_SYNTHESIZED_GAP_DELVEC(merged, canonical_rssid);
+    // Two rowsets in merged: canonical R0 (shared, deduped from B+C) and
+    // R1 (A's compaction output, non-shared).
+    ASSERT_EQ(2, merged->rowsets_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_pk_gap_delvec_middle_child_compacts) {
+    BUILD_THREE_WAY_PK_GAP_MERGE(merged, canonical_rssid, merged_tablet, /*compacted_index=*/1, /*txn_id=*/1002);
+    ASSERT_SYNTHESIZED_GAP_DELVEC(merged, canonical_rssid);
+    ASSERT_EQ(2, merged->rowsets_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_pk_gap_delvec_last_child_compacts) {
+    BUILD_THREE_WAY_PK_GAP_MERGE(merged, canonical_rssid, merged_tablet, /*compacted_index=*/2, /*txn_id=*/1003);
+    ASSERT_SYNTHESIZED_GAP_DELVEC(merged, canonical_rssid);
+    ASSERT_EQ(2, merged->rowsets_size());
+}
+
+// PR-2 deeper assertion: load the merged delvec file and decode its Roaring
+// bitmap, verify the exact rowid set matches the compacted child's range. The
+// shared segment in BUILD_THREE_WAY_PK_GAP_MERGE has c0 = [0..30) so rowid==key
+// when the segment's short-key index resolves the seek range.
+//
+// compacted_index=0 → contributors cover [10,30) → gap [0,10) → masked rowids {0..9}
+// compacted_index=1 → contributors cover [0,10)∪[20,30) → gap [10,20) → masked rowids {10..19}
+// compacted_index=2 → contributors cover [0,20) → gap [20,30) → masked rowids {20..29}
+TEST_F(LakeTabletReshardTest, test_tablet_merging_pk_gap_delvec_rowid_content_matches_compacted_range) {
+    auto check = [&](int compacted_index, int64_t txn_id, uint32_t expected_lo, uint32_t expected_hi) {
+        BUILD_THREE_WAY_PK_GAP_MERGE(merged, canonical_rssid, merged_tablet, compacted_index, txn_id);
+        ASSERT_SYNTHESIZED_GAP_DELVEC(merged, canonical_rssid);
+
+        DelVector loaded;
+        LakeIOOptions io_opts;
+        // get_del_vec takes a const TabletMetadata&; *merged is already that type.
+        ASSERT_OK(get_del_vec(_tablet_manager.get(), *merged, canonical_rssid, /*fill_cache=*/false, io_opts, &loaded));
+        ASSERT_TRUE(loaded.roaring() != nullptr) << "loaded delvec empty for compacted_index=" << compacted_index;
+        const Roaring& bitmap = *loaded.roaring();
+
+        // Expected: exactly {expected_lo .. expected_hi - 1}.
+        Roaring expected;
+        expected.addRange(expected_lo, expected_hi);
+        EXPECT_EQ(expected.cardinality(), bitmap.cardinality())
+                << "cardinality mismatch for compacted_index=" << compacted_index;
+        EXPECT_TRUE(bitmap == expected) << "bitmap mismatch for compacted_index=" << compacted_index;
+    };
+    check(/*compacted_index=*/0, /*txn_id=*/1101, /*expected_lo=*/0, /*expected_hi=*/10);
+    check(/*compacted_index=*/1, /*txn_id=*/1102, /*expected_lo=*/10, /*expected_hi=*/20);
+    check(/*compacted_index=*/2, /*txn_id=*/1103, /*expected_lo=*/20, /*expected_hi=*/30);
+}
+
+// PR-2 contiguous: all children retain the shared rowset → contributors cover
+// the merged tablet range → no synthesized gap delvec generated, no delvec
+// file written. Phase 0 returns empty without opening any segment.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_pk_no_gap_passthrough) {
+    using namespace pr1_helpers;
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t child_c = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(child_c);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = make_shared_child(child_a, base_version, 10, PRIMARY_KEYS, 0, 10);
+    auto meta_b = make_shared_child(child_b, base_version, 10, PRIMARY_KEYS, 10, 20);
+    auto meta_c = make_shared_child(child_c, base_version, 10, PRIMARY_KEYS, 20, 30);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.add_old_tablet_ids(child_c);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(4);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Three shared rowsets dedup down to one canonical (PK always dedups, all contiguous).
+    ASSERT_EQ(1, merged->rowsets_size());
+    // No gap → Phase 0 emits no synthesized specs → no delvec_meta entries.
+    EXPECT_EQ(0, merged->delvec_meta().delvecs_size())
+            << "no children had delvecs and no gap was synthesized; expected empty delvec_meta";
+}
+
+// Non-PK (DUP) skip-dedup: three children with shared rowsets, middle child compacted →
+// the two non-compacted children's ranges are non-adjacent, so dedup is skipped and
+// they remain as separate rowsets in merged metadata.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dup_keys_skip_dedup_on_gap) {
+    using namespace pr1_helpers;
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t child_c = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(child_c);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = make_shared_child(child_a, base_version, 10, DUP_KEYS, 0, 10);
+    auto meta_b = make_compacted_child(child_b, base_version, 11, DUP_KEYS, 10, 20, "cb.dat");
+    auto meta_c = make_shared_child(child_c, base_version, 10, DUP_KEYS, 20, 30);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.add_old_tablet_ids(child_c);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(5);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Expect 3 rowsets: A's shared (range [0,10)), C's shared (range [20,30)) NOT deduped
+    // with A's because [10,20) gap, plus B's compacted output.
+    ASSERT_EQ(3, merged->rowsets_size());
+    int shared_count = 0;
+    int local_count = 0;
+    for (const auto& r : merged->rowsets()) {
+        bool has_shared = false;
+        for (int i = 0; i < r.shared_segments_size(); ++i) {
+            if (r.shared_segments(i)) {
+                has_shared = true;
+                break;
+            }
+        }
+        if (has_shared) {
+            ++shared_count;
+        } else {
+            ++local_count;
+        }
+    }
+    EXPECT_EQ(2, shared_count) << "two non-deduped shared rowsets expected";
+    EXPECT_EQ(1, local_count) << "one local compaction-output rowset expected";
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_agg_keys_skip_dedup_on_gap) {
+    using namespace pr1_helpers;
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t child_c = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(child_c);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = make_shared_child(child_a, base_version, 10, AGG_KEYS, 0, 10);
+    auto meta_b = make_compacted_child(child_b, base_version, 11, AGG_KEYS, 10, 20, "cb.dat");
+    auto meta_c = make_shared_child(child_c, base_version, 10, AGG_KEYS, 20, 30);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.add_old_tablet_ids(child_c);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(6);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(3, merged->rowsets_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_unique_keys_skip_dedup_on_gap) {
+    using namespace pr1_helpers;
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t child_c = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(child_c);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = make_shared_child(child_a, base_version, 10, UNIQUE_KEYS, 0, 10);
+    auto meta_b = make_compacted_child(child_b, base_version, 11, UNIQUE_KEYS, 10, 20, "cb.dat");
+    auto meta_c = make_shared_child(child_c, base_version, 10, UNIQUE_KEYS, 20, 30);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.add_old_tablet_ids(child_c);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(7);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(3, merged->rowsets_size());
+}
+
+// Non-PK + contiguous: the two adjacent shared rowsets dedup into one canonical,
+// matching the pre-PR-1 behavior. No fail-fast (non-PK) and no skip (ranges contiguous).
+TEST_F(LakeTabletReshardTest, test_tablet_merging_non_pk_contiguous_still_dedups) {
+    using namespace pr1_helpers;
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = make_shared_child(child_a, base_version, 10, DUP_KEYS, 0, 10);
+    auto meta_b = make_shared_child(child_b, base_version, 10, DUP_KEYS, 10, 20);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(8);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size());
+}
+
+// Regression for Codex round-1 finding: when a duplicate rowset lacks its own
+// `range` but its tablet metadata has one, the canonical's stored range must
+// still extend to cover the duplicate. Otherwise readers (which prefer
+// rowset.range over tablet.range) miss rows from later contributors. PR-1
+// pushes the *effective* duplicate range (rowset.range || ctx.metadata.range
+// || unbounded) into update_canonical to fix this.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_canonical_range_extends_for_duplicate_without_rowset_range) {
+    using namespace pr1_helpers;
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_no_rowset_range_child = [&](int64_t tid, int tablet_lower, int tablet_upper) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tid);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(11);
+        auto* schema = meta->mutable_schema();
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_id(7777);
+        set_int_range(meta->mutable_range(), tablet_lower, tablet_upper);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(10);
+        rowset->set_version(base_version);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        // intentionally NO rowset->mutable_range(): rely on ctx tablet range
+        return meta;
+    };
+
+    auto meta_a = make_no_rowset_range_child(child_a, 0, 10);
+    auto meta_b = make_no_rowset_range_child(child_b, 10, 20);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(91);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Non-PK + adjacent ranges → dedup into one canonical.
+    ASSERT_EQ(1, merged->rowsets_size());
+    const auto& canonical = merged->rowsets(0);
+    ASSERT_TRUE(canonical.has_range());
+    // canonical.range should be the union [0, 20), not just A's [0, 10).
+    TabletRangePB expected_full;
+    set_int_range(&expected_full, 0, 20);
+    EXPECT_EQ(expected_full.lower_bound().DebugString(), canonical.range().lower_bound().DebugString())
+            << "canonical lower mismatch";
+    EXPECT_EQ(expected_full.upper_bound().DebugString(), canonical.range().upper_bound().DebugString())
+            << "canonical upper mismatch";
+    EXPECT_EQ(expected_full.lower_bound_included(), canonical.range().lower_bound_included());
+    EXPECT_EQ(expected_full.upper_bound_included(), canonical.range().upper_bound_included());
+}
+
+// Delete-predicate dedup keeps the original unconditional-skip path: contiguity
+// is not consulted, and the contribution map gets no entry. Two PK children
+// with delete-only predicate rowsets at the same version dedup down to one.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delete_predicate_dedup_unchanged_pk) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_pred_child = [&](int64_t tid, int tablet_lower, int tablet_upper) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tid);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(11);
+        auto* schema = meta->mutable_schema();
+        schema->set_keys_type(PRIMARY_KEYS);
+        schema->set_id(7777);
+        pr1_helpers::set_int_range(meta->mutable_range(), tablet_lower, tablet_upper);
+        // Pure delete-predicate rowset: no segments, no del_files, just a predicate.
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(10);
+        rowset->set_version(base_version);
+        rowset->set_num_rows(0);
+        rowset->set_data_size(0);
+        auto* pred = rowset->mutable_delete_predicate();
+        pred->set_version(base_version); // required field
+        pred->mutable_in_predicates();   // make has_delete_predicate true
+        return meta;
+    };
+
+    auto meta_a = make_pred_child(child_a, 0, 10);
+    auto meta_b = make_pred_child(child_b, 10, 20);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(9);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Both predicate rowsets dedup'd to single one (unconditional skip path).
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_TRUE(merged->rowsets(0).has_delete_predicate());
+}
+
+// =============================================================================
+// Fast-path v2 — split family inference (commit 1)
+//
+// These tests exercise lake::detail::infer_split_families directly, without
+// running an end-to-end merge. The helper is "passive" in this commit (no
+// caller wires it through merge_rowsets / map_rssid yet); commits 4-5 will.
+// =============================================================================
+
+namespace {
+
+// Lightweight fixture that builds mutable metadata + offsets, then snapshots
+// them as immutable SplitFamilyInferenceInput records when infer_split_
+// families is invoked. Splitting the mutable build phase from the const
+// input phase matches how production constructs TabletMetadataPtr (=
+// shared_ptr<const TabletMetadataPB>).
+struct SplitFamilyTestBuilder {
+    std::vector<std::pair<std::shared_ptr<TabletMetadataPB>, int64_t>> mutable_children;
+
+    uint32_t add_empty_child(int64_t rssid_offset) {
+        mutable_children.emplace_back(std::make_shared<TabletMetadataPB>(), rssid_offset);
+        return static_cast<uint32_t>(mutable_children.size() - 1);
+    }
+
+    // Add a legacy `shared && !has_shared_rssid` PK sstable (used by the
+    // filename edge).
+    void add_legacy_shared_sstable(uint32_t child_index, const std::string& filename) {
+        auto* sstable = mutable_children[child_index].first->mutable_sstable_meta()->add_sstables();
+        sstable->set_filename(filename);
+        sstable->set_filesize(1);
+        sstable->set_shared(true);
+        // !has_shared_rssid is the default — leave shared_rssid unset.
+    }
+
+    // Add a shared-ancestor rowset (segments_size > 0, all shared_segments
+    // true) with the given physical fingerprint. Used by the rowset-
+    // identity edge.
+    void add_shared_ancestor_rowset(uint32_t child_index, uint32_t rowset_id, int64_t version,
+                                    const std::vector<std::string>& segments) {
+        auto* rowset = mutable_children[child_index].first->add_rowsets();
+        rowset->set_id(rowset_id);
+        rowset->set_version(version);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        for (const auto& segment : segments) {
+            rowset->add_segments(segment);
+            rowset->add_segment_size(100);
+            rowset->add_shared_segments(true);
+            auto* segment_meta = rowset->add_segment_metas();
+            segment_meta->set_segment_idx(static_cast<uint32_t>(rowset->segment_metas_size() - 1));
+        }
+    }
+
+    // Add a child-local (NOT shared) rowset. The rowset-identity edge must
+    // ignore these even when the physical fingerprint matches a shared-
+    // ancestor on another child.
+    void add_child_local_rowset(uint32_t child_index, uint32_t rowset_id, int64_t version,
+                                const std::vector<std::string>& segments) {
+        auto* rowset = mutable_children[child_index].first->add_rowsets();
+        rowset->set_id(rowset_id);
+        rowset->set_version(version);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        for (const auto& segment : segments) {
+            rowset->add_segments(segment);
+            rowset->add_segment_size(100);
+            rowset->add_shared_segments(false);
+            auto* segment_meta = rowset->add_segment_metas();
+            segment_meta->set_segment_idx(static_cast<uint32_t>(rowset->segment_metas_size() - 1));
+        }
+    }
+
+    // Add a delete-only rowset (segments_size == 0). The rowset-identity
+    // edge must ignore these too.
+    void add_delete_only_rowset(uint32_t child_index, uint32_t rowset_id, int64_t version) {
+        auto* rowset = mutable_children[child_index].first->add_rowsets();
+        rowset->set_id(rowset_id);
+        rowset->set_version(version);
+        rowset->mutable_delete_predicate(); // mark as a delete predicate; no segments
+    }
+
+    std::vector<lake::detail::SplitFamilyInferenceInput> snapshot() const {
+        std::vector<lake::detail::SplitFamilyInferenceInput> inputs;
+        inputs.reserve(mutable_children.size());
+        for (const auto& [metadata, rssid_offset] : mutable_children) {
+            inputs.push_back({metadata, rssid_offset});
+        }
+        return inputs;
+    }
+
+    // Helper for tests that need to write directly into a child's metadata.
+    TabletMetadataPB* metadata_of(uint32_t child_index) { return mutable_children[child_index].first.get(); }
+};
+
+} // namespace
+
+// Empty input → empty result.
+TEST(SplitFamilyInferenceTest, empty_input) {
+    SplitFamilyTestBuilder builder;
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    EXPECT_TRUE(result.child_to_family.empty());
+    EXPECT_TRUE(result.families.empty());
+}
+
+// Single child with no edges → kNoFamily, no families produced.
+TEST(SplitFamilyInferenceTest, single_child_no_edges) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.child_to_family.size());
+    EXPECT_EQ(lake::detail::InferredSplitFamilies::kNoFamily, result.child_to_family[0]);
+    EXPECT_TRUE(result.families.empty());
+}
+
+// Two children share a legacy `shared && !has_shared_rssid` sstable → one
+// family, canonical = child 0.
+TEST(SplitFamilyInferenceTest, filename_edge_unions_two_children) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_legacy_shared_sstable(0, "shared.sst");
+    builder.add_legacy_shared_sstable(1, "shared.sst");
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.families.size());
+    const auto& family = result.families.front();
+    EXPECT_EQ(0u, family.canonical_child_index);
+    EXPECT_EQ(0, family.canonical_rssid_offset);
+    EXPECT_THAT(family.member_child_indexes, ::testing::ElementsAre(0u, 1u));
+    EXPECT_EQ(0u, result.child_to_family[0]);
+    EXPECT_EQ(0u, result.child_to_family[1]);
+}
+
+// Two children share an exact-match shared-ancestor rowset → one family,
+// canonical = child 0.
+TEST(SplitFamilyInferenceTest, rowset_edge_unions_two_children) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a", "seg_b"});
+    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a", "seg_b"});
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.families.size());
+    EXPECT_EQ(0u, result.families.front().canonical_child_index);
+    EXPECT_EQ(0, result.families.front().canonical_rssid_offset);
+}
+
+// Two children with rowsets that LOOK identical except for segment_idx
+// layout (one inherited contiguous {0,1}, the other has a sparse {0,2}
+// after middle compaction) — they are NOT physically identical and must
+// not be unioned.
+TEST(SplitFamilyInferenceTest, rowset_edge_segment_idx_layout_must_match) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    auto* rowset_a = builder.metadata_of(0)->add_rowsets();
+    rowset_a->set_id(3);
+    rowset_a->set_version(2);
+    rowset_a->add_segments("seg_a");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    rowset_a->add_segments("seg_b");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    rowset_a->add_segment_metas()->set_segment_idx(0);
+    rowset_a->add_segment_metas()->set_segment_idx(1);
+    auto* rowset_b = builder.metadata_of(1)->add_rowsets();
+    rowset_b->set_id(3);
+    rowset_b->set_version(2);
+    rowset_b->add_segments("seg_a");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    rowset_b->add_segments("seg_b");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    rowset_b->add_segment_metas()->set_segment_idx(0);
+    rowset_b->add_segment_metas()->set_segment_idx(2); // sparse!
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    EXPECT_TRUE(result.families.empty()) << "different segment_idx layouts must not union";
+    EXPECT_EQ(lake::detail::InferredSplitFamilies::kNoFamily, result.child_to_family[0]);
+    EXPECT_EQ(lake::detail::InferredSplitFamilies::kNoFamily, result.child_to_family[1]);
+}
+
+// Delete-only rowsets (segments_size == 0) must NOT participate in the
+// rowset-identity edge — two delete-only rowsets with empty vectors would
+// otherwise falsely match each other.
+TEST(SplitFamilyInferenceTest, delete_only_rowsets_excluded_from_edge) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_delete_only_rowset(0, /*rowset_id=*/3, /*version=*/2);
+    builder.add_delete_only_rowset(1, /*rowset_id=*/3, /*version=*/2);
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    EXPECT_TRUE(result.families.empty()) << "delete-only rowsets must not produce family edges";
+}
+
+// Child-local rowsets (shared_segments NOT all true) must not produce edges
+// even when the physical fingerprint matches.
+TEST(SplitFamilyInferenceTest, child_local_rowsets_excluded_from_edge) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_child_local_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    builder.add_child_local_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    EXPECT_TRUE(result.families.empty()) << "child-local rowsets must not produce family edges";
+}
+
+// Three children unioned via filename edge into one family. canonical is
+// the smallest member regardless of which two children matched first.
+TEST(SplitFamilyInferenceTest, three_children_one_family_via_filename) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_empty_child(/*rssid_offset=*/10);
+    builder.add_legacy_shared_sstable(0, "f.sst");
+    builder.add_legacy_shared_sstable(1, "f.sst");
+    builder.add_legacy_shared_sstable(2, "f.sst");
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.families.size());
+    EXPECT_EQ(0u, result.families.front().canonical_child_index);
+    EXPECT_EQ(0, result.families.front().canonical_rssid_offset);
+    EXPECT_THAT(result.families.front().member_child_indexes, ::testing::ElementsAre(0u, 1u, 2u));
+}
+
+// Two disjoint families on the same merge: child{0,1} share file_a;
+// child{2,3} share file_b. Each family gets its own canonical.
+TEST(SplitFamilyInferenceTest, two_disjoint_families) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_empty_child(/*rssid_offset=*/10);
+    builder.add_empty_child(/*rssid_offset=*/15);
+    builder.add_legacy_shared_sstable(0, "file_a.sst");
+    builder.add_legacy_shared_sstable(1, "file_a.sst");
+    builder.add_legacy_shared_sstable(2, "file_b.sst");
+    builder.add_legacy_shared_sstable(3, "file_b.sst");
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(2u, result.families.size());
+    // Families are emitted in ascending canonical_child_index order.
+    EXPECT_EQ(0u, result.families[0].canonical_child_index);
+    EXPECT_EQ(0, result.families[0].canonical_rssid_offset);
+    EXPECT_THAT(result.families[0].member_child_indexes, ::testing::ElementsAre(0u, 1u));
+    EXPECT_EQ(2u, result.families[1].canonical_child_index);
+    EXPECT_EQ(10, result.families[1].canonical_rssid_offset);
+    EXPECT_THAT(result.families[1].member_child_indexes, ::testing::ElementsAre(2u, 3u));
+    EXPECT_EQ(0u, result.child_to_family[0]);
+    EXPECT_EQ(0u, result.child_to_family[1]);
+    EXPECT_EQ(1u, result.child_to_family[2]);
+    EXPECT_EQ(1u, result.child_to_family[3]);
+}
+
+// Filename edge AND rowset-identity edge can BOTH apply to the same pair —
+// the union-find handles re-unions trivially.
+TEST(SplitFamilyInferenceTest, both_edges_apply_to_same_pair) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_legacy_shared_sstable(0, "f.sst");
+    builder.add_legacy_shared_sstable(1, "f.sst");
+    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.families.size());
+    EXPECT_THAT(result.families.front().member_child_indexes, ::testing::ElementsAre(0u, 1u));
+}
+
+// Edge-only-via-rowset case: filename does not match (sstables compacted
+// away on one side) but the underlying shared rowset still proves the
+// family relationship.
+TEST(SplitFamilyInferenceTest, family_inferred_via_rowset_only) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_legacy_shared_sstable(0, "side_a.sst"); // no overlap
+    builder.add_legacy_shared_sstable(1, "side_b.sst");
+    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.families.size());
+    EXPECT_EQ(0u, result.families.front().canonical_child_index);
+}
+
+// Edge-only-via-filename case: the rowsets diverged (one side compacted
+// the rowset away) but the legacy sstable is still common.
+TEST(SplitFamilyInferenceTest, family_inferred_via_filename_only) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_legacy_shared_sstable(0, "f.sst");
+    builder.add_legacy_shared_sstable(1, "f.sst");
+    // Different rowsets on each side; should NOT contribute an edge but
+    // should also not break the filename-driven union.
+    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/4, /*version=*/2, {"seg_b"});
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.families.size());
+    EXPECT_THAT(result.families.front().member_child_indexes, ::testing::ElementsAre(0u, 1u));
+}
+
+// Two children carry the same physical rowset, but one has segment_metas
+// fully populated (segment_idx = positional index) while the other has
+// segment_metas absent. The PB read path falls back to positional index
+// when segment_metas is missing, so both metadata variants describe the
+// same physical layout — they MUST union into one family. (Codex round-1
+// catch: without normalization, the keys differ and family inference
+// silently misses the legacy fast-path.)
+TEST(SplitFamilyInferenceTest, rowset_edge_normalizes_absent_segment_metas) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    auto* rowset_a = builder.metadata_of(0)->add_rowsets();
+    rowset_a->set_id(3);
+    rowset_a->set_version(2);
+    rowset_a->add_segments("seg_a");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    rowset_a->add_segments("seg_b");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    rowset_a->add_segment_metas()->set_segment_idx(0);
+    rowset_a->add_segment_metas()->set_segment_idx(1);
+    auto* rowset_b = builder.metadata_of(1)->add_rowsets();
+    rowset_b->set_id(3);
+    rowset_b->set_version(2);
+    rowset_b->add_segments("seg_a");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    rowset_b->add_segments("seg_b");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    // segment_metas intentionally absent — read path falls back to
+    // positional index, which equals A's explicit (0, 1).
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.families.size()) << "default positional segment_idx must equal explicit (0, 1) layout";
+}
+
+// Same family-defining physical rowset, but one child has bundle_file_
+// offsets explicitly set to (0, 0) while the other has the field absent.
+// PB defaults to 0 per segment when absent, so the two variants describe
+// the same physical placement and must union into one family.
+TEST(SplitFamilyInferenceTest, rowset_edge_normalizes_absent_bundle_file_offsets) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    auto* rowset_a = builder.metadata_of(0)->add_rowsets();
+    rowset_a->set_id(3);
+    rowset_a->set_version(2);
+    rowset_a->add_segments("seg_a");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    rowset_a->add_segments("seg_b");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    rowset_a->add_bundle_file_offsets(0);
+    rowset_a->add_bundle_file_offsets(0);
+    rowset_a->add_segment_metas()->set_segment_idx(0);
+    rowset_a->add_segment_metas()->set_segment_idx(1);
+    auto* rowset_b = builder.metadata_of(1)->add_rowsets();
+    rowset_b->set_id(3);
+    rowset_b->set_version(2);
+    rowset_b->add_segments("seg_a");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    rowset_b->add_segments("seg_b");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    // bundle_file_offsets absent — PB default 0 per segment, equal to A's
+    // explicit (0, 0).
+    rowset_b->add_segment_metas()->set_segment_idx(0);
+    rowset_b->add_segment_metas()->set_segment_idx(1);
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.families.size()) << "absent bundle_file_offsets must equal explicit (0, 0) layout";
+}
+
+// Mix of orphan + family children. The orphan stays kNoFamily; the family
+// records the right canonical_child_index.
+TEST(SplitFamilyInferenceTest, mix_orphan_and_family) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);  // orphan
+    builder.add_empty_child(/*rssid_offset=*/5);  // family member
+    builder.add_empty_child(/*rssid_offset=*/10); // family member
+    builder.add_legacy_shared_sstable(1, "f.sst");
+    builder.add_legacy_shared_sstable(2, "f.sst");
+    ASSIGN_OR_ABORT(auto result, lake::detail::infer_split_families(builder.snapshot()));
+    ASSERT_EQ(1u, result.families.size());
+    EXPECT_EQ(1u, result.families.front().canonical_child_index);
+    EXPECT_EQ(5, result.families.front().canonical_rssid_offset);
+    EXPECT_EQ(lake::detail::InferredSplitFamilies::kNoFamily, result.child_to_family[0]);
+    EXPECT_EQ(0u, result.child_to_family[1]);
+    EXPECT_EQ(0u, result.child_to_family[2]);
+}
+
+// =============================================================================
+// Fast-path v2 — RssidProjectionPlan build (commit 2)
+//
+// These tests exercise lake::detail::build_rssid_projection_plan directly.
+// The plan is "passive" in this commit (no caller wires it through
+// merge_rowsets / map_rssid yet); commit 4 will.
+// =============================================================================
+
+namespace {
+
+// Convenience helper: run inference + plan build in one call, returning the
+// plan. Used by all RssidProjectionPlanTest tests that don't care about the
+// inferred families themselves.
+lake::detail::RssidProjectionPlan build_plan_for(SplitFamilyTestBuilder& builder) {
+    auto inputs = builder.snapshot();
+    auto families_or = lake::detail::infer_split_families(inputs);
+    CHECK_OK(families_or.status());
+    auto plan_or = lake::detail::build_rssid_projection_plan(inputs, *families_or);
+    CHECK_OK(plan_or.status());
+    return std::move(*plan_or);
+}
+
+} // namespace
+
+// Empty input → empty plan, no families, no occupied entries.
+TEST(RssidProjectionPlanTest, empty_input) {
+    SplitFamilyTestBuilder builder;
+    auto plan = build_plan_for(builder);
+    EXPECT_TRUE(plan.explicit_rssid_map.empty());
+    EXPECT_TRUE(plan.family_legacy_sstable_offset.empty());
+    EXPECT_TRUE(plan.occupied_rssids.empty());
+    EXPECT_TRUE(plan.unsafe_families.empty());
+}
+
+// Two-child family with a shared-ancestor rowset, no collisions.
+// explicit_rssid_map records both rowset.id and segment positions.
+TEST(RssidProjectionPlanTest, family_canonical_projection_emitted) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/8);
+    // Shared rowset id=3 with two segments → segment_idx layout [0, 1].
+    // canonical_offset = 0 (canonical = ctx[0]).
+    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a", "seg_b"});
+    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a", "seg_b"});
+    auto plan = build_plan_for(builder);
+
+    EXPECT_TRUE(plan.unsafe_families.empty());
+    ASSERT_EQ(1u, plan.family_legacy_sstable_offset.size());
+    EXPECT_EQ(0, plan.family_legacy_sstable_offset.at(0u));
+
+    // Both children's (3, 4) entries point to canonical-offset finals.
+    // (rs.id=3 → final 3; lifted segment 0 = 3+0=3, lifted segment 1 = 3+1=4 → finals 3, 4.)
+    EXPECT_EQ(3u, plan.explicit_rssid_map.at({0u, 3u}));
+    EXPECT_EQ(4u, plan.explicit_rssid_map.at({0u, 4u}));
+    EXPECT_EQ(3u, plan.explicit_rssid_map.at({1u, 3u}));
+    EXPECT_EQ(4u, plan.explicit_rssid_map.at({1u, 4u}));
+
+    // Occupancy: finals 3, 4 are claimed by the family.
+    ASSERT_EQ(2u, plan.occupied_rssids.size());
+    EXPECT_EQ(0u, plan.occupied_rssids.at(3u).family_id);
+    EXPECT_EQ(0u, plan.occupied_rssids.at(4u).family_id);
+}
+
+// Family canonical_offset != 0: the explicit map's finals shift by it,
+// and family_legacy_sstable_offset records it for the fast-path.
+TEST(RssidProjectionPlanTest, family_with_nonzero_canonical_offset) {
+    SplitFamilyTestBuilder builder;
+    // child 0 has rowsets so phase-1-style next_rowset_id pushes the
+    // canonical offset upward when child 1 is the canonical (per the
+    // SplitFamilyInferenceInput.rssid_offset). Here we pass canonical_offset=10
+    // directly via builder.add_empty_child. Tests don't run phase 1; they
+    // just feed the offset.
+    builder.add_empty_child(/*rssid_offset=*/10);
+    builder.add_empty_child(/*rssid_offset=*/15);
+    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    auto plan = build_plan_for(builder);
+
+    EXPECT_TRUE(plan.unsafe_families.empty());
+    EXPECT_EQ(10, plan.family_legacy_sstable_offset.at(0u));
+    // rs.id=3 → final 3+10=13; segment 0 lifted=3 → final 13.
+    EXPECT_EQ(13u, plan.explicit_rssid_map.at({0u, 3u}));
+    EXPECT_EQ(13u, plan.explicit_rssid_map.at({1u, 3u}));
+}
+
+// Child-local (non-shared) rowset → does NOT enter explicit_rssid_map even
+// if its ctx is a family member. Goes through natural offset; occupancy
+// records it under the family_id of the ctx, but explicit_rssid_map stays
+// silent so commit 4's map_rssid will fall through to the natural-offset
+// path for it.
+TEST(RssidProjectionPlanTest, child_local_rowsets_not_in_explicit_map) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/8);
+    // Family edge via a shared sstable filename; rowsets diverge.
+    builder.add_legacy_shared_sstable(0, "shared.sst");
+    builder.add_legacy_shared_sstable(1, "shared.sst");
+    // Child-local rowset on ctx 1.
+    builder.add_child_local_rowset(1, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    auto plan = build_plan_for(builder);
+    EXPECT_TRUE(plan.unsafe_families.empty());
+    EXPECT_EQ(0u, plan.explicit_rssid_map.count({1u, 3u}));
+}
+
+// Two physically-distinct rowsets want the same final rssid → both
+// involved families are marked unsafe.
+TEST(RssidProjectionPlanTest, cross_family_collision_marks_both_unsafe) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0); // family A canonical
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/0); // family B canonical
+    builder.add_empty_child(/*rssid_offset=*/0);
+    // Family A: ctx 0 + ctx 1 share a rowset that lands at final=5.
+    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/5, /*version=*/2, {"seg_a"});
+    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/5, /*version=*/2, {"seg_a"});
+    // Family B: ctx 2 + ctx 3 share a DIFFERENT physical rowset that ALSO
+    // wants final=5 (same id, but seg_b vs seg_a → different physical key).
+    builder.add_shared_ancestor_rowset(2, /*rowset_id=*/5, /*version=*/3, {"seg_b"});
+    builder.add_shared_ancestor_rowset(3, /*rowset_id=*/5, /*version=*/3, {"seg_b"});
+    auto plan = build_plan_for(builder);
+    // Both families A and B claim final=5 with different physical keys →
+    // both marked unsafe; explicit_rssid_map drops them; family_legacy_
+    // sstable_offset stays empty.
+    EXPECT_EQ(2u, plan.unsafe_families.size());
+    EXPECT_TRUE(plan.unsafe_families.contains(0u));
+    EXPECT_TRUE(plan.unsafe_families.contains(1u));
+    EXPECT_TRUE(plan.explicit_rssid_map.empty());
+    EXPECT_TRUE(plan.family_legacy_sstable_offset.empty());
+}
+
+// Same physical rowset across family members deduplicates in occupied_rssids.
+// The family stays safe and the explicit_rssid_map records all member ctx
+// entries.
+TEST(RssidProjectionPlanTest, same_physical_dedup_is_safe) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/8);
+    builder.add_empty_child(/*rssid_offset=*/16);
+    for (uint32_t child_index : {0u, 1u, 2u}) {
+        builder.add_shared_ancestor_rowset(child_index, /*rowset_id=*/3, /*version=*/2, {"seg_a"});
+    }
+    auto plan = build_plan_for(builder);
+    EXPECT_TRUE(plan.unsafe_families.empty());
+    EXPECT_EQ(0, plan.family_legacy_sstable_offset.at(0u));
+    // All 3 children's (3, 3) entries point to canonical-offset final 3.
+    EXPECT_EQ(3u, plan.explicit_rssid_map.at({0u, 3u}));
+    EXPECT_EQ(3u, plan.explicit_rssid_map.at({1u, 3u}));
+    EXPECT_EQ(3u, plan.explicit_rssid_map.at({2u, 3u}));
+}
+
+// Sparse segment_idx layout ({0, 2}) is preserved by the projection. The
+// occupancy claims rssid 3 and 5 (= 3+0, 3+2), NOT rssid 4 (which would
+// belong to a hypothetical compacted-out segment_idx=1).
+TEST(RssidProjectionPlanTest, sparse_segment_idx_projection) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/8);
+    auto add_sparse_rowset = [&](uint32_t child_index) {
+        auto* rowset = builder.metadata_of(child_index)->add_rowsets();
+        rowset->set_id(3);
+        rowset->set_version(2);
+        rowset->add_segments("seg_0");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        rowset->add_segments("seg_2");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        rowset->add_segment_metas()->set_segment_idx(0);
+        rowset->add_segment_metas()->set_segment_idx(2);
+    };
+    add_sparse_rowset(0);
+    add_sparse_rowset(1);
+    auto plan = build_plan_for(builder);
+    EXPECT_TRUE(plan.unsafe_families.empty());
+    EXPECT_EQ(3u, plan.explicit_rssid_map.at({0u, 3u})); // rs.id
+    EXPECT_EQ(3u, plan.explicit_rssid_map.at({0u, 3u})); // segment_idx=0 → lifted 3
+    EXPECT_EQ(5u, plan.explicit_rssid_map.at({0u, 5u})); // segment_idx=2 → lifted 5
+    // Final 4 was never claimed.
+    EXPECT_EQ(0u, plan.occupied_rssids.count(4u));
+    // Finals 3 and 5 are claimed.
+    EXPECT_EQ(1u, plan.occupied_rssids.count(3u));
+    EXPECT_EQ(1u, plan.occupied_rssids.count(5u));
+}
+
+// Orphan-vs-family collision: an orphan ctx's child-local rowset projects
+// (via natural offset) to the same final as a family's canonical
+// projection. The family is marked unsafe; the orphan stays untouched.
+TEST(RssidProjectionPlanTest, orphan_vs_family_collision_marks_family_unsafe) {
+    SplitFamilyTestBuilder builder;
+    // ctx 0 + ctx 1 form family A (via filename edge).
+    // ctx 2 is an orphan with a child-local rowset that lifts to 5
+    // through natural offset = 5 (rs.id 0 + offset 5).
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/5);
+    builder.add_legacy_shared_sstable(0, "shared.sst");
+    builder.add_legacy_shared_sstable(1, "shared.sst");
+    // Family A's shared-ancestor rowset id=5, canonical_offset=0, claims final 5.
+    builder.add_shared_ancestor_rowset(0, /*rowset_id=*/5, /*version=*/2, {"seg_a"});
+    builder.add_shared_ancestor_rowset(1, /*rowset_id=*/5, /*version=*/2, {"seg_a"});
+    // Orphan ctx 2: a child-local rowset id=0 + offset 5 → final 5, with a
+    // DIFFERENT physical key (different segment filename).
+    builder.add_child_local_rowset(2, /*rowset_id=*/0, /*version=*/3, {"seg_b"});
+    auto plan = build_plan_for(builder);
+    // Family A marked unsafe; orphan family is kNoFamily so nothing else
+    // gets added to unsafe_families.
+    EXPECT_EQ(1u, plan.unsafe_families.size());
+    EXPECT_TRUE(plan.unsafe_families.contains(0u));
+    EXPECT_TRUE(plan.explicit_rssid_map.empty());
+    EXPECT_TRUE(plan.family_legacy_sstable_offset.empty());
+}
+
+// Boundary case: a shared-ancestor rowset with rowset.id() == UINT32_MAX
+// and any non-zero segment_idx would overflow uint32 if we naively added
+// id + segment_idx without checking. The plan must mark the family unsafe
+// so commit 4's map_rssid falls through to natural-offset / v1 path.
+TEST(RssidProjectionPlanTest, segment_rssid_overflow_marks_family_unsafe) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/0);
+    auto add_overflow_rowset = [&](uint32_t child_index) {
+        auto* rowset = builder.metadata_of(child_index)->add_rowsets();
+        rowset->set_id(std::numeric_limits<uint32_t>::max());
+        rowset->set_version(2);
+        rowset->add_segments("seg_0");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        rowset->add_segments("seg_1");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        rowset->add_segment_metas()->set_segment_idx(0); // lifted = UINT32_MAX, OK
+        rowset->add_segment_metas()->set_segment_idx(1); // lifted = UINT32_MAX + 1 → overflow
+    };
+    add_overflow_rowset(0);
+    add_overflow_rowset(1);
+    auto plan = build_plan_for(builder);
+    ASSERT_EQ(1u, plan.unsafe_families.size());
+    EXPECT_TRUE(plan.unsafe_families.contains(0u)) << "rowset.id()+segment_idx overflow must mark the family unsafe, "
+                                                      "not record a wrapped low rssid";
+    EXPECT_TRUE(plan.family_legacy_sstable_offset.empty());
+}
+
+// Delete-only and no-segments rowsets still claim rowset.id() in
+// occupied_rssids (they own the rsid as a watermark even with no segments).
+// Two delete-only rowsets at the same version with the same id are the
+// "same physical" → safe dedup; at different versions → collision.
+TEST(RssidProjectionPlanTest, delete_only_rowset_id_occupancy_dedup) {
+    SplitFamilyTestBuilder builder;
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_empty_child(/*rssid_offset=*/0);
+    builder.add_legacy_shared_sstable(0, "shared.sst");
+    builder.add_legacy_shared_sstable(1, "shared.sst");
+    builder.add_delete_only_rowset(0, /*rowset_id=*/3, /*version=*/2);
+    builder.add_delete_only_rowset(1, /*rowset_id=*/3, /*version=*/2);
+    auto plan = build_plan_for(builder);
+    // Family A is safe (no collision; delete-only rowsets dedup at id 3).
+    EXPECT_TRUE(plan.unsafe_families.empty());
+    // Final 3 is claimed under family A. The delete-only path uses natural
+    // offset (canonical_offset == 0 here, so result is the same).
+    EXPECT_EQ(1u, plan.occupied_rssids.count(3u));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

In shared-data range distribution, after split each child tablet shares physical files via `shared_segments=true`. When some children later compact away their copy of a shared rowset and others do not, the existing dedup logic in `merge_rowsets()` unions the survivors' ranges via `union_range()`. The hull spans the gap left by the compacted child, and `Rowset::get_seek_range()` then surfaces stale rows from the original shared segment alongside the compaction output rowset — duplicate keys / wrong results. PK `multi_get` can also return stale rssids when LSM block-sort order is inverted (e.g., first-child compaction).

Once correctness is restored, the legacy shared PK sstables themselves become a bottleneck: their on-disk `rss_rowid` references the pre-merge child rssid space and must be retargeted to the merged-tablet space. A naive rebuild replays every entry, which dominates merge cost on real workloads. This PR also lands two layers of fast-path projection that skip the rebuild when the sstable's rssid range can be remapped purely via metadata.

The bug applies to all KeysTypes that range distribution supports: DUP_KEYS, AGG_KEYS, UNIQUE_KEYS, PRIMARY_KEYS.

## What I'm doing:

### Correctness

- Differentiate dedup behavior in `merge_rowsets()` by table type when ranges have a gap:
  - **Non-PK (DUP / AGG / UNIQUE)**: skip dedup. Each contributing child keeps its own shared rowset entry with its own contiguous range, so the read path naturally partitions reads with no duplicates.
  - **PK**: still always dedup (the PK-index sstable's `shared_rssid` invariant forces it). `merge_delvecs` gains Phase 0 (`compute_synthesized_gap_specs`) that translates each missing key range — within the merged tablet range — into rowid bitmaps via `segment_seek_range_to_rowid_range`, and Phase 2.5 unions the bitmaps into `target_states`. Phase 4 routes the synthesized-only case through new `write_delvec_file_from_buffer` to avoid `merge_delvec_files`'s DCHECK on (empty old_files + non-empty extra_data). `merge_sstables`'s `shared_rssid` path now always projects delvec from `new_metadata->delvec_meta()[mapped_rssid]` regardless of whether the source sstable had `has_delvec`, so PK `multi_get` filters stale entries even when LSM block-sort is inverted.
  - **Delete-predicate dedup**: keeps the original unconditional skip path.
- `update_canonical` now takes the duplicate's effective child-local range explicitly and unions/copies it unconditionally — fixes the case where a rowset has no `rowset.range` but its ctx tablet range fills the slice.
- `DelVector::union_with(version, const Roaring&)`: ORs a Roaring bitmap directly into the delvec without rowid-vector round-trip; the synthesized-gap inject path uses it (large compacted-away ranges previously allocated O(n) `uint32_t` vectors).
- New `tablet_reshard_helper` helpers: `ranges_are_contiguous`, `sort_and_merge_adjacent_ranges`, `compute_disjoint_gaps_within` (bounded), `compute_non_contributed_ranges` (unbounded), `effective_child_local_range`.
- `merge_sstables` reassigns `fileset_id` on non-contiguous reuse so the merged metadata stays monotonically ordered.
- Legacy shared PK sstables (`shared=true && !has_shared_rssid`) are rebuilt entry-by-entry into the merged tablet's rssid space when the source rowset has been compacted, so the merged sstable never holds dangling references.

### Fast-path v1 — metadata-only projection

For legacy shared PK sstables where the canonical owner kept its rowset alive and emitted the corresponding rssid range, project the sstable into the merged tablet's id space via PB metadata (`rssid_offset`, `max_rss_rowid`) without re-reading entries. Falls back to entry rebuild for any case the metadata alone cannot describe (partial compaction, unsafe family, delvec mismatch, etc.) — counted under the matching `tablet_merge_legacy_sstable_fastpath_fallback_*` bvars.

`max_rss_rowid.high` is unified to EFFECTIVE (post-rssid_offset) semantics so `flush_pk_memtable` / `KeyValueMerger::merge` / `project_source_max_rss_rowid` / fast-path emit / rebuild output all agree, eliminating the stacked-offset double-shift.

### Fast-path v2 — family-canonical projection

The dominant fallback class in v1 was **partial compaction** — a shared-ancestor rowset has been compacted out of one child but is still alive in another, so v1's first-emitter offset misroutes the projected rssids. v2 infers split families across merge contexts and projects every shared-ancestor rowset onto the **canonical child's** rssid offset so all family members map consistently.

- `RowsetPhysicalKey` + `infer_split_families`: union-find across (a) shared sstable filename edges and (b) identical-physical-key rowset edges; each family picks its smallest child index as canonical.
- `RssidProjectionPlan` + `build_rssid_projection_plan`: per-rowset, per-segment occupancy table that detects collisions between families and marks unsafe families to fall back. Plan keys are `(child_index, source_rssid)`.
- `LegacyRssidLookupMaps`: per-family + per-orphan-child sstable lookup maps replace the prior single-map-per-merge.
- `TabletMergeContext` carries `_child_index` + `_projection_plan`; `map_rssid` consults the plan first, then `shared_rssid_map`, then natural offset.
- v2 fast-path emits each safe family's legacy sstable with `accumulated_offset = src.rssid_offset + family.canonical_rssid_offset`.

### Non-shared mixed-reference rebuild

A post-split PK index compaction can emit a non-shared sstable that mixes shared-ancestor rss_rowids with new child-local ones. A single PB `rssid_offset` cannot translate both — without rebuild this would silently corrupt PK lookups. A per-entry rebuild path is gated by a cheap pre-probe (`mapping_disagrees_with_natural_in_range` over a sorted disagreement-key vector) so the canonical ctx still skips the rewrite.

### Phase 1 watermark widen

`compute_cumulative_rowset_id_ceiling` widens each `uint32_t` addend to `int64_t` before summing and clamps the result back, avoiding `uint32_t` wrap when `rowset.id()` approaches `UINT32_MAX`.

### Known limitation

(compacted-child gap × DCG conflict on canonical R0) combination still returns `NotSupported`. The gap delvec masks the missing rowids semantically, but DCG rebuild does not yet consult that bitmap to skip its coverage check. Tracked separately; current FE scheduling avoids the combination.

## TSP validation

Cluster: 1 FE + 0 BE + 3 CN, shared-data, 16c64g.

| Suite | Result |
|---|---|
| Baseline v17 + main (15 scenarios) | **14/15 PASS** — only S13 fails (HASH distribution unsupported, pre-existing, unrelated) |
| Extended (heavy churn / tombstone-heavy / 8-cycle deep / imbalanced range / upsert burst) | **5/5 PASS** |

All scenarios preserve `COUNT(*) == COUNT(DISTINCT pk)` after every cycle. No hangs, no `unexpected segment id`, no `inconsistent fileset_id`.

| Counter | Value | Reading |
|---|---:|---|
| `tablet_merge_legacy_sstable_rebuild_total` | 37 | shared-PK sstables safely rebuilt |
| `tablet_merge_non_shared_sstable_rebuild_total` | 19 | mixed-reference rebuild path firing on real workload |
| `tablet_merge_legacy_sstable_fastpath_total` | 2 | metadata-only projection hits |
| `tablet_merge_legacy_sstable_fastpath_fallback_partial_compaction` | 58 | dominant fallback class (expected) |
| `tablet_merge_legacy_sstable_fastpath_fallback_unsafe_family` | 0 | collision detection clean across all workloads |

Tablet merge has not yet been GA'd, so no live cluster compatibility constraints.

The plan and implementation were iteratively reviewed and approved by Codex across multiple rounds (4 rounds for the v1 plan, 2 rounds each for the v1 / v2 implementation passes).

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4