### PR TITLE
[auto-perf-opt] Log per-phase breakdown of slow Utils.publishVersionBatch

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -135,6 +135,7 @@ public class Utils {
                                            ComputeResource computeResource,
                                            Map<Long, Long> tabletRowNum)
             throws NoAliveBackendException, RpcException {
+        long entryMs = System.currentTimeMillis();
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         if (!warehouseManager.isResourceAvailable(computeResource)) {
             LOG.warn("publish version operation should be successful even if the warehouse is not exist, " +
@@ -146,7 +147,8 @@ public class Utils {
         List<Long> rebuildPindexTabletIds = new ArrayList<>();
         Map<ComputeNode, PublishTabletsInfo> nodeToPublishTabletsInfo = processTablets(tablets, computeResource,
                 warehouseManager, rebuildPindexTabletIds, baseVersion, newVersion);
-        
+        long processTabletsEndMs = System.currentTimeMillis();
+
         List<Future<PublishVersionResponse>> responseList = Lists.newArrayListWithCapacity(nodeToPublishTabletsInfo.size());
         List<ComputeNode> nodeList = Lists.newArrayListWithCapacity(nodeToPublishTabletsInfo.size());
         for (Map.Entry<ComputeNode, PublishTabletsInfo> entry : nodeToPublishTabletsInfo.entrySet()) {
@@ -168,27 +170,39 @@ public class Utils {
             responseList.add(future);
             nodeList.add(node);
         }
+        long submitEndMs = System.currentTimeMillis();
 
-        for (int i = 0; i < responseList.size(); i++) {
-            try {
-                PublishVersionResponse response = responseList.get(i).get();
-                if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
-                    throw new RpcException("Fail to publish version for tablets " + response.failedTablets + ": " +
-                            response.status.errorMsgs.get(0));
-                }
-                if (compactionScores != null && response != null && response.compactionScores != null) {
-                    compactionScores.putAll(response.compactionScores);
-                }
-                if (tabletRanges != null && response != null && response.tabletRanges != null) {
-                    for (Map.Entry<Long, TabletRangePB> entry : response.tabletRanges.entrySet()) {
-                        tabletRanges.put(entry.getKey(), TabletRange.fromProto(entry.getValue()));
+        try {
+            for (int i = 0; i < responseList.size(); i++) {
+                try {
+                    PublishVersionResponse response = responseList.get(i).get();
+                    if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
+                        throw new RpcException("Fail to publish version for tablets " + response.failedTablets + ": " +
+                                response.status.errorMsgs.get(0));
                     }
+                    if (compactionScores != null && response != null && response.compactionScores != null) {
+                        compactionScores.putAll(response.compactionScores);
+                    }
+                    if (tabletRanges != null && response != null && response.tabletRanges != null) {
+                        for (Map.Entry<Long, TabletRangePB> entry : response.tabletRanges.entrySet()) {
+                            tabletRanges.put(entry.getKey(), TabletRange.fromProto(entry.getValue()));
+                        }
+                    }
+                    if (baseVersion == 1 && tabletRowNum != null && response != null && response.tabletRowNums != null) {
+                        tabletRowNum.putAll(response.tabletRowNums);
+                    }
+                } catch (Exception e) {
+                    throw new RpcException(nodeList.get(i).getHost(), e.getMessage());
                 }
-                if (baseVersion == 1 && tabletRowNum != null && response != null && response.tabletRowNums != null) {
-                    tabletRowNum.putAll(response.tabletRowNums);
-                }
-            } catch (Exception e) {
-                throw new RpcException(nodeList.get(i).getHost(), e.getMessage());
+            }
+        } finally {
+            long endMs = System.currentTimeMillis();
+            long totalMs = endMs - entryMs;
+            if (totalMs >= 500) {
+                LOG.warn("Slow publishVersionBatch nodes={} tablets={} total_ms={} process_tablets_ms={} " +
+                                "rpc_submit_ms={} rpc_wait_ms={}",
+                        nodeToPublishTabletsInfo.size(), tablets.size(), totalMs,
+                        processTabletsEndMs - entryMs, submitEndMs - processTabletsEndMs, endMs - submitEndMs);
             }
         }
 


### PR DESCRIPTION
## Summary
Add a 4-LOC WARN log line in `com.starrocks.lake.Utils.publishVersionBatch` that fires only when total wall-clock ≥ 500 ms, breaking the call into three sub-phases:
- `process_tablets_ms` — `processTablets(...)`: tablet-to-node grouping under `WarehouseManager` / `GlobalStateMgr` lookups.
- `rpc_submit_ms` — the per-node submit loop (`BrpcProxy.getLakeService` + async `lakeService.publishVersion`).
- `rpc_wait_ms` — `responseList.get(i).get()` loop = `max(BE response time)` including client-side response receipt.

Steady-state publishes (< 500 ms) log nothing — log volume on the hot path is unchanged.

## Motivation
PR #72557 (iter-025) added per-partition phase logging in `PublishVersionDaemon.publishPartition` and proved **100 % of slow publishPartition wall time lives in `brpc_ms`** (= `Utils.publishVersion(...)`) — none in executor-acquire, lock-wait, or fe-prep. Across iter-026's 20-min benchmark this fired on **10,448 in-test events** (p99 = 10.9 s, max = 25.3 s), with 75 % concentrated in the first 3 min after a fresh deploy.

Combined with iter-024's evidence (BRPC server-side queueing < 0.1 % of slow latency; max BE handler cost on slow events = 200-300 ms while FE wall = 1.5-25 s), the bottleneck localizes inside `publishVersionBatch` itself but the existing measurement window cannot tell us **which of its three sub-phases dominates**.

This patch surfaces the dominant sub-phase the next time the cold-start storm reproduces, so the actual fix can be targeted (per the program's "trace over guess" rule).

## Performance
- 4 `System.currentTimeMillis()` calls per `publishVersionBatch` invocation (+ one threshold branch).
- One `LOG.warn` only on ≥ 500 ms tails. No change to BRPC, no change to thread-pool config, no change to existing log fields.

## Test plan
- [ ] Build via TSP and deploy to my-rt-2 cluster.
- [ ] Re-run the 20-min `999_1gb_1_1tb` benchmark; trigger a fresh-deploy cold-start storm.
- [ ] `grep "Slow publishVersionBatch" fe.log*`; bin events by which sub-phase carries ≥ 50 % of `total_ms`.
- [ ] Cross-correlate with iter-025's `Slow publishPartition` lines (matching by timestamp + node count) to confirm the same events surface in both logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
