### PR TITLE
[BugFix] Python inline UDF creation failing when file='inline' is omitted

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -779,13 +779,10 @@ public class CreateFunctionAnalyzer {
         }
         String symbol = properties.get(CreateFunctionStmt.SYMBOL_KEY);
         String inputType = properties.getOrDefault(CreateFunctionStmt.INPUT_TYPE, "scalar");
-        String objectFile = stmt.getProperties().get(CreateFunctionStmt.FILE_KEY);
+        String objectFile = properties.getOrDefault(CreateFunctionStmt.FILE_KEY, "inline");
 
         if (isInline && !StringUtils.equalsIgnoreCase(objectFile, "inline")) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "inline function file should be 'inline'");
-        }
-        if (isInline) {
-            objectFile = "inline";
         }
 
         if (!inputType.equalsIgnoreCase("arrow") && !inputType.equalsIgnoreCase("scalar")) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
@@ -97,6 +97,20 @@ public class CreateFunctionStmtAnalyzerTest {
                 createFunctionSql, 32).get(0);
     }
 
+    private CreateFunctionStmt createPyInlineStmtNoFile(String symbol) {
+        Config.enable_udf = true;
+        String createFunctionSql = String.format("CREATE FUNCTION ABC.MY_UDF_JSON_GET_NOFILE(string, string) \n"
+                + "RETURNS string \n"
+                + "type = 'Python'\n"
+                + "symbol = '%s'\n"
+                + "AS $$\n"
+                + "def a(b):\n"
+                + "   return b\n"
+                + "$$;", symbol);
+        return (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                createFunctionSql, 32).get(0);
+    }
+
     @Test
     public void testJUDF() {
         assertThrows(Throwable.class, () -> {
@@ -1114,5 +1128,14 @@ public class CreateFunctionStmtAnalyzerTest {
                 Config.enable_udf = false;
             }
         });
+    }
+
+    @Test
+    public void testPyInlineUDFWithoutFileProperty() {
+        CreateFunctionStmt stmt = createPyInlineStmtNoFile("a");
+        Assertions.assertNotNull(stmt.getContent(), "Inline body must be parsed into content");
+        new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+        Assertions.assertEquals("inline", stmt.getFunction().getLocation().toString(),
+                "Analyzer must auto-set location to 'inline' when file property is omitted");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
When creating an inline [Starrocks Python UDF](https://docs.starrocks.io/docs/sql-reference/sql-functions/Python_UDF/) using the AS $$ ... $$ syntax, the documentation states that file='inline' is optional. However, omitting it causes the following error at creation time - inline function file should be 'inline'

## What I'm doing:

StringUtils.equalsIgnoreCase(null, "inline") returns false, so when file is omitted (objectFile == null) and UDF creation failing with `inline function file should be 'inline'` 

Using default value as 'inline as per documentation'.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
