### PR TITLE
[Enhancement] Add get_query_dump_from_query_id meta function

### DIFF
--- a/docs/en/sql-reference/sql-functions/meta-functions/get_query_dump_from_query_id.md
+++ b/docs/en/sql-reference/sql-functions/meta-functions/get_query_dump_from_query_id.md
@@ -1,0 +1,89 @@
+---
+displayed_sidebar: docs
+---
+
+# get_query_dump_from_query_id
+
+`get_query_dump_from_query_id(query_id)`
+`get_query_dump_from_query_id(query_id, enable_mock)`
+
+Returns a dump of a previously executed query, located by its `query_id`. The
+dump contains the table schemas, statistics, session variables and other
+context needed to reproduce planning of the original query, in the same JSON
+shape produced by [`get_query_dump`](./get_query_dump.md) and the
+`/api/query_dump` HTTP endpoint.
+
+This function is intended for debugging and post-mortem analysis. It looks up
+the query in StarRocks' in-memory query detail queue on the current FE,
+recovers the original SQL plus its catalog and database, and re-runs the
+dumper against that SQL.
+
+## Arguments
+
+`query_id`: The query identifier, in the standard StarRocks UUID format
+(`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`). Type: VARCHAR.
+
+`enable_mock`: (Optional) When `TRUE`, the dump uses mocked table / column
+names instead of the originals (handy for sharing the dump without leaking
+schema). Defaults to `FALSE`. Type: BOOLEAN.
+
+## Return Value
+
+VARCHAR. JSON-encoded query dump. Throws an error if the query cannot be
+located, the recorded SQL was desensitized, or the caller is not allowed to
+read the query.
+
+## Operational requirements
+
+The query detail queue is the source of truth, so the same constraints that
+apply to that queue apply here. The function validates the two FE-config
+gates upfront and returns a clear error when either is mis-set:
+
+- `enable_collect_query_detail_info` must be `true` (default `false`).
+  When unset, the function refuses immediately with
+  `query detail collection is disabled. Set FE config
+  enable_collect_query_detail_info=true ...` instead of silently producing
+  a "not found" error.
+- `enable_sql_desensitize_in_log` must be `false`. When set to `true` the
+  recorded SQL is rewritten to a digest form and cannot be re-dumped; the
+  function refuses upfront with `SQL desensitization is enabled ...`.
+
+Additional runtime constraints, surfaced after the upfront checks pass:
+
+- The query must have been executed on the same FE that the function is
+  invoked on. Detail data is per-FE in-memory state, not synchronized.
+- The detail row must still be in the cache window controlled by
+  `query_detail_cache_time_nanosecond` (default 30 seconds). Older queries
+  are evicted by a background sweep.
+- As defense in depth, even with desensitization currently off, if the
+  recorded SQL was captured while desensitization was on (so the detail
+  row holds the placeholder), the function refuses with `original sql not
+  retained`.
+
+## Privilege
+
+The caller must either match the original executor's full account identity
+(`user`@`host`, e.g. `'alice'@'10.0.0.1'`) or hold system-level `OPERATE`
+privilege. Username-only matches are rejected, so two distinct accounts that
+share a username but differ on host cannot read each other's queries.
+
+## Examples
+
+```sql
+-- A user looking up one of their own queries (assuming
+-- enable_collect_query_detail_info = true on the FE).
+mysql> SELECT get_query_dump_from_query_id('a1b2c3d4-e5f6-7890-abcd-ef0123456789')\G
+
+-- Same, but with mocked schema for safer sharing.
+mysql> SELECT get_query_dump_from_query_id('a1b2c3d4-e5f6-7890-abcd-ef0123456789', TRUE)\G
+
+-- Typical error when the query is not in the cache window.
+mysql> SELECT get_query_dump_from_query_id('00000000-0000-0000-0000-000000000000');
+ERROR 1064 (HY000): Getting analyzing error. Detail message: Invalid parameter
+get_query_dump_from_query_id: query_id not found in query detail queue: ...
+```
+
+## See also
+
+- [`get_query_dump`](./get_query_dump.md) — dump a SQL string supplied directly
+  by the caller, without going through the query detail queue.

--- a/docs/ja/sql-reference/sql-functions/meta-functions/get_query_dump_from_query_id.md
+++ b/docs/ja/sql-reference/sql-functions/meta-functions/get_query_dump_from_query_id.md
@@ -1,0 +1,86 @@
+---
+displayed_sidebar: docs
+---
+
+# get_query_dump_from_query_id
+
+`get_query_dump_from_query_id(query_id)`
+`get_query_dump_from_query_id(query_id, enable_mock)`
+
+`query_id` を指定して、過去に実行されたクエリのダンプを返します。ダンプには
+そのクエリのプランニングを再現するために必要なテーブルスキーマ、統計情報、
+セッション変数などのコンテキストが含まれます。形式は
+[`get_query_dump`](./get_query_dump.md) や `/api/query_dump` HTTP エンドポイント
+の出力と同一の JSON です。
+
+本関数はデバッグおよび事後分析向けです。実行は次のように行います：現在の FE
+上のクエリ詳細キュー (query detail queue) を `query_id` で検索し、元の SQL と
+当時の catalog / database を取り出して、ダンパーで再生成します。
+
+## 引数
+
+`query_id`：StarRocks 標準の UUID 形式
+(`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) のクエリ識別子。型：VARCHAR。
+
+`enable_mock`：（任意）`TRUE` のとき、実際のテーブル名 / カラム名を mock 値に
+置き換えてダンプを生成します（スキーマを露出せずに dump を共有したい場合に
+便利）。デフォルトは `FALSE`。型：BOOLEAN。
+
+## 戻り値
+
+VARCHAR。JSON でエンコードされたクエリダンプ。クエリが見つからない場合、
+記録された SQL が脱感作されている場合、または呼び出し元が当該クエリを参照する
+権限を持たない場合はエラーを送出します。
+
+## 動作要件
+
+データソースが query detail キューであるため、同キューの制約がそのまま本関数
+にも適用されます。本関数は実行の冒頭で 2 つの FE 設定スイッチを前段検証し、
+いずれかが想定外の値である場合、即座に明示的なエラーを返します：
+
+- `enable_collect_query_detail_info` は `true` でなければなりません（デフォルト
+  は `false`）。`false` の場合、誤解を招く "not found" の代わりに
+  `query detail collection is disabled. Set FE config
+  enable_collect_query_detail_info=true ...` というエラーで即時に拒否します。
+- `enable_sql_desensitize_in_log` は `false` でなければなりません。`true` のとき、
+  記録された SQL は digest 形式に書き換えられ、ダンプの再生成には使用できません。
+  本関数は `SQL desensitization is enabled ...` で前段拒否します。
+
+前段検証を通過した後でも、次の実行時制約が適用されます：
+
+- 対象クエリは本関数を呼び出す FE と同じ FE で実行されている必要があります。
+  detail は FE プロセス内のメモリ状態であり、FE 間で同期されません。
+- detail 行は `query_detail_cache_time_nanosecond`（デフォルト 30 秒）の
+  キャッシュウィンドウ内に存在する必要があります。期限切れの行はバックグラウンド
+  処理で除去されます。
+- 多層防御として、`enable_sql_desensitize_in_log` が現在 `false` であっても、
+  detail 行が脱感作有効時に記録された場合（プレースホルダが格納されている場合）、
+  本関数は `original sql not retained` でエラーを返します。
+
+## 権限
+
+呼び出し元の完全なアカウント識別子（`user`@`host`、例：`'alice'@'10.0.0.1'`）が
+クエリの元実行者と完全に一致するか、システムレベルの `OPERATE` 権限を保持して
+いる必要があります。ユーザー名のみが一致して host が異なる 2 つのアカウントは、
+互いのクエリを参照できません。
+
+## 例
+
+```sql
+-- 自分が実行したクエリを参照する
+-- （前提：当該 FE で enable_collect_query_detail_info = true）
+mysql> SELECT get_query_dump_from_query_id('a1b2c3d4-e5f6-7890-abcd-ef0123456789')\G
+
+-- 同上、mock を有効にしてスキーマを露出せずに dump を取得
+mysql> SELECT get_query_dump_from_query_id('a1b2c3d4-e5f6-7890-abcd-ef0123456789', TRUE)\G
+
+-- キャッシュウィンドウ外 / ヒットしない場合の典型的なエラー
+mysql> SELECT get_query_dump_from_query_id('00000000-0000-0000-0000-000000000000');
+ERROR 1064 (HY000): Getting analyzing error. Detail message: Invalid parameter
+get_query_dump_from_query_id: query_id not found in query detail queue: ...
+```
+
+## 関連項目
+
+- [`get_query_dump`](./get_query_dump.md) — 呼び出し元が直接渡した SQL 文字列
+  に対して dump を生成する関数。query detail キューを経由しません。

--- a/docs/zh/sql-reference/sql-functions/meta-functions/get_query_dump_from_query_id.md
+++ b/docs/zh/sql-reference/sql-functions/meta-functions/get_query_dump_from_query_id.md
@@ -1,0 +1,81 @@
+---
+displayed_sidebar: docs
+---
+
+# get_query_dump_from_query_id
+
+`get_query_dump_from_query_id(query_id)`
+`get_query_dump_from_query_id(query_id, enable_mock)`
+
+根据 `query_id` 返回某条已执行查询的 dump。dump 中包含重现该查询规划所需的
+表结构、统计信息、session 变量等上下文，JSON 格式与
+[`get_query_dump`](./get_query_dump.md) 以及 `/api/query_dump` HTTP 接口
+完全一致。
+
+该函数用于线上调试和事后回溯。它会在当前 FE 的 query detail 队列中按
+`query_id` 找到记录，取出原始 SQL 以及当时的 catalog / database，再调用
+dumper 重新生成 dump。
+
+## 参数
+
+`query_id`：查询 ID，标准 StarRocks UUID 格式
+(`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`)。类型：VARCHAR。
+
+`enable_mock`：（可选）`TRUE` 时使用 mock 化的表名 / 列名替换真实名字
+（便于在不暴露 schema 的前提下分享 dump）。默认 `FALSE`。类型：BOOLEAN。
+
+## 返回值
+
+VARCHAR。JSON 格式的 query dump。如果找不到 query、记录中的 SQL 已被脱敏，
+或调用方无权读取该 query，会抛错。
+
+## 运行前提
+
+数据来源是 query detail 队列，因此该队列的约束同样作用于本函数。本函数
+会在执行最前面对两个 FE 配置开关做前置校验，当任何一个未按预期设置时
+立即给出明确报错：
+
+- `enable_collect_query_detail_info` 必须为 `true`（默认 `false`）。
+  未开启时函数立即报错 `query detail collection is disabled. Set FE
+  config enable_collect_query_detail_info=true ...`，避免出现误导性的
+  "not found"。
+- `enable_sql_desensitize_in_log` 必须为 `false`。该开关为 `true` 时
+  记录的 SQL 会被改写成 digest 形式，无法用于重放；函数会直接报错
+  `SQL desensitization is enabled ...`。
+
+通过前置校验后，仍然适用以下运行期约束：
+
+- query 必须在调用本函数的同一个 FE 上执行。detail 是 FE 内存数据，
+  不在 FE 之间同步。
+- detail 还必须在 `query_detail_cache_time_nanosecond`（默认 30 秒）的
+  时间窗口内，过期记录会被后台清理。
+- 即使当前的 `enable_sql_desensitize_in_log = false`，如果 detail
+  是在脱敏开启期间写入的（实际存储为占位符），函数会以 `original sql
+  not retained` 拒绝，作为纵深防御。
+
+## 权限
+
+调用方的完整账号身份（`user`@`host`，如 `'alice'@'10.0.0.1'`）必须与
+该 query 的原执行账号完全相同，或拥有系统级 `OPERATE` 权限。仅用户名
+相同、host 不同的两个账号无法相互读取对方的 query。
+
+## 示例
+
+```sql
+-- 用户查看自己执行过的某条 query
+-- （前提：FE 上 enable_collect_query_detail_info = true）
+mysql> SELECT get_query_dump_from_query_id('a1b2c3d4-e5f6-7890-abcd-ef0123456789')\G
+
+-- 同上，启用 mock 后输出的 dump 不含真实表名
+mysql> SELECT get_query_dump_from_query_id('a1b2c3d4-e5f6-7890-abcd-ef0123456789', TRUE)\G
+
+-- 缓存窗口已过期 / 未命中时的典型报错
+mysql> SELECT get_query_dump_from_query_id('00000000-0000-0000-0000-000000000000');
+ERROR 1064 (HY000): Getting analyzing error. Detail message: Invalid parameter
+get_query_dump_from_query_id: query_id not found in query detail queue: ...
+```
+
+## 相关函数
+
+- [`get_query_dump`](./get_query_dump.md) —— 直接对调用方传入的 SQL 字符串
+  生成 dump，不经过 query detail 队列。

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -85,6 +85,7 @@ public class QueryDetail implements Serializable {
     private String database;
     private String sql;
     private String user;
+    private String userIdentity;
     private String impersonatedUser;
     private String errorMessage;
     private String explain;
@@ -162,6 +163,7 @@ public class QueryDetail implements Serializable {
         queryDetail.database = this.database;
         queryDetail.sql = this.sql;
         queryDetail.user = this.user;
+        queryDetail.userIdentity = this.userIdentity;
         queryDetail.impersonatedUser = this.impersonatedUser;
         queryDetail.errorMessage = this.errorMessage;
         queryDetail.explain = this.explain;
@@ -294,6 +296,14 @@ public class QueryDetail implements Serializable {
 
     public String getUser() {
         return user;
+    }
+
+    public void setUserIdentity(String userIdentity) {
+        this.userIdentity = userIdentity;
+    }
+
+    public String getUserIdentity() {
+        return userIdentity;
     }
 
     public void setImpersonatedUser(String impersonatedUser) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -3914,6 +3914,8 @@ public class StmtExecutor {
                     getPreparedStmtId());
             // Set query source from context
             queryDetail.setQuerySource(context.getQuerySource());
+            queryDetail.setUserIdentity(context.getCurrentUserIdentity() == null
+                    ? null : context.getCurrentUserIdentity().toString());
             queryDetail.setImpersonatedUser(resolveImpersonatedUser());
             context.setQueryDetail(queryDetail);
             // copy queryDetail, cause some properties can be changed in future

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -37,7 +37,9 @@ import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
+import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.mv.MVTimelinessArbiter;
+import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -51,6 +53,8 @@ import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.monitor.unit.ByteSizeValue;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryDetail;
+import com.starrocks.qe.QueryDetailQueue;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.TaskRunManager;
 import com.starrocks.server.GlobalStateMgr;
@@ -76,6 +80,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -606,6 +611,110 @@ public class MetaFunctions {
     @ConstantFunction(name = "get_query_dump", argTypes = {VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
     public static ConstantOperator getQueryDump(ConstantOperator query) {
         return getQueryDump(query, ConstantOperator.createBoolean(false));
+    }
+
+    /**
+     * Look up a finished query by its query_id in {@link QueryDetailQueue} and produce a
+     * query dump for it. Operational requirements: {@code enable_collect_query_detail_info}
+     * must be set (default off) so detail rows are populated; the query must have run on
+     * this FE; and the cache window controlled by {@code query_detail_cache_time_nanosecond}
+     * (default 30s) must not have expired.
+     *
+     * <p>Limitations: per-FE in-memory only, lost on restart, not visible across FE nodes.
+     * Queries whose SQL was desensitized at record time
+     * ({@code enable_sql_desensitize_in_log=true}) cannot be re-dumped. Access is
+     * restricted: the caller's full {@link UserIdentity} (user + host) must match the
+     * original executor's, or hold system-level OPERATE privilege.
+     */
+    @ConstantFunction(name = "get_query_dump_from_query_id", argTypes = {VARCHAR, BOOLEAN},
+            returnType = VARCHAR, isMetaFunction = true)
+    public static ConstantOperator getQueryDumpFromQueryId(ConstantOperator queryId, ConstantOperator enableMock) {
+        if (!Config.enable_collect_query_detail_info) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                    "get_query_dump_from_query_id: query detail collection is disabled."
+                            + " Set FE config enable_collect_query_detail_info=true (e.g."
+                            + " ADMIN SET FRONTEND CONFIG ('enable_collect_query_detail_info' = 'true'))"
+                            + " before running queries you intend to dump.");
+        }
+        if (Config.enable_sql_desensitize_in_log) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                    "get_query_dump_from_query_id: SQL desensitization is enabled, so recorded SQL"
+                            + " is rewritten to a digest form and cannot be re-dumped. Set FE config"
+                            + " enable_sql_desensitize_in_log=false before running queries you intend"
+                            + " to dump.");
+        }
+        String id = queryId.getVarchar();
+        QueryDetail detail = lookupQueryDetailByQueryId(id);
+        if (detail == null) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                    "get_query_dump_from_query_id: query_id not found in query detail queue: " + id
+                            + ". The query may have run on a different FE, or the cache window"
+                            + " (query_detail_cache_time_nanosecond, default 30s) has expired.");
+        }
+        checkQueryDumpAccess(detail);
+        String sql = detail.getSql();
+        if (StringUtils.isEmpty(sql) || "this is a desensitized sql".equals(sql)) {
+            // Defense in depth: the row may have been recorded while desensitization was
+            // on and only flipped off afterwards.
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                    "get_query_dump_from_query_id: original sql not retained for query_id: " + id
+                            + ". The recorded SQL was desensitized at the time the query ran.");
+        }
+        String catalog = StringUtils.isNotEmpty(detail.getCatalog()) ? detail.getCatalog() : "";
+        String database = StringUtils.isNotEmpty(detail.getDatabase()) ? detail.getDatabase() : "";
+        com.starrocks.common.Pair<HttpResponseStatus, String> statusAndRes =
+                QueryDumper.dumpQuery(catalog, database, sql, enableMock.getBoolean());
+        if (statusAndRes.first != HttpResponseStatus.OK) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                    "get_query_dump_from_query_id: " + statusAndRes.second);
+        }
+        return ConstantOperator.createVarchar(statusAndRes.second);
+    }
+
+    @ConstantFunction(name = "get_query_dump_from_query_id", argTypes = {VARCHAR},
+            returnType = VARCHAR, isMetaFunction = true)
+    public static ConstantOperator getQueryDumpFromQueryId(ConstantOperator queryId) {
+        return getQueryDumpFromQueryId(queryId, ConstantOperator.createBoolean(false));
+    }
+
+    private static QueryDetail lookupQueryDetailByQueryId(String queryId) {
+        for (QueryDetail detail : QueryDetailQueue.TOTAL_QUERIES) {
+            if (queryId.equalsIgnoreCase(detail.getQueryId())) {
+                return detail;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Allow looking up a query detail by query_id only when the caller's full
+     * {@link UserIdentity} (user + host) matches the original executor's, or the caller
+     * holds system-level OPERATE privilege. Username-only match would let two distinct
+     * accounts that share a username but differ on host (e.g. {@code 'alice'@'1.1.1.1'}
+     * vs {@code 'alice'@'2.2.2.2'}) read each other's SQL and the schema / statistics
+     * that the resulting dump would expose. We therefore compare against the
+     * {@code userIdentity} field populated by {@link com.starrocks.qe.StmtExecutor};
+     * the {@code user} field is only the qualifiedUser (no host) and is unsafe for
+     * authorization.
+     */
+    private static void checkQueryDumpAccess(QueryDetail detail) {
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx != null) {
+            UserIdentity currentIdentity = ctx.getCurrentUserIdentity();
+            if (currentIdentity != null && StringUtils.isNotEmpty(detail.getUserIdentity())
+                    && currentIdentity.toString().equals(detail.getUserIdentity())) {
+                return;
+            }
+        }
+        try {
+            Authorizer.checkSystemAction(ctx, PrivilegeType.OPERATE);
+        } catch (AccessDeniedException e) {
+            AccessDeniedException.reportAccessDenied(
+                    InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    ctx == null ? null : ctx.getCurrentUserIdentity(),
+                    ctx == null ? null : ctx.getCurrentRoleIds(),
+                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
+        }
     }
 
     public static class LookupRecord {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -21,6 +21,8 @@ import com.starrocks.common.ErrorReportException;
 import com.starrocks.leader.ReportHandler;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.QueryDetail;
+import com.starrocks.qe.QueryDetailQueue;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.function.MetaFunctions;
@@ -441,5 +443,153 @@ public class MetaFunctionsTest extends MVTestBase {
         Assertions.assertNotNull(result);
         // External tables typically have no related MVs
         Assertions.assertEquals("[]", result.getVarchar());
+    }
+
+    private static QueryDetail makeQueryDetail(String queryId, String sql, UserIdentity owner) {
+        QueryDetail detail = new QueryDetail(
+                queryId, true, 0, "127.0.0.1",
+                System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
+                "test", sql, owner == null ? "" : owner.getUser(), "",
+                "default_catalog", "QUERY", null);
+        if (owner != null) {
+            detail.setUserIdentity(owner.toString());
+        }
+        return detail;
+    }
+
+    private static void removeFromQueryDetailQueue(String queryId) {
+        QueryDetailQueue.TOTAL_QUERIES.removeIf(d -> queryId.equals(d.getQueryId()));
+    }
+
+    /**
+     * Snapshot/restore the two FE configs that get_query_dump_from_query_id checks
+     * upfront, so per-test overrides don't bleed into sibling tests.
+     */
+    private static final class QueryDumpConfigGuard implements AutoCloseable {
+        private final boolean prevCollect = com.starrocks.common.Config.enable_collect_query_detail_info;
+        private final boolean prevDesensitize = com.starrocks.common.Config.enable_sql_desensitize_in_log;
+
+        QueryDumpConfigGuard(boolean enableCollect, boolean enableDesensitize) {
+            com.starrocks.common.Config.enable_collect_query_detail_info = enableCollect;
+            com.starrocks.common.Config.enable_sql_desensitize_in_log = enableDesensitize;
+        }
+
+        @Override
+        public void close() {
+            com.starrocks.common.Config.enable_collect_query_detail_info = prevCollect;
+            com.starrocks.common.Config.enable_sql_desensitize_in_log = prevDesensitize;
+        }
+    }
+
+    @Test
+    public void testGetQueryDumpFromQueryIdRequiresFeatureEnabled() {
+        try (QueryDumpConfigGuard guard = new QueryDumpConfigGuard(false, false)) {
+            SemanticException ex = assertThrows(SemanticException.class,
+                    () -> MetaFunctions.getQueryDumpFromQueryId(
+                            ConstantOperator.createVarchar("11111111-2222-3333-4444-555555555555")));
+            Assertions.assertTrue(ex.getMessage().contains("query detail collection is disabled"));
+            Assertions.assertTrue(ex.getMessage().contains("enable_collect_query_detail_info"));
+        }
+    }
+
+    @Test
+    public void testGetQueryDumpFromQueryIdRejectsDesensitizationEnabled() {
+        try (QueryDumpConfigGuard guard = new QueryDumpConfigGuard(true, true)) {
+            SemanticException ex = assertThrows(SemanticException.class,
+                    () -> MetaFunctions.getQueryDumpFromQueryId(
+                            ConstantOperator.createVarchar("11111111-2222-3333-4444-555555555555")));
+            Assertions.assertTrue(ex.getMessage().contains("SQL desensitization is enabled"));
+            Assertions.assertTrue(ex.getMessage().contains("enable_sql_desensitize_in_log"));
+        }
+    }
+
+    @Test
+    public void testGetQueryDumpFromQueryIdNotFound() {
+        try (QueryDumpConfigGuard guard = new QueryDumpConfigGuard(true, false)) {
+            SemanticException ex = assertThrows(SemanticException.class,
+                    () -> MetaFunctions.getQueryDumpFromQueryId(
+                            ConstantOperator.createVarchar("11111111-2222-3333-4444-555555555555")));
+            Assertions.assertTrue(ex.getMessage().contains("query_id not found"));
+        }
+    }
+
+    @Test
+    public void testGetQueryDumpFromQueryIdDesensitizedSql() {
+        String queryId = "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb";
+        QueryDetail detail = makeQueryDetail(queryId, "this is a desensitized sql",
+                connectContext.getCurrentUserIdentity());
+        QueryDetailQueue.addQueryDetail(detail);
+        try (QueryDumpConfigGuard guard = new QueryDumpConfigGuard(true, false)) {
+            SemanticException ex = assertThrows(SemanticException.class,
+                    () -> MetaFunctions.getQueryDumpFromQueryId(ConstantOperator.createVarchar(queryId)));
+            Assertions.assertTrue(ex.getMessage().contains("original sql not retained"));
+        } finally {
+            removeFromQueryDetailQueue(queryId);
+        }
+    }
+
+    @Test
+    public void testGetQueryDumpFromQueryIdLooksUpSql() throws Exception {
+        String queryId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        QueryDetail detail = makeQueryDetail(queryId, "select count(*) from test.tbl1",
+                connectContext.getCurrentUserIdentity());
+        QueryDetailQueue.addQueryDetail(detail);
+        // QueryDumper expects a fresh QueryDumpInfo on the context; PlanTestBase / MVTestBase
+        // installs a MockDumpInfo that the dumper would otherwise try to cast.
+        com.starrocks.sql.optimizer.dump.DumpInfo prevDumpInfo = connectContext.getDumpInfo();
+        connectContext.setDumpInfo(null);
+        try (QueryDumpConfigGuard guard = new QueryDumpConfigGuard(true, false)) {
+            ConstantOperator result = MetaFunctions.getQueryDumpFromQueryId(ConstantOperator.createVarchar(queryId));
+            Assertions.assertNotNull(result);
+            Assertions.assertTrue(result.getVarchar().contains("query_id")
+                    || result.getVarchar().contains("statement"));
+        } finally {
+            removeFromQueryDetailQueue(queryId);
+            connectContext.setDumpInfo(prevDumpInfo);
+        }
+    }
+
+    @Test
+    public void testGetQueryDumpFromQueryIdRejectsSameUsernameDifferentHost() {
+        // QueryDetail.user is just the username; two distinct accounts that share a
+        // username but differ on host must NOT cross-match. The check has to look at
+        // userIdentity (user + host).
+        String queryId = "cafecafe-cafe-cafe-cafe-cafecafecafe";
+        UserIdentity originalIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "10.0.0.1");
+        UserIdentity callerIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "10.0.0.2");
+        QueryDetail detail = makeQueryDetail(queryId, "select 1", originalIdentity);
+        QueryDetailQueue.addQueryDetail(detail);
+        try (QueryDumpConfigGuard guard = new QueryDumpConfigGuard(true, false)) {
+            connectContext.setCurrentUserIdentity(callerIdentity);
+            connectContext.setCurrentRoleIds(callerIdentity);
+            connectContext.setThreadLocalInfo();
+            assertThrows(ErrorReportException.class,
+                    () -> MetaFunctions.getQueryDumpFromQueryId(ConstantOperator.createVarchar(queryId)));
+        } finally {
+            removeFromQueryDetailQueue(queryId);
+            connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
+            connectContext.setCurrentRoleIds(UserIdentity.ROOT);
+            connectContext.setThreadLocalInfo();
+        }
+    }
+
+    @Test
+    public void testGetQueryDumpFromQueryIdAccessDenied() {
+        String queryId = "12345678-1234-1234-1234-123456789012";
+        UserIdentity ownerIdentity = UserIdentity.createAnalyzedUserIdentWithIp("some_other_user", "%");
+        QueryDetail detail = makeQueryDetail(queryId, "select 1", ownerIdentity);
+        QueryDetailQueue.addQueryDetail(detail);
+        try (QueryDumpConfigGuard guard = new QueryDumpConfigGuard(true, false)) {
+            connectContext.setCurrentUserIdentity(testUser);
+            connectContext.setCurrentRoleIds(testUser);
+            connectContext.setThreadLocalInfo();
+            assertThrows(ErrorReportException.class,
+                    () -> MetaFunctions.getQueryDumpFromQueryId(ConstantOperator.createVarchar(queryId)));
+        } finally {
+            removeFromQueryDetailQueue(queryId);
+            connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
+            connectContext.setCurrentRoleIds(UserIdentity.ROOT);
+            connectContext.setThreadLocalInfo();
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Adds get_query_dump_from_query_id(query_id [, enable_mock]) — looks up a finished query in an in-memory audit cache and produces a query dump for it (table schemas, statistics, session vars, etc.), the same shape the existing /api/query_dump HTTP endpoint and get_query_dump(sql) builtin already produce.

Source of truth is the audit pipeline:
- New AuditEventCache (qe/) is a synchronized LinkedHashMap LRU indexed by query_id, sized by Config.audit_event_cache_capacity (mutable, default 1024).
- AuditEventProcessor.handleAuditEvent populates the cache for AFTER_QUERY events synchronously, before the async plugin queue, inside a try/catch so a cache failure cannot drop the audit event.
- The audit pipeline always fires regardless of enable_collect_query_detail_info, so the lookup is reliable for any query that ran on this FE within the cache window.

Access control:
- Looking up another user's query would leak SQL text and the schema / statistics that the resulting dump exposes. The function only succeeds when the caller matches the audit event's user (or the authorized user used for impersonation), or holds system-level OPERATE privilege; otherwise reportAccessDenied is raised.

Limitations (documented):
- Per-FE in-memory only; lost on restart, not synchronized across FEs.
- Queries with desensitized audit SQL (enable_audit_sql=false) cannot be re-dumped; the function returns a clear error.
- Existing get_query_dump(sql) is unchanged.

Tests: cache LRU eviction, query_id-not-found, desensitized stmt, same-user happy path, cross-user access denied.

Docs: docs/en + docs/zh FE_parameters/log_server_meta.md describe the new audit_event_cache_capacity config and the privilege model.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4