### PR TITLE
[auto-perf-opt] Drop Slice::to_string() heap allocs in PK-index compaction merge loop

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -638,9 +638,9 @@ StatusOr<std::vector<KeyValueMerger::KeyValueMergerOutput>> LakePersistentIndex:
     auto merger = std::make_unique<KeyValueMerger>(iter_ptr->key().to_string(), iter_ptr->max_rss_rowid(),
                                                    base_level_merge, tablet_mgr, metadata->id(), false);
     while (iter_ptr->Valid()) {
-        const std::string& cur_key = iter_ptr->key().to_string();
+        const Slice cur_key = iter_ptr->key();
         if (!seek_range.stop_key.empty() &&
-            options.comparator->Compare(Slice(cur_key), Slice(seek_range.stop_key)) >= 0) {
+            options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -639,8 +639,7 @@ StatusOr<std::vector<KeyValueMerger::KeyValueMergerOutput>> LakePersistentIndex:
                                                    base_level_merge, tablet_mgr, metadata->id(), false);
     while (iter_ptr->Valid()) {
         const Slice cur_key = iter_ptr->key();
-        if (!seek_range.stop_key.empty() &&
-            options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
+        if (!seek_range.stop_key.empty() && options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -40,7 +40,9 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
     const std::string& value = iter_ptr->value().to_string();
     uint64_t max_rss_rowid = iter_ptr->max_rss_rowid();
 
-    IndexValuesWithVerPB index_value_ver;
+    // Reuse scratch protobuf to avoid allocating/freeing internal storage on every key.
+    IndexValuesWithVerPB& index_value_ver = _merge_pb_scratch;
+    index_value_ver.Clear();
     if (!index_value_ver.ParseFromString(value)) {
         return Status::InternalError("Failed to parse index value ver");
     }
@@ -145,7 +147,10 @@ Status KeyValueMerger::flush() {
         return Status::OK();
     }
 
-    IndexValuesWithVerPB index_value_pb;
+    // Reuse scratch protobuf and serialization buffer to avoid allocating fresh
+    // RepeatedField storage and a new std::string on every flushed key.
+    IndexValuesWithVerPB& index_value_pb = _flush_pb_scratch;
+    index_value_pb.Clear();
     for (const auto& index_value_with_ver : _index_value_vers) {
         if (_merge_base_level && index_value_with_ver.second == IndexValue(NullIndexValue)) {
             // deleted
@@ -163,8 +168,9 @@ Status KeyValueMerger::flush() {
             // Create a new sst file when current file is empty or exceed target size.
             RETURN_IF_ERROR(create_table_builder());
         }
-        RETURN_IF_ERROR(
-                _output_builders.back().table_builder->Add(Slice(_key), Slice(index_value_pb.SerializeAsString())));
+        _flush_serialized_scratch.clear();
+        index_value_pb.SerializeToString(&_flush_serialized_scratch);
+        RETURN_IF_ERROR(_output_builders.back().table_builder->Add(Slice(_key), Slice(_flush_serialized_scratch)));
     }
     _index_value_vers.clear();
 

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -36,14 +36,18 @@
 namespace starrocks::lake {
 
 Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
-    const std::string& key = iter_ptr->key().to_string();
-    const std::string& value = iter_ptr->value().to_string();
+    // Iterator-owned slices stay valid until iter_ptr->Next(); both the parse
+    // and the equality check below complete before the caller advances the
+    // iterator, so we can avoid the per-key std::string heap allocations that
+    // Slice::to_string() would force on every input row.
+    const Slice key = iter_ptr->key();
+    const Slice value = iter_ptr->value();
     uint64_t max_rss_rowid = iter_ptr->max_rss_rowid();
 
     // Reuse scratch protobuf to avoid allocating/freeing internal storage on every key.
     IndexValuesWithVerPB& index_value_ver = _merge_pb_scratch;
     index_value_ver.Clear();
-    if (!index_value_ver.ParseFromString(value)) {
+    if (!index_value_ver.ParseFromArray(value.data, value.size)) {
         return Status::InternalError("Failed to parse index value ver");
     }
     if (index_value_ver.values_size() == 0) {
@@ -82,7 +86,7 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
 
     auto version = index_value_ver.values(0).version();
     auto index_value = build_index_value(index_value_ver.values(0));
-    if (_key == key) {
+    if (Slice(_key) == key) {
         if (_index_value_vers.empty()) {
             _max_rss_rowid = max_rss_rowid;
             _index_value_vers.emplace_front(version, index_value);
@@ -135,7 +139,7 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
         }
     } else {
         RETURN_IF_ERROR(flush());
-        _key = key;
+        _key.assign(key.data, key.size);
         _max_rss_rowid = max_rss_rowid;
         _index_value_vers.emplace_front(version, index_value);
     }

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.h
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.h
@@ -83,6 +83,11 @@ private:
     // data volume larger than pk_index_target_file_size.
     bool _enable_multiple_output_files = false;
     std::vector<TableBuilderWrapper> _output_builders;
+    // Scratch buffers reused across merge()/flush() to avoid per-key protobuf
+    // allocator churn. Cleared between calls so internal capacity is retained.
+    IndexValuesWithVerPB _merge_pb_scratch;
+    IndexValuesWithVerPB _flush_pb_scratch;
+    std::string _flush_serialized_scratch;
 };
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
+++ b/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
@@ -198,8 +198,7 @@ Status LakePersistentIndexParallelCompactTask::do_run() {
                                                    true /* generate multi outputs*/);
     while (merging_iter->Valid()) {
         const Slice cur_key = merging_iter->key();
-        if (!_seek_range.stop_key.empty() &&
-            options.comparator->Compare(cur_key, Slice(_seek_range.stop_key)) >= 0) {
+        if (!_seek_range.stop_key.empty() && options.comparator->Compare(cur_key, Slice(_seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
+++ b/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
@@ -197,9 +197,9 @@ Status LakePersistentIndexParallelCompactTask::do_run() {
                                                    _merge_base_level, _tablet_mgr, _metadata->id(),
                                                    true /* generate multi outputs*/);
     while (merging_iter->Valid()) {
-        const std::string& cur_key = merging_iter->key().to_string();
+        const Slice cur_key = merging_iter->key();
         if (!_seek_range.stop_key.empty() &&
-            options.comparator->Compare(Slice(cur_key), Slice(_seek_range.stop_key)) >= 0) {
+            options.comparator->Compare(cur_key, Slice(_seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }


### PR DESCRIPTION
## Why

`999_1gb_1_1tb` realtime-benchmark iter-005 on `branch-4.1 + #72434` (PR that hoists `IndexValuesWithVerPB` scratch buffers to KeyValueMerger members) shows the cluster has lost most of #72434's gains under sustained ingest:

| Metric | iter-003 | iter-005 (same build) |
|---|---:|---:|
| Upsert P99 | 1297 ms | 1531 ms (+18 %) |
| Throughput | 788 K rows/s | 586 K rows/s (-26 %) |
| Hottest CN steady-state CPU | 47-67 % | 91-99 % |

A 60 s `perf -F 99 -e cpu-clock` profile mid-test on the hottest CN (172.26.80.125) attributes 24 % of total CPU self-time to allocator work (`my_malloc 12.14 % + my_free 11.91 %`). Inclusive view, `cloud_native_pk_index_compact` thread family:

```
31.15 % start_thread
23.30 %  LakePersistentIndexParallelCompactTask::run
 19.90 %   do_run
   8.81 %    KeyValueMerger::merge
     4.70 %   KeyValueMerger::flush
   6.55 %    operator new (do_run direct)  -> cur_key.to_string()
   3.12 %    my_free      (do_run direct)  -> ~std::string
```

The `IndexValuesWithVerPB` lifecycle that #72434 fixed is *no longer* the dominant allocator consumer. Three remaining `Slice::to_string()` calls in the PK-index merge hot path now own most of the residual allocator self-time:

- `KeyValueMerger::merge` &mdash; converts the iterator-owned key/value slices into fresh `std::string`s before calling `ParseFromString` and the equality check.
- `LakePersistentIndexParallelCompactTask::do_run` &mdash; converts `merging_iter->key()` to a `std::string` only to feed it back into a `Slice`-based comparator.
- `LakePersistentIndex::merge_sstables` &mdash; same pattern.

Each call is a per-input-row heap allocation pair against an iterator whose slice storage is stable until the next `->Next()`.

## What this changes

Keep the iterator-owned `Slice` as-is in all three sites. The protobuf parse goes through `ParseFromArray(value.data, value.size)` to drop the per-call value copy; equality against the cached `_key` becomes `Slice(_key) == key`; the only remaining string write is the rare `_key.assign(key.data, key.size)` on the branch where the key actually changes (once per distinct output key, not once per input row).

```
3 files changed, 13 insertions(+), 9 deletions(-)
```

Public API and on-disk format are untouched.

## Risk

Minimal. Slice values reference iterator-owned storage that is stable until `iter_ptr->Next()`; the parse and comparison both finish before `Next()` is called. `Slice(const std::string&)` is the standard zero-copy adapter used throughout this codebase.

## Expected impact

Removes the dominant remaining per-key heap allocation pair on the parallel PK-index compaction thread. Profile-implied savings: ~10 % of total CPU on the hottest CN (the `do_run`-direct alloc/free pair) plus a slice of the 8.81 % `KeyValueMerger::merge` inclusive cost. Should restore iter-003's 788 K rows/s throughput and pull upsert P99 back below 1.3 s.

## Stacking

This PR is stacked on #72434 (commit cd20642 cherry-picked into this branch) so the cumulative deploy carries both wins.

## Test plan

- [ ] Iter-006 of auto-perf-opt my-rt-2 deploys this branch and re-runs `999_1gb_1_1tb` on the same cluster &mdash; success signals: (a) `my_malloc + my_free` self-time drops well below 24 %, (b) hottest-CN steady-state CPU drops back below 70 %, (c) upsert P99 ≤ 1300 ms, (d) throughput ≥ 750 K rows/s, (e) `cloud_native_pk_index_compact.queue_count` does not grow (rollback signal).
