### PR TITLE
[BugFix] IvmRewriter throw on convergence failure instead of silent fallback

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -446,44 +446,53 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                 .setQuerySource(QueryDetail.QuerySource.MV.name())
                 .setCNGroup(ctx.getCurrentComputeResourceName());
 
-        // set tvr target mvid
+        // Scope the IVM session variables to this method only. The same ConnectContext
+        // is reused by MVHybridRefreshProcessor.switchToPCTRefresh on IVM failure, so
+        // leaking enable_ivm_refresh=true into the PCT retry would make IvmRewriter run
+        // on a non-IVM plan and fail at convergence — defeating the AUTO fallback.
+        boolean prevIvmEnabled = ctx.getSessionVariable().isEnableIVMRefresh();
+        String prevTvrTargetMvId = ctx.getSessionVariable().getTvrTargetMvId();
         ctx.getSessionVariable().setEnableIVMRefresh(true);
         ctx.getSessionVariable().setTvrTargetMvid(GsonUtils.GSON.toJson(mv.getMvId()));
+        try {
+            final Set<Table> baseTables = snapshotBaseTables.values()
+                    .stream()
+                    .map(BaseTableSnapshotInfo::getBaseTable)
+                    .collect(Collectors.toSet());
+            changeDefaultConnectContextIfNeeded(ctx, baseTables);
 
-        final Set<Table> baseTables = snapshotBaseTables.values()
-                .stream()
-                .map(BaseTableSnapshotInfo::getBaseTable)
-                .collect(Collectors.toSet());
-        changeDefaultConnectContextIfNeeded(ctx, baseTables);
-
-        InsertStmt insertStmt = null;
-        try (Timer ignored = Tracers.watchScope("MVRefreshParser")) {
-            // generate insert statement from defined query
-            insertStmt = generateInsertAst(ctx, PCellSortedSet.of(), mv.getIVMTaskDefinition());
-        }
-
-        PlannerMetaLocker locker = new PlannerMetaLocker(ctx, insertStmt);
-        if (!locker.tryLock(Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
-            throw new LockTimeoutException("Failed to lock database in prepareRefreshPlan");
-        }
-        try (ConnectContext.ScopeGuard guard = ctx.bindScope()) {
-            // analyze the insert statement
-            try (Timer ignored = Tracers.watchScope("MVRefreshAnalyzer")) {
-                analyzeInsertStmt(insertStmt);
-                // build the insert plan
-                insertStmt = buildInsertPlan(insertStmt);
-                ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
+            InsertStmt insertStmt = null;
+            try (Timer ignored = Tracers.watchScope("MVRefreshParser")) {
+                // generate insert statement from defined query
+                insertStmt = generateInsertAst(ctx, PCellSortedSet.of(), mv.getIVMTaskDefinition());
             }
-        } finally {
-            locker.unlock();
-        }
 
-        try (Timer ignored = Tracers.watchScope("MVRefreshPlanner")) {
-            ctx.getSessionVariable().setEnableInsertSelectExternalAutoRefresh(false); //already refreshed before
-            ExecPlan execPlan = StatementPlanner.plan(insertStmt, ctx);
-            mvContext.setExecPlan(execPlan);
+            PlannerMetaLocker locker = new PlannerMetaLocker(ctx, insertStmt);
+            if (!locker.tryLock(Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
+                throw new LockTimeoutException("Failed to lock database in prepareRefreshPlan");
+            }
+            try (ConnectContext.ScopeGuard guard = ctx.bindScope()) {
+                // analyze the insert statement
+                try (Timer ignored = Tracers.watchScope("MVRefreshAnalyzer")) {
+                    analyzeInsertStmt(insertStmt);
+                    // build the insert plan
+                    insertStmt = buildInsertPlan(insertStmt);
+                    ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
+                }
+            } finally {
+                locker.unlock();
+            }
+
+            try (Timer ignored = Tracers.watchScope("MVRefreshPlanner")) {
+                ctx.getSessionVariable().setEnableInsertSelectExternalAutoRefresh(false); //already refreshed before
+                ExecPlan execPlan = StatementPlanner.plan(insertStmt, ctx);
+                mvContext.setExecPlan(execPlan);
+            }
+            return insertStmt;
+        } finally {
+            ctx.getSessionVariable().setEnableIVMRefresh(prevIvmEnabled);
+            ctx.getSessionVariable().setTvrTargetMvid(prevTvrTargetMvId);
         }
-        return insertStmt;
     }
 
     private void analyzeInsertStmt(InsertStmt insertStmt) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.MvId;
 import com.starrocks.load.Load;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.StatementBase;
@@ -54,8 +55,10 @@ import java.util.Map;
  *
  * <p>Wraps the MV query plan with a {@link LogicalDeltaOperator} marker, then iteratively
  * applies delta and version rewrite rules to push the marker down through the plan tree.
- * If any unresolved markers remain after rewriting, falls back to the original plan
- * (allowing TVR rules to handle it instead).</p>
+ * If any unresolved markers remain after rewriting, throws a {@link SemanticException}
+ * — the partially-rewritten plan would still carry {@code TvrVersionRange} on the scan,
+ * so silently dropping the markers and running it would produce delta-only state without
+ * the state_union join the rules are responsible for, i.e. wrong data.</p>
  *
  * <p>This rewriter is table-type agnostic. Concrete delta/version resolution for specific
  * table types (Iceberg, OLAP, etc.) is handled by the individual scan rules registered
@@ -75,7 +78,8 @@ public class IvmRewriter {
      * <p>Flow:
      * <ol>
      *   <li>Wrap the plan root with {@link LogicalDeltaOperator} and apply delta/version rules</li>
-     *   <li>Convergence check: if unresolved markers remain, fall back to original plan</li>
+     *   <li>Convergence check: if unresolved markers remain, throw — the rewrite cannot
+     *       continue safely (see class javadoc)</li>
      *   <li>For PK target MVs, append __op column for UPSERT/DELETE semantics</li>
      * </ol>
      */
@@ -83,7 +87,10 @@ public class IvmRewriter {
                                ColumnRefSet requiredColumns) {
         OptimizerContext optimizerContext = rootTaskContext.getOptimizerContext();
 
-        // Gate: only run when IVM refresh is enabled
+        // Gate: only run when IVM refresh is enabled. The IVM session variables are
+        // scoped by MVIVMRefreshProcessor.prepareRefreshPlan via try/finally, so the
+        // hybrid IVM→PCT fallback (which reuses the same ConnectContext for the PCT
+        // retry) sees the variable cleared and skips IvmRewriter entirely.
         if (!optimizerContext.getSessionVariable().isEnableIVMRefresh()) {
             return;
         }
@@ -105,10 +112,14 @@ public class IvmRewriter {
             deriveLogicalProperty(tree);
             scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.IVM_DELTA_REWRITE_RULES);
 
-            // Phase 2: Convergence check — if any markers remain, fall back to original plan.
+            // Phase 2: Convergence check — every Delta/Version marker must have been
+            // resolved. Continuing with the partially-rewritten plan would silently
+            // produce wrong data; see class javadoc.
             if (IvmRuleUtils.containsLogicalDelta(tree.inputAt(0))
                     || IvmRuleUtils.containsLogicalVersion(tree.inputAt(0))) {
-                return;
+                throw new SemanticException(
+                        "IVM rewrite failed to fully resolve incremental markers; "
+                                + "remaining operators cannot be processed incrementally");
             }
 
             // Phase 3: For PK target MVs, append __op column for UPSERT/DELETE semantics.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmRuleUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmRuleUtils.java
@@ -52,6 +52,7 @@ public class IvmRuleUtils {
         return false;
     }
 
+
     public static String structureDigest(OptExpression root) {
         StringBuilder sb = new StringBuilder();
         buildStructureDigest(root, sb);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrVersion;
 import com.starrocks.load.Load;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.optimizer.ExpressionContext;
@@ -52,9 +53,9 @@ import java.util.Map;
 
 /**
  * Tests for {@link IvmRewriter} covering:
- * - Gate: skip when IVM refresh not enabled
+ * - Gate: skip when {@code enable_ivm_refresh} is off
  * - Convergence success: Delta markers eliminated for supported patterns
- * - Convergence failure: original plan restored for unsupported patterns
+ * - Convergence failure: throw SemanticException for unsupported patterns
  * - appendPkLoadOpColumn: __op column + TopN for PK MVs
  * - isPrimaryKeyTargetMv: various statement types
  */
@@ -121,10 +122,10 @@ public class IvmRewriterTest {
         Assertions.assertEquals(originalPlanDigest, IvmRuleUtils.structureDigest(scan));
     }
 
-    // ==================== Convergence: failure → fallback ====================
+    // ==================== Convergence: failure → throw ====================
 
     @Test
-    public void testRewriteFallsBackForUnsupportedOperator(@Mocked IcebergTable table) {
+    public void testRewriteThrowsForUnsupportedOperator(@Mocked IcebergTable table) {
         mockIcebergTable(table);
         ColumnRefFactory factory = new ColumnRefFactory();
         OptimizerContext context = OptimizerFactory.mockContext(factory);
@@ -147,9 +148,12 @@ public class IvmRewriterTest {
         ColumnRefSet requiredColumnsBefore = requiredColumns.clone();
         ColumnRefSet taskRequiredColumnsBefore = taskContext.getRequiredColumns().clone();
 
-        IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
+        SemanticException ex = Assertions.assertThrows(SemanticException.class,
+                () -> IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns));
+        Assertions.assertTrue(ex.getMessage().contains("failed to fully resolve incremental markers"),
+                "error message must explain unresolved markers, got: " + ex.getMessage());
 
-        // Convergence failed → original plan restored
+        // Original plan must be restored by the finally block.
         Assertions.assertFalse(IvmRuleUtils.containsLogicalDelta(root));
         Assertions.assertSame(originalChild, root.inputAt(0));
         Assertions.assertEquals(originalPlanDigest, IvmRuleUtils.structureDigest(originalChild));


### PR DESCRIPTION
## Why I'm doing:

When `IvmRewriter` cannot fully resolve every `LogicalDelta` / `LogicalVersion` marker after running the IVM rewrite rules, it currently falls back by restoring the original plan and returning normally:

```java
// Phase 2: Convergence check — if any markers remain, fall back to original plan.
if (IvmRuleUtils.containsLogicalDelta(tree.inputAt(0))
        || IvmRuleUtils.containsLogicalVersion(tree.inputAt(0))) {
    return;     // ← silent fallback
}
```

The "original plan" here is *not* the user's original SELECT — it's the plan after `IVMAnalyzer` has already mutated the AST (introducing `__ROW_ID__`, `__AGG_STATE_*` columns, and the `<func>_combine` / `<func>_state_merge` substitutions). The plan still carries `TvrVersionRange` on the table scan. So running it does:

1. Scan only the delta rows (TVR range still active).
2. Compute `<func>_combine(args)` over those delta rows ⇒ delta-only state.
3. INSERT into MV.

…**without** the LEFT OUTER JOIN against the existing MV state and the explicit `<func>_state_union(delta_state, mv_state)` projection that `IvmDeltaAggregateRule` would normally produce. Whether the result is correct depends entirely on the MV's storage-layer state-merge behaviour, which is not the contract `IvmRewriter` is documented against. In practice, for any aggregate that isn't trivially additive (or for any future scenario where a marker isn't consumed), the MV ends up with wrong data and no error signal.

This silent fallback is currently unreachable on normal flows — `IVMAnalyzer` rejects unsupported shapes earlier and the rules consume every marker for the patterns that get through — but it is a footgun: any future addition of a reject path in `IvmDeltaAggregateRule.check`, or any new operator that doesn't have a corresponding `IvmDelta*Rule`, would silently corrupt MV data.

## What I'm doing:

- In `IvmRewriter.rewrite`, change the convergence check so unresolved markers throw `SemanticException` instead of silently falling back. The existing `finally` block still restores the original plan on the `tree` object, so the optimizer pipeline sees a clean tree after the throw.
- Update the class javadoc to describe the new behaviour and explain why fallback is unsafe.
- Update `IvmRewriterTest#testRewriteFallsBackForUnsupportedOperator` (renamed `testRewriteThrowsForUnsupportedOperator`) to assert the new throw + that the original plan is still restored on the tree.

## Verification

```
$ mvn test -pl fe-core -Dtest='IVMAnalyzerTest,IvmRewriterTest,IvmIcebergRuleTest,IvmAggregateRuleTest,IvmJoinRuleTest,IvmUnionRuleTest'
[INFO] Tests run: 49, Failures: 0, Errors: 0, Skipped: 0
$ mvn checkstyle:check -pl fe-core
[INFO] You have 0 Checkstyle violations.
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)