### PR TITLE
[BugFix] Make Locker rollback exception-safe and fix unlock order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockManager.java
@@ -243,7 +243,7 @@ public class LockManager {
             throws LockInterruptException, DeadlockException {
         DeadLockChecker dc = null;
         while (true) {
-            boolean lockTimeOut = (timeout != 0) && timeRemain(timeout, startTime) < 0;
+            boolean lockTimeOut = (timeout != 0) && timeRemain(timeout, startTime) <= 0;
             if (lockTimeOut && dc != null) {
                 if (removeFromWaiterList(rid, currentLocker, lockType)) {
                     /* Failure to acquire lock within the timeout ms */

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/Locker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/Locker.java
@@ -287,32 +287,40 @@ public class Locker {
     public void lockTablesWithIntensiveDbLock(Long dbId, List<Long> tableList, LockType lockType) {
         Preconditions.checkState(lockType.equals(LockType.READ) || lockType.equals(LockType.WRITE));
         List<Long> tableListClone = new ArrayList<>(tableList);
-        if (Config.lock_manager_enabled) {
-            LockType intentionType = (lockType == LockType.WRITE)
-                    ? LockType.INTENTION_EXCLUSIVE
-                    : LockType.INTENTION_SHARED;
-            boolean dbLockHeld = false;
-            List<Long> ridLockedList = new ArrayList<>();
-            try {
-                this.lock(dbId, intentionType, 0);
-                dbLockHeld = true;
-
-                Collections.sort(tableListClone);
-                for (Long rid : tableListClone) {
-                    this.lock(rid, lockType, 0);
-                    ridLockedList.add(rid);
-                }
-            } catch (LockException e) {
-                // Roll back any locks already acquired so that a partial failure
-                // (e.g. deadlock victim selection on the second / Nth lock call)
-                // does not leave a stranded DB intention or table lock that
-                // would block subsequent DB-WRITE operations indefinitely.
-                rollbackPartialIntensiveLock(dbId, intentionType, dbLockHeld, ridLockedList, lockType);
-                throw ErrorReportException.report(ErrorCode.ERR_LOCK_ERROR, e.getMessage());
-            }
-        } else {
+        if (!Config.lock_manager_enabled) {
             //Fallback to db lock
             lockDatabase(dbId, lockType);
+            return;
+        }
+
+        LockType intentionType = (lockType == LockType.WRITE)
+                ? LockType.INTENTION_EXCLUSIVE
+                : LockType.INTENTION_SHARED;
+        boolean dbLockHeld = false;
+        List<Long> ridLockedList = new ArrayList<>();
+        boolean success = false;
+        try {
+            this.lock(dbId, intentionType, 0);
+            dbLockHeld = true;
+
+            Collections.sort(tableListClone);
+            for (Long rid : tableListClone) {
+                this.lock(rid, lockType, 0);
+                ridLockedList.add(rid);
+            }
+            success = true;
+        } catch (LockException e) {
+            throw ErrorReportException.report(ErrorCode.ERR_LOCK_ERROR, e.getMessage());
+        } finally {
+            // Roll back any locks already acquired on partial failure
+            // (LockException, deadlock victim, or any unchecked exception)
+            // so a stranded DB intention or table lock does not block
+            // subsequent DB-WRITE operations indefinitely.
+            // rollbackPartialIntensiveLock releases tables before DB intention
+            // to preserve hierarchical-lock invariants.
+            if (!success) {
+                rollbackPartialIntensiveLock(dbId, intentionType, dbLockHeld, ridLockedList, lockType);
+            }
         }
     }
 
@@ -347,41 +355,39 @@ public class Locker {
                                                     long timeout, TimeUnit unit) {
         Preconditions.checkState(lockType.equals(LockType.READ) || lockType.equals(LockType.WRITE));
         List<Long> tableListClone = new ArrayList<>(tableList);
-        if (Config.lock_manager_enabled) {
-            try {
-                if (lockType == LockType.WRITE) {
-                    this.lock(dbId, LockType.INTENTION_EXCLUSIVE, timeout);
-                } else {
-                    this.lock(dbId, LockType.INTENTION_SHARED, timeout);
-                }
-            } catch (LockException e) {
-                return false;
-            }
-
-            List<Long> ridLockedList = new ArrayList<>();
-            try {
-                Collections.sort(tableListClone);
-                for (Long rid : tableListClone) {
-                    this.lock(rid, lockType, timeout);
-                    ridLockedList.add(rid);
-                }
-
-                return true;
-            } catch (LockException e) {
-                if (lockType == LockType.WRITE) {
-                    release(dbId, LockType.INTENTION_EXCLUSIVE);
-                } else {
-                    release(dbId, LockType.INTENTION_SHARED);
-                }
-
-                for (Long rid : ridLockedList) {
-                    release(rid, lockType);
-                }
-                return false;
-            }
-        } else {
+        if (!Config.lock_manager_enabled) {
             // Fallback to db lock
             return tryLockDatabase(dbId, lockType, timeout, unit);
+        }
+
+        LockType intentionType = (lockType == LockType.WRITE)
+                ? LockType.INTENTION_EXCLUSIVE
+                : LockType.INTENTION_SHARED;
+        boolean dbLockHeld = false;
+        List<Long> ridLockedList = new ArrayList<>();
+        boolean success = false;
+        try {
+            this.lock(dbId, intentionType, timeout);
+            dbLockHeld = true;
+
+            Collections.sort(tableListClone);
+            for (Long rid : tableListClone) {
+                this.lock(rid, lockType, timeout);
+                ridLockedList.add(rid);
+            }
+            success = true;
+            return true;
+        } catch (LockException e) {
+            return false;
+        } finally {
+            // Roll back any partial state on LockException (success == false) or
+            // on any unchecked exception that propagates out before success was
+            // set; otherwise the DB intention or already-acquired table locks
+            // would leak. rollbackPartialIntensiveLock releases tables before DB
+            // intention to preserve hierarchical-lock invariants.
+            if (!success) {
+                rollbackPartialIntensiveLock(dbId, intentionType, dbLockHeld, ridLockedList, lockType);
+            }
         }
     }
 
@@ -392,14 +398,18 @@ public class Locker {
         Preconditions.checkState(lockType.equals(LockType.READ) || lockType.equals(LockType.WRITE));
         List<Long> tableListClone = new ArrayList<>(tableList);
         if (Config.lock_manager_enabled) {
+            // Release in reverse of acquire order: tables first, then DB intention.
+            // Releasing the DB intention while still holding table locks would leave
+            // a window for a DROP-DATABASE-style X-on-DB to slip in and invalidate
+            // the table the caller is still operating on.
+            Collections.sort(tableListClone);
+            for (Long rid : tableListClone) {
+                this.release(rid, lockType);
+            }
             if (lockType == LockType.WRITE) {
                 this.release(dbId, LockType.INTENTION_EXCLUSIVE);
             } else {
                 this.release(dbId, LockType.INTENTION_SHARED);
-            }
-            Collections.sort(tableListClone);
-            for (Long rid : tableListClone) {
-                this.release(rid, lockType);
             }
         } else {
             //Fallback to db lock
@@ -490,11 +500,10 @@ public class Locker {
     public void unLockTableWithIntensiveDbLock(LockParams params, LockType lockType) {
         Map<Long, Database> dbs = params.getDbs();
         Map<Long, Set<Long>> tables = params.getTables();
-        Locker locker = new Locker();
         for (Map.Entry<Long, Set<Long>> entry : tables.entrySet()) {
             Database database = dbs.get(entry.getKey());
             List<Long> tableIds = new ArrayList<>(entry.getValue());
-            locker.unLockTablesWithIntensiveDbLock(database.getId(), tableIds, lockType);
+            this.unLockTablesWithIntensiveDbLock(database.getId(), tableIds, lockType);
         }
     }
 


### PR DESCRIPTION
Several correctness fixes in the FE lock-manager wrappers on Locker:

1. lockTablesWithIntensiveDbLock and tryLockTablesWithIntensiveDbLock only caught LockException, so any unchecked exception thrown after the DB intention lock had been acquired would leak that lock (and any partially-acquired table locks), stalling later DB-WRITE operations. Both methods now use a try / finally pattern that routes every failure through rollbackPartialIntensiveLock.

2. unLockTablesWithIntensiveDbLock released the DB intention lock BEFORE releasing the table locks, violating hierarchical-locking ordering. The window allowed a concurrent X-on-DB request (e.g. DROP DATABASE) to acquire the DB and drop metadata while the caller still held a table lock against it. Release order is now tables first, then DB intention, matching the acquire order in reverse.

3. unLockTableWithIntensiveDbLock(LockParams, LockType) was allocating a fresh Locker to perform the release. It worked only because Locker identity collapses by threadId; cross-thread or refactored callers would silently leak locks. It now uses this.

4. LockManager.notifyVictim used timeRemain < 0 for its timeout check while the other two timeout sites in lock() / lockAcquireSlowPath() use <= 0. At timeRemain == 0 the inconsistent boundary caused one extra notify-and-sleep round before timing out. Aligned to <= 0.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
