### PR TITLE
[Refactor] Decouple pipeline operator exec stats from QueryContext

### DIFF
--- a/be/src/exec/pipeline/chunk_accumulate_operator.h
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.h
@@ -45,7 +45,7 @@ public:
     Status set_finished(RuntimeState* state) override;
 
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
-    void update_exec_stats(RuntimeState* state) override {}
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override { return OperatorExecStatsSnapshot::ignored(); }
 
 private:
     ChunkPipelineAccumulator _acc;

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
@@ -48,7 +48,7 @@ public:
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
-    void update_exec_stats(RuntimeState* state) override {}
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override { return OperatorExecStatsSnapshot::ignored(); }
 
     std::string get_name() const override;
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -93,7 +93,7 @@ public:
 
     void enter_release_memory_mode() override;
     void set_execute_mode(int performance_level) override;
-    void update_exec_stats(RuntimeState* state) override {}
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override { return OperatorExecStatsSnapshot::ignored(); }
 
     std::string get_name() const override;
 

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h
@@ -48,7 +48,7 @@ public:
 
     void set_execute_mode(int performance_level) override { return _exchanger->enter_release_memory_mode(); }
 
-    void update_exec_stats(RuntimeState* state) override {}
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override { return OperatorExecStatsSnapshot::ignored(); }
 
 protected:
     bool _is_finished = false;

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h
@@ -38,7 +38,7 @@ public:
 
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
-    void update_exec_stats(RuntimeState* state) override {}
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override { return OperatorExecStatsSnapshot::ignored(); }
 
 private:
     bool _is_finished = false;

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -59,7 +59,7 @@ public:
     }
 
     size_t output_amplification_factor() const override;
-    void update_exec_stats(RuntimeState* state) override {}
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override { return OperatorExecStatsSnapshot::ignored(); }
 
 protected:
     HashJoinerPtr _join_builder;

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -16,7 +16,6 @@
 
 #include "exec/hash_joiner.h"
 #include "exec/pipeline/hashjoin/hash_joiner_factory.h"
-#include "exec/pipeline/query_context.h"
 #include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 
@@ -127,20 +126,22 @@ Status HashJoinProbeOperator::reset_state(RuntimeState* state, const vector<Chun
     return Status::OK();
 }
 
-void HashJoinProbeOperator::update_exec_stats(RuntimeState* state) {
-    auto ctx = state->query_ctx();
-    if (ctx != nullptr) {
-        ctx->update_pull_rows_stats(_plan_node_id, COUNTER_VALUE(_pull_row_num_counter));
-        if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
-            ctx->update_pred_filter_stats(
-                    _plan_node_id, COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter));
-        }
-        if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
-            int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
-            int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
-            ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
-        }
+OperatorExecStatsSnapshot HashJoinProbeOperator::exec_stats_snapshot() const {
+    OperatorExecStatsSnapshot snapshot;
+    snapshot.plan_node_id = _plan_node_id;
+    snapshot.update_pull_rows = true;
+    snapshot.pull_rows = COUNTER_VALUE(_pull_row_num_counter);
+    if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
+        snapshot.update_pred_filter_rows = true;
+        snapshot.pred_filter_rows = COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter);
     }
+    if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
+        snapshot.update_rf_filter_rows = true;
+        int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
+        int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
+        snapshot.rf_filter_rows = input_rows - output_rows;
+    }
+    return snapshot;
 }
 
 HashJoinProbeOperatorFactory::HashJoinProbeOperatorFactory(int32_t id, int32_t plan_node_id,

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.h
@@ -50,7 +50,7 @@ public:
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
     Status reset_state(starrocks::RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
-    void update_exec_stats(RuntimeState* state) override;
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override;
 
 protected:
     /// Reference the read-only hash table from builder in the first pull_chunk.

--- a/be/src/exec/pipeline/limit_operator.cpp
+++ b/be/src/exec/pipeline/limit_operator.cpp
@@ -15,7 +15,6 @@
 #include "exec/pipeline/limit_operator.h"
 
 #include "column/chunk.h"
-#include "exec/pipeline/query_context.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
@@ -46,21 +45,27 @@ Status LimitOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     return Status::OK();
 }
 
-void LimitOperator::update_exec_stats(RuntimeState* state) {
-    auto ctx = state->query_ctx();
-    if (!_is_subordinate && ctx != nullptr) {
-        ctx->force_set_pull_rows_stats(_plan_node_id, COUNTER_VALUE(_pull_row_num_counter));
-        if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
-            ctx->update_pred_filter_stats(
-                    _plan_node_id, COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter));
-        }
-
-        if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
-            int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
-            int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
-            ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
-        }
+OperatorExecStatsSnapshot LimitOperator::exec_stats_snapshot() const {
+    if (_is_subordinate) {
+        return OperatorExecStatsSnapshot::ignored();
     }
+
+    OperatorExecStatsSnapshot snapshot;
+    snapshot.plan_node_id = _plan_node_id;
+    snapshot.update_pull_rows = true;
+    snapshot.force_set_pull_rows = true;
+    snapshot.pull_rows = COUNTER_VALUE(_pull_row_num_counter);
+    if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
+        snapshot.update_pred_filter_rows = true;
+        snapshot.pred_filter_rows = COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter);
+    }
+    if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
+        snapshot.update_rf_filter_rows = true;
+        int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
+        int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
+        snapshot.rf_filter_rows = input_rows - output_rows;
+    }
+    return snapshot;
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/limit_operator.h
+++ b/be/src/exec/pipeline/limit_operator.h
@@ -44,7 +44,7 @@ public:
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
-    void update_exec_stats(RuntimeState* state) override;
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override;
 
 private:
     bool _is_finished = false;

--- a/be/src/exec/pipeline/nljoin/nljoin_build_operator.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_build_operator.h
@@ -49,7 +49,7 @@ public:
 
     OutputAmplificationType intra_pipeline_amplification_type() const override;
     size_t output_amplification_factor() const override;
-    void update_exec_stats(RuntimeState* state) override {}
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override { return OperatorExecStatsSnapshot::ignored(); }
 
 private:
     std::atomic<bool> _is_finished = false;

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -19,7 +19,6 @@
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
-#include "exec/pipeline/query_context.h"
 #include "exprs/expr_executor.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/current_thread.h"
@@ -788,21 +787,22 @@ Status NLJoinProbeOperator::push_chunk(RuntimeState* state, const ChunkPtr& chun
     return Status::OK();
 }
 
-void NLJoinProbeOperator::update_exec_stats(RuntimeState* state) {
-    auto ctx = state->query_ctx();
-    if (ctx != nullptr) {
-        ctx->update_pull_rows_stats(_plan_node_id, COUNTER_VALUE(_pull_row_num_counter));
-        if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
-            ctx->update_pred_filter_stats(
-                    _plan_node_id, COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter));
-        }
-
-        if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
-            int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
-            int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
-            ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
-        }
+OperatorExecStatsSnapshot NLJoinProbeOperator::exec_stats_snapshot() const {
+    OperatorExecStatsSnapshot snapshot;
+    snapshot.plan_node_id = _plan_node_id;
+    snapshot.update_pull_rows = true;
+    snapshot.pull_rows = COUNTER_VALUE(_pull_row_num_counter);
+    if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
+        snapshot.update_pred_filter_rows = true;
+        snapshot.pred_filter_rows = COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter);
     }
+    if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
+        snapshot.update_rf_filter_rows = true;
+        int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
+        int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
+        snapshot.rf_filter_rows = input_rows - output_rows;
+    }
+    return snapshot;
 }
 
 void NLJoinProbeOperatorFactory::_init_row_desc() {

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
@@ -60,7 +60,7 @@ public:
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
-    void update_exec_stats(RuntimeState* state) override;
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override;
 
 private:
     enum JoinStage {

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -22,7 +22,6 @@
 #include "common/logging.h"
 #include "common/runtime_profile.h"
 #include "exec/pipeline/operator_factory.h"
-#include "exec/pipeline/query_context.h"
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr_context.h"
 #include "gutil/strings/substitute.h"
@@ -276,22 +275,30 @@ void Operator::_init_conjuct_counters() {
     }
 }
 
-void Operator::update_exec_stats(RuntimeState* state) {
-    auto ctx = state->query_ctx();
-    if (!_is_subordinate && ctx != nullptr && ctx->need_record_exec_stats(_plan_node_id)) {
-        ctx->update_push_rows_stats(_plan_node_id, COUNTER_VALUE(_push_row_num_counter));
-        ctx->update_pull_rows_stats(_plan_node_id, COUNTER_VALUE(_pull_row_num_counter));
-        if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
-            ctx->update_pred_filter_stats(
-                    _plan_node_id, COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter));
-        }
-        if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr &&
-            _bloom_filter_eval_context.join_runtime_filter_output_counter != nullptr) {
-            int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
-            int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
-            ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
-        }
+OperatorExecStatsSnapshot Operator::exec_stats_snapshot() const {
+    if (_is_subordinate) {
+        return OperatorExecStatsSnapshot::ignored();
     }
+
+    OperatorExecStatsSnapshot snapshot;
+    snapshot.plan_node_id = _plan_node_id;
+    snapshot.require_registered_plan_node = true;
+    snapshot.update_push_rows = true;
+    snapshot.update_pull_rows = true;
+    snapshot.push_rows = COUNTER_VALUE(_push_row_num_counter);
+    snapshot.pull_rows = COUNTER_VALUE(_pull_row_num_counter);
+    if (_conjuncts_input_counter != nullptr && _conjuncts_output_counter != nullptr) {
+        snapshot.update_pred_filter_rows = true;
+        snapshot.pred_filter_rows = COUNTER_VALUE(_conjuncts_input_counter) - COUNTER_VALUE(_conjuncts_output_counter);
+    }
+    if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr &&
+        _bloom_filter_eval_context.join_runtime_filter_output_counter != nullptr) {
+        snapshot.update_rf_filter_rows = true;
+        int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
+        int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
+        snapshot.rf_filter_rows = input_rows - output_rows;
+    }
+    return snapshot;
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -19,6 +19,7 @@
 #include "column/vectorized_fwd.h"
 #include "common/runtime_profile.h"
 #include "common/statusor.h"
+#include "exec/pipeline/primitives/operator_exec_stats.h"
 #include "exec/pipeline/primitives/operator_runtime_access.h"
 #include "exec/pipeline/runtime_filter_core_types.h"
 #include "exec/runtime_filter/runtime_filter_probe.h"
@@ -239,7 +240,7 @@ public:
     // apply operation for each child operator
     virtual void for_each_child_operator(const std::function<void(Operator*)>& apply) {}
 
-    virtual void update_exec_stats(RuntimeState* state);
+    virtual OperatorExecStatsSnapshot exec_stats_snapshot() const;
 
     void set_observer(PipelineObserver* observer) { _observer = observer; }
     PipelineObserver* observer() const { return _observer; }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -53,6 +53,36 @@ namespace starrocks::pipeline {
 DEFINE_FAIL_POINT(operator_return_large_column);
 DEFINE_FAIL_POINT(global_runtime_filter_sync_A);
 
+namespace {
+
+void update_operator_exec_stats(QueryContext* query_ctx, const OperatorExecStatsSnapshot& snapshot) {
+    if (!snapshot.valid || query_ctx == nullptr) {
+        return;
+    }
+    if (snapshot.require_registered_plan_node && !query_ctx->need_record_exec_stats(snapshot.plan_node_id)) {
+        return;
+    }
+
+    if (snapshot.update_push_rows) {
+        query_ctx->update_push_rows_stats(snapshot.plan_node_id, snapshot.push_rows);
+    }
+    if (snapshot.update_pull_rows) {
+        if (snapshot.force_set_pull_rows) {
+            query_ctx->force_set_pull_rows_stats(snapshot.plan_node_id, snapshot.pull_rows);
+        } else {
+            query_ctx->update_pull_rows_stats(snapshot.plan_node_id, snapshot.pull_rows);
+        }
+    }
+    if (snapshot.update_pred_filter_rows) {
+        query_ctx->update_pred_filter_stats(snapshot.plan_node_id, snapshot.pred_filter_rows);
+    }
+    if (snapshot.update_rf_filter_rows) {
+        query_ctx->update_rf_filter_stats(snapshot.plan_node_id, snapshot.rf_filter_rows);
+    }
+}
+
+} // namespace
+
 PipelineDriver::PipelineDriver(const Operators& operators, QueryContext* query_ctx, FragmentContext* fragment_ctx,
                                Pipeline* pipeline, int32_t driver_id)
         : _observer(this),
@@ -369,7 +399,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                         _update_scan_statistics(runtime_state);
                         RETURN_IF_ERROR(return_status = _mark_operator_finishing(curr_op, runtime_state));
                     }
-                    curr_op->update_exec_stats(runtime_state);
+                    update_operator_exec_stats(_query_ctx, curr_op->exec_stats_snapshot());
                     _adjust_memory_usage(runtime_state, query_mem_tracker.get(), i + 1, next_op, nullptr);
                     RELEASE_RESERVED_GUARD();
                     RETURN_IF_ERROR(return_status = _mark_operator_finishing(next_op, runtime_state));
@@ -477,7 +507,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                         _update_scan_statistics(runtime_state);
                         RETURN_IF_ERROR(return_status = _mark_operator_finishing(curr_op, runtime_state));
                     }
-                    curr_op->update_exec_stats(runtime_state);
+                    update_operator_exec_stats(_query_ctx, curr_op->exec_stats_snapshot());
                     _adjust_memory_usage(runtime_state, query_mem_tracker.get(), i + 1, next_op, nullptr);
                     RELEASE_RESERVED_GUARD();
                     RETURN_IF_ERROR(return_status = _mark_operator_finishing(next_op, runtime_state));
@@ -512,7 +542,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
         _first_unfinished = new_first_unfinished;
 
         if (sink_operator()->is_finished()) {
-            sink_operator()->update_exec_stats(runtime_state);
+            update_operator_exec_stats(_query_ctx, sink_operator()->exec_stats_snapshot());
             finish_operators(runtime_state);
             set_driver_state(is_still_pending_finish() ? DriverState::PENDING_FINISH : DriverState::FINISH);
             return _state;

--- a/be/src/exec/pipeline/primitives/operator_exec_stats.h
+++ b/be/src/exec/pipeline/primitives/operator_exec_stats.h
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace starrocks::pipeline {
+
+struct OperatorExecStatsSnapshot {
+    static OperatorExecStatsSnapshot ignored() {
+        OperatorExecStatsSnapshot snapshot;
+        snapshot.valid = false;
+        return snapshot;
+    }
+
+    bool valid = true;
+    bool require_registered_plan_node = false;
+    bool update_push_rows = false;
+    bool update_pull_rows = false;
+    bool force_set_pull_rows = false;
+    bool update_pred_filter_rows = false;
+    bool update_rf_filter_rows = false;
+    int32_t plan_node_id = -1;
+    int64_t push_rows = 0;
+    int64_t pull_rows = 0;
+    int64_t pred_filter_rows = 0;
+    int64_t rf_filter_rows = 0;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -254,16 +254,18 @@ void ScanOperator::_detach_chunk_sources() {
     }
 }
 
-void ScanOperator::update_exec_stats(RuntimeState* state) {
-    auto ctx = state->query_ctx();
-    if (ctx != nullptr) {
-        ctx->update_pull_rows_stats(_plan_node_id, COUNTER_VALUE(_pull_row_num_counter));
-        if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
-            int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
-            int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
-            ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
-        }
+OperatorExecStatsSnapshot ScanOperator::exec_stats_snapshot() const {
+    OperatorExecStatsSnapshot snapshot;
+    snapshot.plan_node_id = _plan_node_id;
+    snapshot.update_pull_rows = true;
+    snapshot.pull_rows = COUNTER_VALUE(_pull_row_num_counter);
+    if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
+        snapshot.update_rf_filter_rows = true;
+        int64_t input_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_input_counter);
+        int64_t output_rows = COUNTER_VALUE(_bloom_filter_eval_context.join_runtime_filter_output_counter);
+        snapshot.rf_filter_rows = input_rows - output_rows;
     }
+    return snapshot;
 }
 
 Status ScanOperator::set_finishing(RuntimeState* state) {

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -99,7 +99,7 @@ public:
 
     virtual int64_t get_scan_table_id() const { return -1; }
 
-    void update_exec_stats(RuntimeState* state) override;
+    OperatorExecStatsSnapshot exec_stats_snapshot() const override;
 
     bool has_full_events() { return get_chunk_buffer().limiter()->has_full_events(); }
     virtual bool need_notify_all() { return true; }

--- a/be/test/exec/pipeline/pipeline_control_flow_test.cpp
+++ b/be/test/exec/pipeline/pipeline_control_flow_test.cpp
@@ -22,6 +22,7 @@
 #include "common/config_exec_flow_fwd.h"
 #include "common/util/thrift_util.h"
 #include "exec/pipeline/fragment_context.h"
+#include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/pipeline.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/pipeline_driver.h"
@@ -572,6 +573,66 @@ TEST(OperatorRuntimeAccessTest, test_operator_precondition_ready_uses_runtime_ac
     EXPECT_EQ(factory.local_filters[0], op->runtime_in_filters()[0]);
     EXPECT_EQ(factory.instance_filters[0], op->runtime_in_filters()[1]);
     EXPECT_EQ(factory.instance_filters[1], op->runtime_in_filters()[2]);
+}
+
+TEST(OperatorExecStatsSnapshotTest, test_default_operator_snapshot) {
+    TestNormalOperatorFactory factory(1, 10, std::make_shared<Counter>());
+    RuntimeState state;
+    auto op = factory.create(1, 0);
+
+    ASSERT_OK(op->prepare_local_state(&state));
+    COUNTER_UPDATE(op->_push_row_num_counter, 5);
+    COUNTER_UPDATE(op->_pull_row_num_counter, 3);
+    op->_init_conjuct_counters();
+    COUNTER_UPDATE(op->_conjuncts_input_counter, 11);
+    COUNTER_UPDATE(op->_conjuncts_output_counter, 7);
+    op->_init_rf_counters(true);
+    COUNTER_UPDATE(op->_bloom_filter_eval_context.join_runtime_filter_input_counter, 13);
+    COUNTER_UPDATE(op->_bloom_filter_eval_context.join_runtime_filter_output_counter, 9);
+
+    auto snapshot = op->exec_stats_snapshot();
+
+    EXPECT_TRUE(snapshot.valid);
+    EXPECT_TRUE(snapshot.require_registered_plan_node);
+    EXPECT_EQ(10, snapshot.plan_node_id);
+    EXPECT_TRUE(snapshot.update_push_rows);
+    EXPECT_TRUE(snapshot.update_pull_rows);
+    EXPECT_FALSE(snapshot.force_set_pull_rows);
+    EXPECT_EQ(5, snapshot.push_rows);
+    EXPECT_EQ(3, snapshot.pull_rows);
+    EXPECT_TRUE(snapshot.update_pred_filter_rows);
+    EXPECT_EQ(4, snapshot.pred_filter_rows);
+    EXPECT_TRUE(snapshot.update_rf_filter_rows);
+    EXPECT_EQ(4, snapshot.rf_filter_rows);
+}
+
+TEST(OperatorExecStatsSnapshotTest, test_limit_snapshot_force_sets_pull_rows) {
+    LimitOperatorFactory factory(1, 20, 100);
+    RuntimeState state;
+    auto op = factory.create(1, 0);
+
+    ASSERT_OK(op->prepare_local_state(&state));
+    COUNTER_UPDATE(op->_pull_row_num_counter, 6);
+    op->_init_conjuct_counters();
+    COUNTER_UPDATE(op->_conjuncts_input_counter, 10);
+    COUNTER_UPDATE(op->_conjuncts_output_counter, 4);
+    op->_init_rf_counters(true);
+    COUNTER_UPDATE(op->_bloom_filter_eval_context.join_runtime_filter_input_counter, 8);
+    COUNTER_UPDATE(op->_bloom_filter_eval_context.join_runtime_filter_output_counter, 3);
+
+    auto snapshot = op->exec_stats_snapshot();
+
+    EXPECT_TRUE(snapshot.valid);
+    EXPECT_FALSE(snapshot.require_registered_plan_node);
+    EXPECT_EQ(20, snapshot.plan_node_id);
+    EXPECT_FALSE(snapshot.update_push_rows);
+    EXPECT_TRUE(snapshot.update_pull_rows);
+    EXPECT_TRUE(snapshot.force_set_pull_rows);
+    EXPECT_EQ(6, snapshot.pull_rows);
+    EXPECT_TRUE(snapshot.update_pred_filter_rows);
+    EXPECT_EQ(6, snapshot.pred_filter_rows);
+    EXPECT_TRUE(snapshot.update_rf_filter_rows);
+    EXPECT_EQ(5, snapshot.rf_filter_rows);
 }
 
 TEST(PipelineDriverSpillResourceManagerTest, test_operator_manager_lifecycle) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
