### PR TITLE
[BugFix] Use Statement for JDBC native_query metadata probe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -41,9 +41,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -360,13 +360,13 @@ public class JDBCMetadata implements ConnectorMetadata {
         String normalizedQuery = JDBCTable.normalizePassThroughQuery(query);
         String metadataQuery = "SELECT * FROM (" + normalizedQuery + ") starrocks_query WHERE 1 = 0";
         try (Connection connection = getConnection();
-                PreparedStatement preparedStatement = connection.prepareStatement(metadataQuery)) {
+                Statement statement = connection.createStatement()) {
             int queryTimeoutSeconds = schemaResolver.getQueryTimeoutSeconds();
             if (queryTimeoutSeconds > 0) {
-                preparedStatement.setQueryTimeout(queryTimeoutSeconds);
+                statement.setQueryTimeout(queryTimeoutSeconds);
             }
 
-            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+            try (ResultSet resultSet = statement.executeQuery(metadataQuery)) {
                 Map<String, Integer> originalJdbcTypes = new HashMap<>();
                 List<Column> fullSchema = schemaResolver.convertToSRTable(resultSet.getMetaData(), originalJdbcTypes);
                 if (fullSchema.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -42,6 +42,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -62,6 +63,8 @@ public class JDBCMetadataTest {
     DatabaseMetaData metaData;
     @Mocked
     PreparedStatement preparedStatement;
+    @Mocked
+    Statement statement;
     @Mocked
     ResultSet queryResultSet;
     @Mocked
@@ -401,13 +404,15 @@ public class JDBCMetadataTest {
 
     @Test
     public void testGetTableFromQuery() throws SQLException {
+        String passThroughQuery = "SELECT 1 AS id, payload ? 'k' AS name FROM docs";
+        String metadataQuery = "SELECT * FROM (" + passThroughQuery + ") starrocks_query WHERE 1 = 0";
         new Expectations() {
             {
-                connection.prepareStatement("SELECT * FROM (SELECT 1 AS id, 'abc' AS name) starrocks_query WHERE 1 = 0");
-                result = preparedStatement;
+                connection.createStatement();
+                result = statement;
                 minTimes = 1;
 
-                preparedStatement.executeQuery();
+                statement.executeQuery(metadataQuery);
                 result = queryResultSet;
                 minTimes = 1;
 
@@ -460,11 +465,11 @@ public class JDBCMetadataTest {
         };
 
         JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        Table table = jdbcMetadata.getTableFromQuery(new ConnectContext(), "test", "SELECT 1 AS id, 'abc' AS name;");
+        Table table = jdbcMetadata.getTableFromQuery(new ConnectContext(), "test", passThroughQuery + ";");
         Assertions.assertInstanceOf(JDBCTable.class, table);
         JDBCTable jdbcTable = (JDBCTable) table;
         Assertions.assertTrue(jdbcTable.isQueryTable());
-        Assertions.assertEquals("(SELECT 1 AS id, 'abc' AS name) starrocks_query", jdbcTable.getCatalogTableName());
+        Assertions.assertEquals("(" + passThroughQuery + ") starrocks_query", jdbcTable.getCatalogTableName());
         Assertions.assertEquals(2, jdbcTable.getFullSchema().size());
         Assertions.assertEquals("id", jdbcTable.getFullSchema().get(0).getName());
         Assertions.assertEquals(Types.INTEGER, jdbcTable.getOriginalJdbcColumnTypes().get("id"));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -406,6 +406,7 @@ public class JDBCMetadataTest {
     public void testGetTableFromQuery() throws SQLException {
         String passThroughQuery = "SELECT 1 AS id, payload ? 'k' AS name FROM docs";
         String metadataQuery = "SELECT * FROM (" + passThroughQuery + ") starrocks_query WHERE 1 = 0";
+
         new Expectations() {
             {
                 connection.createStatement();


### PR DESCRIPTION
## Why I am doing:

JDBC native_query schema probing currently prepares the metadata SQL. Some JDBC drivers parse question marks as parameter markers during prepareStatement, so valid pass-through SQL with dialect operators such as PostgreSQL JSON question-mark operators can fail during analysis.

## What I am doing:

Use a plain Statement for the metadata-only probe in getTableFromQuery, while preserving query timeout handling and original JDBC type collection. The unit test now covers a native query containing question-mark syntax.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: metadata probing no longer treats native SQL question marks as JDBC bind markers.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

