### PR TITLE
[auto-perf-opt] iter-041 stack: LakeDelvecLoader fix on top of validated stack

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -490,6 +490,27 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 // without same-pool re-entrance.
 CONF_mInt32(pk_index_inner_io_threadpool_max_threads, "0");
 CONF_mInt32(pk_index_inner_io_threadpool_size, "1048576");
+// Threadpool for splitting a single PersistentIndexSstable::multi_get into key-chunk tasks
+// so the per-Table::MultiGet sequential cache-miss block-read loop runs on multiple threads.
+// MUST be a different pool from pk_index_inner_io_thread_pool: get_from_sstables already
+// dispatches per-fileset multi_get on inner_io, and re-entering inner_io from inside
+// PersistentIndexSstable::multi_get would deadlock the worker via ThreadPool::wait().
+// Default size is num_cores * 4 because each chunk task is dominated by sleeping on OSS
+// HTTP responses; sizing by cores alone leaves available HTTP concurrency unused.
+CONF_mInt32(pk_index_chunk_io_threadpool_max_threads, "0");
+CONF_mInt32(pk_index_chunk_io_threadpool_size, "1048576");
+// Master kill-switch for the per-multi_get key-chunk parallelism. Tunable so the
+// optimization can be disabled at runtime if it turns pathological under load (e.g.
+// pool starvation, pathological cache contention).
+CONF_mBool(enable_pk_index_parallel_chunk_multi_get, "true");
+// Minimum number of keys in one PersistentIndexSstable::multi_get for the chunk-parallel
+// path to engage. Below this, run the legacy sequential path so we don't pay open-file
+// + dispatch overhead for tiny lookups.
+CONF_mInt32(pk_index_parallel_chunk_min_keys, "32");
+// Target keys per chunk. Effective chunk count = clamp(ceil(N/target), 1, max_chunks).
+CONF_mInt32(pk_index_parallel_chunk_target_keys, "64");
+// Hard upper bound on chunks per multi_get to protect the chunk_io pool's queue.
+CONF_mInt32(pk_index_parallel_chunk_max_chunks, "16");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -484,6 +484,12 @@ CONF_mInt32(pk_index_parallel_execution_threadpool_size, "1048576");
 CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
+// Threadpool for inner cache-miss block reads inside LakePersistentIndex::get_from_sstables.
+// Separate from pk_index_execution_thread_pool so parallel-publish workers (which themselves
+// run on pk_index_execution_thread_pool) can submit fileset multi_get tasks here and wait
+// without same-pool re-entrance.
+CONF_mInt32(pk_index_inner_io_threadpool_max_threads, "0");
+CONF_mInt32(pk_index_inner_io_threadpool_size, "1048576");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -511,6 +511,13 @@ CONF_mInt32(pk_index_parallel_chunk_min_keys, "32");
 CONF_mInt32(pk_index_parallel_chunk_target_keys, "64");
 // Hard upper bound on chunks per multi_get to protect the chunk_io pool's queue.
 CONF_mInt32(pk_index_parallel_chunk_max_chunks, "16");
+// Threadpool dedicated to LakePersistentIndex::_open_sstables_parallel. Each task does
+// 4 sequential OSS round-trips (footer + index + metaindex + filter blocks) inside
+// Table::Open, so it is purely I/O-bound. Splitting it off pk_index_execution_thread_pool
+// avoids the cold-start head-of-chain throttle where ~150 SST-open tasks queue behind a
+// 16-thread (num_cores/2) pool that is also shared with parallel-publish workers.
+CONF_mInt32(pk_index_sst_open_threadpool_max_threads, "0");
+CONF_mInt32(pk_index_sst_open_threadpool_size, "1048576");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -526,6 +526,13 @@ CONF_Int32(be_http_port, "8040");
 CONF_Alias(be_http_port, webserver_port);
 // Number of http workers in BE
 CONF_Int32(be_http_num_workers, "48");
+// When true, each HTTP worker creates its own listening socket with
+// SO_REUSEPORT so the kernel load-balances incoming connections in-kernel,
+// instead of all workers epoll-waiting on a single shared listen fd and
+// thundering-herd-racing on accept(). Eliminates the kernel
+// inet_csk_accept / native_queued_spin_lock_slowpath contention that
+// dominates HTTP-server CPU when be_http_num_workers is large.
+CONF_Bool(enable_http_server_so_reuseport, "true");
 // Period to update rate counters and sampling counters in ms.
 CONF_mInt32(periodic_counter_update_period_ms, "500");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -303,7 +303,14 @@ CONF_mInt64(column_dictionary_key_size_threshold, "0");
 CONF_mInt32(memory_limitation_per_thread_for_schema_change, "2");
 CONF_mDouble(memory_ratio_for_sorting_schema_change, "0.8");
 
-CONF_mInt32(update_cache_expire_sec, "360");
+// Time-based eviction window for the PK-index / update-state caches in
+// `UpdateManager`. The previous 6-minute default was aggressive enough that any
+// brief lull (idle gap, deploy, traffic dip) drained the entire `_index_cache`,
+// causing every tablet to cold-load its PK index in parallel on resume — a
+// thunder-herd that saturates local block-cache disk and inflates publish
+// latency by 10×+. Memory pressure is already handled separately by
+// `UpdateManager::evict_cache`, so a longer time bound here cannot cause OOM.
+CONF_mInt32(update_cache_expire_sec, "7200");
 CONF_mInt32(file_descriptor_cache_clean_interval, "3600");
 CONF_mInt32(disk_stat_monitor_interval, "5");
 CONF_mInt32(profile_report_interval, "30");

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -49,6 +49,13 @@
 #include <sstream>
 #include <utility>
 
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+
+#include "common/config.h"
 #include "common/logging.h"
 #include "http/http_channel.h"
 #include "http/http_handler.h"
@@ -106,6 +113,54 @@ static int on_connection(struct evhttp_request* req, void* param) {
     return 0;
 }
 
+// Create a TCP listening socket with SO_REUSEADDR + SO_REUSEPORT, bound to
+// `point`. Returns -1 on any failure (and `errno` is set). When SO_REUSEPORT
+// is set on every listener for the same {addr, port}, the kernel load-balances
+// new connections across them — workers no longer thundering-herd on a single
+// shared listen fd's accept queue lock.
+static int listen_with_reuseport(const butil::EndPoint& point) {
+#ifndef SO_REUSEPORT
+    errno = ENOTSUP;
+    return -1;
+#else
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    int yes = 1;
+    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) != 0) {
+        int saved = errno;
+        ::close(fd);
+        errno = saved;
+        return -1;
+    }
+    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)) != 0) {
+        int saved = errno;
+        ::close(fd);
+        errno = saved;
+        return -1;
+    }
+    sockaddr_in addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(point.port);
+    addr.sin_addr = point.ip;
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        int saved = errno;
+        ::close(fd);
+        errno = saved;
+        return -1;
+    }
+    if (::listen(fd, 65535) != 0) {
+        int saved = errno;
+        ::close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+#endif
+}
+
 EvHttpServer::EvHttpServer(int port, int num_workers) : _port(port), _num_workers(num_workers), _real_port(0) {
     _host = BackendOptions::get_service_bind_address();
     DCHECK_GT(_num_workers, 0);
@@ -127,8 +182,25 @@ EvHttpServer::~EvHttpServer() {
 Status EvHttpServer::start() {
     // bind to
     RETURN_IF_ERROR(_bind());
+
+    // Resolve the bind endpoint once, on the main thread, for per-worker
+    // SO_REUSEPORT listeners. _bind() has already populated _real_port (incl.
+    // the port==0 auto-assign case).
+    butil::EndPoint listen_point;
+    bool reuseport_enabled = false;
+#ifdef SO_REUSEPORT
+    if (config::enable_http_server_so_reuseport) {
+        if (butil::str2endpoint(_host.c_str(), _real_port, &listen_point) == 0) {
+            reuseport_enabled = true;
+        } else {
+            LOG(WARNING) << "Failed to resolve listen endpoint " << _host << ":" << _real_port
+                         << " for SO_REUSEPORT mode; falling back to shared-fd accept";
+        }
+    }
+#endif
+
     for (int i = 0; i < _num_workers; ++i) {
-        auto worker = [this]() {
+        auto worker = [this, listen_point, reuseport_enabled, i]() {
             struct event_base* base = event_base_new();
             if (base == nullptr) {
                 LOG(WARNING) << "Couldn't create an event_base.";
@@ -149,7 +221,30 @@ Status EvHttpServer::start() {
             _https.push_back(http);
             pthread_rwlock_unlock(&_rw_lock);
 
-            auto res = evhttp_accept_socket(http, _server_fd);
+            // Worker 0 reuses _server_fd from _bind(); workers 1..N-1 create
+            // their own SO_REUSEPORT listeners so the kernel load-balances
+            // accepts in-kernel rather than waking all workers on every
+            // connection (the cause of native_queued_spin_lock_slowpath
+            // contention seen in perf when be_http_num_workers is large).
+            int worker_fd = _server_fd;
+            if (reuseport_enabled && i > 0) {
+                int new_fd = listen_with_reuseport(listen_point);
+                if (new_fd < 0) {
+                    LOG(WARNING) << "Worker " << i << ": SO_REUSEPORT listen failed, "
+                                 << "falling back to shared fd: " << errno_to_string(errno);
+                } else if (butil::make_non_blocking(new_fd) < 0) {
+                    LOG(WARNING) << "Worker " << i << ": failed to set non-blocking on reuseport fd, "
+                                 << "falling back to shared fd: " << errno_to_string(errno);
+                    ::close(new_fd);
+                } else {
+                    pthread_rwlock_wrlock(&_rw_lock);
+                    _worker_fds.push_back(new_fd);
+                    pthread_rwlock_unlock(&_rw_lock);
+                    worker_fd = new_fd;
+                }
+            }
+
+            auto res = evhttp_accept_socket(http, worker_fd);
             if (res < 0) {
                 LOG(WARNING) << "evhttp accept socket failed"
                              << ", error:" << errno_to_string(errno);
@@ -175,6 +270,12 @@ void EvHttpServer::stop() {
 
     // shutdown the socket to wake up the epoll_wait
     shutdown(_server_fd, SHUT_RDWR);
+    // Per-worker SO_REUSEPORT listeners need their own shutdown, otherwise
+    // their event_base_dispatch will not unblock from epoll_wait and join()
+    // will hang.
+    for (int fd : _worker_fds) {
+        ::shutdown(fd, SHUT_RDWR);
+    }
 }
 
 void EvHttpServer::join() {
@@ -186,6 +287,10 @@ void EvHttpServer::join() {
 
     // close the socket at last
     close(_server_fd);
+    for (int fd : _worker_fds) {
+        ::close(fd);
+    }
+    _worker_fds.clear();
 
     // free the evhttp and event_base
     for (auto http : _https) {
@@ -220,7 +325,23 @@ Status EvHttpServer::_bind() {
         if (rc == 0) {
             _real_port = ntohs(addr.sin_port);
         }
+    } else {
+        _real_port = _port;
     }
+#ifdef SO_REUSEPORT
+    // Mark _server_fd as SO_REUSEPORT before any worker tries to bind another
+    // listener to the same {addr, real_port}. The kernel only permits multiple
+    // listening sockets on the same address when *all* of them carry
+    // SO_REUSEPORT — without setting it on the primary fd, every worker's
+    // bind() would fail with EADDRINUSE.
+    if (config::enable_http_server_so_reuseport) {
+        int yes = 1;
+        if (::setsockopt(_server_fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)) != 0) {
+            LOG(WARNING) << "Failed to set SO_REUSEPORT on primary listener; per-worker listen sockets "
+                         << "will be skipped: " << errno_to_string(errno);
+        }
+    }
+#endif
     res = butil::make_non_blocking(_server_fd);
     if (res < 0) {
         std::stringstream ss;

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -45,15 +45,14 @@
 #include "starrocks_macos_libevent_shims.h"
 #endif
 
-#include <memory>
-#include <sstream>
-#include <utility>
-
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include <cstring>
+#include <memory>
+#include <sstream>
+#include <utility>
 
 #include "common/config.h"
 #include "common/logging.h"

--- a/be/src/http/ev_http_server.h
+++ b/be/src/http/ev_http_server.h
@@ -66,6 +66,9 @@ private:
     int _real_port;
 
     int _server_fd = -1;
+    // Per-worker listening fds bound with SO_REUSEPORT. Empty when reuseport
+    // mode is disabled — in that case all workers share `_server_fd`.
+    std::vector<int> _worker_fds;
     std::vector<std::thread> _workers;
 
     pthread_rwlock_t _rw_lock;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -605,7 +605,10 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_memtable_flush, _pk_index_memtable_flush_thread_pool);
     max_thread_count = config::pk_index_inner_io_threadpool_max_threads;
     if (max_thread_count <= 0) {
-        max_thread_count = CpuInfo::num_cores();
+        // Each fileset task waits on chunk-parallel OSS reads via the chunk_io pool,
+        // so this pool is also I/O-bound. Oversubscribe cores to keep fileset fan-out
+        // unblocked under cold-start storms (matches chunk_io rationale).
+        max_thread_count = CpuInfo::num_cores() * 4;
     }
     RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_inner_io")
                             .set_min_threads(1)

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -603,6 +603,16 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_queue_size(config::pk_index_memtable_flush_threadpool_size)
                             .build(&_pk_index_memtable_flush_thread_pool));
     REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_memtable_flush, _pk_index_memtable_flush_thread_pool);
+    max_thread_count = config::pk_index_inner_io_threadpool_max_threads;
+    if (max_thread_count <= 0) {
+        max_thread_count = CpuInfo::num_cores();
+    }
+    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_inner_io")
+                            .set_min_threads(1)
+                            .set_max_threads(std::max(1, max_thread_count))
+                            .set_max_queue_size(config::pk_index_inner_io_threadpool_size)
+                            .build(&_pk_index_inner_io_thread_pool));
+    REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_inner_io, _pk_index_inner_io_thread_pool);
 
 #elif defined(BE_TEST)
     _lake_location_provider = std::make_shared<lake::FixedLocationProvider>(_store_paths.front().path);
@@ -628,6 +638,11 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_threads(1)
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_pk_index_memtable_flush_thread_pool));
+    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_inner_io")
+                            .set_min_threads(1)
+                            .set_max_threads(1)
+                            .set_max_queue_size(std::numeric_limits<int>::max())
+                            .build(&_pk_index_inner_io_thread_pool));
 #endif
 
     RETURN_IF_ERROR(ThreadPoolBuilder("lake_metadata_fetch")
@@ -749,6 +764,12 @@ void ExecEnv::stop() {
         start = MonotonicMillis();
         _pk_index_memtable_flush_thread_pool->shutdown();
         component_times.emplace_back("pk_index_memtable_flush_thread_pool", MonotonicMillis() - start);
+    }
+
+    if (_pk_index_inner_io_thread_pool) {
+        start = MonotonicMillis();
+        _pk_index_inner_io_thread_pool->shutdown();
+        component_times.emplace_back("pk_index_inner_io_thread_pool", MonotonicMillis() - start);
     }
 
     if (_agent_server) {
@@ -946,6 +967,7 @@ void ExecEnv::destroy() {
     _parallel_compact_mgr.reset();
     _pk_index_execution_thread_pool.reset();
     _pk_index_memtable_flush_thread_pool.reset();
+    _pk_index_inner_io_thread_pool.reset();
     _metrics = nullptr;
 }
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -613,6 +613,18 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_queue_size(config::pk_index_inner_io_threadpool_size)
                             .build(&_pk_index_inner_io_thread_pool));
     REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_inner_io, _pk_index_inner_io_thread_pool);
+    max_thread_count = config::pk_index_chunk_io_threadpool_max_threads;
+    if (max_thread_count <= 0) {
+        // Each chunk task is dominated by sleeping on OSS HTTP responses; oversubscribe
+        // cores to keep available HTTP concurrency saturated under cold-start storms.
+        max_thread_count = CpuInfo::num_cores() * 4;
+    }
+    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_chunk_io")
+                            .set_min_threads(1)
+                            .set_max_threads(std::max(1, max_thread_count))
+                            .set_max_queue_size(config::pk_index_chunk_io_threadpool_size)
+                            .build(&_pk_index_chunk_io_thread_pool));
+    REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_chunk_io, _pk_index_chunk_io_thread_pool);
 
 #elif defined(BE_TEST)
     _lake_location_provider = std::make_shared<lake::FixedLocationProvider>(_store_paths.front().path);
@@ -643,6 +655,11 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_threads(1)
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_pk_index_inner_io_thread_pool));
+    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_chunk_io")
+                            .set_min_threads(1)
+                            .set_max_threads(1)
+                            .set_max_queue_size(std::numeric_limits<int>::max())
+                            .build(&_pk_index_chunk_io_thread_pool));
 #endif
 
     RETURN_IF_ERROR(ThreadPoolBuilder("lake_metadata_fetch")
@@ -770,6 +787,12 @@ void ExecEnv::stop() {
         start = MonotonicMillis();
         _pk_index_inner_io_thread_pool->shutdown();
         component_times.emplace_back("pk_index_inner_io_thread_pool", MonotonicMillis() - start);
+    }
+
+    if (_pk_index_chunk_io_thread_pool) {
+        start = MonotonicMillis();
+        _pk_index_chunk_io_thread_pool->shutdown();
+        component_times.emplace_back("pk_index_chunk_io_thread_pool", MonotonicMillis() - start);
     }
 
     if (_agent_server) {
@@ -968,6 +991,7 @@ void ExecEnv::destroy() {
     _pk_index_execution_thread_pool.reset();
     _pk_index_memtable_flush_thread_pool.reset();
     _pk_index_inner_io_thread_pool.reset();
+    _pk_index_chunk_io_thread_pool.reset();
     _metrics = nullptr;
 }
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -628,6 +628,22 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_queue_size(config::pk_index_chunk_io_threadpool_size)
                             .build(&_pk_index_chunk_io_thread_pool));
     REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_chunk_io, _pk_index_chunk_io_thread_pool);
+    max_thread_count = config::pk_index_sst_open_threadpool_max_threads;
+    if (max_thread_count <= 0) {
+        // Each SST-open task is 4 sequential OSS round-trips (footer + index + metaindex
+        // + filter) inside Table::Open. Pure I/O wait, so oversubscribe cores to keep
+        // OSS HTTP concurrency saturated under cold-start storms (mirrors chunk_io /
+        // inner_io rationale). Splitting from pk_index_execution_thread_pool eliminates
+        // the head-of-chain throttle where ~150 cold-start opens queue behind a 16-thread
+        // pool also shared with parallel-publish workers.
+        max_thread_count = CpuInfo::num_cores() * 4;
+    }
+    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_sst_open")
+                            .set_min_threads(1)
+                            .set_max_threads(std::max(1, max_thread_count))
+                            .set_max_queue_size(config::pk_index_sst_open_threadpool_size)
+                            .build(&_pk_index_sst_open_thread_pool));
+    REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_sst_open, _pk_index_sst_open_thread_pool);
 
 #elif defined(BE_TEST)
     _lake_location_provider = std::make_shared<lake::FixedLocationProvider>(_store_paths.front().path);
@@ -663,6 +679,11 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_threads(1)
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_pk_index_chunk_io_thread_pool));
+    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_sst_open")
+                            .set_min_threads(1)
+                            .set_max_threads(1)
+                            .set_max_queue_size(std::numeric_limits<int>::max())
+                            .build(&_pk_index_sst_open_thread_pool));
 #endif
 
     RETURN_IF_ERROR(ThreadPoolBuilder("lake_metadata_fetch")
@@ -796,6 +817,12 @@ void ExecEnv::stop() {
         start = MonotonicMillis();
         _pk_index_chunk_io_thread_pool->shutdown();
         component_times.emplace_back("pk_index_chunk_io_thread_pool", MonotonicMillis() - start);
+    }
+
+    if (_pk_index_sst_open_thread_pool) {
+        start = MonotonicMillis();
+        _pk_index_sst_open_thread_pool->shutdown();
+        component_times.emplace_back("pk_index_sst_open_thread_pool", MonotonicMillis() - start);
     }
 
     if (_agent_server) {
@@ -995,6 +1022,7 @@ void ExecEnv::destroy() {
     _pk_index_memtable_flush_thread_pool.reset();
     _pk_index_inner_io_thread_pool.reset();
     _pk_index_chunk_io_thread_pool.reset();
+    _pk_index_sst_open_thread_pool.reset();
     _metrics = nullptr;
 }
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -370,6 +370,8 @@ public:
 
     ThreadPool* pk_index_memtable_flush_thread_pool() { return _pk_index_memtable_flush_thread_pool.get(); }
 
+    ThreadPool* pk_index_inner_io_thread_pool() { return _pk_index_inner_io_thread_pool.get(); }
+
     void try_release_resource_before_core_dump();
 
     DiagnoseDaemon* diagnose_daemon() const { return _diagnose_daemon; }
@@ -445,6 +447,7 @@ private:
     std::unique_ptr<lake::LakePersistentIndexParallelCompactMgr> _parallel_compact_mgr;
     std::unique_ptr<ThreadPool> _pk_index_execution_thread_pool = nullptr;
     std::unique_ptr<ThreadPool> _pk_index_memtable_flush_thread_pool = nullptr;
+    std::unique_ptr<ThreadPool> _pk_index_inner_io_thread_pool = nullptr;
 
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -374,6 +374,8 @@ public:
 
     ThreadPool* pk_index_chunk_io_thread_pool() { return _pk_index_chunk_io_thread_pool.get(); }
 
+    ThreadPool* pk_index_sst_open_thread_pool() { return _pk_index_sst_open_thread_pool.get(); }
+
     void try_release_resource_before_core_dump();
 
     DiagnoseDaemon* diagnose_daemon() const { return _diagnose_daemon; }
@@ -451,6 +453,7 @@ private:
     std::unique_ptr<ThreadPool> _pk_index_memtable_flush_thread_pool = nullptr;
     std::unique_ptr<ThreadPool> _pk_index_inner_io_thread_pool = nullptr;
     std::unique_ptr<ThreadPool> _pk_index_chunk_io_thread_pool = nullptr;
+    std::unique_ptr<ThreadPool> _pk_index_sst_open_thread_pool = nullptr;
 
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -372,6 +372,8 @@ public:
 
     ThreadPool* pk_index_inner_io_thread_pool() { return _pk_index_inner_io_thread_pool.get(); }
 
+    ThreadPool* pk_index_chunk_io_thread_pool() { return _pk_index_chunk_io_thread_pool.get(); }
+
     void try_release_resource_before_core_dump();
 
     DiagnoseDaemon* diagnose_daemon() const { return _diagnose_daemon; }
@@ -448,6 +450,7 @@ private:
     std::unique_ptr<ThreadPool> _pk_index_execution_thread_pool = nullptr;
     std::unique_ptr<ThreadPool> _pk_index_memtable_flush_thread_pool = nullptr;
     std::unique_ptr<ThreadPool> _pk_index_inner_io_thread_pool = nullptr;
+    std::unique_ptr<ThreadPool> _pk_index_chunk_io_thread_pool = nullptr;
 
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr;

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -197,6 +197,9 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                                       ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
+    // Server-side BRPC queue time: latency from RPC arrival on this server to handler entry.
+    // Used to attribute the FE-measured publish_rpc cost vs BE handler cost gap.
+    int64_t brpc_queue_us = cntl->latency_us();
 
     if (!request->has_base_version()) {
         cntl->SetFailed("missing base version");
@@ -511,12 +514,13 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
     auto cost = butil::gettimeofday_us() - start_ts;
     auto is_slow = cost >= config::lake_publish_version_slow_log_ms * 1000;
     if (config::lake_enable_publish_version_trace_log && is_slow) {
-        LOG(INFO) << "Published txns=" << get_txn_ids_string(request) << ". cost=" << cost << "us\n"
+        LOG(INFO) << "Published txns=" << get_txn_ids_string(request) << ". cost=" << cost
+                  << "us brpc_queue_us=" << brpc_queue_us << "\n"
                   << trace->DumpToString();
     } else if (is_slow) {
         LOG(INFO) << "Published txns=" << get_txn_ids_string(request)
                   << ". tablets=" << JoinInts(request->tablet_ids(), ",") << " cost=" << cost
-                  << "us, trace: " << trace->MetricsAsJSON();
+                  << "us brpc_queue_us=" << brpc_queue_us << ", trace: " << trace->MetricsAsJSON();
     }
     TEST_SYNC_POINT("LakeServiceImpl::publish_version:return");
 }

--- a/be/src/storage/lake/lake_delvec_loader.cpp
+++ b/be/src/storage/lake/lake_delvec_loader.cpp
@@ -17,6 +17,7 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "storage/lake/location_provider.h"
+#include "storage/lake/tablet_manager.h"
 
 namespace starrocks::lake {
 
@@ -47,12 +48,16 @@ Status LakeDelvecLoader::load_from_file(const TabletSegmentId& tsid, int64_t ver
     if (_cached_metadata != nullptr && _cached_metadata->id() == tsid.tablet_id &&
         _cached_metadata->version() == version) {
         metadata = _cached_metadata;
-    } else if (_lake_io_opts.location_provider) {
-        const std::string filepath = _lake_io_opts.location_provider->tablet_metadata_location(tsid.tablet_id, version);
-        ASSIGN_OR_RETURN(metadata, _tablet_manager->get_tablet_metadata(filepath, _fill_cache, 0, _lake_io_opts.fs));
     } else {
-        ASSIGN_OR_RETURN(metadata, _tablet_manager->get_tablet_metadata(tsid.tablet_id, version, _fill_cache, 0,
-                                                                        _lake_io_opts.fs));
+        // Always go through the path-based overload so we get the cached shared
+        // TabletMetadataPB without an unconditional deep copy (the tablet_id
+        // overload's std::make_shared<TabletMetadata>(*ptr) used to dominate
+        // VerticalCompactionTask CPU on cold-start cluster traces).
+        const std::string filepath = (_lake_io_opts.location_provider != nullptr)
+                                             ? _lake_io_opts.location_provider->tablet_metadata_location(tsid.tablet_id,
+                                                                                                         version)
+                                             : _tablet_manager->tablet_metadata_location(tsid.tablet_id, version);
+        ASSIGN_OR_RETURN(metadata, _tablet_manager->get_tablet_metadata(filepath, _fill_cache, 0, _lake_io_opts.fs));
     }
 
     RETURN_IF_ERROR(

--- a/be/src/storage/lake/lake_delvec_loader.cpp
+++ b/be/src/storage/lake/lake_delvec_loader.cpp
@@ -53,10 +53,10 @@ Status LakeDelvecLoader::load_from_file(const TabletSegmentId& tsid, int64_t ver
         // TabletMetadataPB without an unconditional deep copy (the tablet_id
         // overload's std::make_shared<TabletMetadata>(*ptr) used to dominate
         // VerticalCompactionTask CPU on cold-start cluster traces).
-        const std::string filepath = (_lake_io_opts.location_provider != nullptr)
-                                             ? _lake_io_opts.location_provider->tablet_metadata_location(tsid.tablet_id,
-                                                                                                         version)
-                                             : _tablet_manager->tablet_metadata_location(tsid.tablet_id, version);
+        const std::string filepath =
+                (_lake_io_opts.location_provider != nullptr)
+                        ? _lake_io_opts.location_provider->tablet_metadata_location(tsid.tablet_id, version)
+                        : _tablet_manager->tablet_metadata_location(tsid.tablet_id, version);
         ASSIGN_OR_RETURN(metadata, _tablet_manager->get_tablet_metadata(filepath, _fill_cache, 0, _lake_io_opts.fs));
     }
 

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -638,9 +638,9 @@ StatusOr<std::vector<KeyValueMerger::KeyValueMergerOutput>> LakePersistentIndex:
     auto merger = std::make_unique<KeyValueMerger>(iter_ptr->key().to_string(), iter_ptr->max_rss_rowid(),
                                                    base_level_merge, tablet_mgr, metadata->id(), false);
     while (iter_ptr->Valid()) {
-        const std::string& cur_key = iter_ptr->key().to_string();
+        const Slice cur_key = iter_ptr->key();
         if (!seek_range.stop_key.empty() &&
-            options.comparator->Compare(Slice(cur_key), Slice(seek_range.stop_key)) >= 0) {
+            options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -639,8 +639,7 @@ StatusOr<std::vector<KeyValueMerger::KeyValueMergerOutput>> LakePersistentIndex:
                                                    base_level_merge, tablet_mgr, metadata->id(), false);
     while (iter_ptr->Valid()) {
         const Slice cur_key = iter_ptr->key();
-        if (!seek_range.stop_key.empty() &&
-            options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
+        if (!seek_range.stop_key.empty() && options.comparator->Compare(cur_key, Slice(seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -935,7 +935,7 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
         auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
         if (!st.ok()) {
             std::lock_guard<std::mutex> l(shared_mutex);
-            shared_status.update(st);
+            shared_status.update(st.status());
             return;
         }
         pkcs[del_idx] = std::move(pkc);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -36,6 +36,7 @@
 #include "storage/sstable/merger.h"
 #include "storage/sstable/options.h"
 #include "storage/sstable/table_builder.h"
+#include "util/thread.h"
 #include "util/trace.h"
 
 namespace starrocks::lake {
@@ -375,7 +376,17 @@ Status LakePersistentIndex::get_from_sstables(size_t n, const Slice* keys, Index
     // (preserving the original rbegin->rend ordering semantics). The set_difference shortcut is
     // dropped, but in cold-start most candidate keys are filtered out cheaply by per-fileset bloom
     // filters, so the extra work is negligible compared to the wall-time win.
-    if (config::enable_pk_index_parallel_execution && _sstable_filesets.size() > 1) {
+    //
+    // Skip the parallel path when this thread is itself a worker of
+    // pk_index_execution_thread_pool — submitting tasks to + waiting on the same pool from
+    // one of its workers triggers ThreadPool::check_not_pool_thread_unlocked() and aborts.
+    // This happens on the parallel-publish upsert path, where ParallelPublishContext::token
+    // lives on pk_index_execution_thread_pool and the caller IS a worker of that pool. The
+    // sync caller paths (init/erase/non-ctx upsert) are unaffected and still parallelize.
+    auto* cur_thread = Thread::current_thread();
+    const bool on_pk_index_execution_pool =
+            (cur_thread != nullptr && cur_thread->name() == "cloud_native_pk_index_execution");
+    if (config::enable_pk_index_parallel_execution && _sstable_filesets.size() > 1 && !on_pk_index_execution_pool) {
         const size_t F = _sstable_filesets.size();
         std::vector<std::vector<IndexValue>> local_values(F, std::vector<IndexValue>(n));
         std::vector<KeyIndexSet> local_founds(F);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -79,7 +79,12 @@ StatusOr<std::vector<PersistentIndexSstableUniquePtr>> LakePersistentIndex::_ope
 
     std::unique_ptr<ThreadPoolToken> token;
     if (config::enable_pk_index_parallel_execution) {
-        token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+        // Dispatch SST opens on a dedicated I/O-oversubscribed pool, NOT
+        // pk_index_execution_thread_pool. Each Table::Open issues 4 sequential OSS
+        // round-trips; with the execution pool sized at num_cores/2 (= 16/CN) and
+        // also serving parallel-publish workers, ~150 cold-start opens used to queue
+        // head-of-chain. The dedicated pool defaults to num_cores * 4 (= 128/CN).
+        token = ExecEnv::GetInstance()->pk_index_sst_open_thread_pool()->new_token(
                 ThreadPool::ExecutionMode::CONCURRENT);
     }
     for (int i = 0; i < num_sstables; i++) {

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -36,7 +36,6 @@
 #include "storage/sstable/merger.h"
 #include "storage/sstable/options.h"
 #include "storage/sstable/table_builder.h"
-#include "util/thread.h"
 #include "util/trace.h"
 
 namespace starrocks::lake {
@@ -371,29 +370,27 @@ Status LakePersistentIndex::get_from_sstables(size_t n, const Slice* keys, Index
     }
     // On cold-start, each fileset's multi_get is dominated by sequential cache-miss block reads
     // from object storage (~99 ms p50 per miss). Walking _sstable_filesets sequentially compounds
-    // the latency. With the flag enabled, dispatch each fileset's multi_get on the existing
-    // pk_index_execution_thread_pool and merge results so the most-recent fileset's value wins
+    // the latency. With the flag enabled, dispatch each fileset's multi_get on the dedicated
+    // pk_index_inner_io_thread_pool and merge results so the most-recent fileset's value wins
     // (preserving the original rbegin->rend ordering semantics). The set_difference shortcut is
     // dropped, but in cold-start most candidate keys are filtered out cheaply by per-fileset bloom
     // filters, so the extra work is negligible compared to the wall-time win.
     //
-    // Skip the parallel path when this thread is itself a worker of
-    // pk_index_execution_thread_pool — submitting tasks to + waiting on the same pool from
-    // one of its workers triggers ThreadPool::check_not_pool_thread_unlocked() and aborts.
-    // This happens on the parallel-publish upsert path, where ParallelPublishContext::token
-    // lives on pk_index_execution_thread_pool and the caller IS a worker of that pool. The
-    // sync caller paths (init/erase/non-ctx upsert) are unaffected and still parallelize.
-    auto* cur_thread = Thread::current_thread();
-    const bool on_pk_index_execution_pool =
-            (cur_thread != nullptr && cur_thread->name() == "cloud_native_pk_index_execution");
-    if (config::enable_pk_index_parallel_execution && _sstable_filesets.size() > 1 && !on_pk_index_execution_pool) {
+    // We dispatch on a SEPARATE pool from pk_index_execution_thread_pool: on the parallel-publish
+    // upsert path, this function is invoked from a lambda already running on a
+    // pk_index_execution_thread_pool worker (ParallelPublishContext::token, see
+    // lake_primary_index.cpp:424,605 and update_manager.cpp:931,1069). Submitting tasks to + waiting
+    // on the same pool from one of its workers triggers ThreadPool::check_not_pool_thread_unlocked()
+    // and aborts (iter-031). The dedicated inner-io pool isolates the wait so the cold-start hot
+    // path can fan out across filesets without re-entrance risk.
+    if (config::enable_pk_index_parallel_execution && _sstable_filesets.size() > 1) {
         const size_t F = _sstable_filesets.size();
         std::vector<std::vector<IndexValue>> local_values(F, std::vector<IndexValue>(n));
         std::vector<KeyIndexSet> local_founds(F);
         const KeyIndexSet snapshot = *key_indexes;
         std::mutex status_mu;
         Status shared_status;
-        auto token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+        auto token = ExecEnv::GetInstance()->pk_index_inner_io_thread_pool()->new_token(
                 ThreadPool::ExecutionMode::CONCURRENT);
         size_t idx = 0;
         for (auto iter = _sstable_filesets.rbegin(); iter != _sstable_filesets.rend(); ++iter, ++idx) {

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -896,23 +896,77 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     ASSIGN_OR_RETURN(auto pk_encoding_type, rowset->tablet_schema()->primary_key_encoding_type_or_error());
     MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type));
-    // Iterate all del files and insert into index.
-    for (int del_idx = 0; del_idx < rowset->metadata().del_files_size(); ++del_idx) {
-        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+
+    const int num_del_files = rowset->metadata().del_files_size();
+    // Phase 1 (parallel): read each delete file's bytes from object storage and deserialize
+    // them into a per-file pk column. Index mutations stay sequential below to preserve
+    // erase ordering. Reads dominate cold-start cost (8 files × ~OSS_RTT each = seconds);
+    // parallelising them collapses that wall-clock without changing on-disk semantics.
+    std::vector<MutableColumnPtr> pkcs(num_del_files);
+    std::mutex shared_mutex;
+    Status shared_status;
+    auto read_one = [&](int del_idx) {
         const auto& del = rowset->metadata().del_files(del_idx);
         RandomAccessFileOptions ropts;
         if (!del.encryption_meta().empty()) {
-            ASSIGN_OR_RETURN(ropts.encryption_info, KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
+            auto info_or = KeyCache::instance().unwrap_encryption_meta(del.encryption_meta());
+            if (!info_or.ok()) {
+                std::lock_guard<std::mutex> l(shared_mutex);
+                shared_status.update(info_or.status());
+                return;
+            }
+            ropts.encryption_info = std::move(info_or.value());
         }
-        ASSIGN_OR_RETURN(auto read_file,
-                         fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name())));
-        ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
-        const auto* data = reinterpret_cast<const uint8_t*>(read_buffer.data());
-        const auto* end = data + read_buffer.size();
-        // serialize to column
+        auto rf_or = fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name()));
+        if (!rf_or.ok()) {
+            std::lock_guard<std::mutex> l(shared_mutex);
+            shared_status.update(rf_or.status());
+            return;
+        }
+        auto buf_or = (*rf_or)->read_all();
+        if (!buf_or.ok()) {
+            std::lock_guard<std::mutex> l(shared_mutex);
+            shared_status.update(buf_or.status());
+            return;
+        }
         auto pkc = pk_column->clone();
-        using Serd = serde::ColumnArraySerde;
-        RETURN_IF_ERROR(Serd::deserialize(data, end, pkc.get()));
+        const auto* data = reinterpret_cast<const uint8_t*>(buf_or->data());
+        const auto* end = data + buf_or->size();
+        auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
+        if (!st.ok()) {
+            std::lock_guard<std::mutex> l(shared_mutex);
+            shared_status.update(st);
+            return;
+        }
+        pkcs[del_idx] = std::move(pkc);
+    };
+
+    std::unique_ptr<ThreadPoolToken> token;
+    if (config::enable_pk_index_parallel_execution && num_del_files > 1) {
+        token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
+    }
+    for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
+        if (token) {
+            auto st = token->submit_func([&read_one, del_idx]() { read_one(del_idx); });
+            if (!st.ok()) {
+                read_one(del_idx);
+            }
+        } else {
+            read_one(del_idx);
+        }
+    }
+    if (token) {
+        token->wait();
+    }
+    RETURN_IF_ERROR(shared_status);
+
+    // Phase 2 (sequential): order-dependent index mutations. replay_erase mutates index state
+    // observed by later files' get(); keep iteration order identical to the original.
+    for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
+        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+        const auto& del = rowset->metadata().del_files(del_idx);
+        auto& pkc = pkcs[del_idx];
         // We can't insert delete operation to index directly, because some delete operation is
         // older than current item, and we need to igore these delete operations.
         std::vector<IndexValue> found_values(pkc->size(), IndexValue(NullIndexValue));

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -368,6 +368,60 @@ Status LakePersistentIndex::get_from_sstables(size_t n, const Slice* keys, Index
     if (key_indexes->empty() || _sstable_filesets.empty()) {
         return Status::OK();
     }
+    // On cold-start, each fileset's multi_get is dominated by sequential cache-miss block reads
+    // from object storage (~99 ms p50 per miss). Walking _sstable_filesets sequentially compounds
+    // the latency. With the flag enabled, dispatch each fileset's multi_get on the existing
+    // pk_index_execution_thread_pool and merge results so the most-recent fileset's value wins
+    // (preserving the original rbegin->rend ordering semantics). The set_difference shortcut is
+    // dropped, but in cold-start most candidate keys are filtered out cheaply by per-fileset bloom
+    // filters, so the extra work is negligible compared to the wall-time win.
+    if (config::enable_pk_index_parallel_execution && _sstable_filesets.size() > 1) {
+        const size_t F = _sstable_filesets.size();
+        std::vector<std::vector<IndexValue>> local_values(F, std::vector<IndexValue>(n));
+        std::vector<KeyIndexSet> local_founds(F);
+        const KeyIndexSet snapshot = *key_indexes;
+        std::mutex status_mu;
+        Status shared_status;
+        auto token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
+        size_t idx = 0;
+        for (auto iter = _sstable_filesets.rbegin(); iter != _sstable_filesets.rend(); ++iter, ++idx) {
+            auto* fset = iter->get();
+            auto* lv = local_values[idx].data();
+            auto* lf = &local_founds[idx];
+            const KeyIndexSet* snap = &snapshot;
+            Trace* trace = Trace::CurrentTrace();
+            auto submit_st = token->submit_func([fset, keys, snap, version, lv, lf, &shared_status, &status_mu, trace]() {
+                ADOPT_TRACE(trace);
+                auto s = fset->multi_get(keys, *snap, version, lv, lf);
+                if (!s.ok()) {
+                    std::lock_guard<std::mutex> lg(status_mu);
+                    shared_status.update(s);
+                }
+            });
+            if (!submit_st.ok()) {
+                // Fallback: run inline so we still produce a result for this fileset.
+                auto s = fset->multi_get(keys, snapshot, version, lv, lf);
+                if (!s.ok()) {
+                    std::lock_guard<std::mutex> lg(status_mu);
+                    shared_status.update(s);
+                }
+            }
+        }
+        token->wait();
+        RETURN_IF_ERROR(shared_status);
+        // Merge in rbegin->rend order (most-recent fileset first wins).
+        KeyIndexSet found_master;
+        for (size_t i = 0; i < F; ++i) {
+            for (auto k_idx : local_founds[i]) {
+                if (found_master.insert(k_idx).second) {
+                    values[k_idx] = local_values[i][k_idx];
+                }
+            }
+        }
+        set_difference(key_indexes, found_master);
+        return Status::OK();
+    }
     for (auto iter = _sstable_filesets.rbegin(); iter != _sstable_filesets.rend(); ++iter) {
         KeyIndexSet found_key_indexes;
         RETURN_IF_ERROR((*iter)->multi_get(keys, *key_indexes, version, values, &found_key_indexes));

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -391,14 +391,15 @@ Status LakePersistentIndex::get_from_sstables(size_t n, const Slice* keys, Index
             auto* lf = &local_founds[idx];
             const KeyIndexSet* snap = &snapshot;
             Trace* trace = Trace::CurrentTrace();
-            auto submit_st = token->submit_func([fset, keys, snap, version, lv, lf, &shared_status, &status_mu, trace]() {
-                ADOPT_TRACE(trace);
-                auto s = fset->multi_get(keys, *snap, version, lv, lf);
-                if (!s.ok()) {
-                    std::lock_guard<std::mutex> lg(status_mu);
-                    shared_status.update(s);
-                }
-            });
+            auto submit_st =
+                    token->submit_func([fset, keys, snap, version, lv, lf, &shared_status, &status_mu, trace]() {
+                        ADOPT_TRACE(trace);
+                        auto s = fset->multi_get(keys, *snap, version, lv, lf);
+                        if (!s.ok()) {
+                            std::lock_guard<std::mutex> lg(status_mu);
+                            shared_status.update(s);
+                        }
+                    });
             if (!submit_st.ok()) {
                 // Fallback: run inline so we still produce a result for this fileset.
                 auto s = fset->multi_get(keys, snapshot, version, lv, lf);

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -87,12 +87,12 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
     auto version = index_value_ver.values(0).version();
     auto index_value = build_index_value(index_value_ver.values(0));
     if (Slice(_key) == key) {
-        if (_index_value_vers.empty()) {
+        if (!_current_value.has_value()) {
             _max_rss_rowid = max_rss_rowid;
-            _index_value_vers.emplace_front(version, index_value);
-        } else if ((version > _index_value_vers.front().first) ||
-                   (version == _index_value_vers.front().first && max_rss_rowid > _max_rss_rowid) ||
-                   (version == _index_value_vers.front().first && max_rss_rowid == _max_rss_rowid &&
+            _current_value.emplace(version, index_value);
+        } else if ((version > _current_value->first) ||
+                   (version == _current_value->first && max_rss_rowid > _max_rss_rowid) ||
+                   (version == _current_value->first && max_rss_rowid == _max_rss_rowid &&
                     index_value.get_value() == NullIndexValue)) {
             // NOTICE: we need both version and max_rss_rowid here to decide the order of keys.
             // Consider the following 3 scenarios:
@@ -133,39 +133,34 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
             //   max_rss_rowid, when the second one is only contains delete flag keys.
             //   k3 with delete flag will replace previous one.
             _max_rss_rowid = max_rss_rowid;
-            std::list<std::pair<int64_t, IndexValue>> t;
-            t.emplace_front(version, index_value);
-            _index_value_vers.swap(t);
+            _current_value.emplace(version, index_value);
         }
     } else {
         RETURN_IF_ERROR(flush());
         _key.assign(key.data, key.size);
         _max_rss_rowid = max_rss_rowid;
-        _index_value_vers.emplace_front(version, index_value);
+        _current_value.emplace(version, index_value);
     }
     return Status::OK();
 }
 
 Status KeyValueMerger::flush() {
-    if (_index_value_vers.empty()) {
+    if (!_current_value.has_value()) {
         return Status::OK();
     }
 
-    // Reuse scratch protobuf and serialization buffer to avoid allocating fresh
-    // RepeatedField storage and a new std::string on every flushed key.
-    IndexValuesWithVerPB& index_value_pb = _flush_pb_scratch;
-    index_value_pb.Clear();
-    for (const auto& index_value_with_ver : _index_value_vers) {
-        if (_merge_base_level && index_value_with_ver.second == IndexValue(NullIndexValue)) {
-            // deleted
-            continue;
-        }
+    const auto& current = *_current_value;
+    const bool skip_tombstone = _merge_base_level && current.second == IndexValue(NullIndexValue);
+    if (!skip_tombstone) {
+        // Reuse scratch protobuf and serialization buffer to avoid allocating fresh
+        // RepeatedField storage and a new std::string on every flushed key.
+        IndexValuesWithVerPB& index_value_pb = _flush_pb_scratch;
+        index_value_pb.Clear();
         auto* value = index_value_pb.add_values();
-        value->set_version(index_value_with_ver.first);
-        value->set_rssid(index_value_with_ver.second.get_rssid());
-        value->set_rowid(index_value_with_ver.second.get_rowid());
-    }
-    if (index_value_pb.values_size() > 0) {
+        value->set_version(current.first);
+        value->set_rssid(current.second.get_rssid());
+        value->set_rowid(current.second.get_rowid());
+
         if (_output_builders.empty() ||
             (_enable_multiple_output_files &&
              _output_builders.back().table_builder->FileSize() >= config::pk_index_target_file_size)) {
@@ -176,7 +171,7 @@ Status KeyValueMerger::flush() {
         index_value_pb.SerializeToString(&_flush_serialized_scratch);
         RETURN_IF_ERROR(_output_builders.back().table_builder->Add(Slice(_key), Slice(_flush_serialized_scratch)));
     }
-    _index_value_vers.clear();
+    _current_value.reset();
 
     return Status::OK();
 }

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -40,7 +40,9 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
     const std::string& value = iter_ptr->value().to_string();
     uint64_t max_rss_rowid = iter_ptr->max_rss_rowid();
 
-    IndexValuesWithVerPB index_value_ver;
+    // Reuse scratch protobuf to avoid allocating/freeing internal storage on every key.
+    IndexValuesWithVerPB& index_value_ver = _merge_pb_scratch;
+    index_value_ver.Clear();
     if (!index_value_ver.ParseFromString(value)) {
         return Status::InternalError("Failed to parse index value ver");
     }
@@ -145,7 +147,10 @@ Status KeyValueMerger::flush() {
         return Status::OK();
     }
 
-    IndexValuesWithVerPB index_value_pb;
+    // Reuse scratch protobuf and serialization buffer to avoid allocating fresh
+    // RepeatedField storage and a new std::string on every flushed key.
+    IndexValuesWithVerPB& index_value_pb = _flush_pb_scratch;
+    index_value_pb.Clear();
     for (const auto& index_value_with_ver : _index_value_vers) {
         if (_merge_base_level && index_value_with_ver.second == IndexValue(NullIndexValue)) {
             // deleted
@@ -163,8 +168,9 @@ Status KeyValueMerger::flush() {
             // Create a new sst file when current file is empty or exceed target size.
             RETURN_IF_ERROR(create_table_builder());
         }
-        RETURN_IF_ERROR(
-                _output_builders.back().table_builder->Add(Slice(_key), Slice(index_value_pb.SerializeAsString())));
+        _flush_serialized_scratch.clear();
+        index_value_pb.SerializeToString(&_flush_serialized_scratch);
+        RETURN_IF_ERROR(_output_builders.back().table_builder->Add(Slice(_key), Slice(_flush_serialized_scratch)));
     }
     _index_value_vers.clear();
 

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -36,14 +36,18 @@
 namespace starrocks::lake {
 
 Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
-    const std::string& key = iter_ptr->key().to_string();
-    const std::string& value = iter_ptr->value().to_string();
+    // Iterator-owned slices stay valid until iter_ptr->Next(); both the parse
+    // and the equality check below complete before the caller advances the
+    // iterator, so we can avoid the per-key std::string heap allocations that
+    // Slice::to_string() would force on every input row.
+    const Slice key = iter_ptr->key();
+    const Slice value = iter_ptr->value();
     uint64_t max_rss_rowid = iter_ptr->max_rss_rowid();
 
     // Reuse scratch protobuf to avoid allocating/freeing internal storage on every key.
     IndexValuesWithVerPB& index_value_ver = _merge_pb_scratch;
     index_value_ver.Clear();
-    if (!index_value_ver.ParseFromString(value)) {
+    if (!index_value_ver.ParseFromArray(value.data, value.size)) {
         return Status::InternalError("Failed to parse index value ver");
     }
     if (index_value_ver.values_size() == 0) {
@@ -82,7 +86,7 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
 
     auto version = index_value_ver.values(0).version();
     auto index_value = build_index_value(index_value_ver.values(0));
-    if (_key == key) {
+    if (Slice(_key) == key) {
         if (_index_value_vers.empty()) {
             _max_rss_rowid = max_rss_rowid;
             _index_value_vers.emplace_front(version, index_value);
@@ -135,7 +139,7 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
         }
     } else {
         RETURN_IF_ERROR(flush());
-        _key = key;
+        _key.assign(key.data, key.size);
         _max_rss_rowid = max_rss_rowid;
         _index_value_vers.emplace_front(version, index_value);
     }

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.h
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/types_fwd.h"
 #include "storage/persistent_index.h"
@@ -74,7 +76,11 @@ private:
 private:
     std::string _key;
     uint64_t _max_rss_rowid = 0;
-    std::list<IndexValueWithVer> _index_value_vers;
+    // Holds the winning (version, IndexValue) for the current key, or empty
+    // between flushes. The merge algorithm only ever tracks a single best entry
+    // per key, so storing it inline avoids the per-key heap allocation pair
+    // that std::list<IndexValueWithVer> would incur on every input row.
+    std::optional<IndexValueWithVer> _current_value;
     // If do merge base level, that means we can delete NullIndexValue items safely.
     bool _merge_base_level = false;
     TabletManager* _tablet_mgr = nullptr;

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.h
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.h
@@ -83,6 +83,11 @@ private:
     // data volume larger than pk_index_target_file_size.
     bool _enable_multiple_output_files = false;
     std::vector<TableBuilderWrapper> _output_builders;
+    // Scratch buffers reused across merge()/flush() to avoid per-key protobuf
+    // allocator churn. Cleared between calls so internal capacity is retained.
+    IndexValuesWithVerPB _merge_pb_scratch;
+    IndexValuesWithVerPB _flush_pb_scratch;
+    std::string _flush_serialized_scratch;
 };
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
+++ b/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
@@ -198,8 +198,7 @@ Status LakePersistentIndexParallelCompactTask::do_run() {
                                                    true /* generate multi outputs*/);
     while (merging_iter->Valid()) {
         const Slice cur_key = merging_iter->key();
-        if (!_seek_range.stop_key.empty() &&
-            options.comparator->Compare(cur_key, Slice(_seek_range.stop_key)) >= 0) {
+        if (!_seek_range.stop_key.empty() && options.comparator->Compare(cur_key, Slice(_seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
+++ b/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
@@ -197,9 +197,9 @@ Status LakePersistentIndexParallelCompactTask::do_run() {
                                                    _merge_base_level, _tablet_mgr, _metadata->id(),
                                                    true /* generate multi outputs*/);
     while (merging_iter->Valid()) {
-        const std::string& cur_key = merging_iter->key().to_string();
+        const Slice cur_key = merging_iter->key();
         if (!_seek_range.stop_key.empty() &&
-            options.comparator->Compare(Slice(cur_key), Slice(_seek_range.stop_key)) >= 0) {
+            options.comparator->Compare(cur_key, Slice(_seek_range.stop_key)) >= 0) {
             // meet the scan range boundary, quit.
             break;
         }

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -16,14 +16,18 @@
 
 #include <butil/time.h> // NOLINT
 
+#include <mutex>
+
 #include "fs/fs.h"
 #include "fs/key_cache.h"
 #include "gen_cpp/types.pb.h"
+#include "runtime/exec_env.h"
 #include "storage/lake/lake_delvec_loader.h"
 #include "storage/lake/utils.h"
 #include "storage/sstable/table_builder.h"
 #include "testutil/sync_point.h"
 #include "util/starrocks_metrics.h"
+#include "util/threadpool.h"
 #include "util/trace.h"
 
 namespace starrocks::lake {
@@ -162,11 +166,112 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
     // be read by the persistent index by designed. So even we provide a predicate, all keys read by multi_get
     // will always meet the condition.
     auto start_ts = butil::gettimeofday_us();
-    auto multiget_st = _sst->MultiGet(options, keys, key_indexes.begin(), key_indexes.end(), &index_value_with_vers);
+    Status multiget_st;
+    bool used_chunk_parallel = false;
+    int64_t multiget_chunks = 0;
+    if (config::enable_pk_index_parallel_chunk_multi_get && config::enable_pk_index_parallel_execution &&
+        static_cast<int64_t>(key_indexes.size()) >= config::pk_index_parallel_chunk_min_keys &&
+        ExecEnv::GetInstance() != nullptr &&
+        ExecEnv::GetInstance()->pk_index_chunk_io_thread_pool() != nullptr) {
+        const int target_keys = std::max(1, static_cast<int>(config::pk_index_parallel_chunk_target_keys));
+        const int max_chunks = std::max(1, static_cast<int>(config::pk_index_parallel_chunk_max_chunks));
+        int chunks = static_cast<int>((key_indexes.size() + target_keys - 1) / target_keys);
+        chunks = std::min(chunks, max_chunks);
+        if (chunks > 1) {
+            // Chunk the key_indexes set into `chunks` contiguous, balanced ranges. Each chunk
+            // gets its own RandomAccessFile (the underlying SeekableInputStream is not safe
+            // for concurrent use; per-task files share the AWS S3Client which IS thread-safe).
+            //
+            // The chunk_io ThreadPool is dedicated and distinct from the inner_io pool that
+            // dispatches per-fileset multi_gets in LakePersistentIndex::get_from_sstables —
+            // re-entering inner_io from inside one of its workers would deadlock via
+            // ThreadPool::wait()'s check_not_pool_thread_unlocked() (the same trap PR #72579
+            // / iter-031 fell into for pk_index_execution_thread_pool).
+            std::vector<KeyIndexSet::const_iterator> bounds;
+            bounds.reserve(static_cast<size_t>(chunks) + 1);
+            bounds.push_back(key_indexes.begin());
+            const size_t per = key_indexes.size() / static_cast<size_t>(chunks);
+            const size_t rem = key_indexes.size() % static_cast<size_t>(chunks);
+            auto cur = key_indexes.begin();
+            for (int c = 0; c < chunks; ++c) {
+                size_t step = per + (static_cast<size_t>(c) < rem ? 1 : 0);
+                std::advance(cur, step);
+                bounds.push_back(cur);
+            }
+            std::vector<std::vector<std::string>> chunk_outs(chunks);
+            std::vector<sstable::ReadIOStat> chunk_stats(chunks);
+            std::vector<std::unique_ptr<RandomAccessFile>> chunk_files(chunks);
+            for (int c = 0; c < chunks; ++c) {
+                const size_t sz = static_cast<size_t>(std::distance(bounds[c], bounds[c + 1]));
+                chunk_outs[c].assign(sz, std::string());
+                RandomAccessFileOptions opts2;
+                if (!_sstable_pb.encryption_meta().empty()) {
+                    ASSIGN_OR_RETURN(auto info,
+                                     KeyCache::instance().unwrap_encryption_meta(_sstable_pb.encryption_meta()));
+                    opts2.encryption_info = std::move(info);
+                }
+                ASSIGN_OR_RETURN(chunk_files[c], fs::new_random_access_file(opts2, _rf->filename()));
+            }
+
+            std::mutex status_mu;
+            Status shared_status;
+            auto* pool = ExecEnv::GetInstance()->pk_index_chunk_io_thread_pool();
+            auto token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+            Trace* trace = Trace::CurrentTrace();
+            auto run_chunk = [&](int c) {
+                sstable::ReadOptions local_opts;
+                local_opts.file = chunk_files[c].get();
+                local_opts.stat = &chunk_stats[c];
+                auto s = _sst->MultiGet(local_opts, keys, bounds[c], bounds[c + 1], &chunk_outs[c]);
+                if (!s.ok()) {
+                    std::lock_guard<std::mutex> lg(status_mu);
+                    shared_status.update(s);
+                }
+            };
+            for (int c = 0; c < chunks; ++c) {
+                auto submit_st = token->submit_func([c, &run_chunk, trace]() {
+                    ADOPT_TRACE(trace);
+                    run_chunk(c);
+                });
+                if (!submit_st.ok()) {
+                    // Pool busy / queue full — execute inline so we still produce a result for
+                    // this chunk. We don't ADOPT_TRACE here because we are already on the
+                    // calling thread which has the trace context.
+                    run_chunk(c);
+                }
+            }
+            token->wait();
+            multiget_st = shared_status;
+
+            // Concatenate per-chunk outputs back into index_value_with_vers in key_indexes
+            // iteration order (the chunks are contiguous slices of key_indexes, so simple
+            // concat preserves the alignment with the post-loop below that iterates
+            // key_indexes and indexes into index_value_with_vers by sequential i).
+            size_t out_pos = 0;
+            for (int c = 0; c < chunks; ++c) {
+                for (auto& v : chunk_outs[c]) {
+                    index_value_with_vers[out_pos++] = std::move(v);
+                }
+            }
+            for (const auto& s : chunk_stats) {
+                stat.bytes_from_file += s.bytes_from_file;
+                stat.bytes_from_cache += s.bytes_from_cache;
+                stat.block_cnt_from_file += s.block_cnt_from_file;
+                stat.block_cnt_from_cache += s.block_cnt_from_cache;
+            }
+            used_chunk_parallel = true;
+            multiget_chunks = chunks;
+        }
+    }
+    if (!used_chunk_parallel) {
+        multiget_st = _sst->MultiGet(options, keys, key_indexes.begin(), key_indexes.end(), &index_value_with_vers);
+    }
     TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::multi_get:error", &multiget_st);
     if (multiget_st.is_corruption()) {
         auto drop_status = drop_corrupted_sstable_cache(_rf->filename());
         if (drop_status.ok()) {
+            // Retry on the simple sequential path so retry semantics stay identical to the
+            // pre-iter-034 behaviour on transient corruption.
             multiget_st = _sst->MultiGet(options, keys, key_indexes.begin(), key_indexes.end(), &index_value_with_vers);
             TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::multi_get:retry_error", &multiget_st);
         }
@@ -181,6 +286,9 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
     TRACE_COUNTER_INCREMENT("multi_get_us", end_ts - start_ts);
     TRACE_COUNTER_INCREMENT("read_block_hit_cache_cnt", stat.block_cnt_from_cache);
     TRACE_COUNTER_INCREMENT("read_block_miss_cache_cnt", stat.block_cnt_from_file);
+    if (multiget_chunks > 0) {
+        TRACE_COUNTER_INCREMENT("multi_get_chunk_count", multiget_chunks);
+    }
     size_t i = 0;
     for (auto& key_index : key_indexes) {
         // Index_value_with_vers is empty means key is not found in sst.

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -171,8 +171,7 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
     int64_t multiget_chunks = 0;
     if (config::enable_pk_index_parallel_chunk_multi_get && config::enable_pk_index_parallel_execution &&
         static_cast<int64_t>(key_indexes.size()) >= config::pk_index_parallel_chunk_min_keys &&
-        ExecEnv::GetInstance() != nullptr &&
-        ExecEnv::GetInstance()->pk_index_chunk_io_thread_pool() != nullptr) {
+        ExecEnv::GetInstance() != nullptr && ExecEnv::GetInstance()->pk_index_chunk_io_thread_pool() != nullptr) {
         const int target_keys = std::max(1, static_cast<int>(config::pk_index_parallel_chunk_target_keys));
         const int max_chunks = std::max(1, static_cast<int>(config::pk_index_parallel_chunk_max_chunks));
         int chunks = static_cast<int>((key_indexes.size() + target_keys - 1) / target_keys);

--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -292,6 +292,12 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
     int64_t multiget_t1_us = 0;
     int64_t multiget_t2_us = 0;
     int64_t multiget_t3_us = 0;
+    int64_t multiget_t3_filter_us = 0;
+    int64_t multiget_t3_block_read_us = 0;
+    int64_t multiget_t3_block_read_miss_us = 0;
+    int64_t multiget_t3_search_us = 0;
+    int64_t multiget_block_read_miss_cnt = 0;
+    ReadIOStat* stat = options.stat;
     size_t i = 0;
     bool founded = false;
     for (auto it = begin; it != end; ++it, ++i) {
@@ -314,13 +320,29 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
             Slice handle_value = iiter->value();
             FilterBlockReader* filter = rep_->filter;
             BlockHandle handle;
-            if (filter != nullptr && handle.DecodeFrom(&handle_value).ok() &&
-                !filter->KeyMayMatch(handle.offset(), k)) {
+            int64_t tf_start = butil::gettimeofday_us();
+            bool filter_skip = filter != nullptr && handle.DecodeFrom(&handle_value).ok() &&
+                               !filter->KeyMayMatch(handle.offset(), k);
+            int64_t tf_end = butil::gettimeofday_us();
+            multiget_t3_filter_us += tf_end - tf_start;
+            if (filter_skip) {
                 // Not found
                 sst_bloom_filter_rows++;
             } else {
+                uint32_t miss_before = stat ? stat->block_cnt_from_file : 0;
+                int64_t tb_start = butil::gettimeofday_us();
                 current_block_itr_ptr.reset(BlockReader(this, options, iiter->value()));
+                int64_t tb_end = butil::gettimeofday_us();
+                int64_t br_us = tb_end - tb_start;
+                multiget_t3_block_read_us += br_us;
+                if (stat != nullptr && stat->block_cnt_from_file > miss_before) {
+                    // Cache miss path: BlockReader did an actual file (OSS) read.
+                    multiget_t3_block_read_miss_us += br_us;
+                    multiget_block_read_miss_cnt++;
+                }
                 ASSIGN_OR_RETURN(founded, search_in_block(k, &(*values)[i], current_block_itr_ptr.get()));
+                int64_t ts_end = butil::gettimeofday_us();
+                multiget_t3_search_us += ts_end - tb_end;
             }
         }
         int64_t t3 = butil::gettimeofday_us();
@@ -337,6 +359,11 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
     TRACE_COUNTER_INCREMENT("multiget_t1_us", multiget_t1_us);
     TRACE_COUNTER_INCREMENT("multiget_t2_us", multiget_t2_us);
     TRACE_COUNTER_INCREMENT("multiget_t3_us", multiget_t3_us);
+    TRACE_COUNTER_INCREMENT("multiget_t3_filter_us", multiget_t3_filter_us);
+    TRACE_COUNTER_INCREMENT("multiget_t3_block_read_us", multiget_t3_block_read_us);
+    TRACE_COUNTER_INCREMENT("multiget_t3_block_read_miss_us", multiget_t3_block_read_miss_us);
+    TRACE_COUNTER_INCREMENT("multiget_t3_search_us", multiget_t3_search_us);
+    TRACE_COUNTER_INCREMENT("multiget_block_read_miss_cnt", multiget_block_read_miss_cnt);
     return s;
 }
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -415,6 +415,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_memtable_flush);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_inner_io);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_chunk_io);
+    METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_sst_open);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_compact);
     METRICS_DEFINE_THREAD_POOL(exec_state_report);
     METRICS_DEFINE_THREAD_POOL(priority_exec_state_report);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -414,6 +414,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_execution);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_memtable_flush);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_inner_io);
+    METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_chunk_io);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_compact);
     METRICS_DEFINE_THREAD_POOL(exec_state_report);
     METRICS_DEFINE_THREAD_POOL(priority_exec_state_report);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -413,6 +413,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(lake_metadata_fetch);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_execution);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_memtable_flush);
+    METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_inner_io);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_compact);
     METRICS_DEFINE_THREAD_POOL(exec_state_report);
     METRICS_DEFINE_THREAD_POOL(priority_exec_state_report);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -135,6 +135,7 @@ public class Utils {
                                            ComputeResource computeResource,
                                            Map<Long, Long> tabletRowNum)
             throws NoAliveBackendException, RpcException {
+        long entryMs = System.currentTimeMillis();
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         if (!warehouseManager.isResourceAvailable(computeResource)) {
             LOG.warn("publish version operation should be successful even if the warehouse is not exist, " +
@@ -146,7 +147,8 @@ public class Utils {
         List<Long> rebuildPindexTabletIds = new ArrayList<>();
         Map<ComputeNode, PublishTabletsInfo> nodeToPublishTabletsInfo = processTablets(tablets, computeResource,
                 warehouseManager, rebuildPindexTabletIds, baseVersion, newVersion);
-        
+        long processTabletsEndMs = System.currentTimeMillis();
+
         List<Future<PublishVersionResponse>> responseList = Lists.newArrayListWithCapacity(nodeToPublishTabletsInfo.size());
         List<ComputeNode> nodeList = Lists.newArrayListWithCapacity(nodeToPublishTabletsInfo.size());
         for (Map.Entry<ComputeNode, PublishTabletsInfo> entry : nodeToPublishTabletsInfo.entrySet()) {
@@ -168,27 +170,39 @@ public class Utils {
             responseList.add(future);
             nodeList.add(node);
         }
+        long submitEndMs = System.currentTimeMillis();
 
-        for (int i = 0; i < responseList.size(); i++) {
-            try {
-                PublishVersionResponse response = responseList.get(i).get();
-                if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
-                    throw new RpcException("Fail to publish version for tablets " + response.failedTablets + ": " +
-                            response.status.errorMsgs.get(0));
-                }
-                if (compactionScores != null && response != null && response.compactionScores != null) {
-                    compactionScores.putAll(response.compactionScores);
-                }
-                if (tabletRanges != null && response != null && response.tabletRanges != null) {
-                    for (Map.Entry<Long, TabletRangePB> entry : response.tabletRanges.entrySet()) {
-                        tabletRanges.put(entry.getKey(), TabletRange.fromProto(entry.getValue()));
+        try {
+            for (int i = 0; i < responseList.size(); i++) {
+                try {
+                    PublishVersionResponse response = responseList.get(i).get();
+                    if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
+                        throw new RpcException("Fail to publish version for tablets " + response.failedTablets + ": " +
+                                response.status.errorMsgs.get(0));
                     }
+                    if (compactionScores != null && response != null && response.compactionScores != null) {
+                        compactionScores.putAll(response.compactionScores);
+                    }
+                    if (tabletRanges != null && response != null && response.tabletRanges != null) {
+                        for (Map.Entry<Long, TabletRangePB> entry : response.tabletRanges.entrySet()) {
+                            tabletRanges.put(entry.getKey(), TabletRange.fromProto(entry.getValue()));
+                        }
+                    }
+                    if (baseVersion == 1 && tabletRowNum != null && response != null && response.tabletRowNums != null) {
+                        tabletRowNum.putAll(response.tabletRowNums);
+                    }
+                } catch (Exception e) {
+                    throw new RpcException(nodeList.get(i).getHost(), e.getMessage());
                 }
-                if (baseVersion == 1 && tabletRowNum != null && response != null && response.tabletRowNums != null) {
-                    tabletRowNum.putAll(response.tabletRowNums);
-                }
-            } catch (Exception e) {
-                throw new RpcException(nodeList.get(i).getHost(), e.getMessage());
+            }
+        } finally {
+            long endMs = System.currentTimeMillis();
+            long totalMs = endMs - entryMs;
+            if (totalMs >= 500) {
+                LOG.warn("Slow publishVersionBatch nodes={} tablets={} total_ms={} process_tablets_ms={} " +
+                                "rpc_submit_ms={} rpc_wait_ms={}",
+                        nodeToPublishTabletsInfo.size(), tablets.size(), totalMs,
+                        processTabletsEndMs - entryMs, submitEndMs - processTabletsEndMs, endMs - submitEndMs);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -1000,8 +1000,11 @@ public class PublishVersionDaemon extends FrontendDaemon {
             return CompletableFuture.completedFuture(false);
         }
 
+        long submitTimeMs = System.currentTimeMillis();
         return CompletableFuture.supplyAsync(() -> {
-            boolean success = publishPartition(db, tableCommitInfo, partitionCommitInfo, txnState);
+            long lambdaEntryMs = System.currentTimeMillis();
+            boolean success = publishPartition(db, tableCommitInfo, partitionCommitInfo, txnState,
+                    submitTimeMs, lambdaEntryMs);
             partitionCommitInfo.setVersionTime(success ? System.currentTimeMillis() : -System.currentTimeMillis());
             return success;
         }, getTaskExecutor()).exceptionally(ex -> {
@@ -1013,7 +1016,8 @@ public class PublishVersionDaemon extends FrontendDaemon {
 
     private boolean publishPartition(@NotNull Database db, @NotNull TableCommitInfo tableCommitInfo,
                                      @NotNull PartitionCommitInfo partitionCommitInfo,
-                                     @NotNull TransactionState txnState) {
+                                     @NotNull TransactionState txnState,
+                                     long submitTimeMs, long lambdaEntryMs) {
         long tableId = tableCommitInfo.getTableId();
         long baseVersion = 0;
         long txnVersion = partitionCommitInfo.getVersion();
@@ -1026,6 +1030,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
+        long lockAcquiredMs = System.currentTimeMillis();
         boolean useAggregatePublish = Config.enable_file_bundling;
         try {
             OlapTable table =
@@ -1066,6 +1071,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
         }
 
         TxnInfoPB txnInfo = TxnInfoHelper.fromTransactionState(txnState);
+        long brpcStartMs = System.currentTimeMillis();
         try {
             if (CollectionUtils.isNotEmpty(shadowTablets)) {
                 Utils.publishLogVersion(shadowTablets, txnInfo, txnVersion, computeResource);
@@ -1096,6 +1102,16 @@ public class PublishVersionDaemon extends FrontendDaemon {
             LOG.error("Fail to publish partition {} of txn {}: {}", partitionCommitInfo.getPhysicalPartitionId(),
                     txnId, e.getMessage());
             return false;
+        } finally {
+            long brpcEndMs = System.currentTimeMillis();
+            long totalMs = brpcEndMs - submitTimeMs;
+            if (totalMs >= 500) {
+                LOG.warn("Slow publishPartition txn={} partition={} table={} total_ms={} executor_acquire_ms={} " +
+                                "lock_wait_ms={} fe_prep_ms={} brpc_ms={}",
+                        txnId, partitionCommitInfo.getPhysicalPartitionId(), tableId,
+                        totalMs, lambdaEntryMs - submitTimeMs,
+                        lockAcquiredMs - lambdaEntryMs, brpcStartMs - lockAcquiredMs, brpcEndMs - brpcStartMs);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Iteration 041 dedicated build slot — combines the cumulative validated optimization stack with the iter-040 LakeDelvecLoader deep-copy fix on a single fork branch, so TSP can build them all together.

This PR exists because earlier iterations (iter-040 PR #72667) branched off the run's pinned base `7af3ba7` without the prior validated wins (#72654, #72639, #72622, #72619, #72606, #72591), making the build effectively a "bare branch-4.1 + LakeDelvecLoader" that regressed by 12-15× vs the iter-040 measured cumulative result. This branch is the cumulative stack so iter-042 can deploy and verify the LakeDelvecLoader fix on top of the real validated baseline.

## Stack composition
Top of stack down to run-pinned base `7af3ba7`:
- **iter-040** `[auto-perf-opt] Skip TabletMetadataPB deep copy in LakeDelvecLoader::load_from_file` (the iter-041 verification target)
- **iter-039 / #72654** `[auto-perf-opt] Replace std::list with std::optional in KeyValueMerger`
- **iter-037 / #72639** `[auto-perf-opt] Move SST opens to a dedicated pk_index_sst_open pool`
- **iter-036 / #72622** `[auto-perf-opt] Bump pk_index_inner_io pool default to num_cores * 4`
- **iter-035 / #72619** `[auto-perf-opt] Parallelise PK-index multi_get into key chunks`
- **iter-034 / #72606** `[auto-perf-opt] Move parallel get_from_sstables to dedicated inner-io pool`
- **iter-031 / #72579** stacked precursors
- earlier validated wins (#72591, BRPC instrumentation, SO_REUSEPORT, update_cache_expire_sec, etc.)

## Empirical evidence the stack was missing
Iter-041 deployed PR #72667 (LakeDelvecLoader fix only, on bare branch-4.1) and observed:
- Cluster CPU saturated 99.7-99.8% on 4 of 6 CN — vs iter-040's 71-88% peak with the full stack.
- CPU profile: `my_free` 41% + `my_malloc` 41% (= 82% allocator self-time) on `cloud_native_pk_index_compact` — vs iter-040's ~3% allocator self-time.
- KVMerger `std::list` allocator churn was back as the dominant CPU consumer (1.27%-12.31% per call site of `IndexValuesWithVerPB::~IndexValuesWithVerPB` + `KeyValueMerger::merge` + `KeyValueMerger::flush`).
- Confirms #72654's fix is unmerged in upstream branch-4.1 and TSP-builds of single-PR slots silently lose it.

## Test plan
- [ ] TSP build iter-041 stack PR succeeds.
- [ ] iter-042 deploys this build with fresh `tsp deploy apply`, runs 20-min `999_1gb_1_1tb` benchmark.
- [ ] Cold-start CPU peaks ≤ 88% on ≥ 4 of 6 CN (matches iter-040 envelope).
- [ ] CPU profile shows allocator self-time ≤ 5% (KVMerger + general) — matches iter-040.
- [ ] BE slow-publish ≥ 1 s ≤ 200 (matches iter-040 = 122).
- [ ] FE `prepare→write_end ≥ 10 s` ≤ 1000 (matches iter-040 = 703).
- [ ] LakeDelvecLoader-related profile: `compact_column_group → LakeDelvecLoader::load → TabletManager::get_tablet_metadata` deep copy < 2% inclusive (vs iter-040 measured 6.32%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
