### PR TITLE
[Tool] add global-review job to approve-checker workflow

### DIFF
--- a/.github/workflows/approve-checker.yml
+++ b/.github/workflows/approve-checker.yml
@@ -25,7 +25,8 @@ jobs:
   info:
     if: >
       (github.event.pull_request && github.event.requested_team) ||
-      (github.event.pull_request.requested_teams && github.event.review && github.event.review.state == 'approved')
+      (github.event.pull_request.requested_teams && github.event.review && github.event.review.state == 'approved') ||
+      github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     env:
       REPO: ${{ github.repository }}
@@ -113,6 +114,28 @@ jobs:
 
     steps:
       - name: PROTO-REVIEW
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null
+          ./scripts/check-approve.sh
+
+  global-review:
+    needs: info
+    runs-on: [ self-hosted, normal ]
+    if: >
+      github.event_name == 'pull_request_review' &&
+      needs.info.outputs.BASE_REF == 'main' &&
+      !contains(needs.info.outputs.LABELS, 'sync') &&
+      !startsWith(needs.info.outputs.HEAD_REF, 'mergify/')
+    name: GLOBAL REVIEW
+
+    env:
+      PR_NUMBER: ${{ needs.info.outputs.PR_NUMBER }}
+      REPO: ${{ github.repository }}
+      TEAM: global-reviewer
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: GLOBAL REVIEW
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null
           ./scripts/check-approve.sh


### PR DESCRIPTION
## Why I'm doing:

Add a mandatory QA global review gate for all PRs merging to `main`. Currently the only requirement is 2 generic approvals; this change ensures one of them always comes from the `global-reviewer` team.

## What I'm doing:

- Add `global-review` job to `approve-checker.yml`: checks that a member of the `global-reviewer` team has approved the PR before it can merge to `main`
- Skips sync PRs (`sync` label) and mergify backport PRs (`mergify/` head ref)
- Relax `info` job condition to also trigger on any approved review (previously only ran when a team was explicitly requested for review)

After this PR merges, `GLOBAL REVIEW` needs to be added to the required status checks in main branch protection settings (manual step).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4