### PR TITLE
[Enhancement] Persist ColocateRangeMgr mutations through edit log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -54,6 +54,7 @@ import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.persist.ColocatePersistInfo;
+import com.starrocks.persist.ColocateRangePersistInfo;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.TablePropertyInfo;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -277,6 +278,9 @@ public class ColocateTableIndex implements Writable {
                                         0 /* partitionId: not partition-specific */,
                                         0 /* indexId: not index-specific */,
                                         PlacementPolicy.PACK);
+                        // In-memory only; OP_COLOCATE_RANGE_UPDATE is journaled from OlapTable.onCreate
+                        // after OP_CREATE_TABLE is durably written, so the range record cannot precede the
+                        // table-create record.
                         colocateRangeMgr.initColocateGroup(groupId.grpId, packShardGroupId);
                     }
                 } else if (distributionInfo instanceof HashDistributionInfo) {
@@ -423,6 +427,8 @@ public class ColocateTableIndex implements Writable {
             group2Tables.remove(groupId, tableId);
             if (!group2Tables.containsKey(groupId)) {
                 // all tables of this group are removed, remove the group
+                ColocateGroupSchema schema = group2Schema.get(groupId);
+                boolean wasRangeColocate = schema != null && schema.isRangeColocate();
                 group2BackendsPerBucketSeq.remove(groupId);
                 group2Schema.remove(groupId);
                 unstableGroups.remove(groupId);
@@ -436,6 +442,21 @@ public class ColocateTableIndex implements Writable {
                 }
                 if (fullGroupName != null) {
                     groupName2Id.remove(fullGroupName);
+                }
+                if (wasRangeColocate) {
+                    // colocateRangeMgr is keyed by grpId, which is shared across DBs for cross-DB
+                    // colocation. Only drop the entry when no other DB still holds a GroupId with
+                    // the same grpId; otherwise we would corrupt a peer DB's view.
+                    boolean otherDbStillHasGroup = false;
+                    for (GroupId otherGroupId : group2Schema.keySet()) {
+                        if (Objects.equals(otherGroupId.grpId, groupId.grpId)) {
+                            otherDbStillHasGroup = true;
+                            break;
+                        }
+                    }
+                    if (!otherDbStillHasGroup) {
+                        colocateRangeMgr.removeColocateGroup(groupId.grpId);
+                    }
                 }
             }
         } finally {
@@ -725,6 +746,15 @@ public class ColocateTableIndex implements Writable {
         removeTable(info.getTableId(), null, true /* isReplay */);
     }
 
+    public void replayColocateRangeUpdate(ColocateRangePersistInfo info) {
+        writeLock();
+        try {
+            colocateRangeMgr.setColocateRanges(info.getColocateGroupId(), info.getColocateRanges());
+        } finally {
+            writeUnlock();
+        }
+    }
+
     // only for test
     public void clear() {
         writeLock();
@@ -939,6 +969,14 @@ public class ColocateTableIndex implements Writable {
                                                GroupId assignedGroupId) throws DdlException {
         if (!table.getDefaultDistributionInfo().supportColocate()) {
             throw new DdlException("Table " + table.getName() + " does not support colocation");
+        }
+        // Range colocate group membership is established at CREATE TABLE and tied to a PACK shard
+        // group that owns physical placement; ALTER ... colocate_with cannot atomically rewrite
+        // the OP_MODIFY_TABLE_COLOCATE_V2 + OP_COLOCATE_RANGE_UPDATE ordering, so a crash
+        // between them would leave a follower with schema but no range mgr entry.
+        if (table.isRangeDistribution()) {
+            throw new DdlException(
+                    "ALTER ... colocate_with is not supported for range distribution tables");
         }
 
         String oldGroup = table.getColocateGroup();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -83,6 +83,7 @@ import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.memory.estimate.IgnoreMemoryTrack;
 import com.starrocks.persist.ColocatePersistInfo;
+import com.starrocks.persist.ColocateRangePersistInfo;
 import com.starrocks.persist.OriginStatementInfo;
 import com.starrocks.planner.DescriptorTable.ReferencedPartitionInfo;
 import com.starrocks.qe.ConnectContext;
@@ -2742,6 +2743,19 @@ public class OlapTable extends Table {
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
         if (colocateTableIndex.isColocateTable(getId())) {
             ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(getId());
+            // For range colocate groups, journal the range mgr state ahead of OP_COLOCATE_ADD_TABLE_V2
+            // so the record lands after OP_CREATE_TABLE is durably written. A crash between this
+            // record and the add-table record leaves only an orphan range entry on a fresh grpId,
+            // which is harmless because the next create on the same colocate_with name allocates a
+            // new grpId via getNextId().
+            if (colocateTableIndex.isRangeColocateGroup(groupId)) {
+                List<ColocateRange> ranges = colocateTableIndex.getColocateRangeMgr()
+                        .getColocateRanges(groupId.grpId);
+                if (!ranges.isEmpty()) {
+                    GlobalStateMgr.getCurrentState().getEditLog().logColocateRangeUpdate(
+                            ColocateRangePersistInfo.create(groupId.grpId, ranges));
+                }
+            }
             List<List<Long>> backendsPerBucketSeq = colocateTableIndex.getBackendsPerBucketSeq(groupId);
             ColocatePersistInfo colocatePersistInfo = ColocatePersistInfo.createForAddTable(groupId, getId(),
                     backendsPerBucketSeq);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ColocateRangePersistInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ColocateRangePersistInfo.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.common.io.Writable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Edit log payload for {@link com.starrocks.catalog.ColocateRangeMgr} set mutations.
+ *
+ * <p>Only "set" updates are journaled; range mgr removal is not journaled because the parent
+ * drop/erase journal (e.g. {@code OP_ERASE_TABLE}) already drives followers through
+ * {@code ColocateTableIndex.removeTable}, which performs the in-memory cleanup. Emitting a
+ * separate removal journal here would race the parent record and could leave followers with
+ * a removed range entry but a still-live table, or vice versa, on a leader crash in between.
+ */
+public class ColocateRangePersistInfo implements Writable {
+
+    @SerializedName("cg")
+    private long colocateGroupId;
+
+    @SerializedName("rs")
+    private List<ColocateRange> colocateRanges;
+
+    public ColocateRangePersistInfo() {
+    }
+
+    public static ColocateRangePersistInfo create(long colocateGroupId, List<ColocateRange> colocateRanges) {
+        Preconditions.checkArgument(colocateRanges != null && !colocateRanges.isEmpty(),
+                "colocateRanges must be non-empty");
+        return new ColocateRangePersistInfo(colocateGroupId, new ArrayList<>(colocateRanges));
+    }
+
+    private ColocateRangePersistInfo(long colocateGroupId, List<ColocateRange> colocateRanges) {
+        this.colocateGroupId = colocateGroupId;
+        this.colocateRanges = colocateRanges;
+    }
+
+    public long getColocateGroupId() {
+        return colocateGroupId;
+    }
+
+    public List<ColocateRange> getColocateRanges() {
+        return colocateRanges;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ColocateRangePersistInfo)) {
+            return false;
+        }
+        ColocateRangePersistInfo other = (ColocateRangePersistInfo) obj;
+        return colocateGroupId == other.colocateGroupId
+                && Objects.equals(colocateRanges, other.colocateRanges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(colocateGroupId, colocateRanges);
+    }
+
+    @Override
+    public String toString() {
+        return "ColocateRangePersistInfo{colocateGroupId=" + colocateGroupId
+                + ", colocateRanges=" + colocateRanges + "}";
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -594,6 +594,11 @@ public class EditLog {
                     globalStateMgr.getColocateTableIndex().replayModifyTableColocate(info);
                     break;
                 }
+                case OperationType.OP_COLOCATE_RANGE_UPDATE: {
+                    final ColocateRangePersistInfo info = (ColocateRangePersistInfo) journal.data();
+                    globalStateMgr.getColocateTableIndex().replayColocateRangeUpdate(info);
+                    break;
+                }
                 case OperationType.OP_HEARTBEAT_V2: {
                     final HbPackage hbPackage = (HbPackage) journal.data();
                     GlobalStateMgr.getCurrentState().getHeartbeatMgr().replayHearbeat(hbPackage);
@@ -1852,6 +1857,10 @@ public class EditLog {
 
     public void logModifyTableColocate(TablePropertyInfo info) {
         logJsonObject(OperationType.OP_MODIFY_TABLE_COLOCATE_V2, info);
+    }
+
+    public void logColocateRangeUpdate(ColocateRangePersistInfo info) {
+        logJsonObject(OperationType.OP_COLOCATE_RANGE_UPDATE, info);
     }
 
     public void logHeartbeat(HbPackage hbPackage) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
@@ -150,6 +150,7 @@ public class EditLogDeserializer {
             .put(OperationType.OP_COLOCATE_MARK_UNSTABLE_V2, ColocatePersistInfo.class)
             .put(OperationType.OP_COLOCATE_MARK_STABLE_V2, ColocatePersistInfo.class)
             .put(OperationType.OP_MODIFY_TABLE_COLOCATE_V2, TablePropertyInfo.class)
+            .put(OperationType.OP_COLOCATE_RANGE_UPDATE, ColocateRangePersistInfo.class)
             .put(OperationType.OP_HEARTBEAT_V2, HbPackage.class)
             .put(OperationType.OP_ADD_FUNCTION_V2, Function.class)
             .put(OperationType.OP_DROP_FUNCTION_V2, FunctionSearchDesc.class)

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -421,6 +421,14 @@ public class OperationType {
     @IgnorableOnReplayFailed
     public static final short OP_MODIFY_TABLE_COLOCATE_V2 = 12134;
 
+    // Colocate range mgr update (range distribution colocate). Marked @IgnorableOnReplayFailed
+    // to match the sibling colocate ops; if a follower skips this record under
+    // metadata_journal_ignore_replay_failure, the next DDL on the same group is fail-loud via
+    // ColocateTableIndex.addTableToGroup's range-metadata-missing guard rather than silently
+    // corrupting dispatch.
+    @IgnorableOnReplayFailed
+    public static final short OP_COLOCATE_RANGE_UPDATE = 12135;
+
     //Export json format log
 
     @IgnorableOnReplayFailed

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrReplayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrReplayTest.java
@@ -1,0 +1,166 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Multimap;
+import com.starrocks.catalog.ColocateTableIndex.GroupId;
+import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.Range;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.persist.ColocateRangePersistInfo;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Exercises the OP_COLOCATE_RANGE_UPDATE journal-load path end-to-end via
+ * {@link UtFrameUtils.PseudoJournalReplayer#replayJournalToEnd()} so the test covers
+ * {@link com.starrocks.persist.EditLogDeserializer} registration plus
+ * {@link com.starrocks.persist.EditLog#loadJournal} routing in addition to the replay handler.
+ *
+ * <p>Removal of range mgr state is intentionally not journaled (the parent drop/erase journal
+ * drives followers through removeTable's in-memory cleanup), so removal coverage exercises
+ * removeTable directly rather than the journal path.
+ */
+public class ColocateRangeMgrReplayTest {
+
+    private static final long COLOCATE_GROUP_ID = 9101L;
+    private static final long DB_ID = 9100L;
+    private static final long PEER_DB_ID = 9200L;
+    private static final long TABLE_ID = 9102L;
+    private static final long PEER_TABLE_ID = 9202L;
+
+    private ColocateTableIndex colocateTableIndex;
+
+    private static Tuple makeTuple(int value) {
+        return new Tuple(Collections.singletonList(Variant.of(IntegerType.INT, String.valueOf(value))));
+    }
+
+    @BeforeEach
+    public void setUp() {
+        UtFrameUtils.setUpForPersistTest();
+        colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        colocateTableIndex.getColocateRangeMgr().removeColocateGroup(COLOCATE_GROUP_ID);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+        colocateTableIndex.getColocateRangeMgr().removeColocateGroup(COLOCATE_GROUP_ID);
+    }
+
+    @Test
+    public void testReplayColocateRangeUpdateViaLoadJournal() throws Exception {
+        UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
+        List<ColocateRange> ranges = Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 1001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 1002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 1003L));
+
+        // Direct journal write (mirrors what OlapTable.onCreate does after CREATE_TABLE is durable).
+        GlobalStateMgr.getCurrentState().getEditLog().logColocateRangeUpdate(
+                ColocateRangePersistInfo.create(COLOCATE_GROUP_ID, ranges));
+
+        // Range mgr should be empty until replay applies the journal.
+        Assertions.assertFalse(
+                colocateTableIndex.getColocateRangeMgr().containsColocateGroup(COLOCATE_GROUP_ID));
+
+        UtFrameUtils.PseudoJournalReplayer.replayJournalToEnd();
+
+        Assertions.assertEquals(ranges,
+                colocateTableIndex.getColocateRangeMgr().getColocateRanges(COLOCATE_GROUP_ID));
+    }
+
+    @Test
+    public void testRemoveTableLastTableLeavesClearsRangeMgrInMemory() {
+        GroupId groupId = installRangeColocateGroup(DB_ID, "test_range_group", TABLE_ID);
+        colocateTableIndex.getColocateRangeMgr().setColocateRanges(COLOCATE_GROUP_ID,
+                Collections.singletonList(new ColocateRange(Range.all(), 5050L)));
+
+        Assertions.assertTrue(colocateTableIndex.removeTable(TABLE_ID, null, false /* isReplay */));
+        Assertions.assertFalse(
+                colocateTableIndex.getColocateRangeMgr().containsColocateGroup(COLOCATE_GROUP_ID));
+    }
+
+    @Test
+    public void testRemoveTableKeepsRangeMgrWhenAnotherDbStillHasGroup() {
+        // Two DBs share the same grpId via cross-DB colocation.
+        installRangeColocateGroup(DB_ID, "shared_range_group", TABLE_ID);
+        installRangeColocateGroup(PEER_DB_ID, "peer_shared_range_group", PEER_TABLE_ID);
+        colocateTableIndex.getColocateRangeMgr().setColocateRanges(COLOCATE_GROUP_ID,
+                Collections.singletonList(new ColocateRange(Range.all(), 6060L)));
+
+        // Drop the first DB's table — peer DB still holds the group, range mgr must stay.
+        Assertions.assertTrue(colocateTableIndex.removeTable(TABLE_ID, null, false /* isReplay */));
+        Assertions.assertTrue(
+                colocateTableIndex.getColocateRangeMgr().containsColocateGroup(COLOCATE_GROUP_ID));
+
+        // Now drop the peer DB's table — the last reference is gone, range mgr should clear.
+        Assertions.assertTrue(colocateTableIndex.removeTable(PEER_TABLE_ID, null, false /* isReplay */));
+        Assertions.assertFalse(
+                colocateTableIndex.getColocateRangeMgr().containsColocateGroup(COLOCATE_GROUP_ID));
+    }
+
+    @Test
+    public void testModifyTableColocateRejectsRangeDistribution() {
+        OlapTable table = Mockito.mock(OlapTable.class);
+        // OlapTable.isRangeDistribution() reads the defaultDistributionInfo field directly rather
+        // than via the accessor, so the mock has to stub it explicitly.
+        Mockito.when(table.getDefaultDistributionInfo()).thenReturn(new RangeDistributionInfo());
+        Mockito.when(table.isRangeDistribution()).thenReturn(true);
+        Mockito.when(table.getName()).thenReturn("range_tbl");
+        Mockito.when(table.getColocateGroup()).thenReturn(null);
+
+        DdlException ex = Assertions.assertThrows(DdlException.class,
+                () -> colocateTableIndex.modifyTableColocate(null, table, "another_group",
+                        false /* isReplay */, null));
+        Assertions.assertTrue(ex.getMessage().contains("range distribution"),
+                "expected range-distribution rejection message, got: " + ex.getMessage());
+    }
+
+    /** Installs a single-table range colocate group with the given dbId / table-id pair. */
+    private GroupId installRangeColocateGroup(long dbId, String fullName, long tableId) {
+        GroupId groupId = new GroupId(dbId, COLOCATE_GROUP_ID);
+        ColocateGroupSchema schema = new ColocateGroupSchema(groupId,
+                Collections.singletonList(new Column("k1", IntegerType.INT)),
+                0, (short) 1, DistributionInfoType.RANGE);
+
+        Map<GroupId, ColocateGroupSchema> group2Schema =
+                Deencapsulation.getField(colocateTableIndex, "group2Schema");
+        Multimap<GroupId, Long> group2Tables =
+                Deencapsulation.getField(colocateTableIndex, "group2Tables");
+        Map<Long, GroupId> table2Group =
+                Deencapsulation.getField(colocateTableIndex, "table2Group");
+        Map<String, GroupId> groupName2Id =
+                Deencapsulation.getField(colocateTableIndex, "groupName2Id");
+
+        group2Schema.put(groupId, schema);
+        group2Tables.put(groupId, tableId);
+        table2Group.put(tableId, groupId);
+        groupName2Id.put(dbId + "_" + fullName, groupId);
+        return groupId;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ColocateRangePersistInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ColocateRangePersistInfoTest.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Range;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class ColocateRangePersistInfoTest {
+
+    private static final long COLOCATE_GROUP_ID = 100L;
+
+    private static Tuple makeTuple(int value) {
+        return new Tuple(Collections.singletonList(Variant.of(IntegerType.INT, String.valueOf(value))));
+    }
+
+    @Test
+    public void testRoundTripSingleAllRange() {
+        ColocateRangePersistInfo info = ColocateRangePersistInfo.create(COLOCATE_GROUP_ID,
+                Collections.singletonList(new ColocateRange(Range.all(), 1001L)));
+
+        String json = GsonUtils.GSON.toJson(info);
+        ColocateRangePersistInfo restored = GsonUtils.GSON.fromJson(json, ColocateRangePersistInfo.class);
+
+        Assertions.assertEquals(info, restored);
+        Assertions.assertEquals(COLOCATE_GROUP_ID, restored.getColocateGroupId());
+        Assertions.assertEquals(1, restored.getColocateRanges().size());
+        Assertions.assertTrue(restored.getColocateRanges().get(0).getRange().isAll());
+        Assertions.assertEquals(1001L, restored.getColocateRanges().get(0).getShardGroupId());
+    }
+
+    @Test
+    public void testRoundTripMultipleRanges() {
+        ColocateRangePersistInfo info = ColocateRangePersistInfo.create(COLOCATE_GROUP_ID, Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 1001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 1002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 1003L)));
+
+        String json = GsonUtils.GSON.toJson(info);
+        ColocateRangePersistInfo restored = GsonUtils.GSON.fromJson(json, ColocateRangePersistInfo.class);
+
+        Assertions.assertEquals(info, restored);
+        Assertions.assertEquals(3, restored.getColocateRanges().size());
+        Assertions.assertEquals(1001L, restored.getColocateRanges().get(0).getShardGroupId());
+        Assertions.assertEquals(1002L, restored.getColocateRanges().get(1).getShardGroupId());
+        Assertions.assertEquals(1003L, restored.getColocateRanges().get(2).getShardGroupId());
+    }
+
+    @Test
+    public void testCreateRejectsEmptyList() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ColocateRangePersistInfo.create(COLOCATE_GROUP_ID, Collections.emptyList()));
+    }
+
+    @Test
+    public void testCreateRejectsNullList() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ColocateRangePersistInfo.create(COLOCATE_GROUP_ID, null));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`ColocateRangeMgr` mutations on the leader currently update only in-memory state. In a multi-FE cluster, follower FEs replay the surrounding journal (`OP_CREATE_TABLE`, `OP_COLOCATE_ADD_TABLE_V2`) but receive no range mgr updates, so they end up with empty range info between checkpoints. This:

- silently corrupts P4-part-1's containment-based alignment guard on followers (it sees stale ranges and dispatch diverges from the leader);
- causes `addTableToGroup`'s "range metadata missing" guard to misfire on the next DDL;
- becomes a hard-blocking issue once P3 (BE split → FE `setColocateRanges`) lands.

Image persistence already covers cross-restart consistency. This PR closes the mid-run gap. Range colocate is in-progress (P3, P4-part-2, P5 all unmerged on `main`); no production users yet, so the only at-risk environment is internal dev.

Plan went through 4 rounds of codex-review:plan and 2 rounds of codex-review:code before APPROVED.

## What I'm doing:

- New `OperationType.OP_COLOCATE_RANGE_UPDATE_V2 = 12135` (next free in the colocate block 12130–12134). **Not** `@IgnorableOnReplayFailed`: silent-skip would leave followers with wrong range mgr state and corrupt dispatch.
- New `com.starrocks.persist.ColocateRangePersistInfo` (gson Writable). `create()` rejects empty input defensively — an empty range mgr entry has no meaningful semantics.
- `EditLog.logColocateRangeUpdate` + `loadJournal` switch case + `EditLogDeserializer` registration.
- `ColocateTableIndex.setColocateRangesAndLog(grpId, ranges)`: leader-only wrapper, mutates `ColocateRangeMgr` in memory and journals the new state. `replayColocateRangeUpdate` applies the same mutation on followers.
- `addTableToGroup` init path now flows through `setColocateRangesAndLog` instead of the previously unjournaled `initColocateGroup` call.
- **Removal is intentionally not journaled.** The parent drop/erase journal already drives followers through `removeTable` → in-memory cleanup; emitting a separate removal record only introduces a crash window between the two writes.
- `removeTable`'s last-table-leaves branch now also clears the range mgr entry. **Cross-DB sharing is honored**: `colocateRangeMgr` is keyed by `grpId`, which is shared across DBs for cross-DB colocation, so we scan `group2Schema` for any other GroupId with the same `grpId` and only drop the entry when no peer DB still holds it.
- `prepareModifyTableColocate` now rejects `ALTER ... colocate_with` for range distribution tables. Without this, `OP_MODIFY_TABLE_COLOCATE_V2` would be flushed before the new range-update record on the leader, and a crash in between would leave a follower with the schema but no range mgr entry. Range colocate group membership is established at CREATE TABLE and tied to a PACK shard group; mid-life migration was never supported.
- Tests:
  - `ColocateRangePersistInfoTest`: gson round-trip + `create()` rejects null/empty.
  - `ColocateRangeMgrReplayTest`: real journal-load path via `PseudoJournalReplayer.replayJournalToEnd()` (covers `EditLogDeserializer` + `EditLog.loadJournal` end-to-end), `removeTable` last-table-leaves in-memory cleanup, **cross-DB sharing** (`testRemoveTableKeepsRangeMgrWhenAnotherDbStillHasGroup`), wrapper rejects empty input, ALTER rejection.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4