### PR TITLE
[BugFix] Fix MV refresh with SQL Server table in JDBC catalog (backport #72962)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/SqlServerSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/SqlServerSchemaResolver.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.jdbc;
 
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.PrimitiveType;
@@ -21,6 +22,14 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
+<<<<<<< HEAD
+=======
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
+>>>>>>> bcfe8d0d81 ([BugFix] Fix MV refresh with SQL Server table in JDBC catalog (#72962))
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -67,6 +76,11 @@ public class SqlServerSchemaResolver extends JDBCSchemaResolver {
         Map<String, String> newProp = new HashMap<>(properties);
         newProp.putIfAbsent(JDBCTable.JDBC_TABLENAME, "[" + dbName + "]" + "." + "[" + name + "]");
         return new JDBCTable(id, name, schema, partitionColumns, dbName, catalogName, newProp);
+    }
+
+    @Override
+    public List<Partition> getPartitions(Connection connection, Table table) {
+        return Lists.newArrayList(new Partition(table.getName(), TimeUtils.getEpochSeconds()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/SqlServerSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/SqlServerSchemaResolver.java
@@ -22,14 +22,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
-<<<<<<< HEAD
-=======
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
-import com.starrocks.type.Type;
-import com.starrocks.type.TypeFactory;
->>>>>>> bcfe8d0d81 ([BugFix] Fix MV refresh with SQL Server table in JDBC catalog (#72962))
 
 import java.sql.Connection;
 import java.sql.ResultSet;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/SqlServerSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/SqlServerSchemaResolverTest.java
@@ -230,4 +230,14 @@ public class SqlServerSchemaResolverTest {
         }
     }
 
+    @Test
+    public void testGetPartitions() {
+        SqlServerSchemaResolver sqlServerSchemaResolver = new SqlServerSchemaResolver();
+        List<Partition> partitions = sqlServerSchemaResolver.getPartitions(null, new Table(1L, "tbl1",
+                Table.TableType.JDBC, Lists.newArrayList()));
+        Assertions.assertEquals(1, partitions.size());
+        Assertions.assertEquals("tbl1", partitions.get(0).getPartitionName());
+        Assertions.assertTrue(partitions.get(0).getModifiedTime() > 0);
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

SQL Server JDBC tables can participate in MV refresh through JDBC connector traits. For unpartitioned tables, the refresh path treats the table name as a full-table partition, but `SqlServerSchemaResolver` inherited the default `getPartitions()` implementation that returns an empty list. This makes selected partition names and partition metadata inconsistent during MV refresh.

This is a replacement backport for #72990, which failed because the automatic cherry-pick conflicted on `branch-4.0`.

## What I'm doing:

Override `SqlServerSchemaResolver.getPartitions()` to return a full-table `Partition` named after the table, like https://github.com/StarRocks/starrocks/pull/37676 .

Add a unit test for the SQL Server resolver partition metadata.

Fixes #

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

Original PR: #72962

