### PR TITLE
[BugFix] clone: relax DB locks in TabletScheduler / TabletSchedCtx hot paths

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -864,9 +864,16 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         if (db == null) {
             throw new SchedException(Status.UNRECOVERABLE, "db " + dbId + " not exist");
         }
+        // Intensive path: IX on DB + WRITE on this one table. The mutation is
+        // strictly tablet-local (tablet.addReplica) on a single known table.
+        // Concurrent DROP TABLE / DROP DATABASE still take DB WRITE and conflict
+        // with our IX, so the surrounding correctness invariants (no clone task
+        // for a dropped table) are preserved.
+        // Lock acquisition is outside the try so the finally cannot try to unlock
+        // a never-acquired lock if lockTableWithIntensiveDbLock itself throws.
         Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tblId, LockType.WRITE);
         try {
-            locker.lockDatabase(db.getId(), LockType.WRITE);
             if (tabletHealthStatus == TabletHealthStatus.REPLICA_MISSING
                     || tabletHealthStatus == TabletHealthStatus.REPLICA_RELOCATING
                     || tabletHealthStatus == TabletHealthStatus.LOCATION_MISMATCH
@@ -921,7 +928,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 }
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tblId, LockType.WRITE);
         }
 
         this.state = State.RUNNING;
@@ -939,9 +946,14 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         if (db == null) {
             throw new SchedException(Status.UNRECOVERABLE, "db " + dbId + " does not exist");
         }
+        // Intensive path: IX on DB + WRITE on this one table. The mutation is
+        // tablet-local (tablet.addReplica) on a single known table; reads of
+        // partition / index / schema metadata are all on the same table.
+        // Lock acquisition is outside the try so the finally cannot try to unlock
+        // a never-acquired lock if lockTableWithIntensiveDbLock itself throws.
         Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tblId, LockType.WRITE);
         try {
-            locker.lockDatabase(db.getId(), LockType.WRITE);
             OlapTable olapTable = (OlapTable) globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(
                     globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(dbId),
                     tblId);
@@ -1005,7 +1017,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             state = State.RUNNING;
             return task;
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tblId, LockType.WRITE);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -742,11 +742,17 @@ public class TabletScheduler extends LeaderDaemon {
         }
 
         Pair<TabletHealthStatus, TabletSchedCtx.Priority> statusPair;
+        // Intensive path: IS on DB + READ on this one table. The whole critical
+        // section operates on a single tablet of one known table; we never iterate
+        // db.getTables() here. ALTER on this table still takes IX + table WRITE,
+        // which conflicts with our table READ, so the existing checks for
+        // OlapTableState.NORMAL / WAITING_STABLE remain race-free.
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        long lockTblId = tabletCtx.getTblId();
+        locker.lockTableWithIntensiveDbLock(db.getId(), lockTblId, LockType.READ);
         try {
             OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState()
-                    .getLocalMetastore().getTableIncludeRecycleBin(db, tabletCtx.getTblId());
+                    .getLocalMetastore().getTableIncludeRecycleBin(db, lockTblId);
             if (tbl == null) {
                 throw new SchedException(Status.UNRECOVERABLE, "tbl does not exist");
             }
@@ -877,7 +883,7 @@ public class TabletScheduler extends LeaderDaemon {
                         tabletCtx.getTablet().getReplicaInfos());
             }
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), lockTblId, LockType.READ);
         }
 
         handleTabletByTypeAndStatus(statusPair.first, tabletCtx, batchTask);
@@ -1119,9 +1125,11 @@ public class TabletScheduler extends LeaderDaemon {
         if (db == null) {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
+        // Lock acquisition is outside the try so the finally cannot try to unlock
+        // a never-acquired lock if lockTableWithIntensiveDbLock itself throws.
         Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tabletCtx.getTblId(), LockType.WRITE);
         try {
-            locker.lockTableWithIntensiveDbLock(db.getId(), tabletCtx.getTblId(), LockType.WRITE);
             checkMetaExist(tabletCtx);
             if (deleteBackendDropped(tabletCtx, force)
                     || deleteBadReplica(tabletCtx, force)
@@ -1360,9 +1368,11 @@ public class TabletScheduler extends LeaderDaemon {
         if (db == null) {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
+        // Lock acquisition is outside the try so the finally cannot try to unlock
+        // a never-acquired lock if lockTableWithIntensiveDbLock itself throws.
         Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(db.getId(), tabletCtx.getTblId(), LockType.WRITE);
         try {
-            locker.lockTableWithIntensiveDbLock(db.getId(), tabletCtx.getTblId(), LockType.WRITE);
             checkMetaExist(tabletCtx);
             List<Replica> replicas = tabletCtx.getReplicas();
             for (Replica replica : replicas) {
@@ -1582,14 +1592,11 @@ public class TabletScheduler extends LeaderDaemon {
                 continue;
             }
 
-            Table tbl;
-            Locker locker = new Locker();
-            locker.lockDatabase(db.getId(), LockType.READ);
-            try {
-                tbl = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
-            } finally {
-                locker.unLockDatabase(db.getId(), LockType.READ);
-            }
+            // Lock-free: db.getTable hits Database.idToTable which is a
+            // ConcurrentHashMap, so the get is thread-safe on its own. The result
+            // is only used for an instanceof OlapTable check below; a stale or
+            // null reference is acceptable.
+            Table tbl = db.getTable(tableId);
 
             if (!(tbl instanceof OlapTable)) {
                 newAlternativeTablets.add(schedCtx);
@@ -2094,15 +2101,37 @@ public class TabletScheduler extends LeaderDaemon {
                 continue;
             }
 
+            // Snapshot the table list under IS. getTablesIncludeRecycleBin reads
+            // db.getTables() and then recycleBin.getTables() in two separate steps;
+            // without a lock, a concurrent DROP TABLE (which moves a table from
+            // idToTable to recycleBin under DB WRITE) can interleave with these
+            // two reads and produce a list that contains the table twice (in both
+            // halves) or zero times (during the drop's transient gap). IS conflicts
+            // with DB WRITE so the pair becomes atomic with respect to drops, while
+            // still letting concurrent IX writers on other tables proceed.
+            List<Table> tables;
             Locker locker = new Locker();
-            locker.lockDatabase(db.getId(), LockType.READ);
+            locker.lockDatabase(db.getId(), LockType.INTENTION_SHARED);
             try {
-                for (Table table : localMetastore.getTablesIncludeRecycleBin(db)) {
-                    if (!table.isOlapTableOrMaterializedView()) {
-                        continue;
-                    }
+                tables = localMetastore.getTablesIncludeRecycleBin(db);
+            } finally {
+                locker.unLockDatabase(db.getId(), LockType.INTENTION_SHARED);
+            }
 
-                    OlapTable olapTbl = (OlapTable) table;
+            for (Table table : tables) {
+                if (!table.isOlapTableOrMaterializedView()) {
+                    continue;
+                }
+                OlapTable olapTbl = (OlapTable) table;
+
+                // Per-table READ for the partition / index walk: blocks concurrent
+                // ALTER (IX + table WRITE) on this specific table while letting
+                // unrelated tables in the same DB be ALTERed in parallel. The
+                // state re-check below happens under this lock since pre-filter
+                // would have read state without any lock.
+                long tableId = olapTbl.getId();
+                locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
+                try {
                     // Table not in NORMAL state is not allowed to do balance,
                     // because the change of tablet location can cause Schema change or rollup failed
                     if (olapTbl.getState() != OlapTable.OlapTableState.NORMAL) {
@@ -2133,9 +2162,9 @@ public class TabletScheduler extends LeaderDaemon {
                             }
                         }
                     }
+                } finally {
+                    locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
                 }
-            } finally {
-                locker.unLockDatabase(db.getId(), LockType.READ);
             }
         }
     }


### PR DESCRIPTION
TabletScheduler and TabletSchedCtx run continuously and held DB-wide READ / WRITE locks for what are really single-table operations.

Switch the eligible sites to the intensive-lock path:
  TabletScheduler.scheduleTablet                 DB READ  -> IS + READ
  TabletSchedCtx.createAndSendCloneTask          DB WRITE -> IX + WRITE
  TabletSchedCtx.createEmptyReplicaAndTask       DB WRITE -> IX + WRITE

For each: the critical section operates on one known table id (the TabletSchedCtx.tblId already in hand). The two clone-task paths ultimately only mutate one tablet via tablet.addReplica; ALTER on this table still takes IX + table WRITE which conflicts with our IX + table-WRITE / IS + table-READ, so the surrounding correctness invariants (no clone for a dropped table, no balance against a non- NORMAL state) are preserved.

TabletScheduler.getTabletBalanceTypes also walks db -> table -> partition -> sub-partition -> index hierarchies to gather rebalance hints, and used to hold DB READ for the entire walk of one DB. Refactor to:
  - Snapshot the table list under IS only. getTablesIncludeRecycleBin is two reads -- db.getTables() then recycleBin.getTables() -- so a concurrent DROP TABLE (which moves a table from idToTable to the recycle bin under DB WRITE) can interleave between those two reads and yield a list that contains the table twice (in both halves) or zero times (during the drop's transient gap). IS conflicts with DB WRITE so the pair stays atomic, while unlike DB READ it does not stall concurrent IX writers on other tables.
  - For each surviving OlapTable, take IS + table READ, re-check state == NORMAL under that lock (the pre-filter happens without a lock, so state may have transitioned), then walk that one table's partitions / indices. Concurrent ALTER on other tables in the same DB now proceeds in parallel.

TabletScheduler.filterUnschedulableTablets is now lock-free. Its critical section is a single Database.idToTable lookup -- a ConcurrentHashMap, so the get is thread-safe on its own. The result is only used for an instanceof OlapTable check; a stale or null reference under a concurrent DROP TABLE is acceptable here. We also inline the lookup as db.getTable(tableId) since we already hold the Database reference: LocalMetastore.getTable(dbId, tableId) is just getDb(dbId).getTable(tableId) and the extra getDb buys nothing here.

While here, fix the lock acquisition / try-finally idiom in five sites (the two TabletSchedCtx WRITE paths and three pre-existing TabletScheduler delete-replica paths): move lockTableWithIntensiveDbLock above the try so a thrown lock acquisition cannot leave the finally trying to unlock a never-acquired lock.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
