### PR TITLE
[Enhancement] Compaction-aware async vector index build scheduling

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -54,6 +54,7 @@
 #include "storage/lake/vacuum.h"
 #include "storage/lake/vacuum_full.h"
 #include "storage/lake/vector_index_build_task.h"
+#include "storage/tablet_index.h"
 
 namespace starrocks {
 
@@ -170,6 +171,25 @@ bool should_rebuild_pindex(const std::unordered_set<int64>& rebuild_pindex_table
     }
     for (auto tablet_id_in_txn_log : tablet_info.get_tablet_ids_in_txn_logs()) {
         if (rebuild_pindex_tablets.count(tablet_id_in_txn_log) > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Returns true if any VECTOR index has index_build_mode = "async".
+bool is_async_vector_index_table(const TabletMetadataPB& metadata) {
+    if (!metadata.has_schema()) return false;
+    for (const auto& index_pb : metadata.schema().table_indices()) {
+        if (!index_pb.has_index_type() || index_pb.index_type() != VECTOR) {
+            continue;
+        }
+        TabletIndex parsed;
+        if (!parsed.init_from_pb(index_pb).ok()) {
+            continue;
+        }
+        auto it = parsed.common_properties().find("index_build_mode");
+        if (it != parsed.common_properties().end() && it->second == "async") {
             return true;
         }
     }
@@ -384,20 +404,22 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                         if (prealloc_metadata != nullptr) {
                             prealloc_metadata->CopyFrom(*metadata);
                         }
-                        // Report tablet for async vector index build only if this publish's
-                        // new rowset(s) have vector_index_ids (i.e., met the build threshold).
-                        // Old unbuilt rowsets are handled by recovery scan after leader switch.
+                        // Report tablet for async VI build only on async-mode tables
+                        // whose new rowset(s) have vector_index_ids. Sync-mode tables
+                        // build VI inline on write/compaction, so FE dispatch is unneeded.
                         bool new_rowset_has_vi = false;
-                        for (const auto& rowset : metadata->rowsets()) {
-                            int64_t rv = rowset.has_version() ? rowset.version() : 0;
-                            if (rv <= base_version) continue; // existing rowset, not from this publish
-                            for (int i = 0; i < rowset.segment_metas_size(); i++) {
-                                if (rowset.segment_metas(i).vector_index_ids_size() > 0) {
-                                    new_rowset_has_vi = true;
-                                    break;
+                        if (is_async_vector_index_table(*metadata)) {
+                            for (const auto& rowset : metadata->rowsets()) {
+                                int64_t rv = rowset.has_version() ? rowset.version() : 0;
+                                if (rv <= base_version) continue; // existing rowset, not from this publish
+                                for (int i = 0; i < rowset.segment_metas_size(); i++) {
+                                    if (rowset.segment_metas(i).vector_index_ids_size() > 0) {
+                                        new_rowset_has_vi = true;
+                                        break;
+                                    }
                                 }
+                                if (new_rowset_has_vi) break;
                             }
-                            if (new_rowset_has_vi) break;
                         }
                         if (new_rowset_has_vi) {
                             std::lock_guard l(response_mtx);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -650,8 +650,7 @@ TEST_F(LakeServiceTest, test_publish_version_vector_index_dispatch_gate) {
         log.set_tablet_id(tablet_id);
         log.set_partition_id(_partition_id);
         log.set_txn_id(txn_id);
-        log.mutable_op_write()->mutable_rowset()->add_segments(
-                generate_segment_file_for_tablet(tablet_id, txn_id));
+        log.mutable_op_write()->mutable_rowset()->add_segments(generate_segment_file_for_tablet(tablet_id, txn_id));
         log.mutable_op_write()->mutable_rowset()->add_segment_size(1024);
         auto* segment_meta = log.mutable_op_write()->mutable_rowset()->add_segment_metas();
         segment_meta->set_num_rows(100);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -614,6 +614,131 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
     }
 }
 
+// Verifies the publish-time async VI dispatch gate: only async-mode tables
+// (index_build_mode = "async") generate vector_index_build_infos in the publish
+// response. Sync-mode tables build VI inline during write/compaction, so the FE
+// scheduler should not be involved.
+TEST_F(LakeServiceTest, test_publish_version_vector_index_dispatch_gate) {
+    auto make_vi_metadata = [&](bool async_mode) {
+        auto metadata = lake::generate_simple_tablet_metadata(DUP_KEYS);
+        auto* schema = metadata->mutable_schema();
+        auto* idx = schema->add_table_indices();
+        idx->set_index_id(next_id());
+        idx->set_index_type(VECTOR);
+        idx->add_col_unique_id(schema->column(1).unique_id());
+        std::string props_json = R"({"common_properties": {"index_type": "hnsw")";
+        if (async_mode) {
+            props_json += R"(, "index_build_mode": "async")";
+        }
+        props_json += "}}";
+        idx->set_index_properties(props_json);
+        return metadata;
+    };
+
+    auto sync_metadata = make_vi_metadata(false);
+    auto async_metadata = make_vi_metadata(true);
+    auto sync_tablet_id = sync_metadata->id();
+    auto async_tablet_id = async_metadata->id();
+    auto sync_index_id = sync_metadata->schema().table_indices(0).index_id();
+    auto async_index_id = async_metadata->schema().table_indices(0).index_id();
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(sync_metadata));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(async_metadata));
+
+    auto build_vi_txn_log = [&](int64_t tablet_id, int64_t index_id) {
+        auto txn_id = next_id();
+        TxnLog log;
+        log.set_tablet_id(tablet_id);
+        log.set_partition_id(_partition_id);
+        log.set_txn_id(txn_id);
+        log.mutable_op_write()->mutable_rowset()->add_segments(
+                generate_segment_file_for_tablet(tablet_id, txn_id));
+        log.mutable_op_write()->mutable_rowset()->add_segment_size(1024);
+        auto* segment_meta = log.mutable_op_write()->mutable_rowset()->add_segment_metas();
+        segment_meta->set_num_rows(100);
+        segment_meta->add_vector_index_ids(index_id);
+        log.mutable_op_write()->mutable_rowset()->set_data_size(1024);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(100);
+        log.mutable_op_write()->mutable_rowset()->set_overlapped(false);
+        return log;
+    };
+
+    auto sync_log = build_vi_txn_log(sync_tablet_id, sync_index_id);
+    auto async_log = build_vi_txn_log(async_tablet_id, async_index_id);
+    ASSERT_OK(_tablet_mgr->put_txn_log(sync_log));
+    ASSERT_OK(_tablet_mgr->put_txn_log(async_log));
+
+    // Sync-mode table: response should NOT contain vector_index_build_infos.
+    {
+        PublishVersionRequest request;
+        request.set_base_version(1);
+        request.set_new_version(2);
+        request.add_tablet_ids(sync_tablet_id);
+        request.add_txn_ids(sync_log.txn_id());
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(0, response.failed_tablets_size());
+        EXPECT_EQ(0, response.vector_index_build_infos_size())
+                << "sync-mode tablet must not appear in vector_index_build_infos";
+    }
+
+    // Async-mode table: response should contain one vector_index_build_infos entry
+    // pointing at this tablet/version.
+    {
+        PublishVersionRequest request;
+        request.set_base_version(1);
+        request.set_new_version(2);
+        request.add_tablet_ids(async_tablet_id);
+        request.add_txn_ids(async_log.txn_id());
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(0, response.failed_tablets_size());
+        ASSERT_EQ(1, response.vector_index_build_infos_size())
+                << "async-mode tablet with new vector_index_ids must be reported";
+        EXPECT_EQ(async_tablet_id, response.vector_index_build_infos(0).tablet_id());
+        EXPECT_EQ(2, response.vector_index_build_infos(0).version());
+    }
+}
+
+// Async-mode table whose new rowset has no vector_index_ids (segment under
+// threshold) should also not appear in vector_index_build_infos.
+TEST_F(LakeServiceTest, test_publish_version_async_table_no_vi_ids_skipped) {
+    auto metadata = lake::generate_simple_tablet_metadata(DUP_KEYS);
+    auto* schema = metadata->mutable_schema();
+    auto* idx = schema->add_table_indices();
+    idx->set_index_id(next_id());
+    idx->set_index_type(VECTOR);
+    idx->add_col_unique_id(schema->column(1).unique_id());
+    idx->set_index_properties(R"({"common_properties": {"index_type": "hnsw", "index_build_mode": "async"}})");
+    auto tablet_id = metadata->id();
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+    auto txn_id = next_id();
+    TxnLog log;
+    log.set_tablet_id(tablet_id);
+    log.set_partition_id(_partition_id);
+    log.set_txn_id(txn_id);
+    log.mutable_op_write()->mutable_rowset()->add_segments(generate_segment_file_for_tablet(tablet_id, txn_id));
+    log.mutable_op_write()->mutable_rowset()->add_segment_size(1024);
+    auto* segment_meta = log.mutable_op_write()->mutable_rowset()->add_segment_metas();
+    segment_meta->set_num_rows(100);
+    // intentionally do NOT add vector_index_ids: simulates async + below-threshold
+    log.mutable_op_write()->mutable_rowset()->set_data_size(1024);
+    log.mutable_op_write()->mutable_rowset()->set_num_rows(100);
+    log.mutable_op_write()->mutable_rowset()->set_overlapped(false);
+    ASSERT_OK(_tablet_mgr->put_txn_log(log));
+
+    PublishVersionRequest request;
+    request.set_base_version(1);
+    request.set_new_version(2);
+    request.add_tablet_ids(tablet_id);
+    request.add_txn_ids(txn_id);
+    PublishVersionResponse response;
+    _lake_service.publish_version(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(0, response.failed_tablets_size());
+    EXPECT_EQ(0, response.vector_index_build_infos_size())
+            << "async-mode tablet without vector_index_ids must not be reported";
+}
+
 TEST_F(LakeServiceTest, test_publish_version_for_write_batch) {
     // Empty TxnLog
     {

--- a/docs/en/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/FE_parameters/shared_lake_other.md
@@ -633,6 +633,15 @@ This topic introduces the following types of FE configurations:
 - Description: When this item is set to `true`, the system allows Lake tables to use the combined transaction log path for relevant transactions. Available for shared-data clusters only.
 - Introduced in: v3.3.7, v3.4.0, v3.5.0
 
+### `lake_vi_build_load_tail_delay_ms`
+
+- Default: 300000
+- Type: Long
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: Delay before dispatching async vector index build for a tablet whose latest pending version is load-only (no pending compaction product). Within this window, if a new compaction arrives, its version is built together with the tail; compaction products themselves are always dispatched immediately. Only effective in shared-data mode for tables with an async vector index.
+- Introduced in: v4.2.0
+
 ### `lake_repair_metadata_fetch_max_version_batch_size`
 
 - Default: 160

--- a/docs/zh/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/FE_parameters/shared_lake_other.md
@@ -642,6 +642,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 当此项设置为 `true` 时，系统允许 Lake 表使用组合事务日志路径进行相关事务。仅适用于存算分离集群。
 - 引入版本: v3.3.7, v3.4.0, v3.5.0
 
+### `lake_vi_build_load_tail_delay_ms`
+
+- 默认值：300000
+- 类型：Long
+- 单位：毫秒
+- 是否动态：是
+- 描述：存算分离模式下，若某个 tablet 的最新 pending 版本是纯导入（没有未构建的 compaction 产物），调度 async 向量索引构建前等待的时长。延迟窗口内若有新的 compaction 到来，其版本会和 load tail 一起构建；而 compaction 产物本身总是立即派发。仅对声明了 async 向量索引的表生效。
+- 引入版本：v4.2.0
+
 ### `lake_repair_metadata_fetch_max_version_batch_size`
 
 - 默认值：160

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -765,7 +765,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                     List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
                     Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null,
                             vectorIndexBuildInfos);
-                    VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
+                    VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, /* fromCompaction= */ false);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -336,7 +336,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                     List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
                     Utils.aggregatePublishVersion(tablets, Lists.newArrayList(txnInfo), commitVersion - 1, commitVersion,
                                 null, null, computeResource, null, vectorIndexBuildInfos);
-                    VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
+                    VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, /* fromCompaction= */ false);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -879,7 +879,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                     List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
                     Utils.sendAggregatePublishVersionRequest(request, 1, computeResource, null, null,
                             vectorIndexBuildInfos);
-                    VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
+                    VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, /* fromCompaction= */ false);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -520,7 +520,7 @@ public class MergeTabletJob extends TabletReshardJob {
             List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
             Utils.publishVersion(tablets, txnInfo, commitVersion - 1, commitVersion, null, tabletRange,
                     computeResource, null, useAggregatePublish, vectorIndexBuildInfos);
-            VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
+            VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, /* fromCompaction= */ false);
 
             return tabletRange;
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -535,7 +535,7 @@ public class SplitTabletJob extends TabletReshardJob {
             List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
             Utils.publishVersion(tablets, txnInfo, commitVersion - 1, commitVersion, null, tabletRange,
                     computeResource, null, useAggregatePublish, vectorIndexBuildInfos);
-            VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
+            VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, /* fromCompaction= */ false);
 
             return tabletRange;
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3377,6 +3377,14 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static String lake_vector_index_build_warehouse = "default_warehouse";
 
+    @ConfField(mutable = true, comment =
+            "Delay (ms) before dispatching async vector index build for a tablet " +
+                    "whose latest pending version is load-only (no pending compaction product). " +
+                    "Within this window, if a new compaction arrives, its version is built " +
+                    "together with the tail, avoiding wasted VI build on rowsets soon to be " +
+                    "compacted. Compaction products are always dispatched immediately.")
+    public static long lake_vi_build_load_tail_delay_ms = 5 * 60 * 1000L;
+
     @ConfField(mutable = true)
     public static int lake_warehouse_max_compute_replica = 3;
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -121,7 +121,7 @@ public class Utils {
         List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
         publishVersion(tablets, txnInfo, baseVersion, newVersion, null, computeResource,
                 null, useAggregatePublish, vectorIndexBuildInfos);
-        VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
+        VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, /* fromCompaction= */ false);
     }
 
     public static void publishVersionBatch(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
@@ -11,6 +11,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.proto.BuildVectorIndexResponse;
@@ -46,8 +47,33 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
     private static final long DEFAULT_INTERVAL_MS = 5000;
     static final long BUILD_TIMEOUT_MS = 2 * 60 * 60 * 1000L; // 2 hours
 
-    // Pending queue: tabletId -> target visibleVersion
-    private final ConcurrentHashMap<Long, Long> pendingTablets = new ConcurrentHashMap<>();
+    /**
+     * Per-tablet pending state (two-version frontier). See
+     * docs/design/vector_index_compaction_aware_scheduling.md.
+     */
+    static final class Pending {
+        // Newest pending version (load or compaction).
+        final long latestVersion;
+        // Newest pending compaction-produced version; -1 means no compaction in the
+        // pending span.
+        final long latestCompactionVersion;
+        // Time of first enqueue for this tablet (base for safety-net).
+        final long enqueueTimeMs;
+        // Time when builtVersion first caught up to latestCompactionVersion; -1 means
+        // not caught up yet. Used to start the load-tail delay countdown.
+        final long compactionCaughtUpMs;
+
+        Pending(long latestVersion, long latestCompactionVersion, long enqueueTimeMs,
+                long compactionCaughtUpMs) {
+            this.latestVersion = latestVersion;
+            this.latestCompactionVersion = latestCompactionVersion;
+            this.enqueueTimeMs = enqueueTimeMs;
+            this.compactionCaughtUpMs = compactionCaughtUpMs;
+        }
+    }
+
+    // Pending queue: tabletId -> Pending
+    private final ConcurrentHashMap<Long, Pending> pendingTablets = new ConcurrentHashMap<>();
 
     // Running tasks: tabletId -> task
     private final Map<Long, VectorIndexBuildTask> runningTasks = new ConcurrentHashMap<>();
@@ -90,10 +116,34 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
 
     /**
      * Enqueue a tablet for async vector index building.
-     * Called from {@link com.starrocks.transaction.LakeTableTxnStateListener#preWriteCommitLog}.
+     * Called from {@link com.starrocks.transaction.PublishVersionDaemon} after publish.
+     *
+     * @param fromCompaction true iff the originating transaction's source type is
+     *                       {@code LAKE_COMPACTION}. Drives the two-phase scheduling:
+     *                       compaction products are dispatched immediately; load-only
+     *                       tail versions wait for a possible subsequent compaction.
      */
-    public void addPendingTablet(long tabletId, long version) {
-        pendingTablets.merge(tabletId, version, Math::max);
+    public void addPendingTablet(long tabletId, long version, boolean fromCompaction) {
+        long now = System.currentTimeMillis();
+        pendingTablets.compute(tabletId, (k, old) -> {
+            if (old == null) {
+                long lc = fromCompaction ? version : -1L;
+                return new Pending(version, lc, now, -1L);
+            }
+            // Stale / duplicate event — ignore, keep the more advanced entry.
+            if (version < old.latestVersion
+                    && (!fromCompaction || version <= old.latestCompactionVersion)) {
+                return old;
+            }
+            long newLatest = Math.max(old.latestVersion, version);
+            long newLC = old.latestCompactionVersion;
+            if (fromCompaction) {
+                newLC = Math.max(newLC, version);
+            }
+            // A newer compaction frontier resets caughtUp (phase 1 again).
+            long caughtUp = (newLC > old.latestCompactionVersion) ? -1L : old.compactionCaughtUpMs;
+            return new Pending(newLatest, newLC, old.enqueueTimeMs, caughtUp);
+        });
     }
 
     /**
@@ -114,7 +164,7 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
      * returned by BE in the publish response. No-op if scheduler is not initialized
      * or input is empty.
      */
-    public static void onPublishComplete(List<VectorIndexBuildInfoPB> infos) {
+    public static void onPublishComplete(List<VectorIndexBuildInfoPB> infos, boolean fromCompaction) {
         if (infos == null || infos.isEmpty()) {
             return;
         }
@@ -124,7 +174,7 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
         }
         for (VectorIndexBuildInfoPB info : infos) {
             if (info.tabletId != null && info.version != null) {
-                scheduler.addPendingTablet(info.tabletId, info.version);
+                scheduler.addPendingTablet(info.tabletId, info.version, fromCompaction);
             }
         }
     }
@@ -175,10 +225,12 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                                 builtVersion = ((LakeTablet) tablet).getVectorIndexBuiltVersion();
                             }
                             if (builtVersion < visibleVersion) {
-                                // Use merge(Math::max) so a concurrent onPublishComplete
-                                // enqueue with a newer target version is not overwritten
-                                // by recoveryScan's snapshot of visibleVersion.
-                                pendingTablets.merge(tablet.getId(), visibleVersion, Math::max);
+                                // Conservative recovery after leader switch: the in-memory
+                                // compaction-frontier was lost, so treat visibleVersion as the
+                                // frontier to dispatch the backlog immediately (phase 1).
+                                pendingTablets.put(tablet.getId(),
+                                        new Pending(visibleVersion, visibleVersion,
+                                                System.currentTimeMillis(), -1L));
                                 count++;
                             }
                         }
@@ -208,7 +260,7 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
             if (task.isAlreadyBuilding()) {
                 // CN is still building this tablet. Re-enqueue with cooldown
                 // to avoid tight retry loop. Prefer same CN.
-                pendingTablets.merge(tabletId, targetVersion, Math::max);
+                reEnqueuePreservingFrontier(tabletId, targetVersion);
                 preferredNodes.put(tabletId, task.getNode());
                 cooldownUntil.put(tabletId, System.currentTimeMillis() + DEDUP_COOLDOWN_MS);
                 LOG.info("Vector index build in progress on CN (dedup), "
@@ -228,9 +280,10 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                 }
 
                 if (newBuiltVersion < targetVersion) {
-                    // Not all rowsets built yet (batch_limit), re-enqueue for next round.
+                    // Not all rowsets built yet (batch_limit). Re-enqueue preserving
+                    // the frontier so next tick continues from the new builtVersion.
                     // Keep CN affinity so the next round reuses the same CN's cache warmup.
-                    pendingTablets.merge(tabletId, targetVersion, Math::max);
+                    reEnqueuePreservingFrontier(tabletId, targetVersion);
                     preferredNodes.put(tabletId, task.getNode());
                     LOG.info("Async vector index build partial: tablet={}, newBuiltVersion={}, "
                                     + "targetVersion={}, re-enqueued",
@@ -242,7 +295,7 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                 }
             } catch (Exception e) {
                 // Real failure: re-enqueue, let scheduler freely pick any CN.
-                pendingTablets.merge(tabletId, targetVersion, Math::max);
+                reEnqueuePreservingFrontier(tabletId, targetVersion);
                 LOG.warn("Vector index build failed, re-enqueued: tablet={}", tabletId, e);
             }
             it.remove();
@@ -257,11 +310,32 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
             VectorIndexBuildTask task = entry.getValue();
             if (!task.isDone() && now - task.getStartTimeMs() > BUILD_TIMEOUT_MS) {
                 LOG.warn("Vector index build timeout: tablet={}", task.getTabletId());
-                pendingTablets.merge(task.getTabletId(), task.getVersion(), Math::max);
+                reEnqueuePreservingFrontier(task.getTabletId(), task.getVersion());
                 preferredNodes.put(task.getTabletId(), task.getNode());
                 it.remove();
             }
         }
+    }
+
+    /**
+     * Re-enqueue a tablet after a running task ended (failure / dedup / timeout / partial)
+     * without resetting the two-version frontier. If the pending entry was already
+     * cleared (e.g. tablet deleted mid-run), rebuild a minimal entry so the next tick
+     * can still re-evaluate.
+     */
+    private void reEnqueuePreservingFrontier(long tabletId, long targetVersion) {
+        long now = System.currentTimeMillis();
+        pendingTablets.compute(tabletId, (k, old) -> {
+            if (old == null) {
+                // Treat as a fresh enqueue; we have no frontier info, so be conservative
+                // like recoveryScan: latestCompactionVersion = targetVersion to drive an
+                // immediate phase-1 re-dispatch.
+                return new Pending(targetVersion, targetVersion, now, -1L);
+            }
+            long newLatest = Math.max(old.latestVersion, targetVersion);
+            return new Pending(newLatest, old.latestCompactionVersion,
+                    old.enqueueTimeMs, old.compactionCaughtUpMs);
+        });
     }
 
     /**
@@ -279,16 +353,30 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
 
     // ========== Schedule from pending queue ==========
 
+    /**
+     * Two-phase scheduling. For each pending tablet:
+     * <ul>
+     *   <li>Phase 1: {@code built < latestCompactionVersion} → dispatch immediately with
+     *       {@code target = latestCompactionVersion}. Compaction products don't risk
+     *       being swept by an imminent compaction.</li>
+     *   <li>Phase 2: {@code built ≥ latestCompactionVersion} and
+     *       {@code built < latestVersion} → load-only tail. Wait
+     *       {@code lake_vi_build_load_tail_delay_ms}; within that window a new
+     *       compaction event will bump {@code latestCompactionVersion}, sending us
+     *       back to phase 1 and merging the tail into the combined build.</li>
+     * </ul>
+     */
     void scheduleFromPending() {
-        Iterator<Map.Entry<Long, Long>> it = pendingTablets.entrySet().iterator();
+        long now = System.currentTimeMillis();
+        Iterator<Map.Entry<Long, Pending>> it = pendingTablets.entrySet().iterator();
         while (it.hasNext()) {
             if (runningTasks.size() >= MAX_CONCURRENT_TASKS) {
                 break;
             }
 
-            Map.Entry<Long, Long> entry = it.next();
+            Map.Entry<Long, Pending> entry = it.next();
             long tabletId = entry.getKey();
-            long version = entry.getValue();
+            Pending p = entry.getValue();
 
             if (runningTasks.containsKey(tabletId)) {
                 continue;
@@ -297,23 +385,49 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
             // Skip tablets in dedup cooldown (CN reported "already in progress")
             Long cooldown = cooldownUntil.get(tabletId);
             if (cooldown != null) {
-                if (System.currentTimeMillis() < cooldown) {
+                if (now < cooldown) {
                     continue;
                 }
                 cooldownUntil.remove(tabletId);
             }
 
-            // Tablet dropped or metadata gone, discard orphan entry
             LakeTablet tablet = findLakeTablet(tabletId);
             if (tablet == null) {
+                // Tablet / partition / table deleted after enqueue → clean up.
+                it.remove();
+                preferredNodes.remove(tabletId);
+                continue;
+            }
+
+            long built = tablet.getVectorIndexBuiltVersion();
+
+            // (0) Fully caught up — clean up.
+            if (built >= p.latestVersion) {
                 it.remove();
                 continue;
             }
 
-            // Fast check: already built, skip
-            if (tablet.getVectorIndexBuiltVersion() >= version) {
-                it.remove();
-                continue;
+            long target;
+            int phase;
+            if (built < p.latestCompactionVersion) {
+                // (1) Phase 1: compaction frontier not reached.
+                target = p.latestCompactionVersion;
+                phase = 1;
+            } else {
+                // Just caught up on compaction frontier — stamp and return for next tick.
+                if (p.compactionCaughtUpMs < 0) {
+                    pendingTablets.compute(tabletId, (k, cur) -> cur == null ? null :
+                            new Pending(cur.latestVersion, cur.latestCompactionVersion,
+                                    cur.enqueueTimeMs, now));
+                    continue;
+                }
+                // (2) Phase 2: load tail delay window.
+                long idleMs = now - p.compactionCaughtUpMs;
+                if (idleMs < Config.lake_vi_build_load_tail_delay_ms) {
+                    continue;
+                }
+                target = p.latestVersion;
+                phase = 2;
             }
 
             // Prefer the CN that was previously building this tablet (it has
@@ -331,14 +445,16 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
             }
             preferredNodes.remove(tabletId);
 
-            long builtVersion = (tablet != null) ? tablet.getVectorIndexBuiltVersion() : 0;
-            VectorIndexBuildTask task = new VectorIndexBuildTask(node, tabletId, version, builtVersion);
+            VectorIndexBuildTask task = new VectorIndexBuildTask(node, tabletId, target, built);
             try {
                 task.sendRequest();
                 runningTasks.put(tabletId, task);
-                it.remove();
-                LOG.info("Scheduled async vector index build: tablet={}, version={}, node={}",
-                        tabletId, version, node.getId());
+                // Do NOT remove from pending — the task-completion path will handle
+                // progress. If the build ends up partial or fails, the entry (with
+                // preserved frontier) is reused on the next tick.
+                LOG.info("Scheduled async vector index build: tablet={}, target={}, phase={}, "
+                                + "latestVersion={}, latestCompactionVersion={}, node={}",
+                        tabletId, target, phase, p.latestVersion, p.latestCompactionVersion, node.getId());
             } catch (Exception e) {
                 LOG.warn("Failed to send build vector index request: tablet={}", tabletId, e);
             }
@@ -428,7 +544,15 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
         return runningTasks;
     }
 
-    ConcurrentHashMap<Long, Long> getPendingTabletsForTest() {
+    ConcurrentHashMap<Long, Pending> getPendingTabletsForTest() {
         return pendingTablets;
+    }
+
+    Map<Long, Long> getCooldownUntilForTest() {
+        return cooldownUntil;
+    }
+
+    Map<Long, ComputeNode> getPreferredNodesForTest() {
+        return preferredNodes;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
@@ -423,6 +423,8 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
             long built = tablet.getVectorIndexBuiltVersion();
             if (built >= p.latestVersion) {
                 it.remove();
+                preferredNodes.remove(tabletId);
+                cooldownUntil.remove(tabletId);
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
@@ -57,18 +57,23 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
         // Newest pending compaction-produced version; -1 means no compaction in the
         // pending span.
         final long latestCompactionVersion;
-        // Time of first enqueue for this tablet (base for safety-net).
-        final long enqueueTimeMs;
         // Time when builtVersion first caught up to latestCompactionVersion; -1 means
         // not caught up yet. Used to start the load-tail delay countdown.
         final long compactionCaughtUpMs;
 
-        Pending(long latestVersion, long latestCompactionVersion, long enqueueTimeMs,
-                long compactionCaughtUpMs) {
+        Pending(long latestVersion, long latestCompactionVersion, long compactionCaughtUpMs) {
             this.latestVersion = latestVersion;
             this.latestCompactionVersion = latestCompactionVersion;
-            this.enqueueTimeMs = enqueueTimeMs;
             this.compactionCaughtUpMs = compactionCaughtUpMs;
+        }
+
+        /**
+         * Conservative entry for recovery / re-enqueue without prior frontier info:
+         * treat the version as both the load and compaction frontier so it dispatches
+         * immediately in phase 1.
+         */
+        static Pending conservativeImmediate(long version) {
+            return new Pending(version, version, -1L);
         }
     }
 
@@ -124,25 +129,22 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
      *                       tail versions wait for a possible subsequent compaction.
      */
     public void addPendingTablet(long tabletId, long version, boolean fromCompaction) {
-        long now = System.currentTimeMillis();
         pendingTablets.compute(tabletId, (k, old) -> {
             if (old == null) {
                 long lc = fromCompaction ? version : -1L;
-                return new Pending(version, lc, now, -1L);
+                return new Pending(version, lc, -1L);
             }
-            // Stale / duplicate event — ignore, keep the more advanced entry.
-            if (version < old.latestVersion
+            // Fast path: nothing advances → return old, no allocation.
+            if (version <= old.latestVersion
                     && (!fromCompaction || version <= old.latestCompactionVersion)) {
                 return old;
             }
             long newLatest = Math.max(old.latestVersion, version);
-            long newLC = old.latestCompactionVersion;
-            if (fromCompaction) {
-                newLC = Math.max(newLC, version);
-            }
+            long newLC = fromCompaction ? Math.max(old.latestCompactionVersion, version)
+                    : old.latestCompactionVersion;
             // A newer compaction frontier resets caughtUp (phase 1 again).
             long caughtUp = (newLC > old.latestCompactionVersion) ? -1L : old.compactionCaughtUpMs;
-            return new Pending(newLatest, newLC, old.enqueueTimeMs, caughtUp);
+            return new Pending(newLatest, newLC, caughtUp);
         });
     }
 
@@ -226,11 +228,14 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                             }
                             if (builtVersion < visibleVersion) {
                                 // Conservative recovery after leader switch: the in-memory
-                                // compaction-frontier was lost, so treat visibleVersion as the
-                                // frontier to dispatch the backlog immediately (phase 1).
-                                pendingTablets.put(tablet.getId(),
-                                        new Pending(visibleVersion, visibleVersion,
-                                                System.currentTimeMillis(), -1L));
+                                // compaction-frontier was lost. merge with any concurrent
+                                // pending entry to avoid clobbering a more advanced state
+                                // already populated by an in-flight publish.
+                                final long v = visibleVersion;
+                                pendingTablets.merge(tablet.getId(),
+                                        Pending.conservativeImmediate(v),
+                                        (existing, scan) -> existing.latestVersion >= scan.latestVersion
+                                                ? existing : scan);
                                 count++;
                             }
                         }
@@ -324,17 +329,12 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
      * can still re-evaluate.
      */
     private void reEnqueuePreservingFrontier(long tabletId, long targetVersion) {
-        long now = System.currentTimeMillis();
         pendingTablets.compute(tabletId, (k, old) -> {
             if (old == null) {
-                // Treat as a fresh enqueue; we have no frontier info, so be conservative
-                // like recoveryScan: latestCompactionVersion = targetVersion to drive an
-                // immediate phase-1 re-dispatch.
-                return new Pending(targetVersion, targetVersion, now, -1L);
+                return Pending.conservativeImmediate(targetVersion);
             }
             long newLatest = Math.max(old.latestVersion, targetVersion);
-            return new Pending(newLatest, old.latestCompactionVersion,
-                    old.enqueueTimeMs, old.compactionCaughtUpMs);
+            return new Pending(newLatest, old.latestCompactionVersion, old.compactionCaughtUpMs);
         });
     }
 
@@ -391,6 +391,13 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                 cooldownUntil.remove(tabletId);
             }
 
+            // Cheap fast-path: a tablet stamped as caught-up that's still inside the
+            // load-tail delay window won't dispatch this tick. Skip the metastore lookup.
+            if (p.compactionCaughtUpMs >= 0
+                    && now - p.compactionCaughtUpMs < Config.lake_vi_build_load_tail_delay_ms) {
+                continue;
+            }
+
             LakeTablet tablet = findLakeTablet(tabletId);
             if (tablet == null) {
                 // Tablet / partition / table deleted after enqueue → clean up.
@@ -400,34 +407,29 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
             }
 
             long built = tablet.getVectorIndexBuiltVersion();
-
-            // (0) Fully caught up — clean up.
             if (built >= p.latestVersion) {
                 it.remove();
                 continue;
             }
 
             long target;
-            int phase;
             if (built < p.latestCompactionVersion) {
-                // (1) Phase 1: compaction frontier not reached.
                 target = p.latestCompactionVersion;
-                phase = 1;
             } else {
-                // Just caught up on compaction frontier — stamp and return for next tick.
-                if (p.compactionCaughtUpMs < 0) {
+                // Phase 2: load-only tail. On first observation of catch-up, stamp the
+                // timestamp and re-evaluate the delay window in this same tick (idleMs=0
+                // means we still defer, just without a 1-tick lag).
+                long caughtUp = p.compactionCaughtUpMs;
+                if (caughtUp < 0) {
+                    caughtUp = now;
+                    final long stamp = caughtUp;
                     pendingTablets.compute(tabletId, (k, cur) -> cur == null ? null :
-                            new Pending(cur.latestVersion, cur.latestCompactionVersion,
-                                    cur.enqueueTimeMs, now));
-                    continue;
+                            new Pending(cur.latestVersion, cur.latestCompactionVersion, stamp));
                 }
-                // (2) Phase 2: load tail delay window.
-                long idleMs = now - p.compactionCaughtUpMs;
-                if (idleMs < Config.lake_vi_build_load_tail_delay_ms) {
+                if (now - caughtUp < Config.lake_vi_build_load_tail_delay_ms) {
                     continue;
                 }
                 target = p.latestVersion;
-                phase = 2;
             }
 
             // Prefer the CN that was previously building this tablet (it has
@@ -452,9 +454,9 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                 // Do NOT remove from pending — the task-completion path will handle
                 // progress. If the build ends up partial or fails, the entry (with
                 // preserved frontier) is reused on the next tick.
-                LOG.info("Scheduled async vector index build: tablet={}, target={}, phase={}, "
+                LOG.info("Scheduled async vector index build: tablet={}, target={}, "
                                 + "latestVersion={}, latestCompactionVersion={}, node={}",
-                        tabletId, target, phase, p.latestVersion, p.latestCompactionVersion, node.getId());
+                        tabletId, target, p.latestVersion, p.latestCompactionVersion, node.getId());
             } catch (Exception e) {
                 LOG.warn("Failed to send build vector index request: tablet={}", tabletId, e);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
@@ -234,8 +234,21 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                                 final long v = visibleVersion;
                                 pendingTablets.merge(tablet.getId(),
                                         Pending.conservativeImmediate(v),
-                                        (existing, scan) -> existing.latestVersion >= scan.latestVersion
-                                                ? existing : scan);
+                                        (existing, scan) -> {
+                                            if (existing.latestVersion > scan.latestVersion) {
+                                                return existing;
+                                            }
+                                            if (existing.latestVersion < scan.latestVersion) {
+                                                return scan;
+                                            }
+                                            // tie on latestVersion: prefer the higher
+                                            // latestCompactionVersion so recovery's
+                                            // conservative-immediate wins over a load-only
+                                            // entry that raced ahead of the scan.
+                                            return existing.latestCompactionVersion
+                                                    >= scan.latestCompactionVersion
+                                                    ? existing : scan;
+                                        });
                                 count++;
                             }
                         }
@@ -403,6 +416,7 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                 // Tablet / partition / table deleted after enqueue → clean up.
                 it.remove();
                 preferredNodes.remove(tabletId);
+                cooldownUntil.remove(tabletId);
                 continue;
             }
 
@@ -422,9 +436,20 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
                 long caughtUp = p.compactionCaughtUpMs;
                 if (caughtUp < 0) {
                     caughtUp = now;
+                    // Only stamp if the frontier hasn't moved underneath us. A concurrent
+                    // addPendingTablet that advanced latestCompactionVersion (and reset
+                    // caughtUp to -1) must not be overwritten — that race would bury a
+                    // phase-1 tablet under the load-tail delay for up to delay_ms.
+                    final long expectedLC = p.latestCompactionVersion;
                     final long stamp = caughtUp;
-                    pendingTablets.compute(tabletId, (k, cur) -> cur == null ? null :
-                            new Pending(cur.latestVersion, cur.latestCompactionVersion, stamp));
+                    pendingTablets.compute(tabletId, (k, cur) -> {
+                        if (cur == null
+                                || cur.latestCompactionVersion != expectedLC
+                                || cur.compactionCaughtUpMs >= 0) {
+                            return cur;
+                        }
+                        return new Pending(cur.latestVersion, cur.latestCompactionVersion, stamp);
+                    });
                 }
                 if (now - caughtUp < Config.lake_vi_build_load_tail_delay_ms) {
                     continue;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -707,7 +707,13 @@ public class PublishVersionDaemon extends LeaderDaemon {
                             compactionScores, nodeToTablets, computeResource, null, vectorIndexBuildInfos);
                 }
 
-                VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
+                // Batch path: this batch is "from compaction" only when every txn in it
+                // is a LAKE_COMPACTION source. Mixed batches (rare) fall back to false
+                // so the load-tail delay protects against wasted builds.
+                boolean allFromCompaction = !transactionStates.isEmpty() &&
+                        transactionStates.stream().allMatch(
+                                s -> s.getSourceType() == TransactionState.LoadJobSourceType.LAKE_COMPACTION);
+                VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, allFromCompaction);
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 stateBatch.setCompactionScore(tableId, partitionId, quantiles);
                 stateBatch.putBeTablets(partitionId, nodeToTablets);
@@ -1094,7 +1100,9 @@ public class PublishVersionDaemon extends LeaderDaemon {
                 Utils.publishVersion(normalTablets, txnInfo, baseVersion, txnVersion, compactionScores,
                         computeResource, tabletRowNums, useAggregatePublish, vectorIndexBuildInfos);
 
-                VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos);
+                boolean fromCompaction = txnState.getSourceType() ==
+                        TransactionState.LoadJobSourceType.LAKE_COMPACTION;
+                VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, fromCompaction);
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 partitionCommitInfo.setCompactionScore(quantiles);
                 if (!tabletRowNums.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -707,12 +707,10 @@ public class PublishVersionDaemon extends LeaderDaemon {
                             compactionScores, nodeToTablets, computeResource, null, vectorIndexBuildInfos);
                 }
 
-                // Batch path: this batch is "from compaction" only when every txn in it
-                // is a LAKE_COMPACTION source. Mixed batches (rare) fall back to false
-                // so the load-tail delay protects against wasted builds.
+                // Mixed batches (rare) fall back to false so the load-tail delay protects
+                // against wasted builds.
                 boolean allFromCompaction = !transactionStates.isEmpty() &&
-                        transactionStates.stream().allMatch(
-                                s -> s.getSourceType() == TransactionState.LoadJobSourceType.LAKE_COMPACTION);
+                        transactionStates.stream().allMatch(TransactionState::isFromLakeCompaction);
                 VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, allFromCompaction);
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 stateBatch.setCompactionScore(tableId, partitionId, quantiles);
@@ -1100,9 +1098,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
                 Utils.publishVersion(normalTablets, txnInfo, baseVersion, txnVersion, compactionScores,
                         computeResource, tabletRowNums, useAggregatePublish, vectorIndexBuildInfos);
 
-                boolean fromCompaction = txnState.getSourceType() ==
-                        TransactionState.LoadJobSourceType.LAKE_COMPACTION;
-                VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, fromCompaction);
+                VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, txnState.isFromLakeCompaction());
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 partitionCommitInfo.setCompactionScore(quantiles);
                 if (!tabletRowNums.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -1132,6 +1132,10 @@ public class TransactionState implements Writable, GsonPreProcessable {
         return sourceType;
     }
 
+    public boolean isFromLakeCompaction() {
+        return sourceType == LoadJobSourceType.LAKE_COMPACTION;
+    }
+
     public TransactionType getTransactionType() {
         return sourceType == LoadJobSourceType.REPLICATION ? TransactionType.TXN_REPLICATION
                 : TransactionType.TXN_NORMAL;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/vector/VectorIndexBuildSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/vector/VectorIndexBuildSchedulerTest.java
@@ -85,8 +85,7 @@ public class VectorIndexBuildSchedulerTest {
         if (old != null) {
             scheduler.getPendingTabletsForTest().put(tabletId,
                     new VectorIndexBuildScheduler.Pending(
-                            old.latestVersion, old.latestCompactionVersion,
-                            old.enqueueTimeMs, ms));
+                            old.latestVersion, old.latestCompactionVersion, ms));
         }
     }
 
@@ -235,7 +234,7 @@ public class VectorIndexBuildSchedulerTest {
         setupRecoveryScanExpectations(db);
         scheduler.recoveryScan();
 
-        ConcurrentHashMap<Long, Long> pending = getPendingTablets();
+        ConcurrentHashMap<Long, VectorIndexBuildScheduler.Pending> pending = getPendingTablets();
         Assertions.assertEquals(5L, pending.get(2001L).latestVersion);
         Assertions.assertEquals(5L, pending.get(2002L).latestVersion);
     }
@@ -616,7 +615,9 @@ public class VectorIndexBuildSchedulerTest {
         long tabletId = 8001L;
         long version = 12L;
         LakeTablet tablet = new LakeTablet(tabletId);
-        scheduler.addPendingTablet(tabletId, version, false);
+        // fromCompaction=true so we go through phase 1 and dispatch immediately,
+        // exercising the dispatch mechanism without the phase-2 wait.
+        scheduler.addPendingTablet(tabletId, version, true);
         setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
 
         ComputeNode node = Mockito.mock(ComputeNode.class);
@@ -642,7 +643,7 @@ public class VectorIndexBuildSchedulerTest {
 
         scheduler.scheduleFromPending();
 
-        Assertions.assertTrue(getPendingTablets().isEmpty(), "tablet moved out of pending");
+        // Pending entry is intentionally preserved until task-completion path runs.
         Assertions.assertTrue(getRunningTasks().containsKey(tabletId), "task added to runningTasks");
     }
 
@@ -652,7 +653,7 @@ public class VectorIndexBuildSchedulerTest {
         long tabletId = 8002L;
         long version = 5L;
         LakeTablet tablet = new LakeTablet(tabletId);
-        scheduler.addPendingTablet(tabletId, version, false);
+        scheduler.addPendingTablet(tabletId, version, true);
         setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
 
         ComputeNode preferred = Mockito.mock(ComputeNode.class);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/vector/VectorIndexBuildSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/vector/VectorIndexBuildSchedulerTest.java
@@ -61,8 +61,33 @@ public class VectorIndexBuildSchedulerTest {
         return scheduler.getRunningTasksForTest();
     }
 
-    private ConcurrentHashMap<Long, Long> getPendingTablets() {
+    private ConcurrentHashMap<Long, VectorIndexBuildScheduler.Pending> getPendingTablets() {
         return scheduler.getPendingTabletsForTest();
+    }
+
+    private long latestVersion(long tabletId) {
+        VectorIndexBuildScheduler.Pending p = scheduler.getPendingTabletsForTest().get(tabletId);
+        return p == null ? -1 : p.latestVersion;
+    }
+
+    private long latestCompactionVersion(long tabletId) {
+        VectorIndexBuildScheduler.Pending p = scheduler.getPendingTabletsForTest().get(tabletId);
+        return p == null ? -2 : p.latestCompactionVersion;
+    }
+
+    private long compactionCaughtUpMs(long tabletId) {
+        VectorIndexBuildScheduler.Pending p = scheduler.getPendingTabletsForTest().get(tabletId);
+        return p == null ? Long.MIN_VALUE : p.compactionCaughtUpMs;
+    }
+
+    private void setCompactionCaughtUp(long tabletId, long ms) {
+        VectorIndexBuildScheduler.Pending old = scheduler.getPendingTabletsForTest().get(tabletId);
+        if (old != null) {
+            scheduler.getPendingTabletsForTest().put(tabletId,
+                    new VectorIndexBuildScheduler.Pending(
+                            old.latestVersion, old.latestCompactionVersion,
+                            old.enqueueTimeMs, ms));
+        }
     }
 
     private LakeTable mockLakeTable(boolean asyncVectorIndex) {
@@ -170,22 +195,22 @@ public class VectorIndexBuildSchedulerTest {
 
     @Test
     public void testAddPendingTablet() {
-        scheduler.addPendingTablet(1001L, 5L);
-        Assertions.assertEquals(5L, getPendingTablets().get(1001L));
+        scheduler.addPendingTablet(1001L, 5L, false);
+        Assertions.assertEquals(5L, getPendingTablets().get(1001L).latestVersion);
     }
 
     @Test
     public void testAddPendingTabletMergeMax() {
-        scheduler.addPendingTablet(1001L, 5L);
-        scheduler.addPendingTablet(1001L, 8L);
-        Assertions.assertEquals(8L, getPendingTablets().get(1001L));
+        scheduler.addPendingTablet(1001L, 5L, false);
+        scheduler.addPendingTablet(1001L, 8L, false);
+        Assertions.assertEquals(8L, getPendingTablets().get(1001L).latestVersion);
     }
 
     @Test
     public void testAddPendingTabletNoRegression() {
-        scheduler.addPendingTablet(1001L, 8L);
-        scheduler.addPendingTablet(1001L, 5L);
-        Assertions.assertEquals(8L, getPendingTablets().get(1001L));
+        scheduler.addPendingTablet(1001L, 8L, false);
+        scheduler.addPendingTablet(1001L, 5L, false);
+        Assertions.assertEquals(8L, getPendingTablets().get(1001L).latestVersion);
     }
 
     // ========== Recovery scan tests ==========
@@ -211,8 +236,8 @@ public class VectorIndexBuildSchedulerTest {
         scheduler.recoveryScan();
 
         ConcurrentHashMap<Long, Long> pending = getPendingTablets();
-        Assertions.assertEquals(5L, pending.get(2001L));
-        Assertions.assertEquals(5L, pending.get(2002L));
+        Assertions.assertEquals(5L, pending.get(2001L).latestVersion);
+        Assertions.assertEquals(5L, pending.get(2002L).latestVersion);
     }
 
     @Test
@@ -339,7 +364,7 @@ public class VectorIndexBuildSchedulerTest {
         scheduler.checkRunningTaskTimeout();
 
         Assertions.assertTrue(getRunningTasks().isEmpty());
-        Assertions.assertEquals(7L, getPendingTablets().get(tabletId));
+        Assertions.assertEquals(7L, getPendingTablets().get(tabletId).latestVersion);
     }
 
     @Test
@@ -359,7 +384,7 @@ public class VectorIndexBuildSchedulerTest {
     @Test
     public void testScheduleFromPendingSkipsAlreadyBuilt() {
         long tabletId = 3001L;
-        scheduler.addPendingTablet(tabletId, 5L);
+        scheduler.addPendingTablet(tabletId, 5L, false);
 
         LakeTablet tablet = new LakeTablet(tabletId);
         tablet.setVectorIndexBuiltVersion(5L);
@@ -375,14 +400,14 @@ public class VectorIndexBuildSchedulerTest {
     @Test
     public void testScheduleFromPendingSkipsAlreadyRunning() {
         long tabletId = 3001L;
-        scheduler.addPendingTablet(tabletId, 5L);
+        scheduler.addPendingTablet(tabletId, 5L, false);
 
         VectorIndexBuildTask existing = createTaskWithStartTime(tabletId, 5L, System.currentTimeMillis());
         getRunningTasks().put(tabletId, existing);
 
         scheduler.scheduleFromPending();
 
-        Assertions.assertEquals(5L, getPendingTablets().get(tabletId));
+        Assertions.assertEquals(5L, getPendingTablets().get(tabletId).latestVersion);
     }
 
     // ========== hasAsyncVectorIndex tests ==========
@@ -486,17 +511,17 @@ public class VectorIndexBuildSchedulerTest {
         infos.add(infoOf(4001L, 5L));
         infos.add(infoOf(4002L, 7L));
 
-        VectorIndexBuildScheduler.onPublishComplete(infos);
+        VectorIndexBuildScheduler.onPublishComplete(infos, false);
 
-        Assertions.assertEquals(5L, getPendingTablets().get(4001L));
-        Assertions.assertEquals(7L, getPendingTablets().get(4002L));
+        Assertions.assertEquals(5L, getPendingTablets().get(4001L).latestVersion);
+        Assertions.assertEquals(7L, getPendingTablets().get(4002L).latestVersion);
     }
 
     @Test
     public void testOnPublishCompleteSkipsNullAndEmpty() {
         // No GlobalStateMgr expectation needed — early return on null/empty must not touch state.
-        VectorIndexBuildScheduler.onPublishComplete(null);
-        VectorIndexBuildScheduler.onPublishComplete(Collections.emptyList());
+        VectorIndexBuildScheduler.onPublishComplete(null, false);
+        VectorIndexBuildScheduler.onPublishComplete(Collections.emptyList(), false);
         Assertions.assertTrue(getPendingTablets().isEmpty());
     }
 
@@ -508,7 +533,7 @@ public class VectorIndexBuildSchedulerTest {
         VectorIndexBuildInfoPB missingVersion = new VectorIndexBuildInfoPB();
         missingVersion.tabletId = 9L;
 
-        VectorIndexBuildScheduler.onPublishComplete(Lists.newArrayList(missingTablet, missingVersion));
+        VectorIndexBuildScheduler.onPublishComplete(Lists.newArrayList(missingTablet, missingVersion), false);
 
         Assertions.assertTrue(getPendingTablets().isEmpty());
     }
@@ -518,7 +543,7 @@ public class VectorIndexBuildSchedulerTest {
         mockGetScheduler(null);
         // Must silently no-op when scheduler is not initialized (FE startup race window).
         Assertions.assertDoesNotThrow(
-                () -> VectorIndexBuildScheduler.onPublishComplete(Lists.newArrayList(infoOf(1L, 1L))));
+                () -> VectorIndexBuildScheduler.onPublishComplete(Lists.newArrayList(infoOf(1L, 1L)), false));
     }
 
     // ========== getBuiltVersion tests ==========
@@ -566,7 +591,7 @@ public class VectorIndexBuildSchedulerTest {
         ComputeNode keepNode = Mockito.mock(ComputeNode.class);
         preferredNodes.put(7001L, orphanNode);
         preferredNodes.put(7002L, keepNode);
-        scheduler.addPendingTablet(7002L, 1L); // 7002 still pending → keep
+        scheduler.addPendingTablet(7002L, 1L, false); // 7002 still pending → keep
 
         scheduler.cleanupStaleEntries();
 
@@ -591,7 +616,7 @@ public class VectorIndexBuildSchedulerTest {
         long tabletId = 8001L;
         long version = 12L;
         LakeTablet tablet = new LakeTablet(tabletId);
-        scheduler.addPendingTablet(tabletId, version);
+        scheduler.addPendingTablet(tabletId, version, false);
         setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
 
         ComputeNode node = Mockito.mock(ComputeNode.class);
@@ -627,7 +652,7 @@ public class VectorIndexBuildSchedulerTest {
         long tabletId = 8002L;
         long version = 5L;
         LakeTablet tablet = new LakeTablet(tabletId);
-        scheduler.addPendingTablet(tabletId, version);
+        scheduler.addPendingTablet(tabletId, version, false);
         setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
 
         ComputeNode preferred = Mockito.mock(ComputeNode.class);
@@ -658,20 +683,20 @@ public class VectorIndexBuildSchedulerTest {
     @Test
     public void testScheduleFromPendingSkipsTabletInActiveCooldown() throws Exception {
         long tabletId = 8003L;
-        scheduler.addPendingTablet(tabletId, 5L);
+        scheduler.addPendingTablet(tabletId, 5L, false);
         long futureTs = System.currentTimeMillis() + 60_000;
         getMap("cooldownUntil").put(tabletId, futureTs);
 
         scheduler.scheduleFromPending();
 
-        Assertions.assertEquals(5L, getPendingTablets().get(tabletId), "still pending");
+        Assertions.assertEquals(5L, getPendingTablets().get(tabletId).latestVersion, "still pending");
         Assertions.assertTrue(getRunningTasks().isEmpty(), "no task dispatched");
     }
 
     @Test
     public void testScheduleFromPendingClearsExpiredCooldownAndProceeds() throws Exception {
         long tabletId = 8004L;
-        scheduler.addPendingTablet(tabletId, 5L);
+        scheduler.addPendingTablet(tabletId, 5L, false);
         getMap("cooldownUntil").put(tabletId, System.currentTimeMillis() - 1000);
         // No findLakeTablet mock → tablet null → orphan-removed; this drives the "expired cooldown
         // is cleared, then proceed with normal logic" path which currently sees tablet missing.
@@ -770,7 +795,7 @@ public class VectorIndexBuildSchedulerTest {
 
         Assertions.assertTrue(getRunningTasks().isEmpty(), "task removed");
         Assertions.assertEquals(5L, tablet.getVectorIndexBuiltVersion(), "builtVersion updated to partial");
-        Assertions.assertEquals(10L, getPendingTablets().get(tabletId), "tablet re-enqueued for next round");
+        Assertions.assertEquals(10L, getPendingTablets().get(tabletId).latestVersion, "tablet re-enqueued for next round");
     }
 
     @Test
@@ -788,7 +813,7 @@ public class VectorIndexBuildSchedulerTest {
         scheduler.checkRunningTasks();
 
         Assertions.assertTrue(getRunningTasks().isEmpty(), "task removed");
-        Assertions.assertEquals(7L, getPendingTablets().get(tabletId), "tablet re-enqueued (cooldown)");
+        Assertions.assertEquals(7L, getPendingTablets().get(tabletId).latestVersion, "tablet re-enqueued (cooldown)");
     }
 
     @Test
@@ -799,11 +824,184 @@ public class VectorIndexBuildSchedulerTest {
             getRunningTasks().put((long) (10_000 + i),
                     createTaskWithStartTime(10_000 + i, 1L, System.currentTimeMillis()));
         }
-        scheduler.addPendingTablet(9001L, 5L);
+        scheduler.addPendingTablet(9001L, 5L, false);
 
         scheduler.scheduleFromPending();
 
         // Pending tablet must NOT be promoted to running because we're at the cap.
-        Assertions.assertEquals(5L, getPendingTablets().get(9001L));
+        Assertions.assertEquals(5L, getPendingTablets().get(9001L).latestVersion);
+    }
+
+    // ========== Two-version frontier tests ==========
+
+    @Test
+    public void testAddPendingTabletCompactionSetsLC() {
+        scheduler.addPendingTablet(1001L, 10L, true);
+        Assertions.assertEquals(10L, latestVersion(1001L));
+        Assertions.assertEquals(10L, latestCompactionVersion(1001L));
+    }
+
+    @Test
+    public void testAddPendingTabletCompactionThenLoadKeepsLC() {
+        scheduler.addPendingTablet(1001L, 10L, true);
+        scheduler.addPendingTablet(1001L, 11L, false);
+        Assertions.assertEquals(11L, latestVersion(1001L));
+        // Compaction frontier sticks at v10 even though a load arrived at v11.
+        Assertions.assertEquals(10L, latestCompactionVersion(1001L));
+    }
+
+    @Test
+    public void testAddPendingTabletLoadThenCompactionAdvancesLC() {
+        scheduler.addPendingTablet(1001L, 11L, false);
+        scheduler.addPendingTablet(1001L, 12L, true);
+        Assertions.assertEquals(12L, latestVersion(1001L));
+        Assertions.assertEquals(12L, latestCompactionVersion(1001L));
+    }
+
+    @Test
+    public void testAddPendingTabletNewCompactionResetsCaughtUp() {
+        scheduler.addPendingTablet(1001L, 12L, true);
+        // Simulate "built caught up to compaction frontier" and phase-2 stamp fired.
+        setCompactionCaughtUp(1001L, 1000L);
+        Assertions.assertEquals(1000L, compactionCaughtUpMs(1001L));
+
+        // New compaction bumps frontier → must re-enter phase 1.
+        scheduler.addPendingTablet(1001L, 15L, true);
+        Assertions.assertEquals(15L, latestCompactionVersion(1001L));
+        Assertions.assertEquals(-1L, compactionCaughtUpMs(1001L));
+    }
+
+    @Test
+    public void testAddPendingTabletStaleCompactionIgnored() {
+        scheduler.addPendingTablet(1001L, 15L, true);
+        setCompactionCaughtUp(1001L, 2000L);
+        // A stale compaction event with lower version arrives (out of order).
+        scheduler.addPendingTablet(1001L, 12L, true);
+        Assertions.assertEquals(15L, latestVersion(1001L));
+        Assertions.assertEquals(15L, latestCompactionVersion(1001L));
+        Assertions.assertEquals(2000L, compactionCaughtUpMs(1001L),
+                "stale compaction must not reset the caughtUp timestamp");
+    }
+
+    @Test
+    public void testAddPendingTabletOlderVersionDropped() {
+        scheduler.addPendingTablet(1001L, 10L, false);
+        scheduler.addPendingTablet(1001L, 5L, false);
+        Assertions.assertEquals(10L, latestVersion(1001L));
+        Assertions.assertEquals(-1L, latestCompactionVersion(1001L));
+    }
+
+    @Test
+    public void testScheduleFromPendingMarksCompactionCaughtUp() {
+        long tabletId = 3001L;
+        // built=15, latestVersion=16, lc=15 → phase-2 transition tick, stamps caughtUp.
+        scheduler.addPendingTablet(tabletId, 15L, true);
+        scheduler.addPendingTablet(tabletId, 16L, false);
+
+        LakeTablet tablet = new LakeTablet(tabletId);
+        tablet.setVectorIndexBuiltVersion(15L);
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        long before = System.currentTimeMillis();
+        scheduler.scheduleFromPending();
+        long after = System.currentTimeMillis();
+
+        long stamp = compactionCaughtUpMs(tabletId);
+        Assertions.assertTrue(stamp >= before && stamp <= after,
+                "caughtUp timestamp should be stamped during this tick");
+        // Pending is still present; next tick handles phase 2 logic.
+        Assertions.assertEquals(16L, latestVersion(tabletId));
+        Assertions.assertTrue(getRunningTasks().isEmpty(),
+                "should not dispatch during the caughtUp-marking tick");
+    }
+
+    @Test
+    public void testScheduleFromPendingPhase2DefersWithinDelay() {
+        long tabletId = 3001L;
+        scheduler.addPendingTablet(tabletId, 15L, true);
+        scheduler.addPendingTablet(tabletId, 16L, false);
+        // Simulate caughtUp set very recently (within the delay window).
+        setCompactionCaughtUp(tabletId, System.currentTimeMillis());
+
+        LakeTablet tablet = new LakeTablet(tabletId);
+        tablet.setVectorIndexBuiltVersion(15L);
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        scheduler.scheduleFromPending();
+
+        // Still pending, not dispatched.
+        Assertions.assertEquals(16L, latestVersion(tabletId));
+        Assertions.assertTrue(getRunningTasks().isEmpty());
+    }
+
+    @Test
+    public void testScheduleFromPendingPhase2NewCompactionMergesBackToPhase1() {
+        long tabletId = 3001L;
+        scheduler.addPendingTablet(tabletId, 15L, true);
+        scheduler.addPendingTablet(tabletId, 16L, false);
+        setCompactionCaughtUp(tabletId, System.currentTimeMillis());
+
+        // Before the delay expires, a new compaction arrives.
+        scheduler.addPendingTablet(tabletId, 17L, true);
+
+        Assertions.assertEquals(17L, latestVersion(tabletId));
+        Assertions.assertEquals(17L, latestCompactionVersion(tabletId));
+        Assertions.assertEquals(-1L, compactionCaughtUpMs(tabletId),
+                "new compaction should send us back to phase 1 with caughtUp reset");
+    }
+
+    @Test
+    public void testScheduleFromPendingTabletDeletedCleanup() {
+        long tabletId = 999L;
+        scheduler.addPendingTablet(tabletId, 5L, false);
+        // No setupFindLakeTabletExpectations → findLakeTablet returns null (JMockit default).
+        scheduler.scheduleFromPending();
+        Assertions.assertTrue(getPendingTablets().isEmpty(),
+                "pending entry for a deleted tablet must be cleaned up");
+    }
+
+    @Test
+    public void testCheckRunningTasksPartialPreservesFrontier() {
+        long tabletId = 3001L;
+        // Set pending with a frontier (lc=15, latest=20) as it would look after
+        // a compaction + later load pair had been enqueued.
+        scheduler.addPendingTablet(tabletId, 15L, true);
+        scheduler.addPendingTablet(tabletId, 20L, false);
+
+        // A task was dispatched targeting lc=15 but BE only built up to v11 (batch limit).
+        LakeTablet tablet = new LakeTablet(tabletId);
+        BuildVectorIndexResponse response = new BuildVectorIndexResponse();
+        response.newBuiltVersion = 11L;
+        CompletableFuture<BuildVectorIndexResponse> future = CompletableFuture.completedFuture(response);
+        VectorIndexBuildTask task = createTaskWithFuture(tabletId, 15L, future);
+        getRunningTasks().put(tabletId, task);
+
+        setupFindLakeTabletExpectations(tabletId, tablet, 1L, 2L, 3L, 4L);
+
+        scheduler.checkRunningTasks();
+
+        Assertions.assertTrue(getRunningTasks().isEmpty());
+        Assertions.assertEquals(11L, tablet.getVectorIndexBuiltVersion());
+        // Frontier must be intact so the next tick continues phase 1 toward lc=15.
+        Assertions.assertEquals(20L, latestVersion(tabletId));
+        Assertions.assertEquals(15L, latestCompactionVersion(tabletId));
+    }
+
+    @Test
+    public void testCheckRunningTasksFailurePreservesFrontier() {
+        long tabletId = 3001L;
+        scheduler.addPendingTablet(tabletId, 15L, true);
+        scheduler.addPendingTablet(tabletId, 20L, false);
+
+        CompletableFuture<BuildVectorIndexResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(new RuntimeException("RPC failed"));
+        VectorIndexBuildTask task = createTaskWithFuture(tabletId, 15L, future);
+        getRunningTasks().put(tabletId, task);
+
+        scheduler.checkRunningTasks();
+
+        Assertions.assertTrue(getRunningTasks().isEmpty());
+        Assertions.assertEquals(20L, latestVersion(tabletId));
+        Assertions.assertEquals(15L, latestCompactionVersion(tabletId));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Today the async vector-index build scheduler (`VectorIndexBuildScheduler`) is single-version-aware: it only knows the newest pending version per tablet. This causes two problems on shared-data tables under realistic load:

1. **Wasted builds.** A compaction publishes shortly after a load, but the scheduler may have already dispatched a build at the load version. The just-finished VI is then immediately invalidated by the compaction's new rowset layout, so we rebuild and the first build is wasted.
2. **Missed coalescing.** Conversely, when a compaction lands first, we have no way to wait briefly for an in-flight load tail and merge them — we either dispatch immediately (and rebuild on the load tail) or rely on a uniform delay that hurts the compaction case.

We need scheduling that distinguishes "version produced by compaction" from "version produced by load," so that compaction products dispatch immediately while load tails wait briefly for a coalescing compaction.

## What I'm doing:

Introduce a two-version frontier on each pending tablet:

- `latestVersion` — newest pending version (load or compaction).
- `latestCompactionVersion` — newest pending compaction-produced version.

Two-phase scheduling in `scheduleFromPending`:

- **Phase 1**: `built < latestCompactionVersion` → dispatch immediately to `latestCompactionVersion`. Compaction products are not at risk of being swept by an imminent compaction, so we don't wait.
- **Phase 2**: `built >= latestCompactionVersion && built < latestVersion` → load-only tail. Wait `lake_vi_build_load_tail_delay_ms` (default 5min); if a new compaction arrives within that window it bumps `latestCompactionVersion` and we go back to phase 1, merging the tail into the combined build instead of rebuilding twice.

API changes:

- `addPendingTablet(tabletId, version, fromCompaction)`
- `onPublishComplete(infos, fromCompaction)`

`PublishVersionDaemon` derives `fromCompaction` from `TransactionState.LoadJobSourceType.LAKE_COMPACTION` (per-batch and per-partition publish paths). All non-publish callers (`LakeUtils`, `LakeRollupJob`, `LakeTableSchemaChangeJob`, `LakeTableAlterMetaJobBase`, `SplitTabletJob`, `MergeTabletJob`) pass `fromCompaction=false` since they are not compaction-driven publishes.

Recovery scan after leader switch is conservative: the in-memory compaction-frontier is lost, so we set `latestCompactionVersion = visibleVersion` to re-dispatch the backlog in phase 1 (no extra delay).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4