### PR TITLE
[auto-perf-opt] Parallelise delete-file reads in LakePersistentIndex::load_dels

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -897,23 +897,77 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     ASSIGN_OR_RETURN(auto pk_encoding_type, rowset->tablet_schema()->primary_key_encoding_type_or_error());
     MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type));
-    // Iterate all del files and insert into index.
-    for (int del_idx = 0; del_idx < rowset->metadata().del_files_size(); ++del_idx) {
-        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+
+    const int num_del_files = rowset->metadata().del_files_size();
+    // Phase 1 (parallel): read each delete file's bytes from object storage and deserialize
+    // them into a per-file pk column. Index mutations stay sequential below to preserve
+    // erase ordering. Reads dominate cold-start cost (8 files × ~OSS_RTT each = seconds);
+    // parallelising them collapses that wall-clock without changing on-disk semantics.
+    std::vector<MutableColumnPtr> pkcs(num_del_files);
+    std::mutex shared_mutex;
+    Status shared_status;
+    auto read_one = [&](int del_idx) {
         const auto& del = rowset->metadata().del_files(del_idx);
         RandomAccessFileOptions ropts;
         if (!del.encryption_meta().empty()) {
-            ASSIGN_OR_RETURN(ropts.encryption_info, KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
+            auto info_or = KeyCache::instance().unwrap_encryption_meta(del.encryption_meta());
+            if (!info_or.ok()) {
+                std::lock_guard<std::mutex> l(shared_mutex);
+                shared_status.update(info_or.status());
+                return;
+            }
+            ropts.encryption_info = std::move(info_or.value());
         }
-        ASSIGN_OR_RETURN(auto read_file,
-                         fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name())));
-        ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
-        const auto* data = reinterpret_cast<const uint8_t*>(read_buffer.data());
-        const auto* end = data + read_buffer.size();
-        // serialize to column
+        auto rf_or = fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name()));
+        if (!rf_or.ok()) {
+            std::lock_guard<std::mutex> l(shared_mutex);
+            shared_status.update(rf_or.status());
+            return;
+        }
+        auto buf_or = (*rf_or)->read_all();
+        if (!buf_or.ok()) {
+            std::lock_guard<std::mutex> l(shared_mutex);
+            shared_status.update(buf_or.status());
+            return;
+        }
         auto pkc = pk_column->clone();
-        using Serd = serde::ColumnArraySerde;
-        RETURN_IF_ERROR(Serd::deserialize(data, end, pkc.get()));
+        const auto* data = reinterpret_cast<const uint8_t*>(buf_or->data());
+        const auto* end = data + buf_or->size();
+        auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
+        if (!st.ok()) {
+            std::lock_guard<std::mutex> l(shared_mutex);
+            shared_status.update(st);
+            return;
+        }
+        pkcs[del_idx] = std::move(pkc);
+    };
+
+    std::unique_ptr<ThreadPoolToken> token;
+    if (config::enable_pk_index_parallel_execution && num_del_files > 1) {
+        token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
+    }
+    for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
+        if (token) {
+            auto st = token->submit_func([&read_one, del_idx]() { read_one(del_idx); });
+            if (!st.ok()) {
+                read_one(del_idx);
+            }
+        } else {
+            read_one(del_idx);
+        }
+    }
+    if (token) {
+        token->wait();
+    }
+    RETURN_IF_ERROR(shared_status);
+
+    // Phase 2 (sequential): order-dependent index mutations. replay_erase mutates index state
+    // observed by later files' get(); keep iteration order identical to the original.
+    for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
+        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+        const auto& del = rowset->metadata().del_files(del_idx);
+        auto& pkc = pkcs[del_idx];
         // We can't insert delete operation to index directly, because some delete operation is
         // older than current item, and we need to igore these delete operations.
         std::vector<IndexValue> found_values(pkc->size(), IndexValue(NullIndexValue));


### PR DESCRIPTION
## Summary

Cuts cold-start PK index load wall-clock by parallelising delete-file reads in `LakePersistentIndex::load_dels`. Index mutations stay sequential to preserve erase ordering; only the I/O moves into a parallel pre-fetch.

## Problem

On shared-data clusters with `file_bundling=true`, every publish call routes through `Utils.aggregatePublishVersion` → BE `LakeServiceImpl::aggregate_publish_version`, which fans out internal `publish_version` BRPCs to each destination BE and waits on a `BThreadCountDownLatch`. The aggregator's wait_resp is bounded by the slowest inner handler.

A 20-min benchmark on a fresh deploy (auto-perf-opt my-rt-2 iter-027, 999_1gb_1_1tb workload, 6 BEs, 1 TB + 999 × 1 GB primary-key tables) reproduced the cold-start storm:

- 1,891 inner publish_version handlers ≥ 1 s; max **20.16 s**
- 1,832 / 1,891 (97 %) in the first 4 minutes after deploy
- Aggregate `wait_resp_p99 max`: 5–20 s across 6 CNs (matches FE-observed pub_rpc latency)
- Cluster CPU / pool utilisation NOT saturated — concurrency- not resource-bound

The slowest event's trace breakdown (cost = 20.16 s, tablet 31325402):

```
primary_index_load_latency_us:        18.47 s
├── pindex_init_us (parallel SST opens):  8.26 s   17 SSTs / 4 filesets / 603 MB
└── pindex_load_from_lake_tablet_us:     10.21 s
    ├── rebuild_index_del_cost_us:        9.81 s   ← THIS PR
    ├── rebuild_index_segment_cost_us:    0.29 s
    └── rebuild_get_segment_iterator:     0.11 s
```

`rebuild_index_del_cost_us` covered 8 delete files processed sequentially. Each iteration did a synchronous `read_all()` from object storage, then deserialised and replayed. With 8 files × ~1.2 s each, OSS round-trips dominated and there was no concurrency.

## Fix

Two-phase load_dels:

1. **Parallel** read + deserialise all delete files into per-file pk columns. Submitted through the existing `pk_index_execution_thread_pool` (shared with `_open_sstables_parallel`); gated by `enable_pk_index_parallel_execution` so it can be turned off dynamically. Single-file inputs skip the token entirely. Submit failure falls back to inline execution.
2. **Sequential** `get` → `generate_filter` → `replay_erase` per file in original order. `replay_erase` mutates index state observed by later files' `get()`, so this MUST stay ordered. Per-file logic is unchanged from the original.

Trace counters (`rebuild_index_del_cost_us`, `rebuild_index_del_cnt`) preserved. No change to encryption handling, schema, or filter semantics.

## Expected Impact

For the iter-027 max-tablet trace:

| metric | before | after (estimate) |
|--------|--------|-----------------|
| `rebuild_index_del_cost_us` | 9.81 s | ~1.5–2.5 s |
| `primary_index_load_latency_us` | 18.47 s | ~10–11 s |
| publish_version cost | 20.16 s | ~12 s |
| upsert max | 20 s | < 12 s |

Steady-state envelope (post-iter-021: tput 862-917 K, P99 629-728 ms, max 2.85-5.27 s) is not on this critical path and should be unchanged.

## Test plan
- [ ] Run auto-perf-opt my-rt-2 iter-028: deploy this PR via `tsp build submit --pr <N>`, fresh-deploy benchmark, parse BE Published trace for `rebuild_index_del_cost_us` distribution.
- [ ] Compare slow-event count and max in the cold-start window (03:33-03:38 equivalent) against iter-027.
- [ ] Verify steady-state P99 / throughput unchanged (no regression in the warm path).
- [ ] Verify 0 errors and no test flakiness from concurrent file reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
