### PR TITLE
[BugFix] Reject distinct aggregate functions in IVM at CREATE time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -273,6 +273,13 @@ public class IVMAnalyzer {
         List<IVMAggFunctionInfo> newAggFuncInfos = Lists.newArrayList();
         ExprSubstitutionMap substitutionMap = new ExprSubstitutionMap();
         for (FunctionCallExpr aggFuncExpr : aggregateExprs) {
+            // Distinct flag is dropped by the combinator rewrite below, so incremental
+            // refresh would silently state_union plain state and produce wrong values.
+            if (aggFuncExpr.isDistinct()) {
+                throw new SemanticException(
+                        "IVMAnalyzer does not support distinct aggregate functions, but got: %s",
+                        aggFuncExpr.toString());
+            }
             String aggFuncName = aggFuncExpr.getFunctionName();
             // build intermediate aggregate function
             FunctionCallExpr intermediateAggFuncExpr = buildIntermediateAggregateFunc(aggFuncExpr);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.scheduler.mv.ivm.MVIVMIcebergTestBase;
 import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.QueryStatement;
@@ -33,6 +34,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -83,6 +85,39 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
         assertTrue(result.isPresent(), "aggregate MV query must produce an IVM rewrite result");
         assertEquals(RowIdStrategy.QUERY_COMPUTED, result.get().rowIdStrategy(),
                 "aggregate MV must yield QUERY_COMPUTED: the query encodes group-by keys as __ROW_ID__");
+    }
+
+    /**
+     * Distinct aggregates must be rejected at IVM analysis time; otherwise incremental
+     * refresh would silently produce wrong data (the rewrite drops the DISTINCT flag).
+     * MIN/MAX(DISTINCT) is not covered: the analyzer normalizes their DISTINCT away
+     * earlier, so isDistinct() is already false here.
+     */
+    @Test
+    public void testRejectDistinctAggregate() throws Exception {
+        String[] ddls = {
+                "CREATE MATERIALIZED VIEW mv_count_distinct "
+                        + "REFRESH DEFERRED MANUAL "
+                        + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                        + "AS SELECT id, COUNT(DISTINCT c1) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id",
+                "CREATE MATERIALIZED VIEW mv_sum_distinct "
+                        + "REFRESH DEFERRED MANUAL "
+                        + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                        + "AS SELECT id, SUM(DISTINCT c1) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id",
+        };
+
+        for (String ddl : ddls) {
+            CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+            QueryStatement qs = stmt.getQueryStatement();
+            Analyzer.analyze(qs, connectContext);
+
+            IVMAnalyzer analyzer = new IVMAnalyzer(connectContext, stmt, qs);
+            SemanticException ex = assertThrows(SemanticException.class,
+                    () -> analyzer.rewrite(MaterializedView.RefreshMode.INCREMENTAL),
+                    "INCREMENTAL refresh must reject distinct aggregates: " + ddl);
+            assertTrue(ex.getMessage().contains("does not support distinct aggregate"),
+                    "error message must mention distinct rejection, got: " + ex.getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

`COUNT(DISTINCT)` / `SUM(DISTINCT)` etc. inside an INCREMENTAL materialized view currently produces silently wrong data:

```sql
CREATE TABLE t (k VARCHAR, n INT) ...;
INSERT INTO t VALUES ('A', 10), ('A', 20), ('A', 30);    -- 3 distinct n values

CREATE MATERIALIZED VIEW mv ... PROPERTIES ('refresh_mode'='incremental')
AS SELECT k, COUNT(DISTINCT n) AS cd FROM t GROUP BY k;
REFRESH MATERIALIZED VIEW mv WITH SYNC MODE;
SELECT k, cd FROM mv;
-- A | 3                                                  -- correct so far

INSERT INTO t VALUES ('A', 10), ('A', 40);                -- 1 duplicate + 1 new ⇒ 4 distinct
REFRESH MATERIALIZED VIEW mv WITH SYNC MODE;
SELECT k, cd FROM mv;
-- A | 5                                                  -- WRONG, should be 4
```

The MV silently shows 5 (= 3 + 2 simple addition) instead of 4 (= |{10,20,30,40}|). No error, `task_runs.STATE = SUCCESS`.

**Root cause** is in `IVMAnalyzer.checkAggregate` (and its helpers): the rewrite copies the user's aggregate's children into a new `<func>_combine(args)` combinator call without preserving the `isDistinct` flag. The optimizer's `MultiDistinctByMultiFuncRewriter` runs after this rewrite and sees a non-distinct combinator, so it does nothing. The defensive `isDistinct()` check in `IvmDeltaAggregateRule.check` (line 88) is therefore dead code — by the time it runs, the AST rewrite has already stripped the distinct flag.

The result: any IVM materialized view containing a distinct aggregate that the analyzer's AST rewrite touches (most notably `COUNT(DISTINCT)` / `SUM(DISTINCT)` / `ARRAY_AGG(DISTINCT)`) produces wrong data after every incremental refresh, with no signal to the user.

## What I'm doing:

- In `IVMAnalyzer.checkAggregate`, reject any aggregate with `isDistinct()` at CREATE time, with a clear error message naming the offending aggregate.
- Add `IVMAnalyzerTest#testRejectDistinctAggregate` covering `COUNT(DISTINCT)` and `SUM(DISTINCT)` (and document why `MIN(DISTINCT)` / `MAX(DISTINCT)` cannot be tested at this layer — the analyzer normalizes them away earlier because distinct is semantically a no-op for min/max).

## Verification

```
$ mvn test -pl fe-core -Dtest='IVMAnalyzerTest'
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
$ mvn checkstyle:check -pl fe-core
[INFO] You have 0 Checkstyle violations.
```

After the fix:

```
mysql> CREATE MATERIALIZED VIEW mv ... PROPERTIES ('refresh_mode'='incremental')
       AS SELECT k, COUNT(DISTINCT n) FROM t GROUP BY k;
ERROR: Failed to rewrite the query for IVM: IVMAnalyzer does not support distinct
aggregate functions, but got: count(DISTINCT n)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)