### PR TITLE
[BugFix] Dedupe commutative AND/OR in scalar operator CSE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/exprreuse/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/exprreuse/ScalarOperatorsReuse.java
@@ -366,13 +366,28 @@ public class ScalarOperatorsReuse {
         // enable some special logic codes only for lambda functions.
         private boolean hasLambdaFunction;
 
+        // Normalize children group ids for commutative compound predicates (AND/OR) so that
+        // expressions like `a AND b` and `b AND a` map to the same OperatorId. This mirrors
+        // CompoundPredicateOperator#equals, which sorts AND/OR children before comparing;
+        // without this normalization, the two forms would be tracked as distinct common
+        // subexpressions and later collide as a single key in the rewritten ImmutableMap.
+        private static List<Integer> normalizeChildrenGroup(ScalarOperator operator, List<Integer> groups) {
+            if (operator instanceof CompoundPredicateOperator) {
+                CompoundPredicateOperator compound = (CompoundPredicateOperator) operator;
+                if (compound.isAnd() || compound.isOr()) {
+                    return groups.stream().sorted().toList();
+                }
+            }
+            return groups;
+        }
+
         public boolean hasLambdaFunction() {
             return hasLambdaFunction;
         }
 
         private CommonResult collectCommonOperatorsByDepth(int depth, ScalarOperator operator, List<Integer> groups,
                                                            CommonOperatorContext context) {
-            OperatorId id = new OperatorId(operator, groups);
+            OperatorId id = new OperatorId(operator, normalizeChildrenGroup(operator, groups));
             Map<OperatorId, Integer> level = operatorsByDepth.computeIfAbsent(depth, c -> Maps.newHashMap());
 
             boolean isDuplicated = level.containsKey(id);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
@@ -19,7 +19,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.Config;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -337,6 +339,36 @@ public class ScalarOperatorsReuseTest {
                 ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory);
         assertEquals(0, commonSubScalarOperators.size());
         Config.max_scalar_operator_flat_children = prev;
+    }
+
+    @Test
+    public void testReuseCommutativeCompoundPredicates() {
+        // Regression test: when two distinct OperatorIds (different child group order, e.g.
+        // `a AND b` vs `b AND a`) both qualify as common subexpressions, their rewritten
+        // ScalarOperators are considered equal by CompoundPredicateOperator#equals (which
+        // normalizes child order). The previous ImmutableMap.Builder put failed with
+        // "Multiple entries with same key".
+        ColumnRefOperator c1 = columnRefFactory.create("c1", IntegerType.INT, true);
+        ColumnRefOperator c2 = columnRefFactory.create("c2", IntegerType.INT, true);
+
+        BinaryPredicateOperator a = new BinaryPredicateOperator(BinaryType.GT, c1, ConstantOperator.createInt(1));
+        BinaryPredicateOperator b = new BinaryPredicateOperator(BinaryType.GT, c2, ConstantOperator.createInt(2));
+
+        // Two copies of `a AND b` and two copies of `b AND a` — each pair makes its own OperatorId
+        // qualify as duplicated/common at the same depth.
+        CompoundPredicateOperator andAB1 =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, a, b);
+        CompoundPredicateOperator andAB2 =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, a, b);
+        CompoundPredicateOperator andBA1 =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, b, a);
+        CompoundPredicateOperator andBA2 =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, b, a);
+
+        List<ScalarOperator> oldOperators = Lists.newArrayList(andAB1, andAB2, andBA1, andBA2);
+        // Should not throw IllegalArgumentException("Multiple entries with same key").
+        List<ScalarOperator> newOperators = ScalarOperatorsReuse.rewriteOperators(oldOperators, columnRefFactory);
+        assertEquals(4, newOperators.size());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

ScalarOperatorsReuse used two inconsistent notions of equality:
- OperatorId compared via equalsSelf + ordered childrenGroup, which is position-sensitive.
- CompoundPredicateOperator#equals normalizes child order for AND/OR, so `a AND b` equals `b AND a`.

Two predicates that swap children (e.g. `230 AND 229` vs `229 AND 230`) were therefore tracked as distinct common subexpressions during the collection phase, then collided as a single key when their rewritten forms were inserted into the ImmutableMap, throwing "Multiple entries with same key" from ImmutableMap.Builder#build at QueryOptimizer#physicalRuleRewrite.

Fix at the source: when constructing an OperatorId for a CompoundPredicate whose type is AND or OR, sort the childrenGroup ids so commutative siblings produce one canonical id. This avoids redundant ColumnRefOperator allocation as well.

Added a regression test that constructs `a AND b` and `b AND a` (each duplicated so both qualify as common) and asserts rewriteOperators no longer throws.

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/70313

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
