### PR TITLE
[BugFix] fix partition topn may lose child's output column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTopNOperator.java
@@ -118,6 +118,9 @@ public class LogicalTopNOperator extends LogicalOperator {
         for (Ordering ordering : orderByElements) {
             columns.union(ordering.getColumnRef());
         }
+        if (partitionByColumns != null) {
+            partitionByColumns.forEach(columns::union);
+        }
         if (partitionPreAggCall != null && !partitionPreAggCall.isEmpty()) {
             for (Map.Entry<ColumnRefOperator, CallOperator> entry : partitionPreAggCall.entrySet()) {
                 columns.union(entry.getValue().getUsedColumns());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -181,6 +181,18 @@ public class PhysicalTopNOperator extends PhysicalOperator {
         return visitor.visitPhysicalTopN(optExpression, context);
     }
 
+    @Override
+    public ColumnRefSet getUsedColumns() {
+        ColumnRefSet set = super.getUsedColumns();
+        if (partitionByColumns != null) {
+            partitionByColumns.forEach(set::union);
+        }
+        if (preAggCall != null) {
+            preAggCall.values().forEach(v -> set.union(v.getUsedColumns()));
+        }
+        return set;
+    }
+
     public void fillDisableDictOptimizeColumns(ColumnRefSet resultSet, Set<Integer> dictColIds) {
         // nothing to do
         if (preAggCall == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -31,7 +31,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalSetOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
-import com.starrocks.sql.optimizer.operator.physical.PhysicalOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalSetOperation;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalSetOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalSetOperation;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;
@@ -159,6 +160,10 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
             }
             ColumnRefSet inputCols = optExpression.inputAt(0).getRowOutputInfo().getOutputColumnRefSet();
             ColumnRefSet usedCols = optExpression.getRowOutputInfo().getUsedColumnRefSet();
+            if (optExpression.getOp() instanceof PhysicalOperator) {
+                usedCols.union(((PhysicalOperator) optExpression.getOp()).getUsedColumns());
+            }
+
             if (optExpression.getOp().getPredicate() != null) {
                 ColumnRefSet predicateCols = optExpression.getOp().getPredicate().getUsedColumns();
                 // The predicate cols should be from the input cols or the output cols of this operator

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -160,10 +160,6 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
             }
             ColumnRefSet inputCols = optExpression.inputAt(0).getRowOutputInfo().getOutputColumnRefSet();
             ColumnRefSet usedCols = optExpression.getRowOutputInfo().getUsedColumnRefSet();
-            if (optExpression.getOp() instanceof PhysicalOperator) {
-                usedCols.union(((PhysicalOperator) optExpression.getOp()).getUsedColumns());
-            }
-
             if (optExpression.getOp().getPredicate() != null) {
                 ColumnRefSet predicateCols = optExpression.getOp().getPredicate().getUsedColumns();
                 // The predicate cols should be from the input cols or the output cols of this operator

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/PhysicalTopNOperatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/PhysicalTopNOperatorTest.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.operator.operator;
+
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.OrderSpec;
+import com.starrocks.sql.optimizer.base.Ordering;
+import com.starrocks.sql.optimizer.operator.SortPhase;
+import com.starrocks.sql.optimizer.operator.TopNType;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class PhysicalTopNOperatorTest {
+
+    @Test
+    public void testUsedColumns() {
+        ColumnRefOperator orderColumn = new ColumnRefOperator(1, IntegerType.INT, "order_col", true);
+        ColumnRefOperator partitionColumn = new ColumnRefOperator(2, IntegerType.INT, "partition_col", true);
+        ColumnRefOperator preAggInputColumn = new ColumnRefOperator(3, IntegerType.INT, "pre_agg_input_col", true);
+        ColumnRefOperator preAggOutputColumn = new ColumnRefOperator(4, IntegerType.BIGINT, "pre_agg_output_col", true);
+        PhysicalTopNOperator topN = new PhysicalTopNOperator(
+                new OrderSpec(List.of(new Ordering(orderColumn, true, true))),
+                10,
+                0,
+                List.of(partitionColumn),
+                1,
+                SortPhase.PARTIAL,
+                TopNType.ROW_NUMBER,
+                false,
+                false,
+                false,
+                null,
+                null,
+                Map.of(preAggOutputColumn,
+                        new CallOperator(FunctionSet.SUM, IntegerType.BIGINT, List.of(preAggInputColumn))));
+
+        ColumnRefSet usedColumns = topN.getUsedColumns();
+        Assertions.assertTrue(usedColumns.contains(orderColumn));
+        Assertions.assertTrue(usedColumns.contains(partitionColumn));
+        Assertions.assertTrue(usedColumns.contains(preAggInputColumn));
+        Assertions.assertFalse(usedColumns.contains(preAggOutputColumn));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2369,6 +2369,133 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
+    public void testPartitionTopNChildProjectKeepsLowCardinalityPartitionColumns() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `wat_topn_basic` (\n" +
+                "  `id` bigint NOT NULL,\n" +
+                "  `fab` varchar(64),\n" +
+                "  `product_id` varchar(128),\n" +
+                "  `lot_id` varchar(128),\n" +
+                "  `item_list_id` bigint,\n" +
+                "  `test_program` varchar(1024),\n" +
+                "  `lot_metrology_start_time` datetime,\n" +
+                "  `status` varchar(8),\n" +
+                "  `limit_filename` varchar(256),\n" +
+                "  `limit_version` bigint\n" +
+                ") ENGINE=OLAP DUPLICATE KEY(`id`) DISTRIBUTED BY HASH(`id`) BUCKETS 16\n" +
+                "PROPERTIES (\"replication_num\" = \"1\")");
+        starRocksAssert.withTable("CREATE TABLE `wat_topn_wafer` (\n" +
+                "  `basic_id` bigint,\n" +
+                "  `status` varchar(8),\n" +
+                "  `wafer_id` varchar(128)\n" +
+                ") ENGINE=OLAP DUPLICATE KEY(`basic_id`) DISTRIBUTED BY HASH(`basic_id`) BUCKETS 16\n" +
+                "PROPERTIES (\"replication_num\" = \"1\")");
+        starRocksAssert.withTable("CREATE TABLE `wat_topn_item_param` (\n" +
+                "  `status` varchar(8),\n" +
+                "  `item_list_id` bigint,\n" +
+                "  `test_program` varchar(1024),\n" +
+                "  `limit_filename` varchar(128),\n" +
+                "  `limit_version` bigint,\n" +
+                "  `item_number` varchar(128),\n" +
+                "  `item_name` varchar(2048),\n" +
+                "  `item_unit` varchar(128)\n" +
+                ") ENGINE=OLAP DUPLICATE KEY(`status`, `item_list_id`) DISTRIBUTED BY HASH(`item_list_id`) BUCKETS 16\n" +
+                "PROPERTIES (\"replication_num\" = \"1\")");
+        starRocksAssert.withTable("CREATE TABLE `wat_topn_mapping` (\n" +
+                "  `item_name` varchar(2048),\n" +
+                "  `product_id` varchar(128),\n" +
+                "  `status` varchar(8),\n" +
+                "  `station` varchar(32),\n" +
+                "  `mapping_item_name` varchar(2048)\n" +
+                ") ENGINE=OLAP DUPLICATE KEY(`item_name`, `product_id`) DISTRIBUTED BY HASH(`product_id`) BUCKETS 16\n" +
+                "PROPERTIES (\"replication_num\" = \"1\")");
+
+        String sql = "SELECT item_parameter.lot_id, item_parameter.item_number, item_parameter.limit_filename,\n" +
+                "       item_parameter.mapping_item_name, item_parameter.limit_version, item_parameter.item_unit,\n" +
+                "       item_parameter.product_id, item_parameter.test_program, item_parameter.item_name,\n" +
+                "       item_parameter.itemParamMatch\n" +
+                "FROM (\n" +
+                "  SELECT t.product_id, t.lot_id, t.test_program,\n" +
+                "    t6.item_number, t6.item_name, t6.limit_filename, t6.limit_version,\n" +
+                "    ifnull(t6.item_unit, ' ') AS item_unit,\n" +
+                "    t7.mapping_item_name,\n" +
+                "    t6.item_number AS itemParamMatch,\n" +
+                "    ROW_NUMBER() OVER (\n" +
+                "      PARTITION BY t.product_id, t.lot_id, t.test_program, t6.item_name,\n" +
+                "        t6.item_number, t7.mapping_item_name, t6.limit_filename, t6.limit_version\n" +
+                "      ORDER BY t.product_id, t.lot_id, t.test_program, t6.item_name, t7.mapping_item_name\n" +
+                "    ) AS row_num\n" +
+                "  FROM (\n" +
+                "    SELECT tt.fab, tt.product_id, tt.lot_id, tt.item_list_id,\n" +
+                "      tt.test_program, tt.limit_filename, tt.limit_version\n" +
+                "    FROM (\n" +
+                "      SELECT t.fab, t.product_id, t.lot_id, t.item_list_id,\n" +
+                "        t.test_program, t.limit_filename, t.limit_version,\n" +
+                "        ROW_NUMBER() OVER (\n" +
+                "          PARTITION BY t.fab, t.lot_id, t.test_program, b.wafer_id\n" +
+                "          ORDER BY t.lot_metrology_start_time\n" +
+                "        ) AS row_num\n" +
+                "      FROM wat_topn_basic t\n" +
+                "      JOIN wat_topn_wafer b ON t.id = b.basic_id AND b.status = '1'\n" +
+                "      WHERE t.status = '1'\n" +
+                "        AND t.product_id = 'ES0008AA'\n" +
+                "        AND t.test_program = 'RFsample_ES0008AA'\n" +
+                "        AND t.lot_id = 'AP59051'\n" +
+                "        AND t.limit_filename = 'ES0008AA_RFsample_ES0008AA.lim'\n" +
+                "        AND b.wafer_id = 'AP59051_09'\n" +
+                "    ) tt\n" +
+                "    WHERE tt.row_num = 1\n" +
+                "  ) t\n" +
+                "  JOIN wat_topn_item_param t6 ON t6.status = '1'\n" +
+                "    AND t.item_list_id = t6.item_list_id\n" +
+                "    AND t.test_program = t6.test_program\n" +
+                "    AND t.limit_filename = t6.limit_filename\n" +
+                "    AND t.limit_version = t6.limit_version\n" +
+                "  LEFT JOIN wat_topn_mapping t7 ON t6.item_name = t7.item_name\n" +
+                "    AND t7.product_id = t.product_id\n" +
+                "    AND t7.status = '1'\n" +
+                "    AND t7.station = 'WAT'\n" +
+                "  WHERE t6.test_program = 'RFsample_ES0008AA'\n" +
+                "    AND t6.limit_filename = 'ES0008AA_RFsample_ES0008AA.lim'\n" +
+                "    AND t6.item_number = 'R54'\n" +
+                "    AND ifnull(t6.item_name, t6.item_number) = 'RFdie_STRM04_STRM04_RF_S11_Zp_i'\n" +
+                ") item_parameter\n" +
+                "WHERE item_parameter.row_num = 1";
+        String plan = getCostExplain(sql);
+        assertContains(plan, "PARTITION-TOP-N", "Decode");
+        Assertions.assertEquals(2, plan.split("PARTITION-TOP-N", -1).length - 1, plan);
+        assertContains(plan, "  24:PARTITION-TOP-N\n" +
+                "  |  partition by: [37: product_id, INT, true] , [38: lot_id, INT, true] , " +
+                "[39: test_program, INT, true] , [34: item_name, INT, true] , " +
+                "[33: item_number, INT, true] , [48: mapping_item_name, INT, true] , " +
+                "[32: limit_filename, INT, true] , [19: limit_version, BIGINT, true]",
+                "  23:Project\n" +
+                        "  |  output columns:\n" +
+                        "  |  19 <-> [19: limit_version, BIGINT, true]\n" +
+                        "  |  32 <-> [32: limit_filename, INT, true]\n" +
+                        "  |  33 <-> [33: item_number, INT, true]\n" +
+                        "  |  34 <-> [34: item_name, INT, true]\n" +
+                        "  |  35 <-> [35: item_unit, INT, true]\n" +
+                        "  |  37 <-> [37: product_id, INT, true]\n" +
+                        "  |  38 <-> [38: lot_id, INT, true]\n" +
+                        "  |  39 <-> [39: test_program, INT, true]\n" +
+                        "  |  48 <-> [48: mapping_item_name, INT, true]",
+                "  10:PARTITION-TOP-N\n" +
+                        "  |  partition by: [36: fab, INT, true] , [38: lot_id, INT, true] , " +
+                        "[39: test_program, INT, true] , [43: wafer_id, INT, true]",
+                "  9:Project\n" +
+                        "  |  output columns:\n" +
+                        "  |  5 <-> [5: item_list_id, BIGINT, true]\n" +
+                        "  |  7 <-> [7: lot_metrology_start_time, DATETIME, true]\n" +
+                        "  |  10 <-> [10: limit_version, BIGINT, true]\n" +
+                        "  |  36 <-> [36: fab, INT, true]\n" +
+                        "  |  37 <-> [37: product_id, INT, true]\n" +
+                        "  |  38 <-> [38: lot_id, INT, true]\n" +
+                        "  |  39 <-> [39: test_program, INT, true]\n" +
+                        "  |  41 <-> [41: limit_filename, INT, true]\n" +
+                        "  |  43 <-> [43: wafer_id, INT, true]");
+    }
+
+    @Test
     public void testEnableLowCardinalityOptimizeForJoin() throws Exception {
         FeConstants.runningUnitTest = true;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1685,17 +1685,23 @@ public class LowCardinalityTest2 extends PlanTestBase {
 
     @Test
     public void testCTEWithDecode() throws Exception {
-        connectContext.getSessionVariable().setCboCteReuse(true);
-        connectContext.getSessionVariable().setEnablePipelineEngine(true);
-        connectContext.getSessionVariable().setCboCTERuseRatio(0);
-        String sql = "with v1 as( select S_ADDRESS a, count(*) b from supplier group by S_ADDRESS) " +
-                "select x1.a, x1.b from v1 x1 join v1 x2 on x1.a=x2.a";
-        String plan = getThriftPlan(sql);
-        connectContext.getSessionVariable().setCboCteReuse(false);
-        connectContext.getSessionVariable().setEnablePipelineEngine(false);
-
-        Assertions.assertFalse(
-                plan.contains("query_global_dicts:[TGlobalDict(columnId:28, strings:[6D 6F 63 6B], ids:[1]"));
+        boolean cboCteReuse = connectContext.getSessionVariable().isCboCteReuse();
+        boolean enablePipelineEngine = connectContext.getSessionVariable().isEnablePipelineEngine();
+        double cboCTERuseRatio = connectContext.getSessionVariable().getCboCTERuseRatio();
+        try {
+            connectContext.getSessionVariable().setCboCteReuse(true);
+            connectContext.getSessionVariable().setEnablePipelineEngine(true);
+            connectContext.getSessionVariable().setCboCTERuseRatio(0);
+            String sql = "with v1 as( select S_ADDRESS a, count(*) b from supplier group by S_ADDRESS) " +
+                    "select x1.a, x1.b from v1 x1 join v1 x2 on x1.a=x2.a";
+            String plan = getThriftPlan(sql);
+            Assertions.assertFalse(
+                    plan.contains("query_global_dicts:[TGlobalDict(columnId:28, strings:[6D 6F 63 6B], ids:[1]"));
+        } finally {
+            connectContext.getSessionVariable().setCboCteReuse(cboCteReuse);
+            connectContext.getSessionVariable().setEnablePipelineEngine(enablePipelineEngine);
+            connectContext.getSessionVariable().setCboCTERuseRatio(cboCTERuseRatio);
+        }
     }
 
     @Test
@@ -2370,6 +2376,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
 
     @Test
     public void testPartitionTopNChildProjectKeepsLowCardinalityPartitionColumns() throws Exception {
+        boolean enablePipelineEngine = connectContext.getSessionVariable().isEnablePipelineEngine();
         starRocksAssert.withTable("CREATE TABLE `wat_topn_basic` (\n" +
                 "  `id` bigint NOT NULL,\n" +
                 "  `fab` varchar(64),\n" +
@@ -2409,90 +2416,95 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 ") ENGINE=OLAP DUPLICATE KEY(`item_name`, `product_id`) DISTRIBUTED BY HASH(`product_id`) BUCKETS 16\n" +
                 "PROPERTIES (\"replication_num\" = \"1\")");
 
-        String sql = "SELECT item_parameter.lot_id, item_parameter.item_number, item_parameter.limit_filename,\n" +
-                "       item_parameter.mapping_item_name, item_parameter.limit_version, item_parameter.item_unit,\n" +
-                "       item_parameter.product_id, item_parameter.test_program, item_parameter.item_name,\n" +
-                "       item_parameter.itemParamMatch\n" +
-                "FROM (\n" +
-                "  SELECT t.product_id, t.lot_id, t.test_program,\n" +
-                "    t6.item_number, t6.item_name, t6.limit_filename, t6.limit_version,\n" +
-                "    ifnull(t6.item_unit, ' ') AS item_unit,\n" +
-                "    t7.mapping_item_name,\n" +
-                "    t6.item_number AS itemParamMatch,\n" +
-                "    ROW_NUMBER() OVER (\n" +
-                "      PARTITION BY t.product_id, t.lot_id, t.test_program, t6.item_name,\n" +
-                "        t6.item_number, t7.mapping_item_name, t6.limit_filename, t6.limit_version\n" +
-                "      ORDER BY t.product_id, t.lot_id, t.test_program, t6.item_name, t7.mapping_item_name\n" +
-                "    ) AS row_num\n" +
-                "  FROM (\n" +
-                "    SELECT tt.fab, tt.product_id, tt.lot_id, tt.item_list_id,\n" +
-                "      tt.test_program, tt.limit_filename, tt.limit_version\n" +
-                "    FROM (\n" +
-                "      SELECT t.fab, t.product_id, t.lot_id, t.item_list_id,\n" +
-                "        t.test_program, t.limit_filename, t.limit_version,\n" +
-                "        ROW_NUMBER() OVER (\n" +
-                "          PARTITION BY t.fab, t.lot_id, t.test_program, b.wafer_id\n" +
-                "          ORDER BY t.lot_metrology_start_time\n" +
-                "        ) AS row_num\n" +
-                "      FROM wat_topn_basic t\n" +
-                "      JOIN wat_topn_wafer b ON t.id = b.basic_id AND b.status = '1'\n" +
-                "      WHERE t.status = '1'\n" +
-                "        AND t.product_id = 'ES0008AA'\n" +
-                "        AND t.test_program = 'RFsample_ES0008AA'\n" +
-                "        AND t.lot_id = 'AP59051'\n" +
-                "        AND t.limit_filename = 'ES0008AA_RFsample_ES0008AA.lim'\n" +
-                "        AND b.wafer_id = 'AP59051_09'\n" +
-                "    ) tt\n" +
-                "    WHERE tt.row_num = 1\n" +
-                "  ) t\n" +
-                "  JOIN wat_topn_item_param t6 ON t6.status = '1'\n" +
-                "    AND t.item_list_id = t6.item_list_id\n" +
-                "    AND t.test_program = t6.test_program\n" +
-                "    AND t.limit_filename = t6.limit_filename\n" +
-                "    AND t.limit_version = t6.limit_version\n" +
-                "  LEFT JOIN wat_topn_mapping t7 ON t6.item_name = t7.item_name\n" +
-                "    AND t7.product_id = t.product_id\n" +
-                "    AND t7.status = '1'\n" +
-                "    AND t7.station = 'WAT'\n" +
-                "  WHERE t6.test_program = 'RFsample_ES0008AA'\n" +
-                "    AND t6.limit_filename = 'ES0008AA_RFsample_ES0008AA.lim'\n" +
-                "    AND t6.item_number = 'R54'\n" +
-                "    AND ifnull(t6.item_name, t6.item_number) = 'RFdie_STRM04_STRM04_RF_S11_Zp_i'\n" +
-                ") item_parameter\n" +
-                "WHERE item_parameter.row_num = 1";
-        String plan = getCostExplain(sql);
-        assertContains(plan, "PARTITION-TOP-N", "Decode");
-        Assertions.assertEquals(2, plan.split("PARTITION-TOP-N", -1).length - 1, plan);
-        assertContains(plan, "  24:PARTITION-TOP-N\n" +
-                "  |  partition by: [37: product_id, INT, true] , [38: lot_id, INT, true] , " +
-                "[39: test_program, INT, true] , [34: item_name, INT, true] , " +
-                "[33: item_number, INT, true] , [48: mapping_item_name, INT, true] , " +
-                "[32: limit_filename, INT, true] , [19: limit_version, BIGINT, true]",
-                "  23:Project\n" +
-                        "  |  output columns:\n" +
-                        "  |  19 <-> [19: limit_version, BIGINT, true]\n" +
-                        "  |  32 <-> [32: limit_filename, INT, true]\n" +
-                        "  |  33 <-> [33: item_number, INT, true]\n" +
-                        "  |  34 <-> [34: item_name, INT, true]\n" +
-                        "  |  35 <-> [35: item_unit, INT, true]\n" +
-                        "  |  37 <-> [37: product_id, INT, true]\n" +
-                        "  |  38 <-> [38: lot_id, INT, true]\n" +
-                        "  |  39 <-> [39: test_program, INT, true]\n" +
-                        "  |  48 <-> [48: mapping_item_name, INT, true]",
-                "  10:PARTITION-TOP-N\n" +
-                        "  |  partition by: [36: fab, INT, true] , [38: lot_id, INT, true] , " +
-                        "[39: test_program, INT, true] , [43: wafer_id, INT, true]",
-                "  9:Project\n" +
-                        "  |  output columns:\n" +
-                        "  |  5 <-> [5: item_list_id, BIGINT, true]\n" +
-                        "  |  7 <-> [7: lot_metrology_start_time, DATETIME, true]\n" +
-                        "  |  10 <-> [10: limit_version, BIGINT, true]\n" +
-                        "  |  36 <-> [36: fab, INT, true]\n" +
-                        "  |  37 <-> [37: product_id, INT, true]\n" +
-                        "  |  38 <-> [38: lot_id, INT, true]\n" +
-                        "  |  39 <-> [39: test_program, INT, true]\n" +
-                        "  |  41 <-> [41: limit_filename, INT, true]\n" +
-                        "  |  43 <-> [43: wafer_id, INT, true]");
+        try {
+            connectContext.getSessionVariable().setEnablePipelineEngine(true);
+            String sql = "SELECT item_parameter.lot_id, item_parameter.item_number, item_parameter.limit_filename,\n" +
+                    "       item_parameter.mapping_item_name, item_parameter.limit_version, item_parameter.item_unit,\n" +
+                    "       item_parameter.product_id, item_parameter.test_program, item_parameter.item_name,\n" +
+                    "       item_parameter.itemParamMatch\n" +
+                    "FROM (\n" +
+                    "  SELECT t.product_id, t.lot_id, t.test_program,\n" +
+                    "    t6.item_number, t6.item_name, t6.limit_filename, t6.limit_version,\n" +
+                    "    ifnull(t6.item_unit, ' ') AS item_unit,\n" +
+                    "    t7.mapping_item_name,\n" +
+                    "    t6.item_number AS itemParamMatch,\n" +
+                    "    ROW_NUMBER() OVER (\n" +
+                    "      PARTITION BY t.product_id, t.lot_id, t.test_program, t6.item_name,\n" +
+                    "        t6.item_number, t7.mapping_item_name, t6.limit_filename, t6.limit_version\n" +
+                    "      ORDER BY t.product_id, t.lot_id, t.test_program, t6.item_name, t7.mapping_item_name\n" +
+                    "    ) AS row_num\n" +
+                    "  FROM (\n" +
+                    "    SELECT tt.fab, tt.product_id, tt.lot_id, tt.item_list_id,\n" +
+                    "      tt.test_program, tt.limit_filename, tt.limit_version\n" +
+                    "    FROM (\n" +
+                    "      SELECT t.fab, t.product_id, t.lot_id, t.item_list_id,\n" +
+                    "        t.test_program, t.limit_filename, t.limit_version,\n" +
+                    "        ROW_NUMBER() OVER (\n" +
+                    "          PARTITION BY t.fab, t.lot_id, t.test_program, b.wafer_id\n" +
+                    "          ORDER BY t.lot_metrology_start_time\n" +
+                    "        ) AS row_num\n" +
+                    "      FROM wat_topn_basic t\n" +
+                    "      JOIN wat_topn_wafer b ON t.id = b.basic_id AND b.status = '1'\n" +
+                    "      WHERE t.status = '1'\n" +
+                    "        AND t.product_id = 'ES0008AA'\n" +
+                    "        AND t.test_program = 'RFsample_ES0008AA'\n" +
+                    "        AND t.lot_id = 'AP59051'\n" +
+                    "        AND t.limit_filename = 'ES0008AA_RFsample_ES0008AA.lim'\n" +
+                    "        AND b.wafer_id = 'AP59051_09'\n" +
+                    "    ) tt\n" +
+                    "    WHERE tt.row_num = 1\n" +
+                    "  ) t\n" +
+                    "  JOIN wat_topn_item_param t6 ON t6.status = '1'\n" +
+                    "    AND t.item_list_id = t6.item_list_id\n" +
+                    "    AND t.test_program = t6.test_program\n" +
+                    "    AND t.limit_filename = t6.limit_filename\n" +
+                    "    AND t.limit_version = t6.limit_version\n" +
+                    "  LEFT JOIN wat_topn_mapping t7 ON t6.item_name = t7.item_name\n" +
+                    "    AND t7.product_id = t.product_id\n" +
+                    "    AND t7.status = '1'\n" +
+                    "    AND t7.station = 'WAT'\n" +
+                    "  WHERE t6.test_program = 'RFsample_ES0008AA'\n" +
+                    "    AND t6.limit_filename = 'ES0008AA_RFsample_ES0008AA.lim'\n" +
+                    "    AND t6.item_number = 'R54'\n" +
+                    "    AND ifnull(t6.item_name, t6.item_number) = 'RFdie_STRM04_STRM04_RF_S11_Zp_i'\n" +
+                    ") item_parameter\n" +
+                    "WHERE item_parameter.row_num = 1";
+            String plan = getCostExplain(sql);
+            assertContains(plan, "PARTITION-TOP-N", "Decode");
+            Assertions.assertEquals(2, plan.split("PARTITION-TOP-N", -1).length - 1, plan);
+            assertContains(plan, "  24:PARTITION-TOP-N\n" +
+                    "  |  partition by: [37: product_id, INT, true] , [38: lot_id, INT, true] , " +
+                    "[39: test_program, INT, true] , [34: item_name, INT, true] , " +
+                    "[33: item_number, INT, true] , [48: mapping_item_name, INT, true] , " +
+                    "[32: limit_filename, INT, true] , [19: limit_version, BIGINT, true]",
+                    "  23:Project\n" +
+                            "  |  output columns:\n" +
+                            "  |  19 <-> [19: limit_version, BIGINT, true]\n" +
+                            "  |  32 <-> [32: limit_filename, INT, true]\n" +
+                            "  |  33 <-> [33: item_number, INT, true]\n" +
+                            "  |  34 <-> [34: item_name, INT, true]\n" +
+                            "  |  35 <-> [35: item_unit, INT, true]\n" +
+                            "  |  37 <-> [37: product_id, INT, true]\n" +
+                            "  |  38 <-> [38: lot_id, INT, true]\n" +
+                            "  |  39 <-> [39: test_program, INT, true]\n" +
+                            "  |  48 <-> [48: mapping_item_name, INT, true]",
+                    "  10:PARTITION-TOP-N\n" +
+                            "  |  partition by: [36: fab, INT, true] , [38: lot_id, INT, true] , " +
+                            "[39: test_program, INT, true] , [43: wafer_id, INT, true]",
+                    "  9:Project\n" +
+                            "  |  output columns:\n" +
+                            "  |  5 <-> [5: item_list_id, BIGINT, true]\n" +
+                            "  |  7 <-> [7: lot_metrology_start_time, DATETIME, true]\n" +
+                            "  |  10 <-> [10: limit_version, BIGINT, true]\n" +
+                            "  |  36 <-> [36: fab, INT, true]\n" +
+                            "  |  37 <-> [37: product_id, INT, true]\n" +
+                            "  |  38 <-> [38: lot_id, INT, true]\n" +
+                            "  |  39 <-> [39: test_program, INT, true]\n" +
+                            "  |  41 <-> [41: limit_filename, INT, true]\n" +
+                            "  |  43 <-> [43: wafer_id, INT, true]");
+        } finally {
+            connectContext.getSessionVariable().setEnablePipelineEngine(enablePipelineEngine);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
PruneTopNColumnsRule will use topNOperator.getRequiredChildInputColumns to prune child's output, and if trigger partition topn, partition expr is not included in topNOperator.getRequiredChildInputColumns, which may cause topn's child doesn't output columns which are needed by partition exprs

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
