### PR TITLE
[BugFix] Fix flaky BinlogBuilderTest.test_random_commit_abort_multiple_versions

### DIFF
--- a/be/test/storage/binlog_test_base.cpp
+++ b/be/test/storage/binlog_test_base.cpp
@@ -187,6 +187,7 @@ void BinlogTestBase::verify_dup_key_multiple_versions(std::vector<DupKeyVersionI
                                                       std::vector<BinlogFileMetaPBPtr> file_metas) {
     if (versions.empty()) {
         ASSERT_TRUE(file_metas.empty());
+        return;
     }
     std::shared_ptr<BinlogFileMergeReader> reader =
             std::make_shared<BinlogFileMergeReader>(binlog_storage_path, file_metas);


### PR DESCRIPTION
## Why I'm doing:

`BinlogBuilderTest.test_random_commit_abort_multiple_versions` is flaky and occasionally crashes with SIGSEGV. The test uses `srand(GetCurrentTimeMicros())` in `SetUp()` and aborts each of 5 versions with probability `1/5`. When all 5 happen to abort (~`(1/5)^5 = 0.032%` per run), `version_info_vec` is empty and `BinlogBuilder::abort()` does not populate `result->metas`, so the metas map is empty as well.

`BinlogTestBase::verify_dup_key_multiple_versions` then enters the empty-input branch but does not return:

```cpp
if (versions.empty()) {
    ASSERT_TRUE(file_metas.empty());   // passes when both are empty -> no early return
}
std::shared_ptr<BinlogFileMergeReader> reader =
        std::make_shared<BinlogFileMergeReader>(binlog_storage_path, file_metas);
Status st = reader->seek(versions[0].version, 0);   // UB: versions[] on empty vector
```

`ASSERT_TRUE` only returns from a void function when the assertion fails. With both vectors empty the assertion passes, control falls through, and `versions[0]` dereferences past the end, producing a SIGSEGV.

Observed crash:

```
*** Aborted at 1778151746 (unix time) ***
PC: @ 0x4c1e0e7 starrocks::BinlogTestBase::verify_dup_key_multiple_versions(
        std::vector<starrocks::DupKeyVersionInfo, ...>&,
        std::__cxx11::basic_string<char, ...>,
        std::vector<std::shared_ptr<...> >)
*** SIGSEGV (@0x0) received by PID 1185978 (TID 0x7f30adfcc100) ***
    @ 0x7f309b299ee8 (libc.so.6+0x99ee7)
    @ 0x7404786       google::(anonymous namespace)::FailureSignalHandler
    @ 0x7f309b242520  (libc.so.6+0x4251f)
    @ 0x4c1e0e7       starrocks::BinlogTestBase::verify_dup_key_multiple_versions(...)
    @ 0x4bab2b0       starrocks::BinlogBuilderTest_test_random_commit_abort_multiple_versions_Test::TestBody()
    @ 0xa1e0641       testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(...)
    @ 0xa1d3eb6       testing::Test::Run()
    @ 0xa1d401e       testing::TestInfo::Run()
    @ 0xa1d4107       testing::TestSuite::Run()
    @ 0xa1d4654       testing::internal::UnitTestImpl::RunAllTests()
    @ 0xa1d4833       testing::UnitTest::Run()
    @ 0x4b2283a       starrocks::init_test_env(int, char**)
    @ 0x4b3173f       main
```

## What I'm doing:

Add an explicit `return` in the empty-input branch of `BinlogTestBase::verify_dup_key_multiple_versions` so the function exits cleanly after the sanity assertion instead of falling through into the unguarded `versions[0]` access.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4