### PR TITLE
[BugFix] Avoid redundant latestSnapshot() call in PaimonMetadata#getTableVersionRange

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -385,8 +385,9 @@ public class PaimonMetadata implements ConnectorMetadata {
         if (start.isEmpty() && end.isEmpty()) {
             long snapshotId = -1L;
             try {
-                if (paimonTable.getNativeTable().latestSnapshot().isPresent()) {
-                    snapshotId = paimonTable.getNativeTable().latestSnapshot().get().id();
+                Optional<Snapshot> latestSnapshot = paimonTable.getNativeTable().latestSnapshot();
+                if (latestSnapshot.isPresent()) {
+                    snapshotId = latestSnapshot.get().id();
                 }
             } catch (Exception e) {
                 // System table does not have snapshotId, ignore it.


### PR DESCRIPTION
## What I'm doing:

Fixes #72891
#### Duplicate `latestSnapshot()` in the same method

In `PaimonMetadata.getRemoteFileInfos()` ([source](https://github.com/StarRocks/starrocks/blob/branch-3.3/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java#L276)):

```java
long latestSnapshotId = -1L;
try {
    if (paimonTable.getNativeTable().latestSnapshot().isPresent()) {       // ← 1st S3 call
        latestSnapshotId = paimonTable.getNativeTable().latestSnapshot().get().id();  // ← 2nd S3 call!
    }
} catch (Exception e) { ... }
```

`latestSnapshot()` internally calls `SnapshotManager.latestSnapshot()` → `latestSnapshotFromFileSystem()` → reads the S3 LATEST hint file **every time**. The result is never stored in a local variable.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5