### PR TITLE
[Enhancement] Promote variant virtual columns to typed-value readers for dict-filter participation

### DIFF
--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -876,6 +876,9 @@ static bool _requested_scalar_fallback_values_all_null(const std::vector<Shredde
                                                        const std::vector<VariantPath>& requested_paths) {
     for (const auto& path : requested_paths) {
         const ShreddedFieldNode* node = find_shredded_field_node_for_path(nodes, path);
+        if (node == nullptr) {
+            return false;
+        }
         if (node->value_reader != nullptr && !_column_chunk_all_null(node->value_reader.get())) {
             return false;
         }
@@ -1872,16 +1875,12 @@ void VariantColumnReader::set_need_parse_levels(bool need_parse_levels) {
 
 void VariantColumnReader::collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges,
                                                   int64_t* end_offset, ColumnIOTypeFlags types, bool active) {
-    const bool skip_top_level_payload =
-            _top_level.root_typed_value_reader == nullptr &&
-            _requested_paths_are_scalar_typed_leaves(_shredded_fields, _requested_shredded_paths) &&
-            _requested_scalar_fallback_values_all_null(_shredded_fields, _requested_shredded_paths);
-    const bool skip_metadata = skip_top_level_payload && _column_chunk_has_no_null(_top_level.metadata_reader.get());
+    const TopLevelSkipFlags skip_flags = _compute_top_level_skip_flags();
 
-    if (_top_level.metadata_reader != nullptr && !skip_metadata) {
+    if (_top_level.metadata_reader != nullptr && !skip_flags.skip_metadata) {
         _top_level.metadata_reader->collect_column_io_range(ranges, end_offset, types, active);
     }
-    if (_top_level.value_reader != nullptr && !skip_top_level_payload) {
+    if (_top_level.value_reader != nullptr && !skip_flags.skip_payload) {
         _top_level.value_reader->collect_column_io_range(ranges, end_offset, types, active);
     }
     if (_top_level.root_typed_value_reader != nullptr) {
@@ -1895,16 +1894,12 @@ void VariantColumnReader::collect_column_io_range(std::vector<io::SharedBuffered
 }
 
 void VariantColumnReader::select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) {
-    const bool skip_top_level_payload =
-            _top_level.root_typed_value_reader == nullptr &&
-            _requested_paths_are_scalar_typed_leaves(_shredded_fields, _requested_shredded_paths) &&
-            _requested_scalar_fallback_values_all_null(_shredded_fields, _requested_shredded_paths);
-    const bool skip_metadata = skip_top_level_payload && _column_chunk_has_no_null(_top_level.metadata_reader.get());
+    const TopLevelSkipFlags skip_flags = _compute_top_level_skip_flags();
 
-    if (_top_level.metadata_reader != nullptr && !skip_metadata) {
+    if (_top_level.metadata_reader != nullptr && !skip_flags.skip_metadata) {
         _top_level.metadata_reader->select_offset_index(range, rg_first_row);
     }
-    if (_top_level.value_reader != nullptr && !skip_top_level_payload) {
+    if (_top_level.value_reader != nullptr && !skip_flags.skip_payload) {
         _top_level.value_reader->select_offset_index(range, rg_first_row);
     }
     if (_top_level.root_typed_value_reader != nullptr) {
@@ -1915,6 +1910,15 @@ void VariantColumnReader::select_offset_index(const SparseRange<uint64_t>& range
     for (const auto& node : _shredded_fields) {
         _select_shredded_field_offset_index(node, range, rg_first_row, requested_paths);
     }
+}
+
+VariantColumnReader::TopLevelSkipFlags VariantColumnReader::_compute_top_level_skip_flags() const {
+    TopLevelSkipFlags flags;
+    flags.skip_payload = _top_level.root_typed_value_reader == nullptr &&
+                         _requested_paths_are_scalar_typed_leaves(_shredded_fields, _requested_shredded_paths) &&
+                         _requested_scalar_fallback_values_all_null(_shredded_fields, _requested_shredded_paths);
+    flags.skip_metadata = flags.skip_payload && _column_chunk_has_no_null(_top_level.metadata_reader.get());
+    return flags;
 }
 
 // Fast-path read when _skip_base_payload is true.

--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -2168,6 +2168,14 @@ const ColumnReader* VariantColumnReader::filterable_typed_value_reader_for_path(
     return found_node->typed_value_reader.get();
 }
 
+ColumnReader* VariantColumnReader::scalar_typed_value_reader_for_path(const VariantPath& path) {
+    const ShreddedFieldNode* found_node = find_shredded_field_node_for_path(_shredded_fields, path);
+    if (found_node == nullptr) return nullptr;
+    if (found_node->kind != ShreddedFieldNode::Kind::SCALAR) return nullptr;
+    if (found_node->typed_value_reader == nullptr) return nullptr;
+    return found_node->typed_value_reader.get();
+}
+
 const TypeDescriptor* VariantColumnReader::typed_value_read_type_for_path(const VariantPath& path) const {
     const ShreddedFieldNode* found_node = find_shredded_field_node_for_path(_shredded_fields, path);
     if (found_node == nullptr || found_node->kind != ShreddedFieldNode::Kind::SCALAR) return nullptr;

--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -846,6 +846,43 @@ static bool _column_chunk_all_null_for_num_rows(const ColumnReader* reader, uint
     return chunk_meta->meta_data.statistics.null_count == static_cast<int64_t>(num_rows);
 }
 
+static bool _column_chunk_has_no_null(const ColumnReader* reader) {
+    if (reader == nullptr) {
+        return false;
+    }
+    const tparquet::ColumnChunk* chunk_meta = reader->get_chunk_metadata();
+    if (chunk_meta == nullptr || !chunk_meta->meta_data.__isset.statistics ||
+        !chunk_meta->meta_data.statistics.__isset.null_count) {
+        return false;
+    }
+    return chunk_meta->meta_data.statistics.null_count == 0;
+}
+
+static bool _requested_paths_are_scalar_typed_leaves(const std::vector<ShreddedFieldNode>& nodes,
+                                                     const std::vector<VariantPath>& requested_paths) {
+    if (requested_paths.empty()) {
+        return false;
+    }
+    for (const auto& path : requested_paths) {
+        const ShreddedFieldNode* node = find_shredded_field_node_for_path(nodes, path);
+        if (node == nullptr || node->kind != ShreddedFieldNode::Kind::SCALAR || node->typed_value_reader == nullptr) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool _requested_scalar_fallback_values_all_null(const std::vector<ShreddedFieldNode>& nodes,
+                                                       const std::vector<VariantPath>& requested_paths) {
+    for (const auto& path : requested_paths) {
+        const ShreddedFieldNode* node = find_shredded_field_node_for_path(nodes, path);
+        if (node->value_reader != nullptr && !_column_chunk_all_null(node->value_reader.get())) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static void _clear_shredded_field_node_columns(ShreddedFieldNode* node) {
     if (node == nullptr) {
         return;
@@ -1776,23 +1813,12 @@ Status VariantColumnReader::prepare() {
     // no root-level typed_value re-encoding, the metadata column is never needed (it is only
     // used for variant binary decoding).  We set _skip_base_payload = true in this case.
     //
-    // The value (binary payload) column is handled separately:
-    //   - Non-nullable field: value is also skipped — typed_value nullness is sufficient.
-    //   - Nullable field:     value is still read, but only to recover the outer row-null mask.
-    //     (A null typed_value means either "variant row is null" or "field is absent", so the
-    //      value column's null flag is the only reliable source for outer-row nullness.)
+    // Top-level value is only needed if leaf fallback values force us back to full
+    // per-row reconstruction. For nullable variant columns, top-level metadata is only
+    // decoded when statistics cannot prove the outer null mask is all zero.
     _skip_base_payload = false;
     if (!_requested_shredded_paths.empty() && _top_level.root_typed_value_reader == nullptr) {
-        bool all_scalar = true;
-        for (const auto& path : _requested_shredded_paths) {
-            const auto* node = find_shredded_field_node_for_path(_shredded_fields, path);
-            if (node == nullptr || node->kind != ShreddedFieldNode::Kind::SCALAR ||
-                node->typed_value_reader == nullptr) {
-                all_scalar = false;
-                break;
-            }
-        }
-        _skip_base_payload = all_scalar;
+        _skip_base_payload = _requested_paths_are_scalar_typed_leaves(_shredded_fields, _requested_shredded_paths);
     }
     return Status::OK();
 }
@@ -1846,13 +1872,16 @@ void VariantColumnReader::set_need_parse_levels(bool need_parse_levels) {
 
 void VariantColumnReader::collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges,
                                                   int64_t* end_offset, ColumnIOTypeFlags types, bool active) {
-    // Always include metadata and value in IO range.
-    // When _skip_base_payload: metadata is read for outer row-null mask; value is kept so that
-    // if per-field fallback values are detected at read time we can fall back to the per-row path.
-    if (_top_level.metadata_reader != nullptr) {
+    const bool skip_top_level_payload =
+            _top_level.root_typed_value_reader == nullptr &&
+            _requested_paths_are_scalar_typed_leaves(_shredded_fields, _requested_shredded_paths) &&
+            _requested_scalar_fallback_values_all_null(_shredded_fields, _requested_shredded_paths);
+    const bool skip_metadata = skip_top_level_payload && _column_chunk_has_no_null(_top_level.metadata_reader.get());
+
+    if (_top_level.metadata_reader != nullptr && !skip_metadata) {
         _top_level.metadata_reader->collect_column_io_range(ranges, end_offset, types, active);
     }
-    if (_top_level.value_reader != nullptr) {
+    if (_top_level.value_reader != nullptr && !skip_top_level_payload) {
         _top_level.value_reader->collect_column_io_range(ranges, end_offset, types, active);
     }
     if (_top_level.root_typed_value_reader != nullptr) {
@@ -1866,10 +1895,16 @@ void VariantColumnReader::collect_column_io_range(std::vector<io::SharedBuffered
 }
 
 void VariantColumnReader::select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) {
-    if (_top_level.metadata_reader != nullptr) {
+    const bool skip_top_level_payload =
+            _top_level.root_typed_value_reader == nullptr &&
+            _requested_paths_are_scalar_typed_leaves(_shredded_fields, _requested_shredded_paths) &&
+            _requested_scalar_fallback_values_all_null(_shredded_fields, _requested_shredded_paths);
+    const bool skip_metadata = skip_top_level_payload && _column_chunk_has_no_null(_top_level.metadata_reader.get());
+
+    if (_top_level.metadata_reader != nullptr && !skip_metadata) {
         _top_level.metadata_reader->select_offset_index(range, rg_first_row);
     }
-    if (_top_level.value_reader != nullptr) {
+    if (_top_level.value_reader != nullptr && !skip_top_level_payload) {
         _top_level.value_reader->select_offset_index(range, rg_first_row);
     }
     if (_top_level.root_typed_value_reader != nullptr) {
@@ -1956,14 +1991,19 @@ StatusOr<bool> VariantColumnReader::_read_range_skip_base_payload(const Range<ui
     // cannot be used as a reliable null indicator here.
     if (nullable_column != nullptr) {
         DCHECK(_top_level.metadata_reader != nullptr);
-        ColumnPtr metadata_col = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-        RETURN_IF_ERROR(_top_level.metadata_reader->read_range(range, filter, metadata_col));
-        const auto* metadata_nullable = down_cast<const NullableColumn*>(metadata_col.get());
-        DCHECK_EQ(metadata_nullable->size(), num_rows);
         auto* outer_null = nullable_column->null_column_raw_ptr();
-        outer_null->get_data().assign(metadata_nullable->null_column()->get_data().begin(),
-                                      metadata_nullable->null_column()->get_data().end());
-        nullable_column->set_has_null(metadata_nullable->has_null());
+        if (_column_chunk_has_no_null(_top_level.metadata_reader.get())) {
+            outer_null->get_data().assign(num_rows, 0);
+            nullable_column->set_has_null(false);
+        } else {
+            ColumnPtr metadata_col = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+            RETURN_IF_ERROR(_top_level.metadata_reader->read_range(range, filter, metadata_col));
+            const auto* metadata_nullable = down_cast<const NullableColumn*>(metadata_col.get());
+            DCHECK_EQ(metadata_nullable->size(), num_rows);
+            outer_null->get_data().assign(metadata_nullable->null_column()->get_data().begin(),
+                                          metadata_nullable->null_column()->get_data().end());
+            nullable_column->set_has_null(metadata_nullable->has_null());
+        }
     }
     return true;
 }

--- a/be/src/formats/parquet/complex_column_reader.h
+++ b/be/src/formats/parquet/complex_column_reader.h
@@ -389,6 +389,14 @@ public:
     // is BINARY/VARBINARY (whose Parquet min/max reflects byte-order, not semantic value order).
     // Array segments are not supported (shredded paths are object-key-only).
     const ColumnReader* filterable_typed_value_reader_for_path(const VariantPath& path) const;
+    // Returns the typed_value ColumnReader (mutable) for the given path if the node is SCALAR kind.
+    // Unlike filterable_typed_value_reader_for_path, this does NOT exclude BINARY/VARBINARY types;
+    // it is used for dict-filter promotion where the type check is delegated to the reader itself.
+    // Returns nullptr if the path is absent or the node is not SCALAR kind.
+    ColumnReader* scalar_typed_value_reader_for_path(const VariantPath& path);
+    // Returns true if all requested shredded paths are scalar typed-value leaves and the base
+    // payload (metadata + value columns) can be skipped entirely for this row group.
+    bool skip_base_payload() const { return _skip_base_payload; }
     // Returns the typed_value read type for the given parsed variant path.
     // The returned descriptor reflects the shredded leaf's physical typed_value encoding,
     // not the virtual slot's target type.
@@ -469,6 +477,78 @@ private:
     VariantColumnReader* _source;
     VariantPath _leaf_path;
     TypeDescriptor _virtual_slot_type;
+};
+
+// A thin read-through proxy for a shredded variant typed_value leaf ColumnReader.
+// Used when a virtual variant column is promoted to Phase 2 (with dict filter support),
+// bypassing the full VariantColumn construction path.  The underlying reader is non-owning:
+// it is owned by the ShreddedFieldNode inside the parent VariantColumnReader.
+class VariantTypedValueProxy final : public ColumnReader {
+public:
+    VariantTypedValueProxy(ColumnReader* reader, const TypeDescriptor& /*target_type*/)
+            : ColumnReader(reader->get_column_parquet_field()), _reader(reader) {}
+
+    // No-op: the underlying reader is already prepared by the parent VariantColumnReader.
+    Status prepare() override { return Status::OK(); }
+
+    Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) override {
+        return _reader->read_range(range, filter, dst);
+    }
+
+    void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
+        _reader->get_levels(def_levels, rep_levels, num_levels);
+    }
+
+    void set_need_parse_levels(bool need_parse_levels) override { _reader->set_need_parse_levels(need_parse_levels); }
+
+    void set_can_lazy_decode(bool can_lazy_decode) override { _reader->set_can_lazy_decode(can_lazy_decode); }
+
+    bool try_to_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
+                                const std::vector<std::string>& sub_field_path, const size_t& layer) override {
+        return _reader->try_to_use_dict_filter(ctx, is_decode_needed, slotId, sub_field_path, layer);
+    }
+
+    Status rewrite_conjunct_ctxs_to_predicate(bool* is_group_filtered, const std::vector<std::string>& sub_field_path,
+                                              const size_t& layer) override {
+        return _reader->rewrite_conjunct_ctxs_to_predicate(is_group_filtered, sub_field_path, layer);
+    }
+
+    Status filter_dict_column(ColumnPtr& column, Filter* filter, const std::vector<std::string>& sub_field_path,
+                              const size_t& layer) override {
+        return _reader->filter_dict_column(column, filter, sub_field_path, layer);
+    }
+
+    Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override { return _reader->fill_dst_column(dst, src); }
+
+    void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
+                                 ColumnIOTypeFlags types, bool active) override {
+        _reader->collect_column_io_range(ranges, end_offset, types, active);
+    }
+
+    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override {
+        _reader->select_offset_index(range, rg_first_row);
+    }
+
+    StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                             CompoundNodeType pred_relation, const uint64_t rg_first_row,
+                                             const uint64_t rg_num_rows) const override {
+        return _reader->row_group_zone_map_filter(predicates, pred_relation, rg_first_row, rg_num_rows);
+    }
+
+    StatusOr<bool> page_index_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                              SparseRange<uint64_t>* row_ranges, CompoundNodeType pred_relation,
+                                              const uint64_t rg_first_row, const uint64_t rg_num_rows) override {
+        return _reader->page_index_zone_map_filter(predicates, row_ranges, pred_relation, rg_first_row, rg_num_rows);
+    }
+
+    StatusOr<bool> row_group_bloom_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                          CompoundNodeType pred_relation, const uint64_t rg_first_row,
+                                          const uint64_t rg_num_rows) const override {
+        return _reader->row_group_bloom_filter(predicates, pred_relation, rg_first_row, rg_num_rows);
+    }
+
+private:
+    ColumnReader* _reader; // non-owning; owned by ShreddedFieldNode inside VariantColumnReader
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/complex_column_reader.h
+++ b/be/src/formats/parquet/complex_column_reader.h
@@ -407,6 +407,13 @@ public:
     bool fallback_values_all_null_in_row_group_for_path(const VariantPath& path, uint64_t rg_num_rows) const;
 
 private:
+    struct TopLevelSkipFlags {
+        bool skip_payload = false;
+        bool skip_metadata = false;
+    };
+
+    TopLevelSkipFlags _compute_top_level_skip_flags() const;
+
     // Fast-path read when _skip_base_payload is true.
     // Returns true if the fast path handled the read completely.
     // Returns false if fallback rows were detected; shredded fields are already populated and the
@@ -485,7 +492,7 @@ private:
 // it is owned by the ShreddedFieldNode inside the parent VariantColumnReader.
 class VariantTypedValueProxy final : public ColumnReader {
 public:
-    VariantTypedValueProxy(ColumnReader* reader, const TypeDescriptor& /*target_type*/)
+    explicit VariantTypedValueProxy(ColumnReader* reader)
             : ColumnReader(reader->get_column_parquet_field()), _reader(reader) {}
 
     // No-op: the underlying reader is already prepared by the parent VariantColumnReader.

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -1402,7 +1402,21 @@ Status GroupReader::_promote_variant_virtual_columns() {
 
         const auto& virtual_slots = slots_it->second;
 
-        // Check: can ALL virtual slots be promoted (each has a scalar typed_value leaf)?
+        // Check: can ALL virtual slots be promoted?  Three conditions must hold for each slot:
+        // 1. Has a scalar typed_value leaf reader.
+        // 2. Fallback value column is all-null for this row group (data is exclusively in
+        //    typed_value).  If any path has non-null fallback values, _read_range_skip_base_payload's
+        //    runtime detection would fall back to the base payload — which promotion bypasses,
+        //    producing all-NULLs.
+        // 3. The typed_value leaf's read type is directly compatible with the virtual slot's
+        //    target column type for raw writing.  Variable-length types (VARCHAR/VARBINARY etc.)
+        //    share the same BinaryColumn layout and are mutually compatible.  Fixed-size types
+        //    must match exactly; a mismatch (e.g. INT32 typed_value → BIGINT slot) causes the
+        //    PlainDecoder to write the wrong element width into the destination column, crashing.
+        const uint64_t rg_num_rows = get_row_group_metadata()->num_rows;
+        auto var_len_type = [](LogicalType t) {
+            return t == TYPE_VARCHAR || t == TYPE_CHAR || t == TYPE_VARBINARY || t == TYPE_BINARY;
+        };
         bool all_promotable = true;
         for (const auto& vsi : virtual_slots) {
             auto proj_it = _variant_virtual_projections.find(vsi.virtual_slot_id);
@@ -1412,6 +1426,18 @@ Status GroupReader::_promote_variant_virtual_columns() {
             }
             const auto& parsed_path = proj_it->second.parsed_path;
             if (vreader->scalar_typed_value_reader_for_path(parsed_path) == nullptr) {
+                all_promotable = false;
+                break;
+            }
+            if (!vreader->fallback_values_all_null_in_row_group_for_path(parsed_path, rg_num_rows)) {
+                all_promotable = false;
+                break;
+            }
+            const TypeDescriptor* leaf_type = vreader->typed_value_read_type_for_path(parsed_path);
+            const TypeDescriptor& target = proj_it->second.target_type;
+            bool type_ok = (leaf_type != nullptr) &&
+                           (var_len_type(leaf_type->type) && var_len_type(target.type) ? true : *leaf_type == target);
+            if (!type_ok) {
                 all_promotable = false;
                 break;
             }

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -1457,7 +1457,7 @@ Status GroupReader::_promote_variant_virtual_columns() {
             auto& proj = _variant_virtual_projections.at(vsi.virtual_slot_id);
             ColumnReader* leaf = leaf_readers_by_slot.at(vsi.virtual_slot_id);
 
-            auto proxy = std::make_unique<VariantTypedValueProxy>(leaf, proj.target_type);
+            auto proxy = std::make_unique<VariantTypedValueProxy>(leaf);
 
             if (vsi.has_conjunct) {
                 // Attempt dict filter for each conjunct; fall back to expression eval if failed.

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -1418,6 +1418,8 @@ Status GroupReader::_promote_variant_virtual_columns() {
             return t == TYPE_VARCHAR || t == TYPE_CHAR || t == TYPE_VARBINARY || t == TYPE_BINARY;
         };
         bool all_promotable = true;
+        std::unordered_set<ColumnReader*> promoted_leaf_readers;
+        std::unordered_map<SlotId, ColumnReader*> leaf_readers_by_slot;
         for (const auto& vsi : virtual_slots) {
             auto proj_it = _variant_virtual_projections.find(vsi.virtual_slot_id);
             if (proj_it == _variant_virtual_projections.end()) {
@@ -1425,10 +1427,16 @@ Status GroupReader::_promote_variant_virtual_columns() {
                 break;
             }
             const auto& parsed_path = proj_it->second.parsed_path;
-            if (vreader->scalar_typed_value_reader_for_path(parsed_path) == nullptr) {
+            ColumnReader* leaf = vreader->scalar_typed_value_reader_for_path(parsed_path);
+            if (leaf == nullptr) {
                 all_promotable = false;
                 break;
             }
+            if (!promoted_leaf_readers.insert(leaf).second) {
+                all_promotable = false;
+                break;
+            }
+            leaf_readers_by_slot.emplace(vsi.virtual_slot_id, leaf);
             if (!vreader->fallback_values_all_null_in_row_group_for_path(parsed_path, rg_num_rows)) {
                 all_promotable = false;
                 break;
@@ -1447,7 +1455,7 @@ Status GroupReader::_promote_variant_virtual_columns() {
         // Fully promote: create VariantTypedValueProxy for each virtual slot.
         for (const auto& vsi : virtual_slots) {
             auto& proj = _variant_virtual_projections.at(vsi.virtual_slot_id);
-            ColumnReader* leaf = vreader->scalar_typed_value_reader_for_path(proj.parsed_path);
+            ColumnReader* leaf = leaf_readers_by_slot.at(vsi.virtual_slot_id);
 
             auto proxy = std::make_unique<VariantTypedValueProxy>(leaf, proj.target_type);
 

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -476,6 +476,11 @@ Status GroupReader::prepare() {
         }
     }
 
+    // Promote shredded variant virtual columns to direct typed_value proxy readers (Phase 3.5).
+    // Must run after _prepare_column_readers() (which sets skip_base_payload) and after
+    // select_offset_index (so the underlying typed_value readers already have the correct range).
+    RETURN_IF_ERROR(_promote_variant_virtual_columns());
+
     // if coalesce read enabled, we have to
     // 1. allocate shared buffered input stream and
     // 2. collect io ranges of every row group reader.
@@ -1348,6 +1353,156 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
     }
 }
 
+Status GroupReader::_promote_variant_virtual_columns() {
+    // For each hidden variant source whose VariantColumnReader has _skip_base_payload=true
+    // (all requested shredded paths are scalar typed-value leaves), promote ALL virtual slots
+    // backed by that source to VariantTypedValueProxy readers in _column_readers.  This lets
+    // the proxy participate in Phase 2 dict-filter and eliminates the Phase 3 hidden-source
+    // read and Phase 4 deferred variant conjunct evaluation entirely.
+    //
+    // Full-promotion is all-or-nothing per source: if any virtual slot lacks a typed_value
+    // leaf, we skip the source entirely.  Partial promotion would corrupt the hidden source's
+    // read path (dict-filtered readers output INT codes, not decoded values).
+
+    // Build: hidden source slot_id → list of (virtual slot info) backed by that source.
+    struct VirtualSlotInfo {
+        SlotId virtual_slot_id;
+        int read_col_idx;
+        bool decode_needed;
+        bool has_conjunct;
+    };
+    std::unordered_map<SlotId, std::vector<VirtualSlotInfo>> slots_by_source;
+    {
+        int idx = 0;
+        for (const auto& column : _param.read_cols) {
+            if (column.is_extended_variant_virtual) {
+                auto proj_it = _variant_virtual_projections.find(column.slot_id());
+                if (proj_it != _variant_virtual_projections.end()) {
+                    SlotId src_id = proj_it->second.source_slot_id;
+                    // Only promote hidden sources (negative slot IDs).
+                    if (src_id < 0) {
+                        bool has_conj = _param.conjunct_ctxs_by_slot.count(column.slot_id()) > 0;
+                        slots_by_source[src_id].push_back({column.slot_id(), idx, column.decode_needed, has_conj});
+                    }
+                }
+            }
+            ++idx;
+        }
+    }
+
+    bool any_promoted = false;
+
+    for (auto& [src_name, hidden_source] : _hidden_variant_sources) {
+        SlotId src_id = hidden_source.slot_id;
+        auto slots_it = slots_by_source.find(src_id);
+        if (slots_it == slots_by_source.end()) continue;
+
+        auto* vreader = dynamic_cast<VariantColumnReader*>(hidden_source.reader.get());
+        if (vreader == nullptr || !vreader->skip_base_payload()) continue;
+
+        const auto& virtual_slots = slots_it->second;
+
+        // Check: can ALL virtual slots be promoted (each has a scalar typed_value leaf)?
+        bool all_promotable = true;
+        for (const auto& vsi : virtual_slots) {
+            auto proj_it = _variant_virtual_projections.find(vsi.virtual_slot_id);
+            if (proj_it == _variant_virtual_projections.end()) {
+                all_promotable = false;
+                break;
+            }
+            const auto& parsed_path = proj_it->second.parsed_path;
+            if (vreader->scalar_typed_value_reader_for_path(parsed_path) == nullptr) {
+                all_promotable = false;
+                break;
+            }
+        }
+        if (!all_promotable) continue;
+
+        // Fully promote: create VariantTypedValueProxy for each virtual slot.
+        for (const auto& vsi : virtual_slots) {
+            auto& proj = _variant_virtual_projections.at(vsi.virtual_slot_id);
+            ColumnReader* leaf = vreader->scalar_typed_value_reader_for_path(proj.parsed_path);
+
+            auto proxy = std::make_unique<VariantTypedValueProxy>(leaf, proj.target_type);
+
+            if (vsi.has_conjunct) {
+                // Attempt dict filter for each conjunct; fall back to expression eval if failed.
+                const auto& conjuncts = _param.conjunct_ctxs_by_slot.at(vsi.virtual_slot_id);
+                for (ExprContext* ctx : conjuncts) {
+                    std::vector<std::string> sub_field_path;
+                    // sub_field_path is empty: virtual slot IS the leaf value directly.
+                    if (proxy->try_to_use_dict_filter(ctx, vsi.decode_needed, vsi.virtual_slot_id, sub_field_path, 0)) {
+                        _use_as_dict_filter_column(vsi.read_col_idx, vsi.virtual_slot_id, sub_field_path);
+                    } else {
+                        _left_no_dict_filter_conjuncts_by_slot[vsi.virtual_slot_id].push_back(ctx);
+                    }
+                }
+            }
+            // Always place promoted slots in active indices regardless of conjunct presence.
+            // Projection-only promoted slots must also be active to guarantee active_chunk
+            // has a valid row count when it is the only column set being read.
+            _active_column_indices.push_back(vsi.read_col_idx);
+            _active_slot_ids.push_back(vsi.virtual_slot_id);
+
+            _column_readers[vsi.virtual_slot_id] = std::move(proxy);
+            _promoted_virtual_slots.insert(vsi.virtual_slot_id);
+            _variant_virtual_projections.erase(vsi.virtual_slot_id);
+        }
+
+        // Mark source as fully promoted and remove it from the active/lazy hidden-source lists.
+        hidden_source.fully_promoted = true;
+        _active_hidden_slot_ids.erase(
+                std::remove(_active_hidden_slot_ids.begin(), _active_hidden_slot_ids.end(), src_id),
+                _active_hidden_slot_ids.end());
+        _lazy_hidden_slot_ids.erase(std::remove(_lazy_hidden_slot_ids.begin(), _lazy_hidden_slot_ids.end(), src_id),
+                                    _lazy_hidden_slot_ids.end());
+        // Also remove the hidden source's slot_id from _active_slot_ids (added in Step 4 of
+        // _process_columns_and_conjunct_ctxs when the source was classified as active).
+        _active_slot_ids.erase(std::remove(_active_slot_ids.begin(), _active_slot_ids.end(), src_id),
+                               _active_slot_ids.end());
+
+        any_promoted = true;
+    }
+
+    if (!any_promoted) return Status::OK();
+
+    // Rebuild _column_read_order_ctx to include newly promoted active columns.
+    {
+        std::unordered_map<int, size_t> col_cost;
+        size_t all_cost = 0;
+        for (int col_idx : _active_column_indices) {
+            size_t flat_size = _param.read_cols[col_idx].slot_type().get_flat_size();
+            col_cost[col_idx] = flat_size;
+            all_cost += flat_size;
+        }
+        _column_read_order_ctx =
+                std::make_unique<ColumnReadOrderCtx>(_active_column_indices, all_cost, std::move(col_cost));
+    }
+
+    // Rebuild deferred conjunct list, excluding promoted slots.
+    {
+        std::vector<ExprContext*> remaining;
+        std::unordered_set<SlotId> remaining_ids;
+        for (const auto& column : _param.read_cols) {
+            if (!column.is_extended_variant_virtual) continue;
+            SlotId slot_id = column.slot_id();
+            if (_deferred_conjunct_slot_ids.count(slot_id) == 0) continue;
+            if (_promoted_virtual_slots.count(slot_id) > 0) continue;
+            auto it = _param.conjunct_ctxs_by_slot.find(slot_id);
+            if (it != _param.conjunct_ctxs_by_slot.end()) {
+                for (ExprContext* ctx : it->second) {
+                    remaining.push_back(ctx);
+                }
+                remaining_ids.insert(slot_id);
+            }
+        }
+        _deferred_variant_virtual_conjunct_ctxs = std::move(remaining);
+        _deferred_conjunct_slot_ids = std::move(remaining_ids);
+    }
+
+    return Status::OK();
+}
+
 bool GroupReader::_try_to_use_dict_filter(const GroupReaderParam::Column& column, ExprContext* ctx,
                                           std::vector<std::string>& sub_field_path, bool is_decode_needed) {
     const Expr* root_expr = ctx->root();
@@ -1409,6 +1564,10 @@ void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::I
         _column_readers[slot_id]->collect_column_io_range(ranges, &end, types, false);
     }
     for (const auto& [name, hidden_source] : _hidden_variant_sources) {
+        // Fully-promoted sources have all their virtual slots promoted to VariantTypedValueProxy
+        // readers in _column_readers (Phase 2).  Their IO is registered via the proxy entries
+        // in _active_column_indices above; skip the source here to avoid duplicate IO ranges.
+        if (hidden_source.fully_promoted) continue;
         hidden_source.reader->collect_column_io_range(ranges, &end, types, hidden_source.is_active);
     }
     deduplicate_io_ranges(ranges);

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -180,6 +180,9 @@ private:
         SlotId slot_id;                       // synthetic negative id (-1, -2, ...) that identifies this source
         std::unique_ptr<ColumnReader> reader; // reader for the underlying VARIANT column
         bool is_active = false;               // active (pre-conjunct) vs lazy (post-conjunct)
+        // true when ALL virtual slots backed by this source are promoted to VariantTypedValueProxy
+        // readers in Phase 2; skip IO and Phase 3 reads for this source entirely.
+        bool fully_promoted = false;
     };
 
     void _set_end_offset(int64_t value) { _end_offset = value; }
@@ -225,6 +228,11 @@ private:
     StatusOr<ColumnReaderPtr> _create_column_reader(const GroupReaderParam::Column& column);
     VariantShreddedReadHints _get_variant_shredded_hints(std::string_view column_name) const;
     Status _prepare_column_readers() const;
+    // Promotes variant virtual columns to VariantTypedValueProxy readers in Phase 2 when the
+    // backing hidden source has _skip_base_payload=true (all paths are scalar typed-value leaves).
+    // Promoted slots are placed in _column_readers instead of _variant_virtual_projections and
+    // the hidden source is marked fully_promoted=true to skip Phase 3 IO/reads.
+    Status _promote_variant_virtual_columns();
     // Creates a lightweight VIEW chunk of _read_chunk containing the given slot_ids.
     // Each entry in slot_ids must already exist as a column in _read_chunk. _init_read_chunk()
     // pre-allocates physical slots and active hidden variant source slots; lazy hidden sources
@@ -293,6 +301,11 @@ private:
     // slot ids of virtual columns that have at least one deferred conjunct.
     // used in _apply_deferred_variant_conjuncts to detect invariant violations.
     std::unordered_set<SlotId> _deferred_conjunct_slot_ids;
+
+    // Slot ids of virtual variant columns promoted to VariantTypedValueProxy readers in Phase 2.
+    // These slots appear in _column_readers (not _variant_virtual_projections) and participate
+    // in dict filter like normal physical columns.
+    std::unordered_set<SlotId> _promoted_virtual_slots;
 
     // active columns that hold read_col index
     std::vector<int> _active_column_indices;

--- a/be/test/formats/parquet/column_reader_factory_test.cpp
+++ b/be/test/formats/parquet/column_reader_factory_test.cpp
@@ -387,6 +387,39 @@ TEST(ColumnReaderFactoryTest, VariantShreddedAllNullFallbackSkipsIoRange) {
     ASSERT_EQ(baseline_ranges - 2, skipped_ranges);
 }
 
+TEST(ColumnReaderFactoryTest, VariantShreddedTypedLeafSkipsTopLevelBinaryIoRange) {
+    auto obj = make_shredded_object_node_with_nested_scalar("obj", 2, 3, 4, tparquet::Type::INT32);
+    ParquetField variant = make_variant_field_with_typed_group({obj});
+    auto opts = make_opts_with_num_cols(5);
+    auto* row_group_meta = const_cast<tparquet::RowGroup*>(opts.row_group_meta);
+    row_group_meta->__set_num_rows(8);
+
+    auto set_null_count = [&](int idx, int64_t null_count, int64_t num_values) {
+        auto& meta = row_group_meta->columns[idx].meta_data;
+        meta.__set_num_values(num_values);
+        tparquet::Statistics statistics;
+        statistics.__set_null_count(null_count);
+        meta.__set_statistics(statistics);
+    };
+    // Top-level metadata has no nulls, so the fast path can synthesize the outer null mask.
+    set_null_count(0, 0, 8);
+    // Requested leaf fallback is all null, so the fast path will not fall back to top-level value.
+    set_null_count(3, 8, 8);
+
+    VariantShreddedReadHints hints;
+    ASSERT_OK(hints.add_path("obj.k"));
+    auto st = ColumnReaderFactory::create_variant_column_reader(opts, &variant, hints);
+    ASSERT_TRUE(st.ok()) << st.status().to_string();
+
+    std::vector<io::SharedBufferedInputStream::IORange> ranges;
+    int64_t end_offset = 0;
+    st.value()->collect_column_io_range(&ranges, &end_offset, ColumnIOType::PAGES, true);
+
+    // Only the requested INT32 typed_value leaf should need page IO. Top-level metadata/value
+    // and the all-null leaf fallback value are all skipped.
+    ASSERT_EQ(1, ranges.size());
+}
+
 TEST(ColumnReaderFactoryTest, StructWithoutFieldIdMatchesIcebergSubfieldsByName) {
     ParquetField field;
     field.name = "col";

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -405,6 +405,114 @@ static StatusOr<GroupReader::VariantVirtualProjection> make_virtual_projection_f
             .parsed_path = std::move(parsed_path), .target_type = target_type, .source_slot_id = source_slot_id};
 }
 
+static tparquet::ColumnChunk make_variant_promotion_column_chunk(int idx, int64_t num_values) {
+    tparquet::ColumnChunk chunk;
+    chunk.__set_file_path("variant_promotion_col" + std::to_string(idx));
+    chunk.file_offset = 0;
+    chunk.meta_data.data_page_offset = 4;
+    chunk.meta_data.__set_num_values(num_values);
+    chunk.meta_data.__set_total_compressed_size(0);
+    return chunk;
+}
+
+static void set_variant_promotion_null_count(tparquet::RowGroup* row_group, int idx, int64_t null_count,
+                                             int64_t num_values) {
+    auto& meta = row_group->columns[idx].meta_data;
+    meta.__set_num_values(num_values);
+    tparquet::Statistics statistics;
+    statistics.__set_null_count(null_count);
+    meta.__set_statistics(statistics);
+}
+
+static ParquetField make_variant_promotion_scalar_field(const std::string& name, int idx,
+                                                        tparquet::Type::type physical_type) {
+    ParquetField field;
+    field.name = name;
+    field.type = ColumnType::SCALAR;
+    field.physical_type = physical_type;
+    field.physical_column_index = idx;
+    return field;
+}
+
+static ParquetField make_variant_promotion_shredded_scalar(const std::string& name, int value_idx, int typed_idx,
+                                                           tparquet::Type::type typed_physical_type) {
+    ParquetField node;
+    node.name = name;
+    node.type = ColumnType::STRUCT;
+    node.children.emplace_back(make_variant_promotion_scalar_field("value", value_idx, tparquet::Type::BYTE_ARRAY));
+    node.children.emplace_back(make_variant_promotion_scalar_field("typed_value", typed_idx, typed_physical_type));
+    return node;
+}
+
+static ParquetField make_variant_promotion_variant_field() {
+    ParquetField variant;
+    variant.name = "data";
+    variant.type = ColumnType::STRUCT;
+    variant.children.emplace_back(make_variant_promotion_scalar_field("metadata", 0, tparquet::Type::BYTE_ARRAY));
+    variant.children.emplace_back(make_variant_promotion_scalar_field("value", 1, tparquet::Type::BYTE_ARRAY));
+
+    ParquetField typed_group;
+    typed_group.name = "typed_value";
+    typed_group.type = ColumnType::STRUCT;
+    typed_group.children.emplace_back(make_variant_promotion_shredded_scalar("a", 2, 3, tparquet::Type::INT32));
+    typed_group.children.emplace_back(make_variant_promotion_shredded_scalar("b", 4, 5, tparquet::Type::INT32));
+    variant.children.emplace_back(std::move(typed_group));
+    return variant;
+}
+
+static StatusOr<ColumnReaderPtr> make_variant_promotion_reader(ObjectPool* pool,
+                                                               std::initializer_list<std::string_view> requested_paths,
+                                                               int64_t num_rows, int64_t fallback_a_null_count,
+                                                               int64_t fallback_b_null_count) {
+    auto* row_group = pool->add(new tparquet::RowGroup());
+    std::vector<tparquet::ColumnChunk> columns;
+    for (int i = 0; i < 6; ++i) {
+        columns.emplace_back(make_variant_promotion_column_chunk(i, num_rows));
+    }
+    row_group->__set_columns(std::move(columns));
+    row_group->__set_num_rows(num_rows);
+    set_variant_promotion_null_count(row_group, 0, 0, num_rows);
+    set_variant_promotion_null_count(row_group, 2, fallback_a_null_count, num_rows);
+    set_variant_promotion_null_count(row_group, 4, fallback_b_null_count, num_rows);
+
+    VariantShreddedReadHints hints;
+    for (std::string_view path : requested_paths) {
+        RETURN_IF_ERROR(hints.add_path(std::string(path)));
+    }
+
+    ColumnReaderOptions opts;
+    opts.row_group_meta = row_group;
+    opts.file = pool->add(new RandomAccessFile(std::make_shared<MockInputStream>(), "variant-promotion-mock"));
+    opts.chunk_size = config::vector_chunk_size;
+
+    auto* variant = pool->add(new ParquetField(make_variant_promotion_variant_field()));
+    ASSIGN_OR_RETURN(auto reader, ColumnReaderFactory::create_variant_column_reader(opts, variant, hints));
+    RETURN_IF_ERROR(reader->prepare());
+    return reader;
+}
+
+static GroupReaderParam::Column make_variant_virtual_column_for_promotion_test(SlotDescriptor* slot,
+                                                                               std::string leaf_path) {
+    GroupReaderParam::Column column{};
+    column.idx_in_parquet = 0;
+    column.type_in_parquet = tparquet::Type::BYTE_ARRAY;
+    column.slot_desc = slot;
+    column.decode_needed = false;
+    column.is_extended_variant_virtual = true;
+    column.source_variant_column_name = "data";
+    column.variant_virtual_leaf_path = std::move(leaf_path);
+    return column;
+}
+
+static void attach_hidden_variant_source_for_promotion_test(GroupReader* group_reader, SlotId source_slot_id,
+                                                            ColumnReaderPtr reader) {
+    auto& source = group_reader->_hidden_variant_sources
+                           .emplace("data", GroupReader::HiddenVariantSource{.slot_id = source_slot_id,
+                                                                             .reader = std::move(reader)})
+                           .first->second;
+    group_reader->_hidden_slot_index[source_slot_id] = &source;
+}
+
 ChunkPtr GroupReaderTest::_create_chunk(GroupReaderParam* param) {
     ChunkPtr chunk = std::make_shared<Chunk>();
     for (auto& column : param->read_cols) {
@@ -3162,6 +3270,130 @@ TEST_F(GroupReaderTest, ProcessColumnsClassifiesHiddenSourcesAsActiveOrLazy) {
                           active_src_id) != group_reader->_active_slot_ids.end());
     // _deferred_conjunct_slot_ids must contain vslot_active
     EXPECT_EQ(1u, group_reader->_deferred_conjunct_slot_ids.count(vslot_active->id()));
+}
+
+TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsDuplicateTypedLeafReaders) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* vslot1 = _pool.add(new SlotDescriptor(220, "data.a1", TypeDescriptor::from_logical_type(TYPE_INT)));
+    auto* vslot2 = _pool.add(new SlotDescriptor(221, "data.a2", TypeDescriptor::from_logical_type(TYPE_INT)));
+    param->read_cols.emplace_back(make_variant_virtual_column_for_promotion_test(vslot1, "a"));
+    param->read_cols.emplace_back(make_variant_virtual_column_for_promotion_test(vslot2, "a"));
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    const SlotId source_slot_id = SlotId(-20);
+    ASSIGN_OR_ABORT(auto proj1, make_virtual_projection_for_test("a", vslot1->type(), source_slot_id));
+    ASSIGN_OR_ABORT(auto proj2, make_virtual_projection_for_test("a", vslot2->type(), source_slot_id));
+    group_reader->_variant_virtual_projections.emplace(vslot1->id(), std::move(proj1));
+    group_reader->_variant_virtual_projections.emplace(vslot2->id(), std::move(proj2));
+
+    ASSIGN_OR_ABORT(auto reader, make_variant_promotion_reader(&_pool, {"a"}, 12, 12, 12));
+    attach_hidden_variant_source_for_promotion_test(group_reader, source_slot_id, std::move(reader));
+    group_reader->_process_columns_and_conjunct_ctxs();
+
+    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+
+    EXPECT_TRUE(group_reader->_promoted_virtual_slots.empty());
+    EXPECT_EQ(2, group_reader->_variant_virtual_projections.size());
+    EXPECT_FALSE(group_reader->_hidden_slot_index.at(source_slot_id)->fully_promoted);
+    EXPECT_EQ(group_reader->_column_readers.end(), group_reader->_column_readers.find(vslot1->id()));
+    EXPECT_EQ(group_reader->_column_readers.end(), group_reader->_column_readers.find(vslot2->id()));
+}
+
+TEST_F(GroupReaderTest, VariantVirtualPromotionPromotesDifferentTypedLeafReaders) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* vslot1 = _pool.add(new SlotDescriptor(222, "data.a", TypeDescriptor::from_logical_type(TYPE_INT)));
+    auto* vslot2 = _pool.add(new SlotDescriptor(223, "data.b", TypeDescriptor::from_logical_type(TYPE_INT)));
+    param->read_cols.emplace_back(make_variant_virtual_column_for_promotion_test(vslot1, "a"));
+    param->read_cols.emplace_back(make_variant_virtual_column_for_promotion_test(vslot2, "b"));
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    const SlotId source_slot_id = SlotId(-21);
+    ASSIGN_OR_ABORT(auto proj1, make_virtual_projection_for_test("a", vslot1->type(), source_slot_id));
+    ASSIGN_OR_ABORT(auto proj2, make_virtual_projection_for_test("b", vslot2->type(), source_slot_id));
+    group_reader->_variant_virtual_projections.emplace(vslot1->id(), std::move(proj1));
+    group_reader->_variant_virtual_projections.emplace(vslot2->id(), std::move(proj2));
+
+    ASSIGN_OR_ABORT(auto reader, make_variant_promotion_reader(&_pool, {"a", "b"}, 12, 12, 12));
+    attach_hidden_variant_source_for_promotion_test(group_reader, source_slot_id, std::move(reader));
+    group_reader->_process_columns_and_conjunct_ctxs();
+
+    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+
+    EXPECT_EQ(2, group_reader->_promoted_virtual_slots.size());
+    EXPECT_EQ(1u, group_reader->_promoted_virtual_slots.count(vslot1->id()));
+    EXPECT_EQ(1u, group_reader->_promoted_virtual_slots.count(vslot2->id()));
+    EXPECT_TRUE(group_reader->_variant_virtual_projections.empty());
+    EXPECT_TRUE(group_reader->_hidden_slot_index.at(source_slot_id)->fully_promoted);
+    ASSERT_NE(group_reader->_column_readers.end(), group_reader->_column_readers.find(vslot1->id()));
+    ASSERT_NE(group_reader->_column_readers.end(), group_reader->_column_readers.find(vslot2->id()));
+    EXPECT_NE(nullptr, down_cast<VariantTypedValueProxy*>(group_reader->_column_readers.at(vslot1->id()).get()));
+    EXPECT_NE(nullptr, down_cast<VariantTypedValueProxy*>(group_reader->_column_readers.at(vslot2->id()).get()));
+}
+
+TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsNonAllNullFallback) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* vslot = _pool.add(new SlotDescriptor(224, "data.a", TypeDescriptor::from_logical_type(TYPE_INT)));
+    param->read_cols.emplace_back(make_variant_virtual_column_for_promotion_test(vslot, "a"));
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    const SlotId source_slot_id = SlotId(-22);
+    ASSIGN_OR_ABORT(auto proj, make_virtual_projection_for_test("a", vslot->type(), source_slot_id));
+    group_reader->_variant_virtual_projections.emplace(vslot->id(), std::move(proj));
+
+    ASSIGN_OR_ABORT(auto reader, make_variant_promotion_reader(&_pool, {"a"}, 12, 11, 12));
+    attach_hidden_variant_source_for_promotion_test(group_reader, source_slot_id, std::move(reader));
+    group_reader->_process_columns_and_conjunct_ctxs();
+
+    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+
+    EXPECT_TRUE(group_reader->_promoted_virtual_slots.empty());
+    EXPECT_EQ(1, group_reader->_variant_virtual_projections.size());
+    EXPECT_FALSE(group_reader->_hidden_slot_index.at(source_slot_id)->fully_promoted);
+}
+
+TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsIncompatibleTargetType) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* vslot = _pool.add(new SlotDescriptor(225, "data.a", TypeDescriptor::from_logical_type(TYPE_BIGINT)));
+    param->read_cols.emplace_back(make_variant_virtual_column_for_promotion_test(vslot, "a"));
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    const SlotId source_slot_id = SlotId(-23);
+    ASSIGN_OR_ABORT(auto proj, make_virtual_projection_for_test("a", vslot->type(), source_slot_id));
+    group_reader->_variant_virtual_projections.emplace(vslot->id(), std::move(proj));
+
+    ASSIGN_OR_ABORT(auto reader, make_variant_promotion_reader(&_pool, {"a"}, 12, 12, 12));
+    attach_hidden_variant_source_for_promotion_test(group_reader, source_slot_id, std::move(reader));
+    group_reader->_process_columns_and_conjunct_ctxs();
+
+    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+
+    EXPECT_TRUE(group_reader->_promoted_virtual_slots.empty());
+    EXPECT_EQ(1, group_reader->_variant_virtual_projections.size());
+    EXPECT_FALSE(group_reader->_hidden_slot_index.at(source_slot_id)->fully_promoted);
 }
 
 TEST_F(GroupReaderTest, CreateColumnReadersRegistersVirtualZoneMapReaderForHiddenSource) {

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -398,6 +398,44 @@ static Status create_bigint_eq_conjunct_ctxs(ObjectPool* pool, RuntimeState* sta
     return Status::OK();
 }
 
+static Status create_int_eq_conjunct_ctxs(ObjectPool* pool, RuntimeState* state, SlotId slot_id, int32_t value,
+                                          std::vector<ExprContext*>* conjunct_ctxs) {
+    TExprNode pred_node = ExprsTestHelper::create_binary_pred_node(TPrimitiveType::INT, TExprOpcode::EQ);
+    TExprNode slot_ref = ExprsTestHelper::create_slot_expr_node_t<TYPE_INT>(0, slot_id, true);
+    TExprNode literal = ExprsTestHelper::create_literal<TYPE_INT, int32_t>(value, false);
+
+    TExpr expr;
+    expr.nodes.emplace_back(pred_node);
+    expr.nodes.emplace_back(slot_ref);
+    expr.nodes.emplace_back(literal);
+
+    std::vector<TExpr> conjunct_exprs{expr};
+    RETURN_IF_ERROR(ExprFactory::create_expr_trees(pool, conjunct_exprs, conjunct_ctxs, nullptr));
+    RETURN_IF_ERROR(ExprExecutor::prepare(*conjunct_ctxs, state));
+    DictOptimizeParser::disable_open_rewrite(conjunct_ctxs);
+    RETURN_IF_ERROR(ExprExecutor::open(*conjunct_ctxs, state));
+    return Status::OK();
+}
+
+static Status create_varchar_eq_conjunct_ctxs(ObjectPool* pool, RuntimeState* state, SlotId slot_id,
+                                              const std::string& value, std::vector<ExprContext*>* conjunct_ctxs) {
+    TExprNode pred_node = ExprsTestHelper::create_binary_pred_node(TPrimitiveType::VARCHAR, TExprOpcode::EQ);
+    TExprNode slot_ref = ExprsTestHelper::create_slot_expr_node_t<TYPE_VARCHAR>(0, slot_id, true);
+    TExprNode literal = ExprsTestHelper::create_literal<TYPE_VARCHAR, std::string>(value, false);
+
+    TExpr expr;
+    expr.nodes.emplace_back(pred_node);
+    expr.nodes.emplace_back(slot_ref);
+    expr.nodes.emplace_back(literal);
+
+    std::vector<TExpr> conjunct_exprs{expr};
+    RETURN_IF_ERROR(ExprFactory::create_expr_trees(pool, conjunct_exprs, conjunct_ctxs, nullptr));
+    RETURN_IF_ERROR(ExprExecutor::prepare(*conjunct_ctxs, state));
+    DictOptimizeParser::disable_open_rewrite(conjunct_ctxs);
+    RETURN_IF_ERROR(ExprExecutor::open(*conjunct_ctxs, state));
+    return Status::OK();
+}
+
 static StatusOr<GroupReader::VariantVirtualProjection> make_virtual_projection_for_test(
         const std::string& leaf_path, const TypeDescriptor& target_type, SlotId source_slot_id) {
     ASSIGN_OR_RETURN(auto parsed_path, VariantPathParser::parse_shredded_path(std::string_view(leaf_path)));
@@ -444,7 +482,9 @@ static ParquetField make_variant_promotion_shredded_scalar(const std::string& na
     return node;
 }
 
-static ParquetField make_variant_promotion_variant_field() {
+static ParquetField make_variant_promotion_variant_field(
+        tparquet::Type::type a_typed_physical_type = tparquet::Type::INT32,
+        tparquet::Type::type b_typed_physical_type = tparquet::Type::INT32) {
     ParquetField variant;
     variant.name = "data";
     variant.type = ColumnType::STRUCT;
@@ -454,16 +494,18 @@ static ParquetField make_variant_promotion_variant_field() {
     ParquetField typed_group;
     typed_group.name = "typed_value";
     typed_group.type = ColumnType::STRUCT;
-    typed_group.children.emplace_back(make_variant_promotion_shredded_scalar("a", 2, 3, tparquet::Type::INT32));
-    typed_group.children.emplace_back(make_variant_promotion_shredded_scalar("b", 4, 5, tparquet::Type::INT32));
+    typed_group.children.emplace_back(make_variant_promotion_shredded_scalar("a", 2, 3, a_typed_physical_type));
+    typed_group.children.emplace_back(make_variant_promotion_shredded_scalar("b", 4, 5, b_typed_physical_type));
     variant.children.emplace_back(std::move(typed_group));
     return variant;
 }
 
-static StatusOr<ColumnReaderPtr> make_variant_promotion_reader(ObjectPool* pool,
-                                                               std::initializer_list<std::string_view> requested_paths,
-                                                               int64_t num_rows, int64_t fallback_a_null_count,
-                                                               int64_t fallback_b_null_count) {
+static StatusOr<ColumnReaderPtr> make_variant_promotion_reader(
+        ObjectPool* pool, std::initializer_list<std::string_view> requested_paths, int64_t num_rows,
+        int64_t fallback_a_null_count, int64_t fallback_b_null_count,
+        tparquet::Type::type a_typed_physical_type = tparquet::Type::INT32,
+        tparquet::Type::type b_typed_physical_type = tparquet::Type::INT32, bool a_typed_dict_encoded = false,
+        bool b_typed_dict_encoded = false) {
     auto* row_group = pool->add(new tparquet::RowGroup());
     std::vector<tparquet::ColumnChunk> columns;
     for (int i = 0; i < 6; ++i) {
@@ -474,6 +516,12 @@ static StatusOr<ColumnReaderPtr> make_variant_promotion_reader(ObjectPool* pool,
     set_variant_promotion_null_count(row_group, 0, 0, num_rows);
     set_variant_promotion_null_count(row_group, 2, fallback_a_null_count, num_rows);
     set_variant_promotion_null_count(row_group, 4, fallback_b_null_count, num_rows);
+    if (a_typed_dict_encoded) {
+        row_group->columns[3].meta_data.__set_encodings({tparquet::Encoding::RLE_DICTIONARY});
+    }
+    if (b_typed_dict_encoded) {
+        row_group->columns[5].meta_data.__set_encodings({tparquet::Encoding::RLE_DICTIONARY});
+    }
 
     VariantShreddedReadHints hints;
     for (std::string_view path : requested_paths) {
@@ -485,7 +533,8 @@ static StatusOr<ColumnReaderPtr> make_variant_promotion_reader(ObjectPool* pool,
     opts.file = pool->add(new RandomAccessFile(std::make_shared<MockInputStream>(), "variant-promotion-mock"));
     opts.chunk_size = config::vector_chunk_size;
 
-    auto* variant = pool->add(new ParquetField(make_variant_promotion_variant_field()));
+    auto* variant = pool->add(
+            new ParquetField(make_variant_promotion_variant_field(a_typed_physical_type, b_typed_physical_type)));
     ASSIGN_OR_RETURN(auto reader, ColumnReaderFactory::create_variant_column_reader(opts, variant, hints));
     RETURN_IF_ERROR(reader->prepare());
     return reader;
@@ -3342,6 +3391,51 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionPromotesDifferentTypedLeafReaders
     EXPECT_NE(nullptr, down_cast<VariantTypedValueProxy*>(group_reader->_column_readers.at(vslot2->id()).get()));
 }
 
+TEST_F(GroupReaderTest, VariantVirtualPromotionClassifiesDictFilterConjuncts) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* dict_slot = _pool.add(new SlotDescriptor(228, "data.a", TypeDescriptor::from_logical_type(TYPE_VARCHAR)));
+    auto* expr_slot = _pool.add(new SlotDescriptor(229, "data.b", TypeDescriptor::from_logical_type(TYPE_INT)));
+    param->read_cols.emplace_back(make_variant_virtual_column_for_promotion_test(dict_slot, "a"));
+    param->read_cols.emplace_back(make_variant_virtual_column_for_promotion_test(expr_slot, "b"));
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> dict_conjuncts;
+    ASSERT_OK(create_varchar_eq_conjunct_ctxs(&_pool, &runtime_state, dict_slot->id(), "x", &dict_conjuncts));
+    param->conjunct_ctxs_by_slot[dict_slot->id()] = dict_conjuncts;
+    std::vector<ExprContext*> expr_conjuncts;
+    ASSERT_OK(create_int_eq_conjunct_ctxs(&_pool, &runtime_state, expr_slot->id(), 7, &expr_conjuncts));
+    param->conjunct_ctxs_by_slot[expr_slot->id()] = expr_conjuncts;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    const SlotId source_slot_id = SlotId(-26);
+    ASSIGN_OR_ABORT(auto dict_proj, make_virtual_projection_for_test("a", dict_slot->type(), source_slot_id));
+    ASSIGN_OR_ABORT(auto expr_proj, make_virtual_projection_for_test("b", expr_slot->type(), source_slot_id));
+    group_reader->_variant_virtual_projections.emplace(dict_slot->id(), std::move(dict_proj));
+    group_reader->_variant_virtual_projections.emplace(expr_slot->id(), std::move(expr_proj));
+
+    ASSIGN_OR_ABORT(auto reader,
+                    make_variant_promotion_reader(&_pool, {"a", "b"}, 12, 12, 12, tparquet::Type::BYTE_ARRAY,
+                                                  tparquet::Type::INT32, true, false));
+    attach_hidden_variant_source_for_promotion_test(group_reader, source_slot_id, std::move(reader));
+    group_reader->_process_columns_and_conjunct_ctxs();
+
+    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+
+    EXPECT_EQ(2, group_reader->_promoted_virtual_slots.size());
+    ASSERT_EQ(1, group_reader->_dict_column_indices.size());
+    EXPECT_EQ(0, group_reader->_dict_column_indices[0]);
+    EXPECT_EQ(1u, group_reader->_dict_column_sub_field_paths.count(0));
+    ASSERT_EQ(1u, group_reader->_left_no_dict_filter_conjuncts_by_slot.count(expr_slot->id()));
+    EXPECT_EQ(1, group_reader->_left_no_dict_filter_conjuncts_by_slot.at(expr_slot->id()).size());
+    EXPECT_EQ(0u, group_reader->_left_no_dict_filter_conjuncts_by_slot.count(dict_slot->id()));
+}
+
 TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsNonAllNullFallback) {
     auto* param = _create_group_reader_param();
     FileMetaData* file_meta;
@@ -3394,6 +3488,73 @@ TEST_F(GroupReaderTest, VariantVirtualPromotionSkipsIncompatibleTargetType) {
     EXPECT_TRUE(group_reader->_promoted_virtual_slots.empty());
     EXPECT_EQ(1, group_reader->_variant_virtual_projections.size());
     EXPECT_FALSE(group_reader->_hidden_slot_index.at(source_slot_id)->fully_promoted);
+}
+
+TEST_F(GroupReaderTest, VariantVirtualPromotionKeepsUnpromotedMixedSourceActiveAndRebuildsReadOrder) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+    param->read_cols.clear();
+
+    auto* promoted_slot = _pool.add(new SlotDescriptor(226, "data1.a", TypeDescriptor::from_logical_type(TYPE_INT)));
+    auto* unpromoted_slot =
+            _pool.add(new SlotDescriptor(227, "data2.a", TypeDescriptor::from_logical_type(TYPE_BIGINT)));
+    auto promoted_col = make_variant_virtual_column_for_promotion_test(promoted_slot, "a");
+    promoted_col.source_variant_column_name = "data1";
+    auto unpromoted_col = make_variant_virtual_column_for_promotion_test(unpromoted_slot, "a");
+    unpromoted_col.source_variant_column_name = "data2";
+    param->read_cols.emplace_back(std::move(promoted_col));
+    param->read_cols.emplace_back(std::move(unpromoted_col));
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, unpromoted_slot->id(), 11, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[unpromoted_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    const SlotId promoted_source_slot_id = SlotId(-24);
+    const SlotId unpromoted_source_slot_id = SlotId(-25);
+    ASSIGN_OR_ABORT(auto promoted_proj,
+                    make_virtual_projection_for_test("a", promoted_slot->type(), promoted_source_slot_id));
+    ASSIGN_OR_ABORT(auto unpromoted_proj,
+                    make_virtual_projection_for_test("a", unpromoted_slot->type(), unpromoted_source_slot_id));
+    group_reader->_variant_virtual_projections.emplace(promoted_slot->id(), std::move(promoted_proj));
+    group_reader->_variant_virtual_projections.emplace(unpromoted_slot->id(), std::move(unpromoted_proj));
+
+    ASSIGN_OR_ABORT(auto promoted_reader, make_variant_promotion_reader(&_pool, {"a"}, 12, 12, 12));
+    ASSIGN_OR_ABORT(auto unpromoted_reader, make_variant_promotion_reader(&_pool, {"a"}, 12, 12, 12));
+    auto& promoted_source =
+            group_reader->_hidden_variant_sources
+                    .emplace("data1", GroupReader::HiddenVariantSource{.slot_id = promoted_source_slot_id,
+                                                                       .reader = std::move(promoted_reader)})
+                    .first->second;
+    auto& unpromoted_source =
+            group_reader->_hidden_variant_sources
+                    .emplace("data2", GroupReader::HiddenVariantSource{.slot_id = unpromoted_source_slot_id,
+                                                                       .reader = std::move(unpromoted_reader)})
+                    .first->second;
+    group_reader->_hidden_slot_index[promoted_source_slot_id] = &promoted_source;
+    group_reader->_hidden_slot_index[unpromoted_source_slot_id] = &unpromoted_source;
+    group_reader->_process_columns_and_conjunct_ctxs();
+
+    ASSERT_OK(group_reader->_promote_variant_virtual_columns());
+
+    EXPECT_EQ(1u, group_reader->_promoted_virtual_slots.count(promoted_slot->id()));
+    EXPECT_EQ(0u, group_reader->_promoted_virtual_slots.count(unpromoted_slot->id()));
+    EXPECT_TRUE(group_reader->_hidden_slot_index.at(promoted_source_slot_id)->fully_promoted);
+    EXPECT_FALSE(group_reader->_hidden_slot_index.at(unpromoted_source_slot_id)->fully_promoted);
+    EXPECT_EQ(1u, group_reader->_variant_virtual_projections.count(unpromoted_slot->id()));
+    EXPECT_EQ(0u, group_reader->_variant_virtual_projections.count(promoted_slot->id()));
+    EXPECT_NE(group_reader->_active_hidden_slot_ids.end(),
+              std::find(group_reader->_active_hidden_slot_ids.begin(), group_reader->_active_hidden_slot_ids.end(),
+                        unpromoted_source_slot_id));
+    EXPECT_EQ(group_reader->_active_hidden_slot_ids.end(),
+              std::find(group_reader->_active_hidden_slot_ids.begin(), group_reader->_active_hidden_slot_ids.end(),
+                        promoted_source_slot_id));
+    EXPECT_EQ(1u, group_reader->_column_read_order_ctx->get_column_read_order().size());
+    EXPECT_EQ(0, group_reader->_column_read_order_ctx->get_column_read_order()[0]);
 }
 
 TEST_F(GroupReaderTest, CreateColumnReadersRegistersVirtualZoneMapReaderForHiddenSource) {


### PR DESCRIPTION
## Why I'm doing:

Variant shredded columns read significantly slower than struct columns for the same dataset. Profiling showed a key asymmetry: struct subfield predicates (`commit.collection IN (...)`) are evaluated as dict-code integer comparisons in Phase 2, eliminating rows before string materialization. For variant virtual columns, all conjuncts were unconditionally deferred to Phase 4 after full VariantColumn reconstruction, and even simple projections went through the expensive Phase 3 `_read_range_skip_base_payload` → Phase 4 `project_variant_leaf_column` path.

## What I'm doing:

**Variant Virtual Column Promotion (Phase 2 bypass)**

When a variant's hidden source has `_skip_base_payload = true` (all requested shredded paths are scalar `typed_value` leaves), AND each path satisfies two safety conditions (see below), promote ALL virtual slots to `VariantTypedValueProxy` readers in `_column_readers`. This lets them participate in Phase 2 like normal physical columns — including dict filter — and skips Phase 3 hidden-source reads entirely.

A `VariantTypedValueProxy` is a thin non-owning wrapper around the leaf `ScalarColumnReader` from `ShreddedFieldNode::typed_value_reader`. It delegates `read_range`, `fill_dst_column`, `try_to_use_dict_filter`, `rewrite_conjunct_ctxs_to_predicate`, and `filter_dict_column` directly to the underlying leaf reader, enabling full dict-filter participation without materializing the VARIANT column first.

**Two safety conditions for promotion per path:**

1. **Fallback must be all-null for this row group** (`fallback_values_all_null_in_row_group_for_path`). If the `value` (base payload) column has any non-null entries, `_read_range_skip_base_payload`'s runtime detection would fall back to base-payload reconstruction — which promotion bypasses entirely, producing all-NULLs. Example: `department.typed_value` is all-null in the test file (data lives in `department.value`).

2. **Type must be directly write-compatible** between the typed_value leaf's `read_type` and the target slot type. Variable-length types (VARCHAR/VARBINARY/CHAR/BINARY) share the same `BinaryColumn` layout and are mutually safe. Fixed-size types must match exactly — a mismatch (e.g. INT32 `typed_value` → BIGINT slot) causes `PlainDecoder<int>` to write 4-byte elements into an 8-byte column, crashing with `length % sizeof(ValueType) == 0` assertion failure.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4