### PR TITLE
[auto-perf-opt] Reuse protobuf scratch buffers in KeyValueMerger to cut PK-index compaction CPU

### DIFF
--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -40,7 +40,9 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
     const std::string& value = iter_ptr->value().to_string();
     uint64_t max_rss_rowid = iter_ptr->max_rss_rowid();
 
-    IndexValuesWithVerPB index_value_ver;
+    // Reuse scratch protobuf to avoid allocating/freeing internal storage on every key.
+    IndexValuesWithVerPB& index_value_ver = _merge_pb_scratch;
+    index_value_ver.Clear();
     if (!index_value_ver.ParseFromString(value)) {
         return Status::InternalError("Failed to parse index value ver");
     }
@@ -145,7 +147,10 @@ Status KeyValueMerger::flush() {
         return Status::OK();
     }
 
-    IndexValuesWithVerPB index_value_pb;
+    // Reuse scratch protobuf and serialization buffer to avoid allocating fresh
+    // RepeatedField storage and a new std::string on every flushed key.
+    IndexValuesWithVerPB& index_value_pb = _flush_pb_scratch;
+    index_value_pb.Clear();
     for (const auto& index_value_with_ver : _index_value_vers) {
         if (_merge_base_level && index_value_with_ver.second == IndexValue(NullIndexValue)) {
             // deleted
@@ -163,8 +168,9 @@ Status KeyValueMerger::flush() {
             // Create a new sst file when current file is empty or exceed target size.
             RETURN_IF_ERROR(create_table_builder());
         }
-        RETURN_IF_ERROR(
-                _output_builders.back().table_builder->Add(Slice(_key), Slice(index_value_pb.SerializeAsString())));
+        _flush_serialized_scratch.clear();
+        index_value_pb.SerializeToString(&_flush_serialized_scratch);
+        RETURN_IF_ERROR(_output_builders.back().table_builder->Add(Slice(_key), Slice(_flush_serialized_scratch)));
     }
     _index_value_vers.clear();
 

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.h
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.h
@@ -83,6 +83,11 @@ private:
     // data volume larger than pk_index_target_file_size.
     bool _enable_multiple_output_files = false;
     std::vector<TableBuilderWrapper> _output_builders;
+    // Scratch buffers reused across merge()/flush() to avoid per-key protobuf
+    // allocator churn. Cleared between calls so internal capacity is retained.
+    IndexValuesWithVerPB _merge_pb_scratch;
+    IndexValuesWithVerPB _flush_pb_scratch;
+    std::string _flush_serialized_scratch;
 };
 } // namespace lake
 } // namespace starrocks


### PR DESCRIPTION
## Summary

Cloud-native PK-index compaction (`cloud_native_pk_index_compact`) burns ~38% of all BE/CN CPU in `my_free` (jemalloc) under sustained upsert workloads. A 60-second `perf` capture on the hottest CN of an `auto-perf-opt my-rt-2` 999_1gb_1_1tb run (6×32-core CNs, all at 99-100% non-idle CPU) traces it back to per-key allocator churn inside `starrocks::lake::KeyValueMerger`:

```
78.91% LakePersistentIndexParallelCompactTask::run
 55.26%  KeyValueMerger::merge
  26.59%  KeyValueMerger::flush
   9.63% my_free                                 # dtor of local index_value_pb
   9.62% operator new                            # RepeatedField growth
   4.92% ~IndexValuesWithVerPB
   1.76% sstable::TableBuilder::Add
  11.62% my_free                                 # dtor of local index_value_ver
  11.18% MessageLite::ParseFromString  (10.72% in operator new)
   5.45% ~IndexValuesWithVerPB
```

Both `merge()` and `flush()` allocate a fresh `IndexValuesWithVerPB` on the stack on every call and let the destructor free all of the protobuf's internal `RepeatedField` storage at scope exit. The merger is constructed once per compact task and called once per key from the merging iterator — millions of malloc/free pairs per task. At the per-task exec time of 46.6 s observed in `auto-perf-opt my-rt-2` iteration 001, allocator churn alone accounts for the majority of compaction CPU.

## Change

Hoist the two `IndexValuesWithVerPB` instances and the `SerializeAsString()` output buffer onto `KeyValueMerger` as members, and `Clear()` / `SerializeToString()` into them per call. Clear() preserves `RepeatedField` capacity, so subsequent `ParseFromString` reuses already-grown internal arrays instead of going back to the allocator. The merger is single-threaded within a task, so no synchronization is needed.

Files: `be/src/storage/lake/lake_persistent_index_key_value_merger.{h,cpp}` — 2 files, +15 / -4 lines.

## Expected impact

- **CPU**: removing in-loop allocator churn should shave 30-50% off `cloud_native_pk_index_compact` per-task exec time.
- **Downstream**: freed CPU lets `publish_version` / `async_delta_writer` / `cloud_native_pk_index_execution` finish faster, cutting the `parallel_upsert_wait_us` component of slow publishes (2.5-2.9 s of a 3.1 s total in iter-001).
- **Target metric**: upsert max latency, currently 20.1 s vs the 3 s goal.
- **Risk**: low — change is mechanically equivalent to the prior code modulo the saved allocations. No correctness change to the merge logic itself.

## Relationship to #72428

This PR **supersedes #72428**. That PR proposed capping the compact thread count at `num_cores()` (i.e. dropping 128/CN → 32/CN), which would have throttled a CPU-bound pool doing real work — slashing PK-index compaction throughput 4×, letting SSTs accumulate, and making upserts/queries worse over time. The correct fix is to make each unit of compaction work cheaper, which is what this PR does. #72428 should be closed once this lands.

## Test plan

- [ ] Auto-build via TSP, deploy to `benchmark_luoyixin_1tb_6cn_2disk2`.
- [ ] Re-run realtime-benchmark `999_1gb_1_1tb` template; measure:
  - Upsert P99 / max latency (target: max < 20 s, ideally near 3 s).
  - `cloud_native_pk_index_compact` per-task exec time (target: < 30 s vs. 46.6 s baseline).
  - CN non-idle CPU (target: < 100 %, freeing capacity for publish path).
  - Compact `queue_count` should NOT grow unbounded vs. baseline (rollback signal).
- [ ] Re-take `perf` profile; verify `my_free` self-time falls well below 38 %, and `~IndexValuesWithVerPB` no longer dominates.

🤖 Generated with [auto-perf-opt](https://github.com/StarRocks/starrocks) via Claude Code (my-rt-2 iter-002)
