### PR TITLE
[auto-perf-opt] Instrument Table::MultiGet t3 sub-phases (filter / block-read / search)

### DIFF
--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -292,6 +292,12 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
     int64_t multiget_t1_us = 0;
     int64_t multiget_t2_us = 0;
     int64_t multiget_t3_us = 0;
+    int64_t multiget_t3_filter_us = 0;
+    int64_t multiget_t3_block_read_us = 0;
+    int64_t multiget_t3_block_read_miss_us = 0;
+    int64_t multiget_t3_search_us = 0;
+    int64_t multiget_block_read_miss_cnt = 0;
+    ReadIOStat* stat = options.stat;
     size_t i = 0;
     bool founded = false;
     for (auto it = begin; it != end; ++it, ++i) {
@@ -314,13 +320,29 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
             Slice handle_value = iiter->value();
             FilterBlockReader* filter = rep_->filter;
             BlockHandle handle;
-            if (filter != nullptr && handle.DecodeFrom(&handle_value).ok() &&
-                !filter->KeyMayMatch(handle.offset(), k)) {
+            int64_t tf_start = butil::gettimeofday_us();
+            bool filter_skip = filter != nullptr && handle.DecodeFrom(&handle_value).ok() &&
+                               !filter->KeyMayMatch(handle.offset(), k);
+            int64_t tf_end = butil::gettimeofday_us();
+            multiget_t3_filter_us += tf_end - tf_start;
+            if (filter_skip) {
                 // Not found
                 sst_bloom_filter_rows++;
             } else {
+                uint32_t miss_before = stat ? stat->block_cnt_from_file : 0;
+                int64_t tb_start = butil::gettimeofday_us();
                 current_block_itr_ptr.reset(BlockReader(this, options, iiter->value()));
+                int64_t tb_end = butil::gettimeofday_us();
+                int64_t br_us = tb_end - tb_start;
+                multiget_t3_block_read_us += br_us;
+                if (stat != nullptr && stat->block_cnt_from_file > miss_before) {
+                    // Cache miss path: BlockReader did an actual file (OSS) read.
+                    multiget_t3_block_read_miss_us += br_us;
+                    multiget_block_read_miss_cnt++;
+                }
                 ASSIGN_OR_RETURN(founded, search_in_block(k, &(*values)[i], current_block_itr_ptr.get()));
+                int64_t ts_end = butil::gettimeofday_us();
+                multiget_t3_search_us += ts_end - tb_end;
             }
         }
         int64_t t3 = butil::gettimeofday_us();
@@ -337,6 +359,11 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
     TRACE_COUNTER_INCREMENT("multiget_t1_us", multiget_t1_us);
     TRACE_COUNTER_INCREMENT("multiget_t2_us", multiget_t2_us);
     TRACE_COUNTER_INCREMENT("multiget_t3_us", multiget_t3_us);
+    TRACE_COUNTER_INCREMENT("multiget_t3_filter_us", multiget_t3_filter_us);
+    TRACE_COUNTER_INCREMENT("multiget_t3_block_read_us", multiget_t3_block_read_us);
+    TRACE_COUNTER_INCREMENT("multiget_t3_block_read_miss_us", multiget_t3_block_read_miss_us);
+    TRACE_COUNTER_INCREMENT("multiget_t3_search_us", multiget_t3_search_us);
+    TRACE_COUNTER_INCREMENT("multiget_block_read_miss_cnt", multiget_block_read_miss_cnt);
     return s;
 }
 


### PR DESCRIPTION
## Why

`my-rt-2` 999_1gb_1_1tb realtime-benchmark cold-start publish-version traces at iter-028 (TSP build 1416, `branch-4.1-b0a9851`, this branch's parent + iter-028's parallel `LakePersistentIndex::load_dels`) showed:

- **upsert max 25 s** (8.3× over the 3 s primary goal); cold-start storm in first ~30 s after fresh deploy.
- Among 1882 BE Published events with cost ≥ 1 s, **`multi_get` ≥ 50 % of cost in 71.8 %** of them. `pidx_load ≥ 70 %` only 33.5 %. `multi_get` is the dominant cold-start cost.
- Top-10 slowest events: `multi_get_us` 4-7 s out of 17-18 s total handler cost.

`Table::MultiGet` already emits coarse `multiget_t1_us / t2_us / t3_us`. `t3_us` is the section that does the bloom-filter check, `BlockReader()` (cache-hit OR OSS-read), and `search_in_block()`. We can't tell from existing counters whether the cold tail is OSS-RTT-bound, bandwidth-bound, bloom-filter-CPU-bound, or in-memory-search-bound.

The iter-015 `Table::Open` tail-prefetch attempt (#72476 v4) **regressed** P99 by +78 % because the same-shape OSS path turned out to be bandwidth-bound, not RTT-bound. We must NOT propose another `MultiGet` parallelisation without first measuring which subcomponent dominates.

## What this PR does

Splits `multiget_t3_us` into three phases inside the existing per-key loop in `Table::MultiGet`:

| New counter                          | Measures                                                                 |
|--------------------------------------|--------------------------------------------------------------------------|
| `multiget_t3_filter_us`              | bloom-filter `KeyMayMatch()` time                                        |
| `multiget_t3_block_read_us`          | total `BlockReader()` wall-time (cache hit + miss)                       |
| `multiget_t3_block_read_miss_us`     | `BlockReader()` wall-time only on cache miss (= actual OSS read)         |
| `multiget_t3_search_us`              | `search_in_block()` time on the freshly-loaded block                     |
| `multiget_block_read_miss_cnt`       | number of cache-miss BlockReader calls                                   |

Cache-miss detection uses the existing `ReadIOStat::block_cnt_from_file` counter delta around the `BlockReader` call — no new mutexes / atomics.

All counters emit via existing `TRACE_COUNTER_INCREMENT` so they appear in BE Published trace logs alongside `multi_get_us`, `pidx_load`, `pinit_sst`, etc.

## Behaviour

- No change to data path. Five extra `butil::gettimeofday_us()` calls per key-iter (~few hundred ns each) are dwarfed by even the cheapest OSS round-trip this is meant to measure.
- Counters are zero-initialised; emitted unconditionally at end of `MultiGet`. Safe when `options.stat == nullptr` (cache-miss timing falls back to 0; total `block_read_us` still works).

## How iter-030 will use it

Decision tree for the next code change:

| Dominant signature on slow ≥ 1 s events | Action |
|------------------------------------------|--------|
| `block_read_miss_us / multi_get_us > 70 %` AND avg miss size small | OSS RTT bound — batch / coalesce miss reads (mind the iter-015 trap: bandwidth could regress) |
| `block_read_miss_us / multi_get_us > 70 %` AND avg miss size large | OSS bandwidth bound — reduce per-key block fetch volume (smaller blocks, smarter index) |
| `filter_us` dominant | Bloom-filter CPU — trim filter bits or skip for small key sets |
| `search_us` dominant | In-memory CPU — investigate Block iterator cost in cold path |

## Files changed

- `be/src/storage/sstable/table.cpp` — only file touched. +29 / -2.

No test changes; this is pure observability.