### PR TITLE
[Enhancement] Force PCT for the first refresh of an INCREMENTAL MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessorFactory.java
@@ -14,13 +14,17 @@
 
 package com.starrocks.scheduler.mv;
 
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.mv.hybrid.MVHybridRefreshProcessor;
 import com.starrocks.scheduler.mv.ivm.MVIVMRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
+
+import java.util.Map;
 
 public class MVRefreshProcessorFactory {
     public static final MVRefreshProcessorFactory INSTANCE = new MVRefreshProcessorFactory();
@@ -31,11 +35,30 @@ public class MVRefreshProcessorFactory {
         MaterializedView.RefreshMode refreshMode = mv.getCurrentRefreshMode();
         switch (refreshMode) {
             case INCREMENTAL:
+                // Route through the hybrid processor when any base table lacks a TVR baseline so
+                // PCT can rebuild it. Otherwise run pure IVM with strict semantics (no fallback).
+                if (needsPctBaselineRebuild(mv)) {
+                    return new MVHybridRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
+                }
                 return new MVIVMRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
             case AUTO:
                 return new MVHybridRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
             default:
                 return new MVPCTRefreshProcessor(db, mv, mvContext, mvEntity, refreshMode);
         }
+    }
+
+    private static boolean needsPctBaselineRebuild(MaterializedView mv) {
+        // True for the genuine first refresh and also after MVMetaVersionRepairer rewrites a
+        // BaseTableInfo key without updating baseTableInfoTvrVersionRangeMap, which would
+        // otherwise leave pure IVM throwing "No checkpoint found" with no fallback.
+        Map<BaseTableInfo, TvrVersionRange> tvrMap = mv.getRefreshScheme().getAsyncRefreshContext()
+                .getBaseTableInfoTvrVersionRangeMap();
+        for (BaseTableInfo info : mv.getBaseTableInfos()) {
+            if (!tvrMap.containsKey(info)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -205,8 +205,10 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
             return maxTvrDelta;
         }
 
-        if (maxTvrDelta.start().isEmpty() && mv.getCurrentRefreshMode() == MaterializedView.RefreshMode.AUTO) {
-            throw new SemanticException("No checkpoint found for base table: %s.%s during AUTO IVM planning",
+        if (maxTvrDelta.start().isEmpty() && mv.getCurrentRefreshMode().isIncrementalOrAuto()) {
+            // No TVR baseline. The hybrid processor catches this and falls back to PCT to
+            // rebuild the baseline; on the pure IVM path it propagates as a hard failure.
+            throw new SemanticException("No checkpoint found for base table: %s.%s during IVM planning",
                     baseTableInfo.getDbName(), baseTableInfo.getTableName());
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -64,7 +64,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                 plan -> {
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
                             "TABLE: unpartitioned_db.t0\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
+                                    "     TABLE VERSION: Delta@[0,1]");
                 },
                 plan -> {
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
@@ -82,7 +82,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                             "     TABLE: unpartitioned_db.t0\n" +
                                     "     PREDICATES: 1: id > 10\n" +
                                     "     MIN/MAX PREDICATES: 1: id > 10\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
+                                    "     TABLE VERSION: Delta@[0,1]");
                 },
                 plan -> {
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
@@ -104,7 +104,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     // First run: should have delta scan and snapshot/delta scans via UNION
                     PlanTestBase.assertContains(planStr, "TABLE: unpartitioned_db.t0");
                     PlanTestBase.assertContains(planStr, "TABLE: partitioned_db.t1");
-                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[MIN,1]");
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[0,1]");
                     PlanTestBase.assertContains(planStr, "UNION");
                 },
                 plan -> {
@@ -129,7 +129,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     // First run: 3-table join with delta scans
                     PlanTestBase.assertContains(planStr, "TABLE: unpartitioned_db.t0");
                     PlanTestBase.assertContains(planStr, "TABLE: partitioned_db.t1");
-                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[MIN,1]");
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[0,1]");
                     PlanTestBase.assertContains(planStr, "UNION");
                 },
                 plan -> {
@@ -150,7 +150,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
                             "  0:IcebergScanNode\n" +
                                     "     TABLE: partitioned_db.t1\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
+                                    "     TABLE VERSION: Delta@[0,1]");
                 },
                 plan -> {
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
@@ -169,7 +169,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
                             "  0:IcebergScanNode\n" +
                                     "     TABLE: partitioned_db.t1\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
+                                    "     TABLE VERSION: Delta@[0,1]");
                 },
                 plan -> {
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
@@ -190,11 +190,11 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
                             "  3:IcebergScanNode\n" +
                                     "     TABLE: unpartitioned_db.t0\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
+                                    "     TABLE VERSION: Delta@[0,1]");
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
                             "  0:IcebergScanNode\n" +
                                     "     TABLE: partitioned_db.t1\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
+                                    "     TABLE VERSION: Delta@[0,1]");
                 },
                 plan -> {
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
@@ -218,7 +218,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
                             "  0:IcebergScanNode\n" +
                                     "     TABLE: partitioned_db.t1\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
+                                    "     TABLE VERSION: Delta@[0,1]");
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
                             "  7:HASH JOIN\n" +
                                     "  |  join op: RIGHT OUTER JOIN (BUCKET_SHUFFLE)\n" +
@@ -321,11 +321,11 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
                             "  3:IcebergScanNode\n" +
                                     "     TABLE: unpartitioned_db.t0\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
+                                    "     TABLE VERSION: Delta@[0,1]");
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
                             "  0:IcebergScanNode\n" +
                                     "     TABLE: partitioned_db.t1\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
+                                    "     TABLE VERSION: Delta@[0,1]");
                 },
                 plan -> {
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
@@ -768,6 +768,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental",
                 "`date`", Map.of("partition_refresh_number", "1"));
         Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+        seedTvrBaselineAtVersionZero(mv);
 
         advanceTableVersionTo(2);
         MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
@@ -848,7 +849,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     String planStr = plan.getExplainString(TExplainLevel.NORMAL);
                     // Verify incremental scan
                     PlanTestBase.assertContains(planStr,
-                            "TABLE VERSION: Delta@[MIN,1]");
+                            "TABLE VERSION: Delta@[0,1]");
                     // Verify LEFT/RIGHT OUTER JOIN with __ROW_ID__
                     PlanTestBase.assertContains(planStr, "HASH JOIN");
                     PlanTestBase.assertContains(planStr, "equal join conjunct:");
@@ -907,7 +908,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                         "FROM `iceberg0`.`partitioned_db`.`t1` as a group by date, id;",
                 plan -> {
                     String planStr = plan.getExplainString(TExplainLevel.NORMAL);
-                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[MIN,1]");
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[0,1]");
                     PlanTestBase.assertContains(planStr, "HASH JOIN");
                     PlanTestBase.assertContains(planStr, "state_union");
                     PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
@@ -1289,5 +1290,50 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         Long snapshotId = pinnedSnapshotIdMap.values().iterator().next();
         Assertions.assertEquals(2L, snapshotId.longValue(),
                 "pinnedSnapshotIdMap value should match the PCT-synced snapshot id");
+    }
+
+    @Test
+    public void testIncrementalFirstRefreshRoutesToHybridForPctBaseline() throws Exception {
+        // Empty TVR baseline: factory must route to hybrid so PCT establishes the baseline.
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+        Assertions.assertTrue(
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoTvrVersionRangeMap().isEmpty());
+
+        MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
+        Assertions.assertInstanceOf(MVHybridRefreshProcessor.class, mvTaskRunProcessor.getMVRefreshProcessor());
+    }
+
+    @Test
+    public void testIncrementalSubsequentRefreshUsesPureIvm() throws Exception {
+        // All base tables have a baseline: factory must route to pure IVM (no fallback).
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+        seedTvrBaselineAtVersionZero(mv);
+
+        MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
+        Assertions.assertInstanceOf(MVIVMRefreshProcessor.class, mvTaskRunProcessor.getMVRefreshProcessor());
+    }
+
+    @Test
+    public void testIncrementalRefreshRoutesToHybridWhenAnyBaseTableMissingBaseline() throws Exception {
+        // Map non-empty but current BaseTableInfo has no entry (e.g. after a metadata repair
+        // that rewrote keys without updating baseTableInfoTvrVersionRangeMap). Factory must
+        // still route to hybrid so PCT can rebuild the missing baseline.
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+
+        Map<BaseTableInfo, TvrVersionRange> tvrMap = mv.getRefreshScheme().getAsyncRefreshContext()
+                .getBaseTableInfoTvrVersionRangeMap();
+        BaseTableInfo current = mv.getBaseTableInfos().get(0);
+        BaseTableInfo stale = new BaseTableInfo(current.getCatalogName(), current.getDbName(),
+                current.getTableName(), "stale-table-identifier");
+        tvrMap.put(stale, TvrTableSnapshot.of(0L));
+
+        MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
+        Assertions.assertInstanceOf(MVHybridRefreshProcessor.class, mvTaskRunProcessor.getMVRefreshProcessor());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMTestBase.java
@@ -14,8 +14,11 @@
 
 package com.starrocks.scheduler.mv.ivm;
 
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
+import com.starrocks.common.tvr.TvrTableSnapshot;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.load.loadv2.IVMInsertLoadTxnCallback;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
@@ -23,6 +26,8 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+
+import java.util.Map;
 
 public abstract class MVIVMTestBase extends MVTestBase {
 
@@ -84,6 +89,9 @@ public abstract class MVIVMTestBase extends MVTestBase {
                 "AS %s;", mvQuery);
         starRocksAssert.withMaterializedView(ddl);
         MaterializedView mv = getMv("test_mv1");
+        // Pre-populate the TVR baseline so the factory routes to pure IVM and these tests
+        // exercise IVM plan generation directly instead of the first-refresh PCT path.
+        seedTvrBaselineAtVersionZero(mv);
         // 1th run
         {
             ExecPlan execPlan = getIVMRefreshedExecPlan(mv);
@@ -108,6 +116,18 @@ public abstract class MVIVMTestBase extends MVTestBase {
             ExecPlan execPlan = getIVMRefreshedExecPlan(mv);
             Assertions.assertTrue(execPlan != null);
             run3.check(execPlan);
+        }
+    }
+
+    /**
+     * Seed every base table's TVR baseline at version 0 so the factory routes the next
+     * refresh to the pure IVM processor instead of the first-refresh PCT path.
+     */
+    protected static void seedTvrBaselineAtVersionZero(MaterializedView mv) {
+        Map<BaseTableInfo, TvrVersionRange> tvrMap = mv.getRefreshScheme().getAsyncRefreshContext()
+                .getBaseTableInfoTvrVersionRangeMap();
+        for (BaseTableInfo info : mv.getBaseTableInfos()) {
+            tvrMap.put(info, TvrTableSnapshot.of(0L));
         }
     }
 }

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_incremental
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_incremental
@@ -137,10 +137,13 @@ group by dt;
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-False
+True
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
 -- !result
 SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
 -- result:
@@ -157,10 +160,13 @@ insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-False
+True
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
 -- !result
 SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
 -- result:
@@ -177,10 +183,13 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-False
+True
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:
+2023-12-01	30	0
+2023-12-02	20	1
+2023-12-03	6	0
 -- !result
 SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt order by dt;
 -- result:


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
the very first refresh of an INCREMENTAL materialized view must be a forced PCT refresh that establishes the TVR baseline. Subsequent refreshes are strict IVM with no PCT fallback. The hybrid processor already implements "try IVM, fall back to PCT, capture TVR delta in the afterSyncHook" for the AUTO mode; This PR reuses that machinery for the INCREMENTAL first-refresh path without adding a new processor.

Production:
- MVRefreshProcessorFactory.newProcessor: when the MV is INCREMENTAL and has no persisted TVR baseline (baseTableInfoTvrVersionRangeMap is empty), route through MVHybridRefreshProcessor instead of the pure MVIVMRefreshProcessor. The hybrid's IVM attempt fails fast on the empty checkpoint (see below) and falls back to PCT; the PCT path's afterSyncHook + updatePCTMeta promote the TVR delta to the persisted baseline. Subsequent calls find the baseline populated and run on the pure IVM path with strict semantics (no fallback).
- MVIVMRefreshProcessor.getBaseTableChangedVersionRange: broaden the empty-checkpoint guard from RefreshMode.AUTO to isIncrementalOrAuto(). For AUTO MVs the behaviour is unchanged (already caught by the hybrid); for INCREMENTAL MVs running through the hybrid on first refresh, the guard fires so the hybrid's catch block can switch to PCT. If a pure-IVM INCREMENTAL refresh ever sees an empty checkpoint, the exception propagates as a hard failure.

Tests:
- MVIVMTestBase: introduce seedTvrBaselineAtVersionZero(mv) and call it at the start of doTestWith3Runs, so the existing IVM plan-generation tests continue to exercise the pure-IVM path (factory.newProcessor sees a non-empty baseline). The 13 doTestWith3Runs callers' Delta@[MIN,1] expectations are updated to Delta@[0,1] to match the baseline-at-version-0 setup.
- testIVMPCTMetadataNotTruncatedByPartitionRefreshNumber: also call seedTvrBaselineAtVersionZero so the existing IVM-processor type assertion still applies.
- testIncrementalFirstRefreshRoutesToHybridForPctBaseline: new test asserting that the factory routes a fresh INCREMENTAL MV through MVHybridRefreshProcessor.
- testIncrementalSubsequentRefreshUsesPureIvm: new test asserting that once the TVR baseline is populated the factory returns the pure MVIVMRefreshProcessor (no PCT fallback for subsequent runs).



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
