### PR TITLE
[Enhancement] Add CN-side fallback for cn-free tablet metadata

### DIFF
--- a/be/src/storage/lake/metadata_iterator.cpp
+++ b/be/src/storage/lake/metadata_iterator.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/lake/metadata_iterator.h"
 
+#include "storage/lake/filenames.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
@@ -23,7 +24,15 @@ namespace starrocks::lake {
 template <>
 StatusOr<TabletMetadataPtr> MetadataIterator<TabletMetadataPtr>::get_metadata_from_tablet_manager(
         const std::string& path) {
-    ASSIGN_OR_RETURN(auto tablet_metadata, _manager->get_tablet_metadata(path, false));
+    TabletMetadataPtr tablet_metadata;
+    // For initial metadata path (tablet_id=0 in filename), route to the (tablet_id, version)
+    // overload using the real tablet_id held by this iterator, so that cn-free tablet creation
+    // fallback can be triggered with the correct tablet_id.
+    if (is_tablet_initial_metadata(basename(path))) {
+        ASSIGN_OR_RETURN(tablet_metadata, _manager->get_tablet_metadata(_tablet_id, 1, false));
+    } else {
+        ASSIGN_OR_RETURN(tablet_metadata, _manager->get_tablet_metadata(path, false));
+    }
 
     if (tablet_metadata->gtid() < _max_gtid) {
         return Status::NotFound("no more element");

--- a/be/src/storage/lake/table_schema_service.cpp
+++ b/be/src/storage/lake/table_schema_service.cpp
@@ -404,4 +404,144 @@ StatusOr<TabletSchemaPtr> TableSchemaService::_fallback_load_to_schema_file(int6
     return tablet_schema;
 }
 
+// Latency (in microseconds) for get_tablet_initial_metadata calls (end-to-end including SingleFlight wait).
+bvar::LatencyRecorder g_initial_metadata_fetch_latency_us("table_schema_service", "metadata_fetch_us");
+// Latency (in microseconds) for individual RPC calls to FE for initial metadata fetching.
+bvar::LatencyRecorder g_initial_metadata_rpc_latency_us("table_schema_service", "metadata_rpc_us");
+// Number of initial metadata fetch requests.
+bvar::Adder<int64_t> g_initial_metadata_fetch_count("table_schema_service", "metadata_fetch_count");
+// Number of initial metadata fetch failures.
+bvar::Adder<int64_t> g_initial_metadata_fetch_error("table_schema_service", "metadata_fetch_error");
+// Number of retry attempts for initial metadata fetches (excludes the initial attempt).
+bvar::Adder<int64_t> g_initial_metadata_fetch_retries("table_schema_service", "metadata_fetch_retries");
+
+StatusOr<TGetTabletMetadataResponse> TableSchemaService::get_tablet_initial_metadata(int64_t tablet_id,
+                                                                                     int64_t table_id,
+                                                                                     int64_t partition_id,
+                                                                                     int64_t index_id) {
+    g_initial_metadata_fetch_count << 1;
+    auto start = butil::gettimeofday_us();
+    DeferOp defer([&]() { g_initial_metadata_fetch_latency_us << (butil::gettimeofday_us() - start); });
+
+    const int max_retries = std::max(1, config::table_schema_service_max_retries);
+    InitialMetadataSFResultPtr sf_result;
+    // Use (table_id, index_id) as SingleFlight key so concurrent requests
+    // for different tablets under the same index share one RPC.
+    std::string key = fmt::format("{}:{}", table_id, index_id);
+
+    for (int attempt = 0; attempt < max_retries; ++attempt) {
+        g_initial_metadata_fetch_retries << (attempt == 0 ? 0 : 1);
+        sf_result = _select_initial_metadata_sf_group(key).Do(
+                key, [&]() { return _fetch_initial_metadata_via_rpc(tablet_id, table_id, partition_id, index_id); });
+
+        auto& result = sf_result->result;
+
+        VLOG(2) << "get_tablet_initial_metadata, tablet_id: " << tablet_id << ", table_id: " << table_id
+                << ", partition_id: " << partition_id << ", index_id: " << index_id << ", attempt: " << attempt + 1
+                << "/" << max_retries << ", status: " << result.status();
+
+        if (result.ok()) {
+            return result;
+        }
+
+        const auto& status = result.status();
+
+        // Permanent errors: do not retry
+        if (status.is_not_found() || status.is_table_not_exist()) {
+            break;
+        }
+        if (status.is_thrift_rpc_error()) {
+            break;
+        }
+
+        // Other errors (e.g. INTERNAL_ERROR): retry
+    }
+
+    if (sf_result != nullptr && !sf_result->result.ok()) {
+        g_initial_metadata_fetch_error << 1;
+    }
+    if (sf_result != nullptr) {
+        return sf_result->result;
+    }
+    return Status::InternalError("get_tablet_initial_metadata result is null");
+}
+
+TableSchemaService::InitialMetadataSFResultPtr TableSchemaService::_fetch_initial_metadata_via_rpc(int64_t tablet_id,
+                                                                                                   int64_t table_id,
+                                                                                                   int64_t partition_id,
+                                                                                                   int64_t index_id) {
+    TBatchGetTabletMetadataRequest batch_req;
+    TGetTabletMetadataRequest req;
+    req.__set_tablet_id(tablet_id);
+    req.__set_table_id(table_id);
+    req.__set_partition_id(partition_id);
+    req.__set_index_id(index_id);
+    req.__set_version(1);
+    batch_req.__set_requests({req});
+
+    TNetworkAddress fe = get_master_address();
+    TBatchGetTabletMetadataResponse batch_resp;
+    Status rpc_status;
+    bool mock_thrift_rpc = false;
+
+#ifdef BE_TEST
+    std::array<void*, 4> test_ctx{(void*)&req, (void*)&batch_resp, (void*)&rpc_status, (void*)&mock_thrift_rpc};
+    TEST_SYNC_POINT_CALLBACK("TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", &test_ctx);
+#endif
+
+    int64_t rpc_latency_us = 0;
+    if (!mock_thrift_rpc) {
+        auto start = butil::gettimeofday_us();
+        rpc_status = ThriftRpcHelper::rpc<FrontendServiceClient>(
+                fe.hostname, fe.port,
+                [&batch_req, &batch_resp](FrontendServiceConnection& client) {
+                    client->getTabletMetadata(batch_resp, batch_req);
+                },
+                config::thrift_rpc_timeout_ms);
+        rpc_latency_us = butil::gettimeofday_us() - start;
+    }
+    g_initial_metadata_rpc_latency_us << rpc_latency_us;
+
+    auto result = std::make_shared<InitialMetadataSFResult>();
+
+    if (!rpc_status.ok()) {
+        LOG(WARNING) << "get_tablet_initial_metadata rpc failed, tablet_id: " << tablet_id << ", table_id: " << table_id
+                     << ", partition_id: " << partition_id << ", index_id: " << index_id << ", fe: " << fe.hostname
+                     << ":" << fe.port << ", latency: " << rpc_latency_us << "us, error: " << rpc_status;
+        result->result = rpc_status;
+        return result;
+    }
+
+    Status batch_status(batch_resp.status);
+    if (!batch_status.ok()) {
+        LOG(WARNING) << "get_tablet_initial_metadata batch failed, tablet_id: " << tablet_id
+                     << ", table_id: " << table_id << ", partition_id: " << partition_id << ", index_id: " << index_id
+                     << ", error: " << batch_status;
+        result->result = batch_status;
+        return result;
+    }
+
+    if (!batch_resp.__isset.responses || batch_resp.responses.empty()) {
+        LOG(WARNING) << "get_tablet_initial_metadata empty response, tablet_id: " << tablet_id
+                     << ", table_id: " << table_id << ", partition_id: " << partition_id << ", index_id: " << index_id;
+        result->result = Status::InternalError("empty response");
+        return result;
+    }
+
+    auto& resp = batch_resp.responses[0];
+    Status resp_status(resp.status);
+    if (!resp_status.ok()) {
+        LOG(INFO) << "get_tablet_initial_metadata failed, tablet_id: " << tablet_id << ", table_id: " << table_id
+                  << ", partition_id: " << partition_id << ", index_id: " << index_id << ", error: " << resp_status;
+        result->result = resp_status;
+        return result;
+    }
+
+    VLOG(2) << "get_tablet_initial_metadata success, tablet_id: " << tablet_id << ", table_id: " << table_id
+            << ", partition_id: " << partition_id << ", index_id: " << index_id << ", latency: " << rpc_latency_us
+            << "us";
+    result->result = std::move(resp);
+    return result;
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/table_schema_service.h
+++ b/be/src/storage/lake/table_schema_service.h
@@ -96,6 +96,20 @@ public:
                                                   const TUniqueId& query_id, const TNetworkAddress& coordinator_fe,
                                                   const TabletMetadataPtr& tablet_meta = nullptr);
 
+    /**
+     * @brief Fetch tablet initial metadata from FE Leader for cn-free tablet creation.
+     *
+     * When cn_free_tablet_creation is enabled, DDL skips writing version 1 metadata to
+     * object storage. This method fetches the initial configuration (schema + table-level
+     * properties + tablet ranges) from FE so that the caller can construct version 1
+     * TabletMetadataPB on demand.
+     *
+     * Uses (table_id, index_id) as SingleFlight key so that concurrent requests for
+     * different tablets under the same index share one RPC.
+     */
+    StatusOr<TGetTabletMetadataResponse> get_tablet_initial_metadata(int64_t tablet_id, int64_t table_id,
+                                                                     int64_t partition_id, int64_t index_id);
+
 private:
     /**
      * @brief Context of the actual RPC executed by the SingleFlight leader.
@@ -206,8 +220,24 @@ private:
         return _single_flight_groups[h & (kSingleFlightGroupShards - 1)];
     }
 
+    // Initial metadata fetch for cn-free tablet creation
+    struct InitialMetadataSFResult {
+        StatusOr<TGetTabletMetadataResponse> result;
+    };
+    using InitialMetadataSFResultPtr = std::shared_ptr<const InitialMetadataSFResult>;
+    using InitialMetadataSFGroup = bthreads::singleflight::Group<std::string, InitialMetadataSFResultPtr>;
+
+    InitialMetadataSFResultPtr _fetch_initial_metadata_via_rpc(int64_t tablet_id, int64_t table_id,
+                                                               int64_t partition_id, int64_t index_id);
+
+    InitialMetadataSFGroup& _select_initial_metadata_sf_group(const std::string& key) {
+        const size_t h = std::hash<std::string>{}(key);
+        return _initial_metadata_sf_groups[h & (kSingleFlightGroupShards - 1)];
+    }
+
     TabletManager* _tablet_mgr;
     std::array<SingleFlightGroup, kSingleFlightGroupShards> _single_flight_groups;
+    std::array<InitialMetadataSFGroup, kSingleFlightGroupShards> _initial_metadata_sf_groups;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -208,6 +208,8 @@ UpdateManager* TabletManager::update_mgr() {
     return _update_mgr;
 }
 
+// NOTE: if you add a new field here, also update construct_initial_metadata() and
+// TCloudTabletMeta in FrontendService.thrift to keep them in sync.
 Status TabletManager::create_tablet(const TCreateTabletReq& req) {
     // generate tablet metadata pb
     auto tablet_metadata_pb = std::make_shared<TabletMetadataPB>();
@@ -274,6 +276,146 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
     }
 
     return put_tablet_metadata(std::move(tablet_metadata_pb));
+}
+
+// Parse (table_id, partition_id, index_id) from StarOS shard properties.
+Status TabletManager::parse_shard_properties(int64_t tablet_id,
+                                             const std::unordered_map<std::string, std::string>& properties,
+                                             int64_t* table_id, int64_t* partition_id, int64_t* index_id) {
+    *table_id = -1;
+    *partition_id = -1;
+    *index_id = -1;
+    auto table_id_iter = properties.find("tableId");
+    if (table_id_iter != properties.end()) {
+        *table_id = std::atol(table_id_iter->second.data());
+    }
+    auto partition_id_iter = properties.find("partitionId");
+    if (partition_id_iter != properties.end()) {
+        *partition_id = std::atol(partition_id_iter->second.data());
+    }
+    auto index_id_iter = properties.find("indexId");
+    if (index_id_iter != properties.end()) {
+        *index_id = std::atol(index_id_iter->second.data());
+    }
+    if (*table_id <= 0 || *partition_id <= 0 || *index_id <= 0) {
+        return Status::InternalError(
+                fmt::format("incomplete shard properties, tablet_id: {}, table_id: {}, partition_id: {}, index_id: {}",
+                            tablet_id, *table_id, *partition_id, *index_id));
+    }
+    return Status::OK();
+}
+
+StatusOr<TabletMetadataPtr> TabletManager::construct_initial_metadata(int64_t tablet_id) {
+    TEST_ERROR_POINT("TabletManager::construct_initial_metadata");
+#ifdef BE_TEST
+    // In unit test environment, starlet worker is not available. Return NOT_FOUND so
+    // that callers treat cn-free fallback as a normal "tablet not found" case.
+    return Status::NotFound(fmt::format("cn-free tablet creation disabled in unit test, tablet_id: {}", tablet_id));
+#endif
+    // Get (table_id, partition_id, index_id) from shard info.
+    // These are used for the FE RPC request and for SingleFlight grouping by (table_id, index_id),
+    // so concurrent requests for different tablets under the same index share one RPC.
+    int64_t table_id = -1;
+    int64_t partition_id = -1;
+    int64_t index_id = -1;
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
+    auto worker = get_staros_worker();
+    if (worker == nullptr) {
+        // Fallback prerequisite not available; degrade to NOT_FOUND so the caller
+        // surfaces "v1 metadata missing" instead of escalating to INTERNAL_ERROR.
+        return Status::NotFound(fmt::format("starlet worker not initialized, tablet_id: {}", tablet_id));
+    }
+    auto shard_info_or = worker->retrieve_shard_info(tablet_id);
+    if (!shard_info_or.ok()) {
+        return Status::InternalError(fmt::format("fail to get shard info, tablet_id: {}, error: {}", tablet_id,
+                                                 shard_info_or.status().message()));
+    }
+    RETURN_IF_ERROR(
+            parse_shard_properties(tablet_id, shard_info_or.value().properties, &table_id, &partition_id, &index_id));
+
+    ASSIGN_OR_RETURN(auto resp,
+                     _table_schema_service->get_tablet_initial_metadata(tablet_id, table_id, partition_id, index_id));
+    return build_initial_metadata(tablet_id, resp);
+#else
+    // Build doesn't include StarOS support, so the fallback prerequisites are
+    // permanently unavailable; degrade to NOT_FOUND to preserve the pre-cn-free
+    // behavior of get_tablet_metadata for missing v1 files.
+    return Status::NotFound(fmt::format("cn-free tablet creation requires USE_STAROS, tablet_id: {}", tablet_id));
+#endif
+}
+
+// NOTE: if you add a new field to create_tablet(), also update this method and
+// TCloudTabletMeta in FrontendService.thrift to keep them in sync.
+StatusOr<TabletMetadataPtr> TabletManager::build_initial_metadata(int64_t tablet_id,
+                                                                  const TGetTabletMetadataResponse& resp) {
+    if (!resp.__isset.meta) {
+        return Status::InternalError(strings::Substitute("missing tablet meta in response, tabletId:$0", tablet_id));
+    }
+    const auto& meta = resp.meta;
+    auto metadata = std::make_shared<TabletMetadataPB>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(kInitialVersion);
+    metadata->set_next_rowset_id(1);
+    metadata->set_cumulative_point(0);
+    metadata->set_gtid(meta.gtid);
+
+    // schema
+    auto compress_type = meta.__isset.compression_type ? meta.compression_type : TCompressionType::LZ4_FRAME;
+    RETURN_IF_ERROR(convert_t_schema_to_pb_schema(meta.schema, compress_type, metadata->mutable_schema()));
+    auto compression_level = meta.__isset.compression_level ? meta.compression_level : -1;
+    metadata->mutable_schema()->set_compression_level(compression_level);
+
+    // range: look up this tablet's range from the tablet_ranges map
+    if (meta.__isset.tablet_ranges) {
+        auto it = meta.tablet_ranges.find(tablet_id);
+        if (it != meta.tablet_ranges.end()) {
+            ASSIGN_OR_RETURN(auto range_pb, TabletRangeHelper::convert_t_range_to_pb_range(it->second));
+            *metadata->mutable_range() = range_pb;
+        }
+    }
+
+    // persistent index
+    if (meta.__isset.enable_persistent_index) {
+        metadata->set_enable_persistent_index(meta.enable_persistent_index);
+        if (meta.__isset.persistent_index_type) {
+            switch (meta.persistent_index_type) {
+            case TPersistentIndexType::LOCAL:
+                metadata->set_persistent_index_type(PersistentIndexTypePB::LOCAL);
+                break;
+            case TPersistentIndexType::CLOUD_NATIVE:
+                metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+                break;
+            default:
+                return Status::InternalError(
+                        strings::Substitute("Unknown persistent index type, tabletId:$0", tablet_id));
+            }
+        }
+    }
+
+    // flat json config
+    if (meta.__isset.flat_json_config) {
+        FlatJsonConfig flat_json_config;
+        flat_json_config.update(meta.flat_json_config);
+        flat_json_config.to_pb(metadata->mutable_flat_json_config());
+    }
+
+    // compaction strategy
+    if (meta.__isset.compaction_strategy) {
+        switch (meta.compaction_strategy) {
+        case TCompactionStrategy::DEFAULT:
+            metadata->set_compaction_strategy(CompactionStrategyPB::DEFAULT);
+            break;
+        case TCompactionStrategy::REAL_TIME:
+            metadata->set_compaction_strategy(CompactionStrategyPB::REAL_TIME);
+            break;
+        default:
+            return Status::InternalError(strings::Substitute("Unknown compaction strategy, tabletId:$0", tablet_id));
+        }
+    } else {
+        metadata->set_compaction_strategy(CompactionStrategyPB::DEFAULT);
+    }
+
+    return metadata;
 }
 
 StatusOr<Tablet> TabletManager::get_tablet(int64_t tablet_id) {
@@ -580,6 +722,20 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
             auto metadata = const_cast<starrocks::TabletMetadataPB*>(metadata_or.value().get());
             metadata->set_id(tablet_id);
         }
+    }
+
+    // CN-Free Tablet Creation fallback: when cn_free_tablet_creation is enabled, DDL skips
+    // writing version 1 metadata to object storage. When a consumer first needs version 1
+    // metadata, we fetch the tablet's initial configuration from FE and construct the
+    // TabletMetadataPB on demand.
+    //
+    // The fs == nullptr check excludes cross-cluster replication reads, where |fs| points to
+    // the source cluster's object storage. Without this check, a source tablet_id that
+    // coincidentally matches a local tablet_id would cause us to fetch the wrong metadata
+    // from the local FE. Other local callers that pass non-null fs (e.g. LakeDelvecLoader)
+    // do not request version 1 in practice, since version 1 has no rowsets or delvecs.
+    if (metadata_or.status().is_not_found() && tablet_id != 0 && version == kInitialVersion && fs == nullptr) {
+        metadata_or = construct_initial_metadata(tablet_id);
     }
 
     if (!metadata_or.ok()) {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -39,6 +39,7 @@ struct TabletBasicInfo;
 class Segment;
 class TabletSchemaPB;
 class TCreateTabletReq;
+class TGetTabletMetadataResponse;
 } // namespace starrocks
 
 namespace starrocks::lake {
@@ -301,6 +302,13 @@ private:
     Status put_tablet_metadata(const TabletMetadataPtr& metadata, const std::string& metadata_location);
     StatusOr<TabletMetadataPtr> load_tablet_metadata(const std::string& metadata_location, bool fill_data_cache,
                                                      int64_t expected_gtid, const std::shared_ptr<FileSystem>& fs);
+    StatusOr<TabletMetadataPtr> construct_initial_metadata(int64_t tablet_id);
+    // Build version 1 TabletMetadataPB from a FE response. Exposed for unit tests.
+    StatusOr<TabletMetadataPtr> build_initial_metadata(int64_t tablet_id, const TGetTabletMetadataResponse& resp);
+    // Parse (table_id, partition_id, index_id) from StarOS shard properties. Exposed for unit tests.
+    static Status parse_shard_properties(int64_t tablet_id,
+                                         const std::unordered_map<std::string, std::string>& properties,
+                                         int64_t* table_id, int64_t* partition_id, int64_t* index_id);
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);
     StatusOr<CombinedTxnLogPtr> load_combined_txn_log(const std::string& path, bool fill_cache);
     Status corrupted_tablet_meta_handler(const Status& s, const std::string& metadata_location);

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1460,7 +1460,8 @@ Status drop_tablet_cache(TabletManager* tablet_mgr, int64_t tablet_id, int64_t v
             VLOG(3) << "fail to get file system for tablet " << tablet_id << ", error: " << fs_or.status();
         }
     };
-    while (version > 0) {
+    // Skip version 1 which is the initial empty metadata (no rowsets, no delvecs to drop).
+    while (version > 1) {
         auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false /* No need to fill meta cache */,
                                                    false /* No need to fill data cache */);
         if (res.status().is_not_found()) {

--- a/be/test/storage/lake/table_schema_service_test.cpp
+++ b/be/test/storage/lake/table_schema_service_test.cpp
@@ -212,6 +212,23 @@ protected:
         out.mock_thrift_rpc = static_cast<bool*>((*arr)[3]);
         return out;
     }
+
+    struct InitialMetadataRpcHookArgs {
+        const TGetTabletMetadataRequest* request = nullptr;
+        TBatchGetTabletMetadataResponse* response = nullptr;
+        Status* status = nullptr;
+        bool* mock_thrift_rpc = nullptr;
+    };
+
+    static InitialMetadataRpcHookArgs unpack_initial_metadata_hook_args(void* arg) {
+        auto* arr = static_cast<std::array<void*, 4>*>(arg);
+        InitialMetadataRpcHookArgs out;
+        out.request = static_cast<const TGetTabletMetadataRequest*>((*arr)[0]);
+        out.response = static_cast<TBatchGetTabletMetadataResponse*>((*arr)[1]);
+        out.status = static_cast<Status*>((*arr)[2]);
+        out.mock_thrift_rpc = static_cast<bool*>((*arr)[3]);
+        return out;
+    }
     void clear_and_init_test_dir() {
         (void)fs::remove_all(_test_directory);
         CHECK_OK(fs::create_directories(join_path(_test_directory, kSegmentDirectoryName)));
@@ -344,6 +361,14 @@ protected:
         setup_rpc_test_hook([](const RpcHookArgs& ctx) {
             *ctx.mock_thrift_rpc = true;
             *ctx.status = Status::ThriftRpcError("Invalid method name 'getTableSchema'");
+        });
+    }
+
+    void setup_skip_construct_initial_metadata() {
+        SyncPoint::GetInstance()->SetCallBack("TabletManager::construct_initial_metadata", [](void* arg) {
+            // Return NOT_FOUND to simulate tablet not existing, because construct_initial_metadata
+            // requires g_worker (StarOS) which is unavailable in unit tests.
+            *static_cast<Status*>(arg) = Status::NotFound("skipped by test");
         });
     }
 
@@ -504,7 +529,10 @@ TEST_F(TableSchemaServiceTest, remote_error_handling) {
 
     const std::vector<Case> cases{
             {"method_not_found_maps_to_not_supported",
-             [](TableSchemaServiceTest* t) { t->setup_rpc_method_not_found(); },
+             [](TableSchemaServiceTest* t) {
+                 t->setup_rpc_method_not_found();
+                 t->setup_skip_construct_initial_metadata();
+             },
              [](const Status& st) { ASSERT_TRUE(st.is_not_found()) << st; }},
             {"other_thrift_rpc_error_fail_fast", [](TableSchemaServiceTest* t) { t->setup_rpc_other_thrift_error(); },
              [](const Status& st) { ASSERT_TRUE(st.is_thrift_rpc_error()) << st; }},
@@ -607,6 +635,8 @@ TEST_F(TableSchemaServiceTest, load_fallback_to_tablet_schema) {
 
         setup_rpc_method_not_found();
         mock_tablet_schema_by_id(Status::NotFound("mocked not found"));
+        // Mock cn-free fallback RPC to return NOT_FOUND, otherwise it tries real RPC
+        setup_skip_construct_initial_metadata();
 
         auto result = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), tablet_id, 1);
         ASSERT_TRUE(result.status().is_not_found());
@@ -759,6 +789,376 @@ TEST_F(TableSchemaServiceTest, query_interference) {
     ASSERT_FALSE(barrier.timed_out()) << "Timed out waiting for follower to join singleflight group";
     ASSERT_TRUE((r1.ok() && !r2.ok()) || (!r1.ok() && r2.ok()));
     ASSERT_GE(rpc_call_count.load(), 2);
+}
+
+TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_success) {
+    ScopedSyncPoint sync_point;
+    auto schema_id = next_id();
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                ctx.response->__set_responses(std::vector<TGetTabletMetadataResponse>{});
+                auto& resp = ctx.response->responses.emplace_back();
+                TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+                TCloudTabletMeta meta;
+                meta.__set_tablet_id(ctx.request->tablet_id);
+                meta.__set_schema(TableSchemaServiceTest::make_thrift_schema(schema_id));
+                meta.__set_enable_persistent_index(true);
+                meta.__set_persistent_index_type(TPersistentIndexType::CLOUD_NATIVE);
+                meta.__set_compaction_strategy(TCompactionStrategy::REAL_TIME);
+                meta.__set_compression_type(TCompressionType::LZ4_FRAME);
+                meta.__set_compression_level(3);
+                meta.__set_gtid(12345);
+                resp.__set_meta(meta);
+            });
+
+    auto tablet_id = next_id();
+    auto table_id = next_id();
+    auto partition_id = next_id();
+    auto index_id = next_id();
+    auto result = _schema_service->get_tablet_initial_metadata(tablet_id, table_id, partition_id, index_id);
+    ASSERT_TRUE(result.ok());
+
+    auto& resp = result.value();
+    ASSERT_TRUE(resp.__isset.meta);
+    ASSERT_TRUE(resp.meta.__isset.schema);
+    ASSERT_EQ(schema_id, resp.meta.schema.id);
+    ASSERT_TRUE(resp.meta.enable_persistent_index);
+    ASSERT_EQ(TPersistentIndexType::CLOUD_NATIVE, resp.meta.persistent_index_type);
+    ASSERT_EQ(TCompactionStrategy::REAL_TIME, resp.meta.compaction_strategy);
+    ASSERT_EQ(TCompressionType::LZ4_FRAME, resp.meta.compression_type);
+    ASSERT_EQ(3, resp.meta.compression_level);
+    ASSERT_EQ(12345, resp.meta.gtid);
+}
+
+TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_not_found) {
+    ScopedSyncPoint sync_point;
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                ctx.response->__set_responses(std::vector<TGetTabletMetadataResponse>{});
+                auto& resp = ctx.response->responses.emplace_back();
+                TableSchemaServiceTest::set_status(&resp.status, TStatusCode::NOT_FOUND, "tablet not found");
+            });
+
+    auto result = _schema_service->get_tablet_initial_metadata(next_id(), next_id(), next_id(), next_id());
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_not_found());
+}
+
+TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_rpc_error) {
+    ScopedSyncPoint sync_point;
+
+    SyncPoint::GetInstance()->SetCallBack("TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook",
+                                          [&](void* arg) {
+                                              auto ctx = unpack_initial_metadata_hook_args(arg);
+                                              *ctx.mock_thrift_rpc = true;
+                                              *ctx.status = Status::ThriftRpcError("connection refused");
+                                          });
+
+    auto result = _schema_service->get_tablet_initial_metadata(next_id(), next_id(), next_id(), next_id());
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_thrift_rpc_error());
+}
+
+TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_batch_error) {
+    ScopedSyncPoint sync_point;
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+                // Batch-level status is not OK
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::INTERNAL_ERROR,
+                                                   "mocked batch error");
+            });
+
+    auto result = _schema_service->get_tablet_initial_metadata(next_id(), next_id(), next_id(), next_id());
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_internal_error());
+}
+
+TEST_F(TableSchemaServiceTest, get_tablet_initial_metadata_empty_response) {
+    ScopedSyncPoint sync_point;
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                // No responses set, empty batch response
+            });
+
+    auto result = _schema_service->get_tablet_initial_metadata(next_id(), next_id(), next_id(), next_id());
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_internal_error());
+    ASSERT_TRUE(result.status().message().find("empty response") != std::string::npos);
+}
+
+TEST_F(TableSchemaServiceTest, construct_initial_metadata_fields_match_create_tablet) {
+    auto tablet_id_a = next_id();
+    auto tablet_id_b = next_id();
+    auto schema_id = next_id();
+
+    // 1. Build TCreateTabletReq and create tablet A via create_tablet()
+    TCreateTabletReq create_req;
+    create_req.tablet_id = tablet_id_a;
+    create_req.__set_version(1);
+    create_req.__set_enable_persistent_index(true);
+    create_req.__set_persistent_index_type(TPersistentIndexType::CLOUD_NATIVE);
+    create_req.__set_compaction_strategy(TCompactionStrategy::REAL_TIME);
+    create_req.__set_compression_type(TCompressionType::LZ4_FRAME);
+    create_req.__set_compression_level(5);
+    create_req.__set_gtid(99999);
+    create_req.__set_create_schema_file(false);
+
+    auto thrift_schema = make_thrift_schema(schema_id);
+    create_req.__set_tablet_schema(thrift_schema);
+
+    ASSERT_OK(_tablet_manager->create_tablet(create_req));
+    ASSIGN_OR_ABORT(auto metadata_a, _tablet_manager->get_tablet_metadata(tablet_id_a, 1));
+
+    // 2. Build a mocked FE response with the same field values
+    TGetTabletMetadataResponse resp;
+    set_status(&resp.status, TStatusCode::OK);
+    TCloudTabletMeta meta;
+    meta.__set_tablet_id(tablet_id_b);
+    meta.__set_schema(thrift_schema);
+    meta.__set_enable_persistent_index(true);
+    meta.__set_persistent_index_type(TPersistentIndexType::CLOUD_NATIVE);
+    meta.__set_compaction_strategy(TCompactionStrategy::REAL_TIME);
+    meta.__set_compression_type(TCompressionType::LZ4_FRAME);
+    meta.__set_compression_level(5);
+    meta.__set_gtid(99999);
+    resp.__set_meta(meta);
+
+    // 3. Directly call build_initial_metadata to test field assembly
+    ASSIGN_OR_ABORT(auto metadata_b, _tablet_manager->build_initial_metadata(tablet_id_b, resp));
+
+    // 4. Compare fields
+    ASSERT_EQ(tablet_id_b, metadata_b->id());
+    ASSERT_EQ(metadata_a->version(), metadata_b->version());
+    ASSERT_EQ(metadata_a->next_rowset_id(), metadata_b->next_rowset_id());
+    ASSERT_EQ(metadata_a->cumulative_point(), metadata_b->cumulative_point());
+    ASSERT_EQ(metadata_a->gtid(), metadata_b->gtid());
+    ASSERT_EQ(metadata_a->enable_persistent_index(), metadata_b->enable_persistent_index());
+    ASSERT_EQ(metadata_a->persistent_index_type(), metadata_b->persistent_index_type());
+    ASSERT_EQ(metadata_a->compaction_strategy(), metadata_b->compaction_strategy());
+    ASSERT_EQ(metadata_a->schema().id(), metadata_b->schema().id());
+    ASSERT_EQ(metadata_a->schema().compression_level(), metadata_b->schema().compression_level());
+}
+
+TEST_F(TableSchemaServiceTest, build_initial_metadata) {
+    auto schema_id = next_id();
+
+    // Case 1: defaults (only schema set)
+    {
+        auto tablet_id = next_id();
+        TGetTabletMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+        TCloudTabletMeta meta;
+        meta.__set_tablet_id(tablet_id);
+        meta.__set_schema(make_thrift_schema(schema_id));
+        resp.__set_meta(meta);
+
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
+        ASSERT_EQ(tablet_id, metadata->id());
+        ASSERT_EQ(1, metadata->version());
+        ASSERT_EQ(1, metadata->next_rowset_id());
+        ASSERT_EQ(0, metadata->cumulative_point());
+        ASSERT_FALSE(metadata->has_range());
+        ASSERT_FALSE(metadata->has_flat_json_config());
+        // compaction_strategy defaults to DEFAULT when not set
+        ASSERT_EQ(CompactionStrategyPB::DEFAULT, metadata->compaction_strategy());
+        // compression_level defaults to -1
+        ASSERT_EQ(-1, metadata->schema().compression_level());
+    }
+
+    // Case 2: LOCAL persistent index type
+    {
+        auto tablet_id = next_id();
+        TGetTabletMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+        TCloudTabletMeta meta;
+        meta.__set_tablet_id(tablet_id);
+        meta.__set_schema(make_thrift_schema(schema_id));
+        meta.__set_enable_persistent_index(true);
+        meta.__set_persistent_index_type(TPersistentIndexType::LOCAL);
+        resp.__set_meta(meta);
+
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
+        ASSERT_TRUE(metadata->enable_persistent_index());
+        ASSERT_EQ(PersistentIndexTypePB::LOCAL, metadata->persistent_index_type());
+    }
+
+    // Case 3: tablet_ranges contains this tablet's range
+    {
+        auto tablet_id = next_id();
+        auto other_tablet_id = next_id();
+        TGetTabletMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+        TCloudTabletMeta meta;
+        meta.__set_tablet_id(tablet_id);
+        meta.__set_schema(make_thrift_schema(schema_id));
+
+        std::map<int64_t, TTabletRange> tablet_ranges;
+        TTabletRange range;
+        range.__set_lower_bound_included(true);
+        range.__set_upper_bound_included(false);
+        tablet_ranges[tablet_id] = range;
+        tablet_ranges[other_tablet_id] = TTabletRange();
+        meta.__set_tablet_ranges(tablet_ranges);
+        resp.__set_meta(meta);
+
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
+        ASSERT_TRUE(metadata->has_range());
+        ASSERT_TRUE(metadata->range().lower_bound_included());
+        ASSERT_FALSE(metadata->range().upper_bound_included());
+    }
+
+    // Case 4: tablet_ranges set but does not contain this tablet
+    {
+        auto tablet_id = next_id();
+        TGetTabletMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+        TCloudTabletMeta meta;
+        meta.__set_tablet_id(tablet_id);
+        meta.__set_schema(make_thrift_schema(schema_id));
+        std::map<int64_t, TTabletRange> tablet_ranges;
+        tablet_ranges[next_id()] = TTabletRange();
+        meta.__set_tablet_ranges(tablet_ranges);
+        resp.__set_meta(meta);
+
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
+        ASSERT_FALSE(metadata->has_range());
+    }
+
+    // Case 5: flat_json_config is set
+    {
+        auto tablet_id = next_id();
+        TGetTabletMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+        TCloudTabletMeta meta;
+        meta.__set_tablet_id(tablet_id);
+        meta.__set_schema(make_thrift_schema(schema_id));
+        TFlatJsonConfig flat_json;
+        flat_json.__set_flat_json_enable(true);
+        flat_json.__set_flat_json_null_factor(0.3);
+        flat_json.__set_flat_json_sparsity_factor(0.9);
+        flat_json.__set_flat_json_column_max(100);
+        meta.__set_flat_json_config(flat_json);
+        resp.__set_meta(meta);
+
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
+        ASSERT_TRUE(metadata->has_flat_json_config());
+        ASSERT_TRUE(metadata->flat_json_config().flat_json_enable());
+    }
+
+    // Case 6: missing meta should fail
+    {
+        auto tablet_id = next_id();
+        TGetTabletMetadataResponse resp;
+        set_status(&resp.status, TStatusCode::OK);
+
+        auto result = _tablet_manager->build_initial_metadata(tablet_id, resp);
+        ASSERT_FALSE(result.ok());
+    }
+}
+
+TEST_F(TableSchemaServiceTest, parse_shard_properties) {
+    int64_t tablet_id = next_id();
+
+    // Case 1: all fields present and valid
+    {
+        std::unordered_map<std::string, std::string> properties;
+        properties["tableId"] = "100";
+        properties["partitionId"] = "200";
+        properties["indexId"] = "300";
+        int64_t table_id = 0, partition_id = 0, index_id = 0;
+        ASSERT_OK(TabletManager::parse_shard_properties(tablet_id, properties, &table_id, &partition_id, &index_id));
+        ASSERT_EQ(100, table_id);
+        ASSERT_EQ(200, partition_id);
+        ASSERT_EQ(300, index_id);
+    }
+
+    // Case 2: missing required property
+    {
+        std::unordered_map<std::string, std::string> properties;
+        properties["tableId"] = "100";
+        properties["partitionId"] = "200";
+        // missing indexId
+        int64_t table_id = 0, partition_id = 0, index_id = 0;
+        auto st = TabletManager::parse_shard_properties(tablet_id, properties, &table_id, &partition_id, &index_id);
+        ASSERT_TRUE(st.is_internal_error());
+    }
+}
+
+TEST_F(TableSchemaServiceTest, cn_free_fallback_not_triggered_for_version_gt_1) {
+    ScopedSyncPoint sync_point;
+    std::atomic<int> rpc_calls{0};
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                rpc_calls.fetch_add(1);
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                ctx.response->__set_responses(std::vector<TGetTabletMetadataResponse>{});
+                auto& resp = ctx.response->responses.emplace_back();
+                TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+                TCloudTabletMeta meta;
+                meta.__set_tablet_id(ctx.request->tablet_id);
+                meta.__set_schema(make_thrift_schema(next_id()));
+                resp.__set_meta(meta);
+            });
+
+    // version 2 not found should NOT trigger cn-free fallback
+    auto result = _tablet_manager->get_tablet_metadata(next_id(), 2);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_not_found());
+    ASSERT_EQ(0, rpc_calls.load());
+}
+
+TEST_F(TableSchemaServiceTest, cn_free_fallback_not_triggered_with_external_fs) {
+    ScopedSyncPoint sync_point;
+    std::atomic<int> rpc_calls{0};
+
+    SyncPoint::GetInstance()->SetCallBack(
+            "TableSchemaService::_fetch_initial_metadata_via_rpc::test_hook", [&](void* arg) {
+                rpc_calls.fetch_add(1);
+                auto ctx = unpack_initial_metadata_hook_args(arg);
+                *ctx.mock_thrift_rpc = true;
+                *ctx.status = Status::OK();
+                TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+                ctx.response->__set_responses(std::vector<TGetTabletMetadataResponse>{});
+                auto& resp = ctx.response->responses.emplace_back();
+                TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+                TCloudTabletMeta meta;
+                meta.__set_tablet_id(ctx.request->tablet_id);
+                meta.__set_schema(make_thrift_schema(next_id()));
+                resp.__set_meta(meta);
+            });
+
+    // version 1 not found with non-null fs should NOT trigger cn-free fallback
+    auto external_fs = std::shared_ptr<FileSystem>(FileSystem::Default(), [](FileSystem*) {});
+    auto tablet_id = next_id();
+    auto result = _tablet_manager->get_tablet_metadata(tablet_id, 1, true, 0, external_fs);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_not_found());
+    ASSERT_EQ(0, rpc_calls.load());
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
Introduce the CN-side consumer of getTabletInitialMetadata so that when version 1 tablet metadata is missing from object storage, CN constructs it on demand by calling the FE RPC. Required infrastructure for the upcoming CN-Free Tablet Creation feature, where DDL will skip writing v1 metadata.

This change does not alter existing behavior on its own:
  * FE still sends CreateReplicaTask for every DDL, so v1 metadata is always present and the fallback is dormant in the normal path.
  * The user-visible switch (table property cn_free_tablet_creation and DDL skip in TabletTaskExecutor) lands in a later PR.

Changes:
  * TableSchemaService::get_tablet_initial_metadata calls the RPC with SingleFlight deduplication keyed by (table_id, index_id) so concurrent requests for sibling tablets share one round trip, plus retry and latency/error metrics.
  * TabletManager grows three helpers: parse_shard_properties extracts table/partition/index ids from the StarOS shard, build_initial_metadata converts the RPC response into a TabletMetadataPB, and construct_initial_metadata orchestrates the two with USE_STAROS guards and a #ifdef BE_TEST early return so unit tests do not require a live starlet worker.
  * TabletManager::get_tablet_metadata(path, ...) falls back to construct_initial_metadata when the v1 metadata file is missing, tablet_id is non-zero, version == kInitialVersion, and fs == nullptr. The fs == nullptr guard excludes cross-cluster replication reads, which pass the source cluster's filesystem.
  * MetadataIterator routes the initial-metadata path to the (tablet_id, version) overload so the fallback is reachable from listing as well.
  * vacuum.cpp's drop_tablet_cache loop skips version 1 (the empty initial metadata) so the cn-free fallback's cache is not repeatedly evicted.
  * AgentService.thrift gains a NOTE on TCreateTabletReq reminding future contributors to propagate any new field through TGetTabletMetadataResponse to keep the two paths in sync.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
