### PR TITLE
[BugFix] Fix RuntimeProfile min/max race during serialization

### DIFF
--- a/be/src/common/runtime_profile.cpp
+++ b/be/src/common/runtime_profile.cpp
@@ -825,11 +825,18 @@ void RuntimeProfile::to_thrift(std::vector<TRuntimeProfileNode>* nodes) {
         counter.__set_value(iter_counter->value());
         counter.__set_type(iter_counter->type());
         counter.__set_strategy(iter_counter->strategy());
-        if (iter_counter->_min_value.has_value()) {
-            counter.__set_min_value(iter_counter->_min_value.value());
+        std::optional<int64_t> min_value;
+        std::optional<int64_t> max_value;
+        {
+            std::lock_guard<std::mutex> l(_counter_lock);
+            min_value = iter_counter->_min_value;
+            max_value = iter_counter->_max_value;
         }
-        if (iter_counter->_max_value.has_value()) {
-            counter.__set_max_value(iter_counter->_max_value.value());
+        if (min_value.has_value()) {
+            counter.__set_min_value(min_value.value());
+        }
+        if (max_value.has_value()) {
+            counter.__set_max_value(max_value.value());
         }
         node.counters.push_back(counter);
     }


### PR DESCRIPTION
## Why I'm doing:

`RuntimeProfile::to_thrift()` can read counter min/max optional values while another thread is updating the same counter. The current code checks `has_value()` and then calls `value()` on `_min_value` / `_max_value` without holding the counter lock, so a concurrent reset can trigger `std::bad_optional_access` and crash BE during profile serialization.

This is easier to hit when LoadChannel profile reporting is enabled, because load RPCs may update and serialize profiles concurrently.

## What I'm doing:

Snapshot counter min/max optional values under `_counter_lock` before serializing them into thrift.

After the snapshot is taken, `to_thrift()` uses the local optional copies to set `min_value` and `max_value`, avoiding the race between `has_value()` and `value()` while keeping the rest of profile serialization unchanged.

Fixes #issue
fix https://github.com/StarRocks/StarRocksTest/issues/11273
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
