### PR TITLE
[BugFix] avoid stack-buffer-overflow when formatting into a temporary std::string

### DIFF
--- a/be/src/connector/utils.cpp
+++ b/be/src/connector/utils.cpp
@@ -163,24 +163,33 @@ StatusOr<std::string> HiveUtils::iceberg_column_value(const TypeDescriptor& type
         timeinfo.tm_year = year - 1900;
         timeinfo.tm_mon = month - 1;
         char buffer[10];
-        std::strftime(buffer, sizeof(buffer), "%Y-%m", &timeinfo);
-        value = std::string(buffer);
+        size_t written = std::strftime(buffer, sizeof(buffer), "%Y-%m", &timeinfo);
+        if (written == 0) {
+            return Status::InternalError("strftime overflow formatting iceberg month partition");
+        }
+        value = std::string(buffer, written);
     } else if (transform_expr == "day") {
         const auto days_from_epoch = ColumnViewer<TYPE_BIGINT>(column).value(idx);
         std::time_t seconds = static_cast<std::time_t>(days_from_epoch) * 86400;
         std::tm tm_utc;
         gmtime_r(&seconds, &tm_utc);
         char buffer[20];
-        std::strftime(buffer, sizeof(buffer), "%Y-%m-%d", &tm_utc);
-        value = std::string(buffer);
+        size_t written = std::strftime(buffer, sizeof(buffer), "%Y-%m-%d", &tm_utc);
+        if (written == 0) {
+            return Status::InternalError("strftime overflow formatting iceberg day partition");
+        }
+        value = std::string(buffer, written);
     } else if (transform_expr == "hour") {
         const auto hours_from_epoch = ColumnViewer<TYPE_BIGINT>(column).value(idx);
         std::time_t seconds = static_cast<std::time_t>(hours_from_epoch) * 3600;
         std::tm tm_utc;
         gmtime_r(&seconds, &tm_utc);
         char buffer[20];
-        std::strftime(buffer, sizeof(buffer), "%Y-%m-%d-%H", &tm_utc);
-        value = std::string(buffer);
+        size_t written = std::strftime(buffer, sizeof(buffer), "%Y-%m-%d-%H", &tm_utc);
+        if (written == 0) {
+            return Status::InternalError("strftime overflow formatting iceberg hour partition");
+        }
+        value = std::string(buffer, written);
     } else if (transform_expr.compare(0, 8, "truncate") == 0) {
         ASSIGN_OR_RETURN(value, column_value(type_desc, column, idx));
     } else if (transform_expr.compare(0, 6, "bucket") == 0) {

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -2717,8 +2717,11 @@ StatusOr<ColumnPtr> standard_format(const std::string& fmt, int len, const starr
             result.append_null();
         } else {
             auto ts = (TimestampValue)ts_viewer.value(i);
-            bool b = standard_format_one_row(ts, buf, fmt);
-            result.append(Slice(std::string(buf)), !b);
+            if (!standard_format_one_row(ts, buf, fmt)) {
+                result.append_null();
+            } else {
+                result.append(Slice(buf));
+            }
         }
     }
     return result.build(ColumnHelper::is_all_const(columns));
@@ -2767,8 +2770,11 @@ void common_format_process(ColumnViewer<Type>* viewer_date, ColumnViewer<TYPE_VA
     } else {
         char buf[128];
         auto ts = (TimestampValue)viewer_date->value(i);
-        bool b = standard_format_one_row(ts, buf, viewer_format->value(i).to_string());
-        builder->append(Slice(std::string(buf)), !b);
+        if (!standard_format_one_row(ts, buf, viewer_format->value(i).to_string())) {
+            builder->append_null();
+        } else {
+            builder->append(Slice(buf));
+        }
     }
 }
 
@@ -2910,8 +2916,11 @@ StatusOr<ColumnPtr> joda_standard_format(const std::string& fmt, int len, const 
             result.append_null();
         } else {
             auto ts = (TimestampValue)ts_viewer.value(i);
-            bool b = joda_standard_format_one_row(ts, buf, fmt);
-            result.append(Slice(std::string(buf)), !b);
+            if (!joda_standard_format_one_row(ts, buf, fmt)) {
+                result.append_null();
+            } else {
+                result.append(Slice(buf));
+            }
         }
     }
     return result.build(ColumnHelper::is_all_const(columns));
@@ -2960,8 +2969,11 @@ void common_joda_format_process(ColumnViewer<Type>* viewer_date, ColumnViewer<TY
     } else {
         char buf[128];
         auto ts = (TimestampValue)viewer_date->value(i);
-        bool b = joda_standard_format_one_row(ts, buf, format);
-        builder->append(Slice(std::string(buf)), !b);
+        if (!joda_standard_format_one_row(ts, buf, format)) {
+            builder->append_null();
+        } else {
+            builder->append(Slice(buf));
+        }
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

Several call sites passed a stack buffer to a formatter that does not guarantee NUL-termination on its failure path, then handed the buffer to std::string(const char*) (sometimes via Slice). When the formatter bailed out, the std::string constructor's strlen walked past the buffer end and tripped ASAN -- e.g. datetime_format on a long format string overflowed the 128-byte buf in common_format_process by 7 bytes.

Fix the four time-format helpers to skip buf entirely on failure (append_null + Slice(buf) on success, matching the pattern already used by the other to_format_string callers), and harden the three iceberg partition strftime sites in HiveUtils::iceberg_column_value to honor the strftime return value and build std::string(buffer, written) with an explicit length, returning an error when strftime reports the buffer was too small.

## What I'm doing:

Fixes 
```
Crash Log: 
==9476==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x146dcf2d2d60 at pc 0x00001cb74466 bp 0x146dd071f130 sp 0x146dd071e8f0
READ of size 135 at 0x146dcf2d2d60 thread T298
   #0 0x1cb74465 in strlen.part.0 (/home/disk1/sr/be/lib/starrocks_be+0x1cb74465)
   #1 0x1cc4d831 in std::char_traits<char>::length(char const*) /opt/gcc-toolset-14/include/c++/14.3.0/bits/char_traits.h:391
   #2 0x1cc4f180 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/basic_string.h:653
   #3 0x323759d7 in void starrocks::common_format_process<(starrocks::LogicalType)51>(starrocks::ColumnViewer<(starrocks::LogicalType)51>*, starrocks::ColumnViewer<(starrocks::LogicalType)17>*, starrocks::ColumnBuilder<(starrocks::LogicalType)17>*, int) be/src/exprs/time_functions.cpp:2771
   #4 0x323036e2 in starrocks::TimeFunctions::datetime_format(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) be/src/exprs/time_functions.cpp:2794
   #5 0x220f6c00 in starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > std::__invoke_impl<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> >, starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*&)(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&>(std::__invoke_other, starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*&)(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::FunctionContext*&&, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:61
   #6 0x220f5e6b in std::enable_if<is_invocable_r_v<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> >, starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*&)(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&>, starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > >::type std::__invoke_r<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> >, starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*&)(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&>(starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*&)(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::FunctionContext*&&, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:116
   #7 0x220f52f2 in std::_Function_handler<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*)(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&)>::_M_invoke(std::_Any_data const&, starrocks::FunctionContext*&&, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:291
   #8 0x225d345b in std::function<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&)>::operator()(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) const /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:591
   #9 0x22851ded in starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*) be/src/exprs/function_call_expr.cpp:213
   #10 0x3031d88a in starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*) be/src/exprs/expr_context.cpp:190
   #11 0x22851566 in starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*) be/src/exprs/function_call_expr.cpp:189
   #12 0x31fbfd0e in starrocks::VectorizedIfNullExpr<(starrocks::LogicalType)5>::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*) be/src/exprs/condition_expr.cpp:85
   #13 0x3031d88a in starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*) be/src/exprs/expr_context.cpp:190
   #14 0x3031d0bb in starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*) be/src/exprs/expr_context.cpp:166
   #15 0x2ee57163 in starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&) be/src/exec/pipeline/project_operator.cpp:62
   #16 0x22da230a in starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int) be/src/exec/pipeline/pipeline_driver.cpp:447
   #17 0x24ec2b26 in starrocks::pipeline::GlobalDriverExecutor::_worker_thread() be/src/exec/pipeline/pipeline_driver_executor.cpp:169
   #18 0x24ec11f9 in operator() be/src/exec/pipeline/pipeline_driver_executor.cpp:66
   #19 0x24ecc013 in __invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:61
   #20 0x24ecb49f in __invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:111
   #21 0x24ecae38 in _M_invoke /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:290
   #22 0x24ad33ed in std::function<void ()>::operator()() const /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:591
   #23 0x32d06207 in starrocks::FunctionRunnable::run() be/src/common/thread/threadpool.cpp:61
   #24 0x32d0024e in starrocks::ThreadPool::dispatch_thread() be/src/common/thread/threadpool.cpp:680
   #25 0x32d214c9 in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:74
   #26 0x32d1fe68 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:96
   #27 0x32d1e8b9 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /opt/gcc-toolset-14/include/c++/14.3.0/functional:513
   #28 0x32d1cf15 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /opt/gcc-toolset-14/include/c++/14.3.0/functional:598
   #29 0x32d1b19b in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:61
   #30 0x32d18a9e in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:111
   #31 0x32d14334 in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:290
   #32 0x24ad33ed in std::function<void ()>::operator()() const /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:591
   #33 0x32ce6064 in starrocks::Thread::supervise_thread(void*) be/src/common/thread/thread.cpp:412
   #34 0x1cb56615 in asan_thread_start(void*) (/home/disk1/sr/be/lib/starrocks_be+0x1cb56615)
   #35 0x146eacea3ac2 in start_thread nptl/pthread_create.c:442
   #36 0x146eacf358cf in __clone3 (/lib/x86_64-linux-gnu/libc.so.6+0x1268cf) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)

Address 0x146dcf2d2d60 is located in stack of thread T298 at offset 1376 in frame
   #0 0x32374a93 in void starrocks::common_format_process<(starrocks::LogicalType)51>(starrocks::ColumnViewer<(starrocks::LogicalType)51>*, starrocks::ColumnViewer<(starrocks::LogicalType)17>*, starrocks::ColumnBuilder<(starrocks::LogicalType)17>*, int) be/src/exprs/time_functions.cpp:2747

 This frame has 33 object(s):
   [32, 33) '<unknown>'
   [48, 52) '<unknown>'
   [64, 68) '<unknown>'
   [80, 84) '<unknown>'
   [96, 100) '<unknown>'
   [112, 116) '<unknown>'
   [128, 136) '<unknown>'
   [160, 168) '<unknown>'
   [192, 200) '<unknown>'
   [224, 232) '<unknown>'
   [256, 264) '<unknown>'
   [288, 296) '<unknown>'
   [320, 328) 'ts' (line 2769)
   [352, 368) '<unknown>'
   [384, 400) '<unknown>'
   [416, 432) '<unknown>'
   [448, 464) '<unknown>'
   [480, 496) '<unknown>'
   [512, 528) '<unknown>'
   [544, 560) '<unknown>'
   [576, 592) '<unknown>'
   [608, 624) '<unknown>'
   [640, 656) '<unknown>'
   [672, 704) 'format' (line 2754)
   [736, 768) '<unknown>'
   [800, 832) '<unknown>'
   [864, 896) '<unknown>'
   [928, 960) '<unknown>'
   [992, 1024) '<unknown>'
   [1056, 1088) '<unknown>'
   [1120, 1152) '<unknown>'
   [1184, 1216) '<unknown>'
   [1248, 1376) 'buf' (line 2768) <== Memory access at offset 1376 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
     (longjmp and C++ exceptions *are* supported)
Thread T298 created by T0 here:
   #0 0x1cbe7f21 in pthread_create (/home/disk1/sr/be/lib/starrocks_be+0x1cbe7f21)
   #1 0x32ce559b in starrocks::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, unsigned long, scoped_refptr<starrocks::Thread>*) be/src/common/thread/thread.cpp:363
   #2 0x32d0a04a in starrocks::Status starrocks::Thread::create<void (starrocks::ThreadPool::*)(), starrocks::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void (starrocks::ThreadPool::* const&)(), starrocks::ThreadPool* const&, scoped_refptr<starrocks::Thread>*) be/src/common/thread/thread.h:76
   #3 0x32d02363 in starrocks::ThreadPool::create_thread() be/src/common/thread/threadpool.cpp:764
   #4 0x32cfc7d6 in starrocks::ThreadPool::do_submit(std::shared_ptr<starrocks::Runnable>, starrocks::ThreadPoolToken*, starrocks::ThreadPool::Priority) be/src/common/thread/threadpool.cpp:493
   #5 0x32cfb188 in starrocks::ThreadPool::submit(std::shared_ptr<starrocks::Runnable>, starrocks::ThreadPool::Priority) be/src/common/thread/threadpool.cpp:371
   #6 0x32cfb2e4 in starrocks::ThreadPool::submit_func(std::function<void ()>, starrocks::ThreadPool::Priority) be/src/common/thread/threadpool.cpp:375
   #7 0x24ec1383 in starrocks::pipeline::GlobalDriverExecutor::initialize(int) be/src/exec/pipeline/pipeline_driver_executor.cpp:66
   #8 0x24eab9df in starrocks::workgroup::PipelineExecutorSet::start() be/src/exec/workgroup/pipeline_executor_set.cpp:106
   #9 0x24e985c5 in starrocks::workgroup::ExecutorsManager::start_shared_executors_unlocked() const be/src/exec/workgroup/pipeline_executor_set_manager.cpp:37
   #10 0x24e66fe0 in starrocks::workgroup::WorkGroupManager::start() be/src/exec/workgroup/work_group.cpp:670
   #11 0x29108178 in starrocks::ExecEnv::init(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/runtime/exec_env.cpp:588
   #12 0x2f6ee40f in starrocks::start_be(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/service/service_be/starrocks_be.cpp:129
   #13 0x1cc4aa3f in main be/src/service/starrocks_main.cpp:289
   #14 0x146eace38d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: stack-buffer-overflow (/home/disk1/sr/be/lib/starrocks_be+0x1cb74465) in strlen.part.0
Shadow bytes around the buggy address:
 0x146dcf2d2a80: 00 00 f2 f2 00 00 00 00 f2 f2 f2 f2 00 00 00 00
 0x146dcf2d2b00: f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2 00 00 00 00
 0x146dcf2d2b80: f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2 00 00 00 00
 0x146dcf2d2c00: f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2 f8 f8 f8 f8
 0x146dcf2d2c80: f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2 00 00 00 00
=>0x146dcf2d2d00: 00 00 00 00 00 00 00 00 00 00 00 00[f3]f3 f3 f3
 0x146dcf2d2d80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 0x146dcf2d2e00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 0x146dcf2d2e80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 0x146dcf2d2f00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 0x146dcf2d2f80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
 Addressable:           00
 Partially addressable: 01 02 03 04 05 06 07 
 Heap left redzone:       fa
 Freed heap region:       fd
 Stack left redzone:      f1
 Stack mid redzone:       f2
 Stack right redzone:     f3
 Stack after return:      f5
 Stack use after scope:   f8
 Global redzone:          f9
 Global init order:       f6
 Poisoned by user:        f7
 Container overflow:      fc
 Array cookie:            ac
 Intra object redzone:    bb
 ASan internal:           fe
 Left alloca redzone:     ca
 Right alloca redzone:    cb
==9476==ABORTING

```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
