### PR TITLE
[UT] Fix heap-use-after-free in VariantZoneMap parquet tests

### DIFF
--- a/be/test/formats/parquet/complex_column_reader_test.cpp
+++ b/be/test/formats/parquet/complex_column_reader_test.cpp
@@ -464,8 +464,11 @@ TEST(ParquetComplexColumnReaderTest, AppendVariantBindingRowSeekFail) {
 // When stats_on_age_chunk=true, col 3 gets INT32 statistics [20, 24].
 // When age_value_all_null=true, the fallback `value` payload for this shredded path is
 // marked all-null in the row-group metadata so typed_value statistics are safe to use.
+// Caller owns `root_field`: ColumnReaderFactory stores raw pointers into the field tree,
+// so it must outlive the returned reader.
 static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader(tparquet::RowGroup& rg,
                                                                             ColumnReaderOptions& opts,
+                                                                            ParquetField& root_field,
                                                                             bool stats_on_age_chunk = false,
                                                                             bool age_value_all_null = false,
                                                                             bool include_age_value = true) {
@@ -512,10 +515,10 @@ static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader(tpar
     tv_struct.type = ColumnType::STRUCT;
     tv_struct.children = {age_node};
 
-    ParquetField field;
-    field.name = "data";
-    field.type = ColumnType::STRUCT;
-    field.children = {meta_f, val_f, tv_struct};
+    root_field = ParquetField();
+    root_field.name = "data";
+    root_field.type = ColumnType::STRUCT;
+    root_field.children = {meta_f, val_f, tv_struct};
 
     for (int i = 0; i <= 3; ++i) {
         tparquet::ColumnChunk chunk;
@@ -541,11 +544,12 @@ static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader(tpar
     rg.__set_num_rows(5);
     opts.row_group_meta = &rg;
 
-    return ColumnReaderFactory::create(opts, &field, TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
+    return ColumnReaderFactory::create(opts, &root_field,
+                                       TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
 }
 
 static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader_with_commit_operation_hint(
-        tparquet::RowGroup& rg, ColumnReaderOptions& opts) {
+        tparquet::RowGroup& rg, ColumnReaderOptions& opts, ParquetField& root_field) {
     auto scalar_field = [](std::string name, tparquet::Type::type physical_type, int column_index) {
         ParquetField field;
         field.name = std::move(name);
@@ -595,10 +599,10 @@ static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader_with
     tv_struct.type = ColumnType::STRUCT;
     tv_struct.children = {time_node, commit_node};
 
-    ParquetField field;
-    field.name = "data";
-    field.type = ColumnType::STRUCT;
-    field.children = {meta_f, val_f, tv_struct};
+    root_field = ParquetField();
+    root_field.name = "data";
+    root_field.type = ColumnType::STRUCT;
+    root_field.children = {meta_f, val_f, tv_struct};
 
     for (int i = 0; i <= 8; ++i) {
         tparquet::ColumnChunk chunk;
@@ -615,13 +619,14 @@ static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader_with
 
     VariantShreddedReadHints hints;
     RETURN_IF_ERROR(hints.add_path("commit.operation"));
-    return ColumnReaderFactory::create_variant_column_reader(opts, &field, hints);
+    return ColumnReaderFactory::create_variant_column_reader(opts, &root_field, hints);
 }
 
 TEST(VariantShreddedPruningTest, CollectIORangeSkipsUnrequestedSiblings) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
-    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader_with_commit_operation_hint(rg, opts));
+    ParquetField root_field;
+    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader_with_commit_operation_hint(rg, opts, root_field));
 
     std::vector<io::SharedBufferedInputStream::IORange> ranges;
     int64_t end_offset = 0;
@@ -638,6 +643,7 @@ TEST(VariantShreddedPruningTest, CollectIORangeSkipsUnrequestedSiblings) {
 
 static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_decimal_variant_reader(tparquet::RowGroup& rg,
                                                                                     ColumnReaderOptions& opts,
+                                                                                    ParquetField& root_field,
                                                                                     bool stats_on_leaf_chunk = false,
                                                                                     bool leaf_value_all_null = false,
                                                                                     bool include_leaf_value = true) {
@@ -685,10 +691,10 @@ static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_decimal_variant_rea
                                              : std::vector<ParquetField>{price_typed_f};
     tv_struct.children = {price_node};
 
-    ParquetField field;
-    field.name = "data";
-    field.type = ColumnType::STRUCT;
-    field.children = {meta_f, val_f, tv_struct};
+    root_field = ParquetField();
+    root_field.name = "data";
+    root_field.type = ColumnType::STRUCT;
+    root_field.children = {meta_f, val_f, tv_struct};
 
     for (int i = 0; i <= 3; ++i) {
         tparquet::ColumnChunk chunk;
@@ -715,7 +721,8 @@ static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_decimal_variant_rea
     rg.__set_num_rows(5);
     opts.row_group_meta = &rg;
 
-    return ColumnReaderFactory::create(opts, &field, TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
+    return ColumnReaderFactory::create(opts, &root_field,
+                                       TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
 }
 
 // Build a minimal FileMetaData (writer version "unknown") so that
@@ -744,7 +751,8 @@ static std::unique_ptr<FileMetaData> make_minimal_file_meta() {
 TEST(VariantZoneMapTest, TypedValueReaderForPathEmptyPath) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
-    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts));
+    ParquetField root_field;
+    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts, root_field));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     EXPECT_EQ(nullptr, vr->filterable_typed_value_reader_for_path(VariantPath{}));
@@ -754,7 +762,8 @@ TEST(VariantZoneMapTest, TypedValueReaderForPathEmptyPath) {
 TEST(VariantZoneMapTest, TypedValueReaderForPathNonExistentKey) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
-    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts));
+    ParquetField root_field;
+    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts, root_field));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     auto path = VariantPathParser::parse_shredded_path(std::string_view("nonexistent"));
@@ -766,7 +775,8 @@ TEST(VariantZoneMapTest, TypedValueReaderForPathNonExistentKey) {
 TEST(VariantZoneMapTest, TypedValueReaderForPathValidScalarLeaf) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
-    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts));
+    ParquetField root_field;
+    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts, root_field));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     auto path = VariantPathParser::parse_shredded_path(std::string_view("age"));
@@ -777,7 +787,8 @@ TEST(VariantZoneMapTest, TypedValueReaderForPathValidScalarLeaf) {
 TEST(VariantZoneMapTest, VariantVirtualZoneMapReaderNoOpApis) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
-    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts));
+    ParquetField root_field;
+    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts, root_field));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     auto path = VariantPathParser::parse_shredded_path(std::string_view("age"));
@@ -811,7 +822,8 @@ TEST(VariantZoneMapTest, VariantVirtualZoneMapReaderNoOpApis) {
 TEST(VariantZoneMapTest, ZoneMapReaderNonExistentPathReturnsFalse) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
-    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts));
+    ParquetField root_field;
+    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts, root_field));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     VariantVirtualZoneMapReader zm_reader(vr, *VariantPathParser::parse_shredded_path(std::string_view("nonexistent")));
@@ -829,7 +841,8 @@ TEST(VariantZoneMapTest, ZoneMapReaderNonExistentPathReturnsFalse) {
 TEST(VariantZoneMapTest, ZoneMapReaderValidPathNoStatsReturnsFalse) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
-    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts));
+    ParquetField root_field;
+    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts, root_field));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     VariantVirtualZoneMapReader zm_reader(vr, *VariantPathParser::parse_shredded_path(std::string_view("age")));
@@ -851,9 +864,10 @@ TEST(VariantZoneMapTest, ZoneMapReaderFiltersWhenPredicateOutOfStatRange) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
     opts.file_meta_data = file_meta.get();
+    ParquetField root_field;
     ASSIGN_OR_ABORT(auto reader,
-                    make_shredded_variant_reader(rg, opts, /*stats_on_age_chunk=*/true, /*age_value_all_null=*/false,
-                                                 /*include_age_value=*/false));
+                    make_shredded_variant_reader(rg, opts, root_field, /*stats_on_age_chunk=*/true,
+                                                 /*age_value_all_null=*/false, /*include_age_value=*/false));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     VariantVirtualZoneMapReader zm_reader(vr, *VariantPathParser::parse_shredded_path(std::string_view("age")));
@@ -876,9 +890,10 @@ TEST(VariantZoneMapTest, ZoneMapReaderDoesNotFilterWhenPredicateInStatRange) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
     opts.file_meta_data = file_meta.get();
+    ParquetField root_field;
     ASSIGN_OR_ABORT(auto reader,
-                    make_shredded_variant_reader(rg, opts, /*stats_on_age_chunk=*/true, /*age_value_all_null=*/false,
-                                                 /*include_age_value=*/false));
+                    make_shredded_variant_reader(rg, opts, root_field, /*stats_on_age_chunk=*/true,
+                                                 /*age_value_all_null=*/false, /*include_age_value=*/false));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     VariantVirtualZoneMapReader zm_reader(vr, *VariantPathParser::parse_shredded_path(std::string_view("age")));
@@ -900,9 +915,10 @@ TEST(VariantZoneMapTest, ZoneMapReaderRewritesPredicatesToLeafType) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
     opts.file_meta_data = file_meta.get();
+    ParquetField root_field;
     ASSIGN_OR_ABORT(auto reader,
-                    make_shredded_variant_reader(rg, opts, /*stats_on_age_chunk=*/true, /*age_value_all_null=*/false,
-                                                 /*include_age_value=*/false));
+                    make_shredded_variant_reader(rg, opts, root_field, /*stats_on_age_chunk=*/true,
+                                                 /*age_value_all_null=*/false, /*include_age_value=*/false));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     auto path = VariantPathParser::parse_shredded_path(std::string_view("age"));
@@ -935,8 +951,9 @@ TEST(VariantZoneMapTest, ZoneMapReaderRewritesDecimalPredicatesToLeafType) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
     opts.file_meta_data = file_meta.get();
+    ParquetField root_field;
     ASSIGN_OR_ABORT(auto reader,
-                    make_shredded_decimal_variant_reader(rg, opts, /*stats_on_leaf_chunk=*/true,
+                    make_shredded_decimal_variant_reader(rg, opts, root_field, /*stats_on_leaf_chunk=*/true,
                                                          /*leaf_value_all_null=*/true, /*include_leaf_value=*/true));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
@@ -968,9 +985,10 @@ TEST(VariantZoneMapTest, ZoneMapReaderSkipsPushdownWhenPredicateRewriteFails) {
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
     opts.file_meta_data = file_meta.get();
+    ParquetField root_field;
     ASSIGN_OR_ABORT(auto reader,
-                    make_shredded_variant_reader(rg, opts, /*stats_on_age_chunk=*/true, /*age_value_all_null=*/false,
-                                                 /*include_age_value=*/false));
+                    make_shredded_variant_reader(rg, opts, root_field, /*stats_on_age_chunk=*/true,
+                                                 /*age_value_all_null=*/false, /*include_age_value=*/false));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     auto path = VariantPathParser::parse_shredded_path(std::string_view("age"));
@@ -1001,8 +1019,9 @@ TEST(VariantZoneMapTest, ZoneMapReaderSkipsWhenFallbackValueMayContainNonNullRow
     tparquet::RowGroup rg;
     ColumnReaderOptions opts;
     opts.file_meta_data = file_meta.get();
-    ASSIGN_OR_ABORT(auto reader,
-                    make_shredded_variant_reader(rg, opts, /*stats_on_age_chunk=*/true, /*age_value_all_null=*/false));
+    ParquetField root_field;
+    ASSIGN_OR_ABORT(auto reader, make_shredded_variant_reader(rg, opts, root_field, /*stats_on_age_chunk=*/true,
+                                                              /*age_value_all_null=*/false));
     auto* vr = down_cast<VariantColumnReader*>(reader.get());
 
     auto path = VariantPathParser::parse_shredded_path(std::string_view("age"));

--- a/be/test/formats/parquet/complex_column_reader_test.cpp
+++ b/be/test/formats/parquet/complex_column_reader_test.cpp
@@ -466,12 +466,9 @@ TEST(ParquetComplexColumnReaderTest, AppendVariantBindingRowSeekFail) {
 // marked all-null in the row-group metadata so typed_value statistics are safe to use.
 // Caller owns `root_field`: ColumnReaderFactory stores raw pointers into the field tree,
 // so it must outlive the returned reader.
-static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader(tparquet::RowGroup& rg,
-                                                                            ColumnReaderOptions& opts,
-                                                                            ParquetField& root_field,
-                                                                            bool stats_on_age_chunk = false,
-                                                                            bool age_value_all_null = false,
-                                                                            bool include_age_value = true) {
+static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader(
+        tparquet::RowGroup& rg, ColumnReaderOptions& opts, ParquetField& root_field, bool stats_on_age_chunk = false,
+        bool age_value_all_null = false, bool include_age_value = true) {
     ParquetField meta_f;
     meta_f.name = "metadata";
     meta_f.type = ColumnType::SCALAR;
@@ -544,8 +541,7 @@ static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader(tpar
     rg.__set_num_rows(5);
     opts.row_group_meta = &rg;
 
-    return ColumnReaderFactory::create(opts, &root_field,
-                                       TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
+    return ColumnReaderFactory::create(opts, &root_field, TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
 }
 
 static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader_with_commit_operation_hint(
@@ -641,12 +637,9 @@ TEST(VariantShreddedPruningTest, CollectIORangeSkipsUnrequestedSiblings) {
     EXPECT_EQ(expected_offsets, offsets);
 }
 
-static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_decimal_variant_reader(tparquet::RowGroup& rg,
-                                                                                    ColumnReaderOptions& opts,
-                                                                                    ParquetField& root_field,
-                                                                                    bool stats_on_leaf_chunk = false,
-                                                                                    bool leaf_value_all_null = false,
-                                                                                    bool include_leaf_value = true) {
+static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_decimal_variant_reader(
+        tparquet::RowGroup& rg, ColumnReaderOptions& opts, ParquetField& root_field, bool stats_on_leaf_chunk = false,
+        bool leaf_value_all_null = false, bool include_leaf_value = true) {
     ParquetField meta_f;
     meta_f.name = "metadata";
     meta_f.type = ColumnType::SCALAR;
@@ -721,8 +714,7 @@ static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_decimal_variant_rea
     rg.__set_num_rows(5);
     opts.row_group_meta = &rg;
 
-    return ColumnReaderFactory::create(opts, &root_field,
-                                       TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
+    return ColumnReaderFactory::create(opts, &root_field, TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
 }
 
 // Build a minimal FileMetaData (writer version "unknown") so that


### PR DESCRIPTION
## Why I'm doing:

```
==85668==ERROR: AddressSanitizer: heap-use-after-free on address 0x5140004553a8 at pc 0x0000320e93cb bp 0x7ffef01c6110 sp 0x7ffef01c6108
READ of size 4 at 0x5140004553a8 thread T0
    #0 0x320e93ca in std::unique_ptr<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::default_delete<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > google::logging::internal::Check_EQImpl<tparquet::Type::type, tparquet::Type::type>(tparquet::Type::type const&, tparquet::Type::type const&, char const*) /var/local/thirdparty/installed/include/glog/logging.h:741
    #1 0x328c0b9a in starrocks::parquet::StatisticsHelper::get_min_max_value(starrocks::parquet::FileMetaData const*, starrocks::TypeDescriptor const&, tparquet::ColumnMetaData const*, starrocks::parquet::ParquetField const*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) /root/starrocks/be/src/formats/parquet/statistics_helper.cpp:177
    #2 0x32189f48 in starrocks::parquet::RawColumnReader::_row_group_zone_map_filter(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, starrocks::CompoundNodeType, starrocks::TypeDescriptor const&, unsigned long, unsigned long) const /root/starrocks/be/src/formats/parquet/scalar_column_reader.cpp:246
    #3 0x321971e0 in starrocks::parquet::ScalarColumnReader::row_group_zone_map_filter(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, starrocks::CompoundNodeType, unsigned long, unsigned long) const /root/starrocks/be/src/formats/parquet/scalar_column_reader.h:189
    #4 0x321caf13 in starrocks::parquet::VariantVirtualZoneMapReader::row_group_zone_map_filter(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, starrocks::CompoundNodeType, unsigned long, unsigned long) const /root/starrocks/be/src/formats/parquet/complex_column_reader.cpp:2197
    #5 0x239322b4 in starrocks::parquet::VariantZoneMapTest_ZoneMapReaderFiltersWhenPredicateOutOfStatRange_Test::TestBody() /root/starrocks/be/test/formats/parquet/complex_column_reader_test.cpp:866
    #6 0x40b1ac50 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) googletest-release-1.10.0/googletest/src/gtest.cc:2433
    #7 0x40b1ac50 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) googletest-release-1.10.0/googletest/src/gtest.cc:2469
    #8 0x40b0e075 in testing::Test::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2508
    #9 0x40b0e075 in testing::Test::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2498
    #10 0x40b0e1dd in testing::TestInfo::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2684
    #11 0x40b0e1dd in testing::TestInfo::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2657
    #12 0x40b0e2c6 in testing::TestSuite::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2816
    #13 0x40b0e2c6 in testing::TestSuite::Run() googletest-release-1.10.0/googletest/src/gtest.cc:2795
    #14 0x40b0e813 in testing::internal::UnitTestImpl::RunAllTests() googletest-release-1.10.0/googletest/src/gtest.cc:5338
    #15 0x40b0e9f2 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) googletest-release-1.10.0/googletest/src/gtest.cc:2433
    #16 0x40b0e9f2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) googletest-release-1.10.0/googletest/src/gtest.cc:2469
    #17 0x40b0e9f2 in testing::UnitTest::Run() googletest-release-1.10.0/googletest/src/gtest.cc:4925
    #18 0x1ff11a69 in RUN_ALL_TESTS() /var/local/thirdparty/installed/include/gtest/gtest.h:2473
    #19 0x1ff0d12e in starrocks::init_test_env(int, char**) /root/starrocks/be/src/testutil/init_test_env.h:122
    #20 0x1ff0dd22 in main /root/starrocks/be/test/test_main.cpp:27
    #21 0x7f215575cd8f  (/lib/x86_64-linux-gnu/[libc.so](http://libc.so/).6+0x29d8f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
    #22 0x7f215575ce3f in __libc_start_main (/lib/x86_64-linux-gnu/[libc.so](http://libc.so/).6+0x29e3f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
    #23 0x1fdf7024 in _start (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1fdf7024)
```

## What I'm doing:

The make_shredded_*_variant_reader test helpers declared the root ParquetField as a stack local. ColumnReaderFactory stores raw pointers into the ParquetField tree, so once the helper returned the readers held dangling pointers. ASAN flagged this in
VariantZoneMapTest.ZoneMapReaderFiltersWhenPredicateOutOfStatRange when StatisticsHelper::get_min_max_value read field->physical_type.

Make the caller own the root ParquetField via an out parameter so its lifetime extends through the test.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
