### PR TITLE
[BugFix] Add missing streamvbyte link dependency for SerdeCore

### DIFF
--- a/be/src/serde/CMakeLists.txt
+++ b/be/src/serde/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(SerdeCore PUBLIC
         Base
         Gutil
         StarRocksGen
+        streamvbyte
         )
 
 ADD_BE_LIB(Serde


### PR DESCRIPTION
## Why I'm doing:

PR #72303 extracted `column_array_serde.cpp` into a new `SerdeCore` library but did not declare its dependency on `streamvbyte`. `column_array_serde.cpp` calls `streamvbyte_encode`, `streamvbyte_decode`, `streamvbyte_delta_encode`, and `streamvbyte_delta_decode`, which are provided by the `streamvbyte` third-party library.

This causes a link failure when building with GNU `gold` linker (used on CentOS with glibc < 2.29):

```
be/src/serde/column_array_serde.cpp:116: error: undefined reference to 'streamvbyte_encode'
be/src/serde/column_array_serde.cpp:112: error: undefined reference to 'streamvbyte_delta_encode'
be/src/serde/column_array_serde.cpp:157: error: undefined reference to 'streamvbyte_delta_decode'
be/src/serde/column_array_serde.cpp:159: error: undefined reference to 'streamvbyte_decode'
```

The CI (Ubuntu, `lld` linker) passes because `lld` resolves symbols globally across all `--start-group/--end-group` boundaries, while `gold` strictly respects group scoping for transitive dependencies placed outside the group.

## What I'm doing:

Add `streamvbyte` to `SerdeCore`'s `target_link_libraries` so the dependency is correctly declared regardless of linker.

Introduced in #72303

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4