### PR TITLE
[Tool] improve weekly unstable case review report

### DIFF
--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -288,7 +288,7 @@ jobs:
           echo "REPORT_URL=${REPORT_OSS}report.html" >> $GITHUB_OUTPUT
 
       - name: Commit updated unstable_case.json
-        if: steps.gen.outputs.JSON_UPDATED == 'true'
+        if: false  # temporarily disabled: verify report correctness before enabling auto-update
         run: |
           cd ci-tool
           git config user.name  "wanpengfei-git"

--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -274,6 +274,7 @@ jobs:
           check_name: 'Unstable Case Review'
           fail_on_failure: false
           detailed_summary: true
+          include_passed: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload report to OSS


### PR DESCRIPTION
## Why I'm doing:

The weekly review report had two gaps:
1. The auto-commit step removed cases from `unstable_case.json` before the report logic was verified correct (class-level matching issues, BUILD FAILURE in all runs).
2. The GitHub Checks tab showed no annotations for passing cases since `include_passed` defaulted to false.

## What I'm doing:

- Disable the `Commit updated unstable_case.json` step (`if: false`) until report correctness is confirmed. Re-enable by restoring `if: steps.gen.outputs.JSON_UPDATED == 'true'`.
- Add `include_passed: true` to `mikepenz/action-junit-report` so passing cases appear as annotations in the Checks tab.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Policy changes: use new policy to replace old one, functionality automatically enabled

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch