### PR TITLE
[BugFix] check having clause when disabling agg spill on small limit

### DIFF
--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -176,8 +176,10 @@ StatusOr<pipeline::OpFactories> AggregateBlockingNode::decompose_to_pipeline(
                                         SortedAggregateStreamingSinkOperatorFactory>(ops_with_sink, context, false)));
     } else {
         // disable spill when group by with a small limit
+        // having clause filters rows after aggregation, so a small limit does not bound the
+        // aggregation input size; only disable spill when there is no having clause.
         bool enable_agg_spill = runtime_state()->enable_spill() && runtime_state()->enable_agg_spill();
-        if (limit() != -1 && limit() < runtime_state()->chunk_size()) {
+        if (limit() != -1 && limit() < runtime_state()->chunk_size() && _tnode.conjuncts.empty()) {
             enable_agg_spill = false;
         }
         if (enable_agg_spill && has_group_by_keys) {


### PR DESCRIPTION
## Why I'm doing:

The small-limit guard that disables aggregate spill assumed the limit bounds the aggregation input size. When a HAVING clause is present, the limit applies after post-aggregation filtering, so the aggregator may still need to process far more than limit rows. Skip the disable when the agg node has conjuncts (HAVING).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
