### PR TITLE
[Enhancement] Disable query rewrite over INCREMENTAL/AUTO materialized views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -522,6 +522,12 @@ public class MvRewritePreprocessor {
             OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "is not active");
             return MVPlanValidationResult.invalid("MV is not active");
         }
+        // Query rewrite is not supported for IMV (INCREMENTAL/AUTO refresh_mode).
+        if (mv.getRefreshMode().isIncrementalOrAuto()) {
+            String message = "query rewrite is not supported for refresh_mode=" + mv.getRefreshMode().name();
+            OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), message);
+            return MVPlanValidationResult.invalid(message);
+        }
         if (!mv.isEnableRewrite()) {
             String message = PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE + "=" +
                     mv.getTableProperty().getMvQueryRewriteSwitch();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -522,7 +522,6 @@ public class MvRewritePreprocessor {
             OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "is not active");
             return MVPlanValidationResult.invalid("MV is not active");
         }
-        // Query rewrite is not supported for IMV (INCREMENTAL/AUTO refresh_mode).
         if (mv.getRefreshMode().isIncrementalOrAuto()) {
             String message = "query rewrite is not supported for refresh_mode=" + mv.getRefreshMode().name();
             OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), message);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -308,7 +308,12 @@ public class TextMatchBasedRewriteRule extends Rule {
             logMVRewrite(context, this, "MV is not active: {}", mv.getName());
             return Pair.create(false, "MV is not active");
         }
-
+        // Query rewrite is not supported for IMV (INCREMENTAL/AUTO refresh_mode).
+        if (mv.getRefreshMode().isIncrementalOrAuto()) {
+            String message = "query rewrite is not supported for refresh_mode=" + mv.getRefreshMode().name();
+            logMVRewrite(context, this, message);
+            return Pair.create(false, message);
+        }
         if (!mv.isEnableRewrite()) {
             String message = PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE + "=" +
                     mv.getTableProperty().getMvQueryRewriteSwitch();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -308,7 +308,6 @@ public class TextMatchBasedRewriteRule extends Rule {
             logMVRewrite(context, this, "MV is not active: {}", mv.getName());
             return Pair.create(false, "MV is not active");
         }
-        // Query rewrite is not supported for IMV (INCREMENTAL/AUTO refresh_mode).
         if (mv.getRefreshMode().isIncrementalOrAuto()) {
             String message = "query rewrite is not supported for refresh_mode=" + mv.getRefreshMode().name();
             logMVRewrite(context, this, message);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMTestBase.java
@@ -98,11 +98,12 @@ public abstract class MVIVMTestBase extends MVTestBase {
             Assertions.assertTrue(execPlan != null);
             run1.check(execPlan);
         }
-        // test mv rewrite
+        // Query rewrite is intentionally disabled for INCREMENTAL/AUTO MVs.
         {
             String plan = getFragmentPlan(mvQuery);
             if (isCheckRewrite) {
-                Assertions.assertTrue(plan.contains("test_mv1"));
+                Assertions.assertFalse(plan.contains("test_mv1"),
+                        "Query rewrite should be disabled for INCREMENTAL MV, got plan: " + plan);
             }
         }
         // 2th run

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMTestBase.java
@@ -98,12 +98,11 @@ public abstract class MVIVMTestBase extends MVTestBase {
             Assertions.assertTrue(execPlan != null);
             run1.check(execPlan);
         }
-        // Query rewrite is intentionally disabled for INCREMENTAL/AUTO MVs.
         {
             String plan = getFragmentPlan(mvQuery);
             if (isCheckRewrite) {
                 Assertions.assertFalse(plan.contains("test_mv1"),
-                        "Query rewrite should be disabled for INCREMENTAL MV, got plan: " + plan);
+                        "rewrite should not pick the MV, got plan: " + plan);
             }
         }
         // 2th run

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.mv.MVPlanValidationResult;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -1664,6 +1665,40 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                     long id2 = mv2.getId();
                     int expectedOrder = Long.compare(id1, id2);
                     Assertions.assertEquals(expectedOrder, compareResult);
+                });
+    }
+
+    @Test
+    public void testRewriteRejectedForIncrementalMv() throws Exception {
+        starRocksAssert.withMaterializedView("create materialized view test_rewrite_imv distributed by random " +
+                        "as select v1, sum(v3) as total from t0 group by v1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "test_rewrite_imv");
+                    // Flip the persisted refresh_mode to "incremental" without rerouting the MV through the
+                    // SQL path (IVMAnalyzer rejects INCREMENTAL on non-Iceberg base tables).
+                    mv.getTableProperty().setMvRefreshMode("incremental");
+                    MVPlanValidationResult result = MvRewritePreprocessor.isMVValidToRewriteQuery(
+                            connectContext, mv, ImmutableSet.of(), true, false,
+                            connectContext.getSessionVariable().getOptimizerExecuteTimeout());
+                    Assertions.assertEquals(MVPlanValidationResult.Status.INVALID, result.getStatus());
+                    Assertions.assertTrue(result.getReason().contains("refresh_mode=INCREMENTAL"),
+                            "expected reason to mention INCREMENTAL, got: " + result.getReason());
+                });
+    }
+
+    @Test
+    public void testRewriteRejectedForAutoMv() throws Exception {
+        starRocksAssert.withMaterializedView("create materialized view test_rewrite_auto distributed by random " +
+                        "as select v1, sum(v3) as total from t0 group by v1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "test_rewrite_auto");
+                    mv.getTableProperty().setMvRefreshMode("auto");
+                    MVPlanValidationResult result = MvRewritePreprocessor.isMVValidToRewriteQuery(
+                            connectContext, mv, ImmutableSet.of(), true, false,
+                            connectContext.getSessionVariable().getOptimizerExecuteTimeout());
+                    Assertions.assertEquals(MVPlanValidationResult.Status.INVALID, result.getStatus());
+                    Assertions.assertTrue(result.getReason().contains("refresh_mode=AUTO"),
+                            "expected reason to mention AUTO, got: " + result.getReason());
                 });
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -1674,8 +1674,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                         "as select v1, sum(v3) as total from t0 group by v1",
                 (obj) -> {
                     MaterializedView mv = getMv(DB_NAME, "test_rewrite_imv");
-                    // Flip the persisted refresh_mode to "incremental" without rerouting the MV through the
-                    // SQL path (IVMAnalyzer rejects INCREMENTAL on non-Iceberg base tables).
+                    // IVMAnalyzer rejects INCREMENTAL on non-Iceberg, so set the property directly.
                     mv.getTableProperty().setMvRefreshMode("incremental");
                     MVPlanValidationResult result = MvRewritePreprocessor.isMVValidToRewriteQuery(
                             connectContext, mv, ImmutableSet.of(), true, false,

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_abnormal
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_abnormal
@@ -56,7 +56,7 @@ AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -79,7 +79,7 @@ insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_b', 3, '2
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -98,7 +98,7 @@ ALTER MATERIALIZED VIEW test_mv1 SET("refresh_mode" = "auto");
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
 -- result:

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_aggregate
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_aggregate
@@ -78,7 +78,7 @@ group by dt;
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:
@@ -93,7 +93,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 10, '2023-12-
 -- !result
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:
@@ -107,7 +107,7 @@ SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:
@@ -128,7 +128,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('b', 20, '2023-12-
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:
@@ -154,7 +154,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:
@@ -187,7 +187,7 @@ group by dt, col_int;
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, col_int, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt, col_int;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, col_int, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt, col_int;
 -- result:
@@ -208,7 +208,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 10, '2023-12-
 -- !result
 function: print_hit_materialized_view("SELECT dt, col_int, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt, col_int;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, col_int, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt, col_int;
 -- result:
@@ -227,7 +227,7 @@ SELECT dt, col_int, sum(col_int) as sum_col_int, approx_count_distinct(col_str) 
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, col_int, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt, col_int;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, col_int, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt, col_int;
 -- result:
@@ -252,7 +252,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('b', 20, '2023-12-
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, col_int, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt, col_int;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, col_int, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt, col_int;
 -- result:
@@ -280,7 +280,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, col_int, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt, col_int;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, col_int, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt, col_int;
 -- result:
@@ -327,7 +327,7 @@ WHERE t1.col_int > 5 group by t1.dt, t1.col_int, t2.col_int;
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT t1.dt, t1.col_int, t2.col_int, sum(t1.col_int) as sum_col_int1, sum(t2.col_int) as sum_col_int2, avg(t1.col_int) as avg_col_int1, avg(t2.col_int) as avg_col_int2, min(t1.col_int) as min_col_int1, min(t2.col_int) as min_col_int2, max(t1.col_int) as max_col_int1, max(t2.col_int) as max_col_int2, count(t1.col_int) as count_col_int1, count(t2.col_int) as count_col_int2, approx_count_distinct(t1.col_str) as approx_count_distinct_col_str1, approx_count_distinct(t2.col_str) as approx_count_distinct_col_str2, approx_count_distinct(t2.col_str) as approx_count_distinct_col_str3 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 ON t1.dt = t2.dt WHERE t1.col_int > 5 group by t1.dt, t1.col_int, t2.col_int;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, col_int1, col_int2, sum_col_int1, sum_col_int2, avg_col_int1, avg_col_int2, min_col_int1, min_col_int2, max_col_int1, max_col_int2, count_col_int1, count_col_int2, approx_count_distinct_col_str1, approx_count_distinct_col_str2, approx_count_distinct_col_str3 FROM test_mv1 ORDER BY dt, col_int1, col_int2 limit 5;
 -- result:
@@ -350,12 +350,12 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('a', 10, '2023-12-
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col_int, t2.col_int, sum(t1.col_int) as sum_col_int1, sum(t2.col_int) as sum_col_int2, avg(t1.col_int) as avg_col_int1, avg(t2.col_int) as avg_col_int2, min(t1.col_int) as min_col_int1, min(t2.col_int) as min_col_int2, max(t1.col_int) as max_col_int1, max(t2.col_int) as max_col_int2, count(t1.col_int) as count_col_int1, count(t2.col_int) as count_col_int2, approx_count_distinct(t1.col_str) as approx_count_distinct_col_str1, approx_count_distinct(t2.col_str) as approx_count_distinct_col_str2, approx_count_distinct(t2.col_str) as approx_count_distinct_col_str3 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 ON t1.dt = t2.dt WHERE t1.col_int > 5 group by t1.dt, t1.col_int, t2.col_int;", "test_mv1")
 -- result:
-True
+False
 -- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT t1.dt, t1.col_int, t2.col_int, sum(t1.col_int) as sum_col_int1, sum(t2.col_int) as sum_col_int2, avg(t1.col_int) as avg_col_int1, avg(t2.col_int) as avg_col_int2, min(t1.col_int) as min_col_int1, min(t2.col_int) as min_col_int2, max(t1.col_int) as max_col_int1, max(t2.col_int) as max_col_int2, count(t1.col_int) as count_col_int1, count(t2.col_int) as count_col_int2, approx_count_distinct(t1.col_str) as approx_count_distinct_col_str1, approx_count_distinct(t2.col_str) as approx_count_distinct_col_str2, approx_count_distinct(t2.col_str) as approx_count_distinct_col_str3 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 ON t1.dt = t2.dt WHERE t1.col_int > 5 group by t1.dt, t1.col_int, t2.col_int;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, col_int1, col_int2, sum_col_int1, sum_col_int2, avg_col_int1, avg_col_int2, min_col_int1, min_col_int2, max_col_int1, max_col_int2, count_col_int1, count_col_int2, approx_count_distinct_col_str1, approx_count_distinct_col_str2, approx_count_distinct_col_str3 FROM test_mv1 ORDER BY dt, col_int1, col_int2 limit 5;
 -- result:
@@ -392,7 +392,7 @@ False
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT t1.dt, t1.col_int, t2.col_int, sum(t1.col_int) as sum_col_int1, sum(t2.col_int) as sum_col_int2, avg(t1.col_int) as avg_col_int1, avg(t2.col_int) as avg_col_int2, min(t1.col_int) as min_col_int1, min(t2.col_int) as min_col_int2, max(t1.col_int) as max_col_int1, max(t2.col_int) as max_col_int2, count(t1.col_int) as count_col_int1, count(t2.col_int) as count_col_int2, approx_count_distinct(t1.col_str) as approx_count_distinct_col_str1, approx_count_distinct(t2.col_str) as approx_count_distinct_col_str2, approx_count_distinct(t2.col_str) as approx_count_distinct_col_str3 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 ON t1.dt = t2.dt WHERE t1.col_int > 5 group by t1.dt, t1.col_int, t2.col_int;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, col_int1, col_int2, sum_col_int1, sum_col_int2, avg_col_int1, avg_col_int2, min_col_int1, min_col_int2, max_col_int1, max_col_int2, count_col_int1, count_col_int2, approx_count_distinct_col_str1, approx_count_distinct_col_str2, approx_count_distinct_col_str3 FROM test_mv1 ORDER BY dt, col_int1, col_int2 limit 5;
 -- result:

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_complex
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_complex
@@ -136,7 +136,7 @@ REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1, t2.col1, t3.col1, t4.col1, t5.col1, sum(t1.col2) as col12, sum(t2.col2) as col22, sum(t3.col2) as col32, sum(t4.col2) as col42, sum(t5.col2) as col52 from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 on t1.dt = t2.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t3 on t1.dt = t3.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t4 on t1.dt = t4.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t5 on t1.dt = t5.dt group by t1.dt, t1.col1, t2.col1, t3.col1, t4.col1, t5.col1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -164,7 +164,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1, t2.col1, t3.col1, t4.col1, t5.col1, sum(t1.col2) as col12, sum(t2.col2) as col22, sum(t3.col2) as col32, sum(t4.col2) as col42, sum(t5.col2) as col52 from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 on t1.dt = t2.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t3 on t1.dt = t3.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t4 on t1.dt = t4.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t5 on t1.dt = t5.dt group by t1.dt, t1.col1, t2.col1, t3.col1, t4.col1, t5.col1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -200,7 +200,7 @@ REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1, t2.col1, t3.col1, t4.col1, t5.col1, sum(t1.col2) as col12, sum(t2.col2) as col22, sum(t3.col2) as col32, sum(t4.col2) as col42, sum(t5.col2) as col52 from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 on t1.dt = t2.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t3 on t1.dt = t3.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t4 on t1.dt = t4.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t5 on t1.dt = t5.dt group by t1.dt, t1.col1, t2.col1, t3.col1, t4.col1, t5.col1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -240,7 +240,7 @@ REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1, t2.col1, t3.col1, t4.col1, t5.col1, sum(t1.col2) as col12, sum(t2.col2) as col22, sum(t3.col2) as col32, sum(t4.col2) as col42, sum(t5.col2) as col52 from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 on t1.dt = t2.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t3 on t1.dt = t3.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t4 on t1.dt = t4.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t5 on t1.dt = t5.dt group by t1.dt, t1.col1, t2.col1, t3.col1, t4.col1, t5.col1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -288,7 +288,7 @@ REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1, t2.col1, t3.col1, t4.col1, t5.col1, sum(t1.col2) as col12, sum(t2.col2) as col22, sum(t3.col2) as col32, sum(t4.col2) as col42, sum(t5.col2) as col52 from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 on t1.dt = t2.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t3 on t1.dt = t3.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t4 on t1.dt = t4.dt join mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t5 on t1.dt = t5.dt group by t1.dt, t1.col1, t2.col1, t3.col1, t4.col1, t5.col1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_incremental
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_incremental
@@ -59,7 +59,7 @@ AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -82,7 +82,7 @@ insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'new_b', 3, '2
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -104,7 +104,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE dt <= '2023-12-02' ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -137,7 +137,7 @@ group by dt;
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:
@@ -160,7 +160,7 @@ insert overwrite mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 select 'b', 20, '2023
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:
@@ -183,7 +183,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (NULL, 30, '2023-12
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT dt, sum(col_int) as sum_col_int, approx_count_distinct(col_str) as approx_count_distinct_col_str FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1  WHERE col_int > 5 group by dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT dt, sum_col_int, approx_count_distinct_col_str FROM test_mv1 ORDER BY dt;
 -- result:

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_join
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_join
@@ -121,7 +121,7 @@ REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1 as col11, t2.col1 as col21, t1.col2 as col12, t2.col2 as col22 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 ON t1.dt = t2.dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -153,7 +153,7 @@ REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1 as col11, t2.col1 as col21, t1.col2 as col12, t2.col2 as col22 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 ON t1.dt = t2.dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -189,7 +189,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 values
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1 as col11, t2.col1 as col21, t1.col2 as col12, t2.col2 as col22 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 ON t1.dt = t2.dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -217,7 +217,7 @@ REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1 as col11, t2.col1 as col21, t1.col2 as col12, t2.col2 as col22 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 ON t1.dt = t2.dt;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -265,7 +265,7 @@ REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1 as col11, t2.col1 as col21, t3.col1 as col31, t1.col2 as col12, t2.col2 as col22, t3.col2 as col32 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t3 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t4 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t5 ON t1.dt = t2.dt AND t1.dt = t3.dt AND t1.dt = t4.dt AND t1.dt = t5.dt WHERE t1.col2 > 1 AND t2.col2 > 1 AND t3.col2 > 1 AND t4.col2 > 1 AND t5.col2 > 2;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -301,7 +301,7 @@ REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1 as col11, t2.col1 as col21, t3.col1 as col31, t1.col2 as col12, t2.col2 as col22, t3.col2 as col32 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t3 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t4 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t5 ON t1.dt = t2.dt AND t1.dt = t3.dt AND t1.dt = t4.dt AND t1.dt = t5.dt WHERE t1.col2 > 1 AND t2.col2 > 1 AND t3.col2 > 1 AND t4.col2 > 1 AND t5.col2 > 2;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -337,7 +337,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t3 values
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1 as col11, t2.col1 as col21, t3.col1 as col31, t1.col2 as col12, t2.col2 as col22, t3.col2 as col32 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t3 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t4 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t5 ON t1.dt = t2.dt AND t1.dt = t3.dt AND t1.dt = t4.dt AND t1.dt = t5.dt WHERE t1.col2 > 1 AND t2.col2 > 1 AND t3.col2 > 1 AND t4.col2 > 1 AND t5.col2 > 2;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:
@@ -365,7 +365,7 @@ REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- !result
 function: print_hit_materialized_view("SELECT t1.dt, t1.col1 as col11, t2.col1 as col21, t3.col1 as col31, t1.col2 as col12, t2.col2 as col22, t3.col2 as col32 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t3 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t4 JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t5 ON t1.dt = t2.dt AND t1.dt = t3.dt AND t1.dt = t4.dt AND t1.dt = t5.dt WHERE t1.col2 > 1 AND t2.col2 > 1 AND t3.col2 > 1 AND t4.col2 > 1 AND t5.col2 > 2;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT COUNT(*) FROM test_mv1;
 -- result:

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_scan
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_scan
@@ -56,7 +56,7 @@ AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -76,7 +76,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values
 -- !result
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -93,7 +93,7 @@ None	5	2023-12-03
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -117,7 +117,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values
 -- !result
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -159,7 +159,7 @@ AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int > 3;
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -179,7 +179,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values
 -- !result
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -196,7 +196,7 @@ None	30	2023-12-01
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -220,7 +220,7 @@ insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values
 -- !result
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:
@@ -237,7 +237,7 @@ None	30	2023-12-01
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 function: print_hit_materialized_view("SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;", "test_mv1")
 -- result:
-True
+False
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY col_str, col_int, dt limit 3;
 -- result:


### PR DESCRIPTION
## Why I'm doing:

INCREMENTAL/AUTO (IMV) materialized views are not eligible for query rewrite. Previously the optimizer would still consider them as rewrite candidates, which gives users a behavior surface that isn't supported and makes it harder to reason about why an MV is hit (or not) by a query.

## What I'm doing:

Reject INCREMENTAL/AUTO materialized views from query-rewrite candidate selection in both rewrite paths:

- `MvRewritePreprocessor.isMVValidToRewriteQuery` — used by general SPJG-based rewrite (`MaterializedViewRewriter`) and `MaterializedView.getQueryRewriteStatus`.
- `TextMatchBasedRewriteRule.isValidForTextBasedRewrite` — used by the text-match (AST equality) rewrite path that bypasses candidate validation.

Both paths log `query rewrite is not supported for refresh_mode=INCREMENTAL` (or `AUTO`) via `OptimizerTraceUtil.logMVRewriteFailReason` / `logMVRewrite` and exclude the MV.

Tests:
- `MvRewritePreprocessorTest#testRewriteRejectedForIncrementalMv` / `testRewriteRejectedForAutoMv` — directly cover the new gate via `isMVValidToRewriteQuery`.
- `MVIVMTestBase` shared assertion now requires the rewrite plan NOT to contain the IVM MV name.
- `test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_*` — `print_hit_materialized_view` assertions flipped from `True` to `False` to match the new behavior.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4