### PR TITLE
[BugFix] fix unnecessary memory buildup across cancelled backups

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -892,6 +892,9 @@ public class BackupJob extends AbstractJob {
         }
 
         releaseSnapshots();
+        snapshotInfos.clear();
+        backupMeta = null;
+        jobInfo = null;
 
         BackupJobState curState = state;
         finishedTime = System.currentTimeMillis();

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobTest.java
@@ -787,4 +787,40 @@ public class BackupJobTest {
             Assertions.fail("Failed to test chooseReplica: " + e.getMessage());
         }
     }
+
+    @Test
+    public void testCancelInternalClearsState() {
+        // Setup a pending job
+        List<TableRefPersist> tableRefs = Lists.newArrayList();
+        tableRefs.add(new TableRefPersist(new TableName(UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME), null));
+        BackupJob cancelJob = new BackupJob("label_cancel", dbId, UnitTestUtil.DB_NAME, tableRefs, 
+                13600 * 1000, globalStateMgr, repo.getId());
+
+        // Fill in states mapping
+        Map<Long, SnapshotInfo> snapshotInfos = Maps.newConcurrentMap();
+        snapshotInfos.put(1L, new SnapshotInfo(dbId, tblId, partId, idxId, 1L,
+                backendId, schemaHash, "path", Lists.newArrayList()));
+        Deencapsulation.setField(cancelJob, "snapshotInfos", snapshotInfos);
+        
+        BackupMeta backupMeta = new BackupMeta(Lists.newArrayList());
+        Deencapsulation.setField(cancelJob, "backupMeta", backupMeta);
+        
+        BackupJobInfo jobInfo = new BackupJobInfo();
+        Deencapsulation.setField(cancelJob, "jobInfo", jobInfo);
+
+        // Verify they are set before cancellation
+        Map<Long, SnapshotInfo> retrievedSnapshotInfos = Deencapsulation.getField(cancelJob, "snapshotInfos");
+        Assertions.assertFalse(retrievedSnapshotInfos.isEmpty());
+        Assertions.assertNotNull((Object) Deencapsulation.getField(cancelJob, "backupMeta"));
+        Assertions.assertNotNull((Object) Deencapsulation.getField(cancelJob, "jobInfo"));
+
+        // Cancel the job, this will trigger cancelInternal
+        cancelJob.cancel();
+
+        // Verify they are cleared after cancellation
+        retrievedSnapshotInfos = Deencapsulation.getField(cancelJob, "snapshotInfos");
+        Assertions.assertTrue(retrievedSnapshotInfos.isEmpty());
+        Assertions.assertNull((Object) Deencapsulation.getField(cancelJob, "backupMeta"));
+        Assertions.assertNull((Object) Deencapsulation.getField(cancelJob, "jobInfo"));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
When a BackupJob is cancelled , the objects (snapshotInfos, backupMeta, and jobInfo) are not cleared. These structures can be heavy metadata-wise when a backup includes tables with numerous partitions, indexes, and tablets. Failing to clean these objects results in unneeded internal memory accumulation and artificially inflates journal sizes.

## What I'm doing:
clear the snapshotInfos map and nullify both backupMeta and jobInfo.

Fixes #72760 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
