### PR TITLE
[Enhancement] Implement stats and MCV prop for `date_trunc` (backport #72233)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -73,8 +73,8 @@ import static java.util.Collections.emptyList;
  */
 public final class ConstantOperator extends ScalarOperator implements Comparable<ConstantOperator> {
 
-    private static final LocalDateTime MAX_DATETIME = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
-    private static final LocalDateTime MIN_DATETIME = LocalDateTime.of(0, 1, 1, 0, 0, 0);
+    public static final LocalDateTime MAX_DATETIME = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+    public static final LocalDateTime MIN_DATETIME = LocalDateTime.of(0, 1, 1, 0, 0, 0);
 
     public static final ConstantOperator NULL = ConstantOperator.createNull(Type.BOOLEAN);
     public static final ConstantOperator TRUE = ConstantOperator.createBoolean(true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -34,6 +34,7 @@ import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
 import com.starrocks.sql.spm.SPMFunctions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,6 +43,7 @@ import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -747,6 +749,8 @@ public class ExpressionStatisticCalculator {
                     collectionSize = arrayStats.getCollectionSize();
                     distinctValues = calculateArrayMapNdv(callOperator, List.of(left, right));
                     break;
+                case FunctionSet.DATE_TRUNC:
+                    return calculateDateTruncStats(callOperator, right);
                 default:
                     return ColumnStatistic.unknown();
             }
@@ -758,6 +762,144 @@ public class ExpressionStatisticCalculator {
                     .setDistinctValuesCount(distinctValues)
                     .setCollectionSize(collectionSize);
             return builder.build();
+        }
+
+        private Optional<ConstantOperator> toConstantOperator(ScalarOperator op) {
+            if (op == null || !op.isConstant() || op.isConstantNull()) {
+                return Optional.empty();
+            }
+            if (op instanceof ConstantOperator) {
+                return Optional.of((ConstantOperator) op);
+            }
+            return Optional.empty();
+        }
+
+        private ColumnStatistic calculateDateTruncStats(CallOperator callOperator, ColumnStatistic dateStatistic) {
+            final var fmtArg = toConstantOperator(callOperator.getChild(0));
+            final var type = callOperator.getType();
+            double minValue = Double.NEGATIVE_INFINITY;
+            double maxValue = Double.POSITIVE_INFINITY;
+            double distinctValues = dateStatistic.getDistinctValuesCount();
+
+            Histogram transformedHistogram = null;
+            if (fmtArg.isPresent()) {
+                final var fmtString = fmtArg.get().getVarchar().toLowerCase();
+                final Optional<Long> estimatedNdv;
+                if (!dateStatistic.hasNaNValue() && dateStatistic.getMinValue() != Double.NEGATIVE_INFINITY
+                        && dateStatistic.getMaxValue() != Double.POSITIVE_INFINITY) {
+                    final var minDateTime = Utils.getDatetimeFromLong((long) dateStatistic.getMinValue());
+                    final var maxDateTime = Utils.getDatetimeFromLong((long) dateStatistic.getMaxValue());
+                    final var truncatedMinDateTime = truncateDateValue(fmtString, minDateTime, type);
+                    final var truncatedMaxDateTime = truncateDateValue(fmtString, maxDateTime, type);
+
+                    if (truncatedMinDateTime.isPresent() && truncatedMaxDateTime.isPresent()) {
+                        minValue = Utils.getLongFromDateTime(truncatedMinDateTime.get());
+                        maxValue = Utils.getLongFromDateTime(truncatedMaxDateTime.get());
+                        estimatedNdv = estimateDateTruncDistinctValues(fmtString, truncatedMinDateTime.get(),
+                                truncatedMaxDateTime.get());
+                    } else {
+                        // Fallback if we could not truncate the min or max value.
+                        estimatedNdv = estimateDateTruncDistinctValues(fmtString, type);
+                    }
+                } else {
+                    // Fallback if we do not have min/max stats.
+                    estimatedNdv = estimateDateTruncDistinctValues(fmtString, type);
+                }
+
+                if (estimatedNdv.isPresent()) {
+                    distinctValues = Math.min(dateStatistic.getDistinctValuesCount(), estimatedNdv.get());
+                }
+
+                transformedHistogram = transformHistogramForDateTrunc(fmtString, dateStatistic, callOperator.getType());
+            }
+
+            return ColumnStatistic.buildFrom(dateStatistic) //
+                    .setMinValue(minValue) //
+                    .setMaxValue(maxValue) //
+                    .setDistinctValuesCount(distinctValues) //
+                    .setHistogram(transformedHistogram) //
+                    .build();
+        }
+
+        private Histogram transformHistogramForDateTrunc(String fmtString, ColumnStatistic dateStatistic,
+                                                         Type resultType) {
+            final var histogram = dateStatistic.getHistogram();
+            if (histogram == null || histogram.getMCV() == null || histogram.getMCV().isEmpty()) {
+                return null;
+            }
+
+            Map<String, Long> newMcv = new HashMap<>();
+            for (final var entry : histogram.getMCV().entrySet()) {
+                // Parse MCV key string back to a date/datetime constant
+                final var parsedKey = ConstantOperator.createVarchar(entry.getKey()).castTo(resultType);
+                if (parsedKey.isEmpty() || parsedKey.get().isNull()) {
+                    return null;
+                }
+
+                // Apply date_trunc
+                final var truncatedKey = truncateDateValue(fmtString, parsedKey.get().getDatetime(), resultType);
+                if (truncatedKey.isEmpty()) {
+                    return null;
+                }
+
+                // Convert truncated value back to string key
+                final var truncatedKeyString = ConstantOperator.createDatetime(truncatedKey.get(), resultType)
+                        .castTo(Type.VARCHAR);
+                if (truncatedKeyString.isEmpty()) {
+                    return null;
+                }
+
+                newMcv.merge(truncatedKeyString.get().getVarchar(), entry.getValue(), Long::sum);
+            }
+
+            return new Histogram(Collections.emptyList(), newMcv);
+        }
+
+        private Optional<LocalDateTime> truncateDateValue(String fmt, LocalDateTime value, Type resultType) {
+            try {
+                final var truncatedValue = ScalarOperatorFunctions.dateTrunc(ConstantOperator.createVarchar(fmt),
+                        ConstantOperator.createDatetime(value, resultType));
+                if (truncatedValue == null || truncatedValue.isNull()) {
+                    return Optional.empty();
+                }
+                return Optional.of(truncatedValue.getDatetime());
+            } catch (IllegalArgumentException e) {
+                return Optional.empty();
+            }
+        }
+
+        private Optional<Long> estimateDateTruncDistinctValues(String fmt, LocalDateTime minDateTime, LocalDateTime maxDateTime) {
+            Optional<Long> distinctValues = Optional.empty();
+            distinctValues = switch (fmt) {
+                case FunctionSet.YEAR ->
+                        Optional.of(ChronoUnit.YEARS.between(minDateTime.toLocalDate(), maxDateTime.toLocalDate()) + 1L);
+                case FunctionSet.QUARTER -> Optional.of(quarterOrdinal(maxDateTime) - quarterOrdinal(minDateTime) + 1L);
+                case FunctionSet.MONTH ->
+                        Optional.of(ChronoUnit.MONTHS.between(minDateTime.toLocalDate(), maxDateTime.toLocalDate()) + 1L);
+                case FunctionSet.WEEK ->
+                        Optional.of(ChronoUnit.WEEKS.between(minDateTime.toLocalDate(), maxDateTime.toLocalDate()) + 1L);
+                case FunctionSet.DAY ->
+                        Optional.of(ChronoUnit.DAYS.between(minDateTime.toLocalDate(), maxDateTime.toLocalDate()) + 1L);
+                case FunctionSet.HOUR -> Optional.of(ChronoUnit.HOURS.between(minDateTime, maxDateTime) + 1L);
+                case FunctionSet.MINUTE -> Optional.of(ChronoUnit.MINUTES.between(minDateTime, maxDateTime) + 1L);
+                case FunctionSet.SECOND -> Optional.of(ChronoUnit.SECONDS.between(minDateTime, maxDateTime) + 1L);
+                // Do not estimate for more precise truncations (below seconds), since the upper bound NDV would be very high.
+                default -> distinctValues;
+            };
+            return distinctValues;
+        }
+
+        private Optional<Long> estimateDateTruncDistinctValues(String fmt, Type resultType) {
+            final var truncatedMin = truncateDateValue(fmt, ConstantOperator.MIN_DATETIME, resultType);
+            final var truncatedMax = truncateDateValue(fmt, ConstantOperator.MAX_DATETIME, resultType);
+            if (truncatedMin.isPresent() && truncatedMax.isPresent()) {
+                return estimateDateTruncDistinctValues(fmt, truncatedMin.get(), truncatedMax.get());
+            }
+            return Optional.empty();
+        }
+
+        private long quarterOrdinal(LocalDateTime dateTime) {
+            return dateTime.getYear() * 4L + (dateTime.getMonthValue() - 1L) / 3L;
         }
 
         private ColumnStatistic multiaryExpressionCalculate(CallOperator callOperator,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -37,7 +37,9 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
@@ -1138,5 +1140,337 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertNotNull(ifStat.getHistogram().getMCV());
         Assertions.assertTrue(ifStat.getHistogram().getMCV().containsKey("42"));
     }
-}
 
+    private void assertDateTruncStatistics(Type type, String fmt, LocalDateTime min, LocalDateTime max,
+                                           double inputDistinctValues, double nullsFraction,
+                                           LocalDateTime expectedMin, LocalDateTime expectedMax,
+                                           double expectedDistinctValues) {
+        ColumnRefOperator columnRefOperator = new ColumnRefOperator(0, type, "dt", true);
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(2048)
+                .addColumnStatistic(columnRefOperator, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(min))
+                        .setMaxValue(getLongFromDateTime(max))
+                        .setNullsFraction(nullsFraction)
+                        .setAverageRowSize(type.getTypeSize())
+                        .setDistinctValuesCount(inputDistinctValues)
+                        .build())
+                .build();
+
+        CallOperator callOperator = new CallOperator(
+                FunctionSet.DATE_TRUNC,
+                type,
+                Lists.newArrayList(ConstantOperator.createVarchar(fmt), columnRefOperator));
+        ColumnStatistic columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+
+        Assertions.assertEquals(getLongFromDateTime(expectedMin), columnStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(getLongFromDateTime(expectedMax), columnStatistic.getMaxValue(), 0.001);
+        Assertions.assertEquals(expectedDistinctValues, columnStatistic.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(nullsFraction, columnStatistic.getNullsFraction(), 0.001);
+        Assertions.assertEquals(type.getTypeSize(), columnStatistic.getAverageRowSize(), 0.001);
+    }
+
+    @Test
+    public void testDateTruncStatisticsWithMinMaxStats() {
+        // DATETIME month
+        assertDateTruncStatistics(
+                Type.DATETIME, "month",
+                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
+                LocalDateTime.of(2024, 3, 20, 12, 34, 56),
+                1000, 0.25,
+                LocalDateTime.of(2024, 1, 1, 0, 0),
+                LocalDateTime.of(2024, 3, 1, 0, 0),
+                3);
+
+        // DATETIME week
+        assertDateTruncStatistics(
+                Type.DATETIME, "week",
+                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
+                LocalDateTime.of(2024, 3, 20, 12, 34, 56),
+                1000, 0.25,
+                LocalDateTime.of(2024, 1, 15, 0, 0),
+                LocalDateTime.of(2024, 3, 18, 0, 0),
+                10);
+
+        // DATETIME day
+        assertDateTruncStatistics(
+                Type.DATETIME, "day",
+                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
+                LocalDateTime.of(2024, 3, 20, 12, 34, 56),
+                1000, 0.25,
+                LocalDateTime.of(2024, 1, 15, 0, 0),
+                LocalDateTime.of(2024, 3, 20, 0, 0),
+                66);
+
+        // DATETIME hour
+        assertDateTruncStatistics(
+                Type.DATETIME, "hour",
+                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
+                LocalDateTime.of(2024, 1, 15, 12, 22, 32),
+                1000, 0.25,
+                LocalDateTime.of(2024, 1, 15, 10, 0),
+                LocalDateTime.of(2024, 1, 15, 12, 0),
+                3);
+
+        // DATETIME minute
+        assertDateTruncStatistics(
+                Type.DATETIME, "minute",
+                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
+                LocalDateTime.of(2024, 1, 15, 10, 22, 32),
+                1000, 0.25,
+                LocalDateTime.of(2024, 1, 15, 10, 20),
+                LocalDateTime.of(2024, 1, 15, 10, 22),
+                3);
+
+        // DATETIME second
+        assertDateTruncStatistics(
+                Type.DATETIME, "second",
+                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
+                LocalDateTime.of(2024, 1, 15, 10, 20, 32),
+                1000, 0.25,
+                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
+                LocalDateTime.of(2024, 1, 15, 10, 20, 32),
+                3);
+
+        // DATE year
+        assertDateTruncStatistics(
+                Type.DATE, "year",
+                LocalDateTime.of(2023, 2, 15, 0, 0),
+                LocalDateTime.of(2025, 8, 20, 0, 0),
+                1000, 0.4,
+                LocalDateTime.of(2023, 1, 1, 0, 0),
+                LocalDateTime.of(2025, 1, 1, 0, 0),
+                3);
+
+        // DATE quarter
+        assertDateTruncStatistics(
+                Type.DATE, "quarter",
+                LocalDateTime.of(2023, 2, 15, 0, 0),
+                LocalDateTime.of(2023, 8, 20, 0, 0),
+                1000, 0.4,
+                LocalDateTime.of(2023, 1, 1, 0, 0),
+                LocalDateTime.of(2023, 7, 1, 0, 0),
+                3);
+
+        // DATE month
+        assertDateTruncStatistics(
+                Type.DATE, "month",
+                LocalDateTime.of(2024, 1, 15, 0, 0),
+                LocalDateTime.of(2024, 3, 20, 0, 0),
+                1000, 0.4,
+                LocalDateTime.of(2024, 1, 1, 0, 0),
+                LocalDateTime.of(2024, 3, 1, 0, 0),
+                3);
+
+        // DATE week
+        assertDateTruncStatistics(
+                Type.DATE, "week",
+                LocalDateTime.of(2024, 1, 16, 0, 0),
+                LocalDateTime.of(2024, 2, 1, 0, 0),
+                1000, 0.4,
+                LocalDateTime.of(2024, 1, 15, 0, 0),
+                LocalDateTime.of(2024, 1, 29, 0, 0),
+                3);
+
+        // DATE day
+        assertDateTruncStatistics(
+                Type.DATE, "day",
+                LocalDateTime.of(2024, 1, 15, 0, 0),
+                LocalDateTime.of(2024, 3, 20, 0, 0),
+                5, 0.4,
+                LocalDateTime.of(2024, 1, 15, 0, 0),
+                LocalDateTime.of(2024, 3, 20, 0, 0),
+                5);
+    }
+
+    @Test
+    public void testDateTruncFallbackStatistics() {
+        // Infinite range, NDV capped at truncated(MIN_DATETIME)..truncated(MAX_DATETIME) domain
+        assertDateTruncFallbackStatistics("year", 100_000, 10000);
+        assertDateTruncFallbackStatistics("quarter", 100_000, 40000);
+        assertDateTruncFallbackStatistics("month", 200_000, 120000);
+        // week: date_trunc('week', 0000-01-01) underflows (Saturday → previous Monday is year -1),
+        // so fallback cannot determine valid bounds and input NDV is preserved
+        assertDateTruncFallbackStatistics("week", 1_000_000, 1_000_000);
+        assertDateTruncFallbackStatistics("day", 10_000_000, 3652425);
+        assertDateTruncFallbackStatistics("hour", 100_000_000, 87658200);
+
+        // Minute/second fallback too precise, NDV preserved from input
+        assertDateTruncFallbackStatistics("minute", 500, 500);
+        assertDateTruncFallbackStatistics("second", 500, 500);
+
+        // Input NDV smaller than max, stays at input NDV
+        assertDateTruncFallbackStatistics("year", 10, 10);
+    }
+
+    /**
+     * Tests the fallback path of date_trunc NDV estimation when column statistics have
+     * infinite min/max (no range information available).
+     */
+    private void assertDateTruncFallbackStatistics(String fmt, double inputDistinctValues,
+                                                   double expectedDistinctValues) {
+        // GIVEN
+        final var columnRefOperator = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
+        final var statistics = Statistics.builder()
+                .setOutputRowCount(10_000_000)
+                .addColumnStatistic(columnRefOperator, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(Type.DATETIME.getTypeSize())
+                        .setDistinctValuesCount(inputDistinctValues)
+                        .build())
+                .build();
+
+        // WHEN
+        final var callOperator = new CallOperator(
+                FunctionSet.DATE_TRUNC,
+                Type.DATETIME,
+                Lists.newArrayList(ConstantOperator.createVarchar(fmt), columnRefOperator));
+        final var result = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+
+        // THEN
+        Assertions.assertEquals(expectedDistinctValues, result.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY, result.getMinValue(), 0.001);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, result.getMaxValue(), 0.001);
+    }
+
+    @Test
+    public void testDateTruncMinMaxResetToInfinityWhenTruncationFails() {
+        // date_trunc('week', 0000-01-01) underflows before MIN_DATETIME → truncation fails.
+        // min/max must be set to ±INF (unknown), not left as untruncated input values.
+        final var col = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
+        final var minDt = LocalDateTime.of(0, 1, 1, 0, 0, 0);   // 0000-01-01, a Monday-ish boundary
+        final var maxDt = LocalDateTime.of(0, 1, 10, 0, 0, 0);
+        final var statistics = Statistics.builder()
+                .setOutputRowCount(100)
+                .addColumnStatistic(col, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(minDt))
+                        .setMaxValue(getLongFromDateTime(maxDt))
+                        .setDistinctValuesCount(5)
+                        .build())
+                .build();
+
+        final var call = new CallOperator(FunctionSet.DATE_TRUNC, Type.DATETIME,
+                Lists.newArrayList(ConstantOperator.createVarchar("week"), col));
+        final var result = ExpressionStatisticCalculator.calculate(call, statistics);
+
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY, result.getMinValue());
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, result.getMaxValue());
+    }
+
+    @Test
+    public void testDateTruncMcvPropagation() {
+        // GIVEN
+        final var col = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
+        Map<String, Long> inputMcv = Map.of(
+                "2024-01-15 10:20:30", 100L,
+                "2024-01-15 14:45:00", 200L,  // same day as above
+                "2024-02-20 08:00:00", 150L
+        );
+        final var colStat = ColumnStatistic.builder()
+                .setDistinctValuesCount(1000)
+                .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
+                .build();
+        final var statistics = Statistics.builder()
+                .setOutputRowCount(10000)
+                .addColumnStatistic(col, colStat)
+                .build();
+
+        // WHEN
+        final var dateTruncDay = new CallOperator(FunctionSet.DATE_TRUNC, Type.DATETIME,
+                Lists.newArrayList(ConstantOperator.createVarchar("day"), col));
+        final var result = ExpressionStatisticCalculator.calculate(dateTruncDay, statistics);
+
+        // THEN
+        Assertions.assertNotNull(result.getHistogram());
+        final var mcv = result.getHistogram().getMCV();
+        Assertions.assertEquals(2, mcv.size());
+        Assertions.assertEquals(100L + 200L, mcv.get("2024-01-15 00:00:00"));
+        Assertions.assertEquals(150L, mcv.get("2024-02-20 00:00:00"));
+    }
+
+    @Test
+    public void testDateTruncMcvPropagationWithMonthTruncation() {
+        // GIVEN
+        final var col = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
+        final var inputMcv = Map.of(
+                "2024-03-10 12:00:00", 50L,
+                "2024-03-25 18:30:00", 70L,
+                "2024-04-05 09:00:00", 30L
+        );
+        final var colStat = ColumnStatistic.builder()
+                .setDistinctValuesCount(500)
+                .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
+                .build();
+        final var statistics = Statistics.builder()
+                .setOutputRowCount(5000)
+                .addColumnStatistic(col, colStat)
+                .build();
+
+        // WHEN
+        final var dateTruncMonth = new CallOperator(FunctionSet.DATE_TRUNC, Type.DATETIME,
+                Lists.newArrayList(ConstantOperator.createVarchar("month"), col));
+        final var result = ExpressionStatisticCalculator.calculate(dateTruncMonth, statistics);
+
+        // THEN
+        Assertions.assertNotNull(result.getHistogram());
+        final var mcv = result.getHistogram().getMCV();
+        Assertions.assertEquals(2, mcv.size());
+        Assertions.assertEquals(50L + 70L, mcv.get("2024-03-01 00:00:00"));
+        Assertions.assertEquals(30L, mcv.get("2024-04-01 00:00:00"));
+    }
+
+    @Test
+    public void testDateTruncMcvPropagationWithoutHistogram() {
+        // GIVEN
+        final var col = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
+        final var colStat = ColumnStatistic.builder()
+                .setDistinctValuesCount(100)
+                .build();
+        final var statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(col, colStat)
+                .build();
+
+        // WHEN
+        final var call = new CallOperator(FunctionSet.DATE_TRUNC, Type.DATETIME,
+                Lists.newArrayList(ConstantOperator.createVarchar("month"), col));
+        final var result = ExpressionStatisticCalculator.calculate(call, statistics);
+
+        // THEN
+        Assertions.assertNull(result.getHistogram());
+    }
+
+    @Test
+    public void testDateTruncMcvPropagationWithDateType() {
+        // GIVEN
+        final var col = new ColumnRefOperator(0, Type.DATE, "dt", true);
+        final var inputMcv = Map.of(
+                "2024-01-15", 100L,
+                "2024-01-28", 200L,
+                "2024-02-10", 50L
+        );
+        final var colStat = ColumnStatistic.builder()
+                .setDistinctValuesCount(365)
+                .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
+                .build();
+        final var statistics = Statistics.builder()
+                .setOutputRowCount(5000)
+                .addColumnStatistic(col, colStat)
+                .build();
+
+        // WHEN
+        final var call = new CallOperator(FunctionSet.DATE_TRUNC, Type.DATE,
+                Lists.newArrayList(ConstantOperator.createVarchar("month"), col));
+        final var result = ExpressionStatisticCalculator.calculate(call, statistics);
+
+        // THEN
+        Assertions.assertNotNull(result.getHistogram());
+        final var mcv = result.getHistogram().getMCV();
+        Assertions.assertEquals(2, mcv.size());
+        Assertions.assertEquals(100L + 200L, mcv.get("2024-01-01"));
+        Assertions.assertEquals(50L, mcv.get("2024-02-01"));
+    }
+
+}


### PR DESCRIPTION
Backport of #72233 to `branch-3.5-cc`.

Original commit: 7d586c3ade4d1823b5f1f2267c042ea6a60c0629
Original PR: https://github.com/StarRocks/starrocks/pull/72233

---

<!-- Original PR description below -->

## Why I'm doing:
`date_trunc` did not return any stats. This can lead to suboptimal plans.

## What I'm doing:
Implementing stats propagation for `date_trunc`. I am using the already existing FE implementation used for constant folding to determine min/max values. NDVs can also be determined by using min/max, or if these are not given, by calculating all possibilities. We max-cap NDVs to the input NDVs to avoid overestimation.

Furthermore, this PR also implements MCV propagation by reusing the already existing `date_trunc` implementation in FE.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
