### PR TITLE
[BugFix] Allow 0-arg count combinator for IVM count(*) support

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
@@ -83,10 +83,6 @@ public class AggStateUtils {
             return false;
         }
         String fnName = aggFunc.functionName();
-        // count only support count(col)
-        if (FunctionSet.COUNT.equalsIgnoreCase(fnName) && aggFunc.getArgs().length == 0 && !isAggIf) {
-            return false;
-        }
         if (ONLY_NUMERIC_ARGUMENT_FUNCTIONS_L1.contains(fnName) &&
                 Stream.of(aggFunc.getArgs()).anyMatch(t -> !t.canApplyToNumeric())) {
             return false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -121,6 +121,36 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
     }
 
     /**
+     * {@code COUNT(*)} in an aggregate MV query must be accepted by IVMAnalyzer.
+     *
+     * <p>Regression: until the fix that allows 0-arg count combinators, {@code count(*)}
+     * caused IVM rewrite to fail with {@code No matching function with signature: count_combine()}
+     * because {@code AggStateUtils.isSupportedAggStateFunction} excluded the 0-arg count form
+     * to protect AGG_STATE column DDL — but that DDL path is already blocked by the parser,
+     * so the exclusion was redundant and only blocked IVM.
+     */
+    @Test
+    public void testAggregateQueryWithCountStar() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_count_star "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, COUNT(*) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+
+        CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+        QueryStatement qs = stmt.getQueryStatement();
+        Analyzer.analyze(qs, connectContext);
+
+        IVMAnalyzer analyzer = new IVMAnalyzer(connectContext, stmt, qs);
+        Optional<IVMAnalyzer.IVMAnalyzeResult> result =
+                analyzer.rewrite(MaterializedView.RefreshMode.INCREMENTAL);
+
+        assertTrue(result.isPresent(),
+                "COUNT(*) aggregate MV must produce an IVM rewrite result");
+        assertEquals(RowIdStrategy.QUERY_COMPUTED, result.get().rowIdStrategy(),
+                "COUNT(*) aggregate MV must yield QUERY_COMPUTED");
+    }
+
+    /**
      * A non-aggregate (scan-only) MV query over an append-only Iceberg table must yield
      * {@link RowIdStrategy#AUTO_INCREMENT}.
      *


### PR DESCRIPTION
## Why I'm doing:

`COUNT(*)` cannot currently be used in an INCREMENTAL materialized view because creating such an MV fails at analysis time:

```sql
CREATE MATERIALIZED VIEW mv ... PROPERTIES ('refresh_mode'='incremental')
AS SELECT k, COUNT(*) FROM iceberg_t GROUP BY k;
-- ERROR 1064: Getting analyzing error. Detail message: No matching function with signature: count_combine().
```

This is a real usability gap: `COUNT(*)` is one of the most common aggregate forms, and the equivalent `COUNT(1)` works fine — so users see two semantically-identical SQL forms behave very differently in IVM.

**Root cause** is in `AggStateUtils.isSupportedAggStateFunction`:

```java
// count only support count(col)
if (FunctionSet.COUNT.equalsIgnoreCase(fnName) && aggFunc.getArgs().length == 0 && !isAggIf) {
    return false;
}
```

This filter prevents the 0-arg form of `count` from getting any `_combine` / `_state_merge` / `_state_union` combinator registered, so the IVM rewrite path (which constructs `count_combine()` based on the user's aggregate) cannot find a matching function.

The original rationale (introduced in #50425, parent issue #49000) was that **AGG_STATE column DDL** needs explicit argument types to uniquely identify the aggregate function:

```sql
CREATE TABLE t (cnt count(int) ...);  -- requires explicit arg type
```

So the filter was meant to keep `count()` (no args) out of the AGG_STATE column DDL syntax.

**However, the SQL parser already blocks `count()` in the column type position** with a syntax error (`Unexpected input ')'`) — verified empirically. The filter at `AggStateUtils:87` is therefore redundant: it protects a path that the grammar has already closed off.

Removing the filter:
- ✅ Allows `COUNT(*)` to work in IVM (both first refresh and incremental refresh).
- ✅ Does not affect the AGG_STATE column DDL — that path is still blocked at the parser layer.
- ✅ Does not introduce any new ambiguity: `count_combine()` and `count_combine(1)` resolve correctly and produce equivalent results.
- ✅ Does not regress regular `SELECT COUNT(*)` queries.

## What I'm doing:

- Remove the 4-line filter in `AggStateUtils.isSupportedAggStateFunction` that excluded the 0-arg form of `count` from combinator registration.
- Add a unit test (`IVMAnalyzerTest#testAggregateQueryWithCountStar`) pinning the contract that `COUNT(*)` aggregate MV queries are accepted by the IVM analyzer.

## Verification

End-to-end tested on a dev cluster running the IVM POC build:

| Test | Before fix | After fix |
|---|---|---|
| `CREATE MV ... AS SELECT k, COUNT(*) FROM iceberg_t GROUP BY k` | ❌ `No matching function: count_combine()` | ✅ Created |
| First REFRESH (3 rows in 2 groups) | n/a | ✅ Correct: A=2, B=1 |
| Incremental REFRESH after delta INSERT | n/a | ✅ Correct: A=3, B=2, C=1 (matches `SELECT k, COUNT(*) FROM iceberg_t GROUP BY k`) |
| Regular `SELECT COUNT(*)` (no IVM) | ✅ Works | ✅ Still works |
| `CREATE TABLE t (cnt count() ...)` (AGG_STATE column DDL) | ❌ Parser error | ❌ Parser error (unchanged) |

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)