### PR TITLE
[Enhancement] Tighten shared-data tablet reshard convergence thresholds

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJobFactory.java
@@ -257,6 +257,14 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
 
     private List<List<Long>> createMergeTabletGroups(
             PhysicalPartition physicalPartition, MaterializedIndex oldIndex, long targetSize) {
+        // pairThresh: a single tablet at or above this is excluded from merging — aligned with
+        //             TabletReshardUtils.needMerge() so a tablet that on its own already satisfies
+        //             the new size band cannot be picked up as a merge candidate.
+        // mergeCap:   maximum cumulative size of a merge group; merged output stays strictly below
+        //             splitThreshold so it cannot turn around and trigger a split.
+        long pairThresh = TabletReshardUtils.mergePairThreshold(targetSize);
+        long mergeCap = TabletReshardUtils.mergeGroupCap(targetSize);
+
         // MaterializedIndex tablets are already ordered by range.
         List<Tablet> orderedTablets = oldIndex.getTablets();
         List<List<Long>> mergeTabletGroups = new ArrayList<>();
@@ -266,29 +274,23 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
         long visibleVersionTime = physicalPartition.getVisibleVersionTime();
         for (Tablet tablet : orderedTablets) {
             if (!(tablet instanceof LakeTablet)) {
-                if (currentTabletGroup.size() >= 2) {
-                    mergeTabletGroups.add(currentTabletGroup);
-                }
+                flushMergeTabletGroup(mergeTabletGroups, currentTabletGroup);
                 currentTabletGroup = new ArrayList<>();
                 currentSize = 0;
                 continue;
             }
 
             long dataSize = tablet.getDataSize(true);
-            if (dataSize >= targetSize
+            if (dataSize >= pairThresh
                     || ((LakeTablet) tablet).getDataSizeUpdateTime() < visibleVersionTime) {
-                if (currentTabletGroup.size() >= 2) {
-                    mergeTabletGroups.add(currentTabletGroup);
-                }
+                flushMergeTabletGroup(mergeTabletGroups, currentTabletGroup);
                 currentTabletGroup = new ArrayList<>();
                 currentSize = 0;
                 continue;
             }
 
-            if (currentSize + dataSize > targetSize) {
-                if (currentTabletGroup.size() >= 2) {
-                    mergeTabletGroups.add(currentTabletGroup);
-                }
+            if (currentSize + dataSize > mergeCap) {
+                flushMergeTabletGroup(mergeTabletGroups, currentTabletGroup);
                 currentTabletGroup = new ArrayList<>();
                 currentSize = 0;
             }
@@ -297,11 +299,14 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
             currentSize += dataSize;
         }
 
-        if (currentTabletGroup.size() >= 2) {
-            mergeTabletGroups.add(currentTabletGroup);
-        }
-
+        flushMergeTabletGroup(mergeTabletGroups, currentTabletGroup);
         return mergeTabletGroups;
+    }
+
+    private static void flushMergeTabletGroup(List<List<Long>> groups, List<Long> currentGroup) {
+        if (currentGroup.size() >= 2) {
+            groups.add(currentGroup);
+        }
     }
 
     private List<ReshardingTablet> createReshardingTablets(MaterializedIndex index,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
@@ -14,17 +14,61 @@
 
 package com.starrocks.alter.reshard;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.common.Config;
 
 public class TabletReshardUtils {
 
+    // Reshard size invariants — DO NOT change individually.
+    //
+    // Let T = Config.tablet_reshard_target_size.
+    //   splitThreshold     = ceil(1.5 * T)   (split fires when dataSize >= splitThreshold)
+    //   mergePairThreshold = ceil(0.8 * T)   (merge fires when pair sum < mergePairThreshold)
+    //   mergeGroupCap      = T               (merge groups packed up to mergeGroupCap)
+    //
+    // The thresholds use exclusive ceilings so the strict-`<` and strict-`>=`
+    // comparisons accept the full half-open intervals implied by the design
+    // (pair sum < 0.8*T, dataSize >= 1.5*T) for non-integer multiples too.
+    //
+    // Convergence requires (assuming BE row-count split approximately preserves byte balance):
+    //   2 * (1 - 0.5 / 1.5) > 4/5    // post-split min piece pair > merge pair threshold
+    //   1                  < 1.5     // merge group cap < split threshold
+    //
+    // Helpers below are overflow-safe for T <= MAX_SAFE_TARGET (~4.6 EB),
+    // far above any plausible target. calcSplitCount() guards larger targets
+    // by returning 1 (no split) so the wrap-around in splitThreshold can't
+    // produce a bogus split decision.
+    private static final long MAX_SAFE_TARGET = Long.MAX_VALUE / 2;
+
+    @VisibleForTesting
+    static long splitThreshold(long target) {
+        // ceil(1.5T) = T + ceil(T/2). Overflow-safe for T <= MAX_SAFE_TARGET.
+        return target + target / 2 + (target & 1L);
+    }
+
+    @VisibleForTesting
+    static long mergePairThreshold(long target) {
+        // ceil(0.8T) = (T/5)*4 + ceil(((T%5)*4)/5). Avoids T*4 overflow.
+        return (target / 5) * 4 + (((target % 5) * 4) + 4) / 5;
+    }
+
+    @VisibleForTesting
+    static long mergeGroupCap(long target) {
+        return target;
+    }
+
     public static boolean needSplit(long dataSize) {
+        // Reuse calcSplitCount so we never trigger when no actual split would be produced
+        // (e.g., tablet_reshard_max_split_count <= 1).
         return calcSplitCount(dataSize, Config.tablet_reshard_target_size) > 1;
     }
 
     public static boolean needMerge(long minAdjacentTabletPairSize) {
-        long targetSize = Config.tablet_reshard_target_size;
-        return targetSize > 0 && minAdjacentTabletPairSize <= targetSize;
+        long target = Config.tablet_reshard_target_size;
+        if (target <= 0) {
+            return false;
+        }
+        return minAdjacentTabletPairSize < mergePairThreshold(target);
     }
 
     /*
@@ -43,15 +87,24 @@ public class TabletReshardUtils {
             return (int) splitCount;
         }
 
-        if (dataSize < 2 * targetSize) {
+        if (targetSize > MAX_SAFE_TARGET) {
+            // splitThreshold(targetSize) would wrap around; no plausible long
+            // dataSize can exceed ceil(1.5T) at this magnitude. Treat as "no split"
+            // rather than risking the lower-bounded `Math.max(2, ...)` below
+            // producing a bogus positive split count for any input.
             return 1;
         }
 
-        // Round of (dataSize / targetSize)
-        long splitCount = (dataSize + targetSize / 2) / targetSize;
-        if (splitCount < Config.tablet_reshard_max_split_count) {
-            return (int) splitCount;
+        if (dataSize < splitThreshold(targetSize)) {
+            return 1;
         }
-        return Config.tablet_reshard_max_split_count;
+
+        // round-to-nearest, lower-bounded at 2, fully overflow-safe
+        long quotient = dataSize / targetSize;
+        long remainder = dataSize - quotient * targetSize;
+        long halfTargetCeil = targetSize / 2 + (targetSize & 1L);
+        long n = (remainder >= halfTargetCeil) ? quotient + 1 : quotient;
+        n = Math.max(2L, n);
+        return (int) Math.min((long) Config.tablet_reshard_max_split_count, n);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
@@ -34,16 +34,27 @@ public class TabletReshardUtils {
     //   2 * (1 - 0.5 / 1.5) > 4/5    // post-split min piece pair > merge pair threshold
     //   1                  < 1.5     // merge group cap < split threshold
     //
-    // Helpers below are overflow-safe for T <= MAX_SAFE_TARGET (~4.6 EB),
-    // far above any plausible target. calcSplitCount() guards larger targets
-    // by returning 1 (no split) so the wrap-around in splitThreshold can't
-    // produce a bogus split decision.
-    private static final long MAX_SAFE_TARGET = Long.MAX_VALUE / 2;
+    // mergePairThreshold and mergeGroupCap are overflow-safe for any positive long T.
+    // splitThreshold = T + T/2 + (T & 1) overflows when T > floor(2/3 * Long.MAX_VALUE)
+    // (~6.15 EB). calcSplitCount() detects that exact boundary algebraically and falls
+    // back to "no split" for inputs above it, so the wrap-around can't produce a
+    // bogus positive split count.
 
     @VisibleForTesting
     static long splitThreshold(long target) {
-        // ceil(1.5T) = T + ceil(T/2). Overflow-safe for T <= MAX_SAFE_TARGET.
+        // ceil(1.5T) = T + ceil(T/2). Caller must check splitThresholdOverflows(target) first.
         return target + target / 2 + (target & 1L);
+    }
+
+    /**
+     * True iff splitThreshold(target) would overflow long for the given non-negative target.
+     * Algebraically: T + T/2 + (T & 1) > Long.MAX_VALUE.
+     * Computed via the rearrangement T > Long.MAX_VALUE - T/2 - (T & 1), which never
+     * underflows because T/2 and (T & 1) are themselves non-negative and <= Long.MAX_VALUE.
+     */
+    @VisibleForTesting
+    static boolean splitThresholdOverflows(long target) {
+        return target > Long.MAX_VALUE - target / 2 - (target & 1L);
     }
 
     @VisibleForTesting
@@ -87,11 +98,10 @@ public class TabletReshardUtils {
             return (int) splitCount;
         }
 
-        if (targetSize > MAX_SAFE_TARGET) {
-            // splitThreshold(targetSize) would wrap around; no plausible long
-            // dataSize can exceed ceil(1.5T) at this magnitude. Treat as "no split"
-            // rather than risking the lower-bounded `Math.max(2, ...)` below
-            // producing a bogus positive split count for any input.
+        if (splitThresholdOverflows(targetSize)) {
+            // ceil(1.5 * targetSize) does not fit in long; no possible dataSize can
+            // satisfy the threshold so treat as "no split" instead of letting the
+            // lower-bounded Math.max(2, ...) below produce a bogus positive count.
             return 1;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/AutomaticTabletReshardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/AutomaticTabletReshardTest.java
@@ -86,15 +86,61 @@ public class AutomaticTabletReshardTest {
 
     @Test
     void testTriggerTabletMergeSuccess() {
+        boolean[] mergeCalled = {false};
         new MockUp<TabletReshardJobMgr>() {
             @Mock
             public void createTabletReshardJob(Database db, OlapTable table, MergeTabletClause mergeTabletClause)
                     throws StarRocksException {
-                return;
+                mergeCalled[0] = true;
             }
         };
 
+        // pair sum strictly below mergePairThreshold = ceil(0.8 * target) → triggers merge
+        long t = Config.tablet_reshard_target_size;
+        long pairSumBelowThreshold = TabletReshardUtils.mergePairThreshold(t) - 1;
         Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
-                0L, Config.tablet_reshard_target_size);
+                0L, pairSumBelowThreshold);
+        org.junit.jupiter.api.Assertions.assertTrue(mergeCalled[0],
+                "merge job should be created when minAdjacentPair < mergePairThreshold");
+    }
+
+    @Test
+    void testTriggerTabletMergeBoundaryNotTriggered() {
+        boolean[] mergeCalled = {false};
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public void createTabletReshardJob(Database db, OlapTable table, MergeTabletClause mergeTabletClause)
+                    throws StarRocksException {
+                mergeCalled[0] = true;
+            }
+        };
+
+        // pair sum exactly at mergePairThreshold → strict-less-than means NOT triggered
+        long t = Config.tablet_reshard_target_size;
+        long atThreshold = TabletReshardUtils.mergePairThreshold(t);
+        Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
+                0L, atThreshold);
+        org.junit.jupiter.api.Assertions.assertFalse(mergeCalled[0],
+                "merge must not trigger at the exact threshold (strict <)");
+    }
+
+    @Test
+    void testTriggerTabletSplitBoundaryNotTriggered() {
+        boolean[] splitCalled = {false};
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public void createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
+                    throws StarRocksException {
+                splitCalled[0] = true;
+            }
+        };
+
+        // maxTabletSize one byte below splitThreshold = ceil(1.5 * target) → NOT triggered
+        long t = Config.tablet_reshard_target_size;
+        long justBelow = TabletReshardUtils.splitThreshold(t) - 1;
+        Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
+                justBelow, Long.MAX_VALUE);
+        org.junit.jupiter.api.Assertions.assertFalse(splitCalled[0],
+                "split must not trigger one byte below splitThreshold");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -711,6 +711,59 @@ public class MergeTabletJobTest {
         Assertions.assertThrows(StarRocksException.class, factory::createTabletReshardJob);
     }
 
+    /**
+     * pairThresh = ceil(0.8 * targetSize) is now distinct from mergeGroupCap = targetSize.
+     * A tablet whose size is in [pairThresh, targetSize) must be excluded from merging
+     * (it's already close enough to the target band that merging it produces an output that
+     * would land near or above splitThreshold = ceil(1.5 * targetSize)).
+     */
+    @Test
+    public void testMergeTabletJobFactoryExcludesTabletAtPairThreshold() throws Exception {
+        ensureTabletCount(4);
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex oldIndex = physicalPartition.getLatestBaseIndex();
+
+        List<Tablet> orderedTablets = new ArrayList<>(oldIndex.getTablets());
+        long visibleVersionTime = physicalPartition.getVisibleVersionTime();
+        // targetSize = 100, pairThresh = 80, mergeCap = 100
+        // sizes: [40, 90, 30, 30]
+        // - 40 < 80, group=[40] size=40
+        // - 90 >= 80 (pairThresh), flush group of size 1 (dropped), reset
+        // - 30 < 80, group=[30] size=30
+        // - 30 < 80, group=[30,30] size=60
+        // - end: flush [30,30]
+        // Expected merge groups: [[30, 30]]; the 90-byte tablet is the exclusion under test.
+        long[] sizes = {40L, 90L, 30L, 30L};
+        for (int i = 0; i < orderedTablets.size(); i++) {
+            LakeTablet tablet = (LakeTablet) orderedTablets.get(i);
+            tablet.setDataSize(sizes[i]);
+            tablet.setDataSizeUpdateTime(visibleVersionTime);
+        }
+
+        MergeTabletClause clause = new MergeTabletClause();
+        clause.setTabletReshardTargetSize(100L);
+        MergeTabletJobFactory factory = new MergeTabletJobFactory(db, table, clause);
+        MergeTabletJob mergeJob = (MergeTabletJob) factory.createTabletReshardJob();
+
+        ReshardingPhysicalPartition reshardingPartition =
+                mergeJob.getReshardingPhysicalPartitions().get(physicalPartition.getId());
+        Assertions.assertNotNull(reshardingPartition);
+        ReshardingMaterializedIndex reshardingIndex =
+                reshardingPartition.getReshardingIndexes().get(oldIndex.getId());
+        Assertions.assertNotNull(reshardingIndex);
+
+        List<List<Long>> mergedTabletGroups = new ArrayList<>();
+        for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
+            if (reshardingTablet.getMergingTablet() != null) {
+                mergedTabletGroups.add(reshardingTablet.getMergingTablet().getOldTabletIds());
+            }
+        }
+
+        Assertions.assertEquals(List.of(
+                        List.of(orderedTablets.get(2).getId(), orderedTablets.get(3).getId())),
+                mergedTabletGroups);
+    }
+
     @Test
     public void testMergeTabletJobFactoryRejectNegativeTargetSize() throws Exception {
         MergeTabletClause clause = new MergeTabletClause();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
@@ -1,0 +1,191 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.common.Config;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TabletReshardUtilsTest {
+
+    private long savedTargetSize;
+    private int savedMaxSplitCount;
+
+    @BeforeEach
+    public void setup() {
+        savedTargetSize = Config.tablet_reshard_target_size;
+        savedMaxSplitCount = Config.tablet_reshard_max_split_count;
+        Config.tablet_reshard_target_size = 10L * 1024 * 1024 * 1024; // 10G
+        Config.tablet_reshard_max_split_count = 1024;
+    }
+
+    @AfterEach
+    public void teardown() {
+        Config.tablet_reshard_target_size = savedTargetSize;
+        Config.tablet_reshard_max_split_count = savedMaxSplitCount;
+    }
+
+    @Test
+    public void splitThreshold_ceil1Point5Times() {
+        assertEquals(15L, TabletReshardUtils.splitThreshold(10L));
+        assertEquals(2L, TabletReshardUtils.splitThreshold(1L));        // ceil(1.5*1) = 2
+        assertEquals(0L, TabletReshardUtils.splitThreshold(0L));
+    }
+
+    @Test
+    public void mergePairThreshold_ceil0Point8Times() {
+        // Exact multiples of 5 have ceil == floor.
+        assertEquals(8L, TabletReshardUtils.mergePairThreshold(10L));
+        assertEquals(4L, TabletReshardUtils.mergePairThreshold(5L));
+        // Non-multiples round up so strict-< accepts the full half-open interval [0, 0.8T).
+        assertEquals(6L, TabletReshardUtils.mergePairThreshold(7L));    // ceil(0.8*7) = ceil(5.6) = 6
+        assertEquals(1L, TabletReshardUtils.mergePairThreshold(1L));    // ceil(0.8*1) = 1
+        assertEquals(2L, TabletReshardUtils.mergePairThreshold(2L));    // ceil(0.8*2) = ceil(1.6) = 2
+        assertEquals(3L, TabletReshardUtils.mergePairThreshold(3L));    // ceil(0.8*3) = ceil(2.4) = 3
+        assertEquals(4L, TabletReshardUtils.mergePairThreshold(4L));    // ceil(0.8*4) = ceil(3.2) = 4
+        assertEquals(0L, TabletReshardUtils.mergePairThreshold(0L));
+    }
+
+    @Test
+    public void calcSplitCount_unsafeTargetReturnsOne() {
+        // Targets above MAX_SAFE_TARGET (Long.MAX/2) must not produce a positive split
+        // even when dataSize would bypass the size guard via integer overflow.
+        long unsafeTarget = (Long.MAX_VALUE / 2) + 1;
+        assertEquals(1, TabletReshardUtils.calcSplitCount(0L, unsafeTarget));
+        assertEquals(1, TabletReshardUtils.calcSplitCount(Long.MAX_VALUE, unsafeTarget));
+    }
+
+    @Test
+    public void mergeGroupCap_equalsTarget() {
+        assertEquals(10L, TabletReshardUtils.mergeGroupCap(10L));
+    }
+
+    @Test
+    public void needSplit_threshold() {
+        long t = Config.tablet_reshard_target_size;
+        long splitTrigger = TabletReshardUtils.splitThreshold(t);
+        assertFalse(TabletReshardUtils.needSplit(t));
+        assertFalse(TabletReshardUtils.needSplit(splitTrigger - 1));
+        assertTrue(TabletReshardUtils.needSplit(splitTrigger));
+        assertTrue(TabletReshardUtils.needSplit(t * 100));
+    }
+
+    @Test
+    public void needMerge_strictlyLess() {
+        long t = Config.tablet_reshard_target_size;
+        long pairThresh = TabletReshardUtils.mergePairThreshold(t);
+        assertTrue(TabletReshardUtils.needMerge(pairThresh - 1));
+        assertFalse(TabletReshardUtils.needMerge(pairThresh));    // strict <
+        assertFalse(TabletReshardUtils.needMerge(t));
+    }
+
+    @Test
+    public void needMerge_targetZeroDisabled() {
+        Config.tablet_reshard_target_size = 0L;
+        assertFalse(TabletReshardUtils.needMerge(0));
+        assertFalse(TabletReshardUtils.needMerge(100));
+    }
+
+    @Test
+    public void calcSplitCount_belowTriggerReturnsOne() {
+        long t = Config.tablet_reshard_target_size;
+        assertEquals(1, TabletReshardUtils.calcSplitCount(0L, t));
+        assertEquals(1, TabletReshardUtils.calcSplitCount(t, t));
+        assertEquals(1, TabletReshardUtils.calcSplitCount(TabletReshardUtils.splitThreshold(t) - 1, t));
+    }
+
+    @Test
+    public void calcSplitCount_buckets() {
+        long t = Config.tablet_reshard_target_size;
+        // boundary 1.5T → 2 pieces
+        assertEquals(2, TabletReshardUtils.calcSplitCount(TabletReshardUtils.splitThreshold(t), t));
+        // 2T → 2
+        assertEquals(2, TabletReshardUtils.calcSplitCount(t * 2, t));
+        // 2.49T → 2 (round-to-nearest, just under 2.5)
+        assertEquals(2, TabletReshardUtils.calcSplitCount(t * 5 / 2 - 1, t));
+        // 2.5T → 3
+        assertEquals(3, TabletReshardUtils.calcSplitCount(t * 5 / 2, t));
+        // 3T → 3
+        assertEquals(3, TabletReshardUtils.calcSplitCount(t * 3, t));
+        // 3.5T → 4
+        assertEquals(4, TabletReshardUtils.calcSplitCount(t * 7 / 2, t));
+    }
+
+    @Test
+    public void calcSplitCount_capsAtMaxSplitCount() {
+        long t = 100L;
+        long huge = t * (Config.tablet_reshard_max_split_count + 100L);
+        assertEquals(Config.tablet_reshard_max_split_count, TabletReshardUtils.calcSplitCount(huge, t));
+    }
+
+    @Test
+    public void calcSplitCount_negativeTargetForcedSplitCount() {
+        // negative-target test mode: -k means "force split into k pieces"
+        assertEquals(7, TabletReshardUtils.calcSplitCount(0, -7));
+        assertEquals(0, TabletReshardUtils.calcSplitCount(0, -(Config.tablet_reshard_max_split_count + 1L)));
+    }
+
+    @Test
+    public void calcSplitCount_overflowSafe_largeTarget() {
+        // very large target (1 PiB), well below Long.MAX/2
+        long t = 1L << 50;
+        long data = 5L * t;
+        assertEquals(5, TabletReshardUtils.calcSplitCount(data, t));
+        // Helpers themselves don't overflow at this magnitude
+        assertTrue(TabletReshardUtils.splitThreshold(t) > 0);
+        assertTrue(TabletReshardUtils.mergePairThreshold(t) > 0);
+        assertTrue(TabletReshardUtils.mergeGroupCap(t) > 0);
+    }
+
+    @Test
+    public void calcSplitCount_overflowSafe_largeData() {
+        // dataSize close to Long.MAX, small target — exercises division-then-remainder
+        long t = 100L;
+        // pick a large multiple of t that fits in long
+        long data = (Long.MAX_VALUE / t) * t;
+        // expected to cap at max_split_count
+        assertEquals(Config.tablet_reshard_max_split_count, TabletReshardUtils.calcSplitCount(data, t));
+    }
+
+    /**
+     * Static check of the convergence invariants. These two inequalities are what prevent
+     * split↔merge oscillation. If they ever fail, the algorithm can ping-pong indefinitely.
+     */
+    @Test
+    public void invariants_holdAtCurrentRatios() {
+        long t = Config.tablet_reshard_target_size;
+        long splitTrigger = TabletReshardUtils.splitThreshold(t);
+        long pairThresh = TabletReshardUtils.mergePairThreshold(t);
+        long mergeCap = TabletReshardUtils.mergeGroupCap(t);
+
+        // 1. Two adjacent post-split pieces (each >= splitTrigger / 2 under uniform row width)
+        //    must NOT satisfy needMerge: their pair sum >= splitTrigger > pairThresh required.
+        long minPiece = splitTrigger / 2;
+        assertFalse(TabletReshardUtils.needMerge(minPiece + minPiece),
+                "split output pair must not be a merge candidate");
+
+        // 2. Merged group cap must be strictly below split trigger (otherwise merge output
+        //    immediately re-triggers split).
+        assertTrue(mergeCap < splitTrigger, "mergeGroupCap must be < splitThreshold");
+
+        // 3. Strict inequality on (1): pairThresh < splitTrigger
+        assertTrue(pairThresh < splitTrigger);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
@@ -64,10 +64,36 @@ public class TabletReshardUtilsTest {
     }
 
     @Test
-    public void calcSplitCount_unsafeTargetReturnsOne() {
-        // Targets above MAX_SAFE_TARGET (Long.MAX/2) must not produce a positive split
-        // even when dataSize would bypass the size guard via integer overflow.
-        long unsafeTarget = (Long.MAX_VALUE / 2) + 1;
+    public void splitThresholdOverflows_alignsWithActualBoundary() {
+        // Anything T such that T + T/2 + (T&1) fits in long is safe.
+        assertFalse(TabletReshardUtils.splitThresholdOverflows(0L));
+        assertFalse(TabletReshardUtils.splitThresholdOverflows(1L));
+        assertFalse(TabletReshardUtils.splitThresholdOverflows(Long.MAX_VALUE / 2));
+        // Codex example: target around 5e18 still has splitThreshold 7.5e18 which fits.
+        assertFalse(TabletReshardUtils.splitThresholdOverflows(5_000_000_000_000_000_000L));
+        // Largest exact safe value: floor(2 * Long.MAX_VALUE / 3).
+        long maxSafe = (Long.MAX_VALUE - 1) / 3 * 2 + ((Long.MAX_VALUE - 1) % 3) * 2 / 3;
+        assertFalse(TabletReshardUtils.splitThresholdOverflows(maxSafe));
+        // One past the safe boundary must report overflow.
+        assertTrue(TabletReshardUtils.splitThresholdOverflows(maxSafe + 1));
+        assertTrue(TabletReshardUtils.splitThresholdOverflows(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void calcSplitCount_largeButSafeTargetStillSplits() {
+        // Codex regression: target=5e18, dataSize=8e18 must still produce a valid split.
+        // splitThreshold(5e18) = 7.5e18 fits in long; dataSize 8e18 >= 7.5e18 → split=2.
+        long target = 5_000_000_000_000_000_000L;
+        long dataSize = 8_000_000_000_000_000_000L;
+        assertEquals(2, TabletReshardUtils.calcSplitCount(dataSize, target));
+    }
+
+    @Test
+    public void calcSplitCount_overflowingTargetReturnsOne() {
+        // Targets above the splitThreshold overflow boundary must not produce a positive
+        // split: splitThreshold would wrap around and the lower-bounded Math.max(2, ...)
+        // would otherwise emit a bogus count for any input.
+        long unsafeTarget = Long.MAX_VALUE; // far past the 6.15-EB overflow boundary
         assertEquals(1, TabletReshardUtils.calcSplitCount(0L, unsafeTarget));
         assertEquals(1, TabletReshardUtils.calcSplitCount(Long.MAX_VALUE, unsafeTarget));
     }


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode with range distribution, the auto split/merge logic is supposed to keep tablet sizes near `tablet_reshard_target_size`, but the current thresholds leave a wide convergence band:

- Split fires only at `dataSize >= 2 * target`, so a tablet can grow to almost 2x target before being broken up.
- The split formula uses round-to-nearest, which at boundary inputs (e.g. `2.5 * target`) cuts a tablet into 3 pieces of `~0.83 * target` each — pieces that immediately fall into the merge candidate zone.
- Merge fires at `pair sum <= target` (non-strict), making the boundary case noisy.
- The merge factory uses a single `targetSize` for both "single tablet too large to merge" and "group cumulative cap", which couples two semantically different limits.

Net effect: tablets oscillate within `[~0.5T, ~2T]` rather than tightly tracking T.

## What I'm doing:

Replace the hardcoded `2 * targetSize` and `<= targetSize` with three named, integer-arithmetic helpers in `TabletReshardUtils`:

| Name | Value | Caller comparison |
|---|---|---|
| `splitThreshold(T)` | `ceil(1.5 * T)` | `dataSize >= splitThreshold` (split) |
| `mergePairThreshold(T)` | `ceil(0.8 * T)` | `pair sum < mergePairThreshold` (merge trigger; strict `<`) |
| `mergeGroupCap(T)` | `T` | `currentSize + dataSize > mergeGroupCap` (group cap) |

Also:

- `MergeTabletJobFactory.createMergeTabletGroups` now uses `mergePairThreshold` for the "single tablet excluded" gate (decoupled from the cumulative cap) and extracts a `flushMergeTabletGroup` helper.
- `calcSplitCount` is rewritten as overflow-safe round-to-nearest with a `Math.max(2, ...)` lower bound, plus a `MAX_SAFE_TARGET = Long.MAX_VALUE / 2` guard so an absurd target cannot wrap `splitThreshold` and produce a bogus positive split count.
- `needSplit` keeps reusing `calcSplitCount(...) > 1` so it stays consistent with what is actually splittable (`tablet_reshard_max_split_count`).
- The three ratios are deliberately **hardcoded constants, not Config**: they are coupled algorithm invariants. With `2 * (1 - 0.5 / 1.5) > 4 / 5`, post-split min piece pair stays out of the merge zone; with `1 < 1.5`, post-merge cap stays out of the split zone. Surfacing them as knobs would let users break the convergence proof (e.g. raising `mergePairThreshold` past `splitThreshold` causes split↔merge oscillation).

Tests added/updated:

- New `TabletReshardUtilsTest` (14 cases): boundary thresholds, strict `<` semantics, split bucket transitions at `1.5T / 2T / 2.5T / 3T / 3.5T`, max-split-count cap, overflow safety at `T = 1L << 50` and dataSize near `Long.MAX_VALUE`, the `MAX_SAFE_TARGET` guard, and a static check of the convergence invariants.
- `MergeTabletJobTest`: added a case with sizes `[40, 90, 30, 30]` at target=100 to verify the new `[0.8T, T)` exclusion (90 is now excluded from merging).
- `AutomaticTabletReshardTest`: updated `testTriggerTabletMergeSuccess` to use the new threshold; added two boundary tests confirming neither split nor merge fires one byte off the trigger.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4