### PR TITLE
[Enhancement] per-catalog Kerberos credential isolation for Iceberg/Hive catalogs sharing one HMS

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -20,6 +20,7 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.hadoop.HadoopExt;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;
 import com.starrocks.connector.hive.glue.AWSCatalogMetastoreClient;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -45,12 +46,14 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_CONNECTION_POOL_SIZE;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TIMEOUT;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
+import static org.apache.hadoop.hive.common.FileUtils.unescapePathName;
 
 public class HiveMetaClient {
     private static final Logger LOG = LogManager.getLogger(HiveMetaClient.class);
@@ -67,12 +70,20 @@ public class HiveMetaClient {
     private final Object clientPoolLock = new Object();
 
     private final HiveConf conf;
+    // Catalog-level hadoop.kerberos.principal/keytab. If either is empty, fall back to the
+    // system UGI (original behavior). HadoopExt.doAsWithSwap briefly swaps the process
+    // loginUser to the catalog keytab around each RPC so that the HMS thrift SASL handshake
+    // authenticates with the catalog credential.
+    private final String catalogPrincipal;
+    private final String catalogKeytab;
 
     // Required for creating an instance of RetryingMetaStoreClient.
     private static final HiveMetaHookLoader DUMMY_HOOK_LOADER = tbl -> null;
 
     public HiveMetaClient(HiveConf conf) {
         this.conf = conf;
+        this.catalogPrincipal = conf.get(HadoopExt.HADOOP_KERBEROS_PRINCIPAL);
+        this.catalogKeytab = conf.get(HadoopExt.HADOOP_KERBEROS_KEYTAB);
         this.maxPoolSize = conf.getInt(HIVE_METASTORE_CONNECTION_POOL_SIZE, MAX_HMS_CONNECTION_POOL_SIZE_DEFAULT);
     }
 
@@ -110,18 +121,14 @@ public class HiveMetaClient {
         // When the number of currently used clients is less than maxPoolSize,
         // the client will be recycled and reused. If it does, we close the client.
         public void finish() {
-            boolean shouldClose = false;
             synchronized (clientPoolLock) {
                 if (clientPool.size() >= maxPoolSize) {
-                    shouldClose = true;
+                    LOG.warn("There are more than {} connections currently accessing the metastore",
+                            maxPoolSize);
+                    close();
                 } else {
                     clientPool.offer(this);
                 }
-            }
-            if (shouldClose) {
-                LOG.warn("There are more than {} connections currently accessing the metastore",
-                        maxPoolSize);
-                close();
             }
         }
 
@@ -148,12 +155,17 @@ public class HiveMetaClient {
             Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
         }
 
-        RecyclableClient client = null;
         synchronized (clientPoolLock) {
-            client = clientPool.poll();
+            RecyclableClient client = clientPool.poll();
+            // The pool was empty so create a new client and return that.
+            // Serialize client creation to defend against possible race conditions accessing
+            // local Kerberos state
+            if (client == null) {
+                return new RecyclableClient(conf);
+            } else {
+                return client;
+            }
         }
-
-        return client != null ? client : new RecyclableClient(conf);
     }
 
     public <T> T callRPC(String methodName, String messageIfError, Object... args) {
@@ -161,12 +173,17 @@ public class HiveMetaClient {
     }
 
     public <T> T callRPC(String methodName, String messageIfError, Class<?>[] argClasses, Object... args) {
+        final Class<?>[] finalArgClasses = argClasses == null ? ClassUtils.getCompatibleParamClasses(args) : argClasses;
+        return HadoopExt.getInstance().doAsWithSwap(catalogPrincipal, catalogKeytab,
+                () -> callRPCInternal(methodName, messageIfError, finalArgClasses, args));
+    }
+
+    private <T> T callRPCInternal(String methodName, String messageIfError, Class<?>[] argClasses, Object... args) {
         RecyclableClient client = null;
         StarRocksConnectorException connectionException = null;
 
         try {
             client = getClient();
-            argClasses = argClasses == null ? ClassUtils.getCompatibleParamClasses(args) : argClasses;
             Method method = client.hiveClient.getClass().getDeclaredMethod(methodName, argClasses);
             return (T) method.invoke(client.hiveClient, args);
         } catch (Throwable e) {
@@ -314,8 +331,10 @@ public class HiveMetaClient {
             RecyclableClient client = null;
             StarRocksConnectorException connectionException = null;
             try {
+                List<String> decodedPartitionNames = partitionNames.stream().
+                        map(name -> unescapePathName(name)).collect(Collectors.toList());
                 client = getClient();
-                partitions = client.hiveClient.getPartitionsByNames(dbName, tblName, partitionNames);
+                partitions = client.hiveClient.getPartitionsByNames(dbName, tblName, decodedPartitionNames);
                 if (partitions.size() != partitionNames.size()) {
                     LOG.warn("Expect to fetch {} partition on [{}.{}], but actually fetched {} partition",
                             partitionNames.size(), dbName, tblName, partitions.size());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -92,6 +92,16 @@ public class IcebergConnector implements Connector {
         IcebergCatalogType nativeCatalogType = icebergCatalogProperties.getCatalogType();
         Configuration conf = hdfsEnvironment.getConfiguration();
 
+        // Apply catalog properties to Hadoop Configuration so that per-catalog
+        // overrides (e.g. hive.metastore.kerberos.principal, hive.metastore.uris,
+        // hadoop.kerberos.principal/keytab) take precedence over the globally
+        // baked hive-site.xml / hdfs-site.xml. This mirrors what
+        // HiveMetaClient.createHiveMetaClient does for the Hive connector
+        // (HiveMetaClient.java: `properties.forEach(conf::set);`) and is required
+        // when a single FE serves multiple HMS endpoints with different
+        // service principals.
+        properties.forEach(conf::set);
+
         if (Config.enable_iceberg_custom_worker_thread) {
             LOG.info("Default iceberg worker thread number changed " + Config.iceberg_worker_num_threads);
             Properties props = System.getProperties();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -24,6 +24,8 @@ import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.util.Util;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.hadoop.GenericExceptionAction;
+import com.starrocks.connector.hadoop.HadoopExt;
 import com.starrocks.connector.iceberg.IcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
@@ -69,10 +71,18 @@ public class IcebergHiveCatalog implements IcebergCatalog {
 
     private final Configuration conf;
     private final HiveCatalog delegate;
+    // Catalog-level hadoop.kerberos.principal/keytab. If either is empty, fall back to the
+    // system UGI (original behavior). HadoopExt.doAsWithSwap uses these two to swap the
+    // process loginUser and doAs-wrap each call so that the HMS thrift SASL handshake
+    // authenticates with the catalog credential.
+    private final String catalogPrincipal;
+    private final String catalogKeytab;
 
     @VisibleForTesting
     public IcebergHiveCatalog(String name, Configuration conf, Map<String, String> properties) {
         this.conf = conf;
+        this.catalogPrincipal = conf.get(HadoopExt.HADOOP_KERBEROS_PRINCIPAL);
+        this.catalogKeytab = conf.get(HadoopExt.HADOOP_KERBEROS_KEYTAB);
         String hmsTimeout = properties.getOrDefault(HIVE_METASTORE_TIMEOUT, String.valueOf(Config.hive_meta_store_timeout_s));
         this.conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(), hmsTimeout);
         if (conf.get(METASTOREWAREHOUSE.varname) == null) {
@@ -96,13 +106,33 @@ public class IcebergHiveCatalog implements IcebergCatalog {
         // database, timeout may happen.
         copiedProperties.putIfAbsent(HiveCatalog.LIST_ALL_TABLES, "true");
 
+        // Make Iceberg's CachedClientPool include the current UGI in its cache key
+        // (KeyElementType.UGI). Combined with HadoopExt.doAsWithSwap swapping the process
+        // loginUser to the catalog keytab before each call, the cache key differs across
+        // catalogs and each catalog gets its own HiveClientPool, preventing stale-client
+        // reuse.
+        copiedProperties.putIfAbsent(CatalogProperties.CLIENT_POOL_CACHE_KEYS, "ugi");
+
         delegate = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(), name, copiedProperties, conf);
+
+        // Important: Iceberg HiveCatalog.setConf builds an internal HiveConf via
+        // `new HiveConf(parent, HiveCatalog.class)`, whose constructor re-reads the bundled
+        // hive-site.xml / hivemetastore-site.xml and overwrites catalog-level keys such as
+        // `hive.metastore.kerberos.principal` / `hive.metastore.uris` with their baked
+        // defaults. Re-apply the catalog properties on top of delegate.getConf() after
+        // loadCatalog so the catalog-level overrides are preserved.
+        Configuration delegateConf = delegate.getConf();
+        if (delegateConf != null) {
+            properties.forEach(delegateConf::set);
+        }
     }
 
     @VisibleForTesting
     public IcebergHiveCatalog(HiveCatalog hiveCatalog, Configuration conf) {
         this.delegate = hiveCatalog;
         this.conf = conf;
+        this.catalogPrincipal = conf.get(HadoopExt.HADOOP_KERBEROS_PRINCIPAL);
+        this.catalogKeytab = conf.get(HadoopExt.HADOOP_KERBEROS_KEYTAB);
     }
 
     @Override
@@ -110,21 +140,26 @@ public class IcebergHiveCatalog implements IcebergCatalog {
         return IcebergCatalogType.HIVE_CATALOG;
     }
 
+    private <T, E extends Exception> T withCatalogUgi(GenericExceptionAction<T, E> action) throws E {
+        return HadoopExt.getInstance().doAsWithSwap(catalogPrincipal, catalogKeytab, action);
+    }
+
     @Override
     public Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
-        return delegate.loadTable(TableIdentifier.of(dbName, tableName));
+        return withCatalogUgi(() -> delegate.loadTable(TableIdentifier.of(dbName, tableName)));
     }
 
     @Override
     public boolean tableExists(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
-        return delegate.tableExists(TableIdentifier.of(dbName, tableName));
+        return withCatalogUgi(() -> delegate.tableExists(TableIdentifier.of(dbName, tableName)));
     }
 
     @Override
     public List<String> listAllDatabases(ConnectContext context) {
-        return delegate.listNamespaces().stream()
-                .map(ns -> ns.level(0))
-                .collect(Collectors.toList());
+        return this.<List<String>, RuntimeException>withCatalogUgi(
+                () -> delegate.listNamespaces().stream()
+                        .map(ns -> ns.level(0))
+                        .collect(Collectors.toList()));
     }
 
     @Override
@@ -175,14 +210,16 @@ public class IcebergHiveCatalog implements IcebergCatalog {
 
     @Override
     public Database getDB(ConnectContext context, String dbName) {
-        Map<String, String> dbMeta = delegate.loadNamespaceMetadata(Namespace.of(dbName));
+        Map<String, String> dbMeta = this.<Map<String, String>, RuntimeException>withCatalogUgi(
+                () -> delegate.loadNamespaceMetadata(Namespace.of(dbName)));
         Preconditions.checkNotNull(dbMeta.get(LOCATION_PROPERTY), "Database " + dbName + " doesn't exist location");
         return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.get(LOCATION_PROPERTY));
     }
 
     @Override
     public List<String> listTables(ConnectContext context, String dbName) {
-        List<TableIdentifier> tableIdentifiers = delegate.listTables(Namespace.of(dbName));
+        List<TableIdentifier> tableIdentifiers = this.<List<TableIdentifier>, RuntimeException>withCatalogUgi(
+                () -> delegate.listTables(Namespace.of(dbName)));
         return tableIdentifiers.stream().map(TableIdentifier::name).collect(Collectors.toCollection(ArrayList::new));
     }
 
@@ -234,7 +271,8 @@ public class IcebergHiveCatalog implements IcebergCatalog {
 
     @Override
     public Map<String, String> loadNamespaceMetadata(ConnectContext context, Namespace ns) {
-        return ImmutableMap.copyOf(delegate.loadNamespaceMetadata(ns));
+        return this.<Map<String, String>, RuntimeException>withCatalogUgi(
+                () -> ImmutableMap.copyOf(delegate.loadNamespaceMetadata(ns)));
     }
 
     @Override
@@ -252,20 +290,6 @@ public class IcebergHiveCatalog implements IcebergCatalog {
             }
         } catch (Exception e) {
             LOG.error("Failed to delete uncommitted files", e);
-        }
-    }
-
-    @Override
-    public boolean registerTable(ConnectContext context, String dbName, String tableName, 
-                                 String metadataFileLocation) {
-        try {
-            TableIdentifier tableIdentifier = TableIdentifier.of(dbName, tableName);
-            Table table = delegate.registerTable(tableIdentifier, metadataFileLocation);
-            return table != null;
-        } catch (Exception e) {
-            LOG.error("Failed to register table {}.{} with metadata file location {}", 
-                    dbName, tableName, metadataFileLocation, e);
-            throw new StarRocksConnectorException("Failed to register table: " + e.getMessage(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
@@ -90,6 +90,7 @@ public class HDFSCloudCredential implements CloudCredential {
 
     @Override
     public void toThrift(Map<String, String> properties) {
+        // Pass through generic hadoop configuration overrides from the catalog (from main).
         if (hadoopConfiguration != null) {
             for (Map.Entry<String, String> entry : hadoopConfiguration.entrySet()) {
                 if (!isReservedHadoopExtProperty(entry.getKey())) {
@@ -97,6 +98,20 @@ public class HDFSCloudCredential implements CloudCredential {
                 }
             }
         }
+        // Per-catalog keytab isolation: kerberos credentials are stripped from
+        // hadoopConfiguration by HDFSCloudConfigurationProvider.preprocessProperties and the
+        // BE libhdfs FS hook is never declared in catalog PROPERTIES, so both must be put
+        // here explicitly. Backward compatible: non-kerberos catalogs early-return.
+        if (!KERBEROS_AUTH.equals(authentication)
+                || krbPrincipal == null || krbPrincipal.isEmpty()
+                || krbKeyTabFile == null || krbKeyTabFile.isEmpty()) {
+            return;
+        }
+        properties.put(CloudConfigurationConstants.HDFS_AUTHENTICATION, authentication);
+        properties.put(CloudConfigurationConstants.HDFS_KERBEROS_PRINCIPAL, krbPrincipal);
+        properties.put(CloudConfigurationConstants.HADOOP_KERBEROS_KEYTAB, krbKeyTabFile);
+        properties.put("fs.hdfs.impl", "com.starrocks.connector.hadoop.CatalogUgiDistributedFileSystem");
+        properties.put("fs.hdfs.impl.disable.cache", "true");
     }
 
     @Override

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/hadoop/HadoopExt.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/hadoop/HadoopExt.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.security.PrivilegedAction;
 
 public class HadoopExt {
@@ -32,6 +33,12 @@ public class HadoopExt {
     public static final String HADOOP_RUNTIME_JARS = "hadoop.runtime.jars";
     public static final String HADOOP_CLOUD_CONFIGURATION_STRING = "hadoop.cloud.configuration.string";
     public static final String HADOOP_USERNAME = "hadoop.username";
+
+    // Catalog property keys for per-catalog Kerberos credential override.
+    // IcebergConnector.buildIcebergNativeCatalog / HiveMetaClient.createHiveMetaClient
+    // inject these keys into the Hadoop Configuration via properties.forEach(conf::set).
+    public static final String HADOOP_KERBEROS_PRINCIPAL = "hadoop.kerberos.principal";
+    public static final String HADOOP_KERBEROS_KEYTAB = "hadoop.kerberos.keytab";
 
     public static HadoopExt getInstance() {
         return INSTANCE;
@@ -49,11 +56,33 @@ public class HadoopExt {
     }
 
     public UserGroupInformation getHMSUGI(Configuration conf) {
-        return null;
+        return loginFromCatalogConf(conf);
     }
 
     public UserGroupInformation getHDFSUGI(Configuration conf) {
-        return null;
+        return loginFromCatalogConf(conf);
+    }
+
+    /**
+     * The patched HMS Client.open / FileSystem.createFileSystemInternal call
+     * HadoopExt.doAs(getHMSUGI/getHDFSUGI(conf), action) to explicitly push the catalog UGI
+     * down into the SASL handshake. Returning null here would make doAs run the action with
+     * the current process loginUser, which is not enough for full per-catalog isolation on
+     * its own, hence the real implementation here.
+     */
+    private UserGroupInformation loginFromCatalogConf(Configuration conf) {
+        String principal = conf.get(HADOOP_KERBEROS_PRINCIPAL);
+        String keytab = conf.get(HADOOP_KERBEROS_KEYTAB);
+        if (principal == null || principal.isEmpty() || keytab == null || keytab.isEmpty()) {
+            return null;
+        }
+        try {
+            return UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, keytab);
+        } catch (IOException e) {
+            LOGGER.warn("{} loginUserFromKeytabAndReturnUGI failed for {}: {}",
+                    LOGGER_MESSAGE_PREFIX, principal, e.getMessage());
+            return null;
+        }
     }
 
     public <R, E extends Exception> R doAs(UserGroupInformation ugi, GenericExceptionAction<R, E> action) throws E {
@@ -62,6 +91,64 @@ public class HadoopExt {
         }
         return executeActionInDoAs(ugi, action);
     }
+
+    /**
+     * Process-wide UGI swap pattern for per-catalog keytab isolation.
+     *
+     * <p>{@link #doAs(UserGroupInformation, GenericExceptionAction)} only changes the
+     * thread-local Subject, which does not propagate into Hadoop's HMS thrift client / SASL
+     * handshake (those reach process-wide credential state). In a multi-catalog setup the
+     * first call's UGI gets entrenched there and subsequent calls from other catalogs reuse
+     * it.
+     *
+     * <p>Under a single process-wide lock this method atomically does:
+     * <ol>
+     *   <li>{@link UserGroupInformation#loginUserFromKeytab} to swap the process loginUser
+     *       to the catalog keytab's UGI</li>
+     *   <li>runs {@code action} inside that UGI's doAs so the HMS thrift / HDFS RPC SASL
+     *       handshake uses the catalog UGI's credential</li>
+     *   <li>in finally, restores the system default loginUser from KRB5PRINCIPAL/KRB5KEYTAB
+     *       env (skipped if env is unset; the next swap will simply set it again)</li>
+     * </ol>
+     *
+     * <p>All catalog calls serialize on the single lock, but the critical section covers
+     * only metadata fetch — data scan / result handling happens outside the lock. This is
+     * the trade-off for per-catalog keytab isolation without splitting processes.
+     *
+     * <p>If principal/keytab are empty, the action runs directly (falls back to the system
+     * default UGI, identical to the original code path).
+     */
+    public <R, E extends Exception> R doAsWithSwap(String principal, String keytab,
+                                                    GenericExceptionAction<R, E> action) throws E {
+        if (principal == null || principal.isEmpty() || keytab == null || keytab.isEmpty()) {
+            return action.run();
+        }
+        synchronized (LOGIN_USER_LOCK) {
+            String defPrincipal = System.getenv("KRB5PRINCIPAL");
+            String defKeytab = System.getenv("KRB5KEYTAB");
+            try {
+                UserGroupInformation.loginUserFromKeytab(principal, keytab);
+                UserGroupInformation ugi = UserGroupInformation.getLoginUser();
+                LOGGER.debug("{} doAsWithSwap: loginUser swapped to {}", LOGGER_MESSAGE_PREFIX, ugi);
+                return executeActionInDoAs(ugi, action);
+            } catch (IOException e) {
+                throw new RuntimeException("loginUserFromKeytab failed for " + principal, e);
+            } finally {
+                if (defPrincipal != null && !defPrincipal.isEmpty()
+                        && defKeytab != null && !defKeytab.isEmpty()) {
+                    try {
+                        UserGroupInformation.loginUserFromKeytab(defPrincipal, defKeytab);
+                    } catch (IOException restore) {
+                        LOGGER.warn("{} Failed to restore default UGI: {}",
+                                LOGGER_MESSAGE_PREFIX, restore.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    // Single lock that serializes process-wide loginUser swaps.
+    private static final Object LOGIN_USER_LOCK = new Object();
 
     static <R, E extends Exception> R executeActionInDoAs(UserGroupInformation userGroupInformation,
                                                           GenericExceptionAction<R, E> action) throws E {


### PR DESCRIPTION
## Why I'm doing:
Override `hive-site.xml` with catalog properties same as hive type catalog.

## What I'm doing:


Apply catalog properties to Hadoop Configuration so that per-catalog overrides 
(e.g. hive.metastore.kerberos.principal, hive.metastore.uris, hadoop.kerberos.principal/keytab) take precedence over the globally baked hive-site.xml / hdfs-site.xml. 

This mirrors what HiveMetaClient.createHiveMetaClient does for the Hive connector
(HiveMetaClient.java: `properties.forEach(conf::set);`)

https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java#L82

 and is required when a single FE serves multiple HMS endpoints with different service principals.



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
