### PR TITLE
[auto-perf-opt] Parallelize get_from_sstables across filesets

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -36,6 +36,7 @@
 #include "storage/sstable/merger.h"
 #include "storage/sstable/options.h"
 #include "storage/sstable/table_builder.h"
+#include "util/thread.h"
 #include "util/trace.h"
 
 namespace starrocks::lake {
@@ -375,7 +376,17 @@ Status LakePersistentIndex::get_from_sstables(size_t n, const Slice* keys, Index
     // (preserving the original rbegin->rend ordering semantics). The set_difference shortcut is
     // dropped, but in cold-start most candidate keys are filtered out cheaply by per-fileset bloom
     // filters, so the extra work is negligible compared to the wall-time win.
-    if (config::enable_pk_index_parallel_execution && _sstable_filesets.size() > 1) {
+    //
+    // Skip the parallel path when this thread is itself a worker of
+    // pk_index_execution_thread_pool — submitting tasks to + waiting on the same pool from
+    // one of its workers triggers ThreadPool::check_not_pool_thread_unlocked() and aborts.
+    // This happens on the parallel-publish upsert path, where ParallelPublishContext::token
+    // lives on pk_index_execution_thread_pool and the caller IS a worker of that pool. The
+    // sync caller paths (init/erase/non-ctx upsert) are unaffected and still parallelize.
+    auto* cur_thread = Thread::current_thread();
+    const bool on_pk_index_execution_pool =
+            (cur_thread != nullptr && cur_thread->name() == "cloud_native_pk_index_execution");
+    if (config::enable_pk_index_parallel_execution && _sstable_filesets.size() > 1 && !on_pk_index_execution_pool) {
         const size_t F = _sstable_filesets.size();
         std::vector<std::vector<IndexValue>> local_values(F, std::vector<IndexValue>(n));
         std::vector<KeyIndexSet> local_founds(F);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -368,6 +368,60 @@ Status LakePersistentIndex::get_from_sstables(size_t n, const Slice* keys, Index
     if (key_indexes->empty() || _sstable_filesets.empty()) {
         return Status::OK();
     }
+    // On cold-start, each fileset's multi_get is dominated by sequential cache-miss block reads
+    // from object storage (~99 ms p50 per miss). Walking _sstable_filesets sequentially compounds
+    // the latency. With the flag enabled, dispatch each fileset's multi_get on the existing
+    // pk_index_execution_thread_pool and merge results so the most-recent fileset's value wins
+    // (preserving the original rbegin->rend ordering semantics). The set_difference shortcut is
+    // dropped, but in cold-start most candidate keys are filtered out cheaply by per-fileset bloom
+    // filters, so the extra work is negligible compared to the wall-time win.
+    if (config::enable_pk_index_parallel_execution && _sstable_filesets.size() > 1) {
+        const size_t F = _sstable_filesets.size();
+        std::vector<std::vector<IndexValue>> local_values(F, std::vector<IndexValue>(n));
+        std::vector<KeyIndexSet> local_founds(F);
+        const KeyIndexSet snapshot = *key_indexes;
+        std::mutex status_mu;
+        Status shared_status;
+        auto token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
+        size_t idx = 0;
+        for (auto iter = _sstable_filesets.rbegin(); iter != _sstable_filesets.rend(); ++iter, ++idx) {
+            auto* fset = iter->get();
+            auto* lv = local_values[idx].data();
+            auto* lf = &local_founds[idx];
+            const KeyIndexSet* snap = &snapshot;
+            Trace* trace = Trace::CurrentTrace();
+            auto submit_st = token->submit_func([fset, keys, snap, version, lv, lf, &shared_status, &status_mu, trace]() {
+                ADOPT_TRACE(trace);
+                auto s = fset->multi_get(keys, *snap, version, lv, lf);
+                if (!s.ok()) {
+                    std::lock_guard<std::mutex> lg(status_mu);
+                    shared_status.update(s);
+                }
+            });
+            if (!submit_st.ok()) {
+                // Fallback: run inline so we still produce a result for this fileset.
+                auto s = fset->multi_get(keys, snapshot, version, lv, lf);
+                if (!s.ok()) {
+                    std::lock_guard<std::mutex> lg(status_mu);
+                    shared_status.update(s);
+                }
+            }
+        }
+        token->wait();
+        RETURN_IF_ERROR(shared_status);
+        // Merge in rbegin->rend order (most-recent fileset first wins).
+        KeyIndexSet found_master;
+        for (size_t i = 0; i < F; ++i) {
+            for (auto k_idx : local_founds[i]) {
+                if (found_master.insert(k_idx).second) {
+                    values[k_idx] = local_values[i][k_idx];
+                }
+            }
+        }
+        set_difference(key_indexes, found_master);
+        return Status::OK();
+    }
     for (auto iter = _sstable_filesets.rbegin(); iter != _sstable_filesets.rend(); ++iter) {
         KeyIndexSet found_key_indexes;
         RETURN_IF_ERROR((*iter)->multi_get(keys, *key_indexes, version, values, &found_key_indexes));

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -391,14 +391,15 @@ Status LakePersistentIndex::get_from_sstables(size_t n, const Slice* keys, Index
             auto* lf = &local_founds[idx];
             const KeyIndexSet* snap = &snapshot;
             Trace* trace = Trace::CurrentTrace();
-            auto submit_st = token->submit_func([fset, keys, snap, version, lv, lf, &shared_status, &status_mu, trace]() {
-                ADOPT_TRACE(trace);
-                auto s = fset->multi_get(keys, *snap, version, lv, lf);
-                if (!s.ok()) {
-                    std::lock_guard<std::mutex> lg(status_mu);
-                    shared_status.update(s);
-                }
-            });
+            auto submit_st =
+                    token->submit_func([fset, keys, snap, version, lv, lf, &shared_status, &status_mu, trace]() {
+                        ADOPT_TRACE(trace);
+                        auto s = fset->multi_get(keys, *snap, version, lv, lf);
+                        if (!s.ok()) {
+                            std::lock_guard<std::mutex> lg(status_mu);
+                            shared_status.update(s);
+                        }
+                    });
             if (!submit_st.ok()) {
                 // Fallback: run inline so we still produce a result for this fileset.
                 auto s = fset->multi_get(keys, snapshot, version, lv, lf);


### PR DESCRIPTION
## Bottleneck (iter-030 of auto-perf-opt my-rt-2 run)

Cold-start cache-miss block reads from OSS dominate the publish-version critical path on shared-data PK tables.

### Evidence (1,046,417 Published events parsed across 6 BEs over 20-min fresh-deploy benchmark)

- Slow >= 1s events: **3,578 (0.34%)**
- Of those, 77.1% are multi_get-dominated (2,759 events)
- On multi_get-dominated slow events:
  - `multiget_t3_us / multi_get_us` p50 = **99.8%** (t3 IS multi_get)
  - `multiget_t3_block_read_miss_us / multiget_t3_us` p50 = **99.9%** (block-read on cache miss IS t3)
  - `multiget_t3_filter_us / multiget_t3_us` p50 = 0.0% (bloom filter eval is negligible)
  - `multiget_t3_search_us / multiget_t3_us` p50 = 0.0% (in-block search is negligible)
- Dominant t3 sub-component: `block_read_miss_oss` in **100%** of multi_get-dominated slow events
- Per-miss latency: p50 = **99 ms** / p95 = 307 ms / max = 710 ms (high — OSS first-byte service latency)
- Per-event miss count: p50 = 20, p95 = 37, max = 435

The new t3_* counters were introduced by #72577 specifically to disambiguate this matrix. They show that the cost is purely OSS service latency on cache-miss block reads, not filter CPU, in-memory search, or bandwidth saturation.

### Code path

`LakePersistentIndex::get_from_sstables` walks `_sstable_filesets` SEQUENTIALLY (rbegin -> rend). Each fileset's `multi_get` does its own sequential cache-miss block reads. With ~5-20 filesets per tablet on a fresh deploy and ~99 ms per miss, total publish wall time stacks to 5-25s.

## Change

When `config::enable_pk_index_parallel_execution` is true (existing flag, default true) and there are multiple filesets, dispatch each fileset's `multi_get` on the existing `pk_index_execution_thread_pool` and merge results so the most-recent fileset's value wins (preserves the original rbegin -> rend ordering semantics).

The `set_difference` shortcut is dropped inside the parallel path. On cold-start most candidate keys are rejected cheaply by per-fileset bloom filters, so the extra work is small compared with the wall-time win from overlapping OSS first-byte latency.

## Risk

Risk-managed against the iter-015 trap (large-tail prefetch parallelised on `Table::Open` turning out to be bandwidth-bound on a 2 MB Bloom filter): individual block reads here are small (~32 KB; per-event total ~640 KB for p50 miss-count of 20), so concurrency overlaps OSS service latency rather than saturating bandwidth. Behind the same flag as the earlier parallel-load_dels work (#72574), so a single toggle reverts if regression appears.

## Expected impact (999_1gb_1_1tb fresh-deploy)

- `multi_get_us` p50 on slow events: ~1.84 s -> < 0.5 s
- BE Published cost p99: 7.81 s -> < 2.5 s
- Upsert max latency: 25.9 s -> aim < 10 s
- Steady-state P99 / throughput: unchanged (slow events are 0.34% of all publishes; steady state already hits cache)

A/B will be measured in iter-031 with this PR built and deployed.