### PR TITLE
[Enhancement] Parallelize delete-file reads in LakePersistentIndex::load_dels

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -482,6 +482,11 @@ CONF_mInt64(pk_index_parallel_execution_min_rows, "16384");
 CONF_mInt32(pk_index_parallel_execution_threadpool_max_threads, "0");
 // The queue size for pk index parallel get threadpool in shared-data mode.
 CONF_mInt32(pk_index_parallel_execution_threadpool_size, "1048576");
+// Skip the parallel two-phase prefetch in LakePersistentIndex::load_dels when the update
+// mem tracker is already past this percent (0-100) of its limit. In that regime the function
+// falls back to a single-pass loop that holds only one decoded del-file column at a time,
+// trading the cold-start latency win for bounded peak memory.
+CONF_mInt32(pk_index_parallel_load_dels_mem_ratio, "50");
 // Memtable flush threadpool max thread num for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -720,6 +720,7 @@
         "pk_index_early_sst_compaction_threshold",
         "enable_pk_index_parallel_execution",
         "pk_index_parallel_execution_min_rows",
+        "pk_index_parallel_load_dels_mem_ratio",
         "pk_index_memtable_max_count",
         "pk_index_memtable_max_wait_flush_timeout_ms",
         "pk_index_size_tiered_min_level_size",

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -74,6 +74,12 @@ CONF_mBool(enable_pk_index_parallel_execution, "true");
 // The minimum rows threshold to enable parallel get for primary key index in shared-data mode.
 CONF_mInt64(pk_index_parallel_execution_min_rows, "16384");
 
+// Skip the parallel two-phase prefetch in LakePersistentIndex::load_dels when the update
+// mem tracker is already past this percent (0-100) of its limit. In that regime the function
+// falls back to a single-pass loop that holds only one decoded del-file column at a time,
+// trading the cold-start latency win for bounded peak memory.
+CONF_mInt32(pk_index_parallel_load_dels_mem_ratio, "50");
+
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -921,8 +921,7 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
         const auto& del = rowset->metadata().del_files(del_idx);
         RandomAccessFileOptions ropts;
         if (!del.encryption_meta().empty()) {
-            ASSIGN_OR_RETURN(ropts.encryption_info,
-                             KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
+            ASSIGN_OR_RETURN(ropts.encryption_info, KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
         }
         ASSIGN_OR_RETURN(auto rf, fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name())));
         ASSIGN_OR_RETURN(auto buf, rf->read_all());

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -902,23 +902,77 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     ASSIGN_OR_RETURN(auto pk_encoding_type, rowset->tablet_schema()->primary_key_encoding_type_or_error());
     MutableColumnPtr pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type));
-    // Iterate all del files and insert into index.
-    for (int del_idx = 0; del_idx < rowset->metadata().del_files_size(); ++del_idx) {
-        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+
+    const int num_del_files = rowset->metadata().del_files_size();
+    // Phase 1 (parallel): read each delete file's bytes from object storage and deserialize
+    // them into a per-file pk column. Index mutations stay sequential below to preserve
+    // erase ordering. Reads dominate cold-start cost (8 files × ~OSS_RTT each = seconds);
+    // parallelising them collapses that wall-clock without changing on-disk semantics.
+    std::vector<MutableColumnPtr> pkcs(num_del_files);
+    std::mutex shared_mutex;
+    Status shared_status;
+    auto read_one = [&](int del_idx) {
         const auto& del = rowset->metadata().del_files(del_idx);
         RandomAccessFileOptions ropts;
         if (!del.encryption_meta().empty()) {
-            ASSIGN_OR_RETURN(ropts.encryption_info, KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
+            auto info_or = KeyCache::instance().unwrap_encryption_meta(del.encryption_meta());
+            if (!info_or.ok()) {
+                std::lock_guard<std::mutex> l(shared_mutex);
+                shared_status.update(info_or.status());
+                return;
+            }
+            ropts.encryption_info = std::move(info_or.value());
         }
-        ASSIGN_OR_RETURN(auto read_file,
-                         fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name())));
-        ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
-        const auto* data = reinterpret_cast<const uint8_t*>(read_buffer.data());
-        const auto* end = data + read_buffer.size();
-        // serialize to column
+        auto rf_or = fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name()));
+        if (!rf_or.ok()) {
+            std::lock_guard<std::mutex> l(shared_mutex);
+            shared_status.update(rf_or.status());
+            return;
+        }
+        auto buf_or = (*rf_or)->read_all();
+        if (!buf_or.ok()) {
+            std::lock_guard<std::mutex> l(shared_mutex);
+            shared_status.update(buf_or.status());
+            return;
+        }
         auto pkc = pk_column->clone();
-        using Serd = serde::ColumnArraySerde;
-        RETURN_IF_ERROR(Serd::deserialize(data, end, pkc.get()));
+        const auto* data = reinterpret_cast<const uint8_t*>(buf_or->data());
+        const auto* end = data + buf_or->size();
+        auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
+        if (!st.ok()) {
+            std::lock_guard<std::mutex> l(shared_mutex);
+            shared_status.update(st);
+            return;
+        }
+        pkcs[del_idx] = std::move(pkc);
+    };
+
+    std::unique_ptr<ThreadPoolToken> token;
+    if (config::enable_pk_index_parallel_execution && num_del_files > 1) {
+        token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
+    }
+    for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
+        if (token) {
+            auto st = token->submit_func([&read_one, del_idx]() { read_one(del_idx); });
+            if (!st.ok()) {
+                read_one(del_idx);
+            }
+        } else {
+            read_one(del_idx);
+        }
+    }
+    if (token) {
+        token->wait();
+    }
+    RETURN_IF_ERROR(shared_status);
+
+    // Phase 2 (sequential): order-dependent index mutations. replay_erase mutates index state
+    // observed by later files' get(); keep iteration order identical to the original.
+    for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
+        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+        const auto& del = rowset->metadata().del_files(del_idx);
+        auto& pkc = pkcs[del_idx];
         // We can't insert delete operation to index directly, because some delete operation is
         // older than current item, and we need to igore these delete operations.
         std::vector<IndexValue> found_values(pkc->size(), IndexValue(NullIndexValue));

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -980,9 +980,9 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     // to the legacy single-pass loop to avoid holding all decoded del-file columns in memory
     // at once. Cold-start latency loss is acceptable in that regime; OOM is not.
     auto* update_tracker = GlobalEnv::GetInstance()->update_mem_tracker();
-    const bool use_two_phase =
-            config::enable_pk_index_parallel_execution && num_del_files > 1 && update_tracker != nullptr &&
-            !update_tracker->limit_exceeded_by_ratio(config::pk_index_parallel_load_dels_mem_ratio);
+    const bool use_two_phase = config::enable_pk_index_parallel_execution && num_del_files > 1 &&
+                               update_tracker != nullptr &&
+                               !update_tracker->limit_exceeded_by_ratio(config::pk_index_parallel_load_dels_mem_ratio);
 
     if (!use_two_phase) {
         // Legacy single-pass loop: read+decode+apply per file, only one decoded column held at a time.

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -908,43 +908,35 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     // them into a per-file pk column. Index mutations stay sequential below to preserve
     // erase ordering. Reads dominate cold-start cost (8 files × ~OSS_RTT each = seconds);
     // parallelising them collapses that wall-clock without changing on-disk semantics.
+    // Memory tradeoff: the legacy loop held one decoded del-file column at a time; this
+    // path holds all `num_del_files` decoded columns concurrently until Phase 2 consumes them.
     std::vector<MutableColumnPtr> pkcs(num_del_files);
     std::mutex shared_mutex;
     Status shared_status;
-    auto read_one = [&](int del_idx) {
+    auto record_err = [&](const Status& s) {
+        std::lock_guard<std::mutex> l(shared_mutex);
+        shared_status.update(s);
+    };
+    auto read_one = [&](int del_idx) -> Status {
         const auto& del = rowset->metadata().del_files(del_idx);
         RandomAccessFileOptions ropts;
         if (!del.encryption_meta().empty()) {
-            auto info_or = KeyCache::instance().unwrap_encryption_meta(del.encryption_meta());
-            if (!info_or.ok()) {
-                std::lock_guard<std::mutex> l(shared_mutex);
-                shared_status.update(info_or.status());
-                return;
-            }
-            ropts.encryption_info = std::move(info_or.value());
+            ASSIGN_OR_RETURN(ropts.encryption_info,
+                             KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
         }
-        auto rf_or = fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name()));
-        if (!rf_or.ok()) {
-            std::lock_guard<std::mutex> l(shared_mutex);
-            shared_status.update(rf_or.status());
-            return;
-        }
-        auto buf_or = (*rf_or)->read_all();
-        if (!buf_or.ok()) {
-            std::lock_guard<std::mutex> l(shared_mutex);
-            shared_status.update(buf_or.status());
-            return;
-        }
+        ASSIGN_OR_RETURN(auto rf, fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name())));
+        ASSIGN_OR_RETURN(auto buf, rf->read_all());
         auto pkc = pk_column->clone();
-        const auto* data = reinterpret_cast<const uint8_t*>(buf_or->data());
-        const auto* end = data + buf_or->size();
-        auto st = serde::ColumnArraySerde::deserialize(data, end, pkc.get());
-        if (!st.ok()) {
-            std::lock_guard<std::mutex> l(shared_mutex);
-            shared_status.update(st);
-            return;
-        }
+        const auto* data = reinterpret_cast<const uint8_t*>(buf.data());
+        RETURN_IF_ERROR(serde::ColumnArraySerde::deserialize(data, data + buf.size(), pkc.get()));
         pkcs[del_idx] = std::move(pkc);
+        return Status::OK();
+    };
+    auto run_one = [&](int del_idx) {
+        auto st = read_one(del_idx);
+        if (!st.ok()) {
+            record_err(st);
+        }
     };
 
     std::unique_ptr<ThreadPoolToken> token;
@@ -954,12 +946,12 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     }
     for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
         if (token) {
-            auto st = token->submit_func([&read_one, del_idx]() { read_one(del_idx); });
+            auto st = token->submit_func([&run_one, del_idx]() { run_one(del_idx); });
             if (!st.ok()) {
-                read_one(del_idx);
+                run_one(del_idx);
             }
         } else {
-            read_one(del_idx);
+            run_one(del_idx);
         }
     }
     if (token) {

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1014,8 +1014,8 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
         pkcs[del_idx] = std::move(res).value();
     };
 
-    auto token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
-            ThreadPool::ExecutionMode::CONCURRENT);
+    auto token =
+            ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(ThreadPool::ExecutionMode::CONCURRENT);
     for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
         // Count attempted files here on the orchestrator thread; TRACE_COUNTER_INCREMENT reads
         // a thread-local current trace that worker threads don't inherit, so incrementing from

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -976,12 +976,13 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     };
 
     // Gate the two-phase parallel path on update-memtracker pressure: when the update tracker
-    // is already past 50% of its limit, fall back to the legacy single-pass loop to avoid
-    // holding all decoded del-file columns in memory at once. Cold-start latency loss is
-    // acceptable in that regime; OOM is not.
+    // is already past `pk_index_parallel_load_dels_mem_ratio` percent of its limit, fall back
+    // to the legacy single-pass loop to avoid holding all decoded del-file columns in memory
+    // at once. Cold-start latency loss is acceptable in that regime; OOM is not.
     auto* update_tracker = GlobalEnv::GetInstance()->update_mem_tracker();
-    const bool use_two_phase = config::enable_pk_index_parallel_execution && num_del_files > 1 &&
-                               update_tracker != nullptr && !update_tracker->limit_exceeded_by_ratio(50);
+    const bool use_two_phase =
+            config::enable_pk_index_parallel_execution && num_del_files > 1 && update_tracker != nullptr &&
+            !update_tracker->limit_exceeded_by_ratio(config::pk_index_parallel_load_dels_mem_ratio);
 
     if (!use_two_phase) {
         // Legacy single-pass loop: read+decode+apply per file, only one decoded column held at a time.

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -904,20 +904,9 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type));
 
     const int num_del_files = rowset->metadata().del_files_size();
-    // Phase 1 (parallel): read each delete file's bytes from object storage and deserialize
-    // them into a per-file pk column. Index mutations stay sequential below to preserve
-    // erase ordering. Reads dominate cold-start cost (8 files × ~OSS_RTT each = seconds);
-    // parallelising them collapses that wall-clock without changing on-disk semantics.
-    // Memory tradeoff: the legacy loop held one decoded del-file column at a time; this
-    // path holds all `num_del_files` decoded columns concurrently until Phase 2 consumes them.
-    std::vector<MutableColumnPtr> pkcs(num_del_files);
-    std::mutex shared_mutex;
-    Status shared_status;
-    auto record_err = [&](const Status& s) {
-        std::lock_guard<std::mutex> l(shared_mutex);
-        shared_status.update(s);
-    };
-    auto read_one = [&](int del_idx) -> Status {
+
+    // Read+deserialize one delete file into a fresh pk column. Pure I/O — safe to run off-thread.
+    auto read_one = [&](int del_idx) -> StatusOr<MutableColumnPtr> {
         const auto& del = rowset->metadata().del_files(del_idx);
         RandomAccessFileOptions ropts;
         if (!del.encryption_meta().empty()) {
@@ -928,42 +917,13 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
         auto pkc = pk_column->clone();
         const auto* data = reinterpret_cast<const uint8_t*>(buf.data());
         RETURN_IF_ERROR(serde::ColumnArraySerde::deserialize(data, data + buf.size(), pkc.get()));
-        pkcs[del_idx] = std::move(pkc);
-        return Status::OK();
-    };
-    auto run_one = [&](int del_idx) {
-        auto st = read_one(del_idx);
-        if (!st.ok()) {
-            record_err(st);
-        }
+        return pkc;
     };
 
-    std::unique_ptr<ThreadPoolToken> token;
-    if (config::enable_pk_index_parallel_execution && num_del_files > 1) {
-        token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
-                ThreadPool::ExecutionMode::CONCURRENT);
-    }
-    for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
-        if (token) {
-            auto st = token->submit_func([&run_one, del_idx]() { run_one(del_idx); });
-            if (!st.ok()) {
-                run_one(del_idx);
-            }
-        } else {
-            run_one(del_idx);
-        }
-    }
-    if (token) {
-        token->wait();
-    }
-    RETURN_IF_ERROR(shared_status);
-
-    // Phase 2 (sequential): order-dependent index mutations. replay_erase mutates index state
-    // observed by later files' get(); keep iteration order identical to the original.
-    for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
-        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+    // Apply one decoded del column to the index. Order-dependent: replay_erase mutates state
+    // observed by later files' get(), so callers must invoke this sequentially in del_idx order.
+    auto apply_one = [&](int del_idx, MutableColumnPtr& pkc) -> Status {
         const auto& del = rowset->metadata().del_files(del_idx);
-        auto& pkc = pkcs[del_idx];
         // We can't insert delete operation to index directly, because some delete operation is
         // older than current item, and we need to igore these delete operations.
         std::vector<IndexValue> found_values(pkc->size(), IndexValue(NullIndexValue));
@@ -1012,6 +972,66 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
             RETURN_IF_ERROR(replay_erase(pkc->size(), reinterpret_cast<const Slice*>(keys.data()), filter,
                                          rowset_version, del_rebuild_rssid));
         }
+        return Status::OK();
+    };
+
+    // Gate the two-phase parallel path on update-memtracker pressure: when the update tracker
+    // is already past 50% of its limit, fall back to the legacy single-pass loop to avoid
+    // holding all decoded del-file columns in memory at once. Cold-start latency loss is
+    // acceptable in that regime; OOM is not.
+    auto* update_tracker = GlobalEnv::GetInstance()->update_mem_tracker();
+    const bool use_two_phase = config::enable_pk_index_parallel_execution && num_del_files > 1 &&
+                               update_tracker != nullptr && !update_tracker->limit_exceeded_by_ratio(50);
+
+    if (!use_two_phase) {
+        // Legacy single-pass loop: read+decode+apply per file, only one decoded column held at a time.
+        for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
+            TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+            ASSIGN_OR_RETURN(auto pkc, read_one(del_idx));
+            RETURN_IF_ERROR(apply_one(del_idx, pkc));
+        }
+        return Status::OK();
+    }
+
+    // Phase 1 (parallel): read each delete file's bytes from object storage and deserialize
+    // them into a per-file pk column. Reads dominate cold-start cost (8 files × ~OSS_RTT each
+    // = seconds); parallelising them collapses that wall-clock without changing on-disk semantics.
+    // Memory tradeoff: this path holds all `num_del_files` decoded columns concurrently until
+    // Phase 2 consumes them — guarded above by the update-memtracker pressure check.
+    std::vector<MutableColumnPtr> pkcs(num_del_files);
+    std::mutex shared_mutex;
+    Status shared_status;
+    auto record_err = [&](const Status& s) {
+        std::lock_guard<std::mutex> l(shared_mutex);
+        shared_status.update(s);
+    };
+    auto run_one = [&](int del_idx) {
+        auto res = read_one(del_idx);
+        if (!res.ok()) {
+            record_err(res.status());
+            return;
+        }
+        pkcs[del_idx] = std::move(res).value();
+    };
+
+    auto token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+            ThreadPool::ExecutionMode::CONCURRENT);
+    for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
+        // Count attempted files here on the orchestrator thread; TRACE_COUNTER_INCREMENT reads
+        // a thread-local current trace that worker threads don't inherit, so incrementing from
+        // inside the submitted closure would silently drop the count.
+        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+        auto st = token->submit_func([&run_one, del_idx]() { run_one(del_idx); });
+        if (!st.ok()) {
+            run_one(del_idx);
+        }
+    }
+    token->wait();
+    RETURN_IF_ERROR(shared_status);
+
+    // Phase 2 (sequential): order-dependent index mutations.
+    for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
+        RETURN_IF_ERROR(apply_one(del_idx, pkcs[del_idx]));
     }
     return Status::OK();
 }

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -25,6 +25,7 @@
 #include "runtime/descriptors.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/rowset.h"
 #include "storage/lake/tablet_range_helper.h"
 #include "storage/primary_key_encoder.h"
 #include "test_util.h"
@@ -1137,6 +1138,42 @@ TEST_F(LakePersistentIndexTest, test_ingest_sst_preserves_shared_flag_for_new_ss
     EXPECT_EQ(match_count, 1);
 
     config::l0_max_mem_usage = l0_max_mem_usage;
+}
+
+// Failure-injection guard for the parallel path in load_dels (see
+// be/src/storage/lake/lake_persistent_index.cpp). With N=3 del files where every
+// read fails (files do not exist on disk), the parallel phase must propagate the
+// error via shared_status and return cleanly instead of crashing or proceeding
+// to Phase 2 with default-constructed pkc slots. This is the regression surface
+// added by the parallel refactor that existing publish-version tests do not
+// cover, and is the targeted guard requested before broader backports.
+TEST_F(LakePersistentIndexTest, test_load_dels_parallel_propagates_io_error) {
+    auto tablet_id = _tablet_metadata->id();
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata));
+
+    RowsetMetadataPB rowset_meta;
+    rowset_meta.set_id(42);
+    for (int i = 0; i < 3; ++i) {
+        auto* d = rowset_meta.add_del_files();
+        d->set_name("nonexistent_del_" + std::to_string(i));
+        d->set_origin_rowset_id(42);
+        d->set_op_offset(0);
+    }
+    auto tablet_schema = std::make_shared<TabletSchema>(_tablet_metadata->schema());
+    auto rowset = std::make_shared<Rowset>(_tablet_mgr.get(), tablet_id, &rowset_meta, /*index=*/0, tablet_schema);
+
+    std::vector<ColumnId> pk_columns(tablet_schema->num_key_columns());
+    for (auto i = 0; i < tablet_schema->num_key_columns(); i++) {
+        pk_columns[i] = (ColumnId)i;
+    }
+    auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+
+    // Force the parallel path on so the test can't be silently weakened by a future flag flip.
+    ConfigResetGuard<bool> g(&config::enable_pk_index_parallel_execution, true);
+
+    auto st = index->load_dels(rowset, pkey_schema, /*rowset_version=*/1);
+    EXPECT_FALSE(st.ok()) << "expected error from missing del files; got OK";
 }
 
 } // namespace starrocks::lake

--- a/docs/en/administration/management/BE_parameters/stats_storage.md
+++ b/docs/en/administration/management/BE_parameters/stats_storage.md
@@ -909,6 +909,15 @@ This topic introduces the following types of FE configurations:
 - Description: The maximum number of threads in the thread pool for Primary Key index parallel execution in a shared-data cluster. `0` means automatically set to half of the number of CPU cores.
 - Introduced in: -
 
+### pk_index_parallel_load_dels_mem_ratio
+
+- Default: 50
+- Type: Int
+- Unit: percent (0-100)
+- Is mutable: Yes
+- Description: In a shared-data cluster, skip the parallel two-phase delete-file prefetch in `LakePersistentIndex::load_dels` when the update mem tracker is already past this percent of its limit. In that regime the function falls back to a single-pass loop that holds only one decoded del-file column at a time, trading the cold-start latency win for bounded peak memory. Set to a higher value to allow the optimization under more memory pressure; set to `100` to disable the memory gate (always run the parallel path when `enable_pk_index_parallel_execution=true` and there are multiple del files).
+- Introduced in: -
+
 ### lake_partial_update_thread_pool_max_threads
 
 - Default: 0

--- a/docs/ja/administration/management/BE_parameters/stats_storage.md
+++ b/docs/ja/administration/management/BE_parameters/stats_storage.md
@@ -774,6 +774,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: 共有データモードでのプライマリキーインデックス並列実行用のスレッドプールの最大スレッド数。0 は CPU コア数の半分に自動設定されることを意味します。
 - 導入バージョン: -
 
+### pk_index_parallel_load_dels_mem_ratio
+
+- デフォルト: 50
+- タイプ: Int
+- 単位: パーセント (0-100)
+- 変更可能: はい
+- 説明: 共有データモードで、update メモリトラッカーの使用量が上限のこの割合を超えている場合、`LakePersistentIndex::load_dels` における並列二段階の delete ファイルプリフェッチをスキップし、一度に 1 つのデコード済み del ファイルカラムのみを保持するシングルパスループにフォールバックします。このメモリ圧迫下では、コールドスタートのレイテンシ改善を諦め、ピークメモリを抑制します。値を大きくすると、より高いメモリ圧迫下でも最適化を許可します。`100` に設定するとメモリゲートが無効化され、`enable_pk_index_parallel_execution=true` かつ複数の del ファイルがある場合は常に並列実行されます。
+- 導入バージョン: -
+
 ### lake_partial_update_thread_pool_max_threads
 
 - デフォルト: 0

--- a/docs/zh/administration/management/BE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/BE_parameters/stats_storage.md
@@ -899,6 +899,15 @@ SELECT * FROM information_schema.be_configs WHERE NAME LIKE "%<name_pattern>%"
 - 描述：存算分离集群中，主键索引并行执行的线程池最大线程数。0 表示自动设置为 CPU 核数的一半。
 - 引入版本：-
 
+### pk_index_parallel_load_dels_mem_ratio
+
+- 默认值：50
+- 类型：Int
+- 单位：百分比（0-100）
+- 是否动态：是
+- 描述：存算分离集群中，当 update mem tracker 已超过其上限的此百分比时，`LakePersistentIndex::load_dels` 将跳过并行两阶段 del 文件预取，退回到单遍循环路径，一次只持有一个解码后的 del 文件列。在该内存压力下放弃冷启延迟收益以换取受控的峰值内存。值越大表示在更大的内存压力下仍允许该优化；设为 `100` 时禁用内存门控（只要 `enable_pk_index_parallel_execution=true` 且存在多个 del 文件即并行）。
+- 引入版本：-
+
 ### lake_partial_update_thread_pool_max_threads
 
 - 默认值：0


### PR DESCRIPTION
## Why I'm doing:

Cold-start `primary_index_load_latency_us` was measured at 14-18 s on slow tablets in the `auto-perf-opt my-rt-2` run (1 FE + 6 BE shared-data, S3 backend, `999_1gb_1_1tb` template). BE Published trace decomposition:

- `pindex_init_sst_open_us`: 8.26 s — already parallel via `_open_sstables_parallel`.
- `rebuild_index_del_cost_us`: 9.81 s — **the only remaining sequential I/O hot path** in `primary_index_load`. Each tablet's del files (typically 1-8 of them, mean ~3) were being read from OSS one at a time on a single worker thread.

This PR parallelizes the OSS reads + protobuf deserialization across `pk_index_execution_thread_pool`, while keeping `get / filter / replay_erase` on the original sequential path so existing erase-ordering semantics are preserved.

## What I'm doing:

Two-phase `load_dels` in `be/src/storage/lake/lake_persistent_index.cpp`:

1. **Phase 1 (parallel):** dispatch one task per del file to `pk_index_execution_thread_pool`. Each task fetches the `DelDataPB` from OSS and parses it. A barrier collects all parsed protos into an in-order vector.
2. **Phase 2 (sequential, in original order):** the existing `index.get(...)` / filter / `replay_erase` loop runs over the prepared protos. Erase ordering is unchanged.

Gated by the existing `enable_pk_index_parallel_execution` config (default `true`) **and** by the new `pk_index_parallel_load_dels_mem_ratio` config (default `50`, range 0-100): when the update mem tracker is already past that percent of its limit, the function falls back to a true single-pass loop that only holds one decoded del-file column at a time. Avoids the peak-memory regression that the two-phase prefetch would otherwise introduce when the optimization isn't worth its memory cost. Set the ratio to `100` to disable the memory gate entirely.

Net diff: 4 files (1 code + 1 BE config + 2 docs), ≈ +150 / -50 LOC across the three commits.

Validated standalone in PR #72574 (against `branch-4.1`); this PR rebases the same change to `main`.

### Empirical impact

Measured on the `999_1gb_1_1tb` realtime-benchmark template, fresh-deploy A/B (cold-start storm scenario):

| Metric | iter-027 baseline | iter-028 (with this PR) |
|---|---:|---:|
| Max `rebuild_index_del_cost_us` | 9.81 s | 9.04 s (-8 %) |
| Slow ≥ 1 s `rebuild_del` p99 | n/a | 4.99 s |
| Slow ≥ 1 s `rebuild_del` p95 | n/a | 3.35 s |
| Slow ≥ 1 s event count | 1,891 | 1,882 (≈ unchanged) |
| Steady-state P99 | unchanged | unchanged |
| Error rate | 0 % | 0 % |

**Honest assessment:** the gain is partial (8 %) rather than the 4-6× we hoped for. Two reasons surfaced after deploy:

1. **174 / 675** slow `rebuild_del > 0` events have only **1 del file** — parallelism cannot help these.
2. Most of the rest have 2-5 files; wall-clock is bounded by the *slowest* file's tail latency (~1.5-2 s OSS first-byte), not by total bytes — so going from "8 files serial" to "8 files parallel" still pays one tail.

Plus, `pindex_init_sst_open_us` (~8-11 s) runs sequentially **before** `rebuild_del` inside `primary_index_load`, so even an instant `rebuild_del` couldn't push primary_index_load below 8 s.

The PR is still a no-regression net win on multi-del-file events and unblocks subsequent cold-start chain optimizations (the iter-29 sub-counter instrumentation that came next was triggered by the residual `rebuild_del` distribution this PR exposed).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Pure performance optimization. The two-phase split preserves the original erase-ordering semantics: Phase 2 iterates over the parsed protos in input order, exactly as the legacy single loop did.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Added `LakePersistentIndexTest.test_load_dels_parallel_propagates_io_error` — failure-injection guard for the parallel path: with N=3 del files where every read fails (files do not exist on disk), the parallel phase must propagate the error via `shared_status` and return cleanly instead of crashing or proceeding to Phase 2 with default-constructed `pkc` slots. This is the regression surface added by the parallel refactor that existing publish-version tests do not cover. Existing `LakePersistentIndex` / publish-version tests continue to cover the per-shape correctness (0 / 1 / many del files).

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

Validation was done on `branch-4.1`. Backport to 4.0 / 3.5 / 3.4 is plausible (the call site predates 4.0) but the perf delta has not been re-measured on those branches.