### PR TITLE
[BugFix] Clear LambdaArgument.transformedOp before INSERT OVERWRITE re-plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -418,7 +418,7 @@ public class InsertOverwriteJobRunner {
      * CTE relations, ORDER BY, aggregate, ViewRelation, JoinRelation.onPredicate,
      * and Expr-level Subquery nodes.
      */
-    private void clearLambdaArgumentTransformedOps(InsertStmt stmt) {
+    public void clearLambdaArgumentTransformedOps(InsertStmt stmt) {
         new AstTraverser<Void, Void>() {
             @Override
             public Void visitLambdaArguments(LambdaArgument node, Void context) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -45,12 +45,14 @@ import com.starrocks.sql.analyzer.AlterTableClauseAnalyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddPartitionClause;
+import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.LambdaArgument;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.MetaUtils;
@@ -370,6 +372,14 @@ public class InsertOverwriteJobRunner {
     private void executeInsert() throws Exception {
         long insertStartTimestamp = System.currentTimeMillis();
         // should replan here because prepareInsert has changed the targetPartitionNames of insertStmt
+        // Before re-plan, clear cached LambdaArgument.transformedOp from the first plan.
+        // The first plan() creates ColumnRefOperators via ColumnRefFactory and caches them in
+        // LambdaArgument.transformedOp. The re-plan creates a NEW ColumnRefFactory, but the AST
+        // nodes (including LambdaArgument) are reused. If transformedOp is not cleared, the stale
+        // ColumnRefOperator (from the old ColumnRefFactory) will be returned by
+        // SqlToScalarOperatorTranslator.visitLambdaArguments(), causing ID collisions and
+        // "expr_type does not match slot_type" errors, especially with UNION ALL + lambda expressions.
+        clearLambdaArgumentTransformedOps(insertStmt);
         try (var guard = context.bindScope()) {
             // For dynamic overwrite, set the txnId to insertStmt so that StatementPlanner.beginTransaction()
             // will skip creating a new transaction and reuse the one we created in prepare().
@@ -393,6 +403,29 @@ public class InsertOverwriteJobRunner {
             LOG.warn("insert overwrite failed. error message:{}", context.getState().getErrorMessage());
             throw new DmlException(context.getState().getErrorMessage());
         }
+    }
+
+    /**
+     * Clear all cached LambdaArgument.transformedOp in the AST tree of the InsertStmt.
+     * This is necessary before re-planning because:
+     * 1. The first plan() caches ColumnRefOperator in LambdaArgument.transformedOp
+     * 2. Re-plan creates a new ColumnRefFactory with fresh ID allocation
+     * 3. Stale cached ColumnRefOperators reference IDs from the old ColumnRefFactory
+     * 4. This causes type mismatches when the new ColumnRefFactory assigns the same ID
+     *    to a different column with a different type
+     *
+     * Uses AstTraverser to ensure complete coverage of all AST paths, including
+     * CTE relations, ORDER BY, aggregate, ViewRelation, JoinRelation.onPredicate,
+     * and Expr-level Subquery nodes.
+     */
+    private void clearLambdaArgumentTransformedOps(InsertStmt stmt) {
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitLambdaArguments(LambdaArgument node, Void context) {
+                node.setTransformed(null);
+                return null;
+            }
+        }.visit(stmt);
     }
 
     private void createTempPartitions() throws DdlException {

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -28,9 +28,13 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.expression.LambdaArgument;
 import com.starrocks.sql.common.DmlException;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.statistic.StatisticsMetaManager;
+import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -39,6 +43,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class InsertOverwriteJobRunnerTest {
 
@@ -87,7 +93,13 @@ public class InsertOverwriteJobRunnerTest {
                 .withTable("create table insert_overwrite_test.t4(c1 int, c2 int, c3 int) " +
                         "DUPLICATE KEY(c1, c2) PARTITION BY RANGE(c1) "
                         + "(PARTITION p1 VALUES [('-2147483648'), ('10')), PARTITION p2 VALUES [('10'), ('20')))"
-                        + " DISTRIBUTED BY HASH(`c2`) BUCKETS 2 PROPERTIES('replication_num'='1');");
+                        + " DISTRIBUTED BY HASH(`c2`) BUCKETS 2 PROPERTIES('replication_num'='1');")
+                .withTable("create table insert_overwrite_test.t_lambda_target(k1 int, k2 array<int>) " +
+                        "distributed by hash(k1) buckets 3 properties('replication_num' = '1');")
+                .withTable("create table insert_overwrite_test.t_lambda_src1(k1 int, k2 array<int>) " +
+                        "distributed by hash(k1) buckets 3 properties('replication_num' = '1');")
+                .withTable("create table insert_overwrite_test.t_lambda_src2(k1 int, k2 array<int>) " +
+                        "distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
     }
 
     @Test
@@ -318,5 +330,71 @@ public class InsertOverwriteJobRunnerTest {
         // No temp partitions to clean up since prepare() never completed
         runner.cancel();
         Assertions.assertEquals(InsertOverwriteJobState.OVERWRITE_FAILED, insertOverwriteJob.getJobState());
+    }
+
+    @Test
+    public void testClearLambdaArgumentTransformedOps() throws Exception {
+        // Test that clearLambdaArgumentTransformedOps correctly clears all LambdaArgument.transformedOp
+        // in the AST tree. This is critical for INSERT OVERWRITE re-plan correctness.
+        String sql = "insert overwrite t_lambda_target " +
+                "select k1, array_map(x -> x + 1, k2) from t_lambda_src1 " +
+                "union all " +
+                "select k1, array_map(x -> x + 2, k2) from t_lambda_src2";
+        InsertStmt insertStmt = (InsertStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        // Collect all LambdaArgument nodes from the AST
+        List<LambdaArgument> lambdaArgs = new ArrayList<>();
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitLambdaArguments(LambdaArgument node, Void context) {
+                lambdaArgs.add(node);
+                return null;
+            }
+        }.visit(insertStmt);
+
+        // Verify that lambda arguments exist in the AST
+        Assertions.assertFalse(lambdaArgs.isEmpty(),
+                "InsertStmt with array_map should contain LambdaArgument nodes");
+        // UNION ALL with two array_map calls should have at least 2 lambda arguments
+        Assertions.assertTrue(lambdaArgs.size() >= 2,
+                "Expected at least 2 LambdaArgument nodes for UNION ALL with two array_map calls, got: " + lambdaArgs.size());
+
+        // Simulate the first plan() caching ColumnRefOperators in LambdaArgument.transformedOp
+        for (LambdaArgument arg : lambdaArgs) {
+            ColumnRefOperator mockOp = new ColumnRefOperator(999, IntegerType.INT, "mock_col", true);
+            arg.setTransformed(mockOp);
+            Assertions.assertNotNull(arg.getTransformed(), "transformedOp should be set");
+        }
+
+        // Call clearLambdaArgumentTransformedOps directly
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("insert_overwrite_test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "t_lambda_target");
+        OlapTable olapTable = (OlapTable) table;
+        InsertOverwriteJob job = new InsertOverwriteJob(300L, insertStmt, database.getId(), olapTable.getId(),
+                WarehouseManager.DEFAULT_WAREHOUSE_ID, false);
+        StmtExecutor executor = new StmtExecutor(connectContext, insertStmt);
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job, connectContext, executor);
+
+        runner.clearLambdaArgumentTransformedOps(insertStmt);
+
+        // Verify all LambdaArgument.transformedOp are cleared
+        for (LambdaArgument arg : lambdaArgs) {
+            Assertions.assertNull(arg.getTransformed(),
+                    "LambdaArgument.transformedOp should be null after clearLambdaArgumentTransformedOps");
+        }
+    }
+
+    @Test
+    public void testInsertOverwriteWithUnionAllAndLambda() throws Exception {
+        // Integration test: INSERT OVERWRITE + UNION ALL + Lambda expressions
+        // This is the exact scenario that triggers the "expr_type does not match slot_type" bug
+        // if clearLambdaArgumentTransformedOps is not called before re-plan.
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000000);
+        String sql = "insert overwrite t_lambda_target " +
+                "select k1, array_map(x -> x + 1, k2) from t_lambda_src1 " +
+                "union all " +
+                "select k1, array_map(x -> x + 2, k2) from t_lambda_src2";
+        // This should not throw any exception (especially not "expr_type does not match slot_type")
+        cluster.runSql("insert_overwrite_test", sql);
     }
 }


### PR DESCRIPTION
Fixes #72831

### Root Cause Analysis

`INSERT OVERWRITE` executes a two-phase plan:
1. First `plan()` — determines partitions, creates `ColumnRefFactory #1`, caches `ColumnRefOperator` in `LambdaArgument.transformedOp`
2. `prepareInsert()` — modifies target partition names to temp partitions
3. Second `plan()` (re-plan) — creates `ColumnRefFactory #2` (IDs start from 1 again), but the AST nodes (including `LambdaArgument`) are **reused**

Since `LambdaArgument.transformedOp` still holds the `ColumnRefOperator` from Factory #1, the re-plan returns stale references. The same ID in Factory #2 may be assigned to a different column with a different type, causing the type mismatch error on BE.

**Key code path** — `SqlToScalarOperatorTranslator.java`:

```java
@Override
public ScalarOperator visitLambdaArguments(LambdaArgument node, Context context) {
    if (node.getTransformed() == null) {   // ← Not null during re-plan! Stale cache hit!
        node.setTransformed(columnRefFactory.create(node.getName(), node.getType(), node.isNullable(), true));
    }
    return node.getTransformed();  // ← Returns stale ColumnRefOperator from old Factory!
}
```

### Why all three conditions are required

| Condition | Explanation |
|-----------|-------------|
| **INSERT OVERWRITE** | Only OVERWRITE triggers a second `plan()` call; INSERT INTO plans only once |
| **UNION ALL** | Increases AST complexity via `processSetOperation()`, creating more ColumnRefOperators and raising the probability of ID collision |
| **Lambda expressions** | Only `LambdaArgument` has the `transformedOp` cache field; other AST nodes don't cache ColumnRefOperators |

### What I do

Clear all `LambdaArgument.transformedOp` caches before re-planning by leveraging the existing `AstTraverser`:

```java
// In InsertOverwriteJobRunner.executeInsert(), before StatementPlanner.plan():
private void clearLambdaArgumentTransformedOps(InsertStmt stmt) {
    new AstTraverser<Void, Void>() {
        @Override
        public Void visitLambdaArguments(LambdaArgument node, Void context) {
            node.setTransformed(null);
            return null;
        }
    }.visit(stmt);
}
```

This approach:
- Uses the official `AstTraverser` which correctly covers **all** AST paths (CTE, ORDER BY, Aggregate, ViewRelation, JoinRelation.onPredicate, Expr-level Subquery nodes, etc.)
- Is only 8 lines of core code
- Has zero performance impact (simple AST traversal, no computation)
- Is future-compatible (new AST node types are automatically handled by the framework)

### Additional context

- The bug is **deterministic in trigger conditions** — it always fails when all three conditions (INSERT OVERWRITE + UNION ALL + Lambda) are met.
- CTE (`WITH` clause) containing UNION ALL + Lambda also triggers the same bug.
- The more MAP/Lambda columns in the query, the higher the probability of ID collision, but even a single Lambda column can trigger it.
- `INSERT INTO` (non-OVERWRITE) is **not** affected because it only plans once.
- Pure `SELECT` queries are **not** affected because they only plan once.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
