### PR TITLE
[BugFix] harden url_coding.cpp exception paths and null returns

### DIFF
--- a/be/src/base/url_coding.cpp
+++ b/be/src/base/url_coding.cpp
@@ -172,7 +172,8 @@ StatusOr<std::string> url_decode(const std::string& in) {
         return Status::InvalidArgument("invalid encoding in URL");
     }
     DeferOp guard([&] { curl_free(decoded_value); });
-    return std::string(decoded_value);
+    // Use the explicit length so embedded NULs in the decoded payload are preserved.
+    return std::string(decoded_value, decoded_length);
 }
 
 } // namespace starrocks

--- a/be/src/base/url_coding.cpp
+++ b/be/src/base/url_coding.cpp
@@ -156,10 +156,10 @@ bool base64_decode(const std::string& in, std::string* out) {
 }
 
 // refers to https://stackoverflow.com/questions/154536/encode-decode-urls-in-c
-std::string url_encode(const std::string& decoded) {
+StatusOr<std::string> url_encode(const std::string& decoded) {
     char* encoded_value = curl_easy_escape(nullptr, decoded.c_str(), static_cast<int>(decoded.length()));
     if (encoded_value == nullptr) {
-        return {};
+        return Status::InternalError("curl_easy_escape returned NULL (libcurl out of memory)");
     }
     DeferOp guard([&] { curl_free(encoded_value); });
     return std::string(encoded_value);

--- a/be/src/base/url_coding.cpp
+++ b/be/src/base/url_coding.cpp
@@ -23,6 +23,8 @@
 #include <memory>
 #include <sstream>
 
+#include "base/utility/defer_op.h"
+
 namespace starrocks {
 static void encode_base64_internal(const std::string& in, std::string* out, const unsigned char* basis, bool padding) {
     size_t len = in.size();
@@ -143,35 +145,34 @@ static inline int64_t base64_decode(const char* data, size_t length, char* decod
 }
 
 bool base64_decode(const std::string& in, std::string* out) {
-    char* tmp = new char[in.length()];
-
-    int64_t len = base64_decode(in.c_str(), in.length(), tmp);
+    out->resize(in.length());
+    int64_t len = base64_decode(in.c_str(), in.length(), out->data());
     if (len < 0) {
-        delete[] tmp;
+        out->clear();
         return false;
     }
-    out->assign(tmp, len);
-    delete[] tmp;
+    out->resize(len);
     return true;
 }
 
 // refers to https://stackoverflow.com/questions/154536/encode-decode-urls-in-c
 std::string url_encode(const std::string& decoded) {
-    const auto encoded_value = curl_easy_escape(nullptr, decoded.c_str(), static_cast<int>(decoded.length()));
-    std::string result(encoded_value);
-    curl_free(encoded_value);
-    return result;
+    char* encoded_value = curl_easy_escape(nullptr, decoded.c_str(), static_cast<int>(decoded.length()));
+    if (encoded_value == nullptr) {
+        return {};
+    }
+    DeferOp guard([&] { curl_free(encoded_value); });
+    return std::string(encoded_value);
 }
 
 StatusOr<std::string> url_decode(const std::string& in) {
     int decoded_length = 0;
-    const auto decoded_value = curl_easy_unescape(nullptr, in.c_str(), static_cast<int>(in.length()), &decoded_length);
+    char* decoded_value = curl_easy_unescape(nullptr, in.c_str(), static_cast<int>(in.length()), &decoded_length);
     if (decoded_value == nullptr) {
         return Status::InvalidArgument("invalid encoding in URL");
     }
-    std::string result(decoded_value);
-    curl_free(decoded_value);
-    return result;
+    DeferOp guard([&] { curl_free(decoded_value); });
+    return std::string(decoded_value);
 }
 
 } // namespace starrocks

--- a/be/src/base/url_coding.h
+++ b/be/src/base/url_coding.h
@@ -32,7 +32,8 @@ void base64_encode(const std::string& in, std::string* out);
 bool base64_decode(const std::string& in, std::string* out);
 
 // refers to https://stackoverflow.com/questions/154536/encode-decode-urls-in-c
-std::string url_encode(const std::string& decoded);
+// Returns InternalError if the underlying libcurl call returns NULL (OOM).
+StatusOr<std::string> url_encode(const std::string& decoded);
 
 // Utility method to decode a string that was URL-encoded. Returns
 // true unless the string could not be correctly decoded.

--- a/be/test/base/url_coding_test.cpp
+++ b/be/test/base/url_coding_test.cpp
@@ -50,4 +50,80 @@ TEST(UrlCodingTest, UrlDecodeEdgeCases) {
     EXPECT_EQ(res.value(), "a+b");
 }
 
+TEST(UrlCodingTest, UrlEncodeBasic) {
+    EXPECT_EQ(url_encode("abc"), "abc");
+    // Reserved characters get percent-encoded.
+    EXPECT_EQ(url_encode("a b!c"), "a%20b%21c");
+    EXPECT_EQ(url_encode("a&b=c?d"), "a%26b%3Dc%3Fd");
+}
+
+TEST(UrlCodingTest, UrlEncodeEmpty) {
+    // Must not crash on empty input. libcurl returns NULL or an empty buffer
+    // depending on version; either way the wrapper should produce "".
+    EXPECT_EQ(url_encode(""), "");
+}
+
+TEST(UrlCodingTest, UrlEncodeDecodeRoundtrip) {
+    const std::string cases[] = {
+            "",
+            "plain",
+            "a b!c",
+            "a&b=c?d",
+            "/path/to/resource?x=1&y=2",
+            "testStreamLoad\xe6\xa1\x8c", // UTF-8 "桌"
+            std::string("\x00\x01\x02 binary", 10),
+    };
+    for (const auto& original : cases) {
+        std::string encoded = url_encode(original);
+        auto decoded = url_decode(encoded);
+        ASSERT_TRUE(decoded.ok()) << "round-trip failed for: " << original;
+        EXPECT_EQ(decoded.value(), original);
+    }
+}
+
+TEST(Base64CodingTest, EncodeDecodeRoundtrip) {
+    const std::string cases[] = {
+            "",
+            "f",          // 1 byte  -> 2 chars + 2 pads
+            "fo",         // 2 bytes -> 3 chars + 1 pad
+            "foo",        // 3 bytes -> no pad
+            "foobar",
+            "Hello, World!",
+            std::string("\x00\x01\x02\xff\xfe", 5), // binary
+    };
+    for (const auto& original : cases) {
+        std::string encoded;
+        base64_encode(original, &encoded);
+        std::string decoded;
+        ASSERT_TRUE(base64_decode(encoded, &decoded)) << "decode failed for: " << original;
+        EXPECT_EQ(decoded, original);
+    }
+}
+
+TEST(Base64CodingTest, DecodeInvalidInputClearsOut) {
+    // Pre-fill *out so we can verify it gets cleared when decode fails — the
+    // contract is that on failure the caller observes no half-written buffer.
+    std::string out = "PRE-EXISTING";
+    // '*' is not a valid base64 character (decoding_table[*] == -2).
+    EXPECT_FALSE(base64_decode("abc*def", &out));
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(Base64CodingTest, DecodeReplacesExistingContent) {
+    // base64_decode is replace-semantics, not append. A non-empty *out
+    // must be overwritten, not appended to.
+    std::string encoded;
+    base64_encode("foo", &encoded);
+
+    std::string out = "garbage that should be wiped";
+    ASSERT_TRUE(base64_decode(encoded, &out));
+    EXPECT_EQ(out, "foo");
+}
+
+TEST(Base64CodingTest, DecodeEmptyInput) {
+    std::string out = "leftover";
+    ASSERT_TRUE(base64_decode("", &out));
+    EXPECT_EQ(out, "");
+}
+
 } // namespace starrocks

--- a/be/test/base/url_coding_test.cpp
+++ b/be/test/base/url_coding_test.cpp
@@ -84,12 +84,10 @@ TEST(UrlCodingTest, UrlEncodeDecodeRoundtrip) {
 TEST(Base64CodingTest, EncodeDecodeRoundtrip) {
     const std::string cases[] = {
             "",
-            "f",          // 1 byte  -> 2 chars + 2 pads
-            "fo",         // 2 bytes -> 3 chars + 1 pad
-            "foo",        // 3 bytes -> no pad
-            "foobar",
-            "Hello, World!",
-            std::string("\x00\x01\x02\xff\xfe", 5), // binary
+            "f",                                                               // 1 byte  -> 2 chars + 2 pads
+            "fo",                                                              // 2 bytes -> 3 chars + 1 pad
+            "foo",                                                             // 3 bytes -> no pad
+            "foobar", "Hello, World!", std::string("\x00\x01\x02\xff\xfe", 5), // binary
     };
     for (const auto& original : cases) {
         std::string encoded;

--- a/be/test/base/url_coding_test.cpp
+++ b/be/test/base/url_coding_test.cpp
@@ -51,16 +51,24 @@ TEST(UrlCodingTest, UrlDecodeEdgeCases) {
 }
 
 TEST(UrlCodingTest, UrlEncodeBasic) {
-    EXPECT_EQ(url_encode("abc"), "abc");
+    auto r = url_encode("abc");
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(r.value(), "abc");
     // Reserved characters get percent-encoded.
-    EXPECT_EQ(url_encode("a b!c"), "a%20b%21c");
-    EXPECT_EQ(url_encode("a&b=c?d"), "a%26b%3Dc%3Fd");
+    r = url_encode("a b!c");
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(r.value(), "a%20b%21c");
+    r = url_encode("a&b=c?d");
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(r.value(), "a%26b%3Dc%3Fd");
 }
 
 TEST(UrlCodingTest, UrlEncodeEmpty) {
-    // Must not crash on empty input. libcurl returns NULL or an empty buffer
-    // depending on version; either way the wrapper should produce "".
-    EXPECT_EQ(url_encode(""), "");
+    // Must not crash on empty input. libcurl returns an empty buffer
+    // for empty input on the versions we ship, which encodes to "".
+    auto r = url_encode("");
+    ASSERT_TRUE(r.ok());
+    EXPECT_EQ(r.value(), "");
 }
 
 TEST(UrlCodingTest, UrlEncodeDecodeRoundtrip) {
@@ -74,8 +82,9 @@ TEST(UrlCodingTest, UrlEncodeDecodeRoundtrip) {
             std::string("\x00\x01\x02 binary", 10),
     };
     for (const auto& original : cases) {
-        std::string encoded = url_encode(original);
-        auto decoded = url_decode(encoded);
+        auto encoded = url_encode(original);
+        ASSERT_TRUE(encoded.ok()) << "encode failed for: " << original;
+        auto decoded = url_decode(encoded.value());
         ASSERT_TRUE(decoded.ok()) << "round-trip failed for: " << original;
         EXPECT_EQ(decoded.value(), original);
     }


### PR DESCRIPTION
## Why I'm doing:

Fix the bug found by https://github.com/trueeyu/scan_sr_bugs/blob/main/references/rules_common.md CMN-1

Four latent issues in `be/src/base/url_coding.cpp`:

1. **`base64_decode` leaks on `bad_alloc`.** A raw `new char[in.length()]` was followed by `out->assign(tmp, len)`; if the `assign` allocation throws, the `delete[]` afterward is skipped and the temp buffer leaks.
2. **`url_encode` / `url_decode` leak the libcurl buffer on `bad_alloc`.** `curl_easy_escape` / `curl_easy_unescape` return a libcurl-owned buffer that must be freed via `curl_free`. The old code constructed a `std::string` first and then called `curl_free`; if the `std::string` constructor throws, `curl_free` is skipped.
3. **`url_encode` did not check for a NULL return from `curl_easy_escape`.** libcurl can return NULL on OOM (the `url_decode` sibling already checked, but `url_encode` did not). Feeding NULL into `std::string` is undefined behavior and would crash the BE. Switching `url_encode` to `StatusOr<std::string>` lets that case surface as an `InternalError` instead of a silent empty string.
4. **`url_decode` truncated at embedded NULs.** `curl_easy_unescape` writes the decoded length to an out parameter precisely because the decoded payload may legitimately contain `\0` bytes (e.g. input `"%00..."`). The wrapper was building `std::string(decoded_value)` which falls back to `strlen` and silently dropped everything after the first NUL. Any caller that fed the result into a security check (path validation, downstream parser) would see a shortened string — a classic null-byte truncation.

## What I'm doing:

- `base64_decode`: drop the temp buffer; resize `*out` to the upper bound, decode into `out->data()`, then resize down to the actual length. On failure clear `*out` so callers see no half-written content. The function's contract stays "replace `*out`", which is what the original `assign` already did.
- `url_encode` / `url_decode`: wrap `curl_free` in `DeferOp` so it runs on every exit path including exception unwind.
- `url_encode`: change return type to `StatusOr<std::string>` and return `Status::InternalError` on libcurl OOM. The single in-tree caller (`HiveUtils::column_value` in `be/src/connector/utils.cpp`) already returns `StatusOr<std::string>`, so its `return url_encode(...)` sites propagate the error verbatim with no source change needed.
- `url_decode`: pass the libcurl-reported `decoded_length` to the `std::string` constructor so embedded NULs survive.
- Add tests: base64 encode/decode round-trip (incl. padding + binary), url encode/decode round-trip (incl. UTF-8 + binary-with-leading-NUL), invalid-base64 clears `*out`, base64_decode replace semantics, empty inputs.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Two observable changes:
- `url_encode` now returns `StatusOr<std::string>` instead of `std::string`. The only in-tree caller propagates this; downstream forks should expect the signature change.
- `url_decode` now preserves bytes after a `\0` in the decoded payload. Callers that previously relied on the silent NUL truncation (intentionally or otherwise) will now see the full decoded buffer.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4