### PR TITLE
[BugFix] fix JNI local-ref leak in JDBCScanner::_init_jdbc_scanner

### DIFF
--- a/be/src/exec/jdbc_scanner.cpp
+++ b/be/src/exec/jdbc_scanner.cpp
@@ -204,7 +204,7 @@ Status JDBCScanner::_init_jdbc_scanner() {
 
     auto jdbc_scanner_cls = env->FindClass(JDBC_SCANNER_CLASS_NAME);
     _jdbc_scanner_cls = std::make_unique<JVMClass>(env->NewGlobalRef(jdbc_scanner_cls));
-    LOCAL_REF_GUARD_ENV(env, jdbc_scanner);
+    LOCAL_REF_GUARD_ENV(env, jdbc_scanner_cls);
 
     DCHECK(_jdbc_scanner_cls != nullptr);
     // init jmethod


### PR DESCRIPTION
## Why I'm doing:

Fix the bug found by https://github.com/trueeyu/scan_sr_bugs/blob/main/references/rules_common.md CMN-1

`JDBCScanner::_init_jdbc_scanner` calls `FindClass` for the JDBC scanner class and then guards the wrong local reference: the `LOCAL_REF_GUARD_ENV` macro was passed `jdbc_scanner` (already guarded a few lines above after `CallObjectMethod`) instead of the newly-created `jdbc_scanner_cls` from `FindClass`.

Effect: every scanner initialization leaks one JNI local reference for the jclass into the BE worker thread's local-ref table. The leak is small per call (~16–32 bytes of slot bookkeeping; the jclass itself is held alive by its ClassLoader anyway), but BE worker threads stay attached to the JVM long-term, so the local-ref table grows monotonically across queries. Under heavy long-running JDBC catalog use, the local-ref table can eventually fail to grow.

There is no double-`DeleteLocalRef`: `LOCAL_REF_GUARD_ENV` (`be/src/udf/java/java_udf.h:342`) nulls the captured variable after delete and the second guard sees nullptr and skips.

The correct pattern is right there in the same file at `_init_jdbc_bridge` (lines 89–92), where `jdbc_bridge_cls` is guarded after `FindClass`.

## What I'm doing:

Change `LOCAL_REF_GUARD_ENV(env, jdbc_scanner)` on line 207 to `LOCAL_REF_GUARD_ENV(env, jdbc_scanner_cls)` so the `FindClass` result is correctly released at scope exit.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

A regression test would require either (a) standing up the full JDBCBridge JAR + a real driver to exercise `_init_jdbc_scanner`, or (b) a portable JNI API to inspect the local-ref table count, neither of which is available at unit-test scope. Reviewed by code inspection against the matching pattern at `_init_jdbc_bridge` in the same file.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4