### PR TITLE
fix: tolerate git pull timeout in ci-sync to avoid missing syncs

### DIFF
--- a/.github/workflows/ci-backport-checker.yml
+++ b/.github/workflows/ci-backport-checker.yml
@@ -7,7 +7,6 @@ on:
       - 'branch-[0-9].[0-9]'
       - 'branch-[0-9].[0-9].[0-9]'
     types:
-      - closed
       - labeled
 
 env:
@@ -26,14 +25,7 @@ jobs:
     if: >
       contains(github.event.pull_request.title, 'backport') &&
       startsWith(github.head_ref, 'mergify/bp') &&
-      (
-        (github.event.action == 'labeled' &&
-         (github.event.label.name == 'conflicts' || github.event.label.name == 'conflict')) ||
-        (github.event.action == 'closed' &&
-         github.event.pull_request.merged != true &&
-         (contains(github.event.pull_request.labels.*.name, 'conflicts') ||
-          contains(github.event.pull_request.labels.*.name, 'conflict')))
-      )
+      (github.event.label.name == 'conflicts' || github.event.label.name == 'conflict')
     env:
       STATUS: CONFLICT
 

--- a/.github/workflows/ci-backport-checker.yml
+++ b/.github/workflows/ci-backport-checker.yml
@@ -8,6 +8,7 @@ on:
       - 'branch-[0-9].[0-9].[0-9]'
     types:
       - closed
+      - labeled
 
 env:
   PR_ID: ${{ github.event.number }}
@@ -17,16 +18,22 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
   FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
 jobs:
   backport-close:
     runs-on: [self-hosted, normal]
     if: >
-      github.event.pull_request.merged != true &&
       contains(github.event.pull_request.title, 'backport') &&
-      (contains(github.event.pull_request.labels.*.name, 'conflicts') ||
-      contains(github.event.pull_request.labels.*.name, 'conflict')) &&
-      startsWith(github.head_ref, 'mergify/bp')
+      startsWith(github.head_ref, 'mergify/bp') &&
+      (
+        (github.event.action == 'labeled' &&
+         (github.event.label.name == 'conflicts' || github.event.label.name == 'conflict')) ||
+        (github.event.action == 'closed' &&
+         github.event.pull_request.merged != true &&
+         (contains(github.event.pull_request.labels.*.name, 'conflicts') ||
+          contains(github.event.pull_request.labels.*.name, 'conflict')))
+      )
     env:
       STATUS: CONFLICT
 

--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -37,5 +37,5 @@ jobs:
           COMMIT_ID: ${{ steps.commit_sha.outputs.commit_sha }}
           BRANCH: ${{ github.base_ref }}
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && timeout 60 git pull >/dev/null || echo "git pull timeout, using cached ci-tool"
           ./scripts/run-repo-sync.sh


### PR DESCRIPTION
## Summary

The \`sync\` step in \`ci-sync.yml\` runs:
\`\`\`bash
rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null
./scripts/run-repo-sync.sh
\`\`\`

When the runner cannot reach GitHub (port 443 timeout), \`git pull\` fails after ~2 minutes and the step exits due to \`-e\` mode. \`run-repo-sync.sh\` never executes, so the CelerData sync is silently skipped.

**Fix:** Add \`timeout 60\` + \`|| echo\` fallback so a failed pull uses the pre-cached \`/var/lib/ci-tool\` and the sync still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)