### PR TITLE
[BugFix] Validate vector input regardless of build threshold and tolerate missing .vi during replicate/link

### DIFF
--- a/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
@@ -21,7 +21,6 @@
 #include "column/array_column.h"
 #include "column/raw_data_visitor.h"
 #include "common/config_vector_index_fwd.h"
-#include "gutil/strings/substitute.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "tenann/factory/index_factory.h"
 
@@ -44,9 +43,6 @@ Status TenAnnIndexBuilderProxy::init() {
     if (!params.contains(index::vector::METRIC_TYPE)) {
         return Status::InvalidArgument("metric_type is needed because it's a critical common param");
     }
-    _is_input_normalized = params.contains(index::vector::IS_VECTOR_NORMED) &&
-                           params[index::vector::IS_VECTOR_NORMED] &&
-                           params[index::vector::METRIC_TYPE] == tenann::MetricType::kCosineSimilarity;
 
     auto meta_copy = meta;
     if (meta.index_type() == tenann::IndexType::kFaissIvfPq && config::enable_vector_index_block_cache) {
@@ -79,48 +75,6 @@ Status TenAnnIndexBuilderProxy::init() {
     return Status::OK();
 }
 
-template <bool is_input_normalized>
-static Status valid_input_vector(const ArrayColumn& input_column, const size_t index_dim,
-                                 const uint8_t* is_element_nulls) {
-    if (input_column.empty()) {
-        return Status::OK();
-    }
-
-    const size_t num_rows = input_column.size();
-    const auto& offsets = input_column.offsets().immutable_data();
-    RawDataVisitor rv;
-    RETURN_IF_ERROR(input_column.elements().accept(&rv));
-    const auto* nums = reinterpret_cast<const float*>(rv.result());
-
-    for (size_t i = 0; i < num_rows; i++) {
-        const size_t input_dim = offsets[i + 1] - offsets[i];
-
-        if (input_dim != index_dim) {
-            return Status::InvalidArgument(
-                    strings::Substitute("The dimensions of the vector written are inconsistent, index dim is "
-                                        "$0 but data dim is $1",
-                                        index_dim, input_dim));
-        }
-
-        if constexpr (is_input_normalized) {
-            double sum = 0;
-            for (int j = 0; j < input_dim; j++) {
-                const size_t offset = offsets[i] + j;
-                if (!is_element_nulls[offset]) {
-                    sum += nums[offset] * nums[offset];
-                }
-            }
-            if (std::abs(sum - 1) > 1e-3) {
-                return Status::InvalidArgument(
-                        "The input vector is not normalized but `metric_type` is cosine_similarity and "
-                        "`is_vector_normed` is true");
-            }
-        }
-    }
-
-    return Status::OK();
-}
-
 Status TenAnnIndexBuilderProxy::add(const Column& array_column, const size_t offset) {
     DCHECK(array_column.is_array());
     const auto& array_col = down_cast<const ArrayColumn&>(array_column);
@@ -130,11 +84,10 @@ Status TenAnnIndexBuilderProxy::add(const Column& array_column, const size_t off
     const auto& is_element_nulls = nullable_elements.null_column_ref();
     const uint8_t* is_element_nulls_data = is_element_nulls.raw_data();
 
-    if (_is_input_normalized) {
-        RETURN_IF_ERROR(valid_input_vector<true>(array_col, _dim, is_element_nulls_data));
-    } else {
-        RETURN_IF_ERROR(valid_input_vector<false>(array_col, _dim, is_element_nulls_data));
-    }
+    // Input validation (dim consistency + cosine normalization) is performed
+    // upstream in ArrayColumnWriter::append via validate_vector_index_input
+    // before data ever reaches this proxy, so writes that succeed are always
+    // well-formed. This proxy trusts its caller and skips re-checking.
 
     RawDataVisitor rv;
     RETURN_IF_ERROR(array_col.accept(&rv));

--- a/be/src/storage/index/vector/tenann/tenann_index_builder.h
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.h
@@ -57,10 +57,6 @@ public:
 private:
     std::shared_ptr<tenann::IndexBuilder> _index_builder = nullptr;
     uint32_t _dim = 0;
-    // This will be true when `metric_type` is cosine_similarity and `is_vector_normed` is true.
-    // When it is true, the vector (a row of the array column) is either null or the sum of the squares of all elements
-    // equals 1.
-    bool _is_input_normalized = false;
 
     const bool _is_element_nullable;
     const int _omp_threads;

--- a/be/src/storage/index/vector/vector_index_writer.cpp
+++ b/be/src/storage/index/vector/vector_index_writer.cpp
@@ -14,9 +14,14 @@
 
 #include "storage/index/vector/vector_index_writer.h"
 
+#include <cmath>
+
+#include "column/nullable_column.h"
+#include "column/raw_data_visitor.h"
 #include "common/config_vector_index_fwd.h"
 #include "common/runtime_profile.h"
 #include "fs/fs_util.h"
+#include "gutil/strings/substitute.h"
 #include "storage/index/index_descriptor.h"
 #include "storage/index/vector/vector_index_file_writer.h"
 
@@ -69,6 +74,11 @@ Status VectorIndexWriter::init() {
 }
 
 Status VectorIndexWriter::append(const Column& src) {
+    DCHECK(src.is_array());
+
+    // Input validation is performed by ArrayColumnWriter::append before this
+    // method is reached, so the writer trusts the data and skips re-checking.
+
     int64_t duration = 0;
     {
         SCOPED_RAW_TIMER(&duration);
@@ -167,6 +177,58 @@ Status VectorIndexWriter::_prepare_index_builder() {
 Status VectorIndexWriter::_append_data(const Column& src, size_t offset) {
     DCHECK(src.is_array());
     RETURN_IF_ERROR(_index_builder->add(src, offset));
+    return Status::OK();
+}
+
+// Mirrors the original valid_input_vector<is_input_normalized> in
+// tenann_index_builder.cpp byte-for-byte; the only structural change is that
+// the compile-time template parameter becomes a runtime argument. Behavior
+// parity is intentional — this lifts the same validation up so it runs from
+// every caller (writer below threshold, async build task) instead of only
+// when TenAnnIndexBuilderProxy::add is reached.
+Status validate_vector_index_input(const ArrayColumn& array_col, size_t dim, bool is_input_normalized) {
+    if (array_col.empty()) {
+        return Status::OK();
+    }
+
+    const size_t num_rows = array_col.size();
+    const auto& offsets = array_col.offsets().immutable_data();
+    RawDataVisitor rv;
+    RETURN_IF_ERROR(array_col.elements().accept(&rv));
+    const auto* nums = reinterpret_cast<const float*>(rv.result());
+
+    // Element column is nullable for vector-indexed array columns; the null
+    // mask is only consumed when normalization is checked, but we extract it
+    // unconditionally to mirror the original control flow.
+    const auto& nullable_elements = down_cast<const NullableColumn&>(array_col.elements());
+    const uint8_t* is_element_nulls = nullable_elements.null_column_ref().raw_data();
+
+    for (size_t i = 0; i < num_rows; i++) {
+        const size_t input_dim = offsets[i + 1] - offsets[i];
+
+        if (input_dim != dim) {
+            return Status::InvalidArgument(
+                    strings::Substitute("The dimensions of the vector written are inconsistent, index dim is "
+                                        "$0 but data dim is $1",
+                                        dim, input_dim));
+        }
+
+        if (is_input_normalized) {
+            double sum = 0;
+            for (size_t j = 0; j < input_dim; j++) {
+                const size_t offset = offsets[i] + j;
+                if (!is_element_nulls[offset]) {
+                    sum += nums[offset] * nums[offset];
+                }
+            }
+            if (std::abs(sum - 1) > 1e-3) {
+                return Status::InvalidArgument(
+                        "The input vector is not normalized but `metric_type` is cosine_similarity and "
+                        "`is_vector_normed` is true");
+            }
+        }
+    }
+
     return Status::OK();
 }
 

--- a/be/src/storage/index/vector/vector_index_writer.h
+++ b/be/src/storage/index/vector/vector_index_writer.h
@@ -31,6 +31,15 @@ namespace starrocks {
 class ArrayColumn;
 class VectorIndexFileWriter;
 
+// Validate an array column against the vector index parameters. Every caller
+// that feeds data into a vector index builder must call this first so the
+// same dim and cosine-normalization rules apply regardless of whether the
+// build is inline (VectorIndexWriter::append, sync OLAP path) or asynchronous
+// (lake::VectorIndexBuildTask, shared-data path), and so that buffered data
+// below the build threshold is still checked. Mirrors the original
+// valid_input_vector logic in tenann_index_builder.cpp.
+Status validate_vector_index_input(const ArrayColumn& array_col, size_t dim, bool is_input_normalized);
+
 class VectorIndexWriter {
 public:
     static void create(const std::shared_ptr<TabletIndex>& tablet_index, const std::string& vector_index_file_path,

--- a/be/src/storage/rowset/array_column_writer.cpp
+++ b/be/src/storage/rowset/array_column_writer.cpp
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <boost/algorithm/string.hpp>
+
 #include "column/array_column.h"
 #include "column/nullable_column.h"
 #include "common/status.h"
 #include "gutil/casts.h"
 #include "storage/index/vector/vector_index_writer.h"
 #include "storage/rowset/column_writer.h"
+#include "storage/tablet_index.h"
 
 namespace starrocks {
 
@@ -60,6 +63,17 @@ private:
     std::unique_ptr<ScalarColumnWriter> _array_size_writer;
     std::unique_ptr<ColumnWriter> _element_writer;
     std::unique_ptr<VectorIndexWriter> _vector_index_writer;
+
+    // Vector-index input validation parameters. Populated from
+    // _opts.tablet_index[VECTOR] in init() whenever the schema declares a
+    // vector index for this array column — independently of need_vector_index,
+    // so the same validation runs in both the sync (inline build) and async
+    // (defer_vector_index_build) write paths. Validation runs once per batch
+    // in append() before any column data is written, so writes that succeed
+    // are guaranteed to contain only well-formed vectors.
+    bool _validate_vector_input = false;
+    size_t _vi_dim = 0;
+    bool _vi_is_input_normalized = false;
 };
 
 StatusOr<std::unique_ptr<ColumnWriter>> create_array_column_writer(const ColumnWriterOptions& opts,
@@ -148,6 +162,28 @@ Status ArrayColumnWriter::init() {
         RETURN_IF_ERROR(_vector_index_writer->init());
     }
 
+    // Parse vector-index validation parameters whenever the schema declares
+    // a vector index for this column, regardless of whether the index is
+    // built inline (sync) or asynchronously. Without this the async path
+    // would persist malformed vectors that later break index reads or fail
+    // the deferred build, instead of failing the INSERT at write time.
+    if (_opts.tablet_index.count(IndexType::VECTOR) > 0) {
+        const auto& tablet_index = _opts.tablet_index.at(IndexType::VECTOR);
+        const auto& props = tablet_index.common_properties();
+        auto dim_it = props.find("dim");
+        if (dim_it == props.end()) {
+            return Status::InvalidArgument("dim is needed because it's a critical common param");
+        }
+        _vi_dim = static_cast<size_t>(std::atoi(dim_it->second.c_str()));
+        auto normed_it = props.find("is_vector_normed");
+        auto metric_it = props.find("metric_type");
+        // Lowercase-insensitive parsing mirrors get_vector_meta so the writer
+        // and the index builder agree on whether normalization applies.
+        _vi_is_input_normalized = normed_it != props.end() && boost::iequals(normed_it->second, "true") &&
+                                  metric_it != props.end() && boost::iequals(metric_it->second, "cosine_similarity");
+        _validate_vector_input = true;
+    }
+
     return Status::OK();
 }
 
@@ -160,6 +196,15 @@ Status ArrayColumnWriter::append(const Column& column) {
         null_column = down_cast<const NullColumn*>(nullable_column.null_column().get());
     } else {
         array_column = down_cast<const ArrayColumn*>(&column);
+    }
+
+    // Validate vector input first so writes that succeed are always
+    // well-formed. This single check covers both the sync inline-build path
+    // and the async defer_vector_index_build path; downstream consumers
+    // (VectorIndexWriter, TenAnnIndexBuilderProxy, lake::VectorIndexBuildTask)
+    // trust the data here and skip re-validation.
+    if (_validate_vector_input) {
+        RETURN_IF_ERROR(validate_vector_index_input(*array_column, _vi_dim, _vi_is_input_normalized));
     }
 
     // 1. Write null column when necessary

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -483,6 +483,18 @@ Status Rowset::link_files_to(const std::string& dir, RowsetId new_rowset_id, int
                             dir, new_rowset_id.to_string(), segment_n, index.index_id());
                     std::string src_index_file_path = IndexDescriptor::vector_index_file_path(
                             _rowset_path, rowset_id().to_string(), segment_n, index.index_id());
+                    // .vi may be absent when the writer skipped the build below
+                    // threshold; the segment footer is then set to NONE and
+                    // the read path skips this index without ever opening it.
+                    // Tolerate ENOENT only — fail on real IO errors so we
+                    // don't silently produce a cloned rowset that's missing a
+                    // file the segment metadata still expects.
+                    auto st = FileSystem::Default()->path_exists(src_index_file_path);
+                    if (st.is_not_found()) {
+                        VLOG(2) << "skip linking non-existent vector index file " << src_index_file_path;
+                        continue;
+                    }
+                    if (!st.ok()) return st;
                     if (link(src_index_file_path.c_str(), dst_index_link_path.c_str()) != 0) {
                         PLOG(WARNING) << "Fail to link " << src_index_file_path << " to " << dst_index_link_path;
                         return Status::RuntimeError("Fail to link index data file");

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -340,6 +340,32 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
                 auto& index = mutable_indexes->at(i);
                 if (index.index_type() == VECTOR) {
                     auto index_path = mutable_indexes->at(i).index_path();
+
+                    // .vi may be absent when the writer skipped the build below
+                    // threshold (sync OLAP is the only path here — see
+                    // VectorIndexWriter::finish). The primary's segment footer
+                    // is set to VECTOR_INDEX_STORAGE_NONE in that case, so the
+                    // secondary's read path will skip the vector index without
+                    // ever opening this file. Drop the entry from PB so the
+                    // secondary does not attempt to consume an absent payload
+                    // from the IOBuf stream.
+                    auto exists_st = _fs->path_exists(index_path);
+                    if (exists_st.is_not_found()) {
+                        // Expected on every small-segment publish below the build
+                        // threshold; keep at VLOG so it doesn't dominate logs at
+                        // high QPS.
+                        VLOG(1) << "skip replicating non-existent vector index file " << index_path << " for "
+                                << segment->DebugString();
+                        mutable_indexes->DeleteSubrange(i, 1);
+                        --i;
+                        continue;
+                    }
+                    if (!exists_st.ok()) {
+                        LOG(WARNING) << "Failed to stat index file " << index_path << " by " << debug_string()
+                                     << " err " << exists_st;
+                        return set_status(exists_st);
+                    }
+
                     auto res = _fs->new_random_access_file(index_path);
 
                     if (!res.ok()) {
@@ -367,8 +393,12 @@ void ReplicateToken::_sync_segment(std::unique_ptr<SegmentPB> segment, bool eos)
                         return set_status(st);
                     }
                 }
-                segment->set_seg_index_data_size(total_index_data_size);
             }
+            // Set once after the loop so the final value reflects all
+            // surviving entries (including the empty case where every VECTOR
+            // entry was dropped via DeleteSubrange) instead of being skipped
+            // on iterations that hit `continue`.
+            segment->set_seg_index_data_size(total_index_data_size);
         }
     }
 

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -817,6 +817,18 @@ Status SnapshotManager::assign_new_rowset_id(SnapshotMeta* snapshot_meta, const 
                                 clone_dir, new_rowset_id.to_string(), segment_n, index.index_id());
                         std::string src_index_file_path = IndexDescriptor::vector_index_file_path(
                                 clone_dir, old_rowset_id.to_string(), segment_n, index.index_id());
+                        // .vi may be absent when the writer skipped the build below
+                        // threshold; segment footer is then NONE and the read path
+                        // skips this index without ever opening it. Tolerate ENOENT
+                        // only — fail on real IO errors so we don't produce a
+                        // cloned snapshot that's missing a file segment metadata
+                        // still expects.
+                        auto st = FileSystem::Default()->path_exists(src_index_file_path);
+                        if (st.is_not_found()) {
+                            VLOG(2) << "skip linking non-existent vector index file " << src_index_file_path;
+                            continue;
+                        }
+                        if (!st.ok()) return st;
                         if (link(src_index_file_path.c_str(), dst_index_link_path.c_str()) != 0) {
                             PLOG(WARNING) << "Fail to link " << src_index_file_path << " to " << dst_index_link_path;
                             return Status::RuntimeError("Fail to link index data file");

--- a/be/test/storage/index/vector_index_test.cpp
+++ b/be/test/storage/index/vector_index_test.cpp
@@ -188,4 +188,61 @@ TEST_F(VectorIndexWriterTest, testwrite_with_empty_mark) {
     write_vector_index_below_threshold(index_path, tablet_index);
 }
 
+// Helper: build an ArrayColumn with the given per-row float vectors.
+static MutableColumnPtr make_array_column(const std::vector<std::vector<float>>& rows) {
+    auto element = FixedLengthColumn<float>::create();
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    uint32_t cursor = 0;
+    for (const auto& row : rows) {
+        for (float v : row) element->append(v);
+        cursor += static_cast<uint32_t>(row.size());
+        offsets->append(cursor);
+    }
+    auto null_column = NullColumn::create(element->size(), 0);
+    auto nullable = NullableColumn::create(std::move(element), std::move(null_column));
+    return ArrayColumn::create(std::move(nullable), std::move(offsets));
+}
+
+// Regression for StarRocksTest issue 11268 case 1: a non-normalized vector
+// must be rejected at INSERT time when cosine_similarity + is_vector_normed.
+// validate_vector_index_input is the single check called from
+// ArrayColumnWriter::append covering both sync and async write paths.
+TEST_F(VectorIndexWriterTest, validate_rejects_non_normalized_cosine) {
+    auto col = make_array_column({{1.0f, 2.0f, 3.0f, 4.0f, 5.0f}}); // sum² = 55
+    auto st = validate_vector_index_input(*down_cast<ArrayColumn*>(col.get()), /*dim=*/5,
+                                          /*is_input_normalized=*/true);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_invalid_argument()) << "expected InvalidArgument, got " << st.to_string();
+    ASSERT_NE(st.message().find("not normalized"), std::string_view::npos)
+            << "expected normalization message, got: " << st.message();
+}
+
+TEST_F(VectorIndexWriterTest, validate_accepts_normalized_cosine) {
+    // Vector with sum² ~= 1.
+    auto col = make_array_column({{0.1f, -0.3f, 0.4f, 0.5f, -0.7f}});
+    CHECK_OK(validate_vector_index_input(*down_cast<ArrayColumn*>(col.get()), 5, true));
+}
+
+TEST_F(VectorIndexWriterTest, validate_rejects_dim_mismatch) {
+    auto col = make_array_column({{1.0f, 2.0f, 3.0f}}); // 3 elems, expected 5
+    auto st = validate_vector_index_input(*down_cast<ArrayColumn*>(col.get()), 5, false);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_invalid_argument()) << "expected InvalidArgument, got " << st.to_string();
+    ASSERT_NE(st.message().find("dimensions of the vector"), std::string_view::npos)
+            << "expected dim mismatch message, got: " << st.message();
+}
+
+// Without the cosine + normalized combination, sum² is not checked.
+TEST_F(VectorIndexWriterTest, validate_skips_normalization_when_flag_off) {
+    auto col = make_array_column({{1.0f, 2.0f, 3.0f, 4.0f, 5.0f}});
+    CHECK_OK(validate_vector_index_input(*down_cast<ArrayColumn*>(col.get()), 5, false));
+}
+
+// Empty input is a no-op (mirrors original valid_input_vector behavior).
+TEST_F(VectorIndexWriterTest, validate_empty_is_noop) {
+    auto col = make_array_column({});
+    CHECK_OK(validate_vector_index_input(*down_cast<ArrayColumn*>(col.get()), 5, true));
+}
+
 } // namespace starrocks

--- a/be/test/storage/index/vector_index_test.cpp
+++ b/be/test/storage/index/vector_index_test.cpp
@@ -25,12 +25,15 @@
 #include "base/utility/defer_op.h"
 #include "column/column_helper.h"
 #include "common/config_vector_index_fwd.h"
+#include "fs/fs_memory.h"
 #include "runtime/mem_pool.h"
 #include "storage/index/index_descriptor.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_writer.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "storage/rowset/bitmap_index_writer.h"
+#include "storage/rowset/column_writer.h"
+#include "storage/tablet_schema_helper.h"
 
 namespace starrocks {
 
@@ -243,6 +246,168 @@ TEST_F(VectorIndexWriterTest, validate_skips_normalization_when_flag_off) {
 TEST_F(VectorIndexWriterTest, validate_empty_is_noop) {
     auto col = make_array_column({});
     CHECK_OK(validate_vector_index_input(*down_cast<ArrayColumn*>(col.get()), 5, true));
+}
+
+// Holds the wfile + meta backing an ArrayColumnWriter so the writer's
+// borrowed references stay alive for the lifetime of the test body.
+struct ArrayWriterFixture {
+    std::shared_ptr<MemoryFileSystem> fs;
+    std::unique_ptr<WritableFile> wfile;
+    TabletColumn array_column;
+    ColumnMetaPB meta;
+    ColumnWriterOptions opts;
+    std::unique_ptr<ColumnWriter> writer;
+};
+
+// Build an ArrayColumnWriter fixture with the given vector-index common
+// properties. need_vector_index is left false so we exercise the validation
+// path without instantiating VectorIndexWriter (which would need a
+// standalone_index_file_paths entry and a real file).
+static std::unique_ptr<ArrayWriterFixture> make_array_writer_with_vector_index(
+        const std::vector<std::pair<std::string, std::string>>& common_props) {
+    auto fx = std::make_unique<ArrayWriterFixture>();
+    fx->fs = std::make_shared<MemoryFileSystem>();
+    CHECK(fx->fs->create_dir("/vi_test").ok());
+    auto wfile_status = fx->fs->new_writable_file("/vi_test/array.dat");
+    CHECK(wfile_status.ok()) << wfile_status.status().to_string();
+    fx->wfile = std::move(wfile_status.value());
+
+    fx->array_column = create_array(0, /*is_nullable=*/false, /*length=*/24);
+    TabletColumn float_column;
+    float_column.set_unique_id(1);
+    float_column.set_name("element");
+    float_column.set_type(TYPE_FLOAT);
+    float_column.set_is_nullable(true);
+    float_column.set_length(4);
+    float_column.set_index_length(4);
+    fx->array_column.add_sub_column(float_column);
+
+    fx->meta.set_column_id(0);
+    fx->meta.set_unique_id(0);
+    fx->meta.set_type(TYPE_ARRAY);
+    fx->meta.set_length(24);
+    fx->meta.set_encoding(DEFAULT_ENCODING);
+    fx->meta.set_compression(LZ4_FRAME);
+    fx->meta.set_is_nullable(false);
+
+    auto* element_meta = fx->meta.add_children_columns();
+    element_meta->set_column_id(1);
+    element_meta->set_unique_id(1);
+    element_meta->set_type(TYPE_FLOAT);
+    element_meta->set_length(4);
+    element_meta->set_encoding(DEFAULT_ENCODING);
+    element_meta->set_compression(LZ4_FRAME);
+    element_meta->set_is_nullable(true);
+
+    TabletIndex tablet_index;
+    TabletIndexPB index_pb;
+    index_pb.set_index_id(0);
+    index_pb.set_index_name("vector_index");
+    index_pb.set_index_type(IndexType::VECTOR);
+    index_pb.add_col_unique_id(1);
+    tablet_index.init_from_pb(index_pb);
+    for (const auto& [k, v] : common_props) {
+        tablet_index.add_common_properties(k, v);
+    }
+
+    fx->opts.meta = &fx->meta;
+    fx->opts.need_vector_index = false;
+    fx->opts.tablet_index[IndexType::VECTOR] = std::move(tablet_index);
+
+    auto writer_st = ColumnWriter::create(fx->opts, &fx->array_column, fx->wfile.get());
+    CHECK(writer_st.ok()) << writer_st.status().to_string();
+    fx->writer = std::move(writer_st.value());
+    return fx;
+}
+
+// End-to-end regression for case 1 of PR #72382: a row written below the
+// build threshold must still fail validation. The pre-fix code would have
+// silently accepted bad data because TenAnnIndexBuilderProxy::add (the only
+// validation site) was never reached.
+TEST_F(VectorIndexWriterTest, array_column_writer_rejects_dim_mismatch) {
+    auto fx = make_array_writer_with_vector_index({
+            {"index_type", "hnsw"},
+            {"dim", "5"},
+            {"is_vector_normed", "false"},
+            {"metric_type", "l2_distance"},
+    });
+    CHECK_OK(fx->writer->init());
+
+    auto col = make_array_column({{1.0f, 2.0f, 3.0f}}); // dim=3, expected 5
+    auto st = fx->writer->append(*col);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_invalid_argument()) << st.to_string();
+    ASSERT_NE(st.message().find("dimensions of the vector"), std::string_view::npos) << st.message();
+}
+
+// End-to-end regression for case 1 of PR #72382: cosine + is_vector_normed=true
+// must reject a non-normalized vector at ArrayColumnWriter::append regardless
+// of the build threshold.
+TEST_F(VectorIndexWriterTest, array_column_writer_rejects_non_normalized_cosine) {
+    auto fx = make_array_writer_with_vector_index({
+            {"index_type", "hnsw"},
+            {"dim", "5"},
+            {"is_vector_normed", "true"},
+            {"metric_type", "cosine_similarity"},
+    });
+    CHECK_OK(fx->writer->init());
+
+    auto col = make_array_column({{1.0f, 2.0f, 3.0f, 4.0f, 5.0f}}); // sum² = 55
+    auto st = fx->writer->append(*col);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_invalid_argument()) << st.to_string();
+    ASSERT_NE(st.message().find("not normalized"), std::string_view::npos) << st.message();
+}
+
+// boost::iequals lets the writer accept properties saved with mixed case
+// (e.g. user enters `Cosine_Similarity` in DDL) so the writer and the index
+// builder agree on whether normalization applies. Verifies normalization is
+// still enforced under non-canonical casing.
+TEST_F(VectorIndexWriterTest, array_column_writer_property_parsing_is_case_insensitive) {
+    auto fx = make_array_writer_with_vector_index({
+            {"index_type", "hnsw"},
+            {"dim", "5"},
+            {"is_vector_normed", "TRUE"},
+            {"metric_type", "Cosine_Similarity"},
+    });
+    CHECK_OK(fx->writer->init());
+
+    auto col = make_array_column({{1.0f, 2.0f, 3.0f, 4.0f, 5.0f}});
+    auto st = fx->writer->append(*col);
+    ASSERT_FALSE(st.ok()) << "expected normalization check to fire for mixed-case props";
+    ASSERT_TRUE(st.is_invalid_argument()) << st.to_string();
+    ASSERT_NE(st.message().find("not normalized"), std::string_view::npos) << st.message();
+}
+
+// is_vector_normed=true alone is not enough — normalization is only enforced
+// when metric_type is also cosine_similarity. With l2_distance the writer
+// must accept any vector of the right dim.
+TEST_F(VectorIndexWriterTest, array_column_writer_accepts_unnormalized_when_metric_is_l2) {
+    auto fx = make_array_writer_with_vector_index({
+            {"index_type", "hnsw"},
+            {"dim", "5"},
+            {"is_vector_normed", "true"},
+            {"metric_type", "l2_distance"},
+    });
+    CHECK_OK(fx->writer->init());
+
+    auto col = make_array_column({{1.0f, 2.0f, 3.0f, 4.0f, 5.0f}});
+    CHECK_OK(fx->writer->append(*col));
+}
+
+// Missing dim is fatal: without it the writer cannot validate input. The
+// schema layer should never produce a vector index without dim, but the
+// writer fails fast rather than silently skipping validation.
+TEST_F(VectorIndexWriterTest, array_column_writer_rejects_missing_dim) {
+    auto fx = make_array_writer_with_vector_index({
+            {"index_type", "hnsw"},
+            {"is_vector_normed", "false"},
+            {"metric_type", "l2_distance"},
+    });
+    auto st = fx->writer->init();
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_invalid_argument()) << st.to_string();
+    ASSERT_NE(st.message().find("dim"), std::string_view::npos) << st.message();
 }
 
 } // namespace starrocks

--- a/test/sql/test_vector_index/R/test_vector_index_insert
+++ b/test/sql/test_vector_index/R/test_vector_index_insert
@@ -21,10 +21,31 @@ PROPERTIES (
 );
 -- result:
 -- !result
-INSERT into t1 values 
+INSERT into t1 values
     (1, null, null);
 -- result:
 [REGEX].*Insert has filtered data.*
+-- !result
+INSERT into t1 values
+    (1, [null, null, null, null, null], [1,2,3,4,5]);
+-- result:
+[REGEX].*The input vector is not normalized.*
+-- !result
+INSERT into t1 values
+    (1, [1,2,3,4], [1,2,3,4]);
+-- result:
+[REGEX].*The dimensions of the vector written are inconsistent.*
+-- !result
+INSERT into t1 values
+    (1, [], []);
+-- result:
+[REGEX].*The dimensions of the vector written are inconsistent.*
+-- !result
+INSERT INTO t1 values
+    (1, [1,2,3,4,5], [1,2,3,4,5]),
+    (2, [4,5,6,7,8], [4,5,6,7,8]);
+-- result:
+[REGEX].*The input vector is not normalized.*
 -- !result
 INSERT INTO t1 values
     (1, [0.13483997249264842, 0.26967994498529685, 0.40451991747794525, 0.5393598899705937, 0.674199862463242],
@@ -38,7 +59,14 @@ INSERT INTO t1 values
 -- result:
 -- !result
 INSERT INTO t1 values
-    (1, [0.13483997249264842, 0.26967994498529685, 0.40451991747794525, 0.5393598899705937, 0.674199862463242], 
+    (1, [1,2,3,4,5], [1,2,3,4,5]),
+    (2, [4,5,6,7,8], [4,5,6,7,8]),
+    (3, null, null);
+-- result:
+[REGEX].*The input vector is not normalized.*
+-- !result
+INSERT INTO t1 values
+    (1, [0.13483997249264842, 0.26967994498529685, 0.40451991747794525, 0.5393598899705937, 0.674199862463242],
         [0.13483997249264842, 0.26967994498529685, 0.40451991747794525, 0.5393598899705937, 0.674199862463242]),
     (4, null, null),
     (2, [0.29019050004400465, 0.36273812505500586, 0.435285750066007, 0.5078333750770082, 0.5803810000880093],
@@ -88,6 +116,7 @@ INSERT INTO t2 values
     (4, [null, null, null, null], [null, null, null, null]),
     (5, [4,5,6,7,8], null);
 -- result:
+[REGEX].*The dimensions of the vector written are inconsistent.*
 -- !result
 INSERT INTO t2 values
     (1, [1,2,3,4,5], [1,2,3,4,5]),
@@ -96,19 +125,10 @@ INSERT INTO t2 values
     (4, [null, null, null, null], [null, null, null, null]),
     (5, [4,5,6,7,8], null);
 -- result:
+[REGEX].*The dimensions of the vector written are inconsistent.*
 -- !result
 select * from t2 order by id, v1, v2;
 -- result:
-1	[1,2,3,4,5]	[1,2,3,4,5]
-1	[1,2,3,4,5]	[1,2,3,4,5]
-2	[4,5,6,7]	[4,5,6,7,8]
-2	[4,5,6,7,8]	[4,5,6,7,8]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-4	[null,null,null,null]	[null,null,null,null]
-4	[null,null,null,null]	[null,null,null,null]
-5	[4,5,6,7,8]	None
-5	[4,5,6,7,8]	None
 -- !result
 insert into t1 select * from t2;
 -- result:
@@ -120,32 +140,12 @@ select * from t1 order by id, v1, v2;
 -- result:
 1	[0.13483997,0.26967993,0.40451992,0.53935987,0.6741999]	[0.13483997,0.26967993,0.40451992,0.53935987,0.6741999]
 1	[0.13483997,0.26967993,0.40451992,0.53935987,0.6741999]	[0.13483997,0.26967993,0.40451992,0.53935987,0.6741999]
-1	[1,2,3,4,5]	[1,2,3,4,5]
-1	[1,2,3,4,5]	[1,2,3,4,5]
-1	[1,2,3,4,5]	[1,2,3,4,5]
-1	[1,2,3,4,5]	[1,2,3,4,5]
 2	[0.2901905,0.36273813,0.43528575,0.50783336,0.580381]	[0.2901905,0.36273813,0.43528575,0.50783336,0.580381]
 2	[0.2901905,0.36273813,0.43528575,0.50783336,0.580381]	[0.2901905,0.36273813,0.43528575,0.50783336,0.580381]
-2	[4,5,6,7]	[4,5,6,7,8]
-2	[4,5,6,7]	[4,5,6,7,8]
-2	[4,5,6,7,8]	[4,5,6,7,8]
-2	[4,5,6,7,8]	[4,5,6,7,8]
 3	[0.33686078,0.42107597,0.50529116,null,0.67372155]	[0.33686078,0.42107597,0.50529116,null,0.67372155]
 3	[0.33686078,0.42107597,0.50529116,null,0.67372155]	[0.33686078,0.42107597,0.50529116,null,0.67372155]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-4	[null,null,null,null]	[null,null,null,null]
-4	[null,null,null,null]	[null,null,null,null]
-4	[null,null,null,null]	[null,null,null,null]
-4	[null,null,null,null]	[null,null,null,null]
 4	[0.33686078,0.42107597,0.50529116,null,0.67372155]	None
 4	[0.33686078,0.42107597,0.50529116,null,0.67372155]	None
-5	[4,5,6,7,8]	None
-5	[4,5,6,7,8]	None
-5	[4,5,6,7,8]	None
-5	[4,5,6,7,8]	None
 -- !result
 insert into t2 select * from t1;
 -- result:
@@ -158,42 +158,12 @@ select * from t2 order by id, v1, v2;
 -- result:
 1	[0.13483997,0.26967993,0.40451992,0.53935987,0.6741999]	[0.13483997,0.26967993,0.40451992,0.53935987,0.6741999]
 1	[0.13483997,0.26967993,0.40451992,0.53935987,0.6741999]	[0.13483997,0.26967993,0.40451992,0.53935987,0.6741999]
-1	[1,2,3,4,5]	[1,2,3,4,5]
-1	[1,2,3,4,5]	[1,2,3,4,5]
-1	[1,2,3,4,5]	[1,2,3,4,5]
-1	[1,2,3,4,5]	[1,2,3,4,5]
-1	[1,2,3,4,5]	[1,2,3,4,5]
-1	[1,2,3,4,5]	[1,2,3,4,5]
 2	[0.2901905,0.36273813,0.43528575,0.50783336,0.580381]	[0.2901905,0.36273813,0.43528575,0.50783336,0.580381]
 2	[0.2901905,0.36273813,0.43528575,0.50783336,0.580381]	[0.2901905,0.36273813,0.43528575,0.50783336,0.580381]
-2	[4,5,6,7]	[4,5,6,7,8]
-2	[4,5,6,7]	[4,5,6,7,8]
-2	[4,5,6,7]	[4,5,6,7,8]
-2	[4,5,6,7,8]	[4,5,6,7,8]
-2	[4,5,6,7,8]	[4,5,6,7,8]
-2	[4,5,6,7,8]	[4,5,6,7,8]
 3	[0.33686078,0.42107597,0.50529116,null,0.67372155]	[0.33686078,0.42107597,0.50529116,null,0.67372155]
 3	[0.33686078,0.42107597,0.50529116,null,0.67372155]	[0.33686078,0.42107597,0.50529116,null,0.67372155]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-3	[4,5,6,null,8]	[4,5,6,null,8]
-4	[null,null,null,null]	[null,null,null,null]
-4	[null,null,null,null]	[null,null,null,null]
-4	[null,null,null,null]	[null,null,null,null]
-4	[null,null,null,null]	[null,null,null,null]
-4	[null,null,null,null]	[null,null,null,null]
-4	[null,null,null,null]	[null,null,null,null]
 4	[0.33686078,0.42107597,0.50529116,null,0.67372155]	None
 4	[0.33686078,0.42107597,0.50529116,null,0.67372155]	None
-5	[4,5,6,7,8]	None
-5	[4,5,6,7,8]	None
-5	[4,5,6,7,8]	None
-5	[4,5,6,7,8]	None
-5	[4,5,6,7,8]	None
-5	[4,5,6,7,8]	None
 -- !result
 ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
 -- result:

--- a/test/sql/test_vector_index/T/test_vector_index_insert
+++ b/test/sql/test_vector_index/T/test_vector_index_insert
@@ -20,29 +20,21 @@ PROPERTIES (
     "replication_num" = "1"
 );
 
-INSERT into t1 values 
+INSERT into t1 values
     (1, null, null);
 
--- TODO(sevev): re-enable the INSERTs below after backporting
--- CelerData/celerdata-enterprise#53733. That PR lifts cosine_similarity
--- normalization and dim-mismatch checks from TenAnnIndexBuilderProxy::add up
--- to VectorIndexWriter::append, so the validation runs whether or not the
--- index builder was constructed. Without it the threshold-skip change from
--- PR #72075 lets sub-threshold inserts of malformed vectors silently succeed
--- (regression). The INSERTs that follow expect those validation errors and
--- can only assert them after the backport.
--- INSERT into t1 values
---     (1, [null, null, null, null, null], [1,2,3,4,5]);
---
--- INSERT into t1 values
---     (1, [1,2,3,4], [1,2,3,4]);
---
--- INSERT into t1 values
---     (1, [], []);
---
--- INSERT INTO t1 values
---     (1, [1,2,3,4,5], [1,2,3,4,5]),
---     (2, [4,5,6,7,8], [4,5,6,7,8]);
+INSERT into t1 values
+    (1, [null, null, null, null, null], [1,2,3,4,5]);
+
+INSERT into t1 values
+    (1, [1,2,3,4], [1,2,3,4]);
+
+INSERT into t1 values
+    (1, [], []);
+
+INSERT INTO t1 values
+    (1, [1,2,3,4,5], [1,2,3,4,5]),
+    (2, [4,5,6,7,8], [4,5,6,7,8]);
 
 INSERT INTO t1 values
     (1, [0.13483997249264842, 0.26967994498529685, 0.40451991747794525, 0.5393598899705937, 0.674199862463242],
@@ -55,10 +47,10 @@ INSERT INTO t1 values
         null);
 
 
--- INSERT INTO t1 values
---     (1, [1,2,3,4,5], [1,2,3,4,5]),
---     (2, [4,5,6,7,8], [4,5,6,7,8]),
---     (3, null, null);
+INSERT INTO t1 values
+    (1, [1,2,3,4,5], [1,2,3,4,5]),
+    (2, [4,5,6,7,8], [4,5,6,7,8]),
+    (3, null, null);
 
 INSERT INTO t1 values
     (1, [0.13483997249264842, 0.26967994498529685, 0.40451991747794525, 0.5393598899705937, 0.674199862463242], 


### PR DESCRIPTION
## Why I'm doing:

Fixes two regressions rooted in #72070 (commit which made `VectorIndexWriter` skip `.vi` file generation when the row count is below the build threshold).

**Failing case 1** — a non-normalized vector with `cosine_similarity + is_vector_normed=true` was silently accepted instead of being rejected. The validation lived inside `TenAnnIndexBuilderProxy::add`, but below threshold the data is buffered and the builder is never constructed, so validation never ran.

**Failing case 2** — a 2-row `INSERT` on a vector-indexed table with `replication_num=3` failed with `'<host>: <path>.vi: No such file or directory'`. With only 2 rows the writer skipped `.vi` generation, but `segment_replicate_executor` still tried to open the file unconditionally to ship it to the secondary, returning `ENOENT` and aborting the INSERT.

## What I'm doing:

### Fix 1 — lift input validation from the index builder to the writer

`VectorIndexWriter::init` now extracts `_dim` and `_is_input_normalized` from `common_properties` (case-insensitive, mirroring `get_vector_meta`). `VectorIndexWriter::append` calls a new `_validate_input` on every batch, so the dim and normalization checks fire whether or not the index builder has been constructed yet. The validation logic in `TenAnnIndexBuilderProxy::add` is removed — the proxy now trusts its caller. Single check per batch, no duplication.

### Fix 2 — tolerate missing `.vi` at write-side fan-out sites

When the writer skips `.vi` generation, the segment footer is correctly set to `VECTOR_INDEX_STORAGE_NONE` and the read path already short-circuits via `Segment::_skip_vector_index` and `SegmentIterator` brute-force fallback. Three write-side sites blindly opened/linked the file:

- `segment_replicate_executor.cpp` — drops the entry from `mutable_indexes` (`path_exists` + `DeleteSubrange` + back-step), so the secondary doesn't consume an absent payload off the IOBuf stream.
- `rowset.cpp` `Rowset::link_files_to` — best-effort link, skips when source is absent.
- `snapshot_manager.cpp` clone-link path — same.

Shared-data has no replication and uses object-store metadata instead of hard-link, so this scope is intentionally narrow to the OLAP / shared-nothing paths.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
