### PR TITLE
[UT] No need to generate result in record mode for uncheck stmt

### DIFF
--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1153,7 +1153,7 @@ class StarrocksSQLApiLib(object):
 
             old_this_res_len = len(this_res)
             actual_res, actual_res_log, var, order = self.execute_single_statement(
-                _each_cmd, _cmd_id_str, record_mode, this_res, var_key=exec_id, conn=conn
+                _each_cmd, _cmd_id_str, record_mode and not uncheck, this_res, var_key=exec_id, conn=conn
             )
 
             if record_mode:

--- a/test/test_sql_cases.py
+++ b/test/test_sql_cases.py
@@ -471,7 +471,9 @@ Start to run: %s
                     uncheck = True
                     sql = sql[len(sr_sql_lib.UNCHECK_FLAG) :]
 
-                actual_res, actual_res_log, var, order = self.execute_single_statement(sql, sql_id, record_mode)
+                actual_res, actual_res_log, var, order = self.execute_single_statement(
+                    sql, sql_id, record_mode and not uncheck
+                )
 
                 if not record_mode and not uncheck:
                     # check mode only work in validating mode
@@ -561,7 +563,7 @@ Start to run: %s
                             run_stmt = run_stmt[len(sr_sql_lib.UNCHECK_FLAG):]
 
                         actual_res, actual_res_log, var, order = self.execute_single_statement(
-                            run_stmt, sql_id, True
+                            run_stmt, sql_id, not uncheck
                         )
 
                     # --- remaining combinations: execute & verify against recorded results ---


### PR DESCRIPTION
## Why I'm doing:

The `[UC]` flag is meant to indicate that a statement's result should not be checked. Today it only suppresses validation in `-v` mode; in `-r` (record) mode the framework still writes a `-- result: ... -- !result` block for `[UC]` statements. Whether the result block ends up in the R file actually depends on whether the SQL happens to match a pattern in `test/lib/skip.py::skip_res_cmd`, which is unrelated to `[UC]`. The result is inconsistent and noisy R files: some `[UC]` lines have results, others don't, for no reason the test author can predict.

## What I'm doing:

No need to generate result in record mode for uncheck stmt

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
