### PR TITLE
[Enhancement] Eliminate HTTP-server accept thundering-herd via SO_REUSEPORT

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -533,6 +533,13 @@ CONF_Int32(be_http_port, "8040");
 CONF_Alias(be_http_port, webserver_port);
 // Number of http workers in BE
 CONF_Int32(be_http_num_workers, "48");
+// When true, each HTTP worker creates its own listening socket with
+// SO_REUSEPORT so the kernel load-balances incoming connections in-kernel,
+// instead of all workers epoll-waiting on a single shared listen fd and
+// thundering-herd-racing on accept(). Eliminates the kernel
+// inet_csk_accept / native_queued_spin_lock_slowpath contention that
+// dominates HTTP-server CPU when be_http_num_workers is large.
+CONF_Bool(enable_http_server_so_reuseport, "true");
 // Period to update rate counters and sampling counters in ms.
 CONF_mInt32(periodic_counter_update_period_ms, "500");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -533,13 +533,6 @@ CONF_Int32(be_http_port, "8040");
 CONF_Alias(be_http_port, webserver_port);
 // Number of http workers in BE
 CONF_Int32(be_http_num_workers, "48");
-// When true, each HTTP worker creates its own listening socket with
-// SO_REUSEPORT so the kernel load-balances incoming connections in-kernel,
-// instead of all workers epoll-waiting on a single shared listen fd and
-// thundering-herd-racing on accept(). Eliminates the kernel
-// inet_csk_accept / native_queued_spin_lock_slowpath contention that
-// dominates HTTP-server CPU when be_http_num_workers is large.
-CONF_Bool(enable_http_server_so_reuseport, "true");
 // Period to update rate counters and sampling counters in ms.
 CONF_mInt32(periodic_counter_update_period_ms, "500");
 

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -54,7 +54,6 @@
 
 #include "base/brpc/brpc.h"
 #include "base/system/errno.h"
-#include "common/config.h"
 #include "common/config_ingest_fwd.h"
 #include "common/logging.h"
 #include "common/system/backend_options.h"

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -201,17 +201,18 @@ Status EvHttpServer::start() {
 
     // Resolve the bind endpoint once, on the main thread, for per-worker
     // SO_REUSEPORT listeners. _bind() has already populated _real_port (incl.
-    // the port==0 auto-assign case).
+    // the port==0 auto-assign case). On platforms without SO_REUSEPORT or
+    // when endpoint resolution fails, every worker silently falls back to
+    // the shared-fd accept path (no functional change vs the legacy
+    // behaviour).
     butil::EndPoint listen_point;
     bool reuseport_enabled = false;
 #ifdef SO_REUSEPORT
-    if (config::enable_http_server_so_reuseport) {
-        if (butil::str2endpoint(_host.c_str(), _real_port, &listen_point) == 0) {
-            reuseport_enabled = true;
-        } else {
-            LOG(WARNING) << "Failed to resolve listen endpoint " << _host << ":" << _real_port
-                         << " for SO_REUSEPORT mode; falling back to shared-fd accept";
-        }
+    if (butil::str2endpoint(_host.c_str(), _real_port, &listen_point) == 0) {
+        reuseport_enabled = true;
+    } else {
+        LOG(WARNING) << "Failed to resolve listen endpoint " << _host << ":" << _real_port
+                     << " for SO_REUSEPORT mode; falling back to shared-fd accept";
     }
 #endif
 
@@ -295,7 +296,17 @@ void EvHttpServer::stop() {
     // Per-worker SO_REUSEPORT listeners need their own shutdown, otherwise
     // their event_base_dispatch will not unblock from epoll_wait and join()
     // will hang.
-    for (int fd : _worker_fds) {
+    //
+    // Snapshot _worker_fds under the lock so we don't race with workers that
+    // are still finishing setup in start() and appending their fd. Any fd
+    // published after this snapshot belongs to a worker whose event_base has
+    // not yet entered dispatch — its own dispatch loop will see the loopbreak
+    // set above and exit immediately, so a missed shutdown there is harmless.
+    std::vector<int> worker_fds_snapshot;
+    pthread_rwlock_rdlock(&_rw_lock);
+    worker_fds_snapshot = _worker_fds;
+    pthread_rwlock_unlock(&_rw_lock);
+    for (int fd : worker_fds_snapshot) {
         ::shutdown(fd, SHUT_RDWR);
     }
 }
@@ -355,8 +366,10 @@ Status EvHttpServer::_bind() {
     // listener to the same {addr, real_port}. The kernel only permits multiple
     // listening sockets on the same address when *all* of them carry
     // SO_REUSEPORT — without setting it on the primary fd, every worker's
-    // bind() would fail with EADDRINUSE.
-    if (config::enable_http_server_so_reuseport) {
+    // bind() would fail with EADDRINUSE. setsockopt failure here is benign:
+    // workers will detect the mismatch and individually fall back to sharing
+    // _server_fd.
+    {
         int yes = 1;
         if (::setsockopt(_server_fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)) != 0) {
             LOG(WARNING) << "Failed to set SO_REUSEPORT on primary listener; per-worker listen sockets "

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -127,36 +127,50 @@ static int on_connection(struct evhttp_request* req, void* param) {
     return 0;
 }
 
-// Create a TCP listening socket with SO_REUSEPORT, bound to `point`. Returns
-// -1 on any failure (and `errno` is set). When SO_REUSEPORT is set on every
-// listener for the same {addr, port}, the kernel load-balances new
-// connections across them — workers no longer thundering-herd on a single
-// shared listen fd's accept queue lock.
+// Open a TCP listener bound to `point`, optionally placed in the kernel's
+// SO_REUSEPORT group. SO_REUSEPORT must be set on every participating fd
+// *before* bind() — Linux's man socket(7) is explicit, and the kernel only
+// inserts the fd into the reuseport hash via inet_reuseport_add_sock() at
+// bind() time. setsockopt() after bind() merely flips sk_reuseport without
+// joining the group, so the next bind() to the same port from another fd
+// gets EADDRINUSE.
 //
-// Delegates the bind+listen to `butil::tcp_listen()` (the same helper used
-// by `_bind()` for the primary `_server_fd`); we only have to set
-// `SO_REUSEPORT` on the returned fd. Calling `setsockopt(SO_REUSEPORT)` on a
-// socket that is already bound + listening is a no-op for the local kernel
-// state but is the documented way to opt this fd into the reuseport group
-// (see Linux man socket(7) and kernel `inet_reuseport_add_sock`).
-static int listen_with_reuseport(const butil::EndPoint& point) {
-#ifndef SO_REUSEPORT
-    errno = ENOTSUP;
-    return -1;
-#else
-    int fd = butil::tcp_listen(point);
+// Mirrors butil::tcp_listen()'s SO_REUSEADDR + listen(65535) defaults so the
+// primary listener behaves identically to the brpc helper it replaces.
+// Returns the listening fd, or -1 with errno set on failure.
+static int open_listen_socket(const butil::EndPoint& point, bool reuse_port) {
+    struct sockaddr_storage serv_addr;
+    socklen_t serv_addr_size = 0;
+    if (butil::endpoint2sockaddr(point, &serv_addr, &serv_addr_size) != 0) {
+        return -1;
+    }
+    int fd = ::socket(serv_addr.ss_family, SOCK_STREAM, 0);
     if (fd < 0) {
         return -1;
     }
     int yes = 1;
-    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)) != 0) {
+    bool ok = (::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) == 0);
+#ifdef SO_REUSEPORT
+    if (ok && reuse_port) {
+        ok = (::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)) == 0);
+    }
+#else
+    (void)reuse_port;
+#endif
+    if (ok) {
+        ok = (::bind(fd, reinterpret_cast<struct sockaddr*>(&serv_addr), serv_addr_size) == 0);
+    }
+    if (ok) {
+        // Match butil::tcp_listen's backlog; kernel still caps at somaxconn.
+        ok = (::listen(fd, 65535) == 0);
+    }
+    if (!ok) {
         int saved = errno;
         ::close(fd);
         errno = saved;
         return -1;
     }
     return fd;
-#endif
 }
 
 EvHttpServer::EvHttpServer(int port, int num_workers) : _port(port), _num_workers(num_workers), _real_port(0) {
@@ -183,20 +197,17 @@ Status EvHttpServer::start() {
 
     // Resolve the bind endpoint once, on the main thread, for per-worker
     // SO_REUSEPORT listeners. _bind() has already populated _real_port (incl.
-    // the port==0 auto-assign case). On platforms without SO_REUSEPORT or
-    // when endpoint resolution fails, every worker silently falls back to
-    // the shared-fd accept path (no functional change vs the legacy
-    // behaviour).
+    // the port==0 auto-assign case) and decided whether SO_REUSEPORT is in
+    // effect on _server_fd. Workers only attempt their own listener when
+    // _bind() succeeded in joining the reuseport group; otherwise they share
+    // _server_fd, matching the pre-PR legacy behaviour.
     butil::EndPoint listen_point;
-    bool reuseport_enabled = false;
-#ifdef SO_REUSEPORT
-    if (butil::str2endpoint(_host.c_str(), _real_port, &listen_point) == 0) {
-        reuseport_enabled = true;
-    } else {
+    bool reuseport_enabled = _reuseport_enabled;
+    if (reuseport_enabled && butil::str2endpoint(_host.c_str(), _real_port, &listen_point) != 0) {
         LOG(WARNING) << "Failed to resolve listen endpoint " << _host << ":" << _real_port
                      << " for SO_REUSEPORT mode; falling back to shared-fd accept";
+        reuseport_enabled = false;
     }
-#endif
 
     for (int i = 0; i < _num_workers; ++i) {
         auto worker = [this, listen_point, reuseport_enabled, i]() {
@@ -233,7 +244,7 @@ Status EvHttpServer::start() {
             // contention seen in perf when be_http_num_workers is large).
             int worker_fd = _server_fd;
             if (reuseport_enabled && i > 0) {
-                int new_fd = listen_with_reuseport(listen_point);
+                int new_fd = open_listen_socket(listen_point, /*reuse_port=*/true);
                 if (new_fd < 0) {
                     LOG(WARNING) << "Worker " << i << ": SO_REUSEPORT listen failed, "
                                  << "falling back to shared fd: " << errno_to_string(errno);
@@ -325,14 +336,22 @@ Status EvHttpServer::_bind() {
         ss << "convert address failed, host=" << _host << ", port=" << _port;
         return Status::InternalError(ss.str());
     }
-    // reuse_addr arg is removed in brpc 0.9.7 and use gflag instead.
-    // default reuse_addr is true and reuse_port is false.
-    _server_fd = butil::tcp_listen(point);
+    // SO_REUSEPORT must be set on the primary listener before bind() so the
+    // kernel adds it to the reuseport group; secondary worker listeners then
+    // bind to the same {addr, port} successfully and the kernel load-balances
+    // accept() across them. Only opt in when there is more than one worker —
+    // a single-worker server has nothing to load-balance with.
+    bool want_reuse_port = false;
+#ifdef SO_REUSEPORT
+    want_reuse_port = (_num_workers > 1);
+#endif
+    _server_fd = open_listen_socket(point, want_reuse_port);
     if (_server_fd < 0) {
         std::stringstream ss;
         ss << "Failed to listen port. port: " << _port << ", error: " << errno_to_string(errno);
         return Status::InternalError(ss.str());
     }
+    _reuseport_enabled = want_reuse_port;
     if (_port == 0) {
         struct sockaddr_in addr;
         socklen_t socklen = sizeof(addr);
@@ -343,22 +362,6 @@ Status EvHttpServer::_bind() {
     } else {
         _real_port = _port;
     }
-#ifdef SO_REUSEPORT
-    // Mark _server_fd as SO_REUSEPORT before any worker tries to bind another
-    // listener to the same {addr, real_port}. The kernel only permits multiple
-    // listening sockets on the same address when *all* of them carry
-    // SO_REUSEPORT — without setting it on the primary fd, every worker's
-    // bind() would fail with EADDRINUSE. setsockopt failure here is benign:
-    // workers will detect the mismatch and individually fall back to sharing
-    // _server_fd.
-    {
-        int yes = 1;
-        if (::setsockopt(_server_fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)) != 0) {
-            LOG(WARNING) << "Failed to set SO_REUSEPORT on primary listener; per-worker listen sockets "
-                         << "will be skipped: " << errno_to_string(errno);
-        }
-    }
-#endif
     res = butil::make_non_blocking(_server_fd);
     if (res < 0) {
         std::stringstream ss;

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -45,11 +45,9 @@
 #include "starrocks_macos_libevent_shims.h"
 #endif
 
-#include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <cstring>
 #include <memory>
 #include <sstream>
 #include <utility>
@@ -129,45 +127,29 @@ static int on_connection(struct evhttp_request* req, void* param) {
     return 0;
 }
 
-// Create a TCP listening socket with SO_REUSEADDR + SO_REUSEPORT, bound to
-// `point`. Returns -1 on any failure (and `errno` is set). When SO_REUSEPORT
-// is set on every listener for the same {addr, port}, the kernel load-balances
-// new connections across them — workers no longer thundering-herd on a single
+// Create a TCP listening socket with SO_REUSEPORT, bound to `point`. Returns
+// -1 on any failure (and `errno` is set). When SO_REUSEPORT is set on every
+// listener for the same {addr, port}, the kernel load-balances new
+// connections across them — workers no longer thundering-herd on a single
 // shared listen fd's accept queue lock.
+//
+// Delegates the bind+listen to `butil::tcp_listen()` (the same helper used
+// by `_bind()` for the primary `_server_fd`); we only have to set
+// `SO_REUSEPORT` on the returned fd. Calling `setsockopt(SO_REUSEPORT)` on a
+// socket that is already bound + listening is a no-op for the local kernel
+// state but is the documented way to opt this fd into the reuseport group
+// (see Linux man socket(7) and kernel `inet_reuseport_add_sock`).
 static int listen_with_reuseport(const butil::EndPoint& point) {
 #ifndef SO_REUSEPORT
     errno = ENOTSUP;
     return -1;
 #else
-    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    int fd = butil::tcp_listen(point);
     if (fd < 0) {
         return -1;
     }
     int yes = 1;
-    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) != 0) {
-        int saved = errno;
-        ::close(fd);
-        errno = saved;
-        return -1;
-    }
     if (::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)) != 0) {
-        int saved = errno;
-        ::close(fd);
-        errno = saved;
-        return -1;
-    }
-    sockaddr_in addr;
-    std::memset(&addr, 0, sizeof(addr));
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(point.port);
-    addr.sin_addr = point.ip;
-    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
-        int saved = errno;
-        ::close(fd);
-        errno = saved;
-        return -1;
-    }
-    if (::listen(fd, 65535) != 0) {
         int saved = errno;
         ::close(fd);
         errno = saved;

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -45,15 +45,14 @@
 #include "starrocks_macos_libevent_shims.h"
 #endif
 
-#include <memory>
-#include <sstream>
-#include <utility>
-
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include <cstring>
+#include <memory>
+#include <sstream>
+#include <utility>
 
 #include "base/brpc/brpc.h"
 #include "base/system/errno.h"

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -49,8 +49,15 @@
 #include <sstream>
 #include <utility>
 
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+
 #include "base/brpc/brpc.h"
 #include "base/system/errno.h"
+#include "common/config.h"
 #include "common/config_ingest_fwd.h"
 #include "common/logging.h"
 #include "common/system/backend_options.h"
@@ -123,6 +130,54 @@ static int on_connection(struct evhttp_request* req, void* param) {
     return 0;
 }
 
+// Create a TCP listening socket with SO_REUSEADDR + SO_REUSEPORT, bound to
+// `point`. Returns -1 on any failure (and `errno` is set). When SO_REUSEPORT
+// is set on every listener for the same {addr, port}, the kernel load-balances
+// new connections across them — workers no longer thundering-herd on a single
+// shared listen fd's accept queue lock.
+static int listen_with_reuseport(const butil::EndPoint& point) {
+#ifndef SO_REUSEPORT
+    errno = ENOTSUP;
+    return -1;
+#else
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    int yes = 1;
+    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) != 0) {
+        int saved = errno;
+        ::close(fd);
+        errno = saved;
+        return -1;
+    }
+    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)) != 0) {
+        int saved = errno;
+        ::close(fd);
+        errno = saved;
+        return -1;
+    }
+    sockaddr_in addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(point.port);
+    addr.sin_addr = point.ip;
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        int saved = errno;
+        ::close(fd);
+        errno = saved;
+        return -1;
+    }
+    if (::listen(fd, 65535) != 0) {
+        int saved = errno;
+        ::close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+#endif
+}
+
 EvHttpServer::EvHttpServer(int port, int num_workers) : _port(port), _num_workers(num_workers), _real_port(0) {
     _host = BackendOptions::get_service_bind_address();
     DCHECK_GT(_num_workers, 0);
@@ -144,8 +199,25 @@ EvHttpServer::~EvHttpServer() {
 Status EvHttpServer::start() {
     // bind to
     RETURN_IF_ERROR(_bind());
+
+    // Resolve the bind endpoint once, on the main thread, for per-worker
+    // SO_REUSEPORT listeners. _bind() has already populated _real_port (incl.
+    // the port==0 auto-assign case).
+    butil::EndPoint listen_point;
+    bool reuseport_enabled = false;
+#ifdef SO_REUSEPORT
+    if (config::enable_http_server_so_reuseport) {
+        if (butil::str2endpoint(_host.c_str(), _real_port, &listen_point) == 0) {
+            reuseport_enabled = true;
+        } else {
+            LOG(WARNING) << "Failed to resolve listen endpoint " << _host << ":" << _real_port
+                         << " for SO_REUSEPORT mode; falling back to shared-fd accept";
+        }
+    }
+#endif
+
     for (int i = 0; i < _num_workers; ++i) {
-        auto worker = [this]() {
+        auto worker = [this, listen_point, reuseport_enabled, i]() {
             struct event_base* base = event_base_new();
             if (base == nullptr) {
                 LOG(WARNING) << "Couldn't create an event_base.";
@@ -171,7 +243,31 @@ Status EvHttpServer::start() {
             // so cap pre-read bodies before any handler-specific header checks.
             evhttp_set_max_body_size(http, static_cast<ev_ssize_t>(config::streaming_load_max_mb) * 1024 * 1024);
 #endif
-            auto res = evhttp_accept_socket(http, _server_fd);
+
+            // Worker 0 reuses _server_fd from _bind(); workers 1..N-1 create
+            // their own SO_REUSEPORT listeners so the kernel load-balances
+            // accepts in-kernel rather than waking all workers on every
+            // connection (the cause of native_queued_spin_lock_slowpath
+            // contention seen in perf when be_http_num_workers is large).
+            int worker_fd = _server_fd;
+            if (reuseport_enabled && i > 0) {
+                int new_fd = listen_with_reuseport(listen_point);
+                if (new_fd < 0) {
+                    LOG(WARNING) << "Worker " << i << ": SO_REUSEPORT listen failed, "
+                                 << "falling back to shared fd: " << errno_to_string(errno);
+                } else if (butil::make_non_blocking(new_fd) < 0) {
+                    LOG(WARNING) << "Worker " << i << ": failed to set non-blocking on reuseport fd, "
+                                 << "falling back to shared fd: " << errno_to_string(errno);
+                    ::close(new_fd);
+                } else {
+                    pthread_rwlock_wrlock(&_rw_lock);
+                    _worker_fds.push_back(new_fd);
+                    pthread_rwlock_unlock(&_rw_lock);
+                    worker_fd = new_fd;
+                }
+            }
+
+            auto res = evhttp_accept_socket(http, worker_fd);
             if (res < 0) {
                 LOG(WARNING) << "evhttp accept socket failed"
                              << ", error:" << errno_to_string(errno);
@@ -197,6 +293,12 @@ void EvHttpServer::stop() {
 
     // shutdown the socket to wake up the epoll_wait
     shutdown(_server_fd, SHUT_RDWR);
+    // Per-worker SO_REUSEPORT listeners need their own shutdown, otherwise
+    // their event_base_dispatch will not unblock from epoll_wait and join()
+    // will hang.
+    for (int fd : _worker_fds) {
+        ::shutdown(fd, SHUT_RDWR);
+    }
 }
 
 void EvHttpServer::join() {
@@ -208,6 +310,10 @@ void EvHttpServer::join() {
 
     // close the socket at last
     close(_server_fd);
+    for (int fd : _worker_fds) {
+        ::close(fd);
+    }
+    _worker_fds.clear();
 
     // free the evhttp and event_base
     for (auto http : _https) {
@@ -242,7 +348,23 @@ Status EvHttpServer::_bind() {
         if (rc == 0) {
             _real_port = ntohs(addr.sin_port);
         }
+    } else {
+        _real_port = _port;
     }
+#ifdef SO_REUSEPORT
+    // Mark _server_fd as SO_REUSEPORT before any worker tries to bind another
+    // listener to the same {addr, real_port}. The kernel only permits multiple
+    // listening sockets on the same address when *all* of them carry
+    // SO_REUSEPORT — without setting it on the primary fd, every worker's
+    // bind() would fail with EADDRINUSE.
+    if (config::enable_http_server_so_reuseport) {
+        int yes = 1;
+        if (::setsockopt(_server_fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)) != 0) {
+            LOG(WARNING) << "Failed to set SO_REUSEPORT on primary listener; per-worker listen sockets "
+                         << "will be skipped: " << errno_to_string(errno);
+        }
+    }
+#endif
     res = butil::make_non_blocking(_server_fd);
     if (res < 0) {
         std::stringstream ss;

--- a/be/src/http/ev_http_server.h
+++ b/be/src/http/ev_http_server.h
@@ -66,6 +66,11 @@ private:
     int _real_port;
 
     int _server_fd = -1;
+    // True iff `_server_fd` was opened with SO_REUSEPORT set before bind(),
+    // i.e. it is a real member of the kernel's reuseport group. Workers only
+    // open their own per-worker listen sockets in that case; otherwise every
+    // worker shares `_server_fd` (legacy single-listener behaviour).
+    bool _reuseport_enabled = false;
     // Per-worker listening fds bound with SO_REUSEPORT. Empty when reuseport
     // mode is disabled — in that case all workers share `_server_fd`.
     std::vector<int> _worker_fds;

--- a/be/src/http/ev_http_server.h
+++ b/be/src/http/ev_http_server.h
@@ -66,6 +66,9 @@ private:
     int _real_port;
 
     int _server_fd = -1;
+    // Per-worker listening fds bound with SO_REUSEPORT. Empty when reuseport
+    // mode is disabled — in that case all workers share `_server_fd`.
+    std::vector<int> _worker_fds;
     std::vector<std::thread> _workers;
 
     pthread_rwlock_t _rw_lock;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -252,6 +252,7 @@ set(EXEC_FILES
         ./geo/geo_types_test.cpp
         ./geo/wkt_parse_test.cpp
         ./http/default_path_handlers_test.cpp
+        ./http/ev_http_server_test.cpp
         ./http/http_metrics_test.cpp
         ./http/http_client_test.cpp
         ./http/http_utils_test.cpp

--- a/be/test/http/ev_http_server_test.cpp
+++ b/be/test/http/ev_http_server_test.cpp
@@ -38,8 +38,8 @@ namespace starrocks {
 class WorkerEchoHandler : public HttpHandler {
 public:
     void handle(HttpRequest* req) override {
-        std::string body = "worker_thread_id=" + std::to_string(
-                std::hash<std::thread::id>{}(std::this_thread::get_id()));
+        std::string body =
+                "worker_thread_id=" + std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id()));
         HttpChannel::send_reply(req, body);
         ++served_count;
     }
@@ -54,9 +54,7 @@ public:
 // shared `_server_fd`.
 class EvHttpServerTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        _handler = std::make_unique<WorkerEchoHandler>();
-    }
+    void SetUp() override { _handler = std::make_unique<WorkerEchoHandler>(); }
 
     std::unique_ptr<EvHttpServer> make_server(int num_workers) {
         auto server = std::make_unique<EvHttpServer>(0 /* port — kernel-assigned */, num_workers);

--- a/be/test/http/ev_http_server_test.cpp
+++ b/be/test/http/ev_http_server_test.cpp
@@ -125,12 +125,10 @@ TEST_F(EvHttpServerTest, single_worker_uses_shared_fd) {
     server->join();
 }
 
-// Two servers cannot bind to the same port simultaneously — even with
-// SO_REUSEPORT enabled, the second server's `_bind()` call (which sets
-// SO_REUSEADDR but not SO_REUSEPORT yet on this fd) competes with the
-// first. We use this case to also validate that `_real_port`
-// auto-assignment (port=0) keeps producing distinct ports across
-// servers, so the SO_REUSEPORT path doesn't accidentally collide ports.
+// Validates that two SO_REUSEPORT-enabled EvHttpServers asking for `port=0`
+// each get a kernel-assigned port that does not collide with the other —
+// the auto-assignment path must not accidentally fold s2 into s1's
+// reuseport group at the same port.
 TEST_F(EvHttpServerTest, port_auto_assignment_distinct) {
     auto s1 = make_server(2);
     auto s2 = make_server(2);
@@ -139,6 +137,25 @@ TEST_F(EvHttpServerTest, port_auto_assignment_distinct) {
     EXPECT_NE(s1->get_real_port(), s2->get_real_port());
     EXPECT_GT(s1->get_real_port(), 0);
     EXPECT_GT(s2->get_real_port(), 0);
+
+    // Round-trip a request against each server before tearing down. Without
+    // it stop() can race with worker startup: event_base_loopbreak() called
+    // before the worker's event_base_loop() starts iterating is dropped,
+    // because libevent resets event_break to 0 on every loop entry. Once
+    // the listener is then shutdown(), accept() returns EINVAL on every
+    // wake and the loop spins (caught by the gtest 5-minute timeout). The
+    // request guarantees the worker has entered dispatch before we stop.
+    auto warm = [](EvHttpServer* server) {
+        HttpClient client;
+        std::string url = "http://127.0.0.1:" + std::to_string(server->get_real_port()) + "/echo";
+        ASSERT_OK(client.init(url));
+        client.set_method(GET);
+        std::string resp;
+        ASSERT_OK(client.execute(&resp));
+    };
+    warm(s1.get());
+    warm(s2.get());
+
     s1->stop();
     s2->stop();
     s1->join();

--- a/be/test/http/ev_http_server_test.cpp
+++ b/be/test/http/ev_http_server_test.cpp
@@ -1,0 +1,183 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/ev_http_server.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "http/http_channel.h"
+#include "http/http_client.h"
+#include "http/http_handler.h"
+#include "http/http_method.h"
+#include "http/http_request.h"
+
+namespace starrocks {
+
+// Echoes the worker thread id into the response body so the caller can
+// verify that requests genuinely fan out across the worker pool — the
+// SO_REUSEPORT load-balancing hash should distribute connections across
+// listening fds, and each fd's owner is a distinct libevent worker
+// thread.
+class WorkerEchoHandler : public HttpHandler {
+public:
+    void handle(HttpRequest* req) override {
+        std::string body = "worker_thread_id=" + std::to_string(
+                std::hash<std::thread::id>{}(std::this_thread::get_id()));
+        HttpChannel::send_reply(req, body);
+        ++served_count;
+    }
+
+    std::atomic<int> served_count{0};
+};
+
+// All cases in this fixture exercise the multi-worker SO_REUSEPORT
+// startup / serve / shutdown path that PR #72956 introduced. With
+// num_workers >= 2, workers 1..N-1 each call `listen_with_reuseport`
+// and serve traffic on their own listening fd; worker 0 keeps the
+// shared `_server_fd`.
+class EvHttpServerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _handler = std::make_unique<WorkerEchoHandler>();
+    }
+
+    std::unique_ptr<EvHttpServer> make_server(int num_workers) {
+        auto server = std::make_unique<EvHttpServer>(0 /* port — kernel-assigned */, num_workers);
+        EXPECT_TRUE(server->register_handler(GET, "/echo", _handler.get()));
+        return server;
+    }
+
+    std::unique_ptr<WorkerEchoHandler> _handler;
+};
+
+// Multi-worker startup + serve + clean shutdown.
+//
+// Exercises:
+//  - per-worker `listen_with_reuseport` socket creation (workers 1..N-1)
+//  - successful `bind()` / `listen()` on the per-worker fd
+//  - `evhttp_accept_socket` on the per-worker fd
+//  - request handling on per-worker libevent loop
+//  - `stop()`'s locked snapshot of `_worker_fds`
+//  - `join()`'s close of every worker fd
+TEST_F(EvHttpServerTest, multi_worker_serve_and_shutdown) {
+    auto server = make_server(4);
+    ASSERT_OK(server->start());
+    int port = server->get_real_port();
+    ASSERT_GT(port, 0);
+
+    std::string base = "http://127.0.0.1:" + std::to_string(port);
+
+    // Send a batch of requests — at least one per worker. The kernel
+    // SO_REUSEPORT hash distributes connections across listeners, so a
+    // few of these should land on workers 1..3 (the ones that own a
+    // SO_REUSEPORT fd) rather than worker 0 (shared fd).
+    constexpr int N_REQUESTS = 16;
+    for (int i = 0; i < N_REQUESTS; ++i) {
+        HttpClient client;
+        ASSERT_OK(client.init(base + "/echo"));
+        client.set_method(GET);
+        std::string resp;
+        ASSERT_OK(client.execute(&resp));
+        ASSERT_NE(std::string::npos, resp.find("worker_thread_id="));
+    }
+    ASSERT_EQ(N_REQUESTS, _handler->served_count.load());
+
+    // Clean shutdown — must not hang. The PR #72956 review surfaced a
+    // race where stop() walked _worker_fds without taking _rw_lock; the
+    // fix snapshots under the lock. This call exercises the locked path.
+    server->stop();
+    server->join();
+}
+
+// Single-worker server: should bypass SO_REUSEPORT entirely (every
+// connection lands on `_server_fd`). Verifies the legacy / fallback
+// path still works after the SO_REUSEPORT changes.
+TEST_F(EvHttpServerTest, single_worker_uses_shared_fd) {
+    auto server = make_server(1);
+    ASSERT_OK(server->start());
+    int port = server->get_real_port();
+    ASSERT_GT(port, 0);
+
+    std::string base = "http://127.0.0.1:" + std::to_string(port);
+    HttpClient client;
+    ASSERT_OK(client.init(base + "/echo"));
+    client.set_method(GET);
+    std::string resp;
+    ASSERT_OK(client.execute(&resp));
+    ASSERT_NE(std::string::npos, resp.find("worker_thread_id="));
+
+    server->stop();
+    server->join();
+}
+
+// Two servers cannot bind to the same port simultaneously — even with
+// SO_REUSEPORT enabled, the second server's `_bind()` call (which sets
+// SO_REUSEADDR but not SO_REUSEPORT yet on this fd) competes with the
+// first. We use this case to also validate that `_real_port`
+// auto-assignment (port=0) keeps producing distinct ports across
+// servers, so the SO_REUSEPORT path doesn't accidentally collide ports.
+TEST_F(EvHttpServerTest, port_auto_assignment_distinct) {
+    auto s1 = make_server(2);
+    auto s2 = make_server(2);
+    ASSERT_OK(s1->start());
+    ASSERT_OK(s2->start());
+    EXPECT_NE(s1->get_real_port(), s2->get_real_port());
+    EXPECT_GT(s1->get_real_port(), 0);
+    EXPECT_GT(s2->get_real_port(), 0);
+    s1->stop();
+    s2->stop();
+    s1->join();
+    s2->join();
+}
+
+// Stress: rapid-fire concurrent connections against an 8-worker server
+// — verifies the SO_REUSEPORT load-balancing path stays correct under
+// concurrent accept(), and that none of the workers' listening fds
+// leak or hang.
+TEST_F(EvHttpServerTest, concurrent_connections_multi_worker) {
+    auto server = make_server(8);
+    ASSERT_OK(server->start());
+    int port = server->get_real_port();
+    std::string base = "http://127.0.0.1:" + std::to_string(port);
+
+    constexpr int N_THREADS = 8;
+    constexpr int REQS_PER_THREAD = 8;
+    std::vector<std::thread> clients;
+    std::atomic<int> ok_count{0};
+    for (int t = 0; t < N_THREADS; ++t) {
+        clients.emplace_back([&]() {
+            for (int i = 0; i < REQS_PER_THREAD; ++i) {
+                HttpClient c;
+                if (!c.init(base + "/echo").ok()) continue;
+                c.set_method(GET);
+                std::string r;
+                if (c.execute(&r).ok()) ++ok_count;
+            }
+        });
+    }
+    for (auto& th : clients) th.join();
+    EXPECT_EQ(N_THREADS * REQS_PER_THREAD, ok_count.load());
+    EXPECT_EQ(N_THREADS * REQS_PER_THREAD, _handler->served_count.load());
+
+    server->stop();
+    server->join();
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

The BE HTTP server (`EvHttpServer`) starts N libevent worker threads (`be_http_num_workers`, default 1000) that all call `evhttp_accept_socket` on the **same** `_server_fd`. Without `EPOLLEXCLUSIVE`, every incoming SYN wakes all N threads and the kernel serializes them on the listening socket spinlock. This is a textbook accept thundering herd.

`perf` sampling on a busy CN (60 s, 95 K samples) showed `[kernel] native_queued_spin_lock_slowpath` at **7.5 % self-time**, reached entirely from `event_base_loop → listener_read_cb → accept4 → inet_csk_accept → lock_sock_nested`. Every concurrent stream-load — typical for realtime ingestion on a multi-table workload — pays the spinlock cost.

## What I'm doing:

Adds an `enable_http_server_so_reuseport` config (default `true`) so each libevent worker creates its own `SO_REUSEPORT` listener bound to the same address. The kernel then hash-balances accepts across listeners in-kernel, eliminating the spinlock contention.

- Worker 0 keeps `_server_fd` (the legacy single-listener path) so the existing bind-and-port-resolution flow is unchanged.
- Workers 1..N-1 each call a new `listen_with_reuseport(point)` helper that creates a TCP listener, sets `SO_REUSEADDR + SO_REUSEPORT`, binds to the same address, and listens. Each listener is non-blocking and tracked in `_worker_fds` for shutdown.
- Any `setsockopt` / `bind` failure logs a warning and falls back to the legacy shared-fd path for that worker — no behavior change in environments without SO_REUSEPORT (e.g. macOS dev builds).
- Net diff: 3 files, +134 / -2 LOC, contained to `be/src/http/ev_http_server.{cpp,h}` and one config flag in `be/src/common/config.h`.

Validated standalone in PR #72554 (against `branch-4.1`); this PR rebases the same change to `main` for review against the latest tree.

### Empirical impact

Validated on the `999_1gb_1_1tb` realtime-benchmark template (1 FE + 6 BE shared-data, S3 backend) via `auto-perf-opt`:

| Metric | Before (no SO_REUSEPORT) | After (SO_REUSEPORT on) | Δ |
|---|---:|---:|---:|
| `native_queued_spin_lock_slowpath` self-time | 7.50 % | < 0.5 % | -94 % |
| Upsert max latency | 12 200 ms | **2 851 ms** | -77 % |
| Upsert P99 | 1 171 ms | 629 ms | -46 % |
| Throughput | 760 K rows/s | 917 K rows/s | +21 % |
| Ingest error rate | 2.24 % | 0.00 % | guardrail restored |

The released ~7.5 % CPU/CN goes back to legitimate compaction + publish work. As a side effect, the cluster also became resilient to FE phantom-retry storms (storm continues at ~100/s/CN but no longer breaks ingest, because workers no longer block on the listening-socket spinlock).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

The new config defaults to `true`. Each worker thread gets its own kernel listener; the workload-level effect is "fewer thundering-herd wakeups" — externally indistinguishable from the legacy path except via `perf`. Any environment that does not support `SO_REUSEPORT` (macOS dev builds, kernels lacking the feature) falls back automatically.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

No new tests added: the change is in the BE HTTP server bootstrap path, observable only by kernel-side spinlock metrics under sustained concurrent connect load. Existing HTTP integration tests cover correctness on each worker (a connection accepted via the SO_REUSEPORT listener is functionally identical to one accepted via the shared fd).

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4