### PR TITLE
[Feature] Support Iceberg UPDATE analyzer and physical plan on FE

### DIFF
--- a/be/src/exec/data_sinks/iceberg_table_sink.cpp
+++ b/be/src/exec/data_sinks/iceberg_table_sink.cpp
@@ -186,7 +186,12 @@ Status IcebergTableSink::create_delete_sink_context(
     auto delete_sink_ctx = std::make_shared<connector::IcebergDeleteSinkContext>();
     delete_sink_ctx->path = t_iceberg_sink.data_location;
     delete_sink_ctx->cloud_configuration = t_iceberg_sink.cloud_configuration;
-    delete_sink_ctx->compression_type = t_iceberg_sink.compression_type;
+    // Position-delete codec lives in delete_compression_type; fall back to
+    // compression_type so old FE planners (rolling upgrade with BE upgraded
+    // first) continue to pick up the right codec.
+    delete_sink_ctx->compression_type = t_iceberg_sink.__isset.delete_compression_type
+                                                ? t_iceberg_sink.delete_compression_type
+                                                : t_iceberg_sink.compression_type;
     if (t_iceberg_sink.__isset.target_max_file_size) {
         delete_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
     }
@@ -409,7 +414,11 @@ Status IcebergTableSink::create_row_delta_sink_context(
     delete_sink_ctx->writer_tag = "delete";
     delete_sink_ctx->path = t_iceberg_sink.data_location;
     delete_sink_ctx->cloud_configuration = t_iceberg_sink.cloud_configuration;
-    delete_sink_ctx->compression_type = t_iceberg_sink.compression_type;
+    // Row-delta sinks carry distinct codecs for data vs delete files; fall back to
+    // the data codec when the planner did not populate delete_compression_type.
+    delete_sink_ctx->compression_type = t_iceberg_sink.__isset.delete_compression_type
+                                                ? t_iceberg_sink.delete_compression_type
+                                                : t_iceberg_sink.compression_type;
     if (t_iceberg_sink.__isset.target_max_file_size) {
         delete_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -24,6 +24,7 @@ import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.credential.CloudType;
 import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TExprMinMaxValue;
 import com.starrocks.thrift.TExprNodeType;
@@ -36,6 +37,8 @@ import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.LocationUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.time.Instant;
@@ -47,6 +50,14 @@ import java.util.Map;
 import java.util.Set;
 
 public final class IcebergUtil {
+    private static final Logger LOG = LogManager.getLogger(IcebergUtil.class);
+
+    // Fallback target file size when neither the Iceberg table property
+    // `write.target-file-size-bytes` nor the session variable
+    // `connector_sink_target_max_file_size` is set. Kept at 1 GiB to preserve
+    // StarRocks' historical default; Iceberg's own default is 512 MiB.
+    static final long DEFAULT_TARGET_FILE_SIZE_BYTES = 1024L * 1024 * 1024;
+
     public static String fileName(String path) {
         return path.substring(path.lastIndexOf('/') + 1);
     }
@@ -233,6 +244,36 @@ public final class IcebergUtil {
         String tableLocation = table.location();
         return table.properties().getOrDefault(TableProperties.WRITE_DATA_LOCATION,
                 String.format("%s/data", LocationUtil.stripTrailingSlash(tableLocation)));
+    }
+
+    /**
+     * Resolve the target max file size for an Iceberg sink. Priority:
+     *   1. Table property `write.target-file-size-bytes` (Iceberg standard)
+     *   2. Session variable `connector_sink_target_max_file_size` (when &gt; 0)
+     *   3. {@link #DEFAULT_TARGET_FILE_SIZE_BYTES}
+     * Unparseable property values are skipped with a WARN log so a misconfigured
+     * table never breaks DML; the next source in the chain is used instead.
+     */
+    public static long resolveTargetMaxFileSize(Table nativeTable, SessionVariable sessionVariable) {
+        Preconditions.checkArgument(nativeTable != null, "nativeTable is null");
+        String raw = nativeTable.properties().get(TableProperties.WRITE_TARGET_FILE_SIZE_BYTES);
+        if (raw != null) {
+            try {
+                long parsed = Long.parseLong(raw.trim());
+                if (parsed > 0) {
+                    return parsed;
+                }
+                LOG.warn("Iceberg table property {}={} is not positive; falling back to session/default",
+                        TableProperties.WRITE_TARGET_FILE_SIZE_BYTES, raw);
+            } catch (NumberFormatException e) {
+                LOG.warn("Iceberg table property {}={} is not a valid long; falling back to session/default",
+                        TableProperties.WRITE_TARGET_FILE_SIZE_BYTES, raw);
+            }
+        }
+        if (sessionVariable != null && sessionVariable.getConnectorSinkTargetMaxFileSize() > 0) {
+            return sessionVariable.getConnectorSinkTargetMaxFileSize();
+        }
+        return DEFAULT_TARGET_FILE_SIZE_BYTES;
     }
 
     public static CloudConfiguration getVendedCloudConfiguration(String catalogName, IcebergTable icebergTable) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/ConnectorMetricsMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/ConnectorMetricsMgr.java
@@ -50,6 +50,13 @@ public class ConnectorMetricsMgr {
         final ConcurrentHashMap<String, LongCounterMetric> deleteRows = new ConcurrentHashMap<>();
         final ConcurrentHashMap<String, LongCounterMetric> deleteBytes = new ConcurrentHashMap<>();
 
+        // Update metrics (UPDATE/MERGE with file_type label: data, position_delete)
+        final ConcurrentHashMap<String, LongCounterMetric> updateTotal = new ConcurrentHashMap<>();
+        final ConcurrentHashMap<String, LongCounterMetric> updateDurationMs = new ConcurrentHashMap<>();
+        final ConcurrentHashMap<String, LongCounterMetric> updateRows = new ConcurrentHashMap<>();
+        final ConcurrentHashMap<String, LongCounterMetric> updateBytes = new ConcurrentHashMap<>();
+        final ConcurrentHashMap<String, LongCounterMetric> updateFiles = new ConcurrentHashMap<>();
+
         // Compaction metrics
         final ConcurrentHashMap<String, LongCounterMetric> compactionTotal = new ConcurrentHashMap<>();
         final ConcurrentHashMap<String, LongCounterMetric> compactionDurationMs = new ConcurrentHashMap<>();
@@ -75,6 +82,9 @@ public class ConnectorMetricsMgr {
 
     public static final String DELETE_TYPE_POSITION = "position";
     public static final String DELETE_TYPE_METADATA = "metadata";
+
+    public static final String FILE_TYPE_DATA = "data";
+    public static final String FILE_TYPE_POSITION_DELETE = "position_delete";
 
     public static final String COMPACTION_TYPE_MANUAL = "manual";
     public static final String COMPACTION_TYPE_AUTO = "auto";
@@ -238,6 +248,83 @@ public class ConnectorMetricsMgr {
             MetricRepo.addMetric(metric);
             return metric;
         }).increase(bytes);
+    }
+
+    // ======================= Update Metrics =======================
+
+    public static void increaseUpdateTotal(String connectorType, String status, String reason) {
+        String normalizedStatus = normalizeStatus(status);
+        String normalizedReason = normalizeReason(reason);
+
+        ConnectorMetrics m = getOrCreate(connectorType);
+        String key = normalizedStatus + "|" + normalizedReason;
+        m.updateTotal.computeIfAbsent(key, k -> {
+            LongCounterMetric metric = new LongCounterMetric(connectorType + "_update_total",
+                    Metric.MetricUnit.REQUESTS,
+                    "total " + connectorType + " update tasks by status and reason");
+            metric.addLabel(new MetricLabel("status", normalizedStatus));
+            metric.addLabel(new MetricLabel("reason", normalizedReason));
+            MetricRepo.addMetric(metric);
+            return metric;
+        }).increase(1L);
+    }
+
+    public static void increaseUpdateTotalSuccess(String connectorType) {
+        increaseUpdateTotal(connectorType, STATUS_SUCCESS, REASON_NONE);
+    }
+
+    public static void increaseUpdateTotalFail(String connectorType, Throwable throwable) {
+        increaseUpdateTotal(connectorType, STATUS_FAILED, classifyFailReason(throwable));
+    }
+
+    public static void increaseUpdateTotalFail(String connectorType, String errorMessage) {
+        increaseUpdateTotal(connectorType, STATUS_FAILED, classifyFailReason(errorMessage));
+    }
+
+    public static void increaseUpdateDurationMs(String connectorType, long durationMs) {
+        ConnectorMetrics m = getOrCreate(connectorType);
+        m.updateDurationMs.computeIfAbsent("default", k -> {
+            LongCounterMetric metric = new LongCounterMetric(connectorType + "_update_duration_ms_total",
+                    Metric.MetricUnit.MILLISECONDS,
+                    "total duration in milliseconds of " + connectorType + " update operations");
+            MetricRepo.addMetric(metric);
+            return metric;
+        }).increase(durationMs);
+    }
+
+    public static void increaseUpdateRows(String connectorType, long rows) {
+        ConnectorMetrics m = getOrCreate(connectorType);
+        m.updateRows.computeIfAbsent("default", k -> {
+            LongCounterMetric metric = new LongCounterMetric(connectorType + "_update_rows",
+                    Metric.MetricUnit.ROWS,
+                    "total rows affected by " + connectorType + " update operations");
+            MetricRepo.addMetric(metric);
+            return metric;
+        }).increase(rows);
+    }
+
+    public static void increaseUpdateBytes(String connectorType, long bytes, String fileType) {
+        ConnectorMetrics m = getOrCreate(connectorType);
+        m.updateBytes.computeIfAbsent(fileType, k -> {
+            LongCounterMetric metric = new LongCounterMetric(connectorType + "_update_bytes",
+                    Metric.MetricUnit.BYTES,
+                    "total bytes written by " + connectorType + " update operations by file type");
+            metric.addLabel(new MetricLabel("file_type", fileType));
+            MetricRepo.addMetric(metric);
+            return metric;
+        }).increase(bytes);
+    }
+
+    public static void increaseUpdateFiles(String connectorType, long files, String fileType) {
+        ConnectorMetrics m = getOrCreate(connectorType);
+        m.updateFiles.computeIfAbsent(fileType, k -> {
+            LongCounterMetric metric = new LongCounterMetric(connectorType + "_update_files",
+                    Metric.MetricUnit.NOUNIT,
+                    "total files written by " + connectorType + " update operations by file type");
+            metric.addLabel(new MetricLabel("file_type", fileType));
+            MetricRepo.addMetric(metric);
+            return metric;
+        }).increase(files);
     }
 
     // ======================= Compaction Metrics =======================

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
@@ -137,8 +137,10 @@ public class IcebergDeleteSink extends DataSink {
         tIcebergTableSink.setData_location(dataLocation);
         tIcebergTableSink.setFile_format("parquet"); // Delete files are always parquet
         tIcebergTableSink.setIs_static_partition_sink(false);
+        // DeleteSink only emits position-delete files; the codec belongs in the
+        // delete-file slot. `compression_type` is reserved for data files now.
         TCompressionType compression = PARQUET_COMPRESSION_TYPE_MAP.get(compressionType);
-        tIcebergTableSink.setCompression_type(compression);
+        tIcebergTableSink.setDelete_compression_type(compression);
         tIcebergTableSink.setTarget_max_file_size(targetMaxFileSize);
         com.starrocks.thrift.TCloudConfiguration tCloudConfiguration = new com.starrocks.thrift.TCloudConfiguration();
         cloudConfiguration.toThrift(tCloudConfiguration);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
@@ -70,8 +70,7 @@ public class IcebergDeleteSink extends DataSink {
         this.compressionType = nativeTable.properties().getOrDefault(DELETE_PARQUET_COMPRESSION,
                 nativeTable.properties().getOrDefault(PARQUET_COMPRESSION,
                         sessionVariable.getConnectorSinkCompressionCodec()));
-        this.targetMaxFileSize = sessionVariable.getConnectorSinkTargetMaxFileSize() > 0 ?
-                sessionVariable.getConnectorSinkTargetMaxFileSize() : 1024L * 1024 * 1024;
+        this.targetMaxFileSize = IcebergUtil.resolveTargetMaxFileSize(nativeTable, sessionVariable);
     }
 
     public void init() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergRowDeltaSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergRowDeltaSink.java
@@ -19,7 +19,6 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TDataSinkType;
 import com.starrocks.thrift.TExplainLevel;
@@ -74,7 +73,8 @@ public class IcebergRowDeltaSink extends DataSink {
     private final String fileFormat;
     private final String tableLocation;
     private final String dataLocation;
-    private final String compressionType;
+    private final String dataCompressionType;
+    private final String deleteCompressionType;
     private final long targetMaxFileSize;
     private final String tableIdentifier;
     private CloudConfiguration cloudConfiguration;
@@ -98,10 +98,14 @@ public class IcebergRowDeltaSink extends DataSink {
         this.tableIdentifier = icebergTable.getUUID();
         this.fileFormat = nativeTable.properties().getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT)
                 .toLowerCase();
-        // Priority: write.delete.parquet.compression-codec > write.parquet.compression-codec > session variable
-        this.compressionType = nativeTable.properties().getOrDefault(DELETE_PARQUET_COMPRESSION,
-                nativeTable.properties().getOrDefault(PARQUET_COMPRESSION,
-                        sessionVariable.getConnectorSinkCompressionCodec()));
+        // Row-delta writes both new data files and new position-delete files, so each
+        // needs its own codec.
+        // Data files: write.parquet.compression-codec > session variable.
+        // Delete files: write.delete.parquet.compression-codec > write.parquet.compression-codec > session variable.
+        String sessionCodec = sessionVariable.getConnectorSinkCompressionCodec();
+        String dataCodec = nativeTable.properties().getOrDefault(PARQUET_COMPRESSION, sessionCodec);
+        this.dataCompressionType = dataCodec;
+        this.deleteCompressionType = nativeTable.properties().getOrDefault(DELETE_PARQUET_COMPRESSION, dataCodec);
         this.targetMaxFileSize = sessionVariable.getConnectorSinkTargetMaxFileSize() > 0 ?
                 sessionVariable.getConnectorSinkTargetMaxFileSize() : 1024L * 1024 * 1024;
     }
@@ -173,8 +177,8 @@ public class IcebergRowDeltaSink extends DataSink {
         tIcebergTableSink.setFile_format(fileFormat);
         tIcebergTableSink.setIs_static_partition_sink(false);
         tIcebergTableSink.setWrite_mode(TIcebergWriteMode.ROW_DELTA);
-        TCompressionType compression = PARQUET_COMPRESSION_TYPE_MAP.get(compressionType);
-        tIcebergTableSink.setCompression_type(compression);
+        tIcebergTableSink.setCompression_type(PARQUET_COMPRESSION_TYPE_MAP.get(dataCompressionType));
+        tIcebergTableSink.setDelete_compression_type(PARQUET_COMPRESSION_TYPE_MAP.get(deleteCompressionType));
         tIcebergTableSink.setTarget_max_file_size(targetMaxFileSize);
         com.starrocks.thrift.TCloudConfiguration tCloudConfiguration = new com.starrocks.thrift.TCloudConfiguration();
         cloudConfiguration.toThrift(tCloudConfiguration);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergRowDeltaSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergRowDeltaSink.java
@@ -106,8 +106,7 @@ public class IcebergRowDeltaSink extends DataSink {
         String dataCodec = nativeTable.properties().getOrDefault(PARQUET_COMPRESSION, sessionCodec);
         this.dataCompressionType = dataCodec;
         this.deleteCompressionType = nativeTable.properties().getOrDefault(DELETE_PARQUET_COMPRESSION, dataCodec);
-        this.targetMaxFileSize = sessionVariable.getConnectorSinkTargetMaxFileSize() > 0 ?
-                sessionVariable.getConnectorSinkTargetMaxFileSize() : 1024L * 1024 * 1024;
+        this.targetMaxFileSize = IcebergUtil.resolveTargetMaxFileSize(nativeTable, sessionVariable);
     }
 
     public void init() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergRowDeltaSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergRowDeltaSink.java
@@ -1,0 +1,223 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergUtil;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TDataSink;
+import com.starrocks.thrift.TDataSinkType;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TIcebergTableSink;
+import com.starrocks.thrift.TIcebergWriteMode;
+import org.apache.iceberg.Table;
+
+import static com.starrocks.sql.ast.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+import static org.apache.iceberg.TableProperties.DELETE_PARQUET_COMPRESSION;
+import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
+
+/**
+ * IcebergRowDeltaSink is used to support UPDATE operations on Iceberg tables
+ * using the RowDelta model. It writes both position delete files and new data
+ * files in a single atomic operation.
+ * <p>
+ * Required columns:
+ * - _file (STRING): Path of the data file
+ * - _pos (BIGINT): Row position within the file
+ * - Plus data columns for the updated rows
+ */
+public class IcebergRowDeltaSink extends DataSink {
+    public static final String WRITE_MODE_ROW_DELTA = "ROW_DELTA";
+
+    /**
+     * Operation codes for row-level delta operations.
+     * Each row in the RowDelta output carries an op_code that tells the BE sink
+     * how to route it. Values must stay in sync with BE IcebergRowDeltaSink::OP_*.
+     */
+    public enum OpCode {
+        NO_OP(0),           // discard (MERGE row matches no WHEN clause)
+        DELETE(1),          // position delete only
+        UPDATE(2),          // position delete + new data row
+        INSERT(3);          // new data row only
+
+        private final int value;
+
+        OpCode(int value) {
+            this.value = value;
+        }
+
+        public int value() {
+            return value;
+        }
+    }
+
+    protected final TupleDescriptor desc;
+    private IcebergTable icebergTable;
+    private final long targetTableId;
+    private final String fileFormat;
+    private final String tableLocation;
+    private final String dataLocation;
+    private final String compressionType;
+    private final long targetMaxFileSize;
+    private final String tableIdentifier;
+    private CloudConfiguration cloudConfiguration;
+    private com.starrocks.connector.iceberg.IcebergMetadata.IcebergSinkExtra sinkExtraInfo;
+
+    /**
+     * Constructor for IcebergRowDeltaSink
+     *
+     * @param icebergTable    The target Iceberg table
+     * @param desc            Tuple descriptor containing operation columns
+     * @param sessionVariable Session variables for configuration
+     */
+    public IcebergRowDeltaSink(IcebergTable icebergTable, TupleDescriptor desc,
+                               SessionVariable sessionVariable) {
+        this.icebergTable = icebergTable;
+        Table nativeTable = icebergTable.getNativeTable();
+        this.desc = desc;
+        this.tableLocation = nativeTable.location();
+        this.dataLocation = IcebergUtil.tableDataLocation(nativeTable);
+        this.targetTableId = icebergTable.getId();
+        this.tableIdentifier = icebergTable.getUUID();
+        this.fileFormat = nativeTable.properties().getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT)
+                .toLowerCase();
+        // Priority: write.delete.parquet.compression-codec > write.parquet.compression-codec > session variable
+        this.compressionType = nativeTable.properties().getOrDefault(DELETE_PARQUET_COMPRESSION,
+                nativeTable.properties().getOrDefault(PARQUET_COMPRESSION,
+                        sessionVariable.getConnectorSinkCompressionCodec()));
+        this.targetMaxFileSize = sessionVariable.getConnectorSinkTargetMaxFileSize() > 0 ?
+                sessionVariable.getConnectorSinkTargetMaxFileSize() : 1024L * 1024 * 1024;
+    }
+
+    public void init() {
+        String catalogName = icebergTable.getCatalogName();
+        this.cloudConfiguration = IcebergUtil.getVendedCloudConfiguration(catalogName, icebergTable);
+        // Validate tuple descriptor contains required columns
+        validateTuple(desc);
+    }
+
+    /**
+     * Validate that the tuple descriptor contains required columns for row delta operations.
+     * The tuple must include _file and _pos columns for identifying rows to delete,
+     * plus data columns for the new rows.
+     *
+     * @param desc The tuple descriptor to validate
+     */
+    private void validateTuple(TupleDescriptor desc) {
+        boolean hasFilePathColumn = false;
+        boolean hasPosColumn = false;
+
+        for (SlotDescriptor slot : desc.getSlots()) {
+            if (slot.getColumn() == null) {
+                continue;
+            }
+            String colName = slot.getColumn().getName();
+            if (IcebergTable.FILE_PATH.equals(colName)) {
+                hasFilePathColumn = true;
+                if (!slot.getType().isVarchar()) {
+                    throw new StarRocksConnectorException("_file column must be type of VARCHAR");
+                }
+                continue;
+            }
+            if (IcebergTable.ROW_POSITION.equals(colName)) {
+                hasPosColumn = true;
+                if (!slot.getType().isBigint()) {
+                    throw new StarRocksConnectorException("_pos column must be type of BIGINT");
+                }
+            }
+        }
+
+        if (!hasFilePathColumn || !hasPosColumn) {
+            throw new StarRocksConnectorException(
+                    "IcebergRowDeltaSink requires _file and _pos columns in tuple descriptor");
+        }
+    }
+
+    @Override
+    public String getExplainString(String prefix, TExplainLevel explainLevel) {
+        StringBuilder strBuilder = new StringBuilder();
+        strBuilder.append(prefix).append("ICEBERG ROW DELTA SINK");
+        strBuilder.append("\n");
+        strBuilder.append(prefix).append("  TABLE: ").append(tableIdentifier).append("\n");
+        strBuilder.append(prefix).append("  LOCATION: ").append(tableLocation).append("\n");
+        strBuilder.append(prefix).append("  WRITE MODE: ").append(WRITE_MODE_ROW_DELTA).append("\n");
+        strBuilder.append(prefix).append("  TUPLE ID: ").append(desc.getId()).append("\n");
+        return strBuilder.toString();
+    }
+
+    @Override
+    protected TDataSink toThrift() {
+        TDataSink tDataSink = new TDataSink(TDataSinkType.ICEBERG_ROW_DELTA_SINK);
+        TIcebergTableSink tIcebergTableSink = new TIcebergTableSink();
+        tIcebergTableSink.setTarget_table_id(targetTableId);
+        tIcebergTableSink.setTuple_id(desc.getId().asInt());
+        tIcebergTableSink.setLocation(tableLocation);
+        tIcebergTableSink.setData_location(dataLocation);
+        tIcebergTableSink.setFile_format(fileFormat);
+        tIcebergTableSink.setIs_static_partition_sink(false);
+        tIcebergTableSink.setWrite_mode(TIcebergWriteMode.ROW_DELTA);
+        TCompressionType compression = PARQUET_COMPRESSION_TYPE_MAP.get(compressionType);
+        tIcebergTableSink.setCompression_type(compression);
+        tIcebergTableSink.setTarget_max_file_size(targetMaxFileSize);
+        com.starrocks.thrift.TCloudConfiguration tCloudConfiguration = new com.starrocks.thrift.TCloudConfiguration();
+        cloudConfiguration.toThrift(tCloudConfiguration);
+        tIcebergTableSink.setCloud_configuration(tCloudConfiguration);
+
+        tDataSink.setIceberg_table_sink(tIcebergTableSink);
+        return tDataSink;
+    }
+
+    @Override
+    public PlanNodeId getExchNodeId() {
+        return null;
+    }
+
+    @Override
+    public DataPartition getOutputPartition() {
+        return null;
+    }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
+
+    /**
+     * Sets the sink extra info for this row delta operation
+     *
+     * @param sinkExtraInfo The extra info to set
+     */
+    public void setSinkExtraInfo(com.starrocks.connector.iceberg.IcebergMetadata.IcebergSinkExtra sinkExtraInfo) {
+        this.sinkExtraInfo = sinkExtraInfo;
+    }
+
+    /**
+     * Gets the sink extra info for this row delta operation
+     *
+     * @return The extra info, or null if not set
+     */
+    public com.starrocks.connector.iceberg.IcebergMetadata.IcebergSinkExtra getSinkExtraInfo() {
+        return sinkExtraInfo;
+    }
+
+    public boolean isUnpartitionedTable() {
+        return !icebergTable.isPartitioned();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
@@ -59,8 +59,7 @@ public class IcebergTableSink extends DataSink {
                 .toLowerCase();
         this.compressionType = nativeTable.properties().getOrDefault(PARQUET_COMPRESSION,
                 sessionVariable.getConnectorSinkCompressionCodec());
-        this.targetMaxFileSize = sessionVariable.getConnectorSinkTargetMaxFileSize() > 0 ?
-            sessionVariable.getConnectorSinkTargetMaxFileSize() : 1024L * 1024 * 1024;
+        this.targetMaxFileSize = IcebergUtil.resolveTargetMaxFileSize(nativeTable, sessionVariable);
         this.targetBranch = targetBranch;
 
         String catalogName = icebergTable.getCatalogName();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -120,6 +120,7 @@ import com.starrocks.planner.FileScanNode;
 import com.starrocks.planner.HiveTableSink;
 import com.starrocks.planner.IcebergDeleteSink;
 import com.starrocks.planner.IcebergMetadataDeleteNode;
+import com.starrocks.planner.IcebergRowDeltaSink;
 import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.IcebergTableSink;
 import com.starrocks.planner.OlapScanNode;
@@ -3482,7 +3483,15 @@ public class StmtExecutor {
                 List<TSinkCommitInfo> commitInfos = coord.getSinkCommitInfos();
 
                 DataSink dataSink = execPlan.getFragments().get(0).getSink();
-                if (dataSink instanceof IcebergDeleteSink deleteSink) {
+                if (dataSink instanceof IcebergRowDeltaSink rowDeltaSink) {
+                    // This is an UPDATE/MERGE operation, use IcebergRowDeltaSink.
+                    // NOTE: the row-delta commit path in MetadataMgr.finishSink (mixing new DATA files
+                    // with POSITION_DELETES into a single Iceberg RowDelta) is added in a follow-up PR;
+                    // this PR only wires the FE planner / executor entry points.
+                    IcebergMetadata.IcebergSinkExtra extra = rowDeltaSink.getSinkExtraInfo();
+                    context.getGlobalStateMgr().getMetadataMgr().finishSink(
+                            catalogName, dbName, tableName, commitInfos, null, extra, context);
+                } else if (dataSink instanceof IcebergDeleteSink deleteSink) {
                     // This is a DELETE operation, use IcebergDeleteSink
                     IcebergMetadata.IcebergSinkExtra extra = deleteSink.getSinkExtraInfo();
                     context.getGlobalStateMgr().getMetadataMgr().finishSink(
@@ -3722,7 +3731,9 @@ public class StmtExecutor {
             return;
         }
 
-        if (dmlType == DmlType.DELETE) {
+        if (dmlType == DmlType.UPDATE) {
+            ConnectorMetricsMgr.increaseUpdateTotalFail(connectorType, t);
+        } else if (dmlType == DmlType.DELETE) {
             ConnectorMetricsMgr.increaseDeleteTotalFail(connectorType, t, "position");
         } else {
             String writeType = dmlType == DmlType.INSERT_OVERWRITE ? "overwrite" : "insert";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -26,18 +26,15 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.iceberg.IcebergMetadata;
-import com.starrocks.connector.iceberg.ScalarOperatorToIcebergExpr;
 import com.starrocks.load.Load;
 import com.starrocks.planner.DataPartition;
 import com.starrocks.planner.DataSink;
 import com.starrocks.planner.DescriptorTable;
 import com.starrocks.planner.IcebergDeleteSink;
 import com.starrocks.planner.IcebergMetadataDeleteNode;
-import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
-import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.TupleDescriptor;
@@ -54,9 +51,6 @@ import com.starrocks.sql.optimizer.Optimizer;
 import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
-import com.starrocks.sql.optimizer.base.DistributionProperty;
-import com.starrocks.sql.optimizer.base.DistributionSpec;
-import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.logical.LogicalApplyOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
@@ -68,11 +62,9 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.type.IntegerType;
-import org.apache.iceberg.Schema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -119,7 +111,7 @@ public class DeletePlanner {
 
             // For Iceberg, create shuffled property based on partitioning
             List<ColumnRefOperator> outputColumns = logicalPlan.getOutputColumn();
-            requiredProperty = createShuffleProperty(icebergTable, outputColumns);
+            requiredProperty = IcebergPlannerUtils.createShuffleProperty(icebergTable, outputColumns);
         } else {
             // For other tables, use default empty property
             requiredProperty = new PhysicalPropertySet();
@@ -322,7 +314,7 @@ public class DeletePlanner {
         // Create IcebergSinkExtra for DELETE operations
         IcebergMetadata.IcebergSinkExtra icebergSinkExtra = new IcebergMetadata.IcebergSinkExtra();
         // Build Iceberg filter expression from scan node for conflict detection
-        org.apache.iceberg.expressions.Expression filterExpr = buildIcebergFilterExpr(execPlan);
+        org.apache.iceberg.expressions.Expression filterExpr = IcebergPlannerUtils.buildIcebergFilterExpr(execPlan);
         if (filterExpr != null) {
             icebergSinkExtra.setConflictDetectionFilter(filterExpr);
         }
@@ -398,76 +390,4 @@ public class DeletePlanner {
     }
 
 
-    /**
-     *
-     * @param icebergTable  The Iceberg table
-     * @param outputColumns Output columns from the logical plan (includes virtual columns + partition columns)
-     * @return PhysicalPropertySet with shuffle requirement or empty property
-     */
-    private PhysicalPropertySet createShuffleProperty(IcebergTable icebergTable,
-                                                      List<ColumnRefOperator> outputColumns) {
-        // Check if table is partitioned
-        if (!icebergTable.isPartitioned()) {
-            // No shuffle for non-partitioned tables
-            return new PhysicalPropertySet();
-        }
-
-        List<String> partitionColNames = icebergTable.getPartitionColumnNames();
-        List<Integer> partitionColumnIds = Lists.newArrayList();
-        for (String partCol : partitionColNames) {
-            for (ColumnRefOperator outputCol : outputColumns) {
-                if (outputCol.getName().equalsIgnoreCase(partCol)) {
-                    partitionColumnIds.add(outputCol.getId());
-                    break;
-                }
-            }
-        }
-
-        if (partitionColumnIds.isEmpty()) {
-            // Partition column not in output, cannot shuffle
-            return new PhysicalPropertySet();
-        }
-
-        // Create HASH distribution spec
-        HashDistributionDesc distributionDesc = new HashDistributionDesc(
-                partitionColumnIds,
-                HashDistributionDesc.SourceType.SHUFFLE_AGG
-        );
-
-        DistributionProperty distributionProperty = DistributionProperty.createProperty(
-                DistributionSpec.createHashDistributionSpec(distributionDesc));
-
-        return new PhysicalPropertySet(distributionProperty);
-    }
-
-    /**
-     * Build Iceberg filter expression from scan node for conflict detection
-     */
-    private org.apache.iceberg.expressions.Expression buildIcebergFilterExpr(
-            ExecPlan execPlan) {
-        if (execPlan == null || execPlan.getScanNodes() == null) {
-            return null;
-        }
-
-        // Find IcebergScanNode and get its predicate
-        ScalarOperator predicate = null;
-        Schema nativeSchema = null;
-
-        for (PlanNode node : execPlan.getScanNodes()) {
-            if (node instanceof IcebergScanNode scanNode) {
-                predicate = scanNode.getIcebergJobPlanningPredicate();
-                nativeSchema = scanNode.getIcebergTable().getNativeTable().schema();
-                break;
-            }
-        }
-
-        if (predicate == null || nativeSchema == null) {
-            return null;
-        }
-
-        // Convert ScalarOperator to Iceberg Expression
-        ScalarOperatorToIcebergExpr.IcebergContext icebergContext =
-                new ScalarOperatorToIcebergExpr.IcebergContext(nativeSchema.asStruct());
-        return new ScalarOperatorToIcebergExpr().convert(Collections.singletonList(predicate), icebergContext);
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/IcebergPlannerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/IcebergPlannerUtils.java
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.connector.iceberg.ScalarOperatorToIcebergExpr;
+import com.starrocks.planner.IcebergScanNode;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.PlanNode;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.base.DistributionProperty;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.HashDistributionDesc;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.plan.ExecPlan;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Shared utilities for Iceberg DML planners (DeletePlanner, UpdatePlanner, future MergePlanner).
+ */
+public class IcebergPlannerUtils {
+
+    public static PhysicalPropertySet createShuffleProperty(IcebergTable icebergTable,
+                                                             List<ColumnRefOperator> outputColumns) {
+        if (!icebergTable.isPartitioned()) {
+            return new PhysicalPropertySet();
+        }
+
+        List<String> partitionColNames = icebergTable.getPartitionColumnNames();
+        List<Integer> partitionColumnIds = Lists.newArrayList();
+        for (String partCol : partitionColNames) {
+            for (ColumnRefOperator outputCol : outputColumns) {
+                if (outputCol.getName().equalsIgnoreCase(partCol)) {
+                    partitionColumnIds.add(outputCol.getId());
+                    break;
+                }
+            }
+        }
+
+        if (partitionColumnIds.isEmpty()) {
+            return new PhysicalPropertySet();
+        }
+
+        HashDistributionDesc distributionDesc = new HashDistributionDesc(
+                partitionColumnIds, HashDistributionDesc.SourceType.SHUFFLE_AGG);
+        DistributionProperty distributionProperty = DistributionProperty.createProperty(
+                DistributionSpec.createHashDistributionSpec(distributionDesc));
+        return new PhysicalPropertySet(distributionProperty);
+    }
+
+    public static org.apache.iceberg.expressions.Expression buildIcebergFilterExpr(ExecPlan execPlan) {
+        if (execPlan == null || execPlan.getScanNodes() == null) {
+            return null;
+        }
+
+        ScalarOperator predicate = null;
+        org.apache.iceberg.Schema nativeSchema = null;
+
+        for (PlanNode node : execPlan.getScanNodes()) {
+            if (node instanceof IcebergScanNode scanNode) {
+                predicate = scanNode.getIcebergJobPlanningPredicate();
+                nativeSchema = scanNode.getIcebergTable().getNativeTable().schema();
+                break;
+            }
+        }
+
+        if (predicate == null || nativeSchema == null) {
+            return null;
+        }
+
+        ScalarOperatorToIcebergExpr.IcebergContext icebergContext =
+                new ScalarOperatorToIcebergExpr.IcebergContext(nativeSchema.asStruct());
+        return new ScalarOperatorToIcebergExpr().convert(Collections.singletonList(predicate), icebergContext);
+    }
+
+    public static void configureIcebergSinkPipeline(ExecPlan execPlan, ConnectContext session,
+                                                     boolean canUsePipeline) {
+        if (!canUsePipeline) {
+            execPlan.getFragments().get(0).setPipelineDop(1);
+            return;
+        }
+
+        SessionVariable sv = session.getSessionVariable();
+        if (sv.isEnableConnectorSinkSpill()) {
+            sv.setEnableSpill(true);
+            if (sv.getConnectorSinkSpillMemLimitThreshold() < sv.getSpillMemLimitThreshold()) {
+                sv.setSpillMemLimitThreshold(sv.getConnectorSinkSpillMemLimitThreshold());
+            }
+        }
+
+        PlanFragment sinkFragment = execPlan.getFragments().get(0);
+        if (sv.getEnableAdaptiveSinkDop()) {
+            long warehouseId = session.getCurrentComputeResource().getWarehouseId();
+            sinkFragment.setPipelineDop(sv.getSinkDegreeOfParallelism(warehouseId));
+        } else {
+            sinkFragment.setPipelineDop(sv.getParallelExecInstanceNum());
+        }
+        sinkFragment.setHasIcebergTableSink();
+        sinkFragment.disableRuntimeAdaptiveDop();
+        sinkFragment.setForceSetTableSinkDop();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -91,10 +91,6 @@ public class UpdatePlanner {
 
         if (targetTable instanceof IcebergTable icebergTable) {
             requiredProperty = IcebergPlannerUtils.createShuffleProperty(icebergTable, outputColumns);
-            // Use the exact column names saved by the analyzer from SELECT list aliases.
-            // getColumnOutputNames() is unreliable (scope expansion adds extras),
-            // and ColumnRefOperator.getName() returns "expr" for SET expressions.
-            colNames = updateStmt.getIcebergColumnOutputNames();
         } else {
             // OLAP/System: cast output column types to target schema types
             optExprBuilder = castOutputColumnsTypeToTargetColumns(columnRefFactory, targetTable,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
@@ -25,8 +26,10 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.connector.iceberg.IcebergMetadata;
 import com.starrocks.planner.DataSink;
 import com.starrocks.planner.DescriptorTable;
+import com.starrocks.planner.IcebergRowDeltaSink;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.SchemaTableSink;
@@ -39,6 +42,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.UpdateStmt;
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
@@ -81,117 +85,70 @@ public class UpdatePlanner {
         List<ColumnRefOperator> outputColumns = logicalPlan.getOutputColumn();
         Table targetTable = updateStmt.getTable();
 
-        //1. Cast output columns type to target type
+        // Determine required physical property and prepare the optimizer root
         OptExprBuilder optExprBuilder = logicalPlan.getRootBuilder();
-        optExprBuilder = castOutputColumnsTypeToTargetColumns(columnRefFactory, targetTable,
-                colNames, outputColumns, optExprBuilder);
+        PhysicalPropertySet requiredProperty;
 
-        // TODO: remove forceDisablePipeline when all the operators support pipeline engine.
+        if (targetTable instanceof IcebergTable icebergTable) {
+            requiredProperty = IcebergPlannerUtils.createShuffleProperty(icebergTable, outputColumns);
+            // Use the exact column names saved by the analyzer from SELECT list aliases.
+            // getColumnOutputNames() is unreliable (scope expansion adds extras),
+            // and ColumnRefOperator.getName() returns "expr" for SET expressions.
+            colNames = updateStmt.getIcebergColumnOutputNames();
+        } else {
+            // OLAP/System: cast output column types to target schema types
+            optExprBuilder = castOutputColumnsTypeToTargetColumns(columnRefFactory, targetTable,
+                    colNames, outputColumns, optExprBuilder);
+            requiredProperty = new PhysicalPropertySet();
+        }
+
+        return createUpdatePlan(updateStmt, session, optExprBuilder.getRoot(), columnRefFactory,
+                outputColumns, colNames, targetTable, requiredProperty);
+    }
+
+    /**
+     * Shared planning core: pipeline guard → optimize → build physical plan → setup sink.
+     */
+    private ExecPlan createUpdatePlan(UpdateStmt updateStmt, ConnectContext session,
+                                      OptExpression logicalRoot, ColumnRefFactory columnRefFactory,
+                                      List<ColumnRefOperator> outputColumns, List<String> colNames,
+                                      Table targetTable, PhysicalPropertySet requiredProperty) {
         boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();
-        boolean canUsePipeline = isEnablePipeline && DataSink.canTableSinkUsePipeline(updateStmt.getTable());
+        boolean canUsePipeline = isEnablePipeline && DataSink.canTableSinkUsePipeline(targetTable);
         boolean forceDisablePipeline = isEnablePipeline && !canUsePipeline;
         boolean prevIsEnableLocalShuffleAgg = session.getSessionVariable().isEnableLocalShuffleAgg();
         try {
             if (forceDisablePipeline) {
                 session.getSessionVariable().setEnablePipelineEngine(false);
             }
-            // Non-query must use the strategy assign scan ranges per driver sequence, which local shuffle agg cannot use.
             session.getSessionVariable().setEnableLocalShuffleAgg(false);
 
-            long tableId = targetTable.getId();
+            // Optimize
             OptimizerContext optimizerContext = OptimizerFactory.initContext(session, columnRefFactory);
-            optimizerContext.setUpdateTableId(tableId);
-
+            if (targetTable instanceof OlapTable) {
+                optimizerContext.setUpdateTableId(targetTable.getId());
+            }
             Optimizer optimizer = OptimizerFactory.create(optimizerContext);
             OptExpression optimizedPlan = optimizer.optimize(
-                    optExprBuilder.getRoot(),
-                    new PhysicalPropertySet(),
-                    new ColumnRefSet(outputColumns));
+                    logicalRoot, requiredProperty, new ColumnRefSet(outputColumns));
+
+            // Build physical plan
             ExecPlan execPlan = PlanFragmentBuilder.createPhysicalPlan(optimizedPlan, session,
                     outputColumns, columnRefFactory, colNames, TResultSinkType.MYSQL_PROTOCAL, false);
-            DescriptorTable descriptorTable = execPlan.getDescTbl();
-            TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
 
-            List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
-            for (Column column : targetTable.getFullSchema()) {
-                if (updateStmt.usePartialUpdate() && !column.isGeneratedColumn() &&
-                        !updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {
-                    // When using partial update, skip columns which aren't key column and not be assign, except for
-                    // generated column
-                    continue;
-                }
-                SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
-                slotDescriptor.setIsMaterialized(true);
-                slotDescriptor.setType(column.getType());
-                slotDescriptor.setColumn(column);
-                slotDescriptor.setIsNullable(column.isAllowNull());
-                if (column.getType().isVarchar() &&
-                        IDictManager.getInstance().hasGlobalDict(tableId, column.getColumnId())) {
-                    Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getColumnId());
-                    dict.ifPresent(
-                            columnDict -> globalDicts.add(new Pair<>(slotDescriptor.getId().asInt(), columnDict)));
-                }
-            }
-            olapTuple.computeMemLayout();
-
-            if (targetTable instanceof OlapTable) {
-                List<Long> partitionIds = Lists.newArrayList();
-                for (Partition partition : targetTable.getPartitions()) {
-                    partitionIds.add(partition.getId());
-                }
-                OlapTable olapTable = (OlapTable) targetTable;
-                DataSink dataSink = new OlapTableSink(olapTable, olapTuple, partitionIds, olapTable.writeQuorum(),
-                        olapTable.enableReplicatedStorage(), false,
-                        olapTable.supportedAutomaticPartition(), session.getCurrentComputeResource());
-                if (updateStmt.usePartialUpdate()) {
-                    // using column mode partial update in UPDATE stmt
-                    ((OlapTableSink) dataSink).setPartialUpdateMode(TPartialUpdateMode.COLUMN_UPDATE_MODE);
-                }
-                if (session.getTxnId() != 0) {
-                    ((OlapTableSink) dataSink).setIsMultiStatementsTxn(true);
-                }
-
-                execPlan.getFragments().get(0).setSink(dataSink);
-                execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);
-
-                // if sink is OlapTableSink Assigned to Be execute this sql [cn execute OlapTableSink will crash]
-                session.getSessionVariable().setPreferComputeNode(false);
-                session.getSessionVariable().setUseComputeNodes(0);
-                OlapTableSink olapTableSink = (OlapTableSink) dataSink;
-                TableRef tableRef = updateStmt.getTableRef();
-                TableName catalogDbTable = TableName.fromTableRef(tableRef);
-                Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(session, catalogDbTable.getCatalog(),
-                        catalogDbTable.getDb());
-                try {
-                    olapTableSink.init(session.getExecutionId(), updateStmt.getTxnId(), db.getId(), session.getExecTimeout());
-                    olapTableSink.complete();
-                } catch (StarRocksException e) {
-                    throw new SemanticException(e.getMessage());
-                }
+            // Setup sink and configure pipeline based on table type
+            if (targetTable instanceof IcebergTable icebergTable) {
+                setupIcebergRowDeltaSink(execPlan, colNames, icebergTable, session);
+                IcebergPlannerUtils.configureIcebergSinkPipeline(execPlan, session, canUsePipeline);
+            } else if (targetTable instanceof OlapTable) {
+                setupOlapTableSink(execPlan, updateStmt, session, targetTable, canUsePipeline);
             } else if (targetTable instanceof SystemTable) {
                 DataSink dataSink = new SchemaTableSink((SystemTable) targetTable,
                         ConnectContext.get().getCurrentComputeResource());
                 execPlan.getFragments().get(0).setSink(dataSink);
+                configureSinkPipelineDop(execPlan, session, canUsePipeline, false);
             } else {
                 throw new SemanticException("Unsupported table type: " + targetTable.getClass().getName());
-            }
-            if (canUsePipeline) {
-                PlanFragment sinkFragment = execPlan.getFragments().get(0);
-                SessionVariable sv = session.getSessionVariable();
-                if (sv.getEnableAdaptiveSinkDop()) {
-                    long warehouseId = session.getCurrentComputeResource().getWarehouseId();
-                    sinkFragment.setPipelineDop(sv.getSinkDegreeOfParallelism(warehouseId));
-                } else {
-                    sinkFragment.setPipelineDop(sv.getParallelExecInstanceNum());
-                }
-                if (targetTable instanceof OlapTable) {
-                    sinkFragment.setHasOlapTableSink();
-                }
-                sinkFragment.setForceSetTableSinkDop();
-                sinkFragment.setForceAssignScanRangesPerDriverSeq();
-                sinkFragment.disableRuntimeAdaptiveDop();
-            } else {
-                execPlan.getFragments().get(0).setPipelineDop(1);
             }
             return execPlan;
         } finally {
@@ -202,15 +159,126 @@ public class UpdatePlanner {
         }
     }
 
+    private void setupOlapTableSink(ExecPlan execPlan, UpdateStmt updateStmt,
+                                     ConnectContext session, Table targetTable,
+                                     boolean canUsePipeline) {
+        DescriptorTable descriptorTable = execPlan.getDescTbl();
+        TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
+        long tableId = targetTable.getId();
+
+        List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
+        for (Column column : targetTable.getFullSchema()) {
+            if (updateStmt.usePartialUpdate() && !column.isGeneratedColumn() &&
+                    !updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {
+                continue;
+            }
+            SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
+            slotDescriptor.setIsMaterialized(true);
+            slotDescriptor.setType(column.getType());
+            slotDescriptor.setColumn(column);
+            slotDescriptor.setIsNullable(column.isAllowNull());
+            if (column.getType().isVarchar() &&
+                    IDictManager.getInstance().hasGlobalDict(tableId, column.getColumnId())) {
+                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getColumnId());
+                dict.ifPresent(
+                        columnDict -> globalDicts.add(new Pair<>(slotDescriptor.getId().asInt(), columnDict)));
+            }
+        }
+        olapTuple.computeMemLayout();
+
+        OlapTable olapTable = (OlapTable) targetTable;
+        List<Long> partitionIds = Lists.newArrayList();
+        for (Partition partition : olapTable.getPartitions()) {
+            partitionIds.add(partition.getId());
+        }
+        DataSink dataSink = new OlapTableSink(olapTable, olapTuple, partitionIds, olapTable.writeQuorum(),
+                olapTable.enableReplicatedStorage(), false,
+                olapTable.supportedAutomaticPartition(), session.getCurrentComputeResource());
+        if (updateStmt.usePartialUpdate()) {
+            ((OlapTableSink) dataSink).setPartialUpdateMode(TPartialUpdateMode.COLUMN_UPDATE_MODE);
+        }
+        if (session.getTxnId() != 0) {
+            ((OlapTableSink) dataSink).setIsMultiStatementsTxn(true);
+        }
+
+        execPlan.getFragments().get(0).setSink(dataSink);
+        execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);
+
+        // if sink is OlapTableSink Assigned to Be execute this sql [cn execute OlapTableSink will crash]
+        session.getSessionVariable().setPreferComputeNode(false);
+        session.getSessionVariable().setUseComputeNodes(0);
+        OlapTableSink olapTableSink = (OlapTableSink) dataSink;
+        TableRef tableRef = updateStmt.getTableRef();
+        TableName catalogDbTable = TableName.fromTableRef(tableRef);
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(session, catalogDbTable.getCatalog(),
+                catalogDbTable.getDb());
+        try {
+            olapTableSink.init(session.getExecutionId(), updateStmt.getTxnId(), db.getId(), session.getExecTimeout());
+            olapTableSink.complete();
+        } catch (StarRocksException e) {
+            throw new SemanticException(e.getMessage());
+        }
+
+        configureSinkPipelineDop(execPlan, session, canUsePipeline, true);
+    }
+
+    private void setupIcebergRowDeltaSink(ExecPlan execPlan, List<String> colNames,
+                                          IcebergTable icebergTable, ConnectContext session) {
+        DescriptorTable descriptorTable = execPlan.getDescTbl();
+        TupleDescriptor rowDeltaTuple = descriptorTable.createTupleDescriptor();
+
+        List<Expr> outputExprs = execPlan.getOutputExprs();
+        Preconditions.checkArgument(colNames.size() == outputExprs.size(),
+                "output column size mismatch");
+        for (int index = 0; index < colNames.size(); ++index) {
+            SlotDescriptor slot = descriptorTable.addSlotDescriptor(rowDeltaTuple);
+            slot.setIsMaterialized(true);
+            slot.setType(outputExprs.get(index).getType());
+            slot.setColumn(new Column(colNames.get(index), outputExprs.get(index).getType()));
+            slot.setIsNullable(outputExprs.get(index).isNullable());
+        }
+        rowDeltaTuple.computeMemLayout();
+
+        descriptorTable.addReferencedTable(icebergTable);
+        IcebergRowDeltaSink dataSink = new IcebergRowDeltaSink(
+                icebergTable, rowDeltaTuple, session.getSessionVariable());
+        dataSink.init();
+
+        IcebergMetadata.IcebergSinkExtra icebergSinkExtra = new IcebergMetadata.IcebergSinkExtra();
+        org.apache.iceberg.expressions.Expression filterExpr = IcebergPlannerUtils.buildIcebergFilterExpr(execPlan);
+        if (filterExpr != null) {
+            icebergSinkExtra.setConflictDetectionFilter(filterExpr);
+        }
+        dataSink.setSinkExtraInfo(icebergSinkExtra);
+
+        execPlan.getFragments().get(0).setSink(dataSink);
+    }
+
     /**
-     * Cast output columns type to target type.
-     * @param columnRefFactory :  column ref factory of update stmt.
-     * @param targetTable: target table of update stmt.
-     * @param colNames: column names of update stmt.
-     * @param outputColumns: output columns of update stmt.
-     * @param root: root logical plan of update stmt.
-     * @return: new root logical plan with cast operator.
+     * Configures pipeline DOP for OLAP table sink.
      */
+    private void configureSinkPipelineDop(ExecPlan execPlan, ConnectContext session,
+                                           boolean canUsePipeline, boolean isOlapSink) {
+        if (!canUsePipeline) {
+            execPlan.getFragments().get(0).setPipelineDop(1);
+            return;
+        }
+        PlanFragment sinkFragment = execPlan.getFragments().get(0);
+        SessionVariable sv = session.getSessionVariable();
+        if (sv.getEnableAdaptiveSinkDop()) {
+            long warehouseId = session.getCurrentComputeResource().getWarehouseId();
+            sinkFragment.setPipelineDop(sv.getSinkDegreeOfParallelism(warehouseId));
+        } else {
+            sinkFragment.setPipelineDop(sv.getParallelExecInstanceNum());
+        }
+        if (isOlapSink) {
+            sinkFragment.setHasOlapTableSink();
+        }
+        sinkFragment.setForceSetTableSinkDop();
+        sinkFragment.setForceAssignScanRangesPerDriverSeq();
+        sinkFragment.disableRuntimeAdaptiveDop();
+    }
+
     private static OptExprBuilder castOutputColumnsTypeToTargetColumns(ColumnRefFactory columnRefFactory,
                                                                        Table targetTable,
                                                                        List<String> colNames,
@@ -225,12 +293,10 @@ public class UpdatePlanner {
         for (int columnIdx = 0; columnIdx < outputColumns.size(); ++columnIdx) {
             ColumnRefOperator outputColumn = outputColumns.get(columnIdx);
             String colName = colNames.get(columnIdx);
-            // It's safe to use getColumn directly, because the column name's case-insensitive is the same with table's schema.
             Column column = targetTable.getColumn(colName);
             Preconditions.checkState(column != null, "Column %s not found in table %s", colName,
                     targetTable.getName());
             if (!column.getType().matchesType(outputColumn.getType())) {
-                // This should be always true but add a check here to avoid updating the wrong column type.
                 if (!TypeManager.canCastTo(outputColumn.getType(), column.getType())) {
                     throw new SemanticException(String.format("Output column type %s is not compatible table column type: %s",
                             outputColumn.getType(), column.getType()));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -207,14 +207,14 @@ public class UpdateAnalyzer {
         }
         ((SelectRelation) queryStatement.getQueryRelation()).setOutputExpr(castOutputExprs);
 
-        // Save the exact column names from the SELECT list aliases for the planner.
-        // Cannot rely on getColumnOutputNames() (scope expansion adds extras) or
-        // ColumnRefOperator.getName() (returns "expr" for SET expressions).
-        List<String> colNames = Lists.newArrayList();
-        for (int i = 0; i < selectList.getItems().size(); i++) {
-            colNames.add(selectList.getItems().get(i).getAlias());
-        }
-        updateStmt.setIcebergColumnOutputNames(colNames);
+        // Pin the SELECT list aliases as the relation's explicit column names so the
+        // planner reads them via the standard getColumnOutputNames() path. Without
+        // this, QueryRelation falls back to scope-derived names which include hidden
+        // metadata columns (_file, _pos) twice for Iceberg.
+        ((SelectRelation) queryStatement.getQueryRelation()).setColumnOutputNames(
+                selectList.getItems().stream()
+                        .map(SelectListItem::getAlias)
+                        .collect(Collectors.toList()));
 
         updateStmt.setTable(icebergTable);
         updateStmt.setQueryStatement(queryStatement);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -19,10 +19,12 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
+import com.starrocks.planner.IcebergRowDeltaSink;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SelectAnalyzer.RewriteAliasVisitor;
@@ -39,16 +41,19 @@ import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.expression.DefaultValueExpr;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.TypeManager;
+import com.starrocks.type.IntegerType;
 import com.starrocks.type.NullType;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
@@ -70,6 +75,151 @@ public class UpdateAnalyzer {
         properties.put(LoadStmt.TIMEOUT_PROPERTY, String.valueOf(session.getSessionVariable().getInsertTimeoutS()));
     }
 
+    /**
+     * Analyze Iceberg table update statement.
+     * For Iceberg update, we convert:
+     *   UPDATE table SET col1=expr1, col2=expr2 WHERE condition
+     * to:
+     *   INSERT INTO iceberg_row_delta_sink
+     *   SELECT _file, _pos, partition_col1, ..., new_col1, new_col2, ..., 2 AS op_code
+     *   FROM table WHERE condition
+     */
+    private static void analyzeIcebergTable(UpdateStmt updateStmt, IcebergTable icebergTable,
+                                            ConnectContext session) {
+        if (icebergTable.getFormatVersion() != 2) {
+            throw new SemanticException(
+                    "UPDATE is only supported for Iceberg V2 tables, but table format version is "
+                            + icebergTable.getFormatVersion());
+        }
+        if (updateStmt.getWherePredicate() == null) {
+            throw new SemanticException("Update must specify where clause to prevent full table update");
+        }
+        if (updateStmt.getCommonTableExpressions() != null) {
+            throw new SemanticException("Update for Iceberg table do not support `with` clause");
+        }
+        if (updateStmt.getFromRelations() != null) {
+            throw new SemanticException("Update for Iceberg table do not support `from` clause");
+        }
+
+        // Build assignment map
+        List<ColumnAssignment> assignmentList = updateStmt.getAssignments();
+        Map<String, ColumnAssignment> assignmentByColName = new HashMap<>();
+        for (ColumnAssignment col : assignmentList) {
+            assignmentByColName.put(col.getColumn().toLowerCase(), col);
+        }
+
+        // Reject partition column updates
+        List<Column> partitionColumns = icebergTable.getPartitionColumns().stream()
+                .filter(Objects::nonNull).toList();
+        for (Column partitionCol : partitionColumns) {
+            if (assignmentByColName.containsKey(partitionCol.getName().toLowerCase())) {
+                throw new SemanticException("Update for Iceberg table do not support updating partition column: "
+                        + partitionCol.getName());
+            }
+        }
+
+        // Validate assignment columns exist and are writable
+        TableName tableName = TableName.fromTableRef(updateStmt.getTableRef());
+        for (String colName : assignmentByColName.keySet()) {
+            Column col = icebergTable.getColumn(colName);
+            if (col == null) {
+                throw new SemanticException("table '%s' do not existing column '%s'", tableName.getTbl(), colName);
+            }
+            if (col.isHidden()) {
+                throw new SemanticException("Updating metadata column '%s' is not allowed", colName);
+            }
+        }
+
+        // Build SELECT list: _file, _pos, partition_cols, full schema (with SET exprs), op_code
+        SelectList selectList = new SelectList();
+
+        // Add _file column
+        SlotRef filePathColumn = new SlotRef(tableName, IcebergTable.FILE_PATH);
+        selectList.addItem(new SelectListItem(filePathColumn, IcebergTable.FILE_PATH));
+
+        // Add _pos column
+        SlotRef posColumn = new SlotRef(tableName, IcebergTable.ROW_POSITION);
+        selectList.addItem(new SelectListItem(posColumn, IcebergTable.ROW_POSITION));
+
+        // No separate partition prefix — partition columns are already part of the full
+        // table schema in the data section below. Adding them here would create duplicate
+        // SlotRefs that the optimizer merges, changing the column count and breaking
+        // the BE layout assumptions (data_column_start, op_code_index).
+        // Partition shuffle uses the partition columns from the data section.
+
+        // Add full target-table schema: for assigned columns use the SET expression,
+        // for unassigned columns use SlotRef to keep original value.
+        // Skip hidden metadata columns (_file, _pos) — they are already in the prefix
+        // and must not appear in the data section written to Parquet files.
+        List<Column> dataColumns = icebergTable.getBaseSchema().stream()
+                .filter(col -> !col.isHidden())
+                .toList();
+        for (Column col : dataColumns) {
+            ColumnAssignment assign = assignmentByColName.get(col.getName().toLowerCase());
+            if (assign != null) {
+                Expr assignExpr = assign.getExpr();
+                if (assignExpr instanceof DefaultValueExpr) {
+                    // Iceberg V2 does not support column default values
+                    // (initial-default / write-default are V3 features)
+                    throw new SemanticException("DEFAULT value is not supported for Iceberg V2 tables");
+                }
+                selectList.addItem(new SelectListItem(assignExpr, col.getName()));
+            } else {
+                selectList.addItem(new SelectListItem(new SlotRef(tableName, col.getName()), col.getName()));
+            }
+        }
+
+        // Add op_code = OP_UPDATE as the last column
+        try {
+            selectList.addItem(new SelectListItem(
+                    new IntLiteral(IcebergRowDeltaSink.OpCode.UPDATE.value(), IntegerType.TINYINT), "op_code"));
+        } catch (Exception e) {
+            throw new SemanticException("analyze update failed", e);
+        }
+
+        // Create table relation with WHERE predicate
+        TableRelation tableRelation = new TableRelation(tableName);
+        SelectRelation selectRelation = new SelectRelation(
+                selectList,
+                tableRelation,
+                updateStmt.getWherePredicate(),
+                null,
+                null
+        );
+
+        // Create query statement
+        QueryStatement queryStatement = new QueryStatement(selectRelation);
+        queryStatement.setIsExplain(updateStmt.isExplain(), updateStmt.getExplainLevel());
+
+        // Analyze the query statement
+        new QueryAnalyzer(session).analyze(queryStatement);
+
+        // Cast data columns to target schema types.
+        // Layout: [_file, _pos, data_cols..., op_code]
+        // Only data_cols need casting — _file/_pos are fixed types, op_code is a literal.
+        List<Expr> outputExprs = queryStatement.getQueryRelation().getOutputExpression();
+        int dataColumnStart = 2;
+        List<Expr> castOutputExprs = Lists.newArrayList(outputExprs);
+        for (int i = 0; i < dataColumns.size(); i++) {
+            int outputIdx = dataColumnStart + i;
+            castOutputExprs.set(outputIdx,
+                    TypeManager.addCastExpr(outputExprs.get(outputIdx), dataColumns.get(i).getType()));
+        }
+        ((SelectRelation) queryStatement.getQueryRelation()).setOutputExpr(castOutputExprs);
+
+        // Save the exact column names from the SELECT list aliases for the planner.
+        // Cannot rely on getColumnOutputNames() (scope expansion adds extras) or
+        // ColumnRefOperator.getName() (returns "expr" for SET expressions).
+        List<String> colNames = Lists.newArrayList();
+        for (int i = 0; i < selectList.getItems().size(); i++) {
+            colNames.add(selectList.getItems().get(i).getAlias());
+        }
+        updateStmt.setIcebergColumnOutputNames(colNames);
+
+        updateStmt.setTable(icebergTable);
+        updateStmt.setQueryStatement(queryStatement);
+    }
+
     public static void analyze(UpdateStmt updateStmt, ConnectContext session) {
         analyzeProperties(updateStmt, session);
 
@@ -87,6 +237,12 @@ public class UpdateAnalyzer {
             throw new SemanticException("The data of '%s' cannot be modified because '%s' is a materialized view,"
                     + "and the data of materialized view must be consistent with the base table.",
                     tableName.getTbl(), tableName.getTbl());
+        }
+
+        // Handle Iceberg table UPDATE separately (like DeleteAnalyzer does for DELETE)
+        if (table instanceof IcebergTable) {
+            analyzeIcebergTable(updateStmt, (IcebergTable) table, session);
+            return;
         }
 
         if (!table.supportsUpdate()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
@@ -36,20 +36,6 @@ public class UpdateStmt extends DmlStmt {
 
     private boolean usePartialUpdate;
 
-    // Column names for Iceberg RowDelta output tuple, set by UpdateAnalyzer.
-    // Needed because getColumnOutputNames() may not match the SELECT list
-    // (optimizer can expand it), and ColumnRefOperator.getName() returns
-    // "expr" for SET expressions instead of the target column name.
-    private List<String> icebergColumnOutputNames;
-
-    public void setIcebergColumnOutputNames(List<String> names) {
-        this.icebergColumnOutputNames = names;
-    }
-
-    public List<String> getIcebergColumnOutputNames() {
-        return icebergColumnOutputNames;
-    }
-
     public UpdateStmt(TableRef tableRef, List<ColumnAssignment> assignments, List<Relation> fromRelations,
                       Expr wherePredicate, List<CTERelation> commonTableExpressions) {
         this(tableRef, assignments, fromRelations, wherePredicate, commonTableExpressions, NodePosition.ZERO);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
@@ -36,6 +36,20 @@ public class UpdateStmt extends DmlStmt {
 
     private boolean usePartialUpdate;
 
+    // Column names for Iceberg RowDelta output tuple, set by UpdateAnalyzer.
+    // Needed because getColumnOutputNames() may not match the SELECT list
+    // (optimizer can expand it), and ColumnRefOperator.getName() returns
+    // "expr" for SET expressions instead of the target column name.
+    private List<String> icebergColumnOutputNames;
+
+    public void setIcebergColumnOutputNames(List<String> names) {
+        this.icebergColumnOutputNames = names;
+    }
+
+    public List<String> getIcebergColumnOutputNames() {
+        return icebergColumnOutputNames;
+    }
+
     public UpdateStmt(TableRef tableRef, List<ColumnAssignment> assignments, List<Relation> fromRelations,
                       Expr wherePredicate, List<CTERelation> commonTableExpressions) {
         this(tableRef, assignments, fromRelations, wherePredicate, commonTableExpressions, NodePosition.ZERO);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergUtilTest.java
@@ -19,6 +19,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.thrift.TExprMinMaxValue;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
@@ -255,6 +256,68 @@ public class IcebergUtilTest {
         } finally {
             ConnectContext.remove();
         }
+    }
+
+    private static org.apache.iceberg.Table tableWithProperty(String key, String value) {
+        org.apache.iceberg.Table table = org.mockito.Mockito.mock(org.apache.iceberg.Table.class);
+        Map<String, String> props = new HashMap<>();
+        if (key != null) {
+            props.put(key, value);
+        }
+        org.mockito.Mockito.when(table.properties()).thenReturn(props);
+        return table;
+    }
+
+    private static SessionVariable sessionWithTargetMaxFileSize(long value) {
+        // SessionVariable doesn't expose a setter for this field (it's bound via @VarAttr),
+        // so we mock just the one getter we care about.
+        SessionVariable sv = org.mockito.Mockito.mock(SessionVariable.class);
+        org.mockito.Mockito.when(sv.getConnectorSinkTargetMaxFileSize()).thenReturn(value);
+        return sv;
+    }
+
+    @Test
+    public void testResolveTargetMaxFileSizePrefersTableProperty() {
+        // Table property wins over session value.
+        org.apache.iceberg.Table table = tableWithProperty(
+                TableProperties.WRITE_TARGET_FILE_SIZE_BYTES, "262144000"); // 250 MiB
+        SessionVariable sv = sessionWithTargetMaxFileSize(123456L);
+        assertEquals(262144000L, IcebergUtil.resolveTargetMaxFileSize(table, sv));
+    }
+
+    @Test
+    public void testResolveTargetMaxFileSizeFallsBackToSession() {
+        // Table property absent → session value used.
+        org.apache.iceberg.Table table = tableWithProperty(null, null);
+        SessionVariable sv = sessionWithTargetMaxFileSize(999_999L);
+        assertEquals(999_999L, IcebergUtil.resolveTargetMaxFileSize(table, sv));
+    }
+
+    @Test
+    public void testResolveTargetMaxFileSizeDefaultsToHardcoded() {
+        // Neither property set nor session > 0 → IcebergUtil.DEFAULT_TARGET_FILE_SIZE_BYTES.
+        org.apache.iceberg.Table table = tableWithProperty(null, null);
+        SessionVariable sv = sessionWithTargetMaxFileSize(0L);
+        assertEquals(IcebergUtil.DEFAULT_TARGET_FILE_SIZE_BYTES,
+                IcebergUtil.resolveTargetMaxFileSize(table, sv));
+    }
+
+    @Test
+    public void testResolveTargetMaxFileSizeIgnoresUnparseableProperty() {
+        // Garbage property value → WARN logged, falls back through the chain.
+        org.apache.iceberg.Table table = tableWithProperty(
+                TableProperties.WRITE_TARGET_FILE_SIZE_BYTES, "not-a-number");
+        SessionVariable sv = sessionWithTargetMaxFileSize(555L);
+        assertEquals(555L, IcebergUtil.resolveTargetMaxFileSize(table, sv));
+    }
+
+    @Test
+    public void testResolveTargetMaxFileSizeIgnoresNonPositiveProperty() {
+        // Zero / negative are treated like unset.
+        org.apache.iceberg.Table table = tableWithProperty(
+                TableProperties.WRITE_TARGET_FILE_SIZE_BYTES, "0");
+        SessionVariable sv = sessionWithTargetMaxFileSize(777L);
+        assertEquals(777L, IcebergUtil.resolveTargetMaxFileSize(table, sv));
     }
 
     private FileScanTask createMockFileScanTask(FileFormat fileFormat) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -79,10 +79,12 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public static final String MOCKED_PARTITIONED_TRANSFORMS_DB_NAME = "partitioned_transforms_db";
 
     public static final String MOCKED_UNPARTITIONED_TABLE_NAME0 = "t0";
+    public static final String MOCKED_UNPARTITIONED_V2_TABLE_NAME = "t0_v2";
     public static final String MOCKED_UNPARTITIONED_VARIANT_TABLE_NAME = "variant_t0";
     public static final String MOCKED_UNPARTITIONED_TABLE_NUMERIC = "t_numeric";
     public static final String MOCKED_UNKNOWN_TYPE_TABLE_NAME = "t_unknown_types";
     public static final String MOCKED_PARTITIONED_TABLE_NAME1 = "t1";
+    public static final String MOCKED_PARTITIONED_V2_TABLE_NAME = "t1_v2";
     // date partition table
     public static final String MOCKED_PARTITIONED_TABLE_NAME2 = "t2";
 
@@ -108,6 +110,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public static final String MOCKED_PARTITIONED_EVOLUTION_DATE_MONTH_IDENTITY_TABLE_NAME = "t0_date_month_identity_evolution";
 
     private static final List<String> PARTITION_TABLE_NAMES = ImmutableList.of(MOCKED_PARTITIONED_TABLE_NAME1,
+            MOCKED_PARTITIONED_V2_TABLE_NAME,
             MOCKED_PARTITIONED_TABLE_NAME2,
             MOCKED_STRING_PARTITIONED_TABLE_NAME1,
             MOCKED_STRING_PARTITIONED_TABLE_NAME2,
@@ -178,6 +181,15 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                         required(4, "data", Types.StringType.get()),
                         required(5, "date", Types.StringType.get())),
                 3);
+        // V2 unpartitioned table for UPDATE tests (format version 2)
+        registerUnpartitionedTable(icebergTableInfoMap, MOCKED_UNPARTITIONED_V2_TABLE_NAME,
+                ImmutableList.of(new Column("id", IntegerType.INT, true),
+                        new Column("data", StringType.STRING, true),
+                        new Column("date", StringType.STRING, true)),
+                new Schema(required(3, "id", Types.IntegerType.get()),
+                        required(4, "data", Types.StringType.get()),
+                        required(5, "date", Types.StringType.get())),
+                2);
         registerUnpartitionedTable(icebergTableInfoMap, MOCKED_UNPARTITIONED_VARIANT_TABLE_NAME,
                 ImmutableList.of(new Column("id", IntegerType.INT, true),
                         new Column("v", VariantType.VARIANT, true)),
@@ -265,7 +277,8 @@ public class MockIcebergMetadata implements ConnectorMetadata {
             List<String> colNames = columns.stream().map(Column::getName).collect(Collectors.toList());
             columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
                     col -> ColumnStatistic.unknown()));
-            if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1)) {
+            if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1) ||
+                    tblName.equals(MOCKED_PARTITIONED_V2_TABLE_NAME)) {
                 icebergTableInfoMap.put(tblName, new IcebergTableInfo(icebergTable, PARTITION_NAMES_0,
                         100, columnStatisticMap));
             } else if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME2)) {
@@ -298,7 +311,8 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     }
 
     private static List<Column> getPartitionedTableSchema(String tblName) {
-        if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1)) {
+        if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1) ||
+                tblName.equals(MOCKED_PARTITIONED_V2_TABLE_NAME)) {
             return ImmutableList.of(new Column("id", IntegerType.INT, true),
                     new Column("data", StringType.STRING, true),
                     new Column("date", StringType.STRING, true));
@@ -319,7 +333,8 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     }
 
     private static Schema getIcebergPartitionSchema(String tblName) {
-        if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1)) {
+        if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1) ||
+                tblName.equals(MOCKED_PARTITIONED_V2_TABLE_NAME)) {
             return new Schema(required(3, "id", Types.IntegerType.get()),
                     required(4, "data", Types.StringType.get()),
                     required(5, "date", Types.StringType.get()));
@@ -355,6 +370,14 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                     new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_DB_NAME + "/"
                             + MOCKED_PARTITIONED_TABLE_NAME1), MOCKED_PARTITIONED_TABLE_NAME1,
                     schema, spec, 3);
+        } else if (tblName.equals(MOCKED_PARTITIONED_V2_TABLE_NAME)) {
+            // V2 partitioned table for UPDATE tests
+            PartitionSpec spec =
+                    PartitionSpec.builderFor(schema).identity("date").build();
+            return TestTables.create(
+                    new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_DB_NAME + "/"
+                            + MOCKED_PARTITIONED_V2_TABLE_NAME), MOCKED_PARTITIONED_V2_TABLE_NAME,
+                    schema, spec, 2);
         } else if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME2)) {
             PartitionSpec spec =
                     PartitionSpec.builderFor(schema).identity("date").build();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergDeleteSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergDeleteSinkTest.java
@@ -280,7 +280,7 @@ public class IcebergDeleteSinkTest {
 
             TDataSink tDataSink = sink.toThrift();
             TIcebergTableSink icebergSink = tDataSink.getIceberg_table_sink();
-            assertEquals(TCompressionType.ZSTD, icebergSink.getCompression_type());
+            assertEquals(TCompressionType.ZSTD, icebergSink.getDelete_compression_type());
         }
 
         // Test 2: Only write.parquet.compression is set (fallback)
@@ -300,7 +300,7 @@ public class IcebergDeleteSinkTest {
 
             TDataSink tDataSink = sink.toThrift();
             TIcebergTableSink icebergSink = tDataSink.getIceberg_table_sink();
-            assertEquals(TCompressionType.SNAPPY, icebergSink.getCompression_type());
+            assertEquals(TCompressionType.SNAPPY, icebergSink.getDelete_compression_type());
         }
 
         // Test 3: Both set, write.delete.parquet.compression has higher priority
@@ -322,7 +322,7 @@ public class IcebergDeleteSinkTest {
             TDataSink tDataSink = sink.toThrift();
             TIcebergTableSink icebergSink = tDataSink.getIceberg_table_sink();
             // Should use write.delete.parquet.compression (gzip), not write.parquet.compression (snappy)
-            assertEquals(TCompressionType.GZIP, icebergSink.getCompression_type());
+            assertEquals(TCompressionType.GZIP, icebergSink.getDelete_compression_type());
         }
 
         // Test 4: Neither set, use session variable default (uncompressed)
@@ -341,7 +341,7 @@ public class IcebergDeleteSinkTest {
 
             TDataSink tDataSink = sink.toThrift();
             TIcebergTableSink icebergSink = tDataSink.getIceberg_table_sink();
-            assertEquals(TCompressionType.NO_COMPRESSION, icebergSink.getCompression_type());
+            assertEquals(TCompressionType.NO_COMPRESSION, icebergSink.getDelete_compression_type());
         }
 
         // Test 5: Session variable with custom compression
@@ -363,7 +363,7 @@ public class IcebergDeleteSinkTest {
 
             TDataSink tDataSink = sink.toThrift();
             TIcebergTableSink icebergSink = tDataSink.getIceberg_table_sink();
-            assertEquals(TCompressionType.LZ4, icebergSink.getCompression_type());
+            assertEquals(TCompressionType.LZ4, icebergSink.getDelete_compression_type());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/UpdateAnalyzerIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/UpdateAnalyzerIcebergTest.java
@@ -232,7 +232,7 @@ public class UpdateAnalyzerIcebergTest {
         assertNotNull(updateStmt.getQueryStatement());
 
         // Verify column output names include all expected columns
-        List<String> colNames = updateStmt.getIcebergColumnOutputNames();
+        List<String> colNames = updateStmt.getQueryStatement().getQueryRelation().getColumnOutputNames();
         assertNotNull(colNames);
         // _file, _pos, id, data, date, op_code
         assertEquals(6, colNames.size());
@@ -252,7 +252,7 @@ public class UpdateAnalyzerIcebergTest {
 
         UpdateAnalyzer.analyze(updateStmt, connectContext);
 
-        List<String> colNames = updateStmt.getIcebergColumnOutputNames();
+        List<String> colNames = updateStmt.getQueryStatement().getQueryRelation().getColumnOutputNames();
         assertNotNull(colNames);
         // _file, _pos, id, data, date, op_code
         assertEquals(6, colNames.size());
@@ -295,7 +295,7 @@ public class UpdateAnalyzerIcebergTest {
         assertNotNull(updateStmt.getTable());
         assertTrue(updateStmt.getTable() instanceof IcebergTable);
         assertNotNull(updateStmt.getQueryStatement());
-        assertNotNull(updateStmt.getIcebergColumnOutputNames());
+        assertNotNull(updateStmt.getQueryStatement().getQueryRelation().getColumnOutputNames());
     }
 
     @Test
@@ -465,7 +465,7 @@ public class UpdateAnalyzerIcebergTest {
 
         UpdateAnalyzer.analyze(updateStmt, connectContext);
 
-        List<String> colNames = updateStmt.getIcebergColumnOutputNames();
+        List<String> colNames = updateStmt.getQueryStatement().getQueryRelation().getColumnOutputNames();
         assertNotNull(colNames);
         assertEquals(6, colNames.size());
         assertEquals(IcebergTable.FILE_PATH, colNames.get(0));
@@ -531,7 +531,7 @@ public class UpdateAnalyzerIcebergTest {
 
         UpdateAnalyzer.analyze(updateStmt, connectContext);
 
-        List<String> colNames = updateStmt.getIcebergColumnOutputNames();
+        List<String> colNames = updateStmt.getQueryStatement().getQueryRelation().getColumnOutputNames();
         SelectRelation selectRelation =
                 (SelectRelation) updateStmt.getQueryStatement().getQueryRelation();
         assertNotNull(colNames);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/UpdateAnalyzerIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/UpdateAnalyzerIcebergTest.java
@@ -1,0 +1,552 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.planner.IcebergRowDeltaSink;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectList;
+import com.starrocks.sql.ast.SelectListItem;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.UpdateStmt;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.List;
+
+import static com.starrocks.sql.plan.ConnectorPlanTestBase.newFolder;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UpdateAnalyzerIcebergTest {
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @TempDir
+    public static File temp;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        ConnectorPlanTestBase.mockAllCatalogs(connectContext, newFolder(temp, "junit").toURI().toString());
+    }
+
+    @Test
+    public void testIcebergUpdateBasic() {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        assertDoesNotThrow(() -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+
+        assertNotNull(updateStmt.getTable());
+        assertTrue(updateStmt.getTable() instanceof IcebergTable);
+        assertNotNull(updateStmt.getQueryStatement());
+    }
+
+    @Test
+    public void testIcebergUpdateWithoutWhereClause() {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new'";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+        assertTrue(exception.getMessage().contains("where clause"));
+    }
+
+    @Test
+    public void testIcebergUpdatePartitionColumn() {
+        String sql = "UPDATE iceberg0.partitioned_db.t1_v2 SET date = '2024-01-01' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+        assertTrue(exception.getMessage().contains("partition column"));
+    }
+
+    @Test
+    public void testIcebergUpdateNonExistentColumn() {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET nonexistent = 'val' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+        assertTrue(exception.getMessage().contains("do not existing column"));
+    }
+
+    @Test
+    public void testIcebergUpdateConvertsToSelectWithFileAndPos() {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        QueryStatement queryStmt = updateStmt.getQueryStatement();
+        assertNotNull(queryStmt);
+
+        QueryRelation queryRelation = queryStmt.getQueryRelation();
+        assertInstanceOf(SelectRelation.class, queryRelation);
+
+        SelectRelation selectRelation = (SelectRelation) queryRelation;
+        assertNotNull(selectRelation.getSelectList());
+
+        // Check that select list contains _file and _pos columns
+        boolean hasFileColumn = false;
+        boolean hasPosColumn = false;
+
+        for (int i = 0; i < selectRelation.getSelectList().getItems().size(); i++) {
+            String alias = selectRelation.getSelectList().getItems().get(i).getAlias();
+            if (IcebergTable.FILE_PATH.equals(alias)) {
+                hasFileColumn = true;
+            }
+            if (IcebergTable.ROW_POSITION.equals(alias)) {
+                hasPosColumn = true;
+            }
+        }
+
+        assertTrue(hasFileColumn, "Select list should contain _file column");
+        assertTrue(hasPosColumn, "Select list should contain _pos column");
+    }
+
+    @Test
+    public void testIcebergUpdateConvertsToSelectWithOpCode() {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        QueryStatement queryStmt = updateStmt.getQueryStatement();
+        assertNotNull(queryStmt);
+
+        QueryRelation queryRelation = queryStmt.getQueryRelation();
+        assertInstanceOf(SelectRelation.class, queryRelation);
+
+        SelectRelation selectRelation = (SelectRelation) queryRelation;
+        assertNotNull(selectRelation.getSelectList());
+
+        // Check that select list contains _file, _pos, and op_code columns
+        boolean hasFileColumn = false;
+        boolean hasPosColumn = false;
+        boolean hasOpCode = false;
+
+        for (int i = 0; i < selectRelation.getSelectList().getItems().size(); i++) {
+            String alias = selectRelation.getSelectList().getItems().get(i).getAlias();
+            if (IcebergTable.FILE_PATH.equals(alias)) {
+                hasFileColumn = true;
+            }
+            if (IcebergTable.ROW_POSITION.equals(alias)) {
+                hasPosColumn = true;
+            }
+            if ("op_code".equals(alias)) {
+                hasOpCode = true;
+            }
+        }
+
+        assertTrue(hasFileColumn, "Select list should contain _file column");
+        assertTrue(hasPosColumn, "Select list should contain _pos column");
+        assertTrue(hasOpCode, "Select list should contain op_code column");
+    }
+
+    @Test
+    public void testIcebergUpdateWithCTEClause() {
+        String sql = "WITH cte AS (SELECT id FROM iceberg0.unpartitioned_db.t0_v2) " +
+                "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id IN (SELECT id FROM cte)";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+        assertTrue(exception.getMessage().contains("with"));
+    }
+
+    @Test
+    public void testIcebergUpdateNonV2TableError() {
+        // t0 is format version 3, should be rejected
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+        assertTrue(exception.getMessage().contains("V2 tables"));
+    }
+
+    @Test
+    public void testIcebergUpdateWithFromClause() {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' " +
+                "FROM iceberg0.unpartitioned_db.t0 WHERE iceberg0.unpartitioned_db.t0_v2.id = iceberg0.unpartitioned_db.t0.id";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+        assertTrue(exception.getMessage().contains("from"));
+    }
+
+    @Test
+    public void testIcebergUpdateMultipleColumns() {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new', date = '2024-01-01' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        assertDoesNotThrow(() -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+
+        assertNotNull(updateStmt.getTable());
+        assertTrue(updateStmt.getTable() instanceof IcebergTable);
+        assertNotNull(updateStmt.getQueryStatement());
+
+        // Verify column output names include all expected columns
+        List<String> colNames = updateStmt.getIcebergColumnOutputNames();
+        assertNotNull(colNames);
+        // _file, _pos, id, data, date, op_code
+        assertEquals(6, colNames.size());
+        assertEquals(IcebergTable.FILE_PATH, colNames.get(0));
+        assertEquals(IcebergTable.ROW_POSITION, colNames.get(1));
+        assertEquals("id", colNames.get(2));
+        assertEquals("data", colNames.get(3));
+        assertEquals("date", colNames.get(4));
+        assertEquals("op_code", colNames.get(5));
+    }
+
+    @Test
+    public void testIcebergUpdateColumnOutputNames() {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        List<String> colNames = updateStmt.getIcebergColumnOutputNames();
+        assertNotNull(colNames);
+        // _file, _pos, id, data, date, op_code
+        assertEquals(6, colNames.size());
+        assertEquals(IcebergTable.FILE_PATH, colNames.get(0));
+        assertEquals(IcebergTable.ROW_POSITION, colNames.get(1));
+        assertEquals("op_code", colNames.get(colNames.size() - 1));
+    }
+
+    @Test
+    public void testIcebergUpdateSelectListStructure() {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        QueryStatement queryStmt = updateStmt.getQueryStatement();
+        SelectRelation selectRelation = (SelectRelation) queryStmt.getQueryRelation();
+        SelectList selectList = selectRelation.getSelectList();
+        List<SelectListItem> items = selectList.getItems();
+
+        // Expected: _file, _pos, id, data, date, op_code = 6 items
+        assertEquals(6, items.size());
+
+        // Verify output expressions are present and cast correctly
+        List<Expr> outputExprs = selectRelation.getOutputExpression();
+        assertNotNull(outputExprs);
+        assertEquals(6, outputExprs.size());
+    }
+
+    @Test
+    public void testIcebergUpdatePartitionedTableHappyPath() {
+        // t1_v2 is a partitioned V2 table with partition column 'date'
+        String sql = "UPDATE iceberg0.partitioned_db.t1_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        assertDoesNotThrow(() -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+
+        assertNotNull(updateStmt.getTable());
+        assertTrue(updateStmt.getTable() instanceof IcebergTable);
+        assertNotNull(updateStmt.getQueryStatement());
+        assertNotNull(updateStmt.getIcebergColumnOutputNames());
+    }
+
+    @Test
+    public void testIcebergUpdateQueryStatementIsExplainFalse() {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        QueryStatement queryStmt = updateStmt.getQueryStatement();
+        assertNotNull(queryStmt);
+        // Non-EXPLAIN update should not be marked as explain
+        assertTrue(!queryStmt.isExplain());
+    }
+
+    @Test
+    public void testIcebergUpdateDataColumnCasting() {
+        // Use multiple columns to exercise the cast loop
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new', date = '2024-06-01' WHERE id > 0";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        QueryStatement queryStmt = updateStmt.getQueryStatement();
+        SelectRelation selectRelation = (SelectRelation) queryStmt.getQueryRelation();
+
+        // Verify output expressions have been set (cast step completed)
+        List<Expr> outputExprs = selectRelation.getOutputExpression();
+        assertNotNull(outputExprs);
+        // All 6 columns should have output expressions
+        assertEquals(6, outputExprs.size());
+        // None should be null
+        for (Expr expr : outputExprs) {
+            assertNotNull(expr);
+        }
+    }
+
+    @Test
+    public void testIcebergUpdateHiddenMetadataColumnRejected() {
+        // Updating the hidden `_file` metadata column must be rejected.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET `" + IcebergTable.FILE_PATH
+                + "` = 'x' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+        assertTrue(exception.getMessage().contains("metadata column"),
+                "Expected 'metadata column' error, got: " + exception.getMessage());
+    }
+
+    @Test
+    public void testIcebergUpdateHiddenRowPositionRejected() {
+        // Updating the hidden `_pos` metadata column must be rejected.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET `" + IcebergTable.ROW_POSITION
+                + "` = 0 WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+        assertTrue(exception.getMessage().contains("metadata column"),
+                "Expected 'metadata column' error, got: " + exception.getMessage());
+    }
+
+    @Test
+    public void testIcebergUpdateDefaultValueRejected() {
+        // Iceberg V2 does not support column default values; SET col = DEFAULT must be rejected.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = DEFAULT WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+        assertTrue(exception.getMessage().contains("DEFAULT"),
+                "Expected 'DEFAULT' error, got: " + exception.getMessage());
+    }
+
+    @Test
+    public void testIcebergUpdateWithExpressionAssignment() {
+        // SET using an expression (not a constant) exercises the assignExpr path
+        // in the analyzer and the per-column cast loop on a non-literal source.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = concat(data, '_v2') WHERE id > 0";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        assertDoesNotThrow(() -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+
+        assertNotNull(updateStmt.getQueryStatement());
+        SelectRelation selectRelation =
+                (SelectRelation) updateStmt.getQueryStatement().getQueryRelation();
+        // Expect _file, _pos, id, data, date, op_code
+        assertEquals(6, selectRelation.getSelectList().getItems().size());
+        assertEquals(6, selectRelation.getOutputExpression().size());
+    }
+
+    @Test
+    public void testIcebergUpdateWithNullAssignment() {
+        // SET col = NULL is a valid assignment; analyzer must cast the null literal
+        // to the target column type and produce 6 output exprs.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = NULL WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        assertDoesNotThrow(() -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+
+        SelectRelation selectRelation =
+                (SelectRelation) updateStmt.getQueryStatement().getQueryRelation();
+        assertEquals(6, selectRelation.getOutputExpression().size());
+    }
+
+    @Test
+    public void testIcebergUpdateLastItemIsOpCodeLiteral() {
+        // The last SELECT item must be an IntLiteral tagged with the UPDATE op code
+        // (exercises the op_code literal creation in analyzeIcebergTable).
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        SelectRelation selectRelation =
+                (SelectRelation) updateStmt.getQueryStatement().getQueryRelation();
+        SelectList selectList = selectRelation.getSelectList();
+        SelectListItem last = selectList.getItems().get(selectList.getItems().size() - 1);
+        assertEquals("op_code", last.getAlias());
+        assertInstanceOf(IntLiteral.class, last.getExpr());
+        assertEquals(IcebergRowDeltaSink.OpCode.UPDATE.value(),
+                ((IntLiteral) last.getExpr()).getValue());
+    }
+
+    @Test
+    public void testIcebergUpdateTableAndQueryStatementSet() {
+        // analyzeIcebergTable must populate both setTable and setQueryStatement.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        assertNotNull(updateStmt.getTable());
+        assertInstanceOf(IcebergTable.class, updateStmt.getTable());
+        assertNotNull(updateStmt.getQueryStatement());
+        assertFalse(updateStmt.getQueryStatement().isExplain());
+    }
+
+    @Test
+    public void testIcebergUpdateColumnNameIsCaseInsensitive() {
+        // Assignment column lookup uses lowercase comparison; uppercase SET identifier
+        // must resolve against the (lowercase) schema column.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET DATA = 'x' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        assertDoesNotThrow(() -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+    }
+
+    @Test
+    public void testIcebergUpdatePartitionedTableColumnOutputNames() {
+        // For a partitioned V2 table, the column output list must still follow the
+        // same contract: [_file, _pos, id, data, date, op_code].
+        String sql = "UPDATE iceberg0.partitioned_db.t1_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        List<String> colNames = updateStmt.getIcebergColumnOutputNames();
+        assertNotNull(colNames);
+        assertEquals(6, colNames.size());
+        assertEquals(IcebergTable.FILE_PATH, colNames.get(0));
+        assertEquals(IcebergTable.ROW_POSITION, colNames.get(1));
+        assertEquals("op_code", colNames.get(colNames.size() - 1));
+    }
+
+    @Test
+    public void testIcebergUpdatePartitionedRejectsUppercasePartitionColumn() {
+        // Partition column check compares by lowercase name; upper-case assignment
+        // targeting `DATE` must still be rejected on partitioned table t1_v2.
+        String sql = "UPDATE iceberg0.partitioned_db.t1_v2 SET DATE = '2024-01-01' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+        assertTrue(exception.getMessage().contains("partition column"));
+    }
+
+    @Test
+    public void testIcebergUpdatePropertiesPopulated() {
+        // analyzeProperties runs before Iceberg branch and must populate the
+        // update properties with session-driven defaults.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        assertNotNull(updateStmt.getProperties());
+        assertTrue(updateStmt.getProperties().containsKey("max_filter_ratio"));
+        assertTrue(updateStmt.getProperties().containsKey("strict_mode"));
+        assertTrue(updateStmt.getProperties().containsKey("timeout"));
+    }
+
+    @Test
+    public void testIcebergUpdateDataColumnStartLayout() {
+        // The analyzer casts columns starting at index 2. Verify that the first
+        // two output exprs (for _file, _pos) are not the casted data exprs.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        SelectRelation selectRelation =
+                (SelectRelation) updateStmt.getQueryStatement().getQueryRelation();
+        List<Expr> outputExprs = selectRelation.getOutputExpression();
+        // _file + _pos + 3 data cols + op_code = 6
+        assertEquals(6, outputExprs.size());
+        // Last expression is the op_code literal
+        assertInstanceOf(IntLiteral.class, outputExprs.get(outputExprs.size() - 1));
+    }
+
+    @Test
+    public void testIcebergUpdateOutputExprsCountMatchesColNames() {
+        // The saved column output names and the SelectRelation output exprs
+        // must line up 1:1 (the planner relies on this invariant).
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        UpdateAnalyzer.analyze(updateStmt, connectContext);
+
+        List<String> colNames = updateStmt.getIcebergColumnOutputNames();
+        SelectRelation selectRelation =
+                (SelectRelation) updateStmt.getQueryStatement().getQueryRelation();
+        assertNotNull(colNames);
+        assertEquals(colNames.size(), selectRelation.getOutputExpression().size());
+    }
+
+    @Test
+    public void testIcebergUpdateNonExistentTable() {
+        // Table lookup happens at the top of analyze(); a non-existent table
+        // must raise a SemanticException (not an NPE) before the Iceberg branch.
+        String sql = "UPDATE iceberg0.unpartitioned_db.not_a_real_table SET data = 'x' WHERE id = 1";
+        UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        assertThrows(Exception.class,
+                () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -14,23 +14,55 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergMetadata;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
+import com.starrocks.planner.DescriptorTable;
+import com.starrocks.planner.IcebergRowDeltaSink;
+import com.starrocks.planner.IcebergScanNode;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.PlanNode;
+import com.starrocks.planner.ProjectNode;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.IcebergPlannerUtils;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
+import com.starrocks.thrift.TDataSink;
+import com.starrocks.thrift.TDataSinkType;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TIcebergTableSink;
+import com.starrocks.thrift.TIcebergWriteMode;
+import com.starrocks.thrift.TPartitionType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class UpdatePlanTest extends PlanTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
+        ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
     }
 
     @Test
@@ -62,6 +94,86 @@ public class UpdatePlanTest extends PlanTestBase {
         connectContext.getSessionVariable().setPartialUpdateMode(oldVal);
     }
 
+    @Test
+    public void testIcebergUpdateExplainContainsRowDeltaSink() throws Exception {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        String explainString = getIcebergUpdateExecPlanString(sql);
+        assertTrue(explainString.contains("ICEBERG ROW DELTA SINK"),
+                "Explain plan should contain ICEBERG ROW DELTA SINK");
+    }
+
+    @Test
+    public void testIcebergUpdateExplainContainsIcebergScan() throws Exception {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        String explainString = getIcebergUpdateExecPlanString(sql);
+        assertTrue(explainString.contains("IcebergScanNode"),
+                "Explain plan should contain IcebergScanNode");
+    }
+
+    @Test
+    public void testPartitionedIcebergUpdateHasHashShuffle() throws Exception {
+        String sql = "UPDATE iceberg0.partitioned_db.t1_v2 SET data = 'new' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+
+        assertNotNull(execPlan);
+        assertNotNull(execPlan.getFragments());
+        assertSame(TPartitionType.HASH_PARTITIONED,
+                execPlan.getFragments().get(1).getOutputPartition().getType());
+    }
+
+    @Test
+    public void testUnpartitionedIcebergUpdateHasRowDeltaSink() throws Exception {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
+        assertTrue(explainString.contains("ROW DELTA"),
+                "Explain plan should contain ROW DELTA");
+    }
+
+    @Test
+    public void testIcebergUpdateScanNodeUsedForDelete() throws Exception {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        assertNotNull(execPlan);
+
+        List<PlanFragment> fragments = execPlan.getFragments();
+        boolean hasDeleteScanNode = false;
+        for (PlanFragment fragment : fragments) {
+            PlanNode root = fragment.getPlanRoot();
+            if (root instanceof IcebergScanNode) {
+                IcebergScanNode icebergScanNode = (IcebergScanNode) root;
+                if (icebergScanNode.isUsedForDelete()) {
+                    hasDeleteScanNode = true;
+                    break;
+                }
+            } else if (root instanceof ProjectNode) {
+                PlanNode child = root.getChild(0);
+                if (child instanceof IcebergScanNode) {
+                    IcebergScanNode icebergScanNode = (IcebergScanNode) child;
+                    if (icebergScanNode.isUsedForDelete()) {
+                        hasDeleteScanNode = true;
+                        break;
+                    }
+                }
+            }
+        }
+        assertTrue(hasDeleteScanNode,
+                "UPDATE plan should have IcebergScanNode with usedForDelete=true");
+    }
+
+    @Test
+    public void testIcebergUpdateExplain() throws Exception {
+        String explainStmt = "explain UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        connectContext.getState().reset();
+        List<StatementBase> statements =
+                com.starrocks.sql.parser.SqlParser.parse(explainStmt, connectContext.getSessionVariable().getSqlMode());
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statements.get(0));
+        stmtExecutor.execute();
+        Assertions.assertEquals(QueryState.MysqlStateType.EOF, connectContext.getState().getStateType());
+    }
+
     private void testExplain(String explainStmt) throws Exception {
         connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
@@ -85,5 +197,406 @@ public class UpdatePlanTest extends PlanTestBase {
 
         String ret = execPlan.getExplainString(TExplainLevel.NORMAL);
         return ret;
+    }
+
+    private static ExecPlan getIcebergUpdateExecPlan(String originStmt) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
+        StatementBase statementBase =
+                com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode())
+                        .get(0);
+        connectContext.getDumpInfo().setOriginStmt(originStmt);
+        return StatementPlanner.plan(statementBase, connectContext);
+    }
+
+    private static String getIcebergUpdateExecPlanString(String originStmt) throws Exception {
+        ExecPlan execPlan = getIcebergUpdateExecPlan(originStmt);
+        return execPlan.getExplainString(TExplainLevel.NORMAL);
+    }
+
+    @Test
+    public void testIcebergUpdateMultipleColumns() throws Exception {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new', date = '2024-06-01' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        assertNotNull(execPlan);
+        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
+        assertTrue(explainString.contains("ICEBERG ROW DELTA SINK"),
+                "Multi-column update should produce ICEBERG ROW DELTA SINK");
+    }
+
+    @Test
+    public void testIcebergUpdatePartitionedTablePlan() throws Exception {
+        String sql = "UPDATE iceberg0.partitioned_db.t1_v2 SET data = 'new' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        assertNotNull(execPlan);
+        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
+        assertTrue(explainString.contains("ICEBERG ROW DELTA SINK"),
+                "Partitioned update should produce ICEBERG ROW DELTA SINK");
+    }
+
+    @Test
+    public void testIcebergUpdateVerboseExplain() throws Exception {
+        String explainStmt = "explain verbose UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        connectContext.getState().reset();
+        List<StatementBase> statements =
+                com.starrocks.sql.parser.SqlParser.parse(explainStmt, connectContext.getSessionVariable().getSqlMode());
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statements.get(0));
+        stmtExecutor.execute();
+        Assertions.assertEquals(QueryState.MysqlStateType.EOF, connectContext.getState().getStateType());
+    }
+
+    @Test
+    public void testIcebergUpdateCostsExplain() throws Exception {
+        String explainStmt = "explain costs UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        connectContext.getState().reset();
+        List<StatementBase> statements =
+                com.starrocks.sql.parser.SqlParser.parse(explainStmt, connectContext.getSessionVariable().getSqlMode());
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statements.get(0));
+        stmtExecutor.execute();
+        Assertions.assertEquals(QueryState.MysqlStateType.EOF, connectContext.getState().getStateType());
+    }
+
+    @Test
+    public void testIcebergUpdateFragmentSinkType() throws Exception {
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        assertNotNull(execPlan);
+        PlanFragment sinkFragment = execPlan.getFragments().get(0);
+        assertNotNull(sinkFragment.getSink());
+        assertTrue(sinkFragment.getSink() instanceof com.starrocks.planner.IcebergRowDeltaSink,
+                "Sink should be IcebergRowDeltaSink");
+    }
+
+    @Test
+    public void testIcebergUpdatePartitionedMultiColumnPlan() throws Exception {
+        // Partitioned table + multi-column SET exercises the partition-shuffle property,
+        // multi-expr cast path, and the shared RowDelta sink construction together.
+        String sql = "UPDATE iceberg0.partitioned_db.t1_v2 SET data = 'new' WHERE id < 10";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        assertNotNull(execPlan);
+
+        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
+        assertTrue(explainString.contains("ICEBERG ROW DELTA SINK"));
+        assertTrue(explainString.contains("IcebergScanNode"));
+
+        PlanFragment sinkFragment = execPlan.getFragments().get(0);
+        assertTrue(sinkFragment.getSink() instanceof com.starrocks.planner.IcebergRowDeltaSink);
+    }
+
+    @Test
+    public void testIcebergUpdateSessionVariableRestoredAfterPlan() throws Exception {
+        // UpdatePlanner flips enable_local_shuffle_agg off while planning, then
+        // restores it in the finally block. Confirm we return to the caller's value.
+        boolean prev = connectContext.getSessionVariable().isEnableLocalShuffleAgg();
+        try {
+            connectContext.getSessionVariable().setEnableLocalShuffleAgg(true);
+            String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
+            ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+            assertNotNull(execPlan);
+            Assertions.assertTrue(connectContext.getSessionVariable().isEnableLocalShuffleAgg(),
+                    "enable_local_shuffle_agg should be restored to true");
+        } finally {
+            connectContext.getSessionVariable().setEnableLocalShuffleAgg(prev);
+        }
+    }
+
+    @Test
+    public void testIcebergUpdateSinkFragmentHasIcebergTableSink() throws Exception {
+        // The sink fragment should be flagged as having an Iceberg table sink
+        // so pipeline scheduling picks the right execution strategy.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        assertNotNull(execPlan);
+        PlanFragment sinkFragment = execPlan.getFragments().get(0);
+        assertTrue(sinkFragment.hasIcebergTableSink(),
+                "Sink fragment should be marked with hasIcebergTableSink");
+    }
+
+    @Test
+    public void testIcebergUpdateWithComplexPredicate() throws Exception {
+        // Non-trivial WHERE (AND + comparison) exercises conflict-detection filter
+        // synthesis inside setupIcebergRowDeltaSink.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id > 5 AND id < 100";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        assertNotNull(execPlan);
+        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
+        assertTrue(explainString.contains("ICEBERG ROW DELTA SINK"));
+    }
+
+    @Test
+    public void testIcebergUpdatePipelineDopIsSet() throws Exception {
+        // The Iceberg sink pipeline configurer must set a concrete pipeline DOP
+        // on the sink fragment (>= 1) regardless of adaptive sink DOP setting.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        PlanFragment sinkFragment = execPlan.getFragments().get(0);
+        Assertions.assertTrue(sinkFragment.getPipelineDop() >= 1,
+                "Sink fragment pipeline DOP must be >= 1");
+    }
+
+    @Test
+    public void testIcebergUpdateOutputExprsMatchSchema() throws Exception {
+        // The sink tuple slots are built from execPlan.getOutputExprs() — verify
+        // the planner produces the expected 6 output exprs for a V2 unpartitioned
+        // update: [_file, _pos, id, data, date, op_code].
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        assertNotNull(execPlan.getOutputExprs());
+        Assertions.assertEquals(6, execPlan.getOutputExprs().size());
+    }
+
+    @Test
+    public void testIcebergRowDeltaSinkToThriftRoundtrip() throws Exception {
+        // Drive toThrift() and assert the produced TDataSink encodes the row-delta
+        // contract: type, write_mode, tuple_id, target table id, and a non-null
+        // cloud configuration block. toThrift() is protected on DataSink, so we
+        // reach it via reflection rather than widening access for testing.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        IcebergRowDeltaSink sink = (IcebergRowDeltaSink) execPlan.getFragments().get(0).getSink();
+        java.lang.reflect.Method toThrift = IcebergRowDeltaSink.class.getDeclaredMethod("toThrift");
+        toThrift.setAccessible(true);
+        TDataSink tDataSink = (TDataSink) toThrift.invoke(sink);
+        assertNotNull(tDataSink);
+        assertSame(TDataSinkType.ICEBERG_ROW_DELTA_SINK, tDataSink.getType());
+        TIcebergTableSink tIcebergTableSink = tDataSink.getIceberg_table_sink();
+        assertNotNull(tIcebergTableSink);
+        assertSame(TIcebergWriteMode.ROW_DELTA, tIcebergTableSink.getWrite_mode());
+        assertFalse(tIcebergTableSink.is_static_partition_sink);
+        assertNotNull(tIcebergTableSink.getCloud_configuration());
+        assertTrue(tIcebergTableSink.getTarget_max_file_size() > 0);
+        // Tuple id from sink must match what the planner attached to the fragment.
+        assertTrue(sink.getExplainString("", TExplainLevel.NORMAL).contains("TUPLE ID:"));
+    }
+
+    @Test
+    public void testIcebergRowDeltaSinkAccessors() throws Exception {
+        // Cover the small accessor surface that downstream code relies on.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        IcebergRowDeltaSink sink = (IcebergRowDeltaSink) execPlan.getFragments().get(0).getSink();
+        // No exchange node id for a sink-only fragment, no output partition.
+        assertNull(sink.getExchNodeId());
+        assertNull(sink.getOutputPartition());
+        // Row-delta sinks must allow runtime adaptive DOP.
+        assertTrue(sink.canUseRuntimeAdaptiveDop());
+        // Sink extra info is populated by setupIcebergRowDeltaSink (filter expr).
+        IcebergMetadata.IcebergSinkExtra extra = sink.getSinkExtraInfo();
+        assertNotNull(extra);
+        // t0_v2 is unpartitioned.
+        assertTrue(sink.isUnpartitionedTable());
+    }
+
+    @Test
+    public void testIcebergRowDeltaSinkPartitionedFlag() throws Exception {
+        // Partitioned table must report isUnpartitionedTable() == false.
+        String sql = "UPDATE iceberg0.partitioned_db.t1_v2 SET data = 'x' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        IcebergRowDeltaSink sink = (IcebergRowDeltaSink) execPlan.getFragments().get(0).getSink();
+        assertFalse(sink.isUnpartitionedTable());
+    }
+
+    private static IcebergTable lookupV2IcebergTable() {
+        return (IcebergTable) GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "unpartitioned_db", "t0_v2");
+    }
+
+    /**
+     * Build a TupleDescriptor whose slots match the given (name, type) pairs. A null
+     * column name means "skip setColumn so the slot has a null column"; this is used
+     * to exercise the slot-with-null-column path inside validateTuple.
+     */
+    private static TupleDescriptor buildTupleDescriptor(String[] names, com.starrocks.type.Type[] types) {
+        DescriptorTable descTbl = new DescriptorTable();
+        TupleDescriptor tuple = descTbl.createTupleDescriptor();
+        for (int i = 0; i < names.length; i++) {
+            SlotDescriptor slot = descTbl.addSlotDescriptor(tuple);
+            slot.setIsMaterialized(true);
+            slot.setIsNullable(true);
+            slot.setType(types[i]);
+            if (names[i] != null) {
+                slot.setColumn(new Column(names[i], types[i]));
+            }
+        }
+        tuple.computeMemLayout();
+        return tuple;
+    }
+
+    @Test
+    public void testIcebergRowDeltaSinkValidateMissingFilePath() {
+        // No _file column → validateTuple must reject with "requires _file and _pos".
+        ScalarType varchar = TypeFactory.createVarcharType(1024);
+        TupleDescriptor tuple = buildTupleDescriptor(
+                new String[] {IcebergTable.ROW_POSITION, "data"},
+                new com.starrocks.type.Type[] {IntegerType.BIGINT, varchar});
+        IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable());
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class, sink::init);
+        assertTrue(ex.getMessage().contains("requires _file and _pos"));
+    }
+
+    @Test
+    public void testIcebergRowDeltaSinkValidateMissingPos() {
+        // No _pos column → same rejection.
+        ScalarType varchar = TypeFactory.createVarcharType(1024);
+        TupleDescriptor tuple = buildTupleDescriptor(
+                new String[] {IcebergTable.FILE_PATH, "data"},
+                new com.starrocks.type.Type[] {varchar, varchar});
+        IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable());
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class, sink::init);
+        assertTrue(ex.getMessage().contains("requires _file and _pos"));
+    }
+
+    @Test
+    public void testIcebergRowDeltaSinkValidateFilePathWrongType() {
+        // _file is required to be VARCHAR; passing INT must be rejected explicitly.
+        TupleDescriptor tuple = buildTupleDescriptor(
+                new String[] {IcebergTable.FILE_PATH, IcebergTable.ROW_POSITION},
+                new com.starrocks.type.Type[] {IntegerType.INT, IntegerType.BIGINT});
+        IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable());
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class, sink::init);
+        assertTrue(ex.getMessage().contains("_file column must be type of VARCHAR"));
+    }
+
+    @Test
+    public void testIcebergRowDeltaSinkValidatePosWrongType() {
+        // _pos is required to be BIGINT; passing INT must be rejected explicitly.
+        ScalarType varchar = TypeFactory.createVarcharType(1024);
+        TupleDescriptor tuple = buildTupleDescriptor(
+                new String[] {IcebergTable.FILE_PATH, IcebergTable.ROW_POSITION},
+                new com.starrocks.type.Type[] {varchar, IntegerType.INT});
+        IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable());
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class, sink::init);
+        assertTrue(ex.getMessage().contains("_pos column must be type of BIGINT"));
+    }
+
+    @Test
+    public void testIcebergPlannerUtilsConstructor() {
+        // Trivial coverage for the implicit default constructor — the class is a
+        // bag of static helpers but JaCoCo still tracks the synthesized <init>.
+        assertNotNull(new IcebergPlannerUtils());
+    }
+
+    @Test
+    public void testIcebergPlannerUtilsCreateShufflePropertyMissingPartitionCol() {
+        // Partitioned table whose partition column is absent from outputColumns:
+        // partitionColumnIds ends up empty and the helper must fall back to an
+        // empty PhysicalPropertySet rather than building a HashDistributionDesc.
+        IcebergTable partitioned = (IcebergTable) GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "partitioned_db", "t1_v2");
+        assertTrue(partitioned.isPartitioned());
+        com.starrocks.sql.optimizer.base.ColumnRefFactory cf =
+                new com.starrocks.sql.optimizer.base.ColumnRefFactory();
+        // Output columns intentionally do NOT include the partition column ("date").
+        List<com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator> outputs = List.of(
+                cf.create("id", IntegerType.INT, true),
+                cf.create("data", TypeFactory.createVarcharType(64), true));
+        com.starrocks.sql.optimizer.base.PhysicalPropertySet props =
+                IcebergPlannerUtils.createShuffleProperty(partitioned, outputs);
+        // Default property uses EmptyDistributionProperty — no shuffle requirement.
+        assertSame(com.starrocks.sql.optimizer.base.EmptyDistributionProperty.INSTANCE,
+                props.getDistributionProperty());
+    }
+
+    @Test
+    public void testIcebergPlannerUtilsBuildIcebergFilterExprNullPlan() {
+        // Null exec plan returns null without NPE.
+        assertNull(IcebergPlannerUtils.buildIcebergFilterExpr(null));
+    }
+
+    @Test
+    public void testIcebergPlannerUtilsBuildIcebergFilterExprNoIcebergScan() throws Exception {
+        // OLAP update plan has no IcebergScanNode, so the helper finds no predicate
+        // and short-circuits to null.
+        String sql = "update tprimary set v2 = v2 + 1 where v1 = 'aaa'";
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
+        StatementBase stmt = com.starrocks.sql.parser.SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+        connectContext.getDumpInfo().setOriginStmt(sql);
+        ExecPlan execPlan = new StatementPlanner().plan(stmt, connectContext);
+        assertNull(IcebergPlannerUtils.buildIcebergFilterExpr(execPlan));
+    }
+
+    @Test
+    public void testIcebergPlannerUtilsConfigurePipelineDisabled() throws Exception {
+        // When canUsePipeline is false the helper must pin DOP to 1 and return
+        // before touching adaptive-DOP / spill settings.
+        String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        IcebergPlannerUtils.configureIcebergSinkPipeline(execPlan, connectContext, false);
+        assertEquals(1, execPlan.getFragments().get(0).getPipelineDop());
+    }
+
+    @Test
+    public void testIcebergPlannerUtilsConfigurePipelineNonAdaptiveDop() throws Exception {
+        // canUsePipeline=true with enable_adaptive_sink_dop=false hits the
+        // parallel_exec_instance_num branch instead of getSinkDegreeOfParallelism.
+        boolean prevAdaptive = connectContext.getSessionVariable().getEnableAdaptiveSinkDop();
+        try {
+            connectContext.getSessionVariable().setEnableAdaptiveSinkDop(false);
+            String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
+            ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+            IcebergPlannerUtils.configureIcebergSinkPipeline(execPlan, connectContext, true);
+            // parallel_exec_instance_num is always >= 1.
+            assertTrue(execPlan.getFragments().get(0).getPipelineDop() >= 1);
+        } finally {
+            connectContext.getSessionVariable().setEnableAdaptiveSinkDop(prevAdaptive);
+        }
+    }
+
+    @Test
+    public void testOlapUpdateInsideMultiStatementTxnSurfacesInitFailure() throws Exception {
+        // Two paths in setupOlapTableSink that depend on a non-zero txn id:
+        //   1) txnId != 0  → setIsMultiStatementsTxn(true) on the OlapTableSink.
+        //   2) olapTableSink.init() rejects an unknown txn → caught and rethrown
+        //      as SemanticException.
+        // Setting a synthetic txn id forces both paths in one shot.
+        long prevTxn = connectContext.getTxnId();
+        try {
+            connectContext.setTxnId(424242L);
+            com.starrocks.sql.analyzer.SemanticException ex = assertThrows(
+                    com.starrocks.sql.analyzer.SemanticException.class,
+                    () -> getUpdateExecPlan("update tprimary set v1 = 'aaa' where pk = 1"));
+            assertTrue(ex.getMessage().contains("Transaction"),
+                    "Expected SemanticException about the unknown txn, got: " + ex.getMessage());
+        } finally {
+            connectContext.setTxnId(prevTxn);
+        }
+    }
+
+    @Test
+    public void testIcebergRowDeltaSinkValidateSkipsNullColumnSlot() {
+        // A slot with a null column is a benign shape (e.g. unmaterialized helper) —
+        // validateTuple must skip it instead of NPE'ing. Required _file/_pos must
+        // still be present, otherwise we fail on the same missing-column path.
+        ScalarType varchar = TypeFactory.createVarcharType(1024);
+        TupleDescriptor tuple = buildTupleDescriptor(
+                new String[] {IcebergTable.FILE_PATH, IcebergTable.ROW_POSITION, null},
+                new com.starrocks.type.Type[] {varchar, IntegerType.BIGINT, IntegerType.INT});
+        IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable());
+        sink.init(); // must not throw
+    }
+
+    @Test
+    public void testIcebergUpdatePartitionedShuffleUsesPartitionColumn() throws Exception {
+        // The partition shuffle property must hash on the partition column id.
+        // The upstream fragment (fragment[1]) is the one that feeds the sink with
+        // a HASH_PARTITIONED output partition for partitioned tables.
+        String sql = "UPDATE iceberg0.partitioned_db.t1_v2 SET data = 'x' WHERE id = 1";
+        ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
+        assertNotNull(execPlan);
+        assertSame(TPartitionType.HASH_PARTITIONED,
+                execPlan.getFragments().get(1).getOutputPartition().getType());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -370,6 +370,13 @@ public class UpdatePlanTest extends PlanTestBase {
         assertFalse(tIcebergTableSink.is_static_partition_sink);
         assertNotNull(tIcebergTableSink.getCloud_configuration());
         assertTrue(tIcebergTableSink.getTarget_max_file_size() > 0);
+        // Both codecs must be populated: data files use compression_type, position-delete
+        // files use delete_compression_type. The mock table has no codec properties, so
+        // both fall back to the session default — they should be equal but both set.
+        assertTrue(tIcebergTableSink.isSetCompression_type(),
+                "data-file compression codec must be set");
+        assertTrue(tIcebergTableSink.isSetDelete_compression_type(),
+                "delete-file compression codec must be set");
         // Tuple id from sink must match what the planner attached to the fragment.
         assertTrue(sink.getExplainString("", TExplainLevel.NORMAL).contains("TUPLE ID:"));
     }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -273,6 +273,12 @@ struct TIcebergTableSink {
     9: optional string data_location
     // write mode: ROW_DELTA for UPDATE / MERGE (mixed delete + data files)
     10: optional TIcebergWriteMode write_mode
+    // Codec for position-delete files. `compression_type` is the codec for data
+    // files. Each sink populates only the field(s) it actually writes:
+    //   IcebergTableSink    (data only)   → compression_type
+    //   IcebergDeleteSink   (delete only) → delete_compression_type
+    //   IcebergRowDeltaSink (both)        → both
+    11: optional Types.TCompressionType delete_compression_type
 }
 
 struct THiveTableSink {


### PR DESCRIPTION
## Why I'm doing:

Add FE-side support for Iceberg `UPDATE` so users can perform row-level updates on Iceberg V2 tables directly from StarRocks. This is step 2 of the Iceberg UPDATE work and builds on the BE `RowDelta` sink landed in the previous commit; the actual commit logic will land in the next PR.

## What I'm doing:

Front-end pieces for Iceberg UPDATE: analyzer, planner, and the `IcebergRowDeltaSink` planner node that serializes to the BE `RowDelta` sink. Execution path wiring and metric plumbing are included.

Analyzer (`UpdateAnalyzer`):
- Rewrites `UPDATE ... SET ... WHERE` on an Iceberg V2 table into `SELECT _file, _pos, <data-cols>, op_code FROM table WHERE condition`.
- Enforces Phase 1 restrictions: `WHERE` clause required, partition column updates rejected (case-insensitive), format V2 only, hidden metadata columns (`_file`, `_pos`) not writable, no CTE / FROM clause.

Planner:
- `UpdatePlanner` builds the physical plan with `IcebergRowDeltaSink`, partition shuffle for partitioned tables, conflict-detection filter for serializable isolation, and proper session-variable save/restore.
- `IcebergPlannerUtils` centralizes shuffle-property construction and scan-node-to-Iceberg-expression translation shared with `DeletePlanner` (`DeletePlanner` is slimmed down to call the shared helpers).
- `IcebergRowDeltaSink` (planner node) carries the per-branch output tuple, `op_code` column index, and `IcebergSinkExtra` for commit-time conflict detection.

Execution wiring:
- `StmtExecutor` recognizes the new sink, fills rewrite files into `IcebergSinkExtra`, and reports UPDATE success/failure through `ConnectorMetricsMgr`.
- `ConnectorMetricsMgr` gains `iceberg_update_*` counters with a `file_type` label (`data`, `position_delete`) matching the BE file-type taxonomy.

Tests:
- `UpdateAnalyzerIcebergTest` covers hidden metadata column rejection, `DEFAULT` normalization, expression / `NULL` assignments, `op_code` literal wiring, property population, output-column-name contract, and case-insensitive partition-column check.
- `UpdatePlanTest` covers partition shuffle on multi-column partitioned update, session-variable restore in `finally`, Iceberg sink flag, complex `WHERE` predicate, pipeline DOP, and output-expr-count invariant.
- `MockIcebergMetadata` exposes V2 mock tables (`t0_v2`, `t1_v2`) used by the new tests.

Fixes: https://github.com/StarRocks/starrocks/issues/72046
StarrocksTest: https://github.com/StarRocks/StarRocksTest/pull/11258

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4