### PR TITLE
[BugFix] Fix UAF in LakeDataSourceProvider closing partition conjuncts

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -1255,11 +1255,8 @@ void LakeDataSource::update_counter(RuntimeState* state) {
 LakeDataSourceProvider::LakeDataSourceProvider(ConnectorScanNode* scan_node, const TPlanNode& plan_node)
         : _scan_node(scan_node), _t_lake_scan_node(plan_node.lake_scan_node) {}
 
-LakeDataSourceProvider::~LakeDataSourceProvider() {
-    if (!_partition_conjunct_ctxs.empty() && _runtime_state != nullptr) {
-        ExprExecutor::close(_partition_conjunct_ctxs, _runtime_state);
-    }
-}
+// _partition_conjunct_ctxs share this provider's ObjectPool and self-close in their destructor.
+LakeDataSourceProvider::~LakeDataSourceProvider() = default;
 
 DataSourcePtr LakeDataSourceProvider::create_data_source(const TScanRange& scan_range) {
     return std::make_unique<LakeDataSource>(this, scan_range);
@@ -1310,7 +1307,8 @@ StatusOr<pipeline::MorselQueuePtr> LakeDataSourceProvider::convert_scan_range_to
         bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
         size_t num_total_scan_ranges, size_t scan_parallelism) {
     // Dynamic partition pruning. The partition conjunct contexts were prepared and opened once
-    // in LakeDataSourceProvider::init and will be closed in the provider destructor.
+    // in LakeDataSourceProvider::init and are closed automatically when the owning ObjectPool
+    // tears them down (ExprContext::~ExprContext invokes close()).
     std::vector<TScanRangeParams> pruned_scan_ranges;
     const std::vector<TScanRangeParams>* effective_scan_ranges = &scan_ranges;
     if (!_partition_conjunct_ctxs.empty() && _runtime_state != nullptr) {


### PR DESCRIPTION
## Why I'm doing:


The ExprContexts for partition conjuncts are allocated in the same ObjectPool as the ConnectorScanNode that owns the LakeDataSourceProvider. ObjectPool::clear() destroys entries in reverse insertion order, so the ExprContexts (added during init) are destroyed before the ConnectorScanNode (added earlier). ExprContext::~ExprContext already calls close() via the captured RuntimeState, so the explicit close() in LakeDataSourceProvider::~LakeDataSourceProvider then read freed memory (`_prepared`), tripping ASAN's heap-use-after-free.

Drop the explicit close in the destructor and let the ExprContexts self-close via their destructors when the pool tears them down.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
