### PR TITLE
[BugFix] Fixing dictification for CTEProduce Projections

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -716,12 +716,14 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
                                 context.stringRefToDictRefMap.getOrDefault(e.getKey(), e.getKey()),
                                 context.stringRefToDictRefMap.getOrDefault(e.getValue(), e.getValue())))
                 .collect(Collectors.toMap(p -> p.first, p -> p.second));
+        ColumnRefSet supportColumns = new ColumnRefSet(consume.getCteOutputColumnRefMap().entrySet().stream()
+                .filter(k -> info.inputStringColumns.contains(k.getValue())).map(Map.Entry::getKey).toList());
         PhysicalCTEConsumeOperator newOp = new PhysicalCTEConsumeOperator(
                 consume.getCteId(),
                 newMap,
                 consume.getLimit(),
-                rewritePredicate(consume.getPredicate(), info.outputStringColumns),
-                rewriteProjection(consume.getProjection(), info.outputStringColumns),
+                rewritePredicate(consume.getPredicate(), supportColumns),
+                rewriteProjection(consume.getProjection(), supportColumns),
                 computeDictExpr(fragmentUseDictExprs)
         );
         return rewriteOptExpression(optExpression, newOp, info.outputStringColumns);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2899,4 +2899,34 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "VARCHAR; args nullable: true; result nullable: true]])\n" +
                 "  |  cardinality: 1", plan);
     }
+
+    @Test
+    public void testCTEConsumeWithProjection() throws Exception {
+        String sql = """
+                  WITH CTE AS (
+                    SELECT
+                      C_USER
+                    FROM
+                      low_card_t1
+                  ) [materialized]
+                  SELECT /*+ SET_VAR(cbo_cte_reuse=true, cbo_cte_reuse_rate_v2=0) */
+                    UPPER(C_USER) s1
+                  FROM
+                    CTE
+                  """;
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "Global Dict Exprs:\n" +
+                "    16: DictDefine(14: c_user, [upper(<place-holder>)])\n" +
+                "    15: DictDefine(14: c_user, [<place-holder>])\n" +
+                "\n" +
+                "  4:Decode\n" +
+                "  |  <dict id 16> : <string id 13>\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  3:Project\n" +
+                "  |  output columns:\n" +
+                "  |  16 <-> DictDefine([15: c_user, INT, true], [upper[(<place-holder>); args: VARCHAR; result: " +
+                "VARCHAR; args nullable: true; result nullable: true]])\n" +
+                "  |  cardinality: 1", plan);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
The dictification rewrite does not currently work correctly for CTEConsume projects, and it produces incorrect plans which fail the plan validation.

## What I'm doing:
Fixing the rewrite. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
