### PR TITLE
[BugFix] Fix duplicate format-version key when creating Iceberg table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -468,7 +468,9 @@ public class IcebergApiConverter {
         } else if (compressionCodec != null) {
             setCompressionProperties(tableProperties, fileFormat, compressionCodec);
         }
-        tableProperties.put(TableProperties.FORMAT_VERSION, "2");
+        if (!createProperties.containsKey(TableProperties.FORMAT_VERSION)) {
+            tableProperties.put(TableProperties.FORMAT_VERSION, "2");
+        }
 
         return tableProperties.build();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -60,6 +60,7 @@ import static com.starrocks.connector.PartitionUtil.convertIcebergPartitionToPar
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CATALOG_TYPE;
 import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import static org.apache.iceberg.TableProperties.ORC_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -313,6 +314,18 @@ public class IcebergApiConverterTest {
         target = IcebergApiConverter.rebuildCreateTableProperties(source);
         assertEquals("parquet", target.get(DEFAULT_FILE_FORMAT));
         assertEquals("snappy", target.get(PARQUET_COMPRESSION));
+
+        source = ImmutableMap.of(FORMAT_VERSION, "2");
+        target = IcebergApiConverter.rebuildCreateTableProperties(source);
+        assertEquals("2", target.get(FORMAT_VERSION));
+
+        source = ImmutableMap.of(FORMAT_VERSION, "1");
+        target = IcebergApiConverter.rebuildCreateTableProperties(source);
+        assertEquals("1", target.get(FORMAT_VERSION));
+
+        source = ImmutableMap.of("file_format", "parquet");
+        target = IcebergApiConverter.rebuildCreateTableProperties(source);
+        assertEquals("2", target.get(FORMAT_VERSION));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

When a user explicitly specifies `"format-version"` in `CREATE TABLE ... PROPERTIES (...)` for an Iceberg table, the statement fails with:

```
ERROR 1064 (HY000): Multiple entries with same key: format-version=2 and format-version=2
```

Reproduction (from StarRocks/StarRocksTest#11276):

```sql
CREATE TABLE iceberg_catalog.db.t (
    granularity string,
    business    string,
    city_id     int,
    date_id     int,
    online_seconds bigint,
    driver_id   bigint
) PARTITION BY (date_id) PROPERTIES ("format-version" = "2");
```

Root cause: `IcebergApiConverter.rebuildCreateTableProperties` first copies all user properties into an `ImmutableMap.Builder` and then unconditionally puts `TableProperties.FORMAT_VERSION` ("format-version") again. Guava's `ImmutableMap.Builder.build()` rejects duplicate keys, hence the IAE. Note that the adjacent `DEFAULT_FILE_FORMAT` put is already correctly guarded with a `containsKey` check — `FORMAT_VERSION` was simply missing the same guard.

## What I'm doing:

- Guard the `FORMAT_VERSION` put with `!createProperties.containsKey(TableProperties.FORMAT_VERSION)` in `IcebergApiConverter.rebuildCreateTableProperties`, mirroring the existing `DEFAULT_FILE_FORMAT` guard.
- When the user supplies `format-version`, their value is preserved (works for both `"1"` and `"2"`); when absent, the previous default of `"2"` is applied — so existing behavior is unchanged.
- Add unit-test coverage in `IcebergApiConverterTest.testRebuildCreateTableProperties` for the three cases: user-supplied `"2"`, user-supplied `"1"`, and absent (default `"2"`).

Because the main and branch-4.1 has fixed this issue, so we only fix the branch-4.0 by this PR.

Fixes StarRocks/StarRocksTest#11276

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
