### PR TITLE
[Enhancement] Surface clear partition-shape change errors for INCREMENTAL MVs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -220,13 +220,19 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                     .listTableDeltaTraits(baseTableInfo.getDbName(), snapshotTable,
                             maxTvrDelta.fromSnapshot(), maxTvrDelta.toSnapshot());
         } catch (StarRocksConnectorException e) {
-            // Snapshot ancestry is broken (e.g., expire_snapshots, branch reset, table replaced).
-            // Incremental refresh cannot recover; the user must drop and recreate the MV.
-            logger.warn("Snapshot ancestry broken for base table: {}.{}: {}",
-                    baseTableInfo.getDbName(), baseTableInfo.getTableName(), e.getMessage(), e);
-            throw new SemanticException(formatPartitionShapeChangeError(
-                    String.format("snapshot ancestry broken for base table %s.%s (%s)",
-                            baseTableInfo.getDbName(), baseTableInfo.getTableName(), e.getMessage())));
+            // Only ancestry-break failures (e.g. expire_snapshots, branch reset, table replaced)
+            // are user-actionable as drop-and-recreate. Other connector failures (transient I/O,
+            // auth, programmer error like missing snapshot id) must surface unmodified so the
+            // user/operator can diagnose the real cause and not be told to recreate the MV.
+            if (isAncestryBrokenError(e)) {
+                logger.warn("Snapshot ancestry broken for base table: {}.{}: {}",
+                        baseTableInfo.getDbName(), baseTableInfo.getTableName(), e.getMessage(), e);
+                throw new SemanticException(formatPartitionShapeChangeError(
+                        String.format("snapshot ancestry broken for base table %s.%s (%s)",
+                                baseTableInfo.getDbName(), baseTableInfo.getTableName(), e.getMessage())),
+                        e);
+            }
+            throw e;
         }
         if (CollectionUtils.isEmpty(tableDeltaTraits)) {
             logger.warn("No tvr delta traits found for base table: {}, db: {}", baseTableInfo.getTableName(),
@@ -269,6 +275,18 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                     baseTableInfo.getTableName(), baseTableInfo.getDbName(), maxTvrDelta);
             return maxTvrDelta;
         }
+    }
+
+    /**
+     * True only for connector failures that signal the IVM anchor snapshot is no longer reachable
+     * from the current snapshot (expire_snapshots, branch reset, table replacement). The Iceberg
+     * connector surfaces this as "Starting snapshot (exclusive) X is not a parent ancestor of end
+     * snapshot Y". Other StarRocksConnectorException reasons (e.g. transient I/O, auth, missing
+     * snapshot id) must propagate unchanged so the operator can act on the real root cause.
+     */
+    private static boolean isAncestryBrokenError(StarRocksConnectorException e) {
+        String message = e.getMessage();
+        return message != null && message.contains("is not a parent ancestor");
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -220,13 +220,7 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                     .listTableDeltaTraits(baseTableInfo.getDbName(), snapshotTable,
                             maxTvrDelta.fromSnapshot(), maxTvrDelta.toSnapshot());
         } catch (StarRocksConnectorException e) {
-            // Only ancestry-break failures (e.g. expire_snapshots, branch reset, table replaced)
-            // are user-actionable as drop-and-recreate. Other connector failures (transient I/O,
-            // auth, programmer error like missing snapshot id) must surface unmodified so the
-            // user/operator can diagnose the real cause and not be told to recreate the MV.
             if (isAncestryBrokenError(e)) {
-                logger.warn("Snapshot ancestry broken for base table: {}.{}: {}",
-                        baseTableInfo.getDbName(), baseTableInfo.getTableName(), e.getMessage(), e);
                 throw new SemanticException(formatPartitionShapeChangeError(
                         String.format("snapshot ancestry broken for base table %s.%s (%s)",
                                 baseTableInfo.getDbName(), baseTableInfo.getTableName(), e.getMessage())),
@@ -256,8 +250,6 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         for (TvrTableDeltaTrait deltaTrait : tableDeltaTraits) {
             if (!deltaTrait.isAppendOnly()) {
                 if (refreshMode.isIncremental()) {
-                    // DELETE / OVERWRITE / partition-shape change on the base table breaks IVM.
-                    // INCREMENTAL MVs do not fall back to PCT, so the only recovery path is recreate.
                     throw new SemanticException(formatPartitionShapeChangeError(
                             String.format("non-append-only change on base table %s.%s (delta: %s)",
                                     baseTableInfo.getDbName(), baseTableInfo.getTableName(), deltaTrait)));
@@ -277,23 +269,11 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         }
     }
 
-    /**
-     * True only for connector failures that signal the IVM anchor snapshot is no longer reachable
-     * from the current snapshot (expire_snapshots, branch reset, table replacement). The Iceberg
-     * connector surfaces this as "Starting snapshot (exclusive) X is not a parent ancestor of end
-     * snapshot Y". Other StarRocksConnectorException reasons (e.g. transient I/O, auth, missing
-     * snapshot id) must propagate unchanged so the operator can act on the real root cause.
-     */
     private static boolean isAncestryBrokenError(StarRocksConnectorException e) {
         String message = e.getMessage();
         return message != null && message.contains("is not a parent ancestor");
     }
 
-    /**
-     * Format an error indicating the IVM cannot recover from a partition-shape / lineage change on
-     * a base table, and instruct the user to drop and recreate the materialized view. The reason
-     * fragment should describe what was detected (e.g. "non-append-only change on base table x.y").
-     */
     private String formatPartitionShapeChangeError(String reasonFragment) {
         return String.format(
                 "Cannot incrementally refresh materialized view %s: %s. "

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -33,6 +33,7 @@ import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
@@ -213,29 +214,47 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         }
 
         // check the delta traits between the max delta
-        List<TvrTableDeltaTrait> tableDeltaTraits = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .listTableDeltaTraits(baseTableInfo.getDbName(), snapshotTable,
-                        maxTvrDelta.fromSnapshot(), maxTvrDelta.toSnapshot());
+        List<TvrTableDeltaTrait> tableDeltaTraits;
+        try {
+            tableDeltaTraits = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .listTableDeltaTraits(baseTableInfo.getDbName(), snapshotTable,
+                            maxTvrDelta.fromSnapshot(), maxTvrDelta.toSnapshot());
+        } catch (StarRocksConnectorException e) {
+            // Snapshot ancestry is broken (e.g., expire_snapshots, branch reset, table replaced).
+            // Incremental refresh cannot recover; the user must drop and recreate the MV.
+            logger.warn("Snapshot ancestry broken for base table: {}.{}: {}",
+                    baseTableInfo.getDbName(), baseTableInfo.getTableName(), e.getMessage(), e);
+            throw new SemanticException(formatPartitionShapeChangeError(
+                    String.format("snapshot ancestry broken for base table %s.%s (%s)",
+                            baseTableInfo.getDbName(), baseTableInfo.getTableName(), e.getMessage())));
+        }
         if (CollectionUtils.isEmpty(tableDeltaTraits)) {
             logger.warn("No tvr delta traits found for base table: {}, db: {}", baseTableInfo.getTableName(),
                     baseTableInfo.getDbName());
-            throw new SemanticException("No tvr delta traits found for base table: %s.%s",
-                    baseTableInfo.getDbName(), baseTableInfo.getTableName());
+            throw new SemanticException(formatPartitionShapeChangeError(
+                    String.format("no tvr delta traits found for base table %s.%s",
+                            baseTableInfo.getDbName(), baseTableInfo.getTableName())));
         }
         // check whether the last delta trait is equal to the max delta
         TvrTableDeltaTrait lastTvrDeltaTrait = tableDeltaTraits.get(tableDeltaTraits.size() - 1);
         TvrTableSnapshot lastTvrDeltaSnapshot = lastTvrDeltaTrait.getTvrDelta().toSnapshot();
         if (!lastTvrDeltaSnapshot.equals(maxTvrDelta.toSnapshot())) {
-            logger.warn("The last tvr delta snapshot: {} is not equal to the max tvr delta snapshot: {}, " +
-                    "use the max tvr delta instead", lastTvrDeltaSnapshot, maxTvrDelta.toSnapshot());
-            throw new SemanticException("The last tvr delta snapshot: %s is not equal to the max tvr delta snapshot: %s",
+            logger.warn("The last tvr delta snapshot: {} is not equal to the max tvr delta snapshot: {}",
                     lastTvrDeltaSnapshot, maxTvrDelta.toSnapshot());
+            throw new SemanticException(formatPartitionShapeChangeError(
+                    String.format("tvr delta lineage inconsistent for base table %s.%s "
+                                    + "(last delta snapshot %s != max delta snapshot %s)",
+                            baseTableInfo.getDbName(), baseTableInfo.getTableName(),
+                            lastTvrDeltaSnapshot, maxTvrDelta.toSnapshot())));
         }
         for (TvrTableDeltaTrait deltaTrait : tableDeltaTraits) {
             if (!deltaTrait.isAppendOnly()) {
                 if (refreshMode.isIncremental()) {
-                    throw new SemanticException("TvrTableDeltaTrait is not append-only for base table: %s.%s, delta:%s",
-                            baseTableInfo.getDbName(), baseTableInfo.getTableName(), deltaTrait);
+                    // DELETE / OVERWRITE / partition-shape change on the base table breaks IVM.
+                    // INCREMENTAL MVs do not fall back to PCT, so the only recovery path is recreate.
+                    throw new SemanticException(formatPartitionShapeChangeError(
+                            String.format("non-append-only change on base table %s.%s (delta: %s)",
+                                    baseTableInfo.getDbName(), baseTableInfo.getTableName(), deltaTrait)));
                 } else {
                     logger.info("TvrTableDeltaTrait is not append-only for base table: {}, db: {}, delta:{}, " +
                                     "use the max tvr delta instead", baseTableInfo.getTableName(),
@@ -250,6 +269,20 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                     baseTableInfo.getTableName(), baseTableInfo.getDbName(), maxTvrDelta);
             return maxTvrDelta;
         }
+    }
+
+    /**
+     * Format an error indicating the IVM cannot recover from a partition-shape / lineage change on
+     * a base table, and instruct the user to drop and recreate the materialized view. The reason
+     * fragment should describe what was detected (e.g. "non-append-only change on base table x.y").
+     */
+    private String formatPartitionShapeChangeError(String reasonFragment) {
+        return String.format(
+                "Cannot incrementally refresh materialized view %s: %s. "
+                        + "INCREMENTAL materialized views do not support partition-shape changes "
+                        + "(DELETE / OVERWRITE / DROP PARTITION / snapshot expiration / table replacement). "
+                        + "Drop and recreate the materialized view to recover.",
+                mv.getName(), reasonFragment);
     }
 
     public TvrTableDelta getBaseTableMaxChangedDelta(BaseTableSnapshotInfo snapshotInfo,

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -1339,7 +1339,6 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
 
     @Test
     public void testIncrementalRefreshSurfacesPartitionShapeChangeWhenNoDeltaTraits() throws Exception {
-        // listTableDeltaTraits returns empty -> snapshot lineage is unrecoverable for IVM.
         String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
         seedTvrBaselineAtVersionZero(mv);
@@ -1356,8 +1355,6 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
 
     @Test
     public void testIncrementalRefreshSurfacesPartitionShapeChangeWhenLineageBroken() throws Exception {
-        // Connector throws ancestry error -> wrapped with drop-and-recreate hint.
-        // The original StarRocksConnectorException is preserved as the cause for diagnostics.
         String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
         seedTvrBaselineAtVersionZero(mv);
@@ -1390,7 +1387,6 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
 
     @Test
     public void testIncrementalRefreshSurfacesPartitionShapeChangeOnNonAppendOnly() throws Exception {
-        // Non-append-only delta (DELETE / OVERWRITE / DROP PARTITION) -> dropAndRecreate error.
         String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
         seedTvrBaselineAtVersionZero(mv);
@@ -1409,9 +1405,6 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
 
     @Test
     public void testIncrementalRefreshPropagatesNonAncestryConnectorError() throws Exception {
-        // A non-ancestry connector failure (e.g. transient I/O or programmer error from the
-        // metadata implementation) must NOT be rewritten as a drop-and-recreate hint. The
-        // original message should reach the user so the real root cause stays visible.
         String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
         seedTvrBaselineAtVersionZero(mv);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -1336,4 +1336,67 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
         Assertions.assertInstanceOf(MVHybridRefreshProcessor.class, mvTaskRunProcessor.getMVRefreshProcessor());
     }
+
+    @Test
+    public void testIncrementalRefreshSurfacesPartitionShapeChangeWhenNoDeltaTraits() throws Exception {
+        // listTableDeltaTraits returns empty -> snapshot lineage is unrecoverable for IVM.
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        seedTvrBaselineAtVersionZero(mv);
+        advanceTableVersionTo(1);
+        mockListTableDeltaTraits(ImmutableList.of());
+
+        Throwable thrown = Assertions.assertThrows(Throwable.class, () -> getIVMRefreshedExecPlan(mv));
+        Throwable root = thrown;
+        while (root.getCause() != null && root != root.getCause()) {
+            root = root.getCause();
+        }
+        Assertions.assertTrue(root.getMessage().contains("no tvr delta traits"),
+                "expected 'no tvr delta traits' in message, got: " + root.getMessage());
+        Assertions.assertTrue(root.getMessage().contains("Drop and recreate"),
+                "expected drop-and-recreate guidance, got: " + root.getMessage());
+    }
+
+    @Test
+    public void testIncrementalRefreshSurfacesPartitionShapeChangeWhenLineageBroken() throws Exception {
+        // Connector throws ancestry error -> wrapped with drop-and-recreate hint.
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        seedTvrBaselineAtVersionZero(mv);
+        advanceTableVersionTo(1);
+        mockListTableDeltaTraitsThrowsConnector(
+                "Starting snapshot (exclusive) 0 is not a parent ancestor of end snapshot 1");
+
+        Throwable thrown = Assertions.assertThrows(Throwable.class, () -> getIVMRefreshedExecPlan(mv));
+        Throwable root = thrown;
+        while (root.getCause() != null && root != root.getCause()) {
+            root = root.getCause();
+        }
+        Assertions.assertTrue(root.getMessage().contains("snapshot ancestry broken"),
+                "expected 'snapshot ancestry broken' in message, got: " + root.getMessage());
+        Assertions.assertTrue(root.getMessage().contains("Drop and recreate"),
+                "expected drop-and-recreate guidance, got: " + root.getMessage());
+    }
+
+    @Test
+    public void testIncrementalRefreshSurfacesPartitionShapeChangeOnNonAppendOnly() throws Exception {
+        // Non-append-only delta (DELETE / OVERWRITE / DROP PARTITION) -> dropAndRecreate error.
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        seedTvrBaselineAtVersionZero(mv);
+        advanceTableVersionTo(1);
+        mockListTableDeltaTraits(ImmutableList.of(
+                TvrTableDeltaTrait.ofRetractable(
+                        TvrTableDelta.of(0L, 1L), TvrDeltaStats.EMPTY)));
+
+        Throwable thrown = Assertions.assertThrows(Throwable.class, () -> getIVMRefreshedExecPlan(mv));
+        Throwable root = thrown;
+        while (root.getCause() != null && root != root.getCause()) {
+            root = root.getCause();
+        }
+        Assertions.assertTrue(root.getMessage().contains("non-append-only"),
+                "expected 'non-append-only' in message, got: " + root.getMessage());
+        Assertions.assertTrue(root.getMessage().contains("Drop and recreate"),
+                "expected drop-and-recreate guidance, got: " + root.getMessage());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -1347,19 +1347,17 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         mockListTableDeltaTraits(ImmutableList.of());
 
         Throwable thrown = Assertions.assertThrows(Throwable.class, () -> getIVMRefreshedExecPlan(mv));
-        Throwable root = thrown;
-        while (root.getCause() != null && root != root.getCause()) {
-            root = root.getCause();
-        }
-        Assertions.assertTrue(root.getMessage().contains("no tvr delta traits"),
-                "expected 'no tvr delta traits' in message, got: " + root.getMessage());
-        Assertions.assertTrue(root.getMessage().contains("Drop and recreate"),
-                "expected drop-and-recreate guidance, got: " + root.getMessage());
+        String chain = collectMessages(thrown);
+        Assertions.assertTrue(chain.contains("no tvr delta traits"),
+                "expected 'no tvr delta traits' in chain, got: " + chain);
+        Assertions.assertTrue(chain.contains("Drop and recreate"),
+                "expected drop-and-recreate guidance in chain, got: " + chain);
     }
 
     @Test
     public void testIncrementalRefreshSurfacesPartitionShapeChangeWhenLineageBroken() throws Exception {
         // Connector throws ancestry error -> wrapped with drop-and-recreate hint.
+        // The original StarRocksConnectorException is preserved as the cause for diagnostics.
         String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
         seedTvrBaselineAtVersionZero(mv);
@@ -1368,14 +1366,26 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                 "Starting snapshot (exclusive) 0 is not a parent ancestor of end snapshot 1");
 
         Throwable thrown = Assertions.assertThrows(Throwable.class, () -> getIVMRefreshedExecPlan(mv));
-        Throwable root = thrown;
-        while (root.getCause() != null && root != root.getCause()) {
-            root = root.getCause();
+        String chain = collectMessages(thrown);
+        Assertions.assertTrue(chain.contains("snapshot ancestry broken"),
+                "expected 'snapshot ancestry broken' in chain, got: " + chain);
+        Assertions.assertTrue(chain.contains("Drop and recreate"),
+                "expected drop-and-recreate guidance in chain, got: " + chain);
+        Assertions.assertTrue(chain.contains("is not a parent ancestor"),
+                "expected original connector reason preserved in chain, got: " + chain);
+    }
+
+    private static String collectMessages(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        Throwable cur = t;
+        while (cur != null) {
+            sb.append(cur.getMessage()).append('\n');
+            if (cur.getCause() == cur) {
+                break;
+            }
+            cur = cur.getCause();
         }
-        Assertions.assertTrue(root.getMessage().contains("snapshot ancestry broken"),
-                "expected 'snapshot ancestry broken' in message, got: " + root.getMessage());
-        Assertions.assertTrue(root.getMessage().contains("Drop and recreate"),
-                "expected drop-and-recreate guidance, got: " + root.getMessage());
+        return sb.toString();
     }
 
     @Test
@@ -1390,13 +1400,34 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                         TvrTableDelta.of(0L, 1L), TvrDeltaStats.EMPTY)));
 
         Throwable thrown = Assertions.assertThrows(Throwable.class, () -> getIVMRefreshedExecPlan(mv));
-        Throwable root = thrown;
-        while (root.getCause() != null && root != root.getCause()) {
-            root = root.getCause();
-        }
-        Assertions.assertTrue(root.getMessage().contains("non-append-only"),
-                "expected 'non-append-only' in message, got: " + root.getMessage());
-        Assertions.assertTrue(root.getMessage().contains("Drop and recreate"),
-                "expected drop-and-recreate guidance, got: " + root.getMessage());
+        String chain = collectMessages(thrown);
+        Assertions.assertTrue(chain.contains("non-append-only"),
+                "expected 'non-append-only' in chain, got: " + chain);
+        Assertions.assertTrue(chain.contains("Drop and recreate"),
+                "expected drop-and-recreate guidance in chain, got: " + chain);
+    }
+
+    @Test
+    public void testIncrementalRefreshPropagatesNonAncestryConnectorError() throws Exception {
+        // A non-ancestry connector failure (e.g. transient I/O or programmer error from the
+        // metadata implementation) must NOT be rewritten as a drop-and-recreate hint. The
+        // original message should reach the user so the real root cause stays visible.
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental");
+        seedTvrBaselineAtVersionZero(mv);
+        advanceTableVersionTo(1);
+        String unrelatedConnectorMessage = "transient connector failure: io error reading manifest list";
+        mockListTableDeltaTraitsThrowsConnector(unrelatedConnectorMessage);
+
+        Throwable thrown = Assertions.assertThrows(Throwable.class, () -> getIVMRefreshedExecPlan(mv));
+        String chain = collectMessages(thrown);
+        Assertions.assertTrue(chain.contains(unrelatedConnectorMessage),
+                "expected original connector message preserved in chain, got: " + chain);
+        Assertions.assertFalse(chain.contains("Drop and recreate"),
+                "drop-and-recreate hint must not apply to non-ancestry connector failures, got: " + chain);
+        Assertions.assertFalse(chain.contains("snapshot ancestry broken"),
+                "ancestry-broken framing must not apply to non-ancestry connector failures, got: " + chain);
+        Assertions.assertFalse(chain.contains("INCREMENTAL materialized views do not support partition-shape"),
+                "partition-shape framing must not apply to non-ancestry connector failures, got: " + chain);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMIcebergTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMIcebergTestBase.java
@@ -20,6 +20,7 @@ import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersion;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
@@ -78,6 +79,18 @@ public class MVIVMIcebergTestBase extends MVIVMTestBase {
                                                                  TvrTableSnapshot fromSnapshotExclusive,
                                                                  TvrTableSnapshot toSnapshotInclusive) {
                 throw new SemanticException(message);
+            }
+        };
+    }
+
+    /** Simulate the connector layer's snapshot-ancestry error (e.g. expire_snapshots, branch reset). */
+    public void mockListTableDeltaTraitsThrowsConnector(String message) {
+        new MockUp<MockIcebergMetadata>() {
+            @Mock
+            public List<TvrTableDeltaTrait> listTableDeltaTraits(String dbName, com.starrocks.catalog.Table table,
+                                                                 TvrTableSnapshot fromSnapshotExclusive,
+                                                                 TvrTableSnapshot toSnapshotInclusive) {
+                throw new StarRocksConnectorException(message);
             }
         };
     }

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_delete
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_delete
@@ -384,7 +384,11 @@ SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' 
 -- result:
 FAILED
 -- !result
-SELECT ERROR_MESSAGE LIKE '%not append-only%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%non-append-only%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+SELECT ERROR_MESSAGE LIKE '%Drop and recreate%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
 -- result:
 1
 -- !result

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_expire_snapshots
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_expire_snapshots
@@ -308,7 +308,11 @@ SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}'
 -- result:
 FAILED
 -- !result
-SELECT ERROR_MESSAGE REGEXP '(not append-only|not a parent ancestor)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE REGEXP '(non-append-only|snapshot ancestry broken)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+SELECT ERROR_MESSAGE LIKE '%Drop and recreate%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
 -- result:
 1
 -- !result

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_expire_snapshots
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_expire_snapshots
@@ -308,7 +308,7 @@ SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}'
 -- result:
 FAILED
 -- !result
-SELECT ERROR_MESSAGE REGEXP '(non-append-only|snapshot ancestry broken)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%snapshot ancestry broken%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
 -- result:
 1
 -- !result

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_partition_shape_error
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_partition_shape_error
@@ -1,0 +1,125 @@
+-- name: test_ivm_with_iceberg_partition_shape_error @slow
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt)
+properties ('history.expire.max-snapshot-age-ms' = '1');
+-- result:
+-- !result
+insert into t1 values
+  ('a', 1, '2023-12-01'), ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'), ('b', 4, '2023-12-02'),
+  ('c', 5, '2023-12-03'), ('c', 6, '2023-12-03');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "incremental")
+AS SELECT col_str, col_int, dt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+-- result:
+mv-0
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 2;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT ERROR_MESSAGE LIKE '%non-append-only%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+SELECT ERROR_MESSAGE LIKE '%Drop and recreate%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv2 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "incremental")
+AS SELECT col_str, col_int, dt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC]TASK_NAME2=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv2';
+-- result:
+mv-0
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('d', 7, '2023-12-04');
+-- result:
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 8, '2023-12-05');
+-- result:
+-- !result
+shell: sleep 2
+-- result:
+0
+
+-- !result
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(retain_last = 1);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+FAILED
+-- !result
+SELECT ERROR_MESSAGE REGEXP '(non-append-only|snapshot ancestry broken)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+SELECT ERROR_MESSAGE LIKE '%Drop and recreate%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+1
+-- !result
+DROP MATERIALIZED VIEW test_mv2;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_partition_shape_error
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_partition_shape_error
@@ -103,7 +103,7 @@ SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}'
 -- result:
 FAILED
 -- !result
-SELECT ERROR_MESSAGE REGEXP '(non-append-only|snapshot ancestry broken)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%snapshot ancestry broken%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
 -- result:
 1
 -- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_delete
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_delete
@@ -217,9 +217,11 @@ SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.t
 
 DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 2;
 [UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
--- Refresh must FAIL because incremental mode does not allow non-append-only delta
+-- Refresh must FAIL because incremental mode does not allow non-append-only delta.
+-- The error must surface both the specific reason and the drop-and-recreate guidance.
 SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
-SELECT ERROR_MESSAGE LIKE '%not append-only%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%non-append-only%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%Drop and recreate%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
 
 DROP MATERIALIZED VIEW test_mv1;
 

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_expire_snapshots
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_expire_snapshots
@@ -178,7 +178,7 @@ ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(r
 -- partition-shape change error and drop-and-recreate guidance.
 [UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
 SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
-SELECT ERROR_MESSAGE REGEXP '(non-append-only|snapshot ancestry broken)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%snapshot ancestry broken%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
 SELECT ERROR_MESSAGE LIKE '%Drop and recreate%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
 
 DROP MATERIALIZED VIEW test_mv2;

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_expire_snapshots
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_expire_snapshots
@@ -174,10 +174,12 @@ ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(r
 -- The Iceberg connector surfaces this as "Starting snapshot ... is
 -- not a parent ancestor of end snapshot ..." because the MV's TVR
 -- anchor is no longer part of the current snapshot chain after
--- expire_snapshots removed it.
+-- expire_snapshots removed it. The IVM processor wraps this with the
+-- partition-shape change error and drop-and-recreate guidance.
 [UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
 SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
-SELECT ERROR_MESSAGE REGEXP '(not append-only|not a parent ancestor)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE REGEXP '(non-append-only|snapshot ancestry broken)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%Drop and recreate%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
 
 DROP MATERIALIZED VIEW test_mv2;
 

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_partition_shape_error
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_partition_shape_error
@@ -1,0 +1,82 @@
+-- name: test_ivm_with_iceberg_partition_shape_error @slow
+-- INCREMENTAL MV cannot recover from partition-shape changes (DELETE / OVERWRITE /
+-- DROP PARTITION / snapshot expiration / table replacement). The refresh must FAIL
+-- with a deterministic error that names the drop-and-recreate recovery path.
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt)
+properties ('history.expire.max-snapshot-age-ms' = '1');
+
+insert into t1 values
+  ('a', 1, '2023-12-01'), ('a', 2, '2023-12-01'),
+  ('b', 3, '2023-12-02'), ('b', 4, '2023-12-02'),
+  ('c', 5, '2023-12-03'), ('c', 6, '2023-12-03');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+set enable_materialized_view_rewrite = false;
+
+-- ==============================================================
+-- Case 1: INCREMENTAL + DELETE -> non-append-only delta
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "incremental")
+AS SELECT col_str, col_int, dt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+
+DELETE FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int = 2;
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%non-append-only%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%Drop and recreate%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+-- ==============================================================
+-- Case 2: INCREMENTAL + expire_snapshots -> snapshot ancestry broken
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_mv2 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "incremental")
+AS SELECT col_str, col_int, dt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC]TASK_NAME2=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv2';
+
+-- Produce newer snapshots, age them past the expire window, then expire the anchor.
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('d', 7, '2023-12-04');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 8, '2023-12-05');
+shell: sleep 2
+ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(retain_last = 1);
+
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE REGEXP '(non-append-only|snapshot ancestry broken)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%Drop and recreate%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+
+DROP MATERIALIZED VIEW test_mv2;
+
+-- ==============================================================
+-- Cleanup
+-- ==============================================================
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_partition_shape_error
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_partition_shape_error
@@ -1,7 +1,4 @@
 -- name: test_ivm_with_iceberg_partition_shape_error @slow
--- INCREMENTAL MV cannot recover from partition-shape changes (DELETE / OVERWRITE /
--- DROP PARTITION / snapshot expiration / table replacement). The refresh must FAIL
--- with a deterministic error that names the drop-and-recreate recovery path.
 create external catalog mv_iceberg_${uuid0}
 properties
 (

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_partition_shape_error
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_partition_shape_error
@@ -69,7 +69,7 @@ ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE expire_snapshots(r
 
 [UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
 SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
-SELECT ERROR_MESSAGE REGEXP '(non-append-only|snapshot ancestry broken)' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT ERROR_MESSAGE LIKE '%snapshot ancestry broken%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
 SELECT ERROR_MESSAGE LIKE '%Drop and recreate%' FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME2}' ORDER BY FINISH_TIME DESC LIMIT 1;
 
 DROP MATERIALIZED VIEW test_mv2;


### PR DESCRIPTION
## Why I'm doing:

When the base table of an INCREMENTAL materialized view changes in a way that breaks IVM (DELETE / OVERWRITE / DROP PARTITION / `expire_snapshots` / table replacement), the refresh fails with one of four different messages — none of which tell the user what to do. INCREMENTAL MVs do not fall back to PCT, so the only recovery is to drop and recreate the MV. The user-facing error should say so deterministically.

## What I'm doing:

Funnel the four refresh-time error sites in `MVIVMRefreshProcessor.getBaseTableChangedVersionRange` through a single `formatPartitionShapeChangeError(reason)` helper. The new message is consistent across the failure modes:

> Cannot incrementally refresh materialized view `<name>`: `<reason>`. INCREMENTAL materialized views do not support partition-shape changes (DELETE / OVERWRITE / DROP PARTITION / snapshot expiration / table replacement). Drop and recreate the materialized view to recover.

The four sites covered:

- `listTableDeltaTraits` returns empty — snapshot lineage missing.
- `listTableDeltaTraits` throws `StarRocksConnectorException` — e.g. `expire_snapshots`, branch reset, or table replacement breaks ancestry. Previously this surfaced the raw connector message (`Starting snapshot ... is not a parent ancestor of end snapshot ...`) with no recovery hint.
- Last delta trait does not match the max delta — internal lineage inconsistency.
- Non-append-only delta on an INCREMENTAL MV (the `isAppendOnly` check) — DELETE / OVERWRITE / DROP PARTITION on the base table.

Tests:

- FE unit tests in `IVMBasedMvRefreshProcessorIcebergTest`:
  - `testIncrementalRefreshSurfacesPartitionShapeChangeWhenNoDeltaTraits` — empty-traits path.
  - `testIncrementalRefreshSurfacesPartitionShapeChangeWhenLineageBroken` — connector ancestry error path; uses the new `mockListTableDeltaTraitsThrowsConnector` helper in `MVIVMIcebergTestBase`.
  - `testIncrementalRefreshSurfacesPartitionShapeChangeOnNonAppendOnly` — retractable delta path.

  Each test asserts both the specific reason fragment and the `Drop and recreate` guidance are present in the thrown message.

- SQL tester end-to-end coverage on a real Iceberg base table:
  - New `test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_partition_shape_error` — INCREMENTAL-only (runs today, not skipped). Covers DELETE -> `non-append-only` + `Drop and recreate`, and `expire_snapshots` -> `non-append-only` or `snapshot ancestry broken` + `Drop and recreate`.
  - Strengthen Part B assertions in the existing AUTO-coupled `test_ivm_with_iceberg_delete` and `test_ivm_with_iceberg_expire_snapshots` so that, when AUTO is unhidden in a future iteration and they get unskipped, the expectations already align with the new error wording.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4