### PR TITLE
[BugFix] Fix sync-MV rewrite of sum(case when ... col ...) with widened column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
@@ -18,9 +18,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -33,8 +35,10 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
+import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.type.BitmapType;
 import com.starrocks.type.HLLType;
@@ -45,6 +49,8 @@ import com.starrocks.type.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
 
@@ -96,7 +102,16 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                     Map<ColumnRefOperator, ScalarOperator> replaceMap = new HashMap<>();
                     replaceMap.put(context.queryColumnRef, context.mvColumnRef);
                     ReplaceColumnRefRewriter replaceColumnRefRewriter = new ReplaceColumnRefRewriter(replaceMap);
-                    newProjectMap.put(queryColRef, replaceColumnRefRewriter.rewrite(kv.getValue()));
+                    ScalarOperator rewritten = widenConditional(replaceColumnRefRewriter.rewrite(kv.getValue()));
+                    // Propagate the (possibly widened) result type onto the slot
+                    // ColumnRefOperator. ColumnRefOperator equality is by id only,
+                    // so this updates every consumer that holds the same ref --
+                    // notably the upstream aggregate's input arg, which we then
+                    // re-resolve in visitLogicalAggregate.
+                    if (!rewritten.getType().matchesType(queryColRef.getType())) {
+                        queryColRef.setType(rewritten.getType());
+                    }
+                    newProjectMap.put(queryColRef, rewritten);
                 } else {
                     // eg: bitmap_union(to_bitmap(a)), still rewrite to bitmap_union(to_bitmap(a))
                     newProjectMap.put(queryColRef, context.mvColumnRef);
@@ -140,13 +155,13 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                     queryAggFunc.getType(),
                     queryAggFunc.getChildren(),
                     ExprUtils.getBuiltinFunction(FunctionSet.SUM, new Type[] {IntegerType.BIGINT}, IS_IDENTICAL));
-            return (CallOperator) replaceColumnRefRewriter.rewrite(callOperator);
+            return finalizeAgg(replaceColumnRefRewriter, callOperator);
         } else if (functionName.equals(FunctionSet.SUM) && !queryAggFunc.isDistinct()) {
             CallOperator callOperator = new CallOperator(FunctionSet.SUM,
                     queryAggFunc.getType(),
                     queryAggFunc.getChildren(),
                     ScalarOperatorUtil.findSumFn(new Type[] {mvColumn.getType()}));
-            return (CallOperator) replaceColumnRefRewriter.rewrite(callOperator);
+            return finalizeAgg(replaceColumnRefRewriter, callOperator);
         } else if (((functionName.equals(FunctionSet.COUNT) && queryAggFunc.isDistinct())
                 || functionName.equals(FunctionSet.MULTI_DISTINCT_COUNT)) &&
                 mvColumn.getAggregationType() == AggregateType.BITMAP_UNION) {
@@ -155,7 +170,7 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                     queryAggFunc.getChildren(),
                     ExprUtils.getBuiltinFunction(FunctionSet.BITMAP_UNION_COUNT, new Type[] {BitmapType.BITMAP},
                             IS_IDENTICAL));
-            return (CallOperator) replaceColumnRefRewriter.rewrite(callOperator);
+            return finalizeAgg(replaceColumnRefRewriter, callOperator);
         } else if (functionName.equals(FunctionSet.BITMAP_AGG) &&
                 mvColumn.getAggregationType() == AggregateType.BITMAP_UNION) {
             CallOperator callOperator = new CallOperator(FunctionSet.BITMAP_UNION,
@@ -163,7 +178,7 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                     queryAggFunc.getChildren(),
                     ExprUtils.getBuiltinFunction(FunctionSet.BITMAP_UNION, new Type[] {BitmapType.BITMAP},
                             IS_IDENTICAL));
-            return (CallOperator) replaceColumnRefRewriter.rewrite(callOperator);
+            return finalizeAgg(replaceColumnRefRewriter, callOperator);
         } else if (
                 (functionName.equals(FunctionSet.NDV) || functionName.equals(FunctionSet.APPROX_COUNT_DISTINCT))
                         && mvColumn.getAggregationType() == AggregateType.HLL_UNION) {
@@ -171,7 +186,7 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                     queryAggFunc.getType(),
                     queryAggFunc.getChildren(),
                     ExprUtils.getBuiltinFunction(FunctionSet.HLL_UNION_AGG, new Type[] {HLLType.HLL}, IS_IDENTICAL));
-            return (CallOperator) replaceColumnRefRewriter.rewrite(callOperator);
+            return finalizeAgg(replaceColumnRefRewriter, callOperator);
         } else if (functionName.equals(FunctionSet.PERCENTILE_APPROX) &&
                 mvColumn.getAggregationType() == AggregateType.PERCENTILE_UNION) {
 
@@ -185,10 +200,147 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                     Lists.newArrayList(child),
                     ExprUtils.getBuiltinFunction(FunctionSet.PERCENTILE_UNION,
                             new Type[] {PercentileType.PERCENTILE}, IS_IDENTICAL));
-            return (CallOperator) replaceColumnRefRewriter.rewrite(callOperator);
+            return finalizeAgg(replaceColumnRefRewriter, callOperator);
         } else {
-            return (CallOperator) replaceColumnRefRewriter.rewrite(queryAggFunc);
+            return finalizeAgg(replaceColumnRefRewriter, queryAggFunc);
         }
+    }
+
+    /**
+     * Apply the column-ref substitution and propagate any widened child types
+     * up through wrapping IF / IFNULL / COALESCE / CASE WHEN nodes.
+     */
+    private CallOperator finalizeAgg(ReplaceColumnRefRewriter replaceColumnRefRewriter, CallOperator call) {
+        return (CallOperator) widenConditional(replaceColumnRefRewriter.rewrite(call));
+    }
+
+    /**
+     * Retype every IF / IFNULL / COALESCE / CASE WHEN inside {@code op} to the
+     * common supertype of its value-producing branches.
+     *
+     * <p>An MV column substitution can widen a value child (e.g. SMALLINT k3
+     * is replaced by BIGINT mv_sum_k3). Without retyping, the wrapping
+     * conditional keeps its original narrow result type and the BE
+     * instantiates the Expr at the wrong type, crashing in down_cast.
+     */
+    private static ScalarOperator widenConditional(ScalarOperator op) {
+        return op == null ? null : op.accept(WIDEN_CONDITIONAL_SHUTTLE, null);
+    }
+
+    private static final BaseScalarOperatorShuttle WIDEN_CONDITIONAL_SHUTTLE = new BaseScalarOperatorShuttle() {
+        @Override
+        public ScalarOperator visitCall(CallOperator call, Void context) {
+            CallOperator c = (CallOperator) super.visitCall(call, context);
+            String name = c.getFnName();
+            if (FunctionSet.IF.equalsIgnoreCase(name) && c.getChildren().size() == 3) {
+                return tryWiden(c, Lists.newArrayList(c.getChild(1), c.getChild(2)));
+            }
+            if (FunctionSet.COALESCE.equalsIgnoreCase(name) || FunctionSet.IFNULL.equalsIgnoreCase(name)) {
+                return tryWiden(c, c.getChildren());
+            }
+            return c;
+        }
+
+        @Override
+        public ScalarOperator visitCaseWhenOperator(CaseWhenOperator op, Void context) {
+            CaseWhenOperator cw = (CaseWhenOperator) super.visitCaseWhenOperator(op, context);
+            List<ScalarOperator> branches = Lists.newArrayList();
+            for (int i = 0; i < cw.getWhenClauseSize(); i++) {
+                branches.add(cw.getThenClause(i));
+            }
+            if (cw.hasElse()) {
+                branches.add(cw.getElseClause());
+            }
+            return tryWiden(cw, branches);
+        }
+
+        private ScalarOperator tryWiden(ScalarOperator op, List<ScalarOperator> branches) {
+            if (branches.isEmpty()) {
+                return op;
+            }
+            Type newType = TypeManager.getCommonSuperType(
+                    branches.stream().map(ScalarOperator::getType).collect(Collectors.toList()));
+            if (newType == null || !newType.isValid() || newType.matchesType(op.getType())) {
+                return op;
+            }
+            return rebuildWidened(op, newType);
+        }
+    };
+
+    /**
+     * Cast value branches of {@code op} to {@code newType} and rebuild it.
+     * For CallOperator conditionals also re-resolves the Function so the
+     * declared signature matches the new child types.
+     */
+    private static ScalarOperator rebuildWidened(ScalarOperator op, Type newType) {
+        if (op instanceof CaseWhenOperator) {
+            CaseWhenOperator cw = (CaseWhenOperator) op;
+            ScalarOperator caseClause = cw.hasCase() ? cw.getCaseClause() : null;
+            List<ScalarOperator> whenThens = Lists.newArrayList();
+            for (int i = 0; i < cw.getWhenClauseSize(); i++) {
+                whenThens.add(cw.getWhenClause(i));
+                whenThens.add(castIfNeeded(cw.getThenClause(i), newType));
+            }
+            ScalarOperator elseClause = cw.hasElse() ? castIfNeeded(cw.getElseClause(), newType) : null;
+            return new CaseWhenOperator(newType, caseClause, elseClause, whenThens);
+        }
+        CallOperator call = (CallOperator) op;
+        String name = call.getFnName();
+        // IF reserves arg 0 for the condition; COALESCE/IFNULL widen all args.
+        int firstValueIdx = FunctionSet.IF.equalsIgnoreCase(name) ? 1 : 0;
+        List<ScalarOperator> args = Lists.newArrayList(call.getChildren());
+        for (int i = firstValueIdx; i < args.size(); i++) {
+            args.set(i, castIfNeeded(args.get(i), newType));
+        }
+        Type[] argTypes = args.stream().map(ScalarOperator::getType).toArray(Type[]::new);
+        Function fn = ExprUtils.getBuiltinFunction(name, argTypes,
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        return new CallOperator(name, newType, args, fn != null ? fn : call.getFunction(), call.isDistinct());
+    }
+
+    private static ScalarOperator castIfNeeded(ScalarOperator op, Type target) {
+        if (target.matchesType(op.getType())) {
+            return op;
+        }
+        // Fold cast(literal as T) so the rendered plan stays tidy.
+        if (op instanceof ConstantOperator) {
+            Optional<ConstantOperator> folded = ((ConstantOperator) op).castTo(target);
+            if (folded.isPresent()) {
+                return folded.get();
+            }
+        }
+        return new CastOperator(target, op, true);
+    }
+
+    /**
+     * Re-resolve {@code call}'s Function when its actual children types no
+     * longer match the resolved signature, returning the original call when
+     * no change is needed.
+     */
+    private static CallOperator reResolveSignature(CallOperator call) {
+        Function fn = call.getFunction();
+        if (fn == null || call.getChildren().isEmpty()) {
+            return call;
+        }
+        Type[] expected = fn.getArgs();
+        Type[] actual = call.getChildren().stream().map(ScalarOperator::getType).toArray(Type[]::new);
+        boolean changed = false;
+        for (int i = 0; i < actual.length && i < expected.length; i++) {
+            if (!actual[i].matchesType(expected[i])) {
+                changed = true;
+                break;
+            }
+        }
+        if (!changed) {
+            return call;
+        }
+        Function newFn = ExprUtils.getBuiltinFunction(call.getFnName(), actual,
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        if (newFn == null) {
+            return call;
+        }
+        return new CallOperator(call.getFnName(), newFn.getReturnType(),
+                Lists.newArrayList(call.getChildren()), newFn, call.isDistinct());
     }
 
     @Override
@@ -221,6 +373,12 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                 }
             }
         }
+        // The child Project may have widened a slot type via setType above; any
+        // aggregate whose argument is that slot still has its Function resolved
+        // against the narrow type and would make the BE pick the wrong
+        // SumAggregateFunction template. Re-resolve signatures whose actual
+        // child types no longer match the previously-resolved Function.
+        newAggMap.replaceAll((k, v) -> reResolveSignature(v));
         return OptExpression.create(new LogicalAggregationOperator(
                 aggregationOperator.getType(),
                 aggregationOperator.getGroupingKeys(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -968,6 +968,31 @@ public class MaterializedViewRule extends Rule {
                     return false;
                 }
             }
+            // Create a RewriteContext so MaterializedViewRewriter substitutes the
+            // MV's pre-aggregated column inside the case-when. Without it, queries
+            // whose only match is this branch (no plain sum(col) anchor) leave the
+            // project's IF/CASE WHEN bound to the original narrow-typed colRef,
+            // which makes the BE construct VectorizedIfExpr<NARROW_TYPE> over the
+            // MV's wider runtime column and crash in down_cast.
+            ColumnRefOperator mvColumnRef =
+                    factory.getColumnRef(mvColumnFnChild0.getUsedColumns().getFirstId());
+            Column mvColumn = mvColumnRef == null ? null : factory.getColumn(mvColumnRef);
+            if (mvColumn != null && mvColumn.getRefColumns() != null
+                    && !mvColumn.getRefColumns().isEmpty()) {
+                String mvBaseName = mvColumn.getRefColumns().get(0).getColumnName();
+                for (int queryColumnId : queryColumnIds) {
+                    ColumnRefOperator candidate = factory.getColumnRef(queryColumnId);
+                    Column candidateColumn = candidate == null ? null : factory.getColumn(candidate);
+                    if (candidateColumn != null
+                            && candidateColumn.getName().equalsIgnoreCase(mvBaseName)
+                            && factory.getRelationId(candidate.getId())
+                                    .equals(factory.getRelationId(mvColumnRef.getId()))) {
+                        mvIdToRewriteContexts.computeIfAbsent(indexId, k -> Lists.newArrayList())
+                                .add(new RewriteContext(queryFn, candidate, mvColumnRef, mvColumn));
+                        break;
+                    }
+                }
+            }
             return true;
         } else {
             ColumnRefOperator queryColumnRef = factory.getColumnRef(queryFnChild0.getUsedColumns().getFirstId());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -1212,11 +1212,8 @@ public class MVRewriteTest extends StarRocksTestBase {
             String plan  = starRocksAssert.query(query).explainQuery();
             PlanTestBase.assertContains(plan, "  1:Project\n" +
                     "  |  <slot 3> : 3: dt\n" +
-                    "  |  <slot 6> : if(1: is_finish = '1', 4: user_id_td, NULL)\n");
-            PlanTestBase.assertContains(plan, "     TABLE: kkk\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=1/1\n" +
-                    "     rollup: kkk_mv");
+                    "  |  <slot 6> : if(1: is_finish = '1', 5: mv_bitmap_union_user_id_td, NULL)\n" +
+                    "  |  ");
         }
         {
 
@@ -1260,10 +1257,12 @@ public class MVRewriteTest extends StarRocksTestBase {
         String plan = starRocksAssert.query(query).explainQuery();
         PlanTestBase.assertContains(plan, "  1:Project\n" +
                 "  |  <slot 1> : 1: k1\n" +
-                "  |  <slot 6> : if(2: k2 = 0, 3: k3, 0)\n");
-        PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                "     PREAGGREGATION: OFF. Reason: The result of ELSE isn't value column\n" +
-                "     partitions=1/1");
+                "  |  <slot 6> : if(2: k2 = 0, 5: mv_sum_k3, 0)");
+        PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                "     TABLE: t1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=1/1\n" +
+                "     rollup: test_mv1");
         starRocksAssert.dropTable("t1");
         starRocksAssert.dropMaterializedView("test_mv1");
     }
@@ -1289,9 +1288,11 @@ public class MVRewriteTest extends StarRocksTestBase {
                 "  |  <slot 1> : 1: k1\n" +
                 "  |  <slot 5> : 5: mv_sum_k3\n" +
                 "  |  <slot 6> : if(2: k2 = 0, 5: mv_sum_k3, 0)");
-        PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
-                "     PREAGGREGATION: OFF. Reason: The result of ELSE isn't value column\n" +
-                "     partitions=1/1");
+        PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                "     TABLE: t1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=1/1\n" +
+                "     rollup: test_mv1");
         starRocksAssert.dropTable("t1");
         starRocksAssert.dropMaterializedView("test_mv1");
     }

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_case_when_sum_widening_type.sql
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_case_when_sum_widening_type.sql
@@ -1,0 +1,48 @@
+-- name: test_mv_rewrite_case_when_sum_widening_type
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 DATE NULL,
+    k2 INT  NULL,
+    k3 SMALLINT NULL
+) DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 AS
+  SELECT k1, k2, sum(k3) AS sum1 FROM t1 GROUP BY k1, k2;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+INSERT INTO t1 VALUES
+    ('2024-01-01', 0, 30000),
+    ('2024-01-01', 0, 30000),
+    ('2024-01-01', 0, 30000),
+    ('2024-01-01', 0, 10000),
+    ('2024-01-01', 1, 5);
+-- result:
+-- !result
+SELECT k1,
+       sum(k3) AS sum1,
+       sum(case when k2=0 then k3 else 0 end) AS sum2
+FROM t1 GROUP BY k1;
+-- result:
+2024-01-01	100005	100000
+-- !result
+SELECT k1,
+       sum(if(k2=0, k3, 0)) AS sum_if
+FROM t1 GROUP BY k1;
+-- result:
+2024-01-01	100000
+-- !result
+DROP DATABASE db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_case_when_sum_widening_type.sql
+++ b/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_case_when_sum_widening_type.sql
@@ -1,0 +1,45 @@
+-- name: test_mv_rewrite_case_when_sum_widening_type
+-- Regression test for sync-MV rewrite of `sum(case when ... then col else 0 end)`
+-- when the MV stores `sum(col)` and the aggregator widens the column's type.
+-- Before the fix the rewritten plan kept the inner CASE WHEN / IF declared
+-- as the original (narrower) column type while the THEN branch was already
+-- the widened MV column, so any group whose sum exceeded the original type's
+-- range would be silently truncated at the outer SUM.
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE t1 (
+    k1 DATE NULL,
+    k2 INT  NULL,
+    k3 SMALLINT NULL
+) DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+CREATE MATERIALIZED VIEW test_mv1 AS
+  SELECT k1, k2, sum(k3) AS sum1 FROM t1 GROUP BY k1, k2;
+function: wait_materialized_view_finish()
+
+-- Per-(k1, k2) sum(k3) deliberately overflows SMALLINT (max 32767):
+--   for ('2024-01-01', k2=0) the sum is 30000+30000+30000+10000 = 100000.
+INSERT INTO t1 VALUES
+    ('2024-01-01', 0, 30000),
+    ('2024-01-01', 0, 30000),
+    ('2024-01-01', 0, 30000),
+    ('2024-01-01', 0, 10000),
+    ('2024-01-01', 1, 5);
+
+-- The query rewrites `case when k2=0 then k3 else 0` against test_mv1's
+-- mv_sum_k3 column.  After the fix, the rewritten IF/CASE WHEN result type
+-- is BIGINT (matching mv_sum_k3) so the outer sum is not truncated.
+SELECT k1,
+       sum(k3) AS sum1,
+       sum(case when k2=0 then k3 else 0 end) AS sum2
+FROM t1 GROUP BY k1;
+
+-- Same shape, expressed with IF instead of CASE WHEN.
+SELECT k1,
+       sum(if(k2=0, k3, 0)) AS sum_if
+FROM t1 GROUP BY k1;
+
+DROP DATABASE db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

bug found by plan checker https://github.com/StarRocks/starrocks/pull/72354

```
UNKNOWN ASAN (build UNKNOWN distro ubuntu arch x86_64)
query_id:019ddcef-8898-76d7-acb1-1e3ac87aca22, fragment_instance:019ddcef-8898-76d7-acb1-1e3ac87aca23, plan_node_id:0
*** Aborted at 1777528178 (unix time) try "date -d @1777528178" if you are using GNU date ***
PC: @     0x7eff71a959fc pthread_kill
*** SIGABRT (@0x3eb001bc175) received by PID 1818997 (TID 0x7efc53dd4640) LWP(1819827) from PID 1818997; stack trace: ***
    @         0x36720087 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7eff71a98ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x3671f886 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7eff71a41520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7eff71a959fc pthread_kill
    @     0x7eff71a41476 raise
    @     0x7eff71a277f3 abort
    @     0x7eff71a2771b (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2871a)
    @     0x7eff71a38e96 __assert_fail
    @         0x1d76d97b starrocks::FixedLengthColumn<short> const* down_cast<starrocks::FixedLengthColumn<short> const*, starrocks::Column
 const>(starrocks::Column const*)
    @         0x3135b643 starrocks::SelectIfOP<false, true, (starrocks::LogicalType)3>::eval(starrocks::Cow<starrocks::Column>::ImmutPtr<st
arrocks::Column>&, starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>&, starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::
Col@
    @         0x3132f995 starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::dispatch_nonull_template<starrocks::Sele
ctIfOP, (starrocks::LogicalType)3, starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>&, starrocks::TypeDescriptor const&>(starr
ock@
    @         0x312e1ca8 starrocks::VectorizedIfExpr<(starrocks::LogicalType)3>::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk
*)
    @         0x2f6642ef starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @         0x2f663b20 starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @         0x1f54f2ee starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const
&)
    @         0x1f29c843 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1f24d171 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
```

```
    @         0x2522a80b starrocks::FixedLengthColumn<short> const& down_cast<starrocks::FixedLengthColumn<short> const&, starrocks::Column
 const>(starrocks::Column const&)
    @         0x283d0cf2 starrocks::SumAggregateFunction<(starrocks::LogicalType)3, short, (starrocks::LogicalType)7, long>::update(starroc
ks::FunctionContext*, starrocks::Column const**, unsigned char*, unsigned long) const
    @         0x2836d582 starrocks::NullableAggregateFunctionUnary<starrocks::SumAggregateFunction<(starrocks::LogicalType)3, short, (starr
ocks::LogicalType)7, long>*, starrocks::NullableAggregateFunctionState<starrocks::SumAggregateState<long>, false>, false, true, starrocks::
Agg@
    @         0x1d530def starrocks::AggregateFunction::update_batch_exception_safe(starrocks::FunctionContext*, unsigned long, unsigned lon
g, starrocks::Column const**, unsigned char**) const
    @         0x1d311939 starrocks::Aggregator::compute_batch_agg_states(starrocks::Chunk*, unsigned long)
    @         0x1f85847d starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks
::Chunk> const&)
    @         0x1f29c843 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1f24d171 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x1f24b85a starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x1f2563da void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__in
voke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x1f255866 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, 
void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDri
ver@
    @         0x1f2551ff std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invo
ke(std::_Any_data const&)
```


## What I'm doing:

A sync MV defined as `sum(narrow_col)` stores its pre-aggregated value at the widened type (SMALLINT k3 -> BIGINT mv_sum_k3). When a query wraps that column inside an IF / CASE WHEN / COALESCE / IFNULL inside an outer sum(), `MaterializedViewRule` substitutes the MV column for the base column but does not propagate the widened type through the rewritten plan. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
