### PR TITLE
[BugFix] use unsigned byte order in ColumnDict.merge

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
@@ -22,8 +22,31 @@ import com.starrocks.common.Pair;
 import com.starrocks.persist.gson.GsonUtils;
 
 import java.nio.ByteBuffer;
+import java.util.Comparator;
 
 public final class ColumnDict extends StatsVersion {
+    /**
+     * Unsigned-byte lexicographic comparator. BE sorts dictionary strings via memcmp, which the C
+     * standard defines to compare bytes as unsigned char. ByteBuffer.compareTo on JDK 8 instead
+     * compares bytes as signed (Java 9 fixed this to unsigned), so any UTF-8 string with a high-bit
+     * byte (Cyrillic, CJK, etc.) sorts the opposite way on the two sides. Always use this comparator
+     * when ordering dictionary keys on the FE so the result matches BE regardless of JDK version.
+     */
+    private static final Comparator<ByteBuffer> UNSIGNED_LEX = (a, b) -> {
+        int aPos = a.position();
+        int bPos = b.position();
+        int aLen = a.limit() - aPos;
+        int bLen = b.limit() - bPos;
+        int n = Math.min(aLen, bLen);
+        for (int i = 0; i < n; i++) {
+            int diff = (a.get(aPos + i) & 0xff) - (b.get(bPos + i) & 0xff);
+            if (diff != 0) {
+                return diff;
+            }
+        }
+        return aLen - bLen;
+    };
+
     private final ImmutableMap<ByteBuffer, Integer> dict;
     // olap table use time info as version info.
     // table on lake use num as version, collectedVersion means historical version num,
@@ -94,7 +117,10 @@ public final class ColumnDict extends StatsVersion {
         while (idx1 < n1 && idx2 < n2) {
             ByteBuffer key1 = sortedKeys1[idx1];
             ByteBuffer key2 = sortedKeys2[idx2];
-            int cmp = key1.compareTo(key2);
+            // Must use UNSIGNED_LEX here, not ByteBuffer.compareTo: BE sorted these dicts by
+            // unsigned memcmp, and on JDK 8 ByteBuffer.compareTo is signed, which would walk the
+            // arrays in the wrong order and emit duplicate keys.
+            int cmp = UNSIGNED_LEX.compare(key1, key2);
             if (cmp == 0) {
                 builder.put(key1, newIdx);
                 idx1++;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ColumnDictTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ColumnDictTest.java
@@ -110,6 +110,36 @@ public class ColumnDictTest {
     }
 
     @Test
+    public void testMergeDictWithHighBitBytesUtf8() {
+        // Regression test: BE sorts dict strings via memcmp (unsigned bytes) and assigns ids in
+        // that order. ByteBuffer.compareTo on JDK 8 compares bytes as signed, which inverts the
+        // order of any UTF-8 string with a high-bit byte. Walking the merge with a signed
+        // comparator over a BE-sorted (unsigned) array put d2's high-byte key at newIdx=1, then
+        // drained d1 and put the same key again at a later newIdx, failing ImmutableMap.build()
+        // with "Multiple entries with same key".
+        // Minimal repro: ASCII '7' (0x37) vs Cyrillic 'В' (UTF-8 first byte 0xD0). Signed: 0x37 -
+        // (signed 0xD0) = +103. Unsigned: 0x37 - 0xD0 = -153.
+        ImmutableMap.Builder<ByteBuffer, Integer> builder1 = ImmutableMap.builder();
+        ImmutableMap.Builder<ByteBuffer, Integer> builder2 = ImmutableMap.builder();
+
+        builder1.put(toByteBuffer("78"), 1);
+        builder1.put(toByteBuffer("В"), 2);
+
+        builder2.put(toByteBuffer("В"), 1);
+
+        ColumnDict dict1 = new ColumnDict(builder1.build(), 1);
+        ColumnDict dict2 = new ColumnDict(builder2.build(), 2);
+
+        Pair<ColumnDict, ColumnDict> res = ColumnDict.merge(dict1, dict2);
+
+        Assertions.assertNotNull(res);
+        Assertions.assertEquals(2, res.first.getDictSize());
+        Assertions.assertEquals(1, res.first.getDict().get(toByteBuffer("78")));
+        Assertions.assertEquals(2, res.first.getDict().get(toByteBuffer("В")));
+        Assertions.assertEquals(res.first.getDict(), res.second.getDict());
+    }
+
+    @Test
     public void testMergeDictFail() {
         ImmutableMap.Builder<ByteBuffer, Integer> builder1 = ImmutableMap.builder();
         ImmutableMap.Builder<ByteBuffer, Integer> builder2 = ImmutableMap.builder();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #70313

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
