### PR TITLE
[BugFix] Fix memory leak in JsonFunctions::json_path_prepare

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -124,11 +124,11 @@ Status JsonFunctions::json_path_prepare(FunctionContext* context, FunctionContex
     } catch (const boost::escaped_list_error& e) {
         return Status::InvalidArgument(strings::Substitute("Illegal json path: $0", e.what()));
     }
-    auto* parsed_paths = new std::vector<SimpleJsonPath>();
-    RETURN_IF_ERROR(_get_parsed_paths(path_exprs, parsed_paths));
+    auto parsed_paths = std::make_unique<std::vector<SimpleJsonPath>>();
+    RETURN_IF_ERROR(_get_parsed_paths(path_exprs, parsed_paths.get()));
 
-    context->set_function_state(scope, parsed_paths);
     VLOG(10) << "prepare json path. size: " << parsed_paths->size();
+    context->set_function_state(scope, parsed_paths.release());
     return Status::OK();
 }
 


### PR DESCRIPTION
## Why I'm doing:

When `_get_parsed_paths` returns an error, the `parsed_paths` vector allocated via `new` was never released. Use `std::unique_ptr` and only release ownership to the function state on the success path so the buffer is freed on any early return.

## What I'm doing:

Fix memory leak in JsonFunctions::json_path_prepare

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
