### PR TITLE
[Tool] Weekly review: fix ECI cleanup guards and add MySQL ECI teardown

### DIFF
--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -93,7 +93,7 @@ jobs:
             --linuxdistro ubuntu
 
       - name: Clean ECI
-        if: always()
+        if: always() && steps.run_ut.outputs.ECI_ID != ''
         run: eci rm ${{ steps.run_ut.outputs.ECI_ID }} || true
 
       - name: Clean ENV
@@ -129,7 +129,7 @@ jobs:
             --linuxdistro ubuntu
 
       - name: Clean ECI
-        if: always()
+        if: always() && steps.run_ut.outputs.ECI_ID != ''
         run: eci rm ${{ steps.run_ut.outputs.ECI_ID }} || true
 
       - name: Clean ENV
@@ -182,7 +182,8 @@ jobs:
       CLUSTER_NAME:  ${{ needs.deploy.outputs.CLUSTER_NAME }}
       WEEKLY_REVIEW: 'true'
     outputs:
-      sql_oss_path: ${{ steps.run.outputs.sql_oss_path }}
+      sql_oss_path:   ${{ steps.run.outputs.sql_oss_path }}
+      MYSQL_ECI_ID:   ${{ steps.run.outputs.MYSQL_ECI_ID }}
     steps:
       - name: Run SQL-Tester (inspection mode)
         id: run
@@ -216,6 +217,10 @@ jobs:
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
           ./bin/backup_log_cores.sh || true
+
+      - name: Clean MySQL ECI
+        if: always() && needs.sql-tester-review.outputs.MYSQL_ECI_ID != ''
+        run: eci rm ${{ needs.sql-tester-review.outputs.MYSQL_ECI_ID }} || true
 
       - name: Delete ECS cluster
         if: always()


### PR DESCRIPTION
## Why I'm doing:

Fix resource leaks and spurious errors in the weekly unstable case review workflow.

## What I'm doing:

- Add \`ECI_ID != ''\` guard to FE-UT and BE-UT \`Clean ECI\` steps — prevents spurious \`eci rm\` calls when the ECI was never created (matches \`ci-pipeline.yml\` production pattern)
- Propagate \`MYSQL_ECI_ID\` output from \`sql-tester-review\` job and add \`Clean MySQL ECI\` step in \`teardown\` — fixes MySQL container resource leak on every weekly review run (mirrors production teardown pattern)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4