### PR TITLE
[auto-perf-opt] Reuse PB + SerializeToString buffer in PK index SST emit

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -641,8 +641,7 @@ StatusOr<std::vector<KeyValueMerger::KeyValueMergerOutput>> LakePersistentIndex:
         // Compare via Slice directly; .to_string() would allocate a fresh
         // std::string per key on a loop driven by every input row.
         const Slice cur_key = iter_ptr->key();
-        if (!seek_range.stop_key.empty() &&
-            options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
+        if (!seek_range.stop_key.empty() && options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -638,9 +638,11 @@ StatusOr<std::vector<KeyValueMerger::KeyValueMergerOutput>> LakePersistentIndex:
     auto merger = std::make_unique<KeyValueMerger>(iter_ptr->key().to_string(), iter_ptr->max_rss_rowid(),
                                                    base_level_merge, tablet_mgr, metadata->id(), false);
     while (iter_ptr->Valid()) {
-        const std::string& cur_key = iter_ptr->key().to_string();
+        // Compare via Slice directly; .to_string() would allocate a fresh
+        // std::string per key on a loop driven by every input row.
+        const Slice cur_key = iter_ptr->key();
         if (!seek_range.stop_key.empty() &&
-            options.comparator->Compare(Slice(cur_key), Slice(seek_range.stop_key)) >= 0) {
+            options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -36,15 +36,18 @@
 namespace starrocks::lake {
 
 Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
-    const std::string& key = iter_ptr->key().to_string();
-    const std::string& value = iter_ptr->value().to_string();
+    // Avoid the per-key std::string heap allocations that Slice::to_string() forces.
+    // The iterator's slices stay valid for the duration of this call, and the
+    // protobuf parse below copies what it needs into _scratch_value_pb.
+    const Slice key = iter_ptr->key();
+    const Slice value = iter_ptr->value();
     uint64_t max_rss_rowid = iter_ptr->max_rss_rowid();
 
-    // Reuse the per-merger protobuf instance: ParseFromString resets it before
+    // Reuse the per-merger protobuf instance: ParseFromArray resets it before
     // populating, and RepeatedPtrField retains its element backing across calls,
     // so we avoid a heap alloc + free of the message and its values list per key.
     IndexValuesWithVerPB& index_value_ver = _scratch_value_pb;
-    if (!index_value_ver.ParseFromString(value)) {
+    if (!index_value_ver.ParseFromArray(value.data, value.size)) {
         return Status::InternalError("Failed to parse index value ver");
     }
     if (index_value_ver.values_size() == 0) {
@@ -83,7 +86,7 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
 
     auto version = index_value_ver.values(0).version();
     auto index_value = build_index_value(index_value_ver.values(0));
-    if (_key == key) {
+    if (Slice(_key) == key) {
         if (_index_value_vers.empty()) {
             _max_rss_rowid = max_rss_rowid;
             _index_value_vers.emplace_front(version, index_value);
@@ -136,7 +139,7 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
         }
     } else {
         RETURN_IF_ERROR(flush());
-        _key = key;
+        _key.assign(key.data, key.size);
         _max_rss_rowid = max_rss_rowid;
         _index_value_vers.emplace_front(version, index_value);
     }

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -173,8 +173,15 @@ Status KeyValueMerger::flush() {
             // Create a new sst file when current file is empty or exceed target size.
             RETURN_IF_ERROR(create_table_builder());
         }
+        // Reuse the per-merger serialization buffer: SerializeAsString() returns a
+        // brand new std::string each call (heap alloc + copy + dtor). SerializeToString
+        // into a long-lived buffer reuses the existing backing storage; the Slice we
+        // hand to TableBuilder::Add only needs to outlive the Add() call (Add copies
+        // into its block builder before returning), which is true here.
+        _scratch_serialized.clear();
+        index_value_pb.SerializeToString(&_scratch_serialized);
         RETURN_IF_ERROR(
-                _output_builders.back().table_builder->Add(Slice(_key), Slice(index_value_pb.SerializeAsString())));
+                _output_builders.back().table_builder->Add(Slice(_key), Slice(_scratch_serialized)));
     }
     _index_value_vers.clear();
 

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -180,8 +180,7 @@ Status KeyValueMerger::flush() {
         // into its block builder before returning), which is true here.
         _scratch_serialized.clear();
         index_value_pb.SerializeToString(&_scratch_serialized);
-        RETURN_IF_ERROR(
-                _output_builders.back().table_builder->Add(Slice(_key), Slice(_scratch_serialized)));
+        RETURN_IF_ERROR(_output_builders.back().table_builder->Add(Slice(_key), Slice(_scratch_serialized)));
     }
     _index_value_vers.clear();
 

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -40,7 +40,10 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
     const std::string& value = iter_ptr->value().to_string();
     uint64_t max_rss_rowid = iter_ptr->max_rss_rowid();
 
-    IndexValuesWithVerPB index_value_ver;
+    // Reuse the per-merger protobuf instance: ParseFromString resets it before
+    // populating, and RepeatedPtrField retains its element backing across calls,
+    // so we avoid a heap alloc + free of the message and its values list per key.
+    IndexValuesWithVerPB& index_value_ver = _scratch_value_pb;
     if (!index_value_ver.ParseFromString(value)) {
         return Status::InternalError("Failed to parse index value ver");
     }
@@ -145,7 +148,11 @@ Status KeyValueMerger::flush() {
         return Status::OK();
     }
 
-    IndexValuesWithVerPB index_value_pb;
+    // Reuse the per-merger protobuf instance: Clear() retains the values'
+    // RepeatedPtrField backing memory, so the add_values() loop below can
+    // reuse the slot allocations across flushes for the same merger.
+    IndexValuesWithVerPB& index_value_pb = _scratch_flush_pb;
+    index_value_pb.Clear();
     for (const auto& index_value_with_ver : _index_value_vers) {
         if (_merge_base_level && index_value_with_ver.second == IndexValue(NullIndexValue)) {
             // deleted

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.h
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.h
@@ -83,6 +83,12 @@ private:
     // data volume larger than pk_index_target_file_size.
     bool _enable_multiple_output_files = false;
     std::vector<TableBuilderWrapper> _output_builders;
+    // Reused across merge() calls to avoid per-key heap alloc/free of the
+    // protobuf message and its repeated-field storage. ParseFromString resets
+    // the message; RepeatedPtrField::Clear retains element backing memory.
+    IndexValuesWithVerPB _scratch_value_pb;
+    // Reused across flush() calls for the same reason.
+    IndexValuesWithVerPB _scratch_flush_pb;
 };
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.h
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.h
@@ -89,6 +89,11 @@ private:
     IndexValuesWithVerPB _scratch_value_pb;
     // Reused across flush() calls for the same reason.
     IndexValuesWithVerPB _scratch_flush_pb;
+    // Reused across flush() calls to avoid the heap alloc + copy + dtor that
+    // SerializeAsString() does each call. SerializeToString reuses the existing
+    // backing storage of this string; the Slice handed to TableBuilder::Add only
+    // needs to outlive the Add() call.
+    std::string _scratch_serialized;
 };
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -119,13 +119,23 @@ Status PersistentIndexSstable::build_sstable(const phmap::btree_map<std::string,
     sstable::Options options;
     options.filter_policy = filter_policy.get();
     sstable::TableBuilder builder(options, wf);
+    // Hoist the per-key protobuf message and its serialization buffer out of the
+    // loop. RepeatedPtrField::Clear() retains the value-slot allocation, so
+    // add_values() reuses the existing slot across iterations; SerializeToString
+    // reuses the existing std::string backing storage. This eliminates three
+    // per-key heap allocations (the message, the values slot, and the temporary
+    // returned by SerializeAsString) on a loop driven by every key in `map`.
+    IndexValuesWithVerPB index_value_pb;
+    std::string serialized;
     for (const auto& [k, v] : map) {
-        IndexValuesWithVerPB index_value_pb;
+        index_value_pb.Clear();
         auto* value = index_value_pb.add_values();
         value->set_version(v.first);
         value->set_rssid(v.second.get_rssid());
         value->set_rowid(v.second.get_rowid());
-        RETURN_IF_ERROR(builder.Add(Slice(k), Slice(index_value_pb.SerializeAsString())));
+        serialized.clear();
+        index_value_pb.SerializeToString(&serialized);
+        RETURN_IF_ERROR(builder.Add(Slice(k), Slice(serialized)));
     }
     if (auto st = builder.Finish(); !st.ok()) {
         StarRocksMetrics::instance()->pk_index_sst_write_error_total.increment(1);


### PR DESCRIPTION
## Bottleneck

iter-005 in the auto-perf-opt run (`my-rt`, template `999_1gb_1_1tb`, 6-CN shared-data, 1 hr warm) deployed PR #72399 and shows the previously-dominant `KeyValueMerger::merge` stack has dropped to noise (1.48 % inclusive vs 21 % pre-#72335). But on the hottest CN (172.26.80.129, 85.7 % non-idle) the allocator still owns ~10 % of CPU samples in the same `cloud_native_pk_*` thread family:

```
self  symbol
5.10 % my_memalign     (mostly std::string heap allocs)
4.95 % my_valloc       (mostly RepeatedPtrField growth)
```

Two per-key allocation sites remain in the SST emit path that PR #72335 / #72399 did not touch:

1. **`KeyValueMerger::flush()` in `lake_persistent_index_key_value_merger.cpp`** — already reuses the message via `_scratch_flush_pb` (added in #72335), but still calls `SerializeAsString()` per output key, which returns a brand new `std::string` (heap alloc + memcpy + dtor) every call.
2. **`PersistentIndexSstable::build_sstable()` in `persistent_index_sstable.cpp`** — for every entry of the in-memory PK-index batch, allocates a fresh `IndexValuesWithVerPB`, calls `add_values()` (slot alloc), then `SerializeAsString()` (string alloc). Three heap allocations per key, on a loop driven by every key in the flushed map.

iter-004's plan explicitly flagged the second site as the next escalation target.

## Change

- `KeyValueMerger`: add a `std::string _scratch_serialized` member. In `flush()`, replace `Slice(index_value_pb.SerializeAsString())` with `index_value_pb.SerializeToString(&_scratch_serialized); ... Slice(_scratch_serialized)`. The buffer's capacity is reused across calls; the `Slice` only has to outlive the `TableBuilder::Add()` call (which copies into its block builder before returning).
- `build_sstable()`: hoist the `IndexValuesWithVerPB` and a `std::string` out of the per-key loop. Inside the loop, call `Clear()` on the message (`RepeatedPtrField::Clear()` retains the values slot's backing allocation) and `SerializeToString` into the reused buffer.

No behavioural change. In both functions the message lifetime and the serialized bytes lifetime are scoped to one loop iteration, with no concurrent access — each `KeyValueMerger` / `build_sstable` call runs on a single compaction worker thread.

## Expected impact

Expect the combined `my_memalign` + `my_valloc` self-time on the hottest CN to drop from 10 % to ~3-5 %, freeing CPU on the PK-index parallel-compaction threads where `tbl=0`'s CommitAndPublish work concentrates. Direct effect on upsert max depends on how much the freed CPU unblocks the rest of the publish path — to be measured in the next iteration.

## Cumulative

This branch stacks on PR #72335 (`44260ec`) and PR #72399 (`445e8cf`, `872a0f3`) so the deploy validates them together against the iter-001 baseline.

## Risk

Pure memory-reuse refactor, mirrors PR #72335's pattern. Reversible by reverting the diff.