### PR TITLE
[BugFix] fix spillable hash join probe crash

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -267,7 +267,8 @@ StatusOr<std::function<StatusOr<ChunkPtr>()>> SpillableHashJoinBuildOperator::_c
             _hash_table_iterate_idx++;
             for (; _hash_table_iterate_idx < _hash_tables.size(); _hash_table_iterate_idx++) {
                 auto build_chunk = _hash_tables[_hash_table_iterate_idx]->get_build_chunk();
-                if (build_chunk->num_rows() > 0) {
+                // Every build chunk has a dummy row at index 0. Skip partitions that have no real build rows.
+                if (build_chunk->num_rows() > kHashJoinKeyColumnOffset) {
                     _hash_table_build_chunk_slice.reset(build_chunk);
                     _hash_table_build_chunk_slice.skip(kHashJoinKeyColumnOffset);
                     break;

--- a/test/sql/test_spill/R/test_spill_join_with_empty_partition
+++ b/test/sql/test_spill/R/test_spill_join_with_empty_partition
@@ -1,0 +1,84 @@
+-- name: test_spill_join_with_empty_partition
+CREATE TABLE `hj_build` (
+  `k` bigint(20) NULL COMMENT "",
+  `c01` bigint(20) NULL COMMENT "",
+  `c02` bigint(20) NULL COMMENT "",
+  `c03` bigint(20) NULL COMMENT "",
+  `c04` bigint(20) NULL COMMENT "",
+  `c05` bigint(20) NULL COMMENT "",
+  `c06` bigint(20) NULL COMMENT "",
+  `c07` bigint(20) NULL COMMENT "",
+  `c08` bigint(20) NULL COMMENT "",
+  `c09` bigint(20) NULL COMMENT "",
+  `c10` bigint(20) NULL COMMENT "",
+  `c11` bigint(20) NULL COMMENT "",
+  `c12` bigint(20) NULL COMMENT "",
+  `c13` bigint(20) NULL COMMENT "",
+  `c14` bigint(20) NULL COMMENT "",
+  `c15` bigint(20) NULL COMMENT "",
+  `c16` bigint(20) NULL COMMENT "",
+  `c17` bigint(20) NULL COMMENT "",
+  `c18` bigint(20) NULL COMMENT "",
+  `c19` bigint(20) NULL COMMENT "",
+  `c20` bigint(20) NULL COMMENT "",
+  `c21` bigint(20) NULL COMMENT "",
+  `c22` bigint(20) NULL COMMENT "",
+  `c23` bigint(20) NULL COMMENT "",
+  `c24` bigint(20) NULL COMMENT "",
+  `c25` bigint(20) NULL COMMENT "",
+  `c26` bigint(20) NULL COMMENT "",
+  `c27` bigint(20) NULL COMMENT "",
+  `c28` bigint(20) NULL COMMENT "",
+  `c29` bigint(20) NULL COMMENT "",
+  `c30` bigint(20) NULL COMMENT "",
+  `c31` bigint(20) NULL COMMENT "",
+  `c32` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `hj_probe` (
+  `k` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into hj_probe values (1);
+-- result:
+-- !result
+insert into hj_build values ( 1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1 );
+-- result:
+-- !result
+set enable_spill = true;
+-- result:
+-- !result
+set spillable_operator_mask = 1;
+-- result:
+-- !result
+set spill_revocable_max_bytes = 1;
+-- result:
+-- !result
+set disable_join_reorder = true;
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+select b.c01,b.c02,b.c03,b.c04,b.c05,b.c06,b.c07,b.c08, b.c09,b.c10,b.c11,b.c12,b.c13,b.c14,b.c15,b.c16, b.c17,b.c18,b.c19,b.c20,b.c21,b.c22,b.c23,b.c24, b.c25,b.c26,b.c27,b.c28,b.c29,b.c30,b.c31,b.c32 from hj_probe p right join hj_build b on p.k = b.k;
+-- result:
+1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1
+-- !result

--- a/test/sql/test_spill/T/test_spill_join_with_empty_partition
+++ b/test/sql/test_spill/T/test_spill_join_with_empty_partition
@@ -1,0 +1,70 @@
+-- name: test_spill_join_with_empty_partition
+CREATE TABLE `hj_build` (
+  `k` bigint(20) NULL COMMENT "",
+  `c01` bigint(20) NULL COMMENT "",
+  `c02` bigint(20) NULL COMMENT "",
+  `c03` bigint(20) NULL COMMENT "",
+  `c04` bigint(20) NULL COMMENT "",
+  `c05` bigint(20) NULL COMMENT "",
+  `c06` bigint(20) NULL COMMENT "",
+  `c07` bigint(20) NULL COMMENT "",
+  `c08` bigint(20) NULL COMMENT "",
+  `c09` bigint(20) NULL COMMENT "",
+  `c10` bigint(20) NULL COMMENT "",
+  `c11` bigint(20) NULL COMMENT "",
+  `c12` bigint(20) NULL COMMENT "",
+  `c13` bigint(20) NULL COMMENT "",
+  `c14` bigint(20) NULL COMMENT "",
+  `c15` bigint(20) NULL COMMENT "",
+  `c16` bigint(20) NULL COMMENT "",
+  `c17` bigint(20) NULL COMMENT "",
+  `c18` bigint(20) NULL COMMENT "",
+  `c19` bigint(20) NULL COMMENT "",
+  `c20` bigint(20) NULL COMMENT "",
+  `c21` bigint(20) NULL COMMENT "",
+  `c22` bigint(20) NULL COMMENT "",
+  `c23` bigint(20) NULL COMMENT "",
+  `c24` bigint(20) NULL COMMENT "",
+  `c25` bigint(20) NULL COMMENT "",
+  `c26` bigint(20) NULL COMMENT "",
+  `c27` bigint(20) NULL COMMENT "",
+  `c28` bigint(20) NULL COMMENT "",
+  `c29` bigint(20) NULL COMMENT "",
+  `c30` bigint(20) NULL COMMENT "",
+  `c31` bigint(20) NULL COMMENT "",
+  `c32` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+
+CREATE TABLE `hj_probe` (
+  `k` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into hj_probe values (1);
+insert into hj_build values ( 1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1 );
+
+set enable_spill = true;
+set spillable_operator_mask = 1;
+set spill_revocable_max_bytes = 1;
+set disable_join_reorder = true;
+set pipeline_dop = 1;
+
+
+
+select b.c01,b.c02,b.c03,b.c04,b.c05,b.c06,b.c07,b.c08, b.c09,b.c10,b.c11,b.c12,b.c13,b.c14,b.c15,b.c16, b.c17,b.c18,b.c19,b.c20,b.c21,b.c22,b.c23,b.c24, b.c25,b.c26,b.c27,b.c28,b.c29,b.c30,b.c31,b.c32 from hj_probe p right join hj_build b on p.k = b.k;


### PR DESCRIPTION
## Why I'm doing:
```
*** Aborted at 1773298896 (unix time) try "date -d @1773298896" if you are using GNU date ***
PC: @          0x50c7c4a starrocks::JoinHashTable::probe(starrocks::RuntimeState*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&, std::shared_ptr<starrocks::Chunk@
*** SIGSEGV (@0x0) received by PID 24320 (TID 0x2abbcac3c700) LWP(25306) from PID 0; stack trace: ***
    @     0x2abb31cb420b __pthread_once_slow
    @          0xbf695d4 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2abb31cbd630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x50c7c4a starrocks::JoinHashTable::probe(starrocks::RuntimeState*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&, std::shared_ptr<starrocks::Chunk@
    @          0x586cd10 starrocks::SingleHashJoinProberImpl::probe_chunk(starrocks::RuntimeState*)
    @          0x586fb81 starrocks::PartitionedHashJoinProberImpl::probe_chunk(starrocks::RuntimeState*)
    @          0x585f6ff starrocks::HashJoiner::_pull_probe_output_chunk(starrocks::RuntimeState*)
    @          0x585faa1 starrocks::HashJoiner::pull_chunk(starrocks::RuntimeState*)
    @          0x55002f7 starrocks::pipeline::HashJoinProbeOperator::pull_chunk(starrocks::RuntimeState*)
    @          0x550a73e starrocks::pipeline::SpillableHashJoinProbeOperator::pull_chunk(starrocks::RuntimeState*)
    @          0x549aba7 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x593b2ad starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x465c5d7 starrocks::ThreadPool::dispatch_thread()
    @          0x46533b0 

```
## What I'm doing:

The crash happens because _convert_hash_map_to_chunk() treats dummy-only adaptive hash table partitions as real data.

In AdaptivePartitionHashJoin, every child JoinHashTable has a dummy row, so an empty partition can still have build_chunk->num_rows() == 1. The old code used that to decide whether the partition was non-empty. After skipping the dummy row, the slice became empty, and the code could return EOF early and reset the original builder before converting the real build rows.

Then no data was actually written to the spiller, so probe fell back to the non-spill path and probed a reset/unbuilt hash table, causing JoinHashTable::probe() to crash.

The fix avoids this by checking the real hash table row count, ht->get_row_count(), and skipping partitions with no real rows. This ensures real build rows are spilled and probe uses the correct spilled path.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
