### PR TITLE
[Enhancement] Reject cross-mode ALTER for materialized view refresh_mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -63,7 +63,6 @@ import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.SetStmtAnalyzer;
-import com.starrocks.sql.analyzer.mv.IVMAnalyzer;
 import com.starrocks.sql.ast.AddColumnsClause;
 import com.starrocks.sql.ast.AddMVColumnClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStatusClause;
@@ -244,49 +243,29 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                                     List<Runnable> appliers,
                                     ConnectContext context) {
         String mvRefreshMode = PropertyAnalyzer.analyzeRefreshMode(properties);
-        // cannot alter original pct based mv to incremental or auto, only support original ivm/pct based mv
-        MaterializedView.RefreshMode currentRefreshMode =
+        MaterializedView.RefreshMode targetMode =
                 MaterializedView.RefreshMode.valueOf(mvRefreshMode.toUpperCase(Locale.ROOT));
-        if (currentRefreshMode.isIncrementalOrAuto()) {
-            ParseNode mvDefinedQueryParseNode = materializedView.getDefineQueryParseNode();
-            if ((mvDefinedQueryParseNode instanceof QueryStatement queryStatement)) {
-                IVMAnalyzer ivmAnalyzer = new IVMAnalyzer(context, null, queryStatement);
+        MaterializedView.RefreshMode originalMode = materializedView.getCurrentRefreshMode();
 
-                Optional<IVMAnalyzer.IVMAnalyzeResult> result;
-                try {
-                    result = ivmAnalyzer.rewrite(
-                            MaterializedView.RefreshMode.valueOf(mvRefreshMode.toUpperCase(Locale.ROOT)));
-                } catch (SemanticException e) {
-                    throw new SemanticException("Cannot alter materialized view refresh mode to %s: %s",
-                            mvRefreshMode, e.getMessage());
-                }
-                if (result.isEmpty()) {
-                    throw new SemanticException("Cannot alter materialized view refresh mode to %s," +
-                            " because the materialized view is not eligible for %s refresh mode",
-                            mvRefreshMode, mvRefreshMode);
-                }
-                // if materialized's original refresh mode is not auto or ivm, throw exception
-                if (!materializedView.getCurrentRefreshMode().isIncrementalOrAuto()) {
-                    throw new SemanticException("Cannot alter materialized view refresh mode to %s," +
-                            " only support alter original incremental/auto based materialized view",
-                            mvRefreshMode);
-                }
-                currentRefreshMode = result.get().currentRefreshMode();
-            } else {
-                throw new SemanticException("Cannot alter materialized view refresh mode to %s", mvRefreshMode);
-            }
+        // Cross-mode ALTER is not supported. The recovery path for changing refresh_mode is
+        // drop-and-recreate. Same-mode ALTER is allowed and behaves as a no-op (modulo the
+        // applier below, which keeps the persisted property and the in-memory mode in sync).
+        if (originalMode != targetMode) {
+            throw new SemanticException(
+                    "Altering refresh_mode from %s to %s is not supported. " +
+                            "Please drop and re-create the materialized view if a mode change is required.",
+                    originalMode, targetMode);
         }
 
-        MaterializedView.RefreshMode finalCurrentRefreshMode = currentRefreshMode;
         // Trigger applier when either the persisted property or the in-memory current mode
         // would change. Comparing only the persisted string would miss cases where the two
         // are out of sync (e.g. mode promoted internally without rewriting the property).
         if (!tableProperty.getMvRefreshMode().equals(mvRefreshMode)
-                || materializedView.getCurrentRefreshMode() != finalCurrentRefreshMode) {
+                || materializedView.getCurrentRefreshMode() != targetMode) {
             appliers.add(() -> {
                 tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_MV_REFRESH_MODE, mvRefreshMode);
                 tableProperty.setMvRefreshMode(mvRefreshMode);
-                materializedView.setCurrentRefreshMode(finalCurrentRefreshMode);
+                materializedView.setCurrentRefreshMode(targetMode);
             });
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewTest.java
@@ -54,17 +54,17 @@ public class AlterMaterializedViewTest extends MVTestBase {
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
         Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
 
-        // change refresh mode from auto to incremental
+        // alter auto -> incremental: rejected (cross-mode ALTER not supported)
         {
             String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"incremental\")";
-            alterMaterializedView(alterStmt, false);
-            Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
         }
-        // change refresh mode from incremental to auto: rejected (AUTO is hidden from users)
+        // alter auto -> auto: rejected (AUTO is hidden from users at the analyzer level)
         {
             String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
             alterMaterializedView(alterStmt, true);
-            Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+            Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
         }
     }
 
@@ -103,6 +103,12 @@ public class AlterMaterializedViewTest extends MVTestBase {
         // alter incremental -> auto: rejected (AUTO is hidden from users)
         {
             String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"auto\")";
+            alterMaterializedView(alterStmt, true);
+            Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+        }
+        // alter incremental -> pct: rejected (cross-mode ALTER not supported)
+        {
+            String alterStmt = "alter materialized view test_mv1 set (\"refresh_mode\" = \"pct\")";
             alterMaterializedView(alterStmt, true);
             Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

ALTER MATERIALIZED VIEW SET refresh_mode is restricted to no-op (same mode). Switching between INCREMENTAL and PCT is not supported; the recovery path for changing refresh_mode is drop-and-recreate.

Production:
- AlterMVJobExecutor.alterMVRefreshMode: replace the IVMAnalyzer re-validation block with a single early gate. If the original mode differs from the target mode, throw with a clear error pointing at drop-and-recreate. Same-mode ALTERs still go through the applier so the persisted property and the in-memory currentRefreshMode stay in sync (relied on by the helper-driven test path).
- The IVMAnalyzer.rewrite call here re-walked the MV's defining query to recompute IVM eligibility on every ALTER refresh_mode. Since same-mode ALTER is the only allowed transition under the new gate, that re-validation is no longer reachable; remove it (and the now unused import) to keep the method narrow and avoid a known AST mutation leak in the analyzer's catch-and-fallback path.

Tests:
- testChangeMVRefreshMode1 (AUTO MV): AUTO -> INCREMENTAL now expects rejection (cross-mode). The companion AUTO -> AUTO leg still expects rejection at the PropertyAnalyzer layer (PR2). Mode stays AUTO throughout.
- testChangeMVRefreshMode3 (INCREMENTAL MV): adds a third leg asserting INCREMENTAL -> PCT is rejected, the gap PR6 was created to close.
- testChangeMVRefreshMode2/6/7 already expect failure for their cross-mode legs and continue to pass under the simpler rule.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
