### PR TITLE
[auto-perf-opt] Drop per-key Slice::to_string() heap allocs in PK index merge loop

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -641,8 +641,7 @@ StatusOr<std::vector<KeyValueMerger::KeyValueMergerOutput>> LakePersistentIndex:
         // Compare via Slice directly; .to_string() would allocate a fresh
         // std::string per key on a loop driven by every input row.
         const Slice cur_key = iter_ptr->key();
-        if (!seek_range.stop_key.empty() &&
-            options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
+        if (!seek_range.stop_key.empty() && options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -638,9 +638,11 @@ StatusOr<std::vector<KeyValueMerger::KeyValueMergerOutput>> LakePersistentIndex:
     auto merger = std::make_unique<KeyValueMerger>(iter_ptr->key().to_string(), iter_ptr->max_rss_rowid(),
                                                    base_level_merge, tablet_mgr, metadata->id(), false);
     while (iter_ptr->Valid()) {
-        const std::string& cur_key = iter_ptr->key().to_string();
+        // Compare via Slice directly; .to_string() would allocate a fresh
+        // std::string per key on a loop driven by every input row.
+        const Slice cur_key = iter_ptr->key();
         if (!seek_range.stop_key.empty() &&
-            options.comparator->Compare(Slice(cur_key), Slice(seek_range.stop_key)) >= 0) {
+            options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -36,15 +36,18 @@
 namespace starrocks::lake {
 
 Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
-    const std::string& key = iter_ptr->key().to_string();
-    const std::string& value = iter_ptr->value().to_string();
+    // Avoid the per-key std::string heap allocations that Slice::to_string() forces.
+    // The iterator's slices stay valid for the duration of this call, and the
+    // protobuf parse below copies what it needs into _scratch_value_pb.
+    const Slice key = iter_ptr->key();
+    const Slice value = iter_ptr->value();
     uint64_t max_rss_rowid = iter_ptr->max_rss_rowid();
 
-    // Reuse the per-merger protobuf instance: ParseFromString resets it before
+    // Reuse the per-merger protobuf instance: ParseFromArray resets it before
     // populating, and RepeatedPtrField retains its element backing across calls,
     // so we avoid a heap alloc + free of the message and its values list per key.
     IndexValuesWithVerPB& index_value_ver = _scratch_value_pb;
-    if (!index_value_ver.ParseFromString(value)) {
+    if (!index_value_ver.ParseFromArray(value.data, value.size)) {
         return Status::InternalError("Failed to parse index value ver");
     }
     if (index_value_ver.values_size() == 0) {
@@ -83,7 +86,7 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
 
     auto version = index_value_ver.values(0).version();
     auto index_value = build_index_value(index_value_ver.values(0));
-    if (_key == key) {
+    if (Slice(_key) == key) {
         if (_index_value_vers.empty()) {
             _max_rss_rowid = max_rss_rowid;
             _index_value_vers.emplace_front(version, index_value);
@@ -136,7 +139,7 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
         }
     } else {
         RETURN_IF_ERROR(flush());
-        _key = key;
+        _key.assign(key.data, key.size);
         _max_rss_rowid = max_rss_rowid;
         _index_value_vers.emplace_front(version, index_value);
     }

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -40,7 +40,10 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
     const std::string& value = iter_ptr->value().to_string();
     uint64_t max_rss_rowid = iter_ptr->max_rss_rowid();
 
-    IndexValuesWithVerPB index_value_ver;
+    // Reuse the per-merger protobuf instance: ParseFromString resets it before
+    // populating, and RepeatedPtrField retains its element backing across calls,
+    // so we avoid a heap alloc + free of the message and its values list per key.
+    IndexValuesWithVerPB& index_value_ver = _scratch_value_pb;
     if (!index_value_ver.ParseFromString(value)) {
         return Status::InternalError("Failed to parse index value ver");
     }
@@ -145,7 +148,11 @@ Status KeyValueMerger::flush() {
         return Status::OK();
     }
 
-    IndexValuesWithVerPB index_value_pb;
+    // Reuse the per-merger protobuf instance: Clear() retains the values'
+    // RepeatedPtrField backing memory, so the add_values() loop below can
+    // reuse the slot allocations across flushes for the same merger.
+    IndexValuesWithVerPB& index_value_pb = _scratch_flush_pb;
+    index_value_pb.Clear();
     for (const auto& index_value_with_ver : _index_value_vers) {
         if (_merge_base_level && index_value_with_ver.second == IndexValue(NullIndexValue)) {
             // deleted

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.h
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.h
@@ -83,6 +83,12 @@ private:
     // data volume larger than pk_index_target_file_size.
     bool _enable_multiple_output_files = false;
     std::vector<TableBuilderWrapper> _output_builders;
+    // Reused across merge() calls to avoid per-key heap alloc/free of the
+    // protobuf message and its repeated-field storage. ParseFromString resets
+    // the message; RepeatedPtrField::Clear retains element backing memory.
+    IndexValuesWithVerPB _scratch_value_pb;
+    // Reused across flush() calls for the same reason.
+    IndexValuesWithVerPB _scratch_flush_pb;
 };
 } // namespace lake
 } // namespace starrocks


### PR DESCRIPTION
## Bottleneck (iter-004)

Even with PR #72335 (KeyValueMerger protobuf reuse) deployed, steady-state perf on `999_1gb_1_1tb` on a 1 hr-warm cluster shows the `cloud_native_pk_*` thread family pinned at 91-99 % CPU on the 3 CNs that host the 60 buckets of the 1 TB table — vs 47-67 % in iter-003 immediately post-restart. `my_valloc` self-time on the hottest CN is **22.4 %** (cpu-clock perf, 99 Hz, 20 s, 63 K samples). PR #72335 removed the dominant `KeyValueMerger::merge` allocator stack (was 31 % allocator self pre-PR, 6 % post-PR in iter-003); the remaining 22 % comes from elsewhere in the same thread family.

## Root cause

The compaction merge loop calls `KeyValueMerger::merge(iter)` once per input row. The very first two lines do:

```cpp
const std::string& key   = iter_ptr->key().to_string();   // heap alloc + memcpy
const std::string& value = iter_ptr->value().to_string(); // heap alloc + memcpy
```

These force **two `std::string` heap allocations per input row**. They exist solely to (a) feed `ParseFromString(value)` and (b) compare against the cached `_key`. Both are unnecessary: the iterator's `Slice` already owns the byte ranges for the duration of the call.

The same anti-pattern lives in `LakePersistentIndex::merge_sstables` (`lake_persistent_index.cpp:641`):

```cpp
const std::string& cur_key = iter_ptr->key().to_string(); // per-row heap alloc
```

`cur_key` is only used as a `Slice` for `Compare(...)`, so the conversion is pure waste.

At >270 async-delta-writer tasks/s and millions of keys per merge cycle, this yields 100s of millions of `new`/`free` per benchmark run — exactly the working set that surfaced as `my_valloc` 22 %.

## Change

`be/src/storage/lake/lake_persistent_index_key_value_merger.cpp`:
- Replace `to_string()` calls in `merge()` with raw `Slice` reads of `iter_ptr->key()` and `iter_ptr->value()`.
- Switch `ParseFromString(value)` to `ParseFromArray(value.data, value.size)`.
- Compare cached `_key` (`std::string`) with the input via `Slice(_key) == key`.
- On the rare key-changes-from-previous branch (once per distinct output key, not once per input row), assign with `_key.assign(key.data, key.size)`.

`be/src/storage/lake/lake_persistent_index.cpp`:
- Same `to_string()` → `Slice` conversion in the `merge_sstables` `while (iter_ptr->Valid())` loop.

## Why it's safe

- The iterator's `Slice`s reference storage owned by the iterator (block buffer / SST cache page), valid until `iter_ptr->Next()` advances.
- Parse and comparison both finish before `Next()` is called.
- `Slice(const std::string&)` is a zero-copy adapter used throughout the codebase.
- `KeyValueMerger` is single-threaded per merger instance (one per compaction worker), so no concurrency concerns.
- No public API changes; no on-disk format changes. Reversible by reverting the diff.

## Expected impact

Removes the last per-row heap allocation pair on the PK-index parallel compaction thread. Should push `my_valloc` self-time below the 20 % escalation threshold from the iter-001 review note, and free CPU on the hottest CNs in long-warm runs where SST counts have grown. Effect on upsert max latency depends on how much of the residual ~8 s tail (iter-004 max) is allocator-bound vs locking/IO; iter-005 will measure.

## Stacked on #72335

This PR contains both PR #72335's `KeyValueMerger::_scratch_value_pb` / `_scratch_flush_pb` reuse and this iter's `to_string()` removal. Built off `branch-4.1` pinned at `7af3ba7`. Once #72335 merges, this PR will rebase to a single-commit diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
