### PR TITLE
[BugFix] Avoid holding coordinator lock during external resource cleanup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -83,6 +83,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.IcebergTable.DATA_SEQUENCE_NUMBER;
@@ -95,6 +98,7 @@ import static com.starrocks.connector.iceberg.IcebergUtil.checkFileFormatSupport
 
 public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     private static final Logger LOG = LogManager.getLogger(IcebergConnectorScanRangeSource.class);
+    private static final long CLOSE_WARN_DELAY_SECONDS = 60;
 
     private final IcebergTable table;
     private final TupleDescriptor desc;
@@ -177,10 +181,21 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
 
     @Override
     public void close() {
+        AtomicBoolean finished = new AtomicBoolean(false);
+        CompletableFuture.delayedExecutor(CLOSE_WARN_DELAY_SECONDS, TimeUnit.SECONDS).execute(() -> {
+            if (!finished.get()) {
+                LOG.warn("Iceberg remote file info source close is still running after {} seconds, "
+                                + "table: {}.{}, remoteFileInfoSource: {}",
+                        CLOSE_WARN_DELAY_SECONDS, table.getCatalogDBName(), table.getCatalogTableName(),
+                        remoteFileInfoSource.getClass().getName());
+            }
+        });
         try {
             remoteFileInfoSource.close();
         } catch (Exception e) {
             LOG.warn("close RemoteFileInfoSource failed", e);
+        } finally {
+            finished.set(true);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -178,8 +178,11 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -202,6 +205,7 @@ import static org.apache.iceberg.TableProperties.ENCRYPTION_TABLE_KEY;
 public class IcebergMetadata implements ConnectorMetadata {
 
     private static final Logger LOG = LogManager.getLogger(IcebergMetadata.class);
+    private static final long CLOSE_WARN_DELAY_SECONDS = 60;
 
     public static final String LOCATION_PROPERTY = "location";
     public static final String FILE_FORMAT = "file_format";
@@ -1350,12 +1354,13 @@ public class IcebergMetadata implements ConnectorMetadata {
             private void openPlannedTaskIterator(Scan tableScan) {
                 fileScanTaskIterable = normalizePlannedTaskIterable(tableScan.planFiles());
                 fileScanTaskIterator = buildSplitFileScanTaskIterator(
-                        fileScanTaskIterable, fileScanTaskIterable.iterator(), tableScan.targetSplitSize());
+                        fileScanTaskIterable, fileScanTaskIterable.iterator(), tableScan.targetSplitSize(),
+                        dbName, tableName, snapshotId);
             }
 
             private void closePlannedTaskIterator() {
-                closeQuietly(fileScanTaskIterator);
-                closeQuietly(fileScanTaskIterable);
+                closeQuietly(fileScanTaskIterator, "fileScanTaskIterator", dbName, tableName, snapshotId);
+                closeQuietly(fileScanTaskIterable, "fileScanTaskIterable", dbName, tableName, snapshotId);
                 fileScanTaskIterator = null;
                 fileScanTaskIterable = null;
             }
@@ -1427,17 +1432,20 @@ public class IcebergMetadata implements ConnectorMetadata {
     private CloseableIterator<FileScanTask> buildSplitFileScanTaskIterator(
             CloseableIterable<FileScanTask> plannedTaskIterable,
             CloseableIterator<FileScanTask> plannedTaskIterator,
-            long targetSplitSize) {
+            long targetSplitSize,
+            String dbName,
+            String tableName,
+            long snapshotId) {
         return new CloseableIterator<>() {
             private CloseableIterable<FileScanTask> currentTaskIterable = CloseableIterable.empty();
             private CloseableIterator<FileScanTask> currentTaskIterator = CloseableIterator.empty();
 
             @Override
             public void close() throws IOException {
-                currentTaskIterator.close();
-                currentTaskIterable.close();
-                plannedTaskIterator.close();
-                plannedTaskIterable.close();
+                closeUnchecked(currentTaskIterator, "currentTaskIterator", dbName, tableName, snapshotId);
+                closeUnchecked(currentTaskIterable, "currentTaskIterable", dbName, tableName, snapshotId);
+                closeUnchecked(plannedTaskIterator, "plannedTaskIterator", dbName, tableName, snapshotId);
+                closeUnchecked(plannedTaskIterable, "plannedTaskIterable", dbName, tableName, snapshotId);
             }
 
             @Override
@@ -1491,6 +1499,20 @@ public class IcebergMetadata implements ConnectorMetadata {
         Tracers.record(EXTERNAL, name, value);
     }
 
+    private void closeUnchecked(AutoCloseable closeable, String closeableName, String dbName, String tableName,
+                                long snapshotId) {
+        AtomicBoolean finished = watchSlowClose(closeable, closeableName, dbName, tableName, snapshotId);
+        try {
+            closeable.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            finished.set(true);
+        }
+    }
+
     private void closeUnchecked(AutoCloseable closeable) {
         try {
             closeable.close();
@@ -1501,14 +1523,32 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
     }
 
-    private void closeQuietly(AutoCloseable closeable) {
+    private void closeQuietly(AutoCloseable closeable, String closeableName, String dbName, String tableName,
+                              long snapshotId) {
         if (closeable == null) {
             return;
         }
+        AtomicBoolean finished = watchSlowClose(closeable, closeableName, dbName, tableName, snapshotId);
         try {
             closeable.close();
         } catch (Exception ignore) {
+        } finally {
+            finished.set(true);
         }
+    }
+
+    private AtomicBoolean watchSlowClose(AutoCloseable closeable, String closeableName, String dbName, String tableName,
+                                         long snapshotId) {
+        AtomicBoolean finished = new AtomicBoolean(false);
+        CompletableFuture.delayedExecutor(CLOSE_WARN_DELAY_SECONDS, TimeUnit.SECONDS).execute(() -> {
+            if (!finished.get()) {
+                LOG.warn("Iceberg planned task close is still running after {} seconds, table: {}.{}, snapshot: {}, "
+                                + "closeable name: {}, closeable class: {}",
+                        CLOSE_WARN_DELAY_SECONDS, dbName, tableName, snapshotId, closeableName,
+                        closeable.getClass().getName());
+            }
+        });
+        return finished;
     }
 
     public Set<DeleteFile> getDeleteFiles(IcebergTable icebergTable, Long snapshotId,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -51,6 +51,7 @@ import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.ThriftServer;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
@@ -121,7 +122,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -132,6 +136,8 @@ public class DefaultCoordinator extends Coordinator {
     private static final Logger LOG = LogManager.getLogger(DefaultCoordinator.class);
 
     private static final int DEFAULT_PROFILE_TIMEOUT_SECOND = 2;
+    private static final ExecutorService EXTERNAL_RESOURCE_CLEANUP_EXECUTOR =
+            ThreadPoolManager.newDaemonCacheThreadPool(32, 1024, "external-resource-cleanup", false);
 
     private final JobSpec jobSpec;
     private final ExecutionDAG executionDAG;
@@ -172,6 +178,8 @@ public class DefaultCoordinator extends Coordinator {
     private ShortCircuitExecutor shortCircuitExecutor = null;
     private boolean isShortCircuit = false;
     private boolean isBinaryRow = false;
+    private final AtomicBoolean externalResourcesCleared = new AtomicBoolean(false);
+    private final AtomicBoolean externalResourcesCleanupScheduled = new AtomicBoolean(false);
 
     private long estimatedMemCost;
     private ExecutionSchedule scheduler;
@@ -1087,7 +1095,7 @@ public class DefaultCoordinator extends Coordinator {
 
     private void cancelInternal(PPlanFragmentCancelReason cancelReason) {
         jobSpec.getSlotProvider().cancelSlotRequirement(slot);
-        clearExternalResources();
+        clearExternalResourcesAsync();
 
         if (!isInternalCancel(cancelReason) && StringUtils.isEmpty(connectContext.getState().getErrorMessage())) {
             String errorMsg = String.format("[reason=%s] [msg=%s]", cancelReason, queryStatus.getErrorMsg());
@@ -1115,6 +1123,29 @@ public class DefaultCoordinator extends Coordinator {
 
     @Override
     public void clearExternalResources() {
+        if (!externalResourcesCleared.compareAndSet(false, true)) {
+            return;
+        }
+        doClearExternalResources();
+    }
+
+    private void clearExternalResourcesAsync() {
+        if (externalResourcesCleared.get() || !externalResourcesCleanupScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        // This is a containment for connector cleanup stalls, not a fix for the connector close itself.
+        // Some connectors may block while closing remote metadata/file iterators. Run cleanup outside the
+        // coordinator lock so KILL/query cancellation can still make progress if external cleanup stalls.
+        try {
+            EXTERNAL_RESOURCE_CLEANUP_EXECUTOR.execute(this::clearExternalResources);
+        } catch (RejectedExecutionException e) {
+            externalResourcesCleanupScheduled.set(false);
+            LOG.warn("submit external resource cleanup task failed, query id: {}",
+                    DebugUtil.printId(jobSpec.getQueryId()), e);
+        }
+    }
+
+    private void doClearExternalResources() {
         for (ScanNode scanNode : jobSpec.getScanNodes()) {
             try {
                 scanNode.clear();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -29,6 +29,7 @@ import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.RuntimeFilterDescription;
+import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
@@ -40,6 +41,8 @@ import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TPartitionType;
+import com.starrocks.thrift.TPlanNode;
+import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TUniqueId;
@@ -55,6 +58,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class CoordinatorTest extends PlanTestBase {
     ConnectContext ctx;
@@ -178,6 +182,34 @@ public class CoordinatorTest extends PlanTestBase {
         // After catch, hint falls back to session variable query_timeout.
         Assertions.assertTrue(ex.getMessage().contains("query_timeout"));
         Assertions.assertTrue(ex.getMessage().contains("please increase"));
+    }
+
+    @Test
+    public void testClearExternalResourcesOnlyOnce() {
+        AtomicInteger clearCount = new AtomicInteger();
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        ScanNode scanNode = new ScanNode(new PlanNodeId(0), desc, "counting-scan") {
+            @Override
+            public void clear() {
+                clearCount.incrementAndGet();
+            }
+
+            @Override
+            public java.util.List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength) {
+                return Collections.emptyList();
+            }
+
+            @Override
+            protected void toThrift(TPlanNode msg) {
+            }
+        };
+        DefaultCoordinator coordinatorWithScan = new DefaultCoordinator.Factory().createQueryScheduler(
+                ctx, Lists.newArrayList(), Collections.singletonList(scanNode), new TDescriptorTable(), null);
+
+        coordinatorWithScan.clearExternalResources();
+        coordinatorWithScan.clearExternalResources();
+
+        Assertions.assertEquals(1, clearCount.get());
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:

A customer query became unkillable on an FE follower. The saved jstack showed multiple KILL / timeout threads blocked in `DefaultCoordinator.cancel()` while waiting for the same coordinator lock:

```text
parking to wait for <0x0000eee53b179400>
  java.util.concurrent.locks.ReentrantLock.lock
  com.starrocks.qe.DefaultCoordinator.lock
  com.starrocks.qe.DefaultCoordinator.cancel
  com.starrocks.qe.StmtExecutor.cancel
  com.starrocks.qe.ConnectContext.kill
```

At the same time, another coordinator thread was already inside the cancellation / cleanup path and was stuck while closing Iceberg scan resources:

```text
query-deploy-16
  org.apache.iceberg.io.CloseableGroup.close
  org.apache.iceberg.io.CloseableIterable$3.close
  com.starrocks.connector.iceberg.IcebergMetadata$4.close
  com.starrocks.connector.iceberg.IcebergMetadata.closeQuietly
  com.starrocks.connector.iceberg.IcebergMetadata$3.closePlannedTaskIterator
  com.starrocks.connector.iceberg.IcebergMetadata$3.close
  com.starrocks.connector.iceberg.IcebergMetadata$1.close
  com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.close
  com.starrocks.planner.IcebergScanNode.clear
  com.starrocks.qe.DefaultCoordinator.clearExternalResources
  com.starrocks.qe.DefaultCoordinator.cancelInternal
  com.starrocks.qe.DefaultCoordinator.cancel
```

There was also a query execution thread stuck in a similar Iceberg cleanup path:

```text
starrocks-mysql-nio-pool-779
  org.apache.iceberg.io.CloseableGroup.close
  org.apache.iceberg.io.CloseableIterable$3.close
  com.starrocks.connector.iceberg.IcebergMetadata$4.close
  com.starrocks.connector.iceberg.IcebergMetadata.closeQuietly
  com.starrocks.connector.iceberg.IcebergMetadata$3.closePlannedTaskIterator
  com.starrocks.connector.iceberg.IcebergMetadata$3.close
  com.starrocks.connector.iceberg.IcebergMetadata$1.close
  com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.close
  com.starrocks.planner.IcebergScanNode.clear
  com.starrocks.qe.DefaultCoordinator.clearExternalResources
  com.starrocks.qe.DefaultCoordinator.cancelInternal
  com.starrocks.qe.DefaultCoordinator.getNext
```

This means external connector cleanup could run while the `DefaultCoordinator` lock was held. When Iceberg close stalled, the coordinator lock was not released, and all later KILL attempts blocked on the same lock. That is why the query appeared unkillable.

The current evidence suggests the stuck close is likely in the Iceberg planned-task iterator cleanup path, around `tableScan.planFiles()` / `plannedTaskIterable.close()`. However, the jstack stops at Iceberg `CloseableGroup.close()`, so it does not reveal which internal Iceberg closeable inside the group failed to finish. More diagnostics are needed from the next occurrence to identify the exact Iceberg-side root cause.

## What I'm doing:

This PR makes external scan resource cleanup no longer block the coordinator cancellation critical section.

Specifically:

- `cancelInternal()` now schedules external resource cleanup asynchronously instead of calling `clearExternalResources()` directly while the coordinator lock may be held.
- Cleanup runs on a dedicated `external-resource-cleanup` executor instead of the JVM-wide `ForkJoinPool.commonPool`, so a stalled connector close does not consume commonPool workers.
- External cleanup remains idempotent through `externalResourcesCleared`.
- Async scheduling is tracked separately through `externalResourcesCleanupScheduled`, so we do not mark resources as cleared before the cleanup task actually runs. If the async task is only queued, the normal synchronous `StmtExecutor` cleanup path can still take over.
- If cleanup task submission is rejected, the scheduled flag is reset and a WARN is logged.

This PR also adds slow-close diagnostics for Iceberg cleanup. These logs only fire if close is still running after 60 seconds, so normal queries do not emit extra logs.

The new diagnostics identify whether cleanup is stuck at:

```text
IcebergConnectorScanRangeSource.remoteFileInfoSource.close()
```

or at one of the Iceberg planned-task close layers:

```text
fileScanTaskIterator
fileScanTaskIterable
currentTaskIterator
currentTaskIterable
plannedTaskIterator
plannedTaskIterable
```

The log includes table name, snapshot id where available, closeable name, and closeable class.

With this change, if Iceberg or another connector stalls while closing metadata/file iterators, it may still delay the cleanup task, but it should no longer hold the `DefaultCoordinator` lock or block later KILL/query cancellation attempts. The slow-close logs should help determine the exact Iceberg close path if the issue happens again.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
