### PR TITLE
[BugFix] Allow SHOW statements inside explicit transaction (backport #72954)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -274,7 +274,7 @@ public enum ErrorCode {
     ERR_TXN_FORBID_CROSS_DB(5304, new byte[] {'2', '5', 'P', '0', '1'},
             "Cannot execute cross-database transactions. All DML target tables must belong to the same db"),
     ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT(5305, new byte[] {'2', '5', 'P', '0', '1'},
-            "Explicit transaction only support begin/commit/rollback/insert/update/delete/set/select statements"),
+            "Explicit transaction only support begin/commit/rollback/insert/update/delete/set/select/show statements"),
     ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT_ORDER(5306, new byte[] {'2', '5', 'P', '0', '1'},
             "Explicit transaction only support single update/delete before insert statement"),
     ERR_EXPLICIT_TXN_SELECT_ON_MODIFIED_TABLE(5307, new byte[] {'2', '5', 'P', '0', '1'},

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/ExplicitTxnStatementValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/ExplicitTxnStatementValidator.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SetStmt;
+import com.starrocks.sql.ast.ShowStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.txn.BeginStmt;
 import com.starrocks.sql.ast.txn.CommitStmt;
@@ -47,9 +48,10 @@ public final class ExplicitTxnStatementValidator {
         boolean isSet = statement instanceof SetStmt;
         boolean isDml = statement instanceof DmlStmt; // insert/update/delete
         boolean isSelect = statement instanceof QueryStatement;
+        boolean isShow = statement instanceof ShowStmt;
         boolean isTransactionStmt = statement instanceof BeginStmt
                 || statement instanceof CommitStmt || statement instanceof RollbackStmt;
-        if (!(isSet || isDml || isSelect || isTransactionStmt)) {
+        if (!(isSet || isDml || isSelect || isShow || isTransactionStmt)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT);
             return true;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -38,10 +38,12 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.ShowGrantsStmt;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.ast.txn.BeginStmt;
 import com.starrocks.sql.ast.txn.CommitStmt;
 import com.starrocks.sql.ast.txn.RollbackStmt;
+import com.starrocks.sql.ast.warehouse.ShowWarehousesStmt;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
@@ -152,6 +154,22 @@ public class ExplicitTxnTest {
 
         Assertions.assertTrue(context.getState().isError());
         Assertions.assertEquals(ErrorCode.ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT, context.getState().getErrorCode());
+    }
+
+    @Test
+    public void testShowStmtAllowedInExplicitTxn() {
+        // SHOW statements are read-only metadata queries and must be allowed inside an
+        // explicit transaction (regression for ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT on SHOW GRANTS / SHOW WAREHOUSES).
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setTxnId(1);
+
+        ShowGrantsStmt showGrants = new ShowGrantsStmt(new UserIdentity("u1", "%"), NodePosition.ZERO);
+        Assertions.assertDoesNotThrow(() -> ExplicitTxnStatementValidator.validate(showGrants, context));
+
+        ShowWarehousesStmt showWarehouses = new ShowWarehousesStmt(null);
+        Assertions.assertDoesNotThrow(() -> ExplicitTxnStatementValidator.validate(showWarehouses, context));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Backport of #72954 to branch-4.0.

## What I'm doing:

`SHOW GRANTS`, `SHOW WAREHOUSES`, and other `SHOW` statements were rejected with `ERR_EXPLICIT_TXN_NOT_SUPPORT_STMT (5305)` when issued inside an explicit transaction (`BEGIN ... COMMIT`). Since `SHOW` statements are read-only metadata queries, they should be allowed alongside `SELECT`.

This change adds `ShowStmt` to the allow-list in `ExplicitTxnStatementValidator` and updates the corresponding error message. A regression test exercising `SHOW GRANTS` and `SHOW WAREHOUSES` inside an explicit transaction is also included.

### Backport notes

- `ErrorCode.java` lives at `fe/fe-core/.../common/ErrorCode.java` on this branch (vs. `fe/fe-spi/...` on main); auto-merge handled this.
- `ShowGrantsStmt` still takes a `UserIdentity` (not `UserRef`) on this branch, so the test was adjusted to construct the statement with `new UserIdentity("u1", "%")`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4