### PR TITLE
[BugFix] Reject multi-request batches in getTabletMetadata

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -3601,11 +3601,28 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             TBatchGetTabletMetadataRequest batchRequest) {
         TBatchGetTabletMetadataResponse batchResponse = new TBatchGetTabletMetadataResponse();
         batchResponse.setStatus(new TStatus(OK));
-        if (batchRequest.isSetRequests()) {
-            for (TGetTabletMetadataRequest request : batchRequest.getRequests()) {
-                batchResponse.addToResponses(handleGetTabletMetadata(request));
-            }
+        if (!batchRequest.isSetRequests() || batchRequest.getRequests().isEmpty()) {
+            return batchResponse;
         }
+        // The thrift type is a batch but only single-request payloads are accepted today.
+        // A real batch implementation would have to take a read lock on every distinct
+        // (db, table) covered by the batch and hold all of them for the full batch so that
+        // sibling tablets observe one consistent snapshot. Otherwise a schema change
+        // committing between two per-request locks would leave sibling responses with
+        // mismatched schemas and CN would assemble inconsistent TabletMetadataPBs. The
+        // grouping, lock-ordering (to avoid deadlocks against other DDL), and partial-failure
+        // bookkeeping needed to do that correctly are not worth the complexity given that
+        // the current CN caller packs exactly one request.
+        // Keep the wire shape so a future change can lift the restriction; reject the
+        // overflow case loudly until then.
+        if (batchRequest.getRequests().size() > 1) {
+            TStatus status = new TStatus(TStatusCode.NOT_IMPLEMENTED_ERROR);
+            status.addToError_msgs("multi-request batches are not supported, got: "
+                    + batchRequest.getRequests().size());
+            batchResponse.setStatus(status);
+            return batchResponse;
+        }
+        batchResponse.addToResponses(handleGetTabletMetadata(batchRequest.getRequests().get(0)));
         return batchResponse;
     }
 
@@ -3698,7 +3715,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
             // tablet_ranges holds all tablets' ranges in this index, only for range distribution
             if (olapTable.isRangeDistribution()) {
-                Map<Long, TTabletRange> tabletRanges = new java.util.HashMap<>();
+                Map<Long, TTabletRange> tabletRanges = new HashMap<>();
                 for (Tablet tablet : index.getTablets()) {
                     if (tablet.getRange() != null) {
                         tabletRanges.put(tablet.getId(), tablet.getRange().toThrift());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.LightWeightDeltaLakeTable;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -774,5 +775,36 @@ public class CreateLakeTableTest {
             Assertions.assertEquals(TStatusCode.OK, batchResp.getStatus().getStatus_code());
             Assertions.assertFalse(batchResp.isSetResponses());
         }
+    }
+
+    @Test
+    public void testGetTabletMetadataBatchSizeRejected() throws Exception {
+        // Multi-request batches are intentionally not implemented: see comment on
+        // getTabletMetadata. Verify that any batch with more than one request is rejected
+        // at the batch level and no per-request response is produced.
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.tablet_metadata_batch_reject_test\n" +
+                        "(c0 int, c1 string)\n" +
+                        "duplicate key(c0)\n" +
+                        "distributed by hash(c0) buckets 2"));
+        LakeTable lakeTable = getLakeTable("lake_test", "tablet_metadata_batch_reject_test");
+        Partition partition = lakeTable.getPartitions().stream().findFirst().get();
+        MaterializedIndex index = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(null);
+        TBatchGetTabletMetadataRequest batchReq = new TBatchGetTabletMetadataRequest();
+        for (Tablet tablet : index.getTablets()) {
+            TGetTabletMetadataRequest req = new TGetTabletMetadataRequest();
+            req.setTable_id(lakeTable.getId());
+            req.setPartition_id(partition.getDefaultPhysicalPartition().getId());
+            req.setIndex_id(index.getId());
+            req.setTablet_id(tablet.getId());
+            req.setVersion(1);
+            batchReq.addToRequests(req);
+        }
+
+        TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
+        Assertions.assertEquals(TStatusCode.NOT_IMPLEMENTED_ERROR, batchResp.getStatus().getStatus_code());
+        Assertions.assertFalse(batchResp.isSetResponses());
     }
 }


### PR DESCRIPTION
Multiple TGetTabletMetadataRequests for sibling tablets under the same index each acquired and released the table read lock independently. A schema change (or other DDL) committing between two iterations could leave sibling responses in the same batch with mismatched schemas, leading CN to assemble TabletMetadataPB with inconsistent fields.

A correct multi-request implementation would have to take a read lock on every distinct (db, table) covered by the batch and hold all of them for the full duration so that sibling tablets observe one consistent snapshot. The grouping, lock-ordering (to avoid deadlocks against other DDL), and partial-failure bookkeeping needed to do that correctly are not worth the complexity given that the current CN caller packs exactly one request. Reject batches with more than one request at the batch level with NOT_IMPLEMENTED_ERROR. The thrift wire shape is preserved so a future change can lift the restriction without breaking compatibility.

Add testGetTabletMetadataBatchSizeRejected to verify the rejection path.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
