### PR TITLE
[BugFix] Allow SHOW statements inside explicit transaction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/ExplicitTxnStatementValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/ExplicitTxnStatementValidator.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SetStmt;
+import com.starrocks.sql.ast.ShowStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.txn.BeginStmt;
 import com.starrocks.sql.ast.txn.CommitStmt;
@@ -48,9 +49,10 @@ public final class ExplicitTxnStatementValidator {
         boolean isSet = statement instanceof SetStmt;
         boolean isDml = statement instanceof DmlStmt; // insert/update/delete
         boolean isSelect = statement instanceof QueryStatement;
+        boolean isShow = statement instanceof ShowStmt;
         boolean isTransactionStmt = statement instanceof BeginStmt
                 || statement instanceof CommitStmt || statement instanceof RollbackStmt;
-        if (!(isSet || isDml || isSelect || isTransactionStmt)) {
+        if (!(isSet || isDml || isSelect || isShow || isTransactionStmt)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -40,9 +40,12 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.ShowGrantsStmt;
+import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.txn.BeginStmt;
 import com.starrocks.sql.ast.txn.CommitStmt;
 import com.starrocks.sql.ast.txn.RollbackStmt;
+import com.starrocks.sql.ast.warehouse.ShowWarehousesStmt;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
@@ -153,6 +156,22 @@ public class ExplicitTxnTest {
 
         Assertions.assertTrue(context.getState().isError());
         Assertions.assertEquals(ErrorCode.ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT, context.getState().getErrorCode());
+    }
+
+    @Test
+    public void testShowStmtAllowedInExplicitTxn() {
+        // SHOW statements are read-only metadata queries and must be allowed inside an
+        // explicit transaction (regression for ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT on SHOW GRANTS / SHOW WAREHOUSES).
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setTxnId(1);
+
+        ShowGrantsStmt showGrants = new ShowGrantsStmt(new UserRef("u1", "%"), NodePosition.ZERO);
+        Assertions.assertDoesNotThrow(() -> ExplicitTxnStatementValidator.validate(showGrants, context));
+
+        ShowWarehousesStmt showWarehouses = new ShowWarehousesStmt(null);
+        Assertions.assertDoesNotThrow(() -> ExplicitTxnStatementValidator.validate(showWarehouses, context));
     }
 
     @Test

--- a/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
@@ -278,7 +278,7 @@ public enum ErrorCode {
     ERR_TXN_FORBID_CROSS_DB(5304, new byte[] {'2', '5', 'P', '0', '1'},
             "Cannot execute cross-database transactions. All DML target tables must belong to the same db"),
     ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT(5305, new byte[] {'2', '5', 'P', '0', '1'},
-            "Explicit transaction only support begin/commit/rollback/insert/update/delete/set/select statements"),
+            "Explicit transaction only support begin/commit/rollback/insert/update/delete/set/select/show statements"),
     ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT_ORDER(5306, new byte[] {'2', '5', 'P', '0', '1'},
             "Explicit transaction only support single update/delete before insert statement"),
     ERR_EXPLICIT_TXN_SELECT_ON_MODIFIED_TABLE(5307, new byte[] {'2', '5', 'P', '0', '1'},


### PR DESCRIPTION
## Why I'm doing:

Inside an explicit transaction (after `BEGIN`), running a SHOW statement currently fails with:

```
ERROR 5305 (25P01): Getting analyzing error. Detail message: Explicit transaction only support
begin/commit/rollback/insert/update/delete/set/select statements.
```

`SHOW GRANTS`, `SHOW WAREHOUSES`, etc. are read-only metadata queries that don't participate in the explicit transaction at all. Many BI / JDBC clients automatically issue `SHOW` (e.g. to refresh metadata) and break the user's explicit transaction flow.

## What I'm doing:

- Add `ShowStmt` to the whitelist in `ExplicitTxnStatementValidator`. The same `else { return; }` branch in the validator that already exists for non-`QueryStatement` / non-`InsertStmt` statements means SHOW will not engage the modified-table check, which is correct — SHOW does not touch table data.
- Update the `ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT` (5305) message to reflect the relaxed whitelist.
- Add a unit test (`ExplicitTxnTest#testShowStmtAllowedInExplicitTxn`) covering `SHOW GRANTS` and `SHOW WAREHOUSES` inside an explicit transaction.

Reproduction before fix:

```
mysql> begin;
Query OK
mysql> show grants;
ERROR 5305 (25P01): ... Explicit transaction only support begin/commit/rollback/insert/update/delete/set/select statements.
mysql> show warehouses;
ERROR 5305 (25P01): ... same.
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4