### PR TITLE
[Enhancement] Add adaptive ef_search for HNSW vector index queries

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1862,6 +1862,17 @@ CONF_mInt32(config_vector_index_default_build_threshold, "10000");
 // value may exceed nproc * this value.
 CONF_mDouble(vector_index_build_max_cpu_ratio, "0.5");
 
+// Per-segment adaptive ef_search for HNSW vector queries.
+// Compensates for recall degradation on larger segments (e.g. after compaction
+// merges many small segments into one large segment).
+//
+// Formula:
+//   ef_effective = max(user_ef, query_k) * min(1 + alpha * log2(rows/baseline), cap)
+CONF_mBool(enable_vector_adaptive_search, "true");
+CONF_mDouble(vector_adaptive_ef_alpha, "1.0");
+CONF_mDouble(vector_adaptive_ef_cap, "8.0");
+CONF_mInt64(vector_adaptive_ef_baseline_rows, "300000");
+
 // When upgrade thrift to 0.20.0, the MaxMessageSize member defines the maximum size of a (received) message, in bytes.
 // The default value is represented by a constant named DEFAULT_MAX_MESSAGE_SIZE, whose value is 100 * 1024 * 1024 bytes.
 // This will cause FE to fail during deserialization when the returned result set is larger than 100M. Therefore,

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -339,7 +339,11 @@
         "enable_vector_index_block_cache",
         "config_vector_index_build_concurrency",
         "config_vector_index_default_build_threshold",
-        "vector_index_build_max_cpu_ratio"
+        "vector_index_build_max_cpu_ratio",
+        "enable_vector_adaptive_search",
+        "vector_adaptive_ef_alpha",
+        "vector_adaptive_ef_cap",
+        "vector_adaptive_ef_baseline_rows"
       ]
     },
     {

--- a/be/src/common/config_vector_index_fwd.h
+++ b/be/src/common/config_vector_index_fwd.h
@@ -39,4 +39,18 @@ CONF_mInt32(config_vector_index_default_build_threshold, "10000");
 // value may exceed nproc * this value.
 CONF_mDouble(vector_index_build_max_cpu_ratio, "0.5");
 
+// Per-segment adaptive ef_search for HNSW vector queries.
+// Compensates for recall degradation on larger segments (e.g. after compaction
+// merges many small segments into one large segment).
+//
+// Formula:
+//   ef_effective = max(user_ef, query_k) * min(1 + alpha * log2(rows/baseline), cap)
+CONF_mBool(enable_vector_adaptive_search, "true");
+
+CONF_mDouble(vector_adaptive_ef_alpha, "1.0");
+
+CONF_mDouble(vector_adaptive_ef_cap, "8.0");
+
+CONF_mInt64(vector_adaptive_ef_baseline_rows, "300000");
+
 } // namespace starrocks::config

--- a/be/src/storage/index/vector/tenann/tenann_index_utils.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_utils.cpp
@@ -16,6 +16,13 @@
 
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 
+#include <algorithm>
+#include <cmath>
+
+#include "common/config_vector_index_fwd.h"
+#include "common/logging.h"
+#include "tenann/index/parameters.h"
+
 namespace starrocks {
 
 #define CHECK_AND_RETURN(STANDARD_STR, NAME, TYPE) \
@@ -118,6 +125,50 @@ StatusOr<tenann::IndexMeta> get_vector_meta(const std::shared_ptr<TabletIndex>& 
     }
 
     return meta;
+}
+
+int compute_adaptive_ef_search(int user_ef, int query_k, size_t segment_num_rows) {
+    int ef_base = std::max(user_ef, query_k);
+    if (ef_base <= 0) return 0;
+    int64_t baseline = config::vector_adaptive_ef_baseline_rows;
+    if (baseline <= 0 || static_cast<int64_t>(segment_num_rows) <= baseline) {
+        return ef_base;
+    }
+    double ratio = static_cast<double>(segment_num_rows) / static_cast<double>(baseline);
+    double factor = 1.0 + config::vector_adaptive_ef_alpha * std::log2(ratio);
+    factor = std::min(factor, static_cast<double>(config::vector_adaptive_ef_cap));
+    if (factor <= 1.0) return ef_base;
+    return static_cast<int>(static_cast<double>(ef_base) * factor);
+}
+
+void apply_adaptive_ef_search(tenann::IndexMeta* meta, size_t segment_num_rows, int query_k, bool user_set_ef) {
+    if (!config::enable_vector_adaptive_search) return;
+    if (user_set_ef) return;
+
+    auto& params = meta->search_params();
+    auto it = params.find(starrocks::index::vector::EF_SEARCH);
+    if (it == params.end()) return;
+
+    int user_ef = 0;
+    try {
+        if (it->is_number_integer()) {
+            user_ef = it->get<int>();
+        } else if (it->is_string()) {
+            user_ef = std::stoi(it->get<std::string>());
+        } else {
+            return;
+        }
+    } catch (...) {
+        return;
+    }
+    if (user_ef <= 0) return;
+
+    int eff_ef = compute_adaptive_ef_search(user_ef, query_k, segment_num_rows);
+    if (eff_ef != user_ef) {
+        params[starrocks::index::vector::EF_SEARCH] = eff_ef;
+        VLOG(2) << "Adaptive ef_search: user_ef=" << user_ef << " query_k=" << query_k << " rows=" << segment_num_rows
+                << " effective=" << eff_ef;
+    }
 }
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/tenann/tenann_index_utils.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_utils.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include "common/config_vector_index_fwd.h"
 #include "common/logging.h"
@@ -138,7 +139,14 @@ int compute_adaptive_ef_search(int user_ef, int query_k, size_t segment_num_rows
     double factor = 1.0 + config::vector_adaptive_ef_alpha * std::log2(ratio);
     factor = std::min(factor, static_cast<double>(config::vector_adaptive_ef_cap));
     if (factor <= 1.0) return ef_base;
-    return static_cast<int>(static_cast<double>(ef_base) * factor);
+    // Clamp before casting to int: float-to-int conversion is UB when the
+    // double exceeds the int range. Pathological cap/ef_base combinations
+    // (or future config tuning) could cross INT_MAX otherwise.
+    double scaled = static_cast<double>(ef_base) * factor;
+    if (scaled >= static_cast<double>(std::numeric_limits<int>::max())) {
+        return std::numeric_limits<int>::max();
+    }
+    return static_cast<int>(scaled);
 }
 
 void apply_adaptive_ef_search(tenann::IndexMeta* meta, size_t segment_num_rows, int query_k, bool user_set_ef) {

--- a/be/src/storage/index/vector/tenann/tenann_index_utils.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_utils.cpp
@@ -135,9 +135,14 @@ int compute_adaptive_ef_search(int user_ef, int query_k, size_t segment_num_rows
     if (baseline <= 0 || static_cast<int64_t>(segment_num_rows) <= baseline) {
         return ef_base;
     }
+    // `vector_adaptive_ef_alpha` / `vector_adaptive_ef_cap` are mutable doubles
+    // and `strtod` accepts "nan"/"inf". Validate up front so the formula below
+    // never produces a non-finite value that would make `static_cast<int>` UB.
+    double alpha = config::vector_adaptive_ef_alpha;
+    double cap = config::vector_adaptive_ef_cap;
+    if (!std::isfinite(alpha) || !std::isfinite(cap)) return ef_base;
     double ratio = static_cast<double>(segment_num_rows) / static_cast<double>(baseline);
-    double factor = 1.0 + config::vector_adaptive_ef_alpha * std::log2(ratio);
-    factor = std::min(factor, static_cast<double>(config::vector_adaptive_ef_cap));
+    double factor = std::min(1.0 + alpha * std::log2(ratio), cap);
     if (factor <= 1.0) return ef_base;
     // Clamp before casting to int: float-to-int conversion is UB when the
     // double exceeds the int range. Pathological cap/ef_base combinations

--- a/be/src/storage/index/vector/tenann/tenann_index_utils.h
+++ b/be/src/storage/index/vector/tenann/tenann_index_utils.h
@@ -43,6 +43,23 @@ static const std::string RANGE_SEARCH_CONFIDENCE = "range_search_confidence";
 namespace starrocks {
 StatusOr<tenann::IndexMeta> get_vector_meta(const std::shared_ptr<TabletIndex>& tablet_index,
                                             const std::map<std::string, std::string>& query_params);
+
+// Compute the effective ef_search for a single segment.
+//
+//   ef_base = max(user_ef, query_k)                      // faiss max(ef,k) floor
+//   factor  = min(1 + alpha * log2(rows/baseline), cap)  // 1.0 when rows<=baseline
+//   return    ef_base * factor
+//
+// `user_ef` and `query_k` must be positive; otherwise the returned value is clamped
+// to a non-negative int. Caller is expected to check
+// `config::enable_vector_adaptive_search` and user_set_ef overrides before calling.
+int compute_adaptive_ef_search(int user_ef, int query_k, size_t segment_num_rows);
+
+// Apply adaptive ef_search to meta.search_params["efSearch"] in place. Honors:
+//   - `config::enable_vector_adaptive_search` (global enable)
+//   - `user_set_ef` (user explicitly specified ef in query -> skip)
+//   - Missing efSearch in meta (non-HNSW indexes -> skip)
+void apply_adaptive_ef_search(tenann::IndexMeta* meta, size_t segment_num_rows, int query_k, bool user_set_ef);
 } // namespace starrocks
 
 #endif

--- a/be/src/storage/index/vector/tenann_index_reader.cpp
+++ b/be/src/storage/index/vector/tenann_index_reader.cpp
@@ -39,6 +39,7 @@
 #include "common/status.h"
 #include "common/statusor.h"
 #include "fs/fs.h"
+#include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_file_reader.h"
 #include "tenann/common/error.h"
 #include "tenann/common/seq_view.h"
@@ -104,6 +105,13 @@ Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const std::str
         return Status::InternalError(e.what());
     }
     return Status::OK();
+}
+
+Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs,
+                                   size_t segment_num_rows, int query_k, bool user_set_ef) {
+    auto adapted_meta = meta;
+    apply_adaptive_ef_search(&adapted_meta, segment_num_rows, query_k, user_set_ef);
+    return init_searcher(adapted_meta, index_path, fs);
 }
 
 Status TenANNReader::search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids,

--- a/be/src/storage/index/vector/tenann_index_reader.h
+++ b/be/src/storage/index/vector/tenann_index_reader.h
@@ -37,6 +37,9 @@ public:
 
     Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs) override;
 
+    Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs,
+                         size_t segment_num_rows, int query_k, bool user_set_ef) override;
+
     Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,
                   tenann::IdFilter* id_filter = nullptr) override;
     Status range_search(tenann::PrimitiveSeqView query_vector, int k, std::vector<int64_t>* result_ids,

--- a/be/src/storage/index/vector/vector_index_reader.h
+++ b/be/src/storage/index/vector/vector_index_reader.h
@@ -57,6 +57,19 @@ public:
         return init_searcher(meta, index_path);
     }
 
+    // Overload that carries context for per-segment adaptive ef_search:
+    //   segment_num_rows: row count of this segment, used as the scaling signal
+    //   query_k: effective k (already multiplied by k_factor) the caller plans
+    //     to pass to search(); used as a floor for ef_base to match faiss's
+    //     internal `ef = max(efSearch, k)` rule
+    //   user_set_ef: true if the user explicitly specified efSearch (e.g. via
+    //     query hint); when true, adaptive scaling is skipped
+    // Default forwards to the row-count-unaware overload.
+    virtual Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs,
+                                 size_t segment_num_rows, int query_k, bool user_set_ef) {
+        return init_searcher(meta, index_path, fs);
+    }
+
     virtual Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,
                           tenann::IdFilter* id_filter = nullptr) = 0;
     virtual Status range_search(tenann::PrimitiveSeqView query_vector, int k, std::vector<int64_t>* result_ids,

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -21,6 +21,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include <boost/algorithm/string/predicate.hpp>
+
 #include "base/format.h"
 #include "base/simd/simd.h"
 #include "base/utility/defer_op.h"
@@ -963,8 +965,16 @@ inline Status SegmentIterator::_init_reader_from_file(const std::string& index_p
     RETURN_IF_ERROR(create_st);
     // Enable per-segment adaptive ef_search. query_params carries a user-explicit
     // efSearch iff the user set one via query hint / session var; that disables
-    // adaptive scaling so user intent is honored.
-    bool user_set_ef = query_params.count(starrocks::index::vector::EF_SEARCH) > 0;
+    // adaptive scaling so user intent is honored. FE preserves the user-typed key
+    // casing for ann_params (e.g. "efsearch", "Efsearch", "EFSEARCH" are all
+    // valid), so the check must be case-insensitive.
+    bool user_set_ef = false;
+    for (const auto& entry : query_params) {
+        if (boost::iequals(entry.first, starrocks::index::vector::EF_SEARCH)) {
+            user_set_ef = true;
+            break;
+        }
+    }
     auto status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), index_path, fs,
                                                                static_cast<size_t>(_segment->num_rows()),
                                                                _vector_index_ctx->k, user_set_ef);

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -15,13 +15,12 @@
 #include "segment_iterator.h"
 
 #include <algorithm>
+#include <boost/algorithm/string/predicate.hpp>
 #include <cmath>
 #include <limits>
 #include <memory>
 #include <unordered_map>
 #include <utility>
-
-#include <boost/algorithm/string/predicate.hpp>
 
 #include "base/format.h"
 #include "base/simd/simd.h"

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -961,7 +961,13 @@ inline Status SegmentIterator::_init_reader_from_file(const std::string& index_p
         return Status::OK();
     }
     RETURN_IF_ERROR(create_st);
-    auto status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), index_path, fs);
+    // Enable per-segment adaptive ef_search. query_params carries a user-explicit
+    // efSearch iff the user set one via query hint / session var; that disables
+    // adaptive scaling so user intent is honored.
+    bool user_set_ef = query_params.count(starrocks::index::vector::EF_SEARCH) > 0;
+    auto status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), index_path, fs,
+                                                               static_cast<size_t>(_segment->num_rows()),
+                                                               _vector_index_ctx->k, user_set_ef);
     // empty ann reader — caller will set up brute-force fallback
     if (status.is_not_supported()) {
         _vector_index_ctx->use_vector_index = false;

--- a/be/test/storage/index/vector_index_test.cpp
+++ b/be/test/storage/index/vector_index_test.cpp
@@ -480,6 +480,21 @@ TEST_F(AdaptiveEfSearchTest, result_clamped_to_int_max) {
     EXPECT_EQ(std::numeric_limits<int>::max(), result);
 }
 
+TEST_F(AdaptiveEfSearchTest, nonfinite_config_falls_back_to_base) {
+    // `vector_adaptive_ef_alpha` / `vector_adaptive_ef_cap` are mutable doubles
+    // and `strtod` accepts "nan"/"inf". A non-finite factor must short-circuit
+    // before the float-to-int cast (which is UB on NaN).
+    config::vector_adaptive_ef_alpha = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 1000000));
+
+    config::vector_adaptive_ef_alpha = std::numeric_limits<double>::infinity();
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 1000000));
+
+    config::vector_adaptive_ef_alpha = 1.0;
+    config::vector_adaptive_ef_cap = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 1000000));
+}
+
 TEST_F(AdaptiveEfSearchTest, respects_max_ef_k_floor) {
     // query_k greater than user_ef: scaling base is query_k.
     // 1M rows, base=100, factor=4.32 -> ef=432 regardless of user_ef=40.

--- a/be/test/storage/index/vector_index_test.cpp
+++ b/be/test/storage/index/vector_index_test.cpp
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include "fs/fs_factory.h"
 
 #ifdef WITH_TENANN
@@ -466,6 +468,16 @@ TEST_F(AdaptiveEfSearchTest, cap_applied_on_huge_segments) {
     EXPECT_EQ(800, compute_adaptive_ef_search(100, 100, 12800000));
     // 100M rows: factor would exceed cap (= 1 + ~10), clamped to 8, ef = 800.
     EXPECT_EQ(800, compute_adaptive_ef_search(100, 100, 100000000));
+}
+
+TEST_F(AdaptiveEfSearchTest, result_clamped_to_int_max) {
+    // Pathological config: extremely large user_ef combined with a high cap
+    // could push `ef_base * factor` past INT_MAX. The cast must clamp instead
+    // of relying on UB float-to-int conversion.
+    config::vector_adaptive_ef_cap = 1e9;
+    const int huge_ef = std::numeric_limits<int>::max() / 2;
+    int result = compute_adaptive_ef_search(huge_ef, 1, /*rows=*/100000000);
+    EXPECT_EQ(std::numeric_limits<int>::max(), result);
 }
 
 TEST_F(AdaptiveEfSearchTest, respects_max_ef_k_floor) {

--- a/be/test/storage/index/vector_index_test.cpp
+++ b/be/test/storage/index/vector_index_test.cpp
@@ -556,6 +556,134 @@ TEST_F(AdaptiveEfSearchTest, apply_noop_when_below_baseline) {
     EXPECT_EQ(100, meta.search_params()[starrocks::index::vector::EF_SEARCH].get<int>());
 }
 
+// ef_base = max(user_ef, query_k); when both are non-positive the helper must
+// short-circuit to 0 so downstream `static_cast<int>` never sees a negative
+// scaled value (which would then be clamped to INT_MAX by the cap check).
+TEST_F(AdaptiveEfSearchTest, compute_returns_zero_when_ef_base_nonpositive) {
+    EXPECT_EQ(0, compute_adaptive_ef_search(0, 0, 1000000));
+    EXPECT_EQ(0, compute_adaptive_ef_search(-5, -3, 1000000));
+    // Row count below baseline doesn't matter: the guard fires before baseline.
+    EXPECT_EQ(0, compute_adaptive_ef_search(0, 0, 50));
+}
+
+// A non-positive baseline disables scaling entirely. Defends against
+// pathological online retuning (`ADMIN SET FRONTEND CONFIG`-style edits to BE
+// configs that set baseline to 0 or a negative value).
+TEST_F(AdaptiveEfSearchTest, compute_no_scale_when_baseline_nonpositive) {
+    config::vector_adaptive_ef_baseline_rows = 0;
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 10000000));
+
+    config::vector_adaptive_ef_baseline_rows = -1;
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 10000000));
+}
+
+// alpha <= 0 produces factor <= 1.0 above baseline; we must NOT shrink ef
+// below the base (faiss already guarantees `ef = max(efSearch, k)` internally,
+// so shrinking would be silently overridden anyway).
+TEST_F(AdaptiveEfSearchTest, compute_no_scale_when_alpha_zero) {
+    config::vector_adaptive_ef_alpha = 0.0;
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 1000000));
+    EXPECT_EQ(200, compute_adaptive_ef_search(200, 50, 100000000));
+}
+
+TEST_F(AdaptiveEfSearchTest, compute_no_scale_when_alpha_negative) {
+    // A negative alpha would mathematically yield factor < 1.0 above baseline.
+    // The `factor <= 1.0` guard must keep us at the floor.
+    config::vector_adaptive_ef_alpha = -1.0;
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 1000000));
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 100000000));
+}
+
+// segment_num_rows = 0 is unusual but legal: the baseline check (rows <=
+// baseline) short-circuits before any log2 is evaluated, avoiding log2(0) = -inf.
+TEST_F(AdaptiveEfSearchTest, compute_no_scale_when_rows_zero) {
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 0));
+}
+
+// efSearch stored as a JSON string ("100") must still drive adaptive scaling.
+// tenann meta serialization can round-trip integers as strings depending on the
+// caller; apply_adaptive_ef_search must accept both shapes.
+TEST_F(AdaptiveEfSearchTest, apply_scales_when_ef_is_string) {
+    tenann::IndexMeta meta;
+    meta.search_params()[starrocks::index::vector::EF_SEARCH] = std::string("100");
+
+    apply_adaptive_ef_search(&meta, /*rows=*/1000000, /*k=*/100, /*user_set_ef=*/false);
+
+    // Effective ef is rewritten as an int (matches compute_adaptive_ef_search return).
+    EXPECT_EQ(432, meta.search_params()[starrocks::index::vector::EF_SEARCH].get<int>());
+}
+
+// A malformed string in efSearch must be tolerated: stoi throws, we swallow and
+// leave the original value alone rather than crashing the query path.
+TEST_F(AdaptiveEfSearchTest, apply_skipped_when_ef_string_invalid) {
+    tenann::IndexMeta meta;
+    meta.search_params()[starrocks::index::vector::EF_SEARCH] = std::string("not-a-number");
+
+    apply_adaptive_ef_search(&meta, 1000000, 100, false);
+
+    EXPECT_EQ("not-a-number", meta.search_params()[starrocks::index::vector::EF_SEARCH].get<std::string>());
+}
+
+// JSON value of an unexpected shape (float, bool, array) must be ignored so we
+// don't silently coerce non-integer types into ef_search.
+TEST_F(AdaptiveEfSearchTest, apply_skipped_when_ef_is_unsupported_type) {
+    {
+        // Float: is_number_integer() == false, is_string() == false.
+        tenann::IndexMeta meta;
+        meta.search_params()[starrocks::index::vector::EF_SEARCH] = 100.5;
+        apply_adaptive_ef_search(&meta, 1000000, 100, false);
+        EXPECT_DOUBLE_EQ(100.5, meta.search_params()[starrocks::index::vector::EF_SEARCH].get<double>());
+    }
+    {
+        tenann::IndexMeta meta;
+        meta.search_params()[starrocks::index::vector::EF_SEARCH] = true;
+        apply_adaptive_ef_search(&meta, 1000000, 100, false);
+        EXPECT_EQ(true, meta.search_params()[starrocks::index::vector::EF_SEARCH].get<bool>());
+    }
+    {
+        tenann::IndexMeta meta;
+        meta.search_params()[starrocks::index::vector::EF_SEARCH] = std::vector<int>{1, 2, 3};
+        apply_adaptive_ef_search(&meta, 1000000, 100, false);
+        EXPECT_TRUE(meta.search_params()[starrocks::index::vector::EF_SEARCH].is_array());
+    }
+}
+
+// efSearch present but non-positive: skip scaling and leave value alone. A
+// non-positive ef wouldn't survive faiss anyway, but the helper must not
+// rewrite it (e.g. into a scaled value that hides the real misconfiguration).
+TEST_F(AdaptiveEfSearchTest, apply_skipped_when_user_ef_nonpositive) {
+    {
+        tenann::IndexMeta meta;
+        meta.search_params()[starrocks::index::vector::EF_SEARCH] = 0;
+        apply_adaptive_ef_search(&meta, 1000000, 100, false);
+        EXPECT_EQ(0, meta.search_params()[starrocks::index::vector::EF_SEARCH].get<int>());
+    }
+    {
+        tenann::IndexMeta meta;
+        meta.search_params()[starrocks::index::vector::EF_SEARCH] = -10;
+        apply_adaptive_ef_search(&meta, 1000000, 100, false);
+        EXPECT_EQ(-10, meta.search_params()[starrocks::index::vector::EF_SEARCH].get<int>());
+    }
+}
+
+// When the formula produces a value identical to user_ef the helper must skip
+// the assignment entirely. We force this with alpha=0 + above-baseline rows so
+// factor==1.0 and compute returns the unmodified ef_base. The distinguishing
+// signal is the JSON value's type stability: we initialize with a string and
+// verify it stays a string (a redundant write would coerce it to int).
+TEST_F(AdaptiveEfSearchTest, apply_no_rewrite_when_effective_equals_user) {
+    config::vector_adaptive_ef_alpha = 0.0;
+    tenann::IndexMeta meta;
+    meta.search_params()[starrocks::index::vector::EF_SEARCH] = std::string("100");
+
+    apply_adaptive_ef_search(&meta, /*rows=*/10000000, /*k=*/100, /*user_set_ef=*/false);
+
+    // Still a string — the helper exited via the `eff_ef == user_ef` branch
+    // before assigning an int back to params.
+    EXPECT_TRUE(meta.search_params()[starrocks::index::vector::EF_SEARCH].is_string());
+    EXPECT_EQ("100", meta.search_params()[starrocks::index::vector::EF_SEARCH].get<std::string>());
+}
+
 #endif // WITH_TENANN
 
 } // namespace starrocks

--- a/be/test/storage/index/vector_index_test.cpp
+++ b/be/test/storage/index/vector_index_test.cpp
@@ -410,4 +410,125 @@ TEST_F(VectorIndexWriterTest, array_column_writer_rejects_missing_dim) {
     ASSERT_NE(st.message().find("dim"), std::string_view::npos) << st.message();
 }
 
+#ifdef WITH_TENANN
+// --------------------------------------------------------------------------
+// Adaptive ef_search
+// --------------------------------------------------------------------------
+
+class AdaptiveEfSearchTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _saved_enable = config::enable_vector_adaptive_search;
+        _saved_alpha = config::vector_adaptive_ef_alpha;
+        _saved_cap = config::vector_adaptive_ef_cap;
+        _saved_baseline = config::vector_adaptive_ef_baseline_rows;
+        config::enable_vector_adaptive_search = true;
+        config::vector_adaptive_ef_alpha = 1.0;
+        config::vector_adaptive_ef_cap = 8.0;
+        config::vector_adaptive_ef_baseline_rows = 100000;
+    }
+
+    void TearDown() override {
+        config::enable_vector_adaptive_search = _saved_enable;
+        config::vector_adaptive_ef_alpha = _saved_alpha;
+        config::vector_adaptive_ef_cap = _saved_cap;
+        config::vector_adaptive_ef_baseline_rows = _saved_baseline;
+    }
+
+    bool _saved_enable = true;
+    double _saved_alpha = 1.0;
+    double _saved_cap = 8.0;
+    int64_t _saved_baseline = 100000;
+};
+
+TEST_F(AdaptiveEfSearchTest, below_baseline_not_scaled) {
+    // rows <= baseline: use max(user_ef, k) without scaling.
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 50000));
+    EXPECT_EQ(100, compute_adaptive_ef_search(100, 100, 100000));
+    // user_ef < k: floor at k.
+    EXPECT_EQ(100, compute_adaptive_ef_search(40, 100, 50000));
+    // user_ef > k: honor user_ef as the base.
+    EXPECT_EQ(200, compute_adaptive_ef_search(200, 100, 50000));
+}
+
+TEST_F(AdaptiveEfSearchTest, log_scaling_above_baseline) {
+    // 1M rows, baseline 100K, alpha=1.0 -> factor = 1 + log2(10) = 4.32.
+    // With base max(100,100)=100, expect ef ~ 432.
+    EXPECT_EQ(432, compute_adaptive_ef_search(100, 100, 1000000));
+    // 200K rows -> factor = 1 + log2(2) = 2.0 -> ef = 200.
+    EXPECT_EQ(200, compute_adaptive_ef_search(100, 100, 200000));
+    // 500K rows -> factor = 1 + log2(5) ~ 3.32 -> ef = 332.
+    EXPECT_EQ(332, compute_adaptive_ef_search(100, 100, 500000));
+}
+
+TEST_F(AdaptiveEfSearchTest, cap_applied_on_huge_segments) {
+    // 12.8M rows: factor = 1 + log2(128) = 8.0 -> at cap, ef = 800.
+    EXPECT_EQ(800, compute_adaptive_ef_search(100, 100, 12800000));
+    // 100M rows: factor would exceed cap (= 1 + ~10), clamped to 8, ef = 800.
+    EXPECT_EQ(800, compute_adaptive_ef_search(100, 100, 100000000));
+}
+
+TEST_F(AdaptiveEfSearchTest, respects_max_ef_k_floor) {
+    // query_k greater than user_ef: scaling base is query_k.
+    // 1M rows, base=100, factor=4.32 -> ef=432 regardless of user_ef=40.
+    EXPECT_EQ(432, compute_adaptive_ef_search(40, 100, 1000000));
+    // user_ef=200, k=100 -> base=200, 1M rows -> ef=200 * 4.32 = 864.
+    EXPECT_EQ(864, compute_adaptive_ef_search(200, 100, 1000000));
+}
+
+TEST_F(AdaptiveEfSearchTest, config_overrides_alpha_and_cap) {
+    config::vector_adaptive_ef_alpha = 1.5;
+    EXPECT_EQ(598, compute_adaptive_ef_search(100, 100, 1000000)); // 1 + 1.5*3.32 = 5.98
+
+    config::vector_adaptive_ef_alpha = 1.0;
+    config::vector_adaptive_ef_cap = 4.0;
+    EXPECT_EQ(400, compute_adaptive_ef_search(100, 100, 1000000)); // capped at 4.0
+}
+
+TEST_F(AdaptiveEfSearchTest, apply_writes_scaled_value_to_meta) {
+    tenann::IndexMeta meta;
+    meta.search_params()[starrocks::index::vector::EF_SEARCH] = 100;
+
+    apply_adaptive_ef_search(&meta, /*rows=*/1000000, /*k=*/100, /*user_set_ef=*/false);
+
+    EXPECT_EQ(432, meta.search_params()[starrocks::index::vector::EF_SEARCH].get<int>());
+}
+
+TEST_F(AdaptiveEfSearchTest, apply_skipped_when_disabled) {
+    config::enable_vector_adaptive_search = false;
+    tenann::IndexMeta meta;
+    meta.search_params()[starrocks::index::vector::EF_SEARCH] = 100;
+
+    apply_adaptive_ef_search(&meta, 1000000, 100, false);
+
+    EXPECT_EQ(100, meta.search_params()[starrocks::index::vector::EF_SEARCH].get<int>());
+}
+
+TEST_F(AdaptiveEfSearchTest, apply_skipped_when_user_set_ef) {
+    tenann::IndexMeta meta;
+    meta.search_params()[starrocks::index::vector::EF_SEARCH] = 100;
+
+    apply_adaptive_ef_search(&meta, 1000000, 100, /*user_set_ef=*/true);
+
+    EXPECT_EQ(100, meta.search_params()[starrocks::index::vector::EF_SEARCH].get<int>());
+}
+
+TEST_F(AdaptiveEfSearchTest, apply_noop_when_no_ef_in_meta) {
+    tenann::IndexMeta meta;
+    // No efSearch key set (non-HNSW index).
+    apply_adaptive_ef_search(&meta, 1000000, 100, false);
+    EXPECT_EQ(meta.search_params().find(starrocks::index::vector::EF_SEARCH), meta.search_params().end());
+}
+
+TEST_F(AdaptiveEfSearchTest, apply_noop_when_below_baseline) {
+    tenann::IndexMeta meta;
+    meta.search_params()[starrocks::index::vector::EF_SEARCH] = 100;
+
+    apply_adaptive_ef_search(&meta, /*rows=*/50000, 100, false);
+
+    EXPECT_EQ(100, meta.search_params()[starrocks::index::vector::EF_SEARCH].get<int>());
+}
+
+#endif // WITH_TENANN
+
 } // namespace starrocks

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -628,6 +628,42 @@ This topic introduces the following types of FE configurations:
 - Description: Fraction of the BE process memory reserved for update-related memory and caches. During startup `GlobalEnv` computes the `MemTracker` for updates as process_mem_limit * clamp(update_memory_limit_percent, 0, 100) / 100. `UpdateManager` also uses this percentage to size its primary-index/index-cache capacity (index cache capacity = GlobalEnv::process_mem_limit * update_memory_limit_percent / 100). The HTTP config update logic registers a callback that calls `update_primary_index_memory_limit` on the update managers, so changes would be applied to the update subsystem if the config were changed. Increasing this value gives more memory to update/primary-index paths (reducing memory available for other pools); decreasing it reduces update memory and cache capacity. Values are clamped to the range 0–100.
 - Introduced in: v3.2.0
 
+### enable_vector_adaptive_search
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Master switch for adaptive `ef_search` scaling on HNSW vector indexes. When enabled, BE scales the effective `ef_search` per segment based on its row count, so recall is preserved when compaction enlarges segments without forcing manual `ef_search` retuning. Set to `false` to disable scaling and use the user-supplied `ef_search` literally.
+- Introduced in: -
+
+### vector_adaptive_ef_alpha
+
+- Default: 1.0
+- Type: Double
+- Unit: -
+- Is mutable: Yes
+- Description: Growth slope for adaptive `ef_search`. The scaling factor is `1 + alpha * log2(segment_rows / vector_adaptive_ef_baseline_rows)`. Higher values raise recall more aggressively at the cost of higher CPU per query; lower values trim CPU at the cost of recall on large segments. Effective only when `enable_vector_adaptive_search` is true and `segment_rows > vector_adaptive_ef_baseline_rows`.
+- Introduced in: -
+
+### vector_adaptive_ef_baseline_rows
+
+- Default: 300000
+- Type: Int
+- Unit: Rows
+- Is mutable: Yes
+- Description: Segment row count below which adaptive `ef_search` does not scale. Segments with fewer rows than this threshold use the user-supplied `ef_search` directly; segments above this threshold receive a higher effective `ef_search` to compensate for the larger HNSW graph. Effective only when `enable_vector_adaptive_search` is true.
+- Introduced in: -
+
+### vector_adaptive_ef_cap
+
+- Default: 8.0
+- Type: Double
+- Unit: -
+- Is mutable: Yes
+- Description: Upper bound on the adaptive `ef_search` multiplier. Caps the worst-case CPU and latency cost of the scaling formula even on extremely large segments. Effective only when `enable_vector_adaptive_search` is true.
+- Introduced in: -
+
 ### vector_chunk_size
 
 - Default: 4096

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -625,6 +625,42 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：BE 进程内存中为更新相关内存和缓存保留的比例。在启动期间，`GlobalEnv` 将更新的 `MemTracker` 计算为 process_mem_limit * clamp(update_memory_limit_percent, 0, 100) / 100。`UpdateManager` 也使用该百分比来确定其 primary-index/index-cache 的容量（index cache capacity = GlobalEnv::process_mem_limit * update_memory_limit_percent / 100）。HTTP 配置更新逻辑会注册一个回调，在配置更改时调用 update managers 的 `update_primary_index_memory_limit`，因此配置更改会应用到更新子系统。增加此值会为更新/primary-index 路径分配更多内存（减少其他内存池可用内存）；减少它会降低更新内存和缓存容量。值会被限定在 0–100 范围内。
 - 引入版本：v3.2.0
 
+### enable_vector_adaptive_search
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：HNSW 向量索引自适应 `ef_search` 缩放的总开关。开启时，BE 会根据 segment 行数为每个 segment 调整有效 `ef_search`，从而在 compaction 合并大 segment 后无需手动调参即可保持召回率。设置为 `false` 时关闭自适应缩放，按用户指定的 `ef_search` 原值执行。
+- 引入版本：-
+
+### vector_adaptive_ef_alpha
+
+- 默认值：1.0
+- 类型：Double
+- 单位：-
+- 是否动态：是
+- 描述：自适应 `ef_search` 的增长斜率。缩放系数为 `1 + alpha * log2(segment_rows / vector_adaptive_ef_baseline_rows)`。值越大召回提升越多但 CPU 开销越高；值越小则相反。仅在 `enable_vector_adaptive_search=true` 且 `segment_rows > vector_adaptive_ef_baseline_rows` 时生效。
+- 引入版本：-
+
+### vector_adaptive_ef_baseline_rows
+
+- 默认值：300000
+- 类型：Int
+- 单位：Rows
+- 是否动态：是
+- 描述：自适应 `ef_search` 不进行缩放的 segment 行数基线。低于该阈值的 segment 使用用户指定的 `ef_search`；高于该阈值的 segment 会得到放大的有效 `ef_search`，用以补偿较大 HNSW 图的搜索深度。仅在 `enable_vector_adaptive_search=true` 时生效。
+- 引入版本：-
+
+### vector_adaptive_ef_cap
+
+- 默认值：8.0
+- 类型：Double
+- 单位：-
+- 是否动态：是
+- 描述：自适应 `ef_search` 倍率上限。即使 segment 极大也将放大倍率限制在该上限内，避免 CPU 与延迟在极端情况下失控。仅在 `enable_vector_adaptive_search=true` 时生效。
+- 引入版本：-
+
 ### vector_chunk_size
 
 - 默认值：4096


### PR DESCRIPTION
## Why I'm doing:

In shared-data (lake) mode, compaction merges segments more aggressively than shared-nothing, producing fewer/larger segments. Empirically, recall on HNSW vector index drops noticeably at the same query parameters as segment row count grows — HNSW search quality scales as roughly `O(ef × log N)`, so a fixed `ef_search` cannot cover enough of the graph as `N` grows.

Benchmark also confirms only `ef_search` (not `k_factor` / candidate pool size) is the effective lever — increasing `k_factor` without growing `ef` returns identical recall, because faiss returns candidates ordered by distance and the global top-k merge discards the "filler" candidates outside the beam.

We need a per-segment, per-query effective `ef_search` that scales with the segment's row count, so recall is preserved when compaction enlarges segments without forcing every cluster operator to retune `ef_search` manually.

## What I'm doing:

Introduce an adaptive effective ef computed per segment at query time:

```
ef_effective = clamp(
    max(user_ef, query_k) * (1 + α * log2(rows / baseline_rows)),
    max(user_ef, query_k),                       // floor
    max(user_ef, query_k) * cap                  // ceiling
)
```

Key design points:

- Base uses `max(user_ef, query_k)` to align with faiss's internal `ef = max(efSearch, k)` rule. Otherwise when the user sets `efSearch < k`, faiss silently bumps `ef` to `k` and the user's `efSearch` becomes a no-op.
- Below `baseline_rows` (default 300K) no scaling is applied — small segments behave exactly as before.
- The per-segment row count is read at query time, so each segment in a tablet can use a different effective ef.
- The whole feature is gated behind a master switch and four mutable BE configs, so users can opt out or retune online.
- If the user supplies `efSearch` explicitly via query hint / session var, adaptive scaling is disabled for that query so user intent is honored.

New BE configs (all mutable):

| Config | Default | Purpose |
|---|---|---|
| `enable_vector_adaptive_search` | `true` | Master switch |
| `vector_adaptive_ef_alpha` | `1.0` | Growth slope |
| `vector_adaptive_ef_baseline_rows` | `300000` | Below this rows, no scaling |
| `vector_adaptive_ef_cap` | `8.0` | Multiplier ceiling |

Implementation surface:

- `tenann_index_utils.{h,cpp}`: new `compute_adaptive_ef_search(rows, user_ef, query_k)` helper applying the formula and clamps, plus `apply_adaptive_ef_search(meta, ...)` that mutates `IndexMeta::search_params["efSearch"]` only when enabled and the user did not set ef explicitly.
- `tenann_index_reader.{h,cpp}` and `vector_index_reader.h`: thread the segment row count and `user_set_ef` flag through `init_searcher`.
- `segment_iterator.cpp`: derive `user_set_ef` from `query_params` and pass the segment row count to `init_searcher`.
- `config.h` + generated `config_vector_index_fwd.h`: register the four new mutable configs (consumed via the forward header per `be/src/common/AGENTS.md`).
- `vector_index_test.cpp` (+121 lines): unit tests covering clamp behavior, the baseline rule, and the faiss `max(ef, k)` interaction.
- `docs/{en,zh}/.../BE_parameters/query_loading.md`: user-facing documentation for the four new configs.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: four new BE configs are added; default `enable_vector_adaptive_search=true` enables adaptive scaling out of the box
- [x] Policy changes: large-segment HNSW queries now use a higher effective ef_search by default to preserve recall
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4