### PR TITLE
[Refactor] Remove lake_enable_publish_version_trace_log config

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1319,7 +1319,6 @@ CONF_mInt64(experimental_lake_wait_per_get_ms, "0");
 CONF_mInt64(experimental_lake_wait_per_delete_ms, "0");
 CONF_mBool(experimental_lake_ignore_pk_consistency_check, "false");
 CONF_mInt64(lake_publish_version_slow_log_ms, "1000");
-CONF_mBool(lake_enable_publish_version_trace_log, "false");
 CONF_mString(lake_vacuum_retry_pattern, "*request rate*");
 CONF_mInt64(lake_vacuum_retry_max_attempts, "5");
 CONF_mInt64(lake_vacuum_retry_min_delay_ms, "100");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -828,7 +828,6 @@
         "lake_metadata_fetch_thread_count",
         "lake_metadata_cache_limit",
         "lake_cache_select_in_physical_way",
-        "lake_enable_publish_version_trace_log",
         "lake_service_max_concurrency",
         "lake_enable_orphan_delvec_cleanup_on_compaction"
       ]

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -71,8 +71,6 @@ CONF_mInt64(experimental_lake_wait_per_delete_ms, "0");
 
 CONF_mInt64(lake_publish_version_slow_log_ms, "1000");
 
-CONF_mBool(lake_enable_publish_version_trace_log, "false");
-
 CONF_mString(lake_vacuum_retry_pattern, "*request rate*");
 
 CONF_mInt64(lake_vacuum_retry_max_attempts, "5");

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -511,10 +511,7 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
     latch.wait();
     auto cost = butil::gettimeofday_us() - start_ts;
     auto is_slow = cost >= config::lake_publish_version_slow_log_ms * 1000;
-    if (config::lake_enable_publish_version_trace_log && is_slow) {
-        LOG(INFO) << "Published txns=" << get_txn_ids_string(request) << ". cost=" << cost << "us\n"
-                  << trace->DumpToString();
-    } else if (is_slow) {
+    if (is_slow) {
         LOG(INFO) << "Published txns=" << get_txn_ids_string(request)
                   << ". tablets=" << JoinInts(request->tablet_ids(), ",") << " cost=" << cost
                   << "us, trace: " << trace->MetricsAsJSON();


### PR DESCRIPTION
## Why I'm doing:

The `lake_enable_publish_version_trace_log` config is unnecessary. When the config is disabled (its default `false` value), the slow-publish log path already emits the trace in JSON format via `Trace::MetricsAsJSON()`, which is the format we want. The alternate enabled-path emitted a multi-line `DumpToString()` dump that we no longer want to support.

## What I'm doing:

- Remove `CONF_mBool(lake_enable_publish_version_trace_log, "false")` from `be/src/common/config.h`.
- In `LakeServiceImpl::publish_version`, drop the conditional branch and always emit the JSON trace when a publish is slow.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4