### PR TITLE
[Enhancement] Support struct args/returns for Java UDAF and UDTF

### DIFF
--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -36,9 +36,13 @@ const AggregateFunction* getJavaUDAFFunction(bool input_nullable) {
 // Build a JavaUDAFSharedContext (class-level, shareable/cacheable).
 // This is the expensive part: class loading, method introspection, and stub class generation.
 // The UDAF object instance is NOT created here — it is per-aggregator (see build_udaf_unique_context).
-static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_udaf_shared_context(const std::string& libpath,
-                                                                                  const std::string& symbol,
-                                                                                  int num_args) {
+//
+// `sql_arg_types` and `sql_return_type` are used solely to construct per-arg / return
+// UdfTypeDesc Java objects when the signature contains STRUCT in any position. They are
+// derived from the FunctionContext's declared arg / return types in `init_udaf_context`.
+static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_udaf_shared_context(
+        const std::string& libpath, const std::string& symbol, int num_args,
+        const std::vector<TypeDescriptor>& sql_arg_types, const TypeDescriptor& sql_return_type) {
     std::string state_cls_name = symbol + "$State";
 
     auto udaf_ctx = std::make_shared<JavaUDAFSharedContext>();
@@ -90,6 +94,29 @@ static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_udaf_shared_contex
     ASSIGN_OR_RETURN(udaf_ctx->states_remove_method, analyzer->get_method_object(state_clazz.clazz(), "remove"));
     ASSIGN_OR_RETURN(udaf_ctx->states_clear_method, analyzer->get_method_object(state_clazz.clazz(), "clear"));
 
+    // Build per-arg / return UdfTypeDesc trees for the SQL signature. STRUCT appearing
+    // anywhere in any arg / return drives the unified Java helpers (createBoxedStructArray
+    // for input boxing, writeResult for output drain); slots without STRUCT are stored
+    // as null-handle entries and the existing fast paths run unchanged.
+    {
+        JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+        // UDAF `update(State, sql_args...)` — SQL args start at parameter index 1. The
+        // method itself returns void, so suppress the helper's return-type pass by
+        // passing a default-constructed (TYPE_UNKNOWN) sql_return_type — otherwise the
+        // helper would try to walk update.getGenericReturnType() against the UDAF's
+        // declared SQL return type (which can be ARRAY / MAP / STRUCT) and fail.
+        ASSIGN_OR_RETURN(JavaUdfMethodTypeDescs update_descs,
+                         build_method_udf_type_descs(env, udaf_ctx->update->method.handle(), sql_arg_types,
+                                                     /*sql_return_type=*/TypeDescriptor(), /*state_offset=*/1));
+        udaf_ctx->update_arg_type_descs = std::move(update_descs.args);
+        // `finalize(State)` carries the actual SQL return type. Pass empty arg list — its
+        // single Java parameter (State) doesn't correspond to any SQL arg.
+        ASSIGN_OR_RETURN(JavaUdfMethodTypeDescs finalize_descs,
+                         build_method_udf_type_descs(env, udaf_ctx->finalize->method.handle(), /*sql_arg_types=*/{},
+                                                     sql_return_type, /*state_offset=*/1));
+        udaf_ctx->finalize_return_type_desc = std::move(finalize_descs.ret);
+    }
+
     return udaf_ctx;
 }
 
@@ -134,6 +161,16 @@ Status init_udaf_context(int64_t id, const std::string& url, const std::string& 
     int num_args = context->get_num_args();
     auto func_cache = UserFunctionCache::instance();
 
+    // Snapshot the SQL signature to feed into the type-desc builder. The shared context
+    // is keyed on (id, num_args), and within a given (id, num_args) the declared arg /
+    // return types must be identical, so caching by num_args alone is correct here.
+    std::vector<TypeDescriptor> sql_arg_types;
+    sql_arg_types.reserve(num_args);
+    for (int i = 0; i < num_args; ++i) {
+        sql_arg_types.emplace_back(*context->get_arg_type(i));
+    }
+    TypeDescriptor sql_return_type = context->get_return_type();
+
     if (use_cache) {
         //assuming id is unique and num_args is small (less than 4096);
         //user defined function is negative.
@@ -141,14 +178,16 @@ Status init_udaf_context(int64_t id, const std::string& url, const std::string& 
         // we adopt the cache key consisting of the function id and the number of arguments, since for non-group-by aggregation,
         // AggBatchCallStub instance in cached JavaUDAFUniqueContext instance depends on the number of arguments.
         int64_t cache_key = (-id) | (static_cast<int64_t>(num_args) << 52);
-        ASSIGN_OR_RETURN(auto result,
-                         func_cache->load_cacheable_java_udf(
-                                 cache_key, url, checksum, TFunctionBinaryType::SRJAR,
-                                 [&symbol, num_args](const std::string& libpath) -> StatusOr<std::any> {
-                                     ASSIGN_OR_RETURN(auto ctx, build_udaf_shared_context(libpath, symbol, num_args));
-                                     return std::any(std::move(ctx));
-                                 },
-                                 cloud_configuration));
+        ASSIGN_OR_RETURN(auto result, func_cache->load_cacheable_java_udf(
+                                              cache_key, url, checksum, TFunctionBinaryType::SRJAR,
+                                              [&symbol, num_args, &sql_arg_types,
+                                               &sql_return_type](const std::string& libpath) -> StatusOr<std::any> {
+                                                  ASSIGN_OR_RETURN(auto ctx, build_udaf_shared_context(
+                                                                                     libpath, symbol, num_args,
+                                                                                     sql_arg_types, sql_return_type));
+                                                  return std::any(std::move(ctx));
+                                              },
+                                              cloud_configuration));
         if (cache_hit_out != nullptr) {
             *cache_hit_out = result.first;
         }
@@ -160,7 +199,8 @@ Status init_udaf_context(int64_t id, const std::string& url, const std::string& 
     std::string libpath;
     RETURN_IF_ERROR(
             func_cache->get_libpath(id, url, checksum, TFunctionBinaryType::SRJAR, &libpath, cloud_configuration));
-    ASSIGN_OR_RETURN(auto shared_ctx, build_udaf_shared_context(libpath, symbol, num_args));
+    ASSIGN_OR_RETURN(auto shared_ctx,
+                     build_udaf_shared_context(libpath, symbol, num_args, sql_arg_types, sql_return_type));
     return build_udaf_unique_context(std::move(shared_ctx), context);
 }
 

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -106,8 +106,10 @@ public:
         auto* udaf_ctx = get_java_udaf_context(ctx);
         DCHECK(udaf_ctx != nullptr);
         jvalue val = udaf_ctx->_func->finalize(this->data(state).handle);
+        // STRUCT-bearing return types route through append_jvalue's STRUCT path with the
+        // cached UdfTypeDesc supplying formal record class info per nested STRUCT slot.
         auto st = append_jvalue(ctx->get_return_type(), udaf_ctx->ctx->finalize->method_desc[0].is_box, to, val,
-                                ctx->error_if_overflow());
+                                ctx->error_if_overflow(), udaf_ctx->ctx->finalize_return_type_desc.handle());
         SET_FUNCTION_CONTEXT_ERR(st, ctx);
         RETURN_IF_UNLIKELY(!st.ok(), (void)0);
         release_jvalue(udaf_ctx->ctx->finalize->method_desc[0].is_box, val);
@@ -139,8 +141,13 @@ public:
         for (int i = 0; i < src.size(); ++i) {
             raw_input_ptrs[i] = src[i].get();
         }
-        auto st =
-                JavaDataTypeConverter::convert_to_boxed_array(ctx, raw_input_ptrs.data(), num_cols, batch_size, &args);
+        std::vector<jobject> arg_type_descs;
+        arg_type_descs.reserve(udf_ctxs->ctx->update_arg_type_descs.size());
+        for (const auto& gref : udf_ctxs->ctx->update_arg_type_descs) {
+            arg_type_descs.emplace_back(gref.handle());
+        }
+        auto st = JavaDataTypeConverter::convert_to_boxed_array(ctx, raw_input_ptrs.data(), num_cols, batch_size, &args,
+                                                                &arg_type_descs);
         SET_FUNCTION_CONTEXT_ERR(st, ctx);
         RETURN_IF_UNLIKELY(!st.ok(), (void)0);
 
@@ -206,6 +213,18 @@ public:
 
     // batch interface
 
+    // Snapshot the per-arg UdfTypeDesc handles cached on the shared context. Slots whose
+    // SQL subtree contains no STRUCT are stored as null-handle entries; the boxer falls
+    // back to JavaArrayConverter for those subtrees.
+    static std::vector<jobject> _collect_update_arg_type_descs(JavaUDAFUniqueContext* udf_ctxs) {
+        std::vector<jobject> out;
+        out.reserve(udf_ctxs->ctx->update_arg_type_descs.size());
+        for (const auto& gref : udf_ctxs->ctx->update_arg_type_descs) {
+            out.emplace_back(gref.handle());
+        }
+        return out;
+    }
+
     void update_batch(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
                       AggDataPtr* states) const override {
         auto& helper = JVMFunctionHelper::getInstance();
@@ -219,7 +238,9 @@ public:
         {
             auto states_arr = JavaDataTypeConverter::convert_to_states(ctx, states, state_offset, batch_size);
             RETURN_IF_UNLIKELY_NULL(states_arr, (void)0);
-            auto st = JavaDataTypeConverter::convert_to_boxed_array(ctx, columns, num_cols, batch_size, &args);
+            auto arg_type_descs = _collect_update_arg_type_descs(udf_ctxs);
+            auto st = JavaDataTypeConverter::convert_to_boxed_array(ctx, columns, num_cols, batch_size, &args,
+                                                                    &arg_type_descs);
             SET_FUNCTION_CONTEXT_ERR(st, ctx);
             RETURN_IF_UNLIKELY(!st.ok(), (void)0);
             helper.batch_update(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->update->method.handle(), states_arr,
@@ -240,7 +261,9 @@ public:
             auto states_arr = JavaDataTypeConverter::convert_to_states_with_filter(ctx, states, state_offset,
                                                                                    filter.data(), batch_size);
             RETURN_IF_UNLIKELY_NULL(states_arr, (void)0);
-            auto st = JavaDataTypeConverter::convert_to_boxed_array(ctx, columns, num_cols, batch_size, &args);
+            auto arg_type_descs = _collect_update_arg_type_descs(udf_ctxs);
+            auto st = JavaDataTypeConverter::convert_to_boxed_array(ctx, columns, num_cols, batch_size, &args,
+                                                                    &arg_type_descs);
             SET_FUNCTION_CONTEXT_ERR(st, ctx);
             RETURN_IF_UNLIKELY(!st.ok(), (void)0);
             helper.batch_update_if_not_null(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->update->method.handle(),
@@ -259,7 +282,9 @@ public:
         env->PushLocalFrame(num_cols * 3 + 1);
         auto defer = DeferOp([env = env]() { env->PopLocalFrame(nullptr); });
         {
-            auto st = JavaDataTypeConverter::convert_to_boxed_array(ctx, columns, num_cols, batch_size, &args);
+            auto arg_type_descs = _collect_update_arg_type_descs(udf_ctxs);
+            auto st = JavaDataTypeConverter::convert_to_boxed_array(ctx, columns, num_cols, batch_size, &args,
+                                                                    &arg_type_descs);
             SET_FUNCTION_CONTEXT_ERR(st, ctx);
             RETURN_IF_UNLIKELY(!st.ok(), (void)0);
 
@@ -454,7 +479,17 @@ public:
         // descriptor type. For DECIMAL, method_desc[0].type is a coarse BigDecimal sentinel;
         // the true precision/scale lives on the UDAF's declared return type.
         const auto& return_type = ctx->get_return_type();
+        jobject return_desc = udf_ctxs->ctx->finalize_return_type_desc.handle();
         auto write_result = [&](Column* col) {
+            if (return_desc != nullptr) {
+                // STRUCT subtree in the return: route through the unified Java writeResult,
+                // which walks the UdfTypeDesc tree and drains records / lists / maps /
+                // scalars into the native column tree.
+                auto st = helper.write_result(res, static_cast<int>(batch_size), reinterpret_cast<jlong>(col),
+                                              return_desc, ctx->error_if_overflow());
+                SET_FUNCTION_CONTEXT_ERR(st, ctx);
+                return;
+            }
             // The unified writer dispatches DECIMAL types internally; precision/scale
             // and the overflow flag are ignored for non-DECIMAL slots.
             helper.get_result_from_boxed_array(ctx, return_type.type, col, res, batch_size, return_type.precision,

--- a/be/src/exprs/java_function_call_expr.cpp
+++ b/be/src/exprs/java_function_call_expr.cpp
@@ -212,159 +212,22 @@ StatusOr<std::shared_ptr<JavaUDFContext>> JavaFunctionCallExpr::_build_udf_func_
     RETURN_IF_ERROR(add_method("evaluate", &desc->evaluate));
 
     // Build a com.starrocks.udf.UdfTypeDesc Java object for each UDF argument and
-    // for the return type whose SQL type subtree contains a STRUCT, walking
-    // Method.getGenericParameterTypes / getGenericReturnType in lockstep with the
-    // SQL type tree. The same UdfTypeDesc tree is the single source of type info
-    // shared with both the input boxing path (via JNI field accessors) and the
-    // unified Java writeResult helper.
+    // for the return type whose SQL type subtree contains a STRUCT. The same
+    // UdfTypeDesc tree is the single source of type info shared with both the input
+    // boxing path (via JNI field accessors) and the unified Java writeResult helper.
     {
-        auto type_subtree_has_struct = [](const TypeDescriptor& td) {
-            std::function<bool(const TypeDescriptor&)> walk = [&](const TypeDescriptor& t) {
-                if (t.type == TYPE_STRUCT) {
-                    return true;
-                }
-                for (const auto& c : t.children) {
-                    if (walk(c)) {
-                        return true;
-                    }
-                }
-                return false;
-            };
-            return walk(td);
-        };
-
         auto& helper = JVMFunctionHelper::getInstance();
         JNIEnv* env = helper.getEnv();
-        jobject method_obj = desc->evaluate->method.handle();
-
-        int num_args = static_cast<int>(_children.size());
-        // JavaGlobalRef is move-only, so vector::resize(n, value) is unavailable.
-        // Pre-fill with null-handle entries; STRUCT-bearing slots overwrite via move below.
-        desc->evaluate_arg_type_descs.reserve(num_args);
-        for (int i = 0; i < num_args; ++i) {
-            desc->evaluate_arg_type_descs.emplace_back(nullptr);
+        std::vector<TypeDescriptor> sql_arg_types;
+        sql_arg_types.reserve(_children.size());
+        for (const auto& child : _children) {
+            sql_arg_types.emplace_back(child->type());
         }
-
-        bool any_struct = type_subtree_has_struct(_type);
-        for (int i = 0; i < num_args && !any_struct; ++i) {
-            if (type_subtree_has_struct(_children[i]->type())) {
-                any_struct = true;
-            }
-        }
-
-        if (any_struct) {
-            jclass method_class = env->FindClass("java/lang/reflect/Method");
-            DCHECK(method_class != nullptr);
-            DeferOp drop_method_class([&]() { env->DeleteLocalRef(method_class); });
-
-            jmethodID get_generic_param =
-                    env->GetMethodID(method_class, "getGenericParameterTypes", "()[Ljava/lang/reflect/Type;");
-            jmethodID get_generic_return =
-                    env->GetMethodID(method_class, "getGenericReturnType", "()Ljava/lang/reflect/Type;");
-            jmethodID is_var_args_mid = env->GetMethodID(method_class, "isVarArgs", "()Z");
-            jmethodID get_param_count_mid = env->GetMethodID(method_class, "getParameterCount", "()I");
-            DCHECK(get_generic_param != nullptr && get_generic_return != nullptr);
-            DCHECK(is_var_args_mid != nullptr && get_param_count_mid != nullptr);
-
-            jobjectArray generic_params = (jobjectArray)env->CallObjectMethod(method_obj, get_generic_param);
-            if (env->ExceptionCheck() || generic_params == nullptr) {
-                env->ExceptionClear();
-                return Status::InternalError("failed to introspect UDF evaluate generic parameter types");
-            }
-            DeferOp drop_generic_params([&]() { env->DeleteLocalRef(generic_params); });
-
-            // Varargs handling: when the Java method declares `T... vs`, reflection exposes
-            // the varargs slot's formal type as either Class<T[]> (raw array) or
-            // GenericArrayType(List<Inner>) for parameterized element types. The expanded SQL
-            // arg list (`_children`) has one entry per actual call-site value, exceeding the
-            // Java parameter count. For SQL args at index >= num_fixed_params we resolve
-            // against the varargs ELEMENT type, unwrapping the array layer once.
-            jboolean is_varargs = env->CallBooleanMethod(method_obj, is_var_args_mid);
-            jint java_param_count = env->CallIntMethod(method_obj, get_param_count_mid);
-            int num_fixed_params = is_varargs ? std::max(0, java_param_count - 1) : java_param_count;
-
-            // Resolve the varargs element type once if the varargs slot is reachable from any
-            // STRUCT-bearing SQL arg. The result is a fresh local ref the caller deletes.
-            jobject varargs_elem_formal = nullptr;
-            DeferOp drop_varargs_elem([&]() {
-                if (varargs_elem_formal) env->DeleteLocalRef(varargs_elem_formal);
-            });
-            if (is_varargs && num_args > num_fixed_params) {
-                jobject varargs_formal = env->GetObjectArrayElement(generic_params, num_fixed_params);
-                if (env->ExceptionCheck() || varargs_formal == nullptr) {
-                    env->ExceptionClear();
-                    return Status::InternalError("failed to read UDF varargs formal type");
-                }
-                DeferOp drop_varargs_formal([&]() { env->DeleteLocalRef(varargs_formal); });
-
-                jclass gat_clazz = env->FindClass("java/lang/reflect/GenericArrayType");
-                DeferOp drop_gat_clazz([&]() {
-                    if (gat_clazz) env->DeleteLocalRef(gat_clazz);
-                });
-                jclass class_clazz = env->FindClass("java/lang/Class");
-                DeferOp drop_class_clazz([&]() {
-                    if (class_clazz) env->DeleteLocalRef(class_clazz);
-                });
-
-                if (gat_clazz != nullptr && env->IsInstanceOf(varargs_formal, gat_clazz)) {
-                    // List<Inner>[] / Map<K,V>[] → ParameterizedType element.
-                    jmethodID get_component =
-                            env->GetMethodID(gat_clazz, "getGenericComponentType", "()Ljava/lang/reflect/Type;");
-                    varargs_elem_formal = env->CallObjectMethod(varargs_formal, get_component);
-                } else if (class_clazz != nullptr && env->IsInstanceOf(varargs_formal, class_clazz)) {
-                    // Raw array Class — e.g. Rec[] for Rec... varargs. Drop the array layer
-                    // via Class.getComponentType().
-                    jmethodID get_component = env->GetMethodID(class_clazz, "getComponentType", "()Ljava/lang/Class;");
-                    varargs_elem_formal = env->CallObjectMethod(varargs_formal, get_component);
-                } else {
-                    return Status::InternalError("UDF varargs formal type is neither Class nor GenericArrayType");
-                }
-                if (env->ExceptionCheck() || varargs_elem_formal == nullptr) {
-                    env->ExceptionClear();
-                    return Status::InternalError("failed to unwrap UDF varargs element type");
-                }
-            }
-
-            for (int i = 0; i < num_args; ++i) {
-                if (!type_subtree_has_struct(_children[i]->type())) {
-                    continue;
-                }
-                jobject formal = nullptr;
-                DeferOp drop_formal([&]() {
-                    if (formal) env->DeleteLocalRef(formal);
-                });
-                if (i < num_fixed_params) {
-                    formal = env->GetObjectArrayElement(generic_params, i);
-                    if (env->ExceptionCheck() || formal == nullptr) {
-                        env->ExceptionClear();
-                        return Status::InternalError(fmt::format("UDF evaluate parameter {} formal type is null", i));
-                    }
-                } else {
-                    // Varargs slot — use the unwrapped element type. Bump its ref count so
-                    // the per-iteration drop_formal can DeleteLocalRef without invalidating
-                    // varargs_elem_formal for the next iteration.
-                    formal = env->NewLocalRef(varargs_elem_formal);
-                    if (formal == nullptr) {
-                        return Status::InternalError("failed to retain UDF varargs element formal type");
-                    }
-                }
-                ASSIGN_OR_RETURN(jobject local_desc, build_udf_type_desc(env, _children[i]->type(), formal));
-                desc->evaluate_arg_type_descs[i] = JavaGlobalRef(env->NewGlobalRef(local_desc));
-                env->DeleteLocalRef(local_desc);
-            }
-
-            if (type_subtree_has_struct(_type)) {
-                jobject ret_formal = env->CallObjectMethod(method_obj, get_generic_return);
-                if (env->ExceptionCheck() || ret_formal == nullptr) {
-                    env->ExceptionClear();
-                    return Status::InternalError("failed to introspect UDF evaluate generic return type");
-                }
-                DeferOp drop_ret([&]() { env->DeleteLocalRef(ret_formal); });
-                ASSIGN_OR_RETURN(jobject local_ret_desc, build_udf_type_desc(env, _type, ret_formal));
-                desc->evaluate_return_type_desc = JavaGlobalRef(env->NewGlobalRef(local_ret_desc));
-                env->DeleteLocalRef(local_ret_desc);
-            }
-        }
+        ASSIGN_OR_RETURN(JavaUdfMethodTypeDescs descs,
+                         build_method_udf_type_descs(env, desc->evaluate->method.handle(), sql_arg_types, _type,
+                                                     /*state_offset=*/0));
+        desc->evaluate_arg_type_descs = std::move(descs.args);
+        desc->evaluate_return_type_desc = std::move(descs.ret);
     }
 
     // create UDF function instance

--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -59,6 +59,17 @@ public:
     jclass get_udtf_clazz() { return _udtf_class.clazz(); }
     jobject handle() { return _udtf_handle.handle(); }
 
+    // Per-SQL-arg / return UdfTypeDesc Java handles. Slots whose type subtree contains
+    // no STRUCT are stored as null-handle and the existing scalar/array/map paths run
+    // unchanged. The handles are owned by `_process_type_descs` (global refs).
+    jobject arg_type_desc_handle(int i) const {
+        if (i < 0 || i >= static_cast<int>(_process_type_descs.args.size())) {
+            return nullptr;
+        }
+        return _process_type_descs.args[i].handle();
+    }
+    jobject return_type_desc_handle() const { return _process_type_descs.ret.handle(); }
+
 private:
     std::string _libpath;
     std::string _symbol;
@@ -70,6 +81,7 @@ private:
     std::unique_ptr<JavaMethodDescriptor> _process;
     std::vector<TypeDescriptor> _arg_type_descs;
     TypeDescriptor _ret_type;
+    JavaUdfMethodTypeDescs _process_type_descs;
 };
 
 Status JavaUDTFState::open() {
@@ -92,9 +104,28 @@ Status JavaUDTFState::open() {
         (*res)->name = std::move(method_name);
         (*res)->signature = std::move(signature);
         (*res)->method_desc = std::move(mtdesc);
+        // The reflective Method object is needed for STRUCT-aware UdfTypeDesc construction
+        // (walks getGenericParameterTypes / getGenericReturnType). For non-STRUCT signatures
+        // it's unused but harmless.
+        ASSIGN_OR_RETURN((*res)->method, analyzer->get_method_object(clazz, name));
         return Status::OK();
     };
     RETURN_IF_ERROR(add_method("process", _udtf_class.clazz(), &_process));
+
+    // Build per-SQL-arg / return UdfTypeDesc trees for the `process` method when STRUCT
+    // appears anywhere in the signature. The same UdfTypeDesc is consulted by both
+    // cast_to_jvalue (per-row input boxing) and append_jvalue / check_type_matched
+    // (per-row output drain).
+    //
+    // UDTF's Java method returns `T[]` (an array of rows) but the SQL return type is the
+    // per-row element type, so pass `unwrap_return_array_layer=true` to drop the array
+    // layer off the reflective formal type before pairing it with `_ret_type`.
+    {
+        JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+        ASSIGN_OR_RETURN(_process_type_descs,
+                         build_method_udf_type_descs(env, _process->method.handle(), _arg_type_descs, _ret_type,
+                                                     /*state_offset=*/0, /*unwrap_return_array_layer=*/true));
+    }
 
     return Status::OK();
 }
@@ -185,7 +216,8 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
 
         for (int j = 0; j < num_cols; ++j) {
             auto method_type = stateUDTF->method_process()->method_desc[j + 1];
-            auto val_st = cast_to_jvalue(stateUDTF->arg_type_descs()[j], method_type.is_box, cols[j].get(), i);
+            auto val_st = cast_to_jvalue(stateUDTF->arg_type_descs()[j], method_type.is_box, cols[j].get(), i,
+                                         stateUDTF->arg_type_desc_handle(j));
             if (!val_st.ok()) {
                 stateUDTF->set_status(val_st.status());
                 return {};
@@ -219,13 +251,14 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
         for (int j = 0; j < len; ++j) {
             jobject vi = env->GetObjectArrayElement((jobjectArray)rets[i], j);
             LOCAL_REF_GUARD_ENV(env, vi);
-            auto st = check_type_matched(stateUDTF->type_desc(), vi);
+            auto st = check_type_matched(stateUDTF->type_desc(), vi, stateUDTF->return_type_desc_handle());
             if (UNLIKELY(!st.ok())) {
                 state->set_status(st);
                 return {};
             }
             auto res = append_jvalue(stateUDTF->type_desc(), true, col.get(), {.l = vi},
-                                     runtime_state != nullptr && runtime_state->error_if_overflow());
+                                     runtime_state != nullptr && runtime_state->error_if_overflow(),
+                                     stateUDTF->return_type_desc_handle());
             if (UNLIKELY(!res.ok())) {
                 state->set_status(Status::InternalError(res.to_string()));
                 return {};

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -282,8 +282,21 @@ void release_jvalue(bool is_box, jvalue val) {
     }
 }
 
-// Used in UDAF/convert const columns
-StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, const Column* col, int row_num) {
+// Forward declarations for helpers that read fields off a UdfTypeDesc jobject.
+// Defined later in this file, but we need them in cast_to_jvalue / append_jvalue /
+// check_type_matched for STRUCT support.
+static jobject get_type_desc_child(JVMFunctionHelper& helper, jobject type_desc, int index);
+static jclass get_type_desc_record_class(JVMFunctionHelper& helper, jobject type_desc);
+
+// Used in UDAF/UDTF per-row paths and convert const columns.
+//
+// For TYPE_STRUCT, `type_desc_obj` (a UdfTypeDesc jobject) supplies the formal Java
+// record class so we can construct a record instance via UDFHelper.createBoxedStructArray
+// (re-used for the single-row case by feeding it 1-element field arrays). For non-STRUCT
+// subtrees `type_desc_obj` may be null and the existing scalar/array/map paths run
+// unchanged.
+StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, const Column* col, int row_num,
+                                jobject type_desc_obj) {
     DCHECK(!col->is_constant());
 
     auto type = type_desc.type;
@@ -362,8 +375,13 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
         ASSIGN_OR_RETURN(auto object, meta.array_list_class->newLocalInstance());
         LOCAL_REF_GUARD(object);
         JavaListStub list_stub(object);
+        jobject elem_desc = get_type_desc_child(helper, type_desc_obj, 0);
+        DeferOp drop_elem_desc([&]() {
+            if (elem_desc) helper.getEnv()->DeleteLocalRef(elem_desc);
+        });
         for (size_t i = offset; i < offset + size; ++i) {
-            ASSIGN_OR_RETURN(auto e, cast_to_jvalue(type_desc.children[0], true, spec_col->elements_column().get(), i));
+            ASSIGN_OR_RETURN(auto e, cast_to_jvalue(type_desc.children[0], true, spec_col->elements_column().get(), i,
+                                                    elem_desc));
             auto local_obj = e.l;
             LOCAL_REF_GUARD(local_obj);
             RETURN_IF_ERROR(list_stub.add(local_obj));
@@ -384,14 +402,23 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
         LOCAL_REF_GUARD(val_lists);
         JavaListStub val_list_stub(val_lists);
 
+        jobject key_desc = get_type_desc_child(helper, type_desc_obj, 0);
+        DeferOp drop_key_desc([&]() {
+            if (key_desc) helper.getEnv()->DeleteLocalRef(key_desc);
+        });
+        jobject val_desc = get_type_desc_child(helper, type_desc_obj, 1);
+        DeferOp drop_val_desc([&]() {
+            if (val_desc) helper.getEnv()->DeleteLocalRef(val_desc);
+        });
         for (size_t i = offset; i < offset + size; ++i) {
-            ASSIGN_OR_RETURN(auto key, cast_to_jvalue(type_desc.children[0], true, spec_col->keys_column().get(), i));
+            ASSIGN_OR_RETURN(auto key,
+                             cast_to_jvalue(type_desc.children[0], true, spec_col->keys_column().get(), i, key_desc));
             auto key_obj = key.l;
             LOCAL_REF_GUARD(key_obj);
             RETURN_IF_ERROR(key_list_stub.add(key_obj));
 
             ASSIGN_OR_RETURN(auto value,
-                             cast_to_jvalue(type_desc.children[1], true, spec_col->values_column().get(), i));
+                             cast_to_jvalue(type_desc.children[1], true, spec_col->values_column().get(), i, val_desc));
             auto value_obj = value.l;
             LOCAL_REF_GUARD(value_obj);
             RETURN_IF_ERROR(val_list_stub.add(value_obj));
@@ -400,6 +427,69 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
         ASSIGN_OR_RETURN(auto m, immutable_map_meta.newLocalInstance(key_lists, val_lists));
         auto res = jvalue{.l = m};
         return res;
+    }
+    case TYPE_STRUCT: {
+        if (type_desc_obj == nullptr) {
+            return Status::InternalError("STRUCT cast_to_jvalue requires a UdfTypeDesc with the formal record class");
+        }
+        jclass record_class = get_type_desc_record_class(helper, type_desc_obj);
+        if (record_class == nullptr) {
+            return Status::InternalError("STRUCT cast_to_jvalue: missing formal record class on UdfTypeDesc");
+        }
+        DeferOp drop_record_class([&]() { helper.getEnv()->DeleteLocalRef(record_class); });
+
+        if (!col->is_struct()) {
+            return Status::InternalError("expected StructColumn for STRUCT slot");
+        }
+        const auto* struct_col = down_cast<const StructColumn*>(col);
+        int num_fields = static_cast<int>(struct_col->fields_size());
+        if (static_cast<int>(type_desc.children.size()) != num_fields) {
+            return Status::InternalError("STRUCT cast_to_jvalue: SQL field count != column field count");
+        }
+
+        // Build a single-row Object[1] for each subfield. We re-use the existing
+        // batched helper UDFHelper.createBoxedStructArray with num_rows=1 instead of
+        // bringing up a parallel single-row record-construction path: it takes
+        // per-field Object[1] arrays and a null bitmap and returns Object[1] holding
+        // the constructed record (or null when row 0 is null).
+        JNIEnv* env = helper.getEnv();
+        jclass object_clazz = env->FindClass("java/lang/Object");
+        DeferOp drop_object_clazz([&]() { env->DeleteLocalRef(object_clazz); });
+        jobjectArray field_arrays = env->NewObjectArray(num_fields, object_clazz, nullptr);
+        if (field_arrays == nullptr) {
+            return Status::InternalError("failed to allocate field_arrays for STRUCT cast_to_jvalue");
+        }
+        DeferOp drop_field_arrays([&]() { env->DeleteLocalRef(field_arrays); });
+
+        for (int f = 0; f < num_fields; ++f) {
+            const Column* field_col = struct_col->field_column_raw_ptr(f);
+            jobject child_desc = get_type_desc_child(helper, type_desc_obj, f);
+            DeferOp drop_child_desc([&]() {
+                if (child_desc) env->DeleteLocalRef(child_desc);
+            });
+            ASSIGN_OR_RETURN(jvalue field_val,
+                             cast_to_jvalue(type_desc.children[f], true, field_col, row_num, child_desc));
+            // Wrap the single field value in a 1-element Object[].
+            jobjectArray cell = env->NewObjectArray(1, object_clazz, field_val.l);
+            release_jvalue(true, field_val);
+            if (cell == nullptr) {
+                return Status::InternalError("failed to allocate cell array for STRUCT field");
+            }
+            env->SetObjectArrayElement(field_arrays, f, cell);
+            env->DeleteLocalRef(cell);
+        }
+
+        // STRUCT cell may itself be null; the parent NullableColumn was already peeled
+        // by the prologue of cast_to_jvalue, so `col` here is the data column. No null
+        // bitmap is needed at this point — we always have a non-null struct value.
+        ASSIGN_OR_RETURN(jobject out_arr, helper.create_boxed_struct_array(record_class, /*num_rows=*/1,
+                                                                           /*null_buff=*/nullptr, field_arrays));
+        DeferOp drop_out_arr([&]() { env->DeleteLocalRef(out_arr); });
+        // out_arr is Object[1] containing the constructed record. Lift index 0 out as
+        // a fresh local ref since the array itself is dropped on scope exit.
+        jobject record = env->GetObjectArrayElement((jobjectArray)out_arr, 0);
+        v.l = record;
+        break;
     }
     default:
         DCHECK(false) << "unsupported UDF type:" << type;
@@ -534,7 +624,8 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
     return Status::OK();
 }
 
-Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, jvalue val, bool error_if_overflow) {
+Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, jvalue val, bool error_if_overflow,
+                     jobject type_desc_obj) {
     auto& helper = JVMFunctionHelper::getInstance();
     if (col->is_nullable() && val.l == nullptr) {
         col->append_nulls(1);
@@ -603,10 +694,14 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
             }
             auto* data_column = ColumnHelper::get_data_column(col);
             auto* array_column = down_cast<ArrayColumn*>(data_column);
+            jobject elem_desc = get_type_desc_child(helper, type_desc_obj, 0);
+            DeferOp drop_elem_desc([&]() {
+                if (elem_desc) helper.getEnv()->DeleteLocalRef(elem_desc);
+            });
             for (size_t i = 0; i < len; ++i) {
                 ASSIGN_OR_RETURN(auto element, list_stub.get(i));
                 RETURN_IF_ERROR(append_jvalue(type_desc.children[0], true, array_column->elements_column_raw_ptr(),
-                                              {.l = element}));
+                                              {.l = element}, error_if_overflow, elem_desc));
             }
             auto* offsets_col = array_column->offsets_column_raw_ptr();
             size_t last_offset = offsets_col->get_data().back();
@@ -629,19 +724,102 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
 
             ASSIGN_OR_RETURN(auto len, key_list_stub.size());
 
+            jobject key_desc = get_type_desc_child(helper, type_desc_obj, 0);
+            DeferOp drop_key_desc([&]() {
+                if (key_desc) helper.getEnv()->DeleteLocalRef(key_desc);
+            });
+            jobject val_desc = get_type_desc_child(helper, type_desc_obj, 1);
+            DeferOp drop_val_desc([&]() {
+                if (val_desc) helper.getEnv()->DeleteLocalRef(val_desc);
+            });
             for (size_t i = 0; i < len; ++i) {
                 ASSIGN_OR_RETURN(auto key_element, key_list_stub.get(i));
                 RETURN_IF_ERROR(append_jvalue(type_desc.children[0], true, map_column->keys_column_raw_ptr(),
-                                              {.l = key_element}));
+                                              {.l = key_element}, error_if_overflow, key_desc));
 
                 ASSIGN_OR_RETURN(auto val_element, val_list_stub.get(i));
                 RETURN_IF_ERROR(append_jvalue(type_desc.children[1], true, map_column->values_column_raw_ptr(),
-                                              {.l = val_element}));
+                                              {.l = val_element}, error_if_overflow, val_desc));
             }
 
             auto* offsets_col = map_column->offsets_column_raw_ptr();
             size_t last_offset = offsets_col->get_data().back();
             offsets_col->get_data().push_back(last_offset + len);
+            break;
+        }
+        case TYPE_STRUCT: {
+            // Recurse into each subfield by reading the matching record component
+            // accessor and forwarding the boxed value to the subfield column. This
+            // mirrors the per-row drain logic that writeResult does in batch on
+            // the Java side, but stays per-row to fit the existing UDTF/UDAF
+            // single-row append path.
+            if (col->is_nullable()) {
+                down_cast<NullableColumn*>(col)->null_column_data().emplace_back(0);
+            }
+            auto* data_column = ColumnHelper::get_data_column(col);
+            if (!data_column->is_struct()) {
+                return Status::InternalError("expected StructColumn for STRUCT slot in append_jvalue");
+            }
+            auto* struct_col = down_cast<StructColumn*>(data_column);
+            int num_fields = static_cast<int>(struct_col->fields_size());
+            if (static_cast<int>(type_desc.children.size()) != num_fields) {
+                return Status::InternalError("STRUCT append_jvalue: SQL field count != column field count");
+            }
+
+            // Look up record component accessors via reflection on Class<?>.
+            // The record instance's runtime class is the formal record type the FE
+            // analyzer bound to this STRUCT slot; getRecordComponents lives on Class.
+            JNIEnv* env = helper.getEnv();
+            jclass record_class = env->GetObjectClass(val.l);
+            DeferOp drop_record_class([&]() { env->DeleteLocalRef(record_class); });
+            jclass class_clazz = env->FindClass("java/lang/Class");
+            DeferOp drop_class_clazz([&]() { env->DeleteLocalRef(class_clazz); });
+            jmethodID get_components =
+                    env->GetMethodID(class_clazz, "getRecordComponents", "()[Ljava/lang/reflect/RecordComponent;");
+            if (get_components == nullptr) {
+                env->ExceptionClear();
+                return Status::InternalError("STRUCT append_jvalue requires Java records (JDK 14+)");
+            }
+            jobjectArray comps = (jobjectArray)env->CallObjectMethod(record_class, get_components);
+            if (env->ExceptionCheck() || comps == nullptr) {
+                env->ExceptionClear();
+                return Status::InternalError("getRecordComponents failed in append_jvalue");
+            }
+            DeferOp drop_comps([&]() { env->DeleteLocalRef(comps); });
+            jclass rc_clazz = env->FindClass("java/lang/reflect/RecordComponent");
+            DeferOp drop_rc_clazz([&]() { env->DeleteLocalRef(rc_clazz); });
+            jmethodID get_accessor = env->GetMethodID(rc_clazz, "getAccessor", "()Ljava/lang/reflect/Method;");
+            jclass method_clazz = env->FindClass("java/lang/reflect/Method");
+            DeferOp drop_method_clazz([&]() { env->DeleteLocalRef(method_clazz); });
+            jmethodID method_invoke = env->GetMethodID(method_clazz, "invoke",
+                                                       "(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;");
+
+            for (int f = 0; f < num_fields; ++f) {
+                jobject comp = env->GetObjectArrayElement(comps, f);
+                DeferOp drop_comp([&]() { env->DeleteLocalRef(comp); });
+                jobject accessor = env->CallObjectMethod(comp, get_accessor);
+                DeferOp drop_accessor([&]() {
+                    if (accessor) env->DeleteLocalRef(accessor);
+                });
+                if (env->ExceptionCheck() || accessor == nullptr) {
+                    env->ExceptionClear();
+                    return Status::InternalError("RecordComponent.getAccessor returned null");
+                }
+                jobject sub = env->CallObjectMethod(accessor, method_invoke, val.l, nullptr);
+                DeferOp drop_sub([&]() {
+                    if (sub) env->DeleteLocalRef(sub);
+                });
+                if (env->ExceptionCheck()) {
+                    env->ExceptionClear();
+                    return Status::InternalError("Method.invoke on record accessor threw");
+                }
+                jobject child_desc = get_type_desc_child(helper, type_desc_obj, f);
+                DeferOp drop_child_desc([&]() {
+                    if (child_desc) env->DeleteLocalRef(child_desc);
+                });
+                RETURN_IF_ERROR(append_jvalue(type_desc.children[f], true, struct_col->field_column_raw_ptr(f),
+                                              {.l = sub}, error_if_overflow, child_desc));
+            }
             break;
         }
         default:
@@ -652,7 +830,7 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
     return Status::OK();
 }
 
-Status check_type_matched(const TypeDescriptor& type_desc, jobject val) {
+Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject type_desc_obj) {
     if (val == nullptr) {
         return Status::OK();
     }
@@ -732,6 +910,26 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val) {
             LOCAL_REF_GUARD(clazz);
             return Status::InternalError(
                     fmt::format("Type not matched, expect Map, but got {}", helper.to_string(clazz)));
+        }
+        break;
+    }
+    case TYPE_STRUCT: {
+        // The FE analyzer already validates the formal record class matches the SQL
+        // STRUCT shape at CREATE FUNCTION time, so per-row class identity is enough.
+        // We accept any record subclass of the declared formal class.
+        if (type_desc_obj == nullptr) {
+            return Status::InternalError("STRUCT check_type_matched requires UdfTypeDesc with formal record class");
+        }
+        jclass record_class = get_type_desc_record_class(helper, type_desc_obj);
+        if (record_class == nullptr) {
+            return Status::InternalError("STRUCT check_type_matched: missing formal record class");
+        }
+        DeferOp drop_record_class([&]() { env->DeleteLocalRef(record_class); });
+        if (!env->IsInstanceOf(val, record_class)) {
+            auto clazz = env->GetObjectClass(val);
+            LOCAL_REF_GUARD(clazz);
+            return Status::InternalError(fmt::format("Type not matched, expect record {}, but got {}",
+                                                     helper.to_string(record_class), helper.to_string(clazz)));
         }
         break;
     }
@@ -1222,6 +1420,178 @@ static StatusOr<jobject> box_column(JVMFunctionHelper& helper, const TypeDescrip
     return conv.result();
 }
 
+// Walk the SQL type tree to determine whether a STRUCT exists anywhere in it.
+// Used to short-circuit the per-arg / return UdfTypeDesc construction when no
+// STRUCT is reachable from the slot.
+static bool type_subtree_has_struct(const TypeDescriptor& td) {
+    if (td.type == TYPE_STRUCT) return true;
+    for (const auto& c : td.children) {
+        if (type_subtree_has_struct(c)) return true;
+    }
+    return false;
+}
+
+StatusOr<JavaUdfMethodTypeDescs> build_method_udf_type_descs(JNIEnv* env, jobject method_obj,
+                                                             const std::vector<TypeDescriptor>& sql_arg_types,
+                                                             const TypeDescriptor& sql_return_type, int state_offset,
+                                                             bool unwrap_return_array_layer) {
+    JavaUdfMethodTypeDescs out;
+    int num_sql_args = static_cast<int>(sql_arg_types.size());
+    out.args.reserve(num_sql_args);
+    for (int i = 0; i < num_sql_args; ++i) {
+        out.args.emplace_back(JavaGlobalRef(nullptr));
+    }
+
+    bool any_struct = type_subtree_has_struct(sql_return_type);
+    for (int i = 0; i < num_sql_args && !any_struct; ++i) {
+        if (type_subtree_has_struct(sql_arg_types[i])) {
+            any_struct = true;
+        }
+    }
+    if (!any_struct) {
+        return out;
+    }
+
+    jclass method_class = env->FindClass("java/lang/reflect/Method");
+    DCHECK(method_class != nullptr);
+    DeferOp drop_method_class([&]() { env->DeleteLocalRef(method_class); });
+
+    jmethodID get_generic_param =
+            env->GetMethodID(method_class, "getGenericParameterTypes", "()[Ljava/lang/reflect/Type;");
+    jmethodID get_generic_return = env->GetMethodID(method_class, "getGenericReturnType", "()Ljava/lang/reflect/Type;");
+    jmethodID is_var_args_mid = env->GetMethodID(method_class, "isVarArgs", "()Z");
+    jmethodID get_param_count_mid = env->GetMethodID(method_class, "getParameterCount", "()I");
+    DCHECK(get_generic_param != nullptr && get_generic_return != nullptr);
+    DCHECK(is_var_args_mid != nullptr && get_param_count_mid != nullptr);
+
+    jobjectArray generic_params = (jobjectArray)env->CallObjectMethod(method_obj, get_generic_param);
+    if (env->ExceptionCheck() || generic_params == nullptr) {
+        env->ExceptionClear();
+        return Status::InternalError("failed to introspect UDF method generic parameter types");
+    }
+    DeferOp drop_generic_params([&]() { env->DeleteLocalRef(generic_params); });
+
+    // Java method parameter layout: [state_offset opaque slots][SQL fixed slots][optional varargs slot]
+    // Varargs slot's formal type is either Class<T[]> or GenericArrayType(T<...>[]).
+    jboolean is_varargs = env->CallBooleanMethod(method_obj, is_var_args_mid);
+    jint java_param_count = env->CallIntMethod(method_obj, get_param_count_mid);
+    int sql_fixed_count = std::max(0, java_param_count - state_offset - (is_varargs ? 1 : 0));
+
+    jobject varargs_elem_formal = nullptr;
+    DeferOp drop_varargs_elem([&]() {
+        if (varargs_elem_formal) env->DeleteLocalRef(varargs_elem_formal);
+    });
+    if (is_varargs && num_sql_args > sql_fixed_count) {
+        jobject varargs_formal = env->GetObjectArrayElement(generic_params, state_offset + sql_fixed_count);
+        if (env->ExceptionCheck() || varargs_formal == nullptr) {
+            env->ExceptionClear();
+            return Status::InternalError("failed to read UDF varargs formal type");
+        }
+        DeferOp drop_varargs_formal([&]() { env->DeleteLocalRef(varargs_formal); });
+
+        jclass gat_clazz = env->FindClass("java/lang/reflect/GenericArrayType");
+        DeferOp drop_gat_clazz([&]() {
+            if (gat_clazz) env->DeleteLocalRef(gat_clazz);
+        });
+        jclass class_clazz = env->FindClass("java/lang/Class");
+        DeferOp drop_class_clazz([&]() {
+            if (class_clazz) env->DeleteLocalRef(class_clazz);
+        });
+
+        if (gat_clazz != nullptr && env->IsInstanceOf(varargs_formal, gat_clazz)) {
+            jmethodID get_component =
+                    env->GetMethodID(gat_clazz, "getGenericComponentType", "()Ljava/lang/reflect/Type;");
+            varargs_elem_formal = env->CallObjectMethod(varargs_formal, get_component);
+        } else if (class_clazz != nullptr && env->IsInstanceOf(varargs_formal, class_clazz)) {
+            jmethodID get_component = env->GetMethodID(class_clazz, "getComponentType", "()Ljava/lang/Class;");
+            varargs_elem_formal = env->CallObjectMethod(varargs_formal, get_component);
+        } else {
+            return Status::InternalError("UDF varargs formal type is neither Class nor GenericArrayType");
+        }
+        if (env->ExceptionCheck() || varargs_elem_formal == nullptr) {
+            env->ExceptionClear();
+            return Status::InternalError("failed to unwrap UDF varargs element type");
+        }
+    }
+
+    for (int i = 0; i < num_sql_args; ++i) {
+        if (!type_subtree_has_struct(sql_arg_types[i])) {
+            continue;
+        }
+        jobject formal = nullptr;
+        DeferOp drop_formal([&]() {
+            if (formal) env->DeleteLocalRef(formal);
+        });
+        if (i < sql_fixed_count) {
+            formal = env->GetObjectArrayElement(generic_params, state_offset + i);
+            if (env->ExceptionCheck() || formal == nullptr) {
+                env->ExceptionClear();
+                return Status::InternalError(fmt::format("UDF method parameter {} formal type is null", i));
+            }
+        } else {
+            formal = env->NewLocalRef(varargs_elem_formal);
+            if (formal == nullptr) {
+                return Status::InternalError("failed to retain UDF varargs element formal type");
+            }
+        }
+        ASSIGN_OR_RETURN(jobject local_desc, build_udf_type_desc(env, sql_arg_types[i], formal));
+        out.args[i] = JavaGlobalRef(env->NewGlobalRef(local_desc));
+        env->DeleteLocalRef(local_desc);
+    }
+
+    if (type_subtree_has_struct(sql_return_type)) {
+        jobject ret_formal = env->CallObjectMethod(method_obj, get_generic_return);
+        if (env->ExceptionCheck() || ret_formal == nullptr) {
+            env->ExceptionClear();
+            return Status::InternalError("failed to introspect UDF method generic return type");
+        }
+        DeferOp drop_ret([&]() {
+            if (ret_formal) env->DeleteLocalRef(ret_formal);
+        });
+
+        if (unwrap_return_array_layer) {
+            // UDTF: SQL return type is the per-row element, but the Java method returns
+            // `T[]` (zero or more rows per call). Drop the array layer once before pairing
+            // the formal type with the SQL type — otherwise getRecordComponents() on a
+            // STRUCT-of-record return would fire on `Class<Record[]>` (an array class) and
+            // come back null, since array classes are not records.
+            jclass gat_clazz = env->FindClass("java/lang/reflect/GenericArrayType");
+            DeferOp drop_gat_clazz([&]() {
+                if (gat_clazz) env->DeleteLocalRef(gat_clazz);
+            });
+            jclass class_clazz = env->FindClass("java/lang/Class");
+            DeferOp drop_class_clazz([&]() {
+                if (class_clazz) env->DeleteLocalRef(class_clazz);
+            });
+            jobject element_formal = nullptr;
+            if (gat_clazz != nullptr && env->IsInstanceOf(ret_formal, gat_clazz)) {
+                jmethodID get_component =
+                        env->GetMethodID(gat_clazz, "getGenericComponentType", "()Ljava/lang/reflect/Type;");
+                element_formal = env->CallObjectMethod(ret_formal, get_component);
+            } else if (class_clazz != nullptr && env->IsInstanceOf(ret_formal, class_clazz)) {
+                jmethodID get_component = env->GetMethodID(class_clazz, "getComponentType", "()Ljava/lang/Class;");
+                element_formal = env->CallObjectMethod(ret_formal, get_component);
+            } else {
+                return Status::InternalError("UDTF return formal type is neither Class nor GenericArrayType");
+            }
+            if (env->ExceptionCheck() || element_formal == nullptr) {
+                env->ExceptionClear();
+                return Status::InternalError("failed to unwrap UDTF return array element type");
+            }
+            // Swap ret_formal for the unwrapped element type. Drop the original; the
+            // DeferOp above guards `ret_formal` so reassign and delete the old one explicitly.
+            env->DeleteLocalRef(ret_formal);
+            ret_formal = element_formal;
+        }
+
+        ASSIGN_OR_RETURN(jobject local_ret_desc, build_udf_type_desc(env, sql_return_type, ret_formal));
+        out.ret = JavaGlobalRef(env->NewGlobalRef(local_ret_desc));
+        env->DeleteLocalRef(local_ret_desc);
+    }
+
+    return out;
+}
+
 Status JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, const Column** columns, int num_cols,
                                                      int num_rows, std::vector<jobject>* res,
                                                      const std::vector<jobject>* arg_type_descs) {
@@ -1239,7 +1609,7 @@ Status JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, const
         } else if (columns[i]->is_constant()) {
             auto* data_column = down_cast<const ConstColumn*>(columns[i])->data_column_raw_ptr();
             data_column->as_mutable_raw_ptr()->resize(1);
-            ASSIGN_OR_RETURN(jvalue jval, cast_to_jvalue(arg_type, true, data_column, 0));
+            ASSIGN_OR_RETURN(jvalue jval, cast_to_jvalue(arg_type, true, data_column, 0, type_desc_obj));
             arg = helper.create_object_array(jval.l, num_rows);
             env->DeleteLocalRef(jval.l);
         } else {

--- a/be/src/udf/java/java_data_converter.h
+++ b/be/src/udf/java/java_data_converter.h
@@ -55,19 +55,56 @@ public:
 // promotes to a JavaGlobalRef for storage on the UDF context.
 StatusOr<jobject> build_udf_type_desc(JNIEnv* env, const TypeDescriptor& td, jobject formal_type);
 
+// Per-arg / per-return UdfTypeDesc tree built from a Java reflective Method object.
+// Slots whose SQL type subtree contains no STRUCT are stored as null-handle JavaGlobalRef
+// so callers can pass the vector verbatim to the boxer / writer (which fall back to the
+// non-STRUCT path when a slot is null).
+struct JavaUdfMethodTypeDescs {
+    std::vector<JavaGlobalRef> args;
+    JavaGlobalRef ret = JavaGlobalRef(nullptr);
+};
+
+// Walk Method.getGenericParameterTypes() / getGenericReturnType() in lockstep with the SQL
+// type tree, and produce one UdfTypeDesc Java object per arg / return slot whose subtree
+// contains a STRUCT. Slots with no STRUCT remain null-handle in the result vector.
+//
+// `state_offset` is the number of Java-method parameters that come BEFORE the SQL args.
+// Scalar UDF and UDTF use 0; UDAF `update` has `State` as parameter 0, so state_offset = 1.
+// Varargs handling unwraps the trailing array layer once per overflowing SQL arg.
+//
+// `unwrap_return_array_layer` strips one array layer off the Java reflective return type
+// before pairing it with `sql_return_type`. UDTF needs this because the SQL return type
+// is the per-row element while the Java method returns `T[]` (zero or more rows per call).
+// Scalar UDF and UDAF return types match 1:1 and pass false.
+//
+// The result entries are global refs owned by the caller; null-handle entries are normal
+// (built via JavaGlobalRef(nullptr)) and consume no JVM resources.
+StatusOr<JavaUdfMethodTypeDescs> build_method_udf_type_descs(JNIEnv* env, jobject method_obj,
+                                                             const std::vector<TypeDescriptor>& sql_arg_types,
+                                                             const TypeDescriptor& sql_return_type, int state_offset,
+                                                             bool unwrap_return_array_layer = false);
+
 #define SET_FUNCTION_CONTEXT_ERR(status, context)       \
     if (UNLIKELY(!status.ok())) {                       \
         context->set_error(status.to_string().c_str()); \
     }
 
-StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, const Column* col, int row_num);
+// Build a jvalue for a single-row cell of `col` at `row_num` according to `type_desc`.
+// `type_desc_obj` is an optional UdfTypeDesc Java object (held by caller as a non-owning
+// jobject local/global handle). It is required when `type_desc` contains STRUCT in any
+// position (the formal record class lives in there); when the subtree has no STRUCT it
+// may be null and the existing scalar/array/map paths are used unchanged.
+StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, const Column* col, int row_num,
+                                jobject type_desc_obj = nullptr);
 
 void release_jvalue(bool is_boxed, jvalue val);
 
 // Append a Java-side jvalue to `col`, converting DECIMAL via the column's declared
 // precision/scale. When the value overflows, `error_if_overflow == true` (default)
 // returns an error Status (REPORT_ERROR), `false` appends NULL (OUTPUT_NULL).
+//
+// `type_desc_obj` is an optional UdfTypeDesc Java object; same contract as cast_to_jvalue.
 Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, jvalue val,
-                     bool error_if_overflow = true);
-Status check_type_matched(const TypeDescriptor& type_desc, jobject val);
+                     bool error_if_overflow = true, jobject type_desc_obj = nullptr);
+Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject type_desc_obj = nullptr);
 } // namespace starrocks

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -681,6 +681,16 @@ struct JavaUDAFSharedContext {
     JavaGlobalRef states_add_method = nullptr;
     JavaGlobalRef states_remove_method = nullptr;
     JavaGlobalRef states_clear_method = nullptr;
+
+    // Per-argument UdfTypeDesc Java objects mirroring the SQL TypeDescriptor of each
+    // UDAF arg (read by `update`). Slots whose type subtree contains no STRUCT are
+    // null-handle. Built once at shared-context construction by walking
+    // update.getGenericParameterTypes() (with state_offset=1 for the leading State arg).
+    std::vector<JavaGlobalRef> update_arg_type_descs;
+    // UdfTypeDesc for `finalize`'s return type when the subtree contains a STRUCT;
+    // null-handle otherwise. Used by the UDAF finalize / batch_finalize paths to
+    // route through the unified UDFHelper.writeResult drain.
+    JavaGlobalRef finalize_return_type_desc = nullptr;
 };
 
 // Per-aggregator UDAF context stored as FunctionContext::THREAD_LOCAL.

--- a/be/test/udf/java/java_data_converter_test.cpp
+++ b/be/test/udf/java/java_data_converter_test.cpp
@@ -1126,4 +1126,305 @@ TEST_F(DataConverterTest, convert_to_boxed_array_struct_input) {
     env->DeleteLocalRef(res[0]);
 }
 
+namespace {
+// Resolve a UdfTestSupport static method as a java.lang.reflect.Method object.
+// Used by the build_method_udf_type_descs tests below to drive the helper with
+// concrete UDAF / UDTF method shapes without standing up a real UDF classloader.
+jobject reflected_test_support_method(JNIEnv* env, const char* method_name, const char* signature) {
+    jclass support_cls = env->FindClass("com/starrocks/udf/UdfTestSupport");
+    EXPECT_NE(support_cls, nullptr);
+    if (support_cls == nullptr) return nullptr;
+    jmethodID mid = env->GetStaticMethodID(support_cls, method_name, signature);
+    EXPECT_NE(mid, nullptr) << method_name;
+    jobject method_obj = env->ToReflectedMethod(support_cls, mid, JNI_TRUE);
+    env->DeleteLocalRef(support_cls);
+    return method_obj;
+}
+
+// Read UdfTypeDesc.logicalType field via the cached jfieldID.
+jint read_logical_type(JVMFunctionHelper& helper, JNIEnv* env, jobject desc) {
+    return env->GetIntField(desc, env->GetFieldID(helper.udf_type_desc_class(), "logicalType", "I"));
+}
+} // namespace
+
+// build_method_udf_type_descs short-circuits when no STRUCT appears anywhere in
+// the signature: returns one null-handle entry per SQL arg and a null-handle ret.
+// Skips the JNI walk over Method.getGenericParameterTypes entirely.
+TEST_F(DataConverterTest, build_method_udf_type_descs_no_struct_short_circuit) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    // Any method handle works since we early-return before reading it.
+    jobject method = reflected_test_support_method(
+            env, "udafUpdateWithStruct",
+            "(Lcom/starrocks/udf/UdfTestSupport$State;Lcom/starrocks/udf/UdfTestStructRecord;)V");
+    ASSERT_NE(method, nullptr);
+    LOCAL_REF_GUARD(method);
+
+    // SQL signature: udf(INT, BIGINT) -> VARCHAR — no STRUCT anywhere.
+    std::vector<TypeDescriptor> args = {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_BIGINT)};
+    TypeDescriptor ret(TYPE_VARCHAR);
+
+    ASSIGN_OR_ASSERT_FAIL(JavaUdfMethodTypeDescs descs,
+                          build_method_udf_type_descs(env, method, args, ret, /*state_offset=*/0));
+    ASSERT_EQ(2u, descs.args.size());
+    EXPECT_EQ(nullptr, descs.args[0].handle());
+    EXPECT_EQ(nullptr, descs.args[1].handle());
+    EXPECT_EQ(nullptr, descs.ret.handle());
+}
+
+// UDAF shape: state_offset=1 makes the helper skip the leading State parameter
+// and start pairing SQL args at parameter index 1. Verifies the SQL-arg
+// UdfTypeDesc carries the correct STRUCT recordClass; return desc is suppressed
+// here by passing a TYPE_UNKNOWN sentinel (the production UDAF path uses this
+// to avoid walking update.getGenericReturnType() which is `void`).
+TEST_F(DataConverterTest, build_method_udf_type_descs_udaf_state_offset) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    // void udafUpdateWithStruct(State state, UdfTestStructRecord record)
+    jobject method = reflected_test_support_method(
+            env, "udafUpdateWithStruct",
+            "(Lcom/starrocks/udf/UdfTestSupport$State;Lcom/starrocks/udf/UdfTestStructRecord;)V");
+    ASSERT_NE(method, nullptr);
+    LOCAL_REF_GUARD(method);
+
+    std::vector<TypeDescriptor> args = {make_test_struct_typedesc()};
+    // Sentinel return type: TYPE_UNKNOWN — type_subtree_has_struct returns false
+    // and the helper skips the return-type pass for `update` (Java return is void).
+    TypeDescriptor ret = TypeDescriptor();
+
+    ASSIGN_OR_ASSERT_FAIL(JavaUdfMethodTypeDescs descs,
+                          build_method_udf_type_descs(env, method, args, ret, /*state_offset=*/1));
+    ASSERT_EQ(1u, descs.args.size());
+    ASSERT_NE(nullptr, descs.args[0].handle());
+    EXPECT_EQ(static_cast<jint>(TYPE_STRUCT), read_logical_type(helper, env, descs.args[0].handle()));
+    jobject record_class = env->GetObjectField(descs.args[0].handle(), helper.udf_type_desc_record_class_field());
+    LOCAL_REF_GUARD(record_class);
+    ASSERT_NE(nullptr, record_class);
+    jclass expected = test_struct_record_class(env);
+    LOCAL_REF_GUARD(expected);
+    EXPECT_TRUE(env->IsSameObject(record_class, expected));
+    // ret is TYPE_UNKNOWN — return desc must be null (no walk performed).
+    EXPECT_EQ(nullptr, descs.ret.handle());
+}
+
+// UDAF finalize variant: empty SQL args plus a real STRUCT-bearing return type.
+// Confirms the helper builds the return UdfTypeDesc by reading
+// finalize.getGenericReturnType() (List<UdfTestStructRecord>) and the resulting
+// desc carries logicalType=ARRAY with an element child carrying the record class.
+TEST_F(DataConverterTest, build_method_udf_type_descs_udaf_finalize_array_of_struct) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    jobject method = reflected_test_support_method(env, "udafFinalizeArrayOfStruct",
+                                                   "(Lcom/starrocks/udf/UdfTestSupport$State;)Ljava/util/List;");
+    ASSERT_NE(method, nullptr);
+    LOCAL_REF_GUARD(method);
+
+    TypeDescriptor ret = TypeDescriptor::create_array_type(make_test_struct_typedesc());
+    ASSIGN_OR_ASSERT_FAIL(JavaUdfMethodTypeDescs descs,
+                          build_method_udf_type_descs(env, method, /*sql_arg_types=*/{}, ret, /*state_offset=*/1));
+    EXPECT_TRUE(descs.args.empty());
+    ASSERT_NE(nullptr, descs.ret.handle());
+    EXPECT_EQ(static_cast<jint>(TYPE_ARRAY), read_logical_type(helper, env, descs.ret.handle()));
+
+    jobjectArray children =
+            (jobjectArray)env->GetObjectField(descs.ret.handle(), helper.udf_type_desc_children_field());
+    LOCAL_REF_GUARD(children);
+    ASSERT_NE(nullptr, children);
+    ASSERT_EQ(1, env->GetArrayLength(children));
+    jobject elem_desc = env->GetObjectArrayElement(children, 0);
+    LOCAL_REF_GUARD(elem_desc);
+    EXPECT_EQ(static_cast<jint>(TYPE_STRUCT), read_logical_type(helper, env, elem_desc));
+    jobject elem_record_class = env->GetObjectField(elem_desc, helper.udf_type_desc_record_class_field());
+    LOCAL_REF_GUARD(elem_record_class);
+    jclass expected = test_struct_record_class(env);
+    LOCAL_REF_GUARD(expected);
+    EXPECT_TRUE(env->IsSameObject(elem_record_class, expected));
+}
+
+// UDTF shape: process(...) returns `T[]` while the SQL return is the per-row
+// element type. unwrap_return_array_layer=true must drop the array layer off
+// the formal return so getRecordComponents() lands on the record class, not
+// the array class (Class<Record[]>).
+TEST_F(DataConverterTest, build_method_udf_type_descs_udtf_unwrap_return_array) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    // UdfTestStructRecord[] udtfProcessReturnsRecordArray(UdfTestStructRecord)
+    jobject method = reflected_test_support_method(
+            env, "udtfProcessReturnsRecordArray",
+            "(Lcom/starrocks/udf/UdfTestStructRecord;)[Lcom/starrocks/udf/UdfTestStructRecord;");
+    ASSERT_NE(method, nullptr);
+    LOCAL_REF_GUARD(method);
+
+    std::vector<TypeDescriptor> args = {make_test_struct_typedesc()};
+    // SQL return = STRUCT (per-row element). Java return = StructRecord[].
+    TypeDescriptor ret = make_test_struct_typedesc();
+
+    ASSIGN_OR_ASSERT_FAIL(JavaUdfMethodTypeDescs descs,
+                          build_method_udf_type_descs(env, method, args, ret, /*state_offset=*/0,
+                                                      /*unwrap_return_array_layer=*/true));
+    ASSERT_EQ(1u, descs.args.size());
+    ASSERT_NE(nullptr, descs.args[0].handle());
+    EXPECT_EQ(static_cast<jint>(TYPE_STRUCT), read_logical_type(helper, env, descs.args[0].handle()));
+    ASSERT_NE(nullptr, descs.ret.handle());
+    EXPECT_EQ(static_cast<jint>(TYPE_STRUCT), read_logical_type(helper, env, descs.ret.handle()));
+
+    // The unwrap must yield Class<UdfTestStructRecord>, not Class<UdfTestStructRecord[]>.
+    jobject record_class = env->GetObjectField(descs.ret.handle(), helper.udf_type_desc_record_class_field());
+    LOCAL_REF_GUARD(record_class);
+    ASSERT_NE(nullptr, record_class);
+    jclass expected = test_struct_record_class(env);
+    LOCAL_REF_GUARD(expected);
+    EXPECT_TRUE(env->IsSameObject(record_class, expected));
+}
+
+// Regression coverage for the bug fix that made build_method_udf_type_descs
+// honor the `unwrap_return_array_layer` flag: without the unwrap, the helper
+// would feed Class<Record[]> into build_udf_type_desc and then
+// getRecordComponents() returns null — the helper must propagate that as an
+// InternalError. Drives the helper with unwrap=false on the same UDTF-shaped
+// method to confirm the path is wired.
+TEST_F(DataConverterTest, build_method_udf_type_descs_struct_return_without_unwrap_fails) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    jobject method = reflected_test_support_method(
+            env, "udtfProcessReturnsRecordArray",
+            "(Lcom/starrocks/udf/UdfTestStructRecord;)[Lcom/starrocks/udf/UdfTestStructRecord;");
+    ASSERT_NE(method, nullptr);
+    LOCAL_REF_GUARD(method);
+
+    std::vector<TypeDescriptor> args = {make_test_struct_typedesc()};
+    TypeDescriptor ret = make_test_struct_typedesc();
+    auto status_or = build_method_udf_type_descs(env, method, args, ret, /*state_offset=*/0,
+                                                 /*unwrap_return_array_layer=*/false);
+    ASSERT_FALSE(status_or.ok())
+            << "build_method_udf_type_descs should reject Class<Record[]> for a STRUCT SQL return when unwrap=false";
+}
+
+// cast_to_jvalue STRUCT path: per-row materialization of a record from a
+// StructColumn cell, used by UDTF process(). Verifies the returned jvalue is a
+// non-null record instance whose components match the column row.
+TEST_F(DataConverterTest, cast_to_jvalue_struct_per_row) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    // Build the per-arg UdfTypeDesc from a method shape — same path UDTF uses.
+    jobject method = reflected_test_support_method(
+            env, "udtfProcessReturnsRecordArray",
+            "(Lcom/starrocks/udf/UdfTestStructRecord;)[Lcom/starrocks/udf/UdfTestStructRecord;");
+    ASSERT_NE(method, nullptr);
+    LOCAL_REF_GUARD(method);
+    TypeDescriptor td = make_test_struct_typedesc();
+    ASSIGN_OR_ASSERT_FAIL(JavaUdfMethodTypeDescs descs,
+                          build_method_udf_type_descs(env, method, {td}, td, /*state_offset=*/0,
+                                                      /*unwrap_return_array_layer=*/true));
+    ASSERT_NE(descs.args[0].handle(), nullptr);
+
+    // Two-row STRUCT column with a null on row 1 to also exercise the null-row branch.
+    auto col = ColumnHelper::create_column(td, /*nullable=*/true);
+    col->append_datum(DatumStruct{Datum(int32_t{42}), Datum(Slice("answer"))});
+    col->append_nulls(1);
+
+    // Row 0 — populated.
+    ASSIGN_OR_ASSERT_FAIL(jvalue v0, cast_to_jvalue(td, /*is_boxed=*/true, col.get(), 0, descs.args[0].handle()));
+    jobject v0_obj = v0.l;
+    LOCAL_REF_GUARD(v0_obj);
+    ASSERT_NE(nullptr, v0_obj);
+    jclass record_cls = test_struct_record_class(env);
+    LOCAL_REF_GUARD(record_cls);
+    EXPECT_TRUE(env->IsInstanceOf(v0_obj, record_cls));
+    jmethodID key_acc = env->GetMethodID(record_cls, "key", "()Ljava/lang/Integer;");
+    jobject key_box = env->CallObjectMethod(v0_obj, key_acc);
+    LOCAL_REF_GUARD(key_box);
+    EXPECT_EQ(42, helper.valint32_t(key_box));
+
+    // Row 1 — null. cast_to_jvalue must short-circuit to {.l = nullptr} via the
+    // NullableColumn prologue, without reading the per-row record_class.
+    ASSIGN_OR_ASSERT_FAIL(jvalue v1, cast_to_jvalue(td, /*is_boxed=*/true, col.get(), 1, descs.args[0].handle()));
+    EXPECT_EQ(nullptr, v1.l);
+}
+
+// cast_to_jvalue STRUCT requires a non-null type_desc_obj — the formal record
+// class lives there. Production callers (UDTF process) always supply it; this
+// guards the explicit error if a future caller forgets.
+TEST_F(DataConverterTest, cast_to_jvalue_struct_requires_type_desc) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    (void)helper;
+
+    TypeDescriptor td = make_test_struct_typedesc();
+    auto col = ColumnHelper::create_column(td, /*nullable=*/true);
+    col->append_datum(DatumStruct{Datum(int32_t{1}), Datum(Slice("x"))});
+    auto status_or = cast_to_jvalue(td, /*is_boxed=*/true, col.get(), 0, /*type_desc_obj=*/nullptr);
+    EXPECT_FALSE(status_or.ok());
+}
+
+// append_jvalue STRUCT path: per-row drain of a record into a StructColumn
+// (UDTF result-write hot path). Builds a record via cast_to_jvalue, then
+// round-trips it through append_jvalue and verifies the resulting column's
+// shape and values.
+TEST_F(DataConverterTest, append_jvalue_struct_per_row_roundtrip) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    jobject method = reflected_test_support_method(
+            env, "udtfProcessReturnsRecordArray",
+            "(Lcom/starrocks/udf/UdfTestStructRecord;)[Lcom/starrocks/udf/UdfTestStructRecord;");
+    ASSERT_NE(method, nullptr);
+    LOCAL_REF_GUARD(method);
+    TypeDescriptor td = make_test_struct_typedesc();
+    ASSIGN_OR_ASSERT_FAIL(JavaUdfMethodTypeDescs descs,
+                          build_method_udf_type_descs(env, method, {td}, td, /*state_offset=*/0,
+                                                      /*unwrap_return_array_layer=*/true));
+
+    auto src = ColumnHelper::create_column(td, /*nullable=*/true);
+    src->append_datum(DatumStruct{Datum(int32_t{7}), Datum(Slice("seven"))});
+    ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(td, /*is_boxed=*/true, src.get(), 0, descs.args[0].handle()));
+    jobject val_obj = val.l;
+    LOCAL_REF_GUARD(val_obj);
+    ASSERT_NE(nullptr, val_obj);
+
+    auto dst = ColumnHelper::create_column(td, /*nullable=*/true);
+    ASSERT_OK(append_jvalue(td, /*is_box=*/true, dst.get(), val,
+                            /*error_if_overflow=*/true, descs.ret.handle()));
+    ASSERT_EQ(1u, dst->size());
+    EXPECT_EQ("{key:7,value:'seven'}", dst->debug_item(0));
+}
+
+// check_type_matched STRUCT path: UDTF result-row validator. Accepts the
+// declared record class and rejects an unrelated runtime class.
+TEST_F(DataConverterTest, check_type_matched_struct) {
+    auto& helper = JVMFunctionHelper::getInstance();
+    auto* env = helper.getEnv();
+
+    jobject method = reflected_test_support_method(
+            env, "udtfProcessReturnsRecordArray",
+            "(Lcom/starrocks/udf/UdfTestStructRecord;)[Lcom/starrocks/udf/UdfTestStructRecord;");
+    ASSERT_NE(method, nullptr);
+    LOCAL_REF_GUARD(method);
+    TypeDescriptor td = make_test_struct_typedesc();
+    ASSIGN_OR_ASSERT_FAIL(JavaUdfMethodTypeDescs descs,
+                          build_method_udf_type_descs(env, method, {td}, td, /*state_offset=*/0,
+                                                      /*unwrap_return_array_layer=*/true));
+
+    // Build a real record instance via cast_to_jvalue.
+    auto src = ColumnHelper::create_column(td, /*nullable=*/true);
+    src->append_datum(DatumStruct{Datum(int32_t{1}), Datum(Slice("a"))});
+    ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(td, /*is_boxed=*/true, src.get(), 0, descs.args[0].handle()));
+    jobject val_obj = val.l;
+    LOCAL_REF_GUARD(val_obj);
+    EXPECT_OK(check_type_matched(td, val_obj, descs.ret.handle()));
+
+    // A String is not a UdfTestStructRecord → reject.
+    jstring stranger = env->NewStringUTF("not a record");
+    LOCAL_REF_GUARD(stranger);
+    EXPECT_FALSE(check_type_matched(td, stranger, descs.ret.handle()).ok());
+
+    // Null value short-circuits to OK regardless of type_desc_obj.
+    EXPECT_OK(check_type_matched(td, /*val=*/nullptr, descs.ret.handle()));
+}
+
 } // namespace starrocks

--- a/docs/en/sql-reference/sql-functions/JAVA_UDF.md
+++ b/docs/en/sql-reference/sql-functions/JAVA_UDF.md
@@ -538,12 +538,18 @@ For more information, see [DROP FUNCTION](../sql-statements/Function/DROP_FUNCTI
 
 > **NOTE**
 >
-> Scalar UDFs support nested `ARRAY` and `MAP` parameter/return types,
-> for example `ARRAY<ARRAY<INT>>`, `ARRAY<MAP<INT, STRING>>`, and
-> `MAP<INT, ARRAY<STRING>>`. The leaf element type must still be one of
+> Scalar UDFs, UDAFs, and UDTFs all support nested `ARRAY`, `MAP`, and
+> `STRUCT` parameter/return types — including arbitrary nesting such as
+> `ARRAY<ARRAY<INT>>`, `ARRAY<MAP<INT, STRING>>`,
+> `MAP<INT, ARRAY<STRING>>`, `STRUCT<a INT, b ARRAY<STRING>>`, and
+> `ARRAY<STRUCT<a INT, b STRING>>`. The leaf element type must still be one of
 > the scalar types listed below. Because of Java type erasure, the Java
-> method signature only needs the raw `java.util.List` / `java.util.Map`;
-> StarRocks drives the per-row conversion from the SQL signature.
+> method signature only needs the raw `java.util.List` / `java.util.Map` for
+> ARRAY / MAP slots whose subtree contains no STRUCT; StarRocks drives the
+> per-row conversion from the SQL signature. STRUCT slots, on the other
+> hand, must be bound to a concrete Java `record` class so the analyzer
+> can preserve the formal record type through the JNI boundary (see
+> [STRUCT type binding](#struct-type-binding) below).
 
 | SQL TYPE                                       | Java TYPE             |
 | ---------------------------------------------- | --------------------- |
@@ -560,6 +566,7 @@ For more information, see [DROP FUNCTION](../sql-statements/Function/DROP_FUNCTI
 | DATETIME                                       | java.time.LocalDateTime |
 | ARRAY                                          | java.util.List        |
 | Map                                            | java.util.Map         |
+| STRUCT                                         | a Java `record` class declared by the UDF author |
 
 > **NOTE**
 >
@@ -571,6 +578,105 @@ For more information, see [DROP FUNCTION](../sql-statements/Function/DROP_FUNCTI
 >
 > - `OUTPUT_NULL` (default): the offending row is written as `NULL`.
 > - `REPORT_ERROR`: the query aborts with an `ArithmeticException`.
+
+### STRUCT type binding
+
+`STRUCT` parameters and return types must be bound to a Java `record`
+class (JDK 14+) declared by the UDF author. The mapping is positional:
+
+- The record's component count must match the SQL `STRUCT` field count.
+- Each component's type must match the corresponding SQL field type by
+  position; component names are not enforced (Java identifiers cannot
+  represent every legal SQL field name, and CREATE FUNCTION binds by
+  position regardless of the session's `STRUCT_CAST_BY_NAME` setting).
+- Nested `STRUCT` is supported in any position: as a record component,
+  as an `ARRAY` element (`List<MyRecord>`), or as a `MAP` key/value
+  (`Map<String, MyRecord>`).
+
+The same record-class binding applies to scalar UDF, UDAF, and UDTF.
+For UDAF, the record class is supplied for the `update(State, ...)`
+arguments and the `finalize(State)` return type. For UDTF, the record
+class is supplied for the `process(...)` arguments and the
+`TYPE[] process(...)` element return type.
+
+#### Scalar UDF example
+
+```java
+public record Address(String street, Integer zip) {}
+
+public record AddressOut(String full, Integer region) {}
+
+public class AddrUdf {
+    public AddressOut evaluate(Address addr) {
+        return new AddressOut(addr.street() + " #" + addr.zip(), addr.zip() / 1000);
+    }
+}
+```
+
+```sql
+CREATE FUNCTION addr_udf(struct<street string, zip int>)
+RETURNS struct<`full` string, region int>
+PROPERTIES (
+    "symbol" = "com.example.AddrUdf",
+    "type" = "StarrocksJar",
+    "file" = "http://localhost:8080/addr_udf.jar"
+);
+```
+
+#### UDAF example
+
+```java
+public record Item(String name, Integer qty) {}
+
+public record TopItem(String name, Long total) {}
+
+public class TopItemAgg {
+    public static class State {
+        // serialization elided for brevity
+        public int serializeLength() { return 0; }
+    }
+    public State create() { return new State(); }
+    public void destroy(State state) {}
+    public void update(State state, Item item) { /* ... */ }
+    public void serialize(State state, java.nio.ByteBuffer buf) { /* ... */ }
+    public void merge(State state, java.nio.ByteBuffer buf) { /* ... */ }
+    public TopItem finalize(State state) { return new TopItem("a", 0L); }
+}
+```
+
+```sql
+CREATE AGGREGATE FUNCTION top_item_agg(struct<name string, qty int>)
+RETURNS struct<name string, total bigint>
+PROPERTIES (
+    "symbol" = "com.example.TopItemAgg",
+    "type" = "StarrocksJar",
+    "file" = "http://localhost:8080/top_item_agg.jar"
+);
+```
+
+#### UDTF example
+
+```java
+public record Pair(String key, Integer value) {}
+
+public class ExplodePairs {
+    public Pair[] process(java.util.Map<String, Integer> m) {
+        return m.entrySet().stream()
+                .map(e -> new Pair(e.getKey(), e.getValue()))
+                .toArray(Pair[]::new);
+    }
+}
+```
+
+```sql
+CREATE TABLE FUNCTION explode_pairs(map<string, int>)
+RETURNS struct<`key` string, `value` int>
+PROPERTIES (
+    "symbol" = "com.example.ExplodePairs",
+    "type" = "StarrocksJar",
+    "file" = "http://localhost:8080/explode_pairs.jar"
+);
+```
 
 ## Parameter settings
 

--- a/docs/ja/sql-reference/sql-functions/JAVA_UDF.md
+++ b/docs/ja/sql-reference/sql-functions/JAVA_UDF.md
@@ -538,13 +538,19 @@ DROP [GLOBAL] FUNCTION <function_name>(arg_type [, ...]);
 
 > **NOTE**
 >
-> スカラー UDF はネストされた `ARRAY` および `MAP` のパラメータ/リターン
-> タイプをサポートします。例えば `ARRAY<ARRAY<INT>>`、
-> `ARRAY<MAP<INT, STRING>>`、`MAP<INT, ARRAY<STRING>>` などです。
-> 葉ノードの要素型は引き続き下表のスカラー型である必要があります。
-> Java の型消去のため、Java メソッドシグネチャには raw 型の
-> `java.util.List` / `java.util.Map` を指定するだけで十分で、
-> 行ごとの変換は SQL シグネチャに基づいて StarRocks 側で行われます。
+> スカラー UDF、UDAF、UDTF はすべて、ネストされた `ARRAY`、`MAP`、
+> `STRUCT` のパラメータ/リターンタイプをサポートします。任意のネストも
+> 可能で、例えば `ARRAY<ARRAY<INT>>`、`ARRAY<MAP<INT, STRING>>`、
+> `MAP<INT, ARRAY<STRING>>`、`STRUCT<a INT, b ARRAY<STRING>>`、
+> `ARRAY<STRUCT<a INT, b STRING>>` などです。葉ノードの要素型は
+> 引き続き下表のスカラー型である必要があります。Java の型消去のため、
+> サブツリーに STRUCT を含まない ARRAY / MAP スロットでは、Java メソッド
+> シグネチャに raw 型の `java.util.List` / `java.util.Map` を指定するだけで
+> 十分で、行ごとの変換は SQL シグネチャに基づいて StarRocks 側で行われます。
+> 一方、STRUCT スロットは具体的な Java `record` クラスへバインドする必要が
+> あり、これによりアナライザは JNI 境界を越えて正式な record 型を保持
+> できます (詳細は下記の [STRUCT 型バインディング](#struct-型バインディング)
+> を参照)。
 
 | SQL TYPE                                       | Java TYPE             |
 | ---------------------------------------------- | --------------------- |
@@ -561,6 +567,7 @@ DROP [GLOBAL] FUNCTION <function_name>(arg_type [, ...]);
 | DATETIME                                       | java.time.LocalDateTime |
 | ARRAY                                          | java.util.List        |
 | Map                                            | java.util.Map         |
+| STRUCT                                         | UDF 作成者が宣言した Java `record` クラス |
 
 > **NOTE**
 >
@@ -571,6 +578,108 @@ DROP [GLOBAL] FUNCTION <function_name>(arg_type [, ...]);
 >
 > - `OUTPUT_NULL`（既定）: 該当行は `NULL` として書き込まれます。
 > - `REPORT_ERROR`: クエリは `ArithmeticException` エラーで中断されます。
+
+### STRUCT 型バインディング
+
+`STRUCT` のパラメータ/リターンタイプは、UDF 作成者が宣言した
+Java `record` クラス (JDK 14+) にバインドする必要があります。
+バインディングは位置ベースで行われます:
+
+- record の構成要素数は SQL `STRUCT` のフィールド数と一致しなければ
+  なりません。
+- 各構成要素の型は、対応する位置の SQL フィールド型と一致しなければ
+  なりません。構成要素名は強制されません (Java 識別子では合法な
+  SQL フィールド名をすべて表現できないため。CREATE FUNCTION は
+  位置でバインドし、セッション変数 `STRUCT_CAST_BY_NAME` の影響は
+  受けません)。
+- ネストした `STRUCT` は任意の位置でサポートされます: 別の record
+  の構成要素として、`ARRAY` の要素 (`List<MyRecord>`) として、
+  あるいは `MAP` のキー/値 (`Map<String, MyRecord>`) として。
+
+同じ record クラスバインディング規則は、スカラー UDF、UDAF、UDTF の
+すべてに適用されます。UDAF では `update(State, ...)` の引数と
+`finalize(State)` の戻り値の record クラスが指定されます。UDTF では
+`process(...)` の引数と `TYPE[] process(...)` の要素戻り値の record
+クラスが指定されます。
+
+#### スカラー UDF の例
+
+```java
+public record Address(String street, Integer zip) {}
+
+public record AddressOut(String full, Integer region) {}
+
+public class AddrUdf {
+    public AddressOut evaluate(Address addr) {
+        return new AddressOut(addr.street() + " #" + addr.zip(), addr.zip() / 1000);
+    }
+}
+```
+
+```sql
+CREATE FUNCTION addr_udf(struct<street string, zip int>)
+RETURNS struct<`full` string, region int>
+PROPERTIES (
+    "symbol" = "com.example.AddrUdf",
+    "type" = "StarrocksJar",
+    "file" = "http://localhost:8080/addr_udf.jar"
+);
+```
+
+#### UDAF の例
+
+```java
+public record Item(String name, Integer qty) {}
+
+public record TopItem(String name, Long total) {}
+
+public class TopItemAgg {
+    public static class State {
+        // シリアライズ部分は省略
+        public int serializeLength() { return 0; }
+    }
+    public State create() { return new State(); }
+    public void destroy(State state) {}
+    public void update(State state, Item item) { /* ... */ }
+    public void serialize(State state, java.nio.ByteBuffer buf) { /* ... */ }
+    public void merge(State state, java.nio.ByteBuffer buf) { /* ... */ }
+    public TopItem finalize(State state) { return new TopItem("a", 0L); }
+}
+```
+
+```sql
+CREATE AGGREGATE FUNCTION top_item_agg(struct<name string, qty int>)
+RETURNS struct<name string, total bigint>
+PROPERTIES (
+    "symbol" = "com.example.TopItemAgg",
+    "type" = "StarrocksJar",
+    "file" = "http://localhost:8080/top_item_agg.jar"
+);
+```
+
+#### UDTF の例
+
+```java
+public record Pair(String key, Integer value) {}
+
+public class ExplodePairs {
+    public Pair[] process(java.util.Map<String, Integer> m) {
+        return m.entrySet().stream()
+                .map(e -> new Pair(e.getKey(), e.getValue()))
+                .toArray(Pair[]::new);
+    }
+}
+```
+
+```sql
+CREATE TABLE FUNCTION explode_pairs(map<string, int>)
+RETURNS struct<`key` string, `value` int>
+PROPERTIES (
+    "symbol" = "com.example.ExplodePairs",
+    "type" = "StarrocksJar",
+    "file" = "http://localhost:8080/explode_pairs.jar"
+);
+```
 
 ## パラメーター設定
 

--- a/docs/zh/sql-reference/sql-functions/JAVA_UDF.md
+++ b/docs/zh/sql-reference/sql-functions/JAVA_UDF.md
@@ -545,12 +545,16 @@ DROP [GLOBAL] FUNCTION <function_name>(arg_type [, ...]);
 
 > **注意**
 >
-> Scalar UDF 支持嵌套的 `ARRAY` 和 `MAP` 参数/返回类型,例如
+> Scalar UDF、UDAF 和 UDTF 都支持嵌套的 `ARRAY`、`MAP` 和 `STRUCT`
+> 参数/返回类型,包括任意嵌套形式,例如
 > `ARRAY<ARRAY<INT>>`、`ARRAY<MAP<INT, STRING>>`、
-> `MAP<INT, ARRAY<STRING>>`。叶子元素类型仍须为下表列出的标量类型。
-> 由于 Java 泛型擦除,Java 方法签名只需声明原始类型
-> `java.util.List` / `java.util.Map`,StarRocks 会根据 SQL 签名
-> 驱动逐行的类型转换。
+> `MAP<INT, ARRAY<STRING>>`、`STRUCT<a INT, b ARRAY<STRING>>`,以及
+> `ARRAY<STRUCT<a INT, b STRING>>`。叶子元素类型仍须为下表列出的标量类型。
+> 由于 Java 泛型擦除,对于子树中不含 STRUCT 的 ARRAY / MAP 槽,
+> Java 方法签名只需声明原始类型 `java.util.List` / `java.util.Map`,
+> StarRocks 会根据 SQL 签名驱动逐行的类型转换。STRUCT 槽则必须绑定
+> 到一个具体的 Java `record` 类,以便分析器在 JNI 边界处保留正式的
+> record 类型(详见下文 [STRUCT 类型绑定](#struct-类型绑定))。
 
 | SQL TYPE                                       | Java TYPE             |
 | ---------------------------------------------- | --------------------- |
@@ -567,6 +571,7 @@ DROP [GLOBAL] FUNCTION <function_name>(arg_type [, ...]);
 | DATETIME                                       | java.time.LocalDateTime |
 | ARRAY                                          | java.util.List        |
 | Map                                            | java.util.Map         |
+| STRUCT                                         | UDF 作者声明的 Java `record` 类 |
 
 > **说明**
 >
@@ -576,6 +581,103 @@ DROP [GLOBAL] FUNCTION <function_name>(arg_type [, ...]);
 >
 > - `OUTPUT_NULL`（默认）：该行写入 `NULL`。
 > - `REPORT_ERROR`：查询以 `ArithmeticException` 错误终止。
+
+### STRUCT 类型绑定
+
+`STRUCT` 参数和返回类型必须绑定到 UDF 作者声明的 Java `record` 类（JDK 14+）。
+绑定按位置进行：
+
+- record 的成员数必须与 SQL `STRUCT` 字段数一致。
+- 每个成员的类型必须与对应位置的 SQL 字段类型匹配；成员名不强制
+  （Java 标识符无法表达所有合法的 SQL 字段名,且 CREATE FUNCTION
+  按位置绑定,与会话变量 `STRUCT_CAST_BY_NAME` 无关）。
+- 嵌套 `STRUCT` 在任意位置都支持：作为 record 的成员、作为 `ARRAY`
+  的元素 (`List<MyRecord>`)、或作为 `MAP` 的 key/value
+  (`Map<String, MyRecord>`)。
+
+同样的 record 类绑定规则同时适用于 scalar UDF、UDAF 和 UDTF。
+对 UDAF,record 类用于 `update(State, ...)` 的参数和 `finalize(State)`
+的返回类型。对 UDTF,record 类用于 `process(...)` 的参数和
+`TYPE[] process(...)` 的元素返回类型。
+
+#### Scalar UDF 示例
+
+```java
+public record Address(String street, Integer zip) {}
+
+public record AddressOut(String full, Integer region) {}
+
+public class AddrUdf {
+    public AddressOut evaluate(Address addr) {
+        return new AddressOut(addr.street() + " #" + addr.zip(), addr.zip() / 1000);
+    }
+}
+```
+
+```sql
+CREATE FUNCTION addr_udf(struct<street string, zip int>)
+RETURNS struct<`full` string, region int>
+PROPERTIES (
+    "symbol" = "com.example.AddrUdf",
+    "type" = "StarrocksJar",
+    "file" = "http://localhost:8080/addr_udf.jar"
+);
+```
+
+#### UDAF 示例
+
+```java
+public record Item(String name, Integer qty) {}
+
+public record TopItem(String name, Long total) {}
+
+public class TopItemAgg {
+    public static class State {
+        // 序列化代码省略
+        public int serializeLength() { return 0; }
+    }
+    public State create() { return new State(); }
+    public void destroy(State state) {}
+    public void update(State state, Item item) { /* ... */ }
+    public void serialize(State state, java.nio.ByteBuffer buf) { /* ... */ }
+    public void merge(State state, java.nio.ByteBuffer buf) { /* ... */ }
+    public TopItem finalize(State state) { return new TopItem("a", 0L); }
+}
+```
+
+```sql
+CREATE AGGREGATE FUNCTION top_item_agg(struct<name string, qty int>)
+RETURNS struct<name string, total bigint>
+PROPERTIES (
+    "symbol" = "com.example.TopItemAgg",
+    "type" = "StarrocksJar",
+    "file" = "http://localhost:8080/top_item_agg.jar"
+);
+```
+
+#### UDTF 示例
+
+```java
+public record Pair(String key, Integer value) {}
+
+public class ExplodePairs {
+    public Pair[] process(java.util.Map<String, Integer> m) {
+        return m.entrySet().stream()
+                .map(e -> new Pair(e.getKey(), e.getValue()))
+                .toArray(Pair[]::new);
+    }
+}
+```
+
+```sql
+CREATE TABLE FUNCTION explode_pairs(map<string, int>)
+RETURNS struct<`key` string, `value` int>
+PROPERTIES (
+    "symbol" = "com.example.ExplodePairs",
+    "type" = "StarrocksJar",
+    "file" = "http://localhost:8080/explode_pairs.jar"
+);
+```
 
 ## 参数配置
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -513,13 +513,16 @@ public class CreateFunctionAnalyzer {
             mainClass.checkMethodNonStaticAndPublic(method);
             mainClass.checkArgumentCount(method, argsDef.getArgTypes().length, argsDef.isVariadic());
             
-            // Validate parameter types
+            // Validate parameter types — STRUCT support requires threading the Parameter's
+            // parameterized type for nested record-class binding, so use the recursive
+            // scalar-style validator.
             if (argsDef.isVariadic()) {
                 mainClass.checkVarargsParameters(method, argsDef.getArgTypes(), 0);
             } else {
                 for (int i = 0; i < method.getParameters().length; i++) {
                     Parameter p = method.getParameters()[i];
-                    mainClass.checkUdfType(method, argsDef.getArgTypes()[i], p.getType(), p.getName());
+                    mainClass.checkScalarUdfType(method, argsDef.getArgTypes()[i], p.getType(),
+                            p.getParameterizedType(), p.getName());
                 }
             }
         }
@@ -697,48 +700,26 @@ public class CreateFunctionAnalyzer {
         }
 
         private void checkParamUdfType(Method method, Type expType, Parameter p) {
-            checkUdfType(method, expType, p.getType(), p.getName());
+            // UDAF/UDTF args go through this path; STRUCT support requires the formal
+            // generic Java type for record-class binding, so delegate to the same recursive
+            // scalar/array/map/struct validator used by scalar UDF.
+            checkScalarUdfType(method, expType, p.getType(), p.getParameterizedType(), p.getName());
         }
 
         private void checkReturnUdfType(Method method, Type expType) {
-            checkUdfType(method, expType, method.getReturnType(), CreateFunctionStmt.RETURN_FIELD_NAME);
+            // UDAF return type validation. STRUCT is supported via the same recursive
+            // checker the scalar UDF uses.
+            checkScalarUdfType(method, expType, method.getReturnType(), method.getGenericReturnType(),
+                    CreateFunctionStmt.RETURN_FIELD_NAME);
         }
 
         private void checkUdfType(Method method, Type expType, Class<?> ptype, String pname) {
-            Class<?> cls = null;
-            if (expType instanceof ScalarType) {
-                ScalarType scalarType = (ScalarType) expType;
-                cls = PRIMITIVE_TYPE_TO_JAVA_CLASS_TYPE.get(scalarType.getPrimitiveType());
-            } else if (expType instanceof MapType) {
-                cls = Map.class;
-            } else if (expType instanceof ArrayType) {
-                cls = List.class;
-            } else if (expType instanceof StructType) {
-                // v1: STRUCT is supported as a scalar UDF input/return only. UDAF/UDTF
-                // paths route through checkUdfType/checkParamUdfType and need additional
-                // BE plumbing (convert_to_boxed_array does not have access to evaluate
-                // parameter classes for UDAF/UDTF), so reject explicitly.
-                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
-                        String.format("UDF class '%s' method '%s' parameter %s: STRUCT is currently " +
-                                        "supported for scalar UDFs only, not UDAF/UDTF",
-                                clazz.getCanonicalName(), method.getName(), pname));
-                return;
-            } else {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
-                        String.format("UDF class '%s' method '%s' does not support type '%s'",
-                                clazz.getCanonicalName(), method.getName(), expType));
-            }
-            if (cls == null) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
-                        String.format("UDF class '%s' method '%s' does not support type '%s'",
-                                clazz.getCanonicalName(), method.getName(), expType));
-            }
-            if (!cls.equals(ptype)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
-                        String.format("UDF class '%s' method '%s' parameter %s[%s] type does not match %s",
-                                clazz.getCanonicalName(), method.getName(), pname, ptype.getCanonicalName(),
-                                cls.getCanonicalName()));
-            }
+            // Legacy entry point retained for callers that hand only the raw java.lang.Class.
+            // UDTF process() routes through this and needs STRUCT support too — the FE
+            // analyzer can still validate the record-class shape against the Parameter's
+            // parameterized type at the call site (see checkParamUdfType for UDAF and the
+            // direct checkScalarUdfType call for UDTF in analyzeStarrocksJarUdtf).
+            checkScalarUdfType(method, expType, ptype, ptype, pname);
         }
 
         private void checkScalarReturnUdfType(Method method, Type expType) {
@@ -1049,12 +1030,11 @@ public class CreateFunctionAnalyzer {
 
         /**
          * Check varargs parameters for UDAFs and UDTFs.
-         * Uses checkUdfType for type validation with an offset for the first parameter.
-         * UDAF/UDTF only support flat scalar/array/map types, so genericType is unused.
+         * Uses checkScalarUdfType so STRUCT (and nested STRUCT inside ARRAY / MAP) is supported
+         * via the same recursive driver as scalar UDFs.
          */
         private void checkVarargsParameters(Method method, Type[] declaredArgTypes, int paramOffset) {
-            checkVarargsParametersGeneric(method, declaredArgTypes, paramOffset,
-                    (m, expType, ptype, gen, pname) -> checkUdfType(m, expType, ptype, pname));
+            checkVarargsParametersGeneric(method, declaredArgTypes, paramOffset, this::checkScalarUdfType);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
@@ -1674,4 +1674,254 @@ public class CreateFunctionStmtAnalyzerTest {
             Config.enable_udf = false;
         }
     }
+
+    // ----- STRUCT support for UDAF / UDTF -----------------------------------
+    //
+    // Scalar UDF struct support shipped first; these tests cover the recursive
+    // analyzer reuse for UDAF (update + finalize) and UDTF (process), plus
+    // STRUCT-bearing types nested inside ARRAY / MAP arg / return slots.
+
+    public static class StructAggEval {
+        public static class State {
+            public int serializeLength() {
+                return 0;
+            }
+        }
+
+        public State create() {
+            return new State();
+        }
+
+        public void destroy(State state) {
+        }
+
+        public final void update(State state, Address addr) {
+        }
+
+        public void serialize(State state, java.nio.ByteBuffer buff) {
+        }
+
+        public void merge(State state, java.nio.ByteBuffer buffer) {
+        }
+
+        public AddressOut finalize(State state) {
+            return null;
+        }
+    }
+
+    private void mockUdafClazz(Class<?> mainClazz, Class<?> stateClazz) {
+        new MockUp<CreateFunctionAnalyzer>() {
+            @Mock
+            public String computeMd5(CreateFunctionStmt stmt) {
+                return "0xff";
+            }
+        };
+        new MockUp<UDFInternalClassLoader>() {
+            @Mock
+            public final Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (name.contains("$")) {
+                    return stateClazz;
+                }
+                return mainClazz;
+            }
+        };
+    }
+
+    @Test
+    public void testStructUDAFRecord() {
+        try {
+            Config.enable_udf = true;
+            mockUdafClazz(StructAggEval.class, StructAggEval.State.class);
+            String sql = "CREATE AGGREGATE FUNCTION ABC.struct_agg(struct<street string, zip int>) \n"
+                    + "RETURNS struct<`full` string, region int> \n"
+                    + "properties (\n"
+                    + "    \"symbol\" = \"symbol\",\n"
+                    + "    \"type\" = \"StarrocksJar\",\n"
+                    + "    \"file\" = \"http://localhost:8080/\"\n"
+                    + ");";
+            CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(sql, 32).get(0);
+            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+        } finally {
+            Config.enable_udf = false;
+        }
+    }
+
+    public static class StructListAggEval {
+        public static class State {
+            public int serializeLength() {
+                return 0;
+            }
+        }
+
+        public State create() {
+            return new State();
+        }
+
+        public void destroy(State state) {
+        }
+
+        public final void update(State state, List<Address> addrs) {
+        }
+
+        public void serialize(State state, java.nio.ByteBuffer buff) {
+        }
+
+        public void merge(State state, java.nio.ByteBuffer buffer) {
+        }
+
+        public List<AddressOut> finalize(State state) {
+            return null;
+        }
+    }
+
+    @Test
+    public void testStructUDAFArrayOfRecord() {
+        try {
+            Config.enable_udf = true;
+            mockUdafClazz(StructListAggEval.class, StructListAggEval.State.class);
+            String sql = "CREATE AGGREGATE FUNCTION ABC.struct_list_agg(array<struct<street string, zip int>>) \n"
+                    + "RETURNS array<struct<`full` string, region int>> \n"
+                    + "properties (\n"
+                    + "    \"symbol\" = \"symbol\",\n"
+                    + "    \"type\" = \"StarrocksJar\",\n"
+                    + "    \"file\" = \"http://localhost:8080/\"\n"
+                    + ");";
+            CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(sql, 32).get(0);
+            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+        } finally {
+            Config.enable_udf = false;
+        }
+    }
+
+    public static class StructUdafFieldCountMismatchEval {
+        public static class State {
+            public int serializeLength() {
+                return 0;
+            }
+        }
+
+        public State create() {
+            return new State();
+        }
+
+        public void destroy(State state) {
+        }
+
+        // Address has 2 components but the SQL declares 3 fields.
+        public final void update(State state, Address addr) {
+        }
+
+        public void serialize(State state, java.nio.ByteBuffer buff) {
+        }
+
+        public void merge(State state, java.nio.ByteBuffer buffer) {
+        }
+
+        public AddressOut finalize(State state) {
+            return null;
+        }
+    }
+
+    @Test
+    public void testStructUDAFFieldCountMismatchRejected() {
+        assertThrows(SemanticException.class, () -> {
+            try {
+                Config.enable_udf = true;
+                mockUdafClazz(StructUdafFieldCountMismatchEval.class,
+                        StructUdafFieldCountMismatchEval.State.class);
+                String sql = "CREATE AGGREGATE FUNCTION ABC.bad(struct<a string, b int, c int>) \n"
+                        + "RETURNS struct<`full` string, region int> \n"
+                        + "properties (\n"
+                        + "    \"symbol\" = \"symbol\",\n"
+                        + "    \"type\" = \"StarrocksJar\",\n"
+                        + "    \"file\" = \"http://localhost:8080/\"\n"
+                        + ");";
+                CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(sql, 32).get(0);
+                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+            } finally {
+                Config.enable_udf = false;
+            }
+        });
+    }
+
+    public static class StructUDTF {
+        public AddressOut[] process(Address addr) {
+            return new AddressOut[0];
+        }
+    }
+
+    @Test
+    public void testStructUDTF() {
+        try {
+            Config.enable_udf = true;
+            mockClazz(StructUDTF.class);
+            String sql = "CREATE TABLE FUNCTION ABC.struct_udtf(struct<street string, zip int>) \n"
+                    + "RETURNS struct<`full` string, region int> \n"
+                    + "properties (\n"
+                    + "    \"symbol\" = \"symbol\",\n"
+                    + "    \"type\" = \"StarrocksJar\",\n"
+                    + "    \"file\" = \"http://localhost:8080/\"\n"
+                    + ");";
+            CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(sql, 32).get(0);
+            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+        } finally {
+            Config.enable_udf = false;
+        }
+    }
+
+    public static class StructListUDTF {
+        public AddressOut[] process(List<Address> addrs) {
+            return new AddressOut[0];
+        }
+    }
+
+    @Test
+    public void testStructUDTFArrayOfRecord() {
+        try {
+            Config.enable_udf = true;
+            mockClazz(StructListUDTF.class);
+            String sql = "CREATE TABLE FUNCTION ABC.struct_list_udtf(array<struct<street string, zip int>>) \n"
+                    + "RETURNS struct<`full` string, region int> \n"
+                    + "properties (\n"
+                    + "    \"symbol\" = \"symbol\",\n"
+                    + "    \"type\" = \"StarrocksJar\",\n"
+                    + "    \"file\" = \"http://localhost:8080/\"\n"
+                    + ");";
+            CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(sql, 32).get(0);
+            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+        } finally {
+            Config.enable_udf = false;
+        }
+    }
+
+    public static class StructUdtfFieldCountMismatchEval {
+        public AddressOut[] process(Address addr) {
+            return new AddressOut[0];
+        }
+    }
+
+    @Test
+    public void testStructUDTFFieldCountMismatchRejected() {
+        assertThrows(SemanticException.class, () -> {
+            try {
+                Config.enable_udf = true;
+                mockClazz(StructUdtfFieldCountMismatchEval.class);
+                String sql = "CREATE TABLE FUNCTION ABC.bad(struct<a string, b int, c int>) \n"
+                        + "RETURNS struct<`full` string, region int> \n"
+                        + "properties (\n"
+                        + "    \"symbol\" = \"symbol\",\n"
+                        + "    \"type\" = \"StarrocksJar\",\n"
+                        + "    \"file\" = \"http://localhost:8080/\"\n"
+                        + ");";
+                CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(sql, 32).get(0);
+                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+            } finally {
+                Config.enable_udf = false;
+            }
+        });
+    }
 }

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UdfTestSupport.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UdfTestSupport.java
@@ -22,14 +22,20 @@ import java.util.Map;
  * input/output paths.
  *
  * <p>Each method exists only so the BE can fetch a concretely-parameterized
- * {@code java.lang.reflect.Type} via {@code Method.getGenericReturnType()},
- * which is what {@code build_udf_type_desc} consumes when building the
- * {@link UdfTypeDesc} tree for ARRAY / MAP / STRUCT slots. The method bodies
- * are never invoked.
+ * {@code java.lang.reflect.Type} via {@code Method.getGenericReturnType()}
+ * (and for UDAF / UDTF shapes, the parameter types via
+ * {@code Method.getGenericParameterTypes()}), which is what
+ * {@code build_udf_type_desc} / {@code build_method_udf_type_descs} consume
+ * when building the {@link UdfTypeDesc} tree for ARRAY / MAP / STRUCT slots.
+ * The method bodies are never invoked.
  *
  * <p>Production code does not reference this class.
  */
 public final class UdfTestSupport {
+    /** Standalone scratch state class used by the UDAF method shapes below. */
+    public static final class State {
+    }
+
     private UdfTestSupport() {
     }
 
@@ -46,6 +52,30 @@ public final class UdfTestSupport {
     }
 
     public static List<List<UdfTestStructRecord>> arrayOfArrayOfStruct() {
+        return null;
+    }
+
+    // --- UDAF method shapes ---------------------------------------------
+    //
+    // `update(State, args...)` lets BE tests exercise build_method_udf_type_descs
+    // with state_offset=1 and a STRUCT-bearing SQL argument. The method's own
+    // return is void, mirroring the production UDAF update contract.
+    public static void udafUpdateWithStruct(State state, UdfTestStructRecord record) {
+    }
+
+    // `finalize(State)` returning List<Record> exercises the UDAF finalize path
+    // where the SQL return is array<struct<...>> while the Java return is the
+    // parameterized List itself (no array unwrap needed for UDAF).
+    public static List<UdfTestStructRecord> udafFinalizeArrayOfStruct(State state) {
+        return null;
+    }
+
+    // --- UDTF method shapes ---------------------------------------------
+    //
+    // UDTF's process(...) returns `T[]` where T is the per-row SQL return
+    // element type. Used to verify the unwrap_return_array_layer path in
+    // build_method_udf_type_descs (Class<Record[]> -> Class<Record>).
+    public static UdfTestStructRecord[] udtfProcessReturnsRecordArray(UdfTestStructRecord record) {
         return null;
     }
 }

--- a/test/sql/test_udf/R/test_jvm_struct_udat
+++ b/test/sql/test_udf/R/test_jvm_struct_udat
@@ -1,0 +1,117 @@
+-- name: test_jvm_struct_udat @no_arrow_flight_sql
+CREATE TABLE FUNCTION double_struct(struct<`key` int, `value` string>)
+RETURNS struct<`key` int, `value` string>
+PROPERTIES (
+    "symbol" = "DoubleStructA",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/struct_udat.jar"
+);
+-- result:
+-- !result
+CREATE AGGREGATE FUNCTION struct_agg(struct<`key` int, `value` string>)
+RETURNS array<struct<`key` int, `value` string>>
+PROPERTIES (
+    "symbol" = "StructAgg",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/struct_udat.jar"
+);
+-- result:
+-- !result
+CREATE TABLE t_struct (
+    id INT,
+    stru1 struct<`key` int, `value` string>
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 4
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_struct SELECT generate_series, row(generate_series, generate_series) FROM TABLE(generate_series(1,  5));
+-- result:
+-- !result
+insert into t_struct SELECT generate_series, row(generate_series, generate_series) FROM TABLE(generate_series(1,  5));
+-- result:
+-- !result
+select * from t_struct,double_struct(stru1) order by 1, 2, 3;
+-- result:
+1	{"key":1,"value":"1"}	{"key":1,"value":"1"}
+1	{"key":1,"value":"1"}	{"key":1,"value":"1"}
+1	{"key":1,"value":"1"}	{"key":1,"value":"1"}
+1	{"key":1,"value":"1"}	{"key":1,"value":"1"}
+2	{"key":2,"value":"2"}	{"key":2,"value":"2"}
+2	{"key":2,"value":"2"}	{"key":2,"value":"2"}
+2	{"key":2,"value":"2"}	{"key":2,"value":"2"}
+2	{"key":2,"value":"2"}	{"key":2,"value":"2"}
+3	{"key":3,"value":"3"}	{"key":3,"value":"3"}
+3	{"key":3,"value":"3"}	{"key":3,"value":"3"}
+3	{"key":3,"value":"3"}	{"key":3,"value":"3"}
+3	{"key":3,"value":"3"}	{"key":3,"value":"3"}
+4	{"key":4,"value":"4"}	{"key":4,"value":"4"}
+4	{"key":4,"value":"4"}	{"key":4,"value":"4"}
+4	{"key":4,"value":"4"}	{"key":4,"value":"4"}
+4	{"key":4,"value":"4"}	{"key":4,"value":"4"}
+5	{"key":5,"value":"5"}	{"key":5,"value":"5"}
+5	{"key":5,"value":"5"}	{"key":5,"value":"5"}
+5	{"key":5,"value":"5"}	{"key":5,"value":"5"}
+5	{"key":5,"value":"5"}	{"key":5,"value":"5"}
+-- !result
+set streaming_preaggregation_mode = "force_streaming";
+-- result:
+-- !result
+select struct_agg(stru1) from t_struct;
+-- result:
+[{"key":1,"value":"1"},{"key":1,"value":"1"},{"key":2,"value":"2"},{"key":2,"value":"2"},{"key":3,"value":"3"},{"key":3,"value":"3"},{"key":4,"value":"4"},{"key":4,"value":"4"},{"key":5,"value":"5"},{"key":5,"value":"5"}]
+-- !result
+select id, struct_agg(stru1) from t_struct group by 1 order by 1;
+-- result:
+1	[{"key":1,"value":"1"},{"key":1,"value":"1"}]
+2	[{"key":2,"value":"2"},{"key":2,"value":"2"}]
+3	[{"key":3,"value":"3"},{"key":3,"value":"3"}]
+4	[{"key":4,"value":"4"},{"key":4,"value":"4"}]
+5	[{"key":5,"value":"5"},{"key":5,"value":"5"}]
+-- !result
+set streaming_preaggregation_mode = "auto";
+-- result:
+-- !result
+select struct_agg(stru1) from t_struct;
+-- result:
+[{"key":1,"value":"1"},{"key":1,"value":"1"},{"key":2,"value":"2"},{"key":2,"value":"2"},{"key":3,"value":"3"},{"key":3,"value":"3"},{"key":4,"value":"4"},{"key":4,"value":"4"},{"key":5,"value":"5"},{"key":5,"value":"5"}]
+-- !result
+select id, struct_agg(stru1) from t_struct group by 1 order by 1;
+-- result:
+1	[{"key":1,"value":"1"},{"key":1,"value":"1"}]
+2	[{"key":2,"value":"2"},{"key":2,"value":"2"}]
+3	[{"key":3,"value":"3"},{"key":3,"value":"3"}]
+4	[{"key":4,"value":"4"},{"key":4,"value":"4"}]
+5	[{"key":5,"value":"5"},{"key":5,"value":"5"}]
+-- !result
+set streaming_preaggregation_mode = "auto";
+-- result:
+-- !result
+select struct_agg(stru1) from t_struct;
+-- result:
+[{"key":1,"value":"1"},{"key":1,"value":"1"},{"key":2,"value":"2"},{"key":2,"value":"2"},{"key":3,"value":"3"},{"key":3,"value":"3"},{"key":4,"value":"4"},{"key":4,"value":"4"},{"key":5,"value":"5"},{"key":5,"value":"5"}]
+-- !result
+select id, struct_agg(stru1) from t_struct group by 1 order by 1;
+-- result:
+1	[{"key":1,"value":"1"},{"key":1,"value":"1"}]
+2	[{"key":2,"value":"2"},{"key":2,"value":"2"}]
+3	[{"key":3,"value":"3"},{"key":3,"value":"3"}]
+4	[{"key":4,"value":"4"},{"key":4,"value":"4"}]
+5	[{"key":5,"value":"5"},{"key":5,"value":"5"}]
+-- !result
+set new_planner_agg_stage=1;
+-- result:
+-- !result
+select struct_agg(stru1) from t_struct;
+-- result:
+[{"key":1,"value":"1"},{"key":1,"value":"1"},{"key":2,"value":"2"},{"key":2,"value":"2"},{"key":3,"value":"3"},{"key":3,"value":"3"},{"key":4,"value":"4"},{"key":4,"value":"4"},{"key":5,"value":"5"},{"key":5,"value":"5"}]
+-- !result
+select id, struct_agg(stru1) from t_struct group by 1 order by 1;
+-- result:
+1	[{"key":1,"value":"1"},{"key":1,"value":"1"}]
+2	[{"key":2,"value":"2"},{"key":2,"value":"2"}]
+3	[{"key":3,"value":"3"},{"key":3,"value":"3"}]
+4	[{"key":4,"value":"4"},{"key":4,"value":"4"}]
+5	[{"key":5,"value":"5"},{"key":5,"value":"5"}]
+-- !result

--- a/test/sql/test_udf/T/test_jvm_struct_udat
+++ b/test/sql/test_udf/T/test_jvm_struct_udat
@@ -1,0 +1,48 @@
+-- name: test_jvm_struct_udat @no_arrow_flight_sql
+
+CREATE TABLE FUNCTION double_struct(struct<`key` int, `value` string>)
+RETURNS struct<`key` int, `value` string>
+PROPERTIES (
+    "symbol" = "DoubleStructA",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/struct_udat.jar"
+);
+
+CREATE AGGREGATE FUNCTION struct_agg(struct<`key` int, `value` string>)
+RETURNS array<struct<`key` int, `value` string>>
+PROPERTIES (
+    "symbol" = "StructAgg",
+    "type" = "StarrocksJar",
+    "file" = "${udf_url}/starrocks-jdbc/struct_udat.jar"
+);
+
+CREATE TABLE t_struct (
+    id INT,
+    stru1 struct<`key` int, `value` string>
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 4
+PROPERTIES ("replication_num" = "1");
+
+insert into t_struct SELECT generate_series, row(generate_series, generate_series) FROM TABLE(generate_series(1,  5));
+insert into t_struct SELECT generate_series, row(generate_series, generate_series) FROM TABLE(generate_series(1,  5));
+
+
+select * from t_struct,double_struct(stru1) order by 1, 2, 3;
+
+set streaming_preaggregation_mode = "force_streaming";
+select struct_agg(stru1) from t_struct;
+select id, struct_agg(stru1) from t_struct group by 1 order by 1;
+
+set streaming_preaggregation_mode = "auto";
+select struct_agg(stru1) from t_struct;
+select id, struct_agg(stru1) from t_struct group by 1 order by 1;
+
+
+set streaming_preaggregation_mode = "auto";
+select struct_agg(stru1) from t_struct;
+select id, struct_agg(stru1) from t_struct group by 1 order by 1;
+
+set new_planner_agg_stage=1;
+select struct_agg(stru1) from t_struct;
+select id, struct_agg(stru1) from t_struct group by 1 order by 1;


### PR DESCRIPTION
## Why I'm doing:

Extend the per-arg / return UdfTypeDesc plumbing introduced for scalar UDF in #72620 to UDAF (update / finalize) and UDTF (process). The recursion mirrors the SQL TypeDescriptor and captures the formal Java record class at every STRUCT slot via Method.getGenericParameterTypes() / getGenericReturnType(); ARRAY<STRUCT>, MAP<*,STRUCT>, and nested STRUCT all work uniformly with the same machinery.

## What I'm doing:

BE
- Extract `build_method_udf_type_descs` into java_data_converter and reuse it from scalar UDF, UDAF, and UDTF context construction. UDAF passes state_offset=1 for the leading State parameter; UDTF passes unwrap_return_array_layer=true because process() returns `T[]` while the SQL return type is the per-row element.
- Add `update_arg_type_descs` and `finalize_return_type_desc` to JavaUDAFSharedContext; thread them into update_batch / update_batch_selectively / update_batch_single_state / convert_to_serialize_format and route batch_finalize through UDFHelper.writeResult when the return subtree contains STRUCT. The update-method call deliberately suppresses the helper's return-type pass since update() is `void` while the UDAF's declared SQL return can be ARRAY/MAP/STRUCT.
- Build per-arg / return UdfTypeDesc trees on JavaUDTFState and extend cast_to_jvalue / append_jvalue / check_type_matched with an optional `jobject type_desc_obj` so per-row STRUCT inputs and outputs can resolve their formal record class. Single-row STRUCT inputs reuse UDFHelper.createBoxedStructArray with num_rows=1; single-row STRUCT outputs walk RecordComponent.getAccessor().invoke() per field.

FE
- CreateFunctionAnalyzer for UDAF / UDTF now routes through checkScalarUdfType instead of the legacy checkUdfType, so STRUCT (including STRUCT inside ARRAY / MAP) is validated with the same recursive record-class binding the scalar UDF path uses. The varargs path for UDAF / UDTF is updated likewise.

Tests
- New analyzer tests cover STRUCT param/return for UDAF and UDTF, ARRAY-of-STRUCT variants, and field-count-mismatch rejection.
- New SQL integration test test/sql/test_udf/{T,R}/test_jvm_struct_udat exercises a UDTF (struct -> struct) and a UDAF (struct -> array<struct>) end-to-end across streaming / one-stage / two-stage agg paths.

Docs
- JAVA_UDF.md (en/zh/ja): expand the type-mapping NOTE to cover UDAF and UDTF, document the Java `record` binding contract, and add worked scalar UDF / UDAF / UDTF examples.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
