### PR TITLE
[Tool] fix tolerate git pull timeout in ci-sync to avoid missing syncs

### DIFF
--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -37,5 +37,5 @@ jobs:
           COMMIT_ID: ${{ steps.commit_sha.outputs.commit_sha }}
           BRANCH: ${{ github.base_ref }}
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && timeout 60 git pull >/dev/null || echo "git pull timeout, using cached ci-tool"
           ./scripts/run-repo-sync.sh


### PR DESCRIPTION
## Why I'm doing:

The `sync` step in `ci-sync.yml` calls `git pull` to update `ci-tool` before running `run-repo-sync.sh`. When the runner cannot reach GitHub (port 443 timeout, ~2min), the step exits immediately due to shell `-e` mode and `run-repo-sync.sh` never executes — causing PRs merged to StarRocks to be silently skipped and not synced to CelerData.

## What I'm doing:

Add `timeout 60` and `|| echo` fallback to `git pull` so that on network failure the sync still runs using the pre-cached `/var/lib/ci-tool` on the runner.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4