### PR TITLE
[BugFix] Fix unhashable ReflectedPartitionInfo breaking SQLAlchemy reflection cache

### DIFF
--- a/contrib/starrocks-python-client/starrocks/engine/interfaces.py
+++ b/contrib/starrocks-python-client/starrocks/engine/interfaces.py
@@ -145,7 +145,10 @@ class ReflectedMVState(ReflectedViewState):
 
 
 @add_cached_str_clause
-@dataclasses.dataclass
+# eq=False keeps the default identity-based __hash__ from object, so SQLAlchemy
+# can use these objects inside its reflection cache keys (issue #70733). The
+# dataclasses also mutate self in __str__, which rules out frozen=True.
+@dataclasses.dataclass(eq=False)
 class ReflectedRefreshInfo:
     """Stores structured reflection information about a materialized view's refresh scheme."""
     moment: Optional[str] = None
@@ -217,7 +220,7 @@ class ReflectedCKInfo(TypedDict):
 
 
 @add_cached_str_clause
-@dataclasses.dataclass(**dict(kw_only=True) if 'KW_ONLY' in dataclasses.__all__ else {})
+@dataclasses.dataclass(eq=False, **dict(kw_only=True) if 'KW_ONLY' in dataclasses.__all__ else {})
 class ReflectedTableKeyInfo:
     """
     Stores structed reflection information about a table' key/type.
@@ -243,7 +246,7 @@ class ReflectedTableKeyInfo:
 
 
 @add_cached_str_clause
-@dataclasses.dataclass(**dict(kw_only=True) if 'KW_ONLY' in dataclasses.__all__ else {})
+@dataclasses.dataclass(eq=False, **dict(kw_only=True) if 'KW_ONLY' in dataclasses.__all__ else {})
 class ReflectedPartitionInfo:
     """
     Stores structured reflection information about a table's partitioning scheme.
@@ -272,7 +275,7 @@ class ReflectedPartitionInfo:
 
 
 @add_cached_str_clause
-@dataclasses.dataclass(**dict(kw_only=True) if 'KW_ONLY' in dataclasses.__all__ else {})
+@dataclasses.dataclass(eq=False, **dict(kw_only=True) if 'KW_ONLY' in dataclasses.__all__ else {})
 class ReflectedDistributionInfo:
     """Stores reflection information about a view."""
     type: Union[str, None]


### PR DESCRIPTION
## Why I'm doing:

Closes #70733.

The four dataclasses used by the Python client to expose StarRocks table reflection to SQLAlchemy (`ReflectedRefreshInfo`, `ReflectedTableKeyInfo`, `ReflectedPartitionInfo`, `ReflectedDistributionInfo`) used the default `@dataclass` decorator, which generates an `__eq__` method and therefore drops `__hash__` to `None`.

SQLAlchemy hashes `table_options` values when it builds reflection cache keys (`sqlalchemy/engine/reflection.py:53`), so introspecting any partitioned StarRocks table from Apache Superset crashed:

```
TypeError: unhashable type: 'ReflectedPartitionInfo'
```

This blocked dataset creation for every partitioned StarRocks table that Superset is pointed at, reproduced on `starrocks==1.3.3` and Superset 4.1.2 against StarRocks 4.0.

## What I'm doing:

Add `eq=False` to the four affected dataclasses. That keeps the default identity-based `__eq__` and `__hash__` inherited from `object`, which is what SQLAlchemy's cache expects.

`frozen=True` is not an option here because each class mutates `self` inside `__str__` (`self.type = self.type.upper()` etc.), and the existing `@add_cached_str_clause` decorator caches that mutation.

A short comment in the file documents *why* `eq=False` was chosen so the next contributor doesn't reach for `frozen=True`.

Fixes #70733

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Tests

- [x] Manually verified that the four classes are now hashable: `hash(ReflectedPartitionInfo(type='RANGE', partition_method='RANGE(dt)'))` succeeds, `d = {p: 1}` works.
- [ ] Maintainer verification: with `pip install starrocks` from this branch and Superset 4.1.2, dataset creation against a partitioned table no longer raises `TypeError: unhashable type: 'ReflectedPartitionInfo'`.