### PR TITLE
[Enhancement] Generate partial TopN for TopN over aggregate group keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.Explain;
 import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.cost.CostEstimate;
 import com.starrocks.sql.optimizer.cost.feature.PlanFeatures;
@@ -36,6 +37,7 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
@@ -1164,9 +1166,15 @@ public class QueryOptimizer extends Optimizer {
         if (agg.getPredicate() != null) {
             return false;
         }
+        // Native OLAP tables already have their own TopN/Aggregate split path. Only run this extra rewrite chain
+        // for non-OLAP scans, where producing a partial TopN here can later enable scan-side runtime filters.
+        if (!containsNonOlapScan(cur)) {
+            return false;
+        }
 
         List<ColumnRefOperator> groupingKeys = agg.getGroupingKeys();
-        return topN.getOrderByElements().stream().allMatch(ordering -> {
+        List<ColumnRefOperator> mappedOrderByColumns = new ArrayList<>();
+        for (Ordering ordering : topN.getOrderByElements()) {
             ColumnRefOperator colRef = ordering.getColumnRef();
             for (LogicalProjectOperator proj : projectChain) {
                 ScalarOperator mapped = proj.getColumnRefMap().get(colRef);
@@ -1175,8 +1183,19 @@ public class QueryOptimizer extends Optimizer {
                 }
                 colRef = (ColumnRefOperator) mapped;
             }
-            return groupingKeys.contains(colRef);
-        });
+            mappedOrderByColumns.add(colRef);
+        }
+        return groupingKeys.containsAll(mappedOrderByColumns) && mappedOrderByColumns.containsAll(groupingKeys);
+    }
+
+    private boolean containsNonOlapScan(OptExpression tree) {
+        Operator operator = tree.getOp();
+        if (operator instanceof LogicalScanOperator &&
+                !(operator instanceof LogicalOlapScanOperator) &&
+                !(operator instanceof LogicalViewScanOperator)) {
+            return true;
+        }
+        return tree.getInputs().stream().anyMatch(this::containsNonOlapScan);
     }
 
     private void prepareMetaOnlyOnce(OptExpression tree, TaskContext rootTaskContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -35,6 +35,7 @@ import com.starrocks.sql.optimizer.cost.feature.PlanFeatures;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
@@ -79,6 +80,7 @@ import com.starrocks.sql.optimizer.rule.transformation.PushDownPredicateRankingW
 import com.starrocks.sql.optimizer.rule.transformation.PushDownProjectLimitRule;
 import com.starrocks.sql.optimizer.rule.transformation.PushDownTopNBelowOuterJoinRule;
 import com.starrocks.sql.optimizer.rule.transformation.PushDownTopNBelowUnionRule;
+import com.starrocks.sql.optimizer.rule.transformation.PushDownTopNToPreAggRule;
 import com.starrocks.sql.optimizer.rule.transformation.PushLimitAndFilterToCTEProduceRule;
 import com.starrocks.sql.optimizer.rule.transformation.RemoveAggregationFromAggTable;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteGroupingSetsByCTERule;
@@ -92,6 +94,8 @@ import com.starrocks.sql.optimizer.rule.transformation.SkewJoinOptimizeRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitJoinORToUnionRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitScanORToUnionRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitTopNAggregateRule;
+import com.starrocks.sql.optimizer.rule.transformation.SplitTopNRule;
+import com.starrocks.sql.optimizer.rule.transformation.SplitTwoPhaseAggRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitWindowSkewToUnionRule;
 import com.starrocks.sql.optimizer.rule.transformation.UnionToValuesRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVCompensationPruneUnionRule;
@@ -155,6 +159,7 @@ import static com.starrocks.sql.optimizer.operator.OpRuleBit.OP_MV_TRANSPARENT_R
 import static com.starrocks.sql.optimizer.operator.OpRuleBit.OP_MV_UNION_REWRITE;
 import static com.starrocks.sql.optimizer.operator.OpRuleBit.OP_PARTITION_PRUNED;
 import static com.starrocks.sql.optimizer.rule.RuleType.TF_MATERIALIZED_VIEW;
+
 /**
  * QueryOptimizer's entrance class
  */
@@ -616,6 +621,11 @@ public class QueryOptimizer extends Optimizer {
         // Limit push must be after the column prune,
         // otherwise the Node containing limit may be prune
         scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.MERGE_LIMIT_RULES);
+        if (hasTopNOnGroupKeyAgg(tree)) {
+            scheduler.rewriteOnce(tree, rootTaskContext, SplitTopNRule.getInstance());
+            scheduler.rewriteOnce(tree, rootTaskContext, SplitTwoPhaseAggRule.getInstance());
+            scheduler.rewriteOnce(tree, rootTaskContext, PushDownTopNToPreAggRule.getInstance());
+        }
         scheduler.rewriteIterative(tree, rootTaskContext, new PushDownProjectLimitRule());
         scheduler.rewriteIterative(tree, rootTaskContext, new HoistHeavyCostExprsUponTopnRule());
 
@@ -873,7 +883,8 @@ public class QueryOptimizer extends Optimizer {
             if (pushAggFlag || pushDistinctBelowWindowFlag) {
                 deriveLogicalProperty(tree);
             }
-            // if join reorder is not done, we need to do it here, because we need the join's shape to better decide where to push down distinct.
+            // if join reorder is not done, we need to do it here, because we need the join's shape to better decide where to
+            // push down distinct.
             if (!joinReorder && context.getSessionVariable().isEnableJoinReorderBeforeDeduplicate()) {
                 logicalJoinReorder(tree, rootTaskContext);
             }
@@ -1112,6 +1123,51 @@ public class QueryOptimizer extends Optimizer {
         List<PhysicalOlapScanOperator> list = Lists.newArrayList();
         Utils.extractOperator(tree, list, op -> op instanceof PhysicalOlapScanOperator);
         return list;
+    }
+
+    private boolean hasTopNOnGroupKeyAgg(OptExpression tree) {
+        if (isTopNOnGroupKeyAgg(tree)) {
+            return true;
+        }
+        return tree.getInputs().stream().anyMatch(this::hasTopNOnGroupKeyAgg);
+    }
+
+    private boolean isTopNOnGroupKeyAgg(OptExpression tree) {
+        Operator operator = tree.getOp();
+        if (!(operator instanceof LogicalTopNOperator)) {
+            return false;
+        }
+        LogicalTopNOperator topN = (LogicalTopNOperator) operator;
+        if (!topN.hasLimit() || topN.hasOffset() || topN.getPredicate() != null || tree.getInputs().size() != 1) {
+            return false;
+        }
+
+        OptExpression aggExpression = skipLogicalProject(tree.inputAt(0));
+        Operator aggOperator = aggExpression.getOp();
+        if (!(aggOperator instanceof LogicalAggregationOperator)) {
+            return false;
+        }
+        LogicalAggregationOperator agg = (LogicalAggregationOperator) aggOperator;
+        if (agg.getPredicate() != null) {
+            return false;
+        }
+
+        return topN.getOrderByElements().stream()
+                .allMatch(ordering -> agg.getGroupingKeys().contains(ordering.getColumnRef()));
+    }
+
+    private OptExpression skipLogicalProject(OptExpression tree) {
+        OptExpression result = tree;
+        while (result.getInputs().size() == 1) {
+            switch (result.getOp().getOpType()) {
+                case LOGICAL_PROJECT:
+                    result = result.inputAt(0);
+                    break;
+                default:
+                    return result;
+            }
+        }
+        return result;
     }
 
     private void prepareMetaOnlyOnce(OptExpression tree, TaskContext rootTaskContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -628,11 +628,8 @@ public class QueryOptimizer extends Optimizer {
         // otherwise the Node containing limit may be prune
         scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.MERGE_LIMIT_RULES);
         SessionVariable sv = rootTaskContext.getOptimizerContext().getSessionVariable();
-        if (sv.getTopNPushDownAggMode() >= 0 &&
-                hasTopNOnGroupKeyAgg(tree, sv.getCboPushDownTopNLimit())) {
-            scheduler.rewriteOnce(tree, rootTaskContext, SplitTopNRule.getInstance());
-            scheduler.rewriteOnce(tree, rootTaskContext, SplitTwoPhaseAggRule.getInstance());
-            scheduler.rewriteOnce(tree, rootTaskContext, PushDownTopNToPreAggRule.getInstance());
+        if (sv.getTopNPushDownAggMode() >= 0) {
+            rewriteTopNOnGroupKeyAggForNonOlapScan(tree, 0, rootTaskContext, sv.getCboPushDownTopNLimit());
         }
         scheduler.rewriteIterative(tree, rootTaskContext, new PushDownProjectLimitRule());
         scheduler.rewriteIterative(tree, rootTaskContext, new HoistHeavyCostExprsUponTopnRule());
@@ -1133,11 +1130,21 @@ public class QueryOptimizer extends Optimizer {
         return list;
     }
 
-    private boolean hasTopNOnGroupKeyAgg(OptExpression tree, long maxLimit) {
+    private void rewriteTopNOnGroupKeyAggForNonOlapScan(OptExpression parent, int childIndex,
+                                                        TaskContext rootTaskContext, long maxLimit) {
+        OptExpression tree = parent.inputAt(childIndex);
         if (isTopNOnGroupKeyAgg(tree, maxLimit)) {
-            return true;
+            OptExpression subtreeAnchor = OptExpression.create(new LogicalTreeAnchorOperator(), tree);
+            scheduler.rewriteAtMostOnce(subtreeAnchor, rootTaskContext, SplitTopNRule.getInstance());
+            scheduler.rewriteAtMostOnce(subtreeAnchor, rootTaskContext, SplitTwoPhaseAggRule.getInstance());
+            scheduler.rewriteAtMostOnce(subtreeAnchor, rootTaskContext, PushDownTopNToPreAggRule.getInstance());
+            parent.getInputs().set(childIndex, subtreeAnchor.inputAt(0));
+            return;
         }
-        return tree.getInputs().stream().anyMatch(child -> hasTopNOnGroupKeyAgg(child, maxLimit));
+
+        for (int i = 0; i < tree.getInputs().size(); i++) {
+            rewriteTopNOnGroupKeyAggForNonOlapScan(tree, i, rootTaskContext, maxLimit);
+        }
     }
 
     private boolean isTopNOnGroupKeyAgg(OptExpression tree, long maxLimit) {
@@ -1155,7 +1162,11 @@ public class QueryOptimizer extends Optimizer {
         List<LogicalProjectOperator> projectChain = new ArrayList<>();
         OptExpression cur = tree.inputAt(0);
         while (cur.getInputs().size() == 1 && cur.getOp() instanceof LogicalProjectOperator) {
-            projectChain.add((LogicalProjectOperator) cur.getOp());
+            LogicalProjectOperator project = (LogicalProjectOperator) cur.getOp();
+            if (!isColumnRefProject(project)) {
+                return false;
+            }
+            projectChain.add(project);
             cur = cur.inputAt(0);
         }
 
@@ -1196,6 +1207,10 @@ public class QueryOptimizer extends Optimizer {
             return true;
         }
         return tree.getInputs().stream().anyMatch(this::containsNonOlapScan);
+    }
+
+    private boolean isColumnRefProject(LogicalProjectOperator project) {
+        return project.getColumnRefMap().values().stream().allMatch(ScalarOperator::isColumnRef);
     }
 
     private void prepareMetaOnlyOnce(OptExpression tree, TaskContext rootTaskContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -35,11 +35,14 @@ import com.starrocks.sql.optimizer.cost.feature.PlanFeatures;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.ivm.IvmRewriter;
 import com.starrocks.sql.optimizer.rule.join.JoinReorderFactory;
@@ -151,6 +154,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -621,7 +625,9 @@ public class QueryOptimizer extends Optimizer {
         // Limit push must be after the column prune,
         // otherwise the Node containing limit may be prune
         scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.MERGE_LIMIT_RULES);
-        if (hasTopNOnGroupKeyAgg(tree)) {
+        SessionVariable sv = rootTaskContext.getOptimizerContext().getSessionVariable();
+        if (sv.getTopNPushDownAggMode() >= 0 &&
+                hasTopNOnGroupKeyAgg(tree, sv.getCboPushDownTopNLimit())) {
             scheduler.rewriteOnce(tree, rootTaskContext, SplitTopNRule.getInstance());
             scheduler.rewriteOnce(tree, rootTaskContext, SplitTwoPhaseAggRule.getInstance());
             scheduler.rewriteOnce(tree, rootTaskContext, PushDownTopNToPreAggRule.getInstance());
@@ -1125,49 +1131,52 @@ public class QueryOptimizer extends Optimizer {
         return list;
     }
 
-    private boolean hasTopNOnGroupKeyAgg(OptExpression tree) {
-        if (isTopNOnGroupKeyAgg(tree)) {
+    private boolean hasTopNOnGroupKeyAgg(OptExpression tree, long maxLimit) {
+        if (isTopNOnGroupKeyAgg(tree, maxLimit)) {
             return true;
         }
-        return tree.getInputs().stream().anyMatch(this::hasTopNOnGroupKeyAgg);
+        return tree.getInputs().stream().anyMatch(child -> hasTopNOnGroupKeyAgg(child, maxLimit));
     }
 
-    private boolean isTopNOnGroupKeyAgg(OptExpression tree) {
+    private boolean isTopNOnGroupKeyAgg(OptExpression tree, long maxLimit) {
         Operator operator = tree.getOp();
         if (!(operator instanceof LogicalTopNOperator)) {
             return false;
         }
         LogicalTopNOperator topN = (LogicalTopNOperator) operator;
-        if (!topN.hasLimit() || topN.hasOffset() || topN.getPredicate() != null || tree.getInputs().size() != 1) {
+        if (!topN.hasLimit() || topN.getLimit() > maxLimit ||
+                topN.hasOffset() || topN.getPredicate() != null || tree.getInputs().size() != 1) {
             return false;
         }
 
-        OptExpression aggExpression = skipLogicalProject(tree.inputAt(0));
-        Operator aggOperator = aggExpression.getOp();
-        if (!(aggOperator instanceof LogicalAggregationOperator)) {
+        // Collect any project chain between TopN and Agg so we can map column refs through them.
+        List<LogicalProjectOperator> projectChain = new ArrayList<>();
+        OptExpression cur = tree.inputAt(0);
+        while (cur.getInputs().size() == 1 && cur.getOp() instanceof LogicalProjectOperator) {
+            projectChain.add((LogicalProjectOperator) cur.getOp());
+            cur = cur.inputAt(0);
+        }
+
+        if (!(cur.getOp() instanceof LogicalAggregationOperator)) {
             return false;
         }
-        LogicalAggregationOperator agg = (LogicalAggregationOperator) aggOperator;
+        LogicalAggregationOperator agg = (LogicalAggregationOperator) cur.getOp();
         if (agg.getPredicate() != null) {
             return false;
         }
 
-        return topN.getOrderByElements().stream()
-                .allMatch(ordering -> agg.getGroupingKeys().contains(ordering.getColumnRef()));
-    }
-
-    private OptExpression skipLogicalProject(OptExpression tree) {
-        OptExpression result = tree;
-        while (result.getInputs().size() == 1) {
-            switch (result.getOp().getOpType()) {
-                case LOGICAL_PROJECT:
-                    result = result.inputAt(0);
-                    break;
-                default:
-                    return result;
+        List<ColumnRefOperator> groupingKeys = agg.getGroupingKeys();
+        return topN.getOrderByElements().stream().allMatch(ordering -> {
+            ColumnRefOperator colRef = ordering.getColumnRef();
+            for (LogicalProjectOperator proj : projectChain) {
+                ScalarOperator mapped = proj.getColumnRefMap().get(colRef);
+                if (!(mapped instanceof ColumnRefOperator)) {
+                    return false;
+                }
+                colRef = (ColumnRefOperator) mapped;
             }
-        }
-        return result;
+            return groupingKeys.contains(colRef);
+        });
     }
 
     private void prepareMetaOnlyOnce(OptExpression tree, TaskContext rootTaskContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
@@ -19,15 +19,21 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.SortPhase;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class SplitTopNRule extends TransformationRule {
     private SplitTopNRule() {
@@ -55,12 +61,46 @@ public class SplitTopNRule extends TransformationRule {
                 String.format("limit(%d) + offset(%d) is too large and yields an overflow result(%d)", src.getLimit(),
                         src.getOffset(), src.getLimit() + src.getOffset()));
         long limit = src.getLimit() + src.getOffset();
+        LogicalTopNOperator finalSort = LogicalTopNOperator.builder().withOperator(src).setIsSplit(true).build();
+
+        Optional<OptExpression> splitThroughProject = splitThroughProject(input, src, finalSort, limit);
+        if (splitThroughProject.isPresent()) {
+            return Lists.newArrayList(splitThroughProject.get());
+        }
+
         LogicalTopNOperator partialSort = new LogicalTopNOperator(
                 src.getOrderByElements(), limit, Operator.DEFAULT_OFFSET, SortPhase.PARTIAL);
 
-        LogicalTopNOperator finalSort = LogicalTopNOperator.builder().withOperator(src).setIsSplit(true).build();
         OptExpression partialSortExpression = OptExpression.create(partialSort, input.getInputs());
         OptExpression finalSortExpression = OptExpression.create(finalSort, partialSortExpression);
         return Lists.newArrayList(finalSortExpression);
+    }
+
+    private Optional<OptExpression> splitThroughProject(OptExpression input, LogicalTopNOperator src,
+                                                        LogicalTopNOperator finalSort, long limit) {
+        if (input.getInputs().size() != 1 || !(input.inputAt(0).getOp() instanceof LogicalProjectOperator)) {
+            return Optional.empty();
+        }
+        OptExpression projectExpression = input.inputAt(0);
+        LogicalProjectOperator project = projectExpression.getOp().cast();
+        if (project.hasLimit() || projectExpression.getInputs().size() != 1) {
+            return Optional.empty();
+        }
+
+        List<Ordering> rewrittenOrderings = new ArrayList<>();
+        for (Ordering ordering : src.getOrderByElements()) {
+            ScalarOperator mapped = project.getColumnRefMap().get(ordering.getColumnRef());
+            if (!(mapped instanceof ColumnRefOperator)) {
+                return Optional.empty();
+            }
+            rewrittenOrderings.add(new Ordering((ColumnRefOperator) mapped, ordering.isAscending(),
+                    ordering.isNullsFirst()));
+        }
+
+        LogicalTopNOperator partialSort = new LogicalTopNOperator(
+                rewrittenOrderings, limit, Operator.DEFAULT_OFFSET, SortPhase.PARTIAL);
+        OptExpression partialSortExpression = OptExpression.create(partialSort, projectExpression.getInputs());
+        OptExpression projectOverPartialSort = OptExpression.create(project, partialSortExpression);
+        return Optional.of(OptExpression.create(finalSort, projectOverPartialSort));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
@@ -91,6 +91,9 @@ public class SplitTopNRule extends TransformationRule {
             if (proj.hasLimit()) {
                 return Optional.empty();
             }
+            if (!isColumnRefProject(proj)) {
+                return Optional.empty();
+            }
             projectChain.add(cur);
             cur = cur.inputAt(0);
         }
@@ -124,5 +127,9 @@ public class SplitTopNRule extends TransformationRule {
             rebuilt = OptExpression.create(projectChain.get(i).getOp(), rebuilt);
         }
         return Optional.of(rebuilt);
+    }
+
+    private boolean isColumnRefProject(LogicalProjectOperator project) {
+        return project.getColumnRefMap().values().stream().allMatch(ScalarOperator::isColumnRef);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.base.Preconditions;
@@ -76,31 +75,49 @@ public class SplitTopNRule extends TransformationRule {
         return Lists.newArrayList(finalSortExpression);
     }
 
+    // Pushes a PARTIAL TopN through one or more stacked identity-like Project nodes so that
+    // PushDownTopNToPreAggRule can later see TopN(PARTIAL) → Agg(GLOBAL) → Agg(LOCAL) directly.
     private Optional<OptExpression> splitThroughProject(OptExpression input, LogicalTopNOperator src,
                                                         LogicalTopNOperator finalSort, long limit) {
         if (input.getInputs().size() != 1 || !(input.inputAt(0).getOp() instanceof LogicalProjectOperator)) {
             return Optional.empty();
         }
-        OptExpression projectExpression = input.inputAt(0);
-        LogicalProjectOperator project = projectExpression.getOp().cast();
-        if (project.hasLimit() || projectExpression.getInputs().size() != 1) {
-            return Optional.empty();
-        }
 
-        List<Ordering> rewrittenOrderings = new ArrayList<>();
-        for (Ordering ordering : src.getOrderByElements()) {
-            ScalarOperator mapped = project.getColumnRefMap().get(ordering.getColumnRef());
-            if (!(mapped instanceof ColumnRefOperator)) {
+        // Collect the chain of consecutive, non-limiting Project nodes above the agg.
+        List<OptExpression> projectChain = new ArrayList<>();
+        OptExpression cur = input.inputAt(0);
+        while (cur.getInputs().size() == 1 && cur.getOp() instanceof LogicalProjectOperator) {
+            LogicalProjectOperator proj = cur.getOp().cast();
+            if (proj.hasLimit()) {
                 return Optional.empty();
             }
-            rewrittenOrderings.add(new Ordering((ColumnRefOperator) mapped, ordering.isAscending(),
-                    ordering.isNullsFirst()));
+            projectChain.add(cur);
+            cur = cur.inputAt(0);
         }
 
+        // Map each ordering column ref through the entire project chain (outermost → innermost).
+        List<Ordering> rewrittenOrderings = new ArrayList<>();
+        for (Ordering ordering : src.getOrderByElements()) {
+            ColumnRefOperator colRef = ordering.getColumnRef();
+            for (OptExpression projectExpr : projectChain) {
+                LogicalProjectOperator proj = projectExpr.getOp().cast();
+                ScalarOperator mapped = proj.getColumnRefMap().get(colRef);
+                if (!(mapped instanceof ColumnRefOperator)) {
+                    return Optional.empty();
+                }
+                colRef = (ColumnRefOperator) mapped;
+            }
+            rewrittenOrderings.add(new Ordering(colRef, ordering.isAscending(), ordering.isNullsFirst()));
+        }
+
+        // Place PARTIAL TopN below all projects, then rebuild the chain bottom-up.
+        // Result: TopN(FINAL,split) → P1 → ... → Pn → TopN(PARTIAL) → <rest>
         LogicalTopNOperator partialSort = new LogicalTopNOperator(
                 rewrittenOrderings, limit, Operator.DEFAULT_OFFSET, SortPhase.PARTIAL);
-        OptExpression partialSortExpression = OptExpression.create(partialSort, projectExpression.getInputs());
-        OptExpression projectOverPartialSort = OptExpression.create(project, partialSortExpression);
-        return Optional.of(OptExpression.create(finalSort, projectOverPartialSort));
+        OptExpression rebuilt = OptExpression.create(partialSort, cur);
+        for (int i = projectChain.size() - 1; i >= 0; i--) {
+            rebuilt = OptExpression.create(projectChain.get(i).getOp(), rebuilt);
+        }
+        return Optional.of(OptExpression.create(finalSort, rebuilt));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
@@ -75,8 +75,8 @@ public class SplitTopNRule extends TransformationRule {
         return Lists.newArrayList(finalSortExpression);
     }
 
-    // Pushes a PARTIAL TopN through one or more stacked identity-like Project nodes so that
-    // PushDownTopNToPreAggRule can later see TopN(PARTIAL) → Agg(GLOBAL) → Agg(LOCAL) directly.
+    // Pushes split TopN through one or more stacked identity-like Project nodes so that
+    // PushDownTopNToPreAggRule can later see TopN(PARTIAL) -> Agg(GLOBAL) -> Agg(LOCAL) directly.
     private Optional<OptExpression> splitThroughProject(OptExpression input, LogicalTopNOperator src,
                                                         LogicalTopNOperator finalSort, long limit) {
         if (input.getInputs().size() != 1 || !(input.inputAt(0).getOp() instanceof LogicalProjectOperator)) {
@@ -95,7 +95,7 @@ public class SplitTopNRule extends TransformationRule {
             cur = cur.inputAt(0);
         }
 
-        // Map each ordering column ref through the entire project chain (outermost → innermost).
+        // Map each ordering column ref through the entire project chain (outermost -> innermost).
         List<Ordering> rewrittenOrderings = new ArrayList<>();
         for (Ordering ordering : src.getOrderByElements()) {
             ColumnRefOperator colRef = ordering.getColumnRef();
@@ -110,14 +110,19 @@ public class SplitTopNRule extends TransformationRule {
             rewrittenOrderings.add(new Ordering(colRef, ordering.isAscending(), ordering.isNullsFirst()));
         }
 
-        // Place PARTIAL TopN below all projects, then rebuild the chain bottom-up.
-        // Result: TopN(FINAL,split) → P1 → ... → Pn → TopN(PARTIAL) → <rest>
+        // Place the split TopN pair below all projects, then rebuild the chain bottom-up.
+        // Result: P1 -> ... -> Pn -> TopN(FINAL,split) -> TopN(PARTIAL) -> <rest>
+        //
+        // A split final TopN must consume a partial TopN directly when building plan fragments.
+        LogicalTopNOperator rewrittenFinalSort = LogicalTopNOperator.builder().withOperator(finalSort)
+                .setOrderByElements(rewrittenOrderings)
+                .build();
         LogicalTopNOperator partialSort = new LogicalTopNOperator(
                 rewrittenOrderings, limit, Operator.DEFAULT_OFFSET, SortPhase.PARTIAL);
-        OptExpression rebuilt = OptExpression.create(partialSort, cur);
+        OptExpression rebuilt = OptExpression.create(rewrittenFinalSort, OptExpression.create(partialSort, cur));
         for (int i = projectChain.size() - 1; i >= 0; i--) {
             rebuilt = OptExpression.create(projectChain.get(i).getOp(), rebuilt);
         }
-        return Optional.of(OptExpression.create(finalSort, rebuilt));
+        return Optional.of(rebuilt);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergTopNRuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergTopNRuntimeFilterTest.java
@@ -38,17 +38,17 @@ public class IcebergTopNRuntimeFilterTest extends ConnectorPlanTestBase {
         FeConstants.runningUnitTest = originalRunningUnitTest;
     }
 
-    // ORDER BY grouping key — basic case.
+    // ORDER BY grouping key - basic case.
     @Test
     public void testTopNAggOrderByGroupKeyGeneratesRuntimeFilter() throws Exception {
         String sql = "SELECT id, SUM(c1) FROM iceberg0.unpartitioned_db.t_numeric " +
                 "GROUP BY id ORDER BY id LIMIT 10";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "     probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (1: id)");
+                "     - filter_id = 0, probe_expr = (<slot 1> 1: id)");
     }
 
-    // ORDER BY grouping key via alias — the column mapping must be threaded through the Project
+    // ORDER BY grouping key via alias - the column mapping must be threaded through the Project
     // that column pruning inserts between TopN and Agg.  This is the main regression target for
     // the alias/project fix: without the fix isTopNOnGroupKeyAgg() returns false for this shape
     // and no runtime filter is generated.
@@ -59,10 +59,10 @@ public class IcebergTopNRuntimeFilterTest extends ConnectorPlanTestBase {
         String plan = getVerboseExplain(sql);
         // The filter must probe the underlying 'id' column, not the alias 'k'.
         assertContains(plan, "     probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (1: id)");
+                "     - filter_id = 0, probe_expr = (<slot 1> 1: id)");
     }
 
-    // ORDER BY aggregate result — should NOT generate a pre-agg TopN runtime filter because
+    // ORDER BY aggregate result - should NOT generate a pre-agg TopN runtime filter because
     // the ordering column depends on the aggregation output, not a grouping key.
     @Test
     public void testTopNAggOrderByAggregateResultNoRuntimeFilter() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergTopNRuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergTopNRuntimeFilterTest.java
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class IcebergTopNRuntimeFilterTest extends ConnectorPlanTestBase {
+    private static boolean originalRunningUnitTest;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        ConnectorPlanTestBase.beforeClass();
+        originalRunningUnitTest = FeConstants.runningUnitTest;
+        FeConstants.runningUnitTest = true;
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        FeConstants.runningUnitTest = originalRunningUnitTest;
+    }
+
+    @Test
+    public void testTopNAggOrderByGroupKeyGeneratesRuntimeFilter() throws Exception {
+        String sql = "SELECT id, SUM(c1) FROM iceberg0.unpartitioned_db.t_numeric " +
+                "GROUP BY id ORDER BY id LIMIT 10";
+        String plan = getVerboseExplain(sql);
+
+        assertContains(plan, "IcebergScanNode");
+        assertContains(plan, "2:TOP-N");
+        assertContains(plan, "build runtime filters:\n" +
+                "  |  - filter_id = 0, build_expr = (<slot 1> 1: id), remote = false");
+        assertContains(plan, "probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (<slot 1> 1: id)");
+    }
+
+    @Test
+    public void testTopNAggOrderByAggregateResultDoesNotUsePreAggTopNRuntimeFilter() throws Exception {
+        String sql = "SELECT id, SUM(c1) AS revenue FROM iceberg0.unpartitioned_db.t_numeric " +
+                "GROUP BY id ORDER BY revenue LIMIT 10";
+        String plan = getVerboseExplain(sql);
+
+        assertContains(plan, "IcebergScanNode");
+        assertNotContains(plan, "probe runtime filters");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergTopNRuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergTopNRuntimeFilterTest.java
@@ -19,6 +19,10 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+// Tests for the TopN pre-agg runtime filter optimization on Iceberg (non-OLAP) scans.
+// The optimization is triggered by PushDownTopNToPreAggRule when:
+//   TopN(PARTIAL) -> Agg(GLOBAL) -> Agg(LOCAL) -> IcebergScan
+// which causes AggregationNode.buildRuntimeFilters() to push a TOPN_FILTER to the scan.
 public class IcebergTopNRuntimeFilterTest extends ConnectorPlanTestBase {
     private static boolean originalRunningUnitTest;
 
@@ -34,27 +38,37 @@ public class IcebergTopNRuntimeFilterTest extends ConnectorPlanTestBase {
         FeConstants.runningUnitTest = originalRunningUnitTest;
     }
 
+    // ORDER BY grouping key — basic case.
     @Test
     public void testTopNAggOrderByGroupKeyGeneratesRuntimeFilter() throws Exception {
         String sql = "SELECT id, SUM(c1) FROM iceberg0.unpartitioned_db.t_numeric " +
                 "GROUP BY id ORDER BY id LIMIT 10";
         String plan = getVerboseExplain(sql);
-
-        assertContains(plan, "IcebergScanNode");
-        assertContains(plan, "2:TOP-N");
-        assertContains(plan, "build runtime filters:\n" +
-                "  |  - filter_id = 0, build_expr = (<slot 1> 1: id), remote = false");
-        assertContains(plan, "probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (<slot 1> 1: id)");
+        assertContains(plan, "     probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (1: id)");
     }
 
+    // ORDER BY grouping key via alias — the column mapping must be threaded through the Project
+    // that column pruning inserts between TopN and Agg.  This is the main regression target for
+    // the alias/project fix: without the fix isTopNOnGroupKeyAgg() returns false for this shape
+    // and no runtime filter is generated.
     @Test
-    public void testTopNAggOrderByAggregateResultDoesNotUsePreAggTopNRuntimeFilter() throws Exception {
+    public void testTopNAggOrderByAliasedGroupKeyGeneratesRuntimeFilter() throws Exception {
+        String sql = "SELECT id AS k, SUM(c1) FROM iceberg0.unpartitioned_db.t_numeric " +
+                "GROUP BY id ORDER BY k LIMIT 10";
+        String plan = getVerboseExplain(sql);
+        // The filter must probe the underlying 'id' column, not the alias 'k'.
+        assertContains(plan, "     probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (1: id)");
+    }
+
+    // ORDER BY aggregate result — should NOT generate a pre-agg TopN runtime filter because
+    // the ordering column depends on the aggregation output, not a grouping key.
+    @Test
+    public void testTopNAggOrderByAggregateResultNoRuntimeFilter() throws Exception {
         String sql = "SELECT id, SUM(c1) AS revenue FROM iceberg0.unpartitioned_db.t_numeric " +
                 "GROUP BY id ORDER BY revenue LIMIT 10";
         String plan = getVerboseExplain(sql);
-
-        assertContains(plan, "IcebergScanNode");
         assertNotContains(plan, "probe runtime filters");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.google.common.collect.Lists;
@@ -272,7 +271,6 @@ class OrderByTest extends PlanTestBase {
                 "  1:AGGREGATE (update finalize)\n" +
                 "  |  output: sum(1: v1)\n" +
                 "  |  group by: 2: v2, 3: v3");
-
 
         sql = "select abs(t0.v1), abs(t1.v1) from t0, t0_not_null t1 order by t1.v2";
         plan = getFragmentPlan(sql);
@@ -736,7 +734,6 @@ class OrderByTest extends PlanTestBase {
         list.add(Arguments.of("select * from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select t0.* from t0 order by t0.v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select distinct t0.* from t0 order by t0.v1", "order by: <slot 1> 1: v1 ASC"));
-
 
         list.add(Arguments.of("select *, v1 from t0  order by v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select *, v1 from t0  order by abs(v1)", "order by: <slot 4> 4: abs ASC"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -601,6 +601,12 @@ class OrderByTest extends PlanTestBase {
         assertContains(plan, "     probe runtime filters:\n" +
                 "     - filter_id = 0, probe_expr = (1: t1a)");
 
+        // TopN -> Project -> AGG should still split partial TopN through the project.
+        sql = "select t1a as k, count(*) from test_all_type_not_null group by t1a order by k limit 10;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "     probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (1: t1a)");
+
         // shouldn't generate filter for agg column
         sql = "select count(*) cnt from test_all_type_not_null group by t1a order by cnt limit 10;";
         plan = getVerboseExplain(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -605,6 +605,11 @@ class OrderByTest extends PlanTestBase {
         assertContains(plan, "     probe runtime filters:\n" +
                 "     - filter_id = 0, probe_expr = (1: t1a)");
 
+        // ORDER BY is only a subset of GROUP BY keys, so don't insert TopN between local/global agg.
+        sql = "select t1a from test_all_type_not_null group by t1a, t1b order by t1a limit 10;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "streaming preaggregation mode: force_preaggregation");
+
         // shouldn't generate filter for agg column
         sql = "select count(*) cnt from test_all_type_not_null group by t1a order by cnt limit 10;";
         plan = getVerboseExplain(sql);


### PR DESCRIPTION
## Why I'm Doing

Some TopN-over-aggregate queries on external tables cannot produce TopN runtime filters because the plan may not contain a partial TopN before `PushDownTopNToPreAggRule` runs. This affects queries like `GROUP BY key ORDER BY key LIMIT n`, where pushing a partial TopN below the aggregate can enable scan-side runtime filtering.

## What I'm Doing

This change lets the existing TopN split path handle `TopN -> Project -> Aggregate` when the order-by columns can be mapped through the project to aggregate group keys. The optimizer now re-runs the existing split/topn-preagg rule chain for generic TopN-over-group-key aggregates, not just HDFS-family scans. It also adds plan tests for both native and Iceberg tables and leaves `PushDownTopNToPreAggRule` unchanged.

## Tradeoff

`SplitTopNAggregateRule` is an OLAP-specific and more aggressive optimization. It targets queries where `ORDER BY` depends on aggregate outputs, and rewrites the plan into a duplicated scan plus TopN subplan joined back to the original aggregation path. https://github.com/StarRocks/starrocks/pull/64760

This change targets a different pattern: `TopN` over aggregate group keys on non-OLAP scans. For this case, we only need to produce a partial TopN so that the existing `PushDownTopNToPreAggRule` can push it through the two-phase aggregate and enable scan-side runtime filters.

The new rewrite chain is therefore gated to non-OLAP scans. Native OLAP tables keep using their existing TopN/Aggregate optimization path, which avoids changing established OLAP plan baselines while still filling the missing partial-TopN path for external tables.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
