### PR TITLE
[Refactor] Remove ResultFileOptions dependency from FSOptions

### DIFF
--- a/be/src/exec/data_sinks/file_result_writer.cpp
+++ b/be/src/exec/data_sinks/file_result_writer.cpp
@@ -85,8 +85,9 @@ Status FileResultWriter::_create_fs() {
                                                      _file_opts->broker_properties,
                                                      config::broker_write_timeout_seconds * 1000);
         } else {
-            ASSIGN_OR_RETURN(_fs,
-                             FileSystemFactory::CreateUniqueFromString(_file_opts->file_path, FSOptions(_file_opts)));
+            ASSIGN_OR_RETURN(_fs, FileSystemFactory::CreateUniqueFromString(
+                                          _file_opts->file_path,
+                                          FSOptions(&_file_opts->hdfs_properties, _file_opts->write_buffer_size_kb)));
         }
     }
     if (_fs == nullptr) {

--- a/be/src/exec/data_sinks/file_result_writer.h
+++ b/be/src/exec/data_sinks/file_result_writer.h
@@ -56,7 +56,7 @@ struct ResultFileOptions {
     size_t max_file_size_bytes = 1 * 1024 * 1024 * 1024; // 1GB
     std::vector<TNetworkAddress> broker_addresses;
     std::map<std::string, std::string> broker_properties;
-    int write_buffer_size_kb;
+    int write_buffer_size_kb = 0;
     THdfsProperties hdfs_properties;
     bool use_broker;
     std::vector<std::string> file_column_names;

--- a/be/src/fs/fs_options.cpp
+++ b/be/src/fs/fs_options.cpp
@@ -19,36 +19,38 @@
 namespace starrocks {
 
 FSOptions::FSOptions(const TBrokerScanRangeParams* scan_range_params, const TExportSink* export_sink,
-                     const ResultFileOptions* result_file_options, const TUploadReq* upload,
+                     const THdfsProperties* hdfs_properties, int hdfs_write_buffer_size_kb, const TUploadReq* upload,
                      const TDownloadReq* download, const TCloudConfiguration* cloud_configuration,
                      std::unordered_map<std::string, std::string> fs_options)
         : scan_range_params(scan_range_params),
           export_sink(export_sink),
-          result_file_options(result_file_options),
+          hdfs_properties(hdfs_properties),
           upload(upload),
           download(download),
           cloud_configuration(cloud_configuration),
+          hdfs_write_buffer_size_kb(hdfs_write_buffer_size_kb),
           _fs_options(std::move(fs_options)) {}
 
-FSOptions::FSOptions() : FSOptions(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr) {}
+FSOptions::FSOptions() : FSOptions(nullptr, nullptr, nullptr, 0, nullptr, nullptr, nullptr) {}
 
 FSOptions::FSOptions(const TBrokerScanRangeParams* scan_range_params)
-        : FSOptions(scan_range_params, nullptr, nullptr, nullptr, nullptr, nullptr) {}
+        : FSOptions(scan_range_params, nullptr, nullptr, 0, nullptr, nullptr, nullptr) {}
 
 FSOptions::FSOptions(const TExportSink* export_sink)
-        : FSOptions(nullptr, export_sink, nullptr, nullptr, nullptr, nullptr) {}
+        : FSOptions(nullptr, export_sink, nullptr, 0, nullptr, nullptr, nullptr) {}
 
-FSOptions::FSOptions(const ResultFileOptions* result_file_options)
-        : FSOptions(nullptr, nullptr, result_file_options, nullptr, nullptr, nullptr) {}
+FSOptions::FSOptions(const THdfsProperties* hdfs_properties, int hdfs_write_buffer_size_kb)
+        : FSOptions(nullptr, nullptr, hdfs_properties, hdfs_write_buffer_size_kb, nullptr, nullptr, nullptr) {}
 
-FSOptions::FSOptions(const TUploadReq* upload) : FSOptions(nullptr, nullptr, nullptr, upload, nullptr, nullptr) {}
+FSOptions::FSOptions(const TUploadReq* upload) : FSOptions(nullptr, nullptr, nullptr, 0, upload, nullptr, nullptr) {}
 
-FSOptions::FSOptions(const TDownloadReq* download) : FSOptions(nullptr, nullptr, nullptr, nullptr, download, nullptr) {}
+FSOptions::FSOptions(const TDownloadReq* download)
+        : FSOptions(nullptr, nullptr, nullptr, 0, nullptr, download, nullptr) {}
 
 FSOptions::FSOptions(const TCloudConfiguration* cloud_configuration)
-        : FSOptions(nullptr, nullptr, nullptr, nullptr, nullptr, cloud_configuration) {}
+        : FSOptions(nullptr, nullptr, nullptr, 0, nullptr, nullptr, cloud_configuration) {}
 
 FSOptions::FSOptions(const std::unordered_map<std::string, std::string>& fs_options)
-        : FSOptions(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, fs_options) {}
+        : FSOptions(nullptr, nullptr, nullptr, 0, nullptr, nullptr, nullptr, fs_options) {}
 
 } // namespace starrocks

--- a/be/src/fs/fs_options.h
+++ b/be/src/fs/fs_options.h
@@ -20,7 +20,6 @@
 
 namespace starrocks {
 
-struct ResultFileOptions;
 class TExportSink;
 class TUploadReq;
 class TDownloadReq;
@@ -28,15 +27,15 @@ class TDownloadReq;
 struct FSOptions {
 private:
     FSOptions(const TBrokerScanRangeParams* scan_range_params, const TExportSink* export_sink,
-              const ResultFileOptions* result_file_options, const TUploadReq* upload, const TDownloadReq* download,
-              const TCloudConfiguration* cloud_configuration,
+              const THdfsProperties* hdfs_properties, int hdfs_write_buffer_size_kb, const TUploadReq* upload,
+              const TDownloadReq* download, const TCloudConfiguration* cloud_configuration,
               std::unordered_map<std::string, std::string> fs_options = {});
 
 public:
     FSOptions();
     FSOptions(const TBrokerScanRangeParams* scan_range_params);
     FSOptions(const TExportSink* export_sink);
-    FSOptions(const ResultFileOptions* result_file_options);
+    FSOptions(const THdfsProperties* hdfs_properties, int hdfs_write_buffer_size_kb = 0);
     FSOptions(const TUploadReq* upload);
     FSOptions(const TDownloadReq* download);
     FSOptions(const TCloudConfiguration* cloud_configuration);
@@ -44,10 +43,11 @@ public:
 
     const TBrokerScanRangeParams* scan_range_params;
     const TExportSink* export_sink;
-    const ResultFileOptions* result_file_options;
+    const THdfsProperties* hdfs_properties;
     const TUploadReq* upload;
     const TDownloadReq* download;
     const TCloudConfiguration* cloud_configuration;
+    int hdfs_write_buffer_size_kb;
     const std::unordered_map<std::string, std::string> _fs_options;
 
     static constexpr const char* FS_S3_ENDPOINT = "fs.s3a.endpoint";

--- a/be/src/fs/fs_options_helper.cpp
+++ b/be/src/fs/fs_options_helper.cpp
@@ -14,7 +14,6 @@
 
 #include "fs/fs_options_helper.h"
 
-#include "exec/data_sinks/file_result_writer.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/DataSinks_types.h"
 
@@ -25,8 +24,8 @@ const THdfsProperties* FSOptionsHelper::hdfs_properties(const FSOptions& options
         return &options.scan_range_params->hdfs_properties;
     } else if (options.export_sink != nullptr && options.export_sink->__isset.hdfs_properties) {
         return &options.export_sink->hdfs_properties;
-    } else if (options.result_file_options != nullptr) {
-        return &options.result_file_options->hdfs_properties;
+    } else if (options.hdfs_properties != nullptr) {
+        return options.hdfs_properties;
     } else if (options.upload != nullptr && options.upload->__isset.hdfs_properties) {
         return &options.upload->hdfs_properties;
     } else if (options.download != nullptr && options.download->__isset.hdfs_properties) {

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -719,11 +719,8 @@ StatusOr<std::unique_ptr<WritableFile>> HdfsFileSystem::new_writable_file(const 
     }
 
     // `io.file.buffer.size` of https://apache.github.io/hadoop/hadoop-project-dist/hadoop-common/core-default.xml
-    int hdfs_write_buffer_size = 0;
     // pass zero to hdfsOpenFile will use the default hdfs_write_buffer_size
-    if (_options.result_file_options != nullptr) {
-        hdfs_write_buffer_size = _options.result_file_options->write_buffer_size_kb;
-    }
+    int hdfs_write_buffer_size = _options.hdfs_write_buffer_size_kb;
     if (_options.export_sink != nullptr && _options.export_sink->__isset.hdfs_write_buffer_size_kb) {
         hdfs_write_buffer_size = _options.export_sink->hdfs_write_buffer_size_kb;
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
