### PR TITLE
[Tool] disable auto-update of unstable_case.json in weekly review

### DIFF
--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -93,7 +93,7 @@ jobs:
             --linuxdistro ubuntu
 
       - name: Clean ECI
-        if: always()
+        if: always() && steps.run_ut.outputs.ECI_ID != ''
         run: eci rm ${{ steps.run_ut.outputs.ECI_ID }} || true
 
       - name: Clean ENV
@@ -129,7 +129,7 @@ jobs:
             --linuxdistro ubuntu
 
       - name: Clean ECI
-        if: always()
+        if: always() && steps.run_ut.outputs.ECI_ID != ''
         run: eci rm ${{ steps.run_ut.outputs.ECI_ID }} || true
 
       - name: Clean ENV
@@ -182,7 +182,8 @@ jobs:
       CLUSTER_NAME:  ${{ needs.deploy.outputs.CLUSTER_NAME }}
       WEEKLY_REVIEW: 'true'
     outputs:
-      sql_oss_path: ${{ steps.run.outputs.sql_oss_path }}
+      sql_oss_path:   ${{ steps.run.outputs.sql_oss_path }}
+      MYSQL_ECI_ID:   ${{ steps.run.outputs.MYSQL_ECI_ID }}
     steps:
       - name: Run SQL-Tester (inspection mode)
         id: run
@@ -216,6 +217,10 @@ jobs:
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
           ./bin/backup_log_cores.sh || true
+
+      - name: Clean MySQL ECI
+        if: always() && needs.sql-tester-review.outputs.MYSQL_ECI_ID != ''
+        run: eci rm ${{ needs.sql-tester-review.outputs.MYSQL_ECI_ID }} || true
 
       - name: Delete ECS cluster
         if: always()

--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -288,7 +288,7 @@ jobs:
           echo "REPORT_URL=${REPORT_OSS}report.html" >> $GITHUB_OUTPUT
 
       - name: Commit updated unstable_case.json
-        if: steps.gen.outputs.JSON_UPDATED == 'true'
+        if: false  # temporarily disabled: verify report correctness before enabling auto-update
         run: |
           cd ci-tool
           git config user.name  "wanpengfei-git"

--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -274,6 +274,7 @@ jobs:
           check_name: 'Unstable Case Review'
           fail_on_failure: false
           detailed_summary: true
+          include_passed: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload report to OSS


### PR DESCRIPTION
## What type of PR is this?

> Tool

## Why are we doing this? Any context or related work?

The weekly review run found issues that make the auto-removal of cases unreliable:

1. All 3 FE-UT runs reported `BUILD FAILURE` — XML output may be incomplete
2. 7 class-level entries in `unstable_case.json` (no `#method`) are silently classified as `not_found` and skipped, but were incorrectly removed by the auto-commit
3. Report does not yet show per-case run counts, making results hard to verify

Disabling the auto-commit step (`if: false`) until the review logic is confirmed correct. The report and XML upload steps are unaffected — results will still be generated and visible.

Re-enable by restoring `if: steps.gen.outputs.JSON_UPDATED == 'true'`.

## What changes were made?

- `.github/workflows/weekly-unstable-case-review.yml`: set `Commit updated unstable_case.json` step to `if: false`

## Checklist

- [x] I have self-reviewed this PR