### PR TITLE
[auto-perf-opt] Log BRPC server-side queue time on slow publish_version

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -197,6 +197,9 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                                       ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
+    // Server-side BRPC queue time: latency from RPC arrival on this server to handler entry.
+    // Used to attribute the FE-measured publish_rpc cost vs BE handler cost gap.
+    int64_t brpc_queue_us = cntl->latency_us();
 
     if (!request->has_base_version()) {
         cntl->SetFailed("missing base version");
@@ -511,12 +514,13 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
     auto cost = butil::gettimeofday_us() - start_ts;
     auto is_slow = cost >= config::lake_publish_version_slow_log_ms * 1000;
     if (config::lake_enable_publish_version_trace_log && is_slow) {
-        LOG(INFO) << "Published txns=" << get_txn_ids_string(request) << ". cost=" << cost << "us\n"
+        LOG(INFO) << "Published txns=" << get_txn_ids_string(request) << ". cost=" << cost
+                  << "us brpc_queue_us=" << brpc_queue_us << "\n"
                   << trace->DumpToString();
     } else if (is_slow) {
         LOG(INFO) << "Published txns=" << get_txn_ids_string(request)
                   << ". tablets=" << JoinInts(request->tablet_ids(), ",") << " cost=" << cost
-                  << "us, trace: " << trace->MetricsAsJSON();
+                  << "us brpc_queue_us=" << brpc_queue_us << ", trace: " << trace->MetricsAsJSON();
     }
     TEST_SYNC_POINT("LakeServiceImpl::publish_version:return");
 }


### PR DESCRIPTION
## Summary

Adds \`brpc_queue_us=<n>\` to the existing slow-publish log line in \`LakeServiceImpl::publish_version\`. The value comes from \`cntl->latency_us()\` captured at handler entry, which BRPC documents as the time from RPC arrival on the server to handler dispatch. When non-trivial, it points at server-side queueing as the cause of slow publishes.

This is **diagnostic instrumentation, not a fix.** It costs nothing on the steady-state path (the existing slow-log line is only emitted when the publish exceeds the slow threshold; the new field is appended to it).

## Why this is needed

Recent perf work on the \`999_1gb_1_1tb\` realtime-benchmark template surfaced a **1.4 s gap** between FE-measured \`publish rpc cost\` (max 2 610 ms across 148 K txns) and BE-measured per-RPC handler cost (max 1 205 ms across 894 K publishes), localized to coordinator BE 172.26.80.128 (84 % of slow events despite carrying only 16.7 % of workload).

Three hypotheses for the gap:
1. BRPC server-side queueing on the destination BE
2. FE BRPC client serialization or response-send path
3. Coordinator-BE outgoing BRPC client

Without \`cntl->latency_us()\` exposed in the log, those three are indistinguishable from offline traces. This PR makes them distinguishable: \`brpc_queue_us ≈ 1-3 s\` on slow events ⇒ hypothesis 1; \`brpc_queue_us ≈ 0\` ⇒ hypotheses 2 or 3.

## Change

\`be/src/service/service_be/lake_service.cpp\` — capture \`brpc_queue_us\` at handler entry, append to existing slow-publish log line. 4 LOC + 2 LOC for log formatting. No behaviour change outside the slow path.

## Test plan

- [x] Compiles cleanly
- [ ] Deploy + run benchmark + parse \`brpc_queue_us\` from be.INFO slow-publish log lines (this PR's purpose)
- [ ] Confirm log volume on steady-state path is unchanged (no slow-publish events ⇒ no new log lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
