### PR TITLE
[Enhancement] Colocate-aware tablet split with range mgr update on split results

### DIFF
--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -18,7 +18,6 @@
 #include <fmt/format.h>
 
 #include <algorithm>
-#include <set>
 #include <unordered_map>
 #include <vector>
 
@@ -59,6 +58,50 @@ Status SegmentSplitInfo::load_sort_key_samples(const SegmentMetadataPB& segment_
 // ================================================================================
 
 namespace {
+
+// Returns true if the first n DatumVariants of `a` and `b` are not all equal.
+// Used to detect a colocate-prefix transition between two adjacent candidate
+// ranges in the greedy split loop.
+bool colocate_prefix_differs(const VariantTuple& a, const VariantTuple& b, int32_t n) {
+    DCHECK_GE(static_cast<int32_t>(a.size()), n);
+    DCHECK_GE(static_cast<int32_t>(b.size()), n);
+    for (int32_t i = 0; i < n; ++i) {
+        if (a[i].compare(b[i]) != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Returns true iff every position from `colocate_column_count` onward is NULL —
+// i.e. `t` has the canonical (k, NULL, ..., NULL) shape that FE produces from a
+// colocate-range bound via expandToFullSortKey.
+bool is_canonical_tuple(const VariantTuple& t, int32_t colocate_column_count) {
+    for (size_t i = colocate_column_count; i < t.size(); ++i) {
+        if (!t[i].value().is_null()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Build a canonical colocate boundary tuple by copying the leading
+// `colocate_column_count` positions from `source` and NULL-padding the rest. `source`
+// supplies both the prefix values and the column types for the trailing positions.
+VariantTuple build_canonical_boundary(const VariantTuple& source, int32_t colocate_column_count) {
+    DCHECK_GE(static_cast<int32_t>(source.size()), colocate_column_count);
+    VariantTuple canonical;
+    canonical.reserve(source.size());
+    for (int32_t i = 0; i < colocate_column_count; ++i) {
+        canonical.append(source[i]);
+    }
+    Datum null_datum;
+    null_datum.set_null();
+    for (size_t i = colocate_column_count; i < source.size(); ++i) {
+        canonical.emplace(source[i].type(), null_datum);
+    }
+    return canonical;
+}
 
 struct RangeInfo {
     VariantTuple min;
@@ -183,7 +226,8 @@ void distribute_segment_to_ranges(const SegmentSplitInfo& segment, std::vector<R
 StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<SegmentSplitInfo>& segments,
                                                             int32_t target_split_count, int64_t target_value_per_split,
                                                             bool use_num_rows, bool track_sources,
-                                                            const TabletRange* tablet_range) {
+                                                            const TabletRange* tablet_range,
+                                                            int32_t colocate_column_count) {
     RangeSplitResult result;
 
     if (segments.empty() || target_split_count <= 1) {
@@ -191,13 +235,14 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
     }
 
     // Step 1: Collect all unique boundary points (including sort-key samples) and sort them.
-    auto comparator = [](const VariantTuple* a, const VariantTuple* b) { return a->compare(*b) < 0; };
-    std::set<const VariantTuple*, decltype(comparator)> ordered_boundaries(comparator);
+    // Owned VariantTuples (not pointers) so step 1b can insert synthesized canonical
+    // colocate boundaries that don't exist in any segment.
+    std::vector<VariantTuple> ordered_boundary_values;
     for (const auto& segment : segments) {
-        ordered_boundaries.insert(&segment.min_key);
-        ordered_boundaries.insert(&segment.max_key);
+        ordered_boundary_values.push_back(segment.min_key);
+        ordered_boundary_values.push_back(segment.max_key);
         for (const auto& sample : segment.sort_key_samples) {
-            ordered_boundaries.insert(&sample);
+            ordered_boundary_values.push_back(sample);
         }
     }
     // Insert tablet_range bounds so any ordered_range that previously straddled a
@@ -210,28 +255,53 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
     // num_rows is summed into one of the new splits.
     if (tablet_range != nullptr) {
         if (!tablet_range->is_minimum()) {
-            ordered_boundaries.insert(&tablet_range->lower_bound());
+            ordered_boundary_values.push_back(tablet_range->lower_bound());
         }
         if (!tablet_range->is_maximum()) {
-            ordered_boundaries.insert(&tablet_range->upper_bound());
+            ordered_boundary_values.push_back(tablet_range->upper_bound());
         }
     }
+    std::sort(ordered_boundary_values.begin(), ordered_boundary_values.end());
+    ordered_boundary_values.erase(std::unique(ordered_boundary_values.begin(), ordered_boundary_values.end()),
+                                  ordered_boundary_values.end());
 
-    if (ordered_boundaries.size() < 2) {
+    // Step 1b: when colocate-aware, synthesize canonical (k, NULL, ..., NULL) tuples at every
+    // observed colocate-prefix transition so candidate ranges are pre-split at canonical
+    // boundaries. Keeps the post-pass stats walk accurate when the greedy loop picks a
+    // canonical boundary.
+    if (colocate_column_count > 0 && ordered_boundary_values.size() >= 2) {
+        std::vector<VariantTuple> with_canonical;
+        with_canonical.reserve(ordered_boundary_values.size() * 2);
+        for (size_t i = 0; i < ordered_boundary_values.size(); ++i) {
+            if (i > 0 && colocate_prefix_differs(ordered_boundary_values[i - 1], ordered_boundary_values[i],
+                                                 colocate_column_count)) {
+                VariantTuple canonical = build_canonical_boundary(ordered_boundary_values[i], colocate_column_count);
+                // canonical > prev is guaranteed (canonical's prefix matches curr's, which is
+                // > prev's prefix when prefix-differs is true). Only the upper guard is real:
+                // canonical can equal curr when curr already has the (k, NULL...) shape.
+                DCHECK_GT(canonical.compare(ordered_boundary_values[i - 1]), 0);
+                if (canonical.compare(ordered_boundary_values[i]) <= 0) {
+                    with_canonical.push_back(std::move(canonical));
+                }
+            }
+            with_canonical.push_back(ordered_boundary_values[i]);
+        }
+        ordered_boundary_values = std::move(with_canonical);
+        ordered_boundary_values.erase(std::unique(ordered_boundary_values.begin(), ordered_boundary_values.end()),
+                                      ordered_boundary_values.end());
+    }
+
+    if (ordered_boundary_values.size() < 2) {
         return result;
     }
 
     // Step 2: Build ordered ranges between adjacent boundary points.
     std::vector<RangeInfo> ordered_ranges;
-    ordered_ranges.reserve(ordered_boundaries.size());
-    const VariantTuple* last_boundary = nullptr;
-    for (const auto* boundary : ordered_boundaries) {
-        if (last_boundary != nullptr) {
-            auto& range_info = ordered_ranges.emplace_back();
-            range_info.min = *last_boundary;
-            range_info.max = *boundary;
-        }
-        last_boundary = boundary;
+    ordered_ranges.reserve(ordered_boundary_values.size());
+    for (size_t i = 1; i < ordered_boundary_values.size(); ++i) {
+        auto& range_info = ordered_ranges.emplace_back();
+        range_info.min = ordered_boundary_values[i - 1];
+        range_info.max = ordered_boundary_values[i];
     }
 
     if (ordered_ranges.empty()) {
@@ -354,6 +424,13 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
                     break;
                 }
                 if (tablet_range != nullptr && !tablet_range->strictly_contains(candidate_ranges[j]->max)) {
+                    break;
+                }
+                // When colocate-aware, stop the advance once `boundary` is already a canonical
+                // colocate boundary placed by step 1b. Walking past it would force FE to
+                // classify the split as Level 2 even though the data clearly crosses a
+                // prefix transition.
+                if (colocate_column_count > 0 && is_canonical_tuple(*boundary, colocate_column_count)) {
                     break;
                 }
                 boundary = &candidate_ranges[j]->max;
@@ -552,10 +629,22 @@ void apply_rowset_anchor(const std::unordered_map<uint32_t, RowsetAnchor>& ancho
 // is expected to fall back to identical-tablet publish; only new_tablet_ids(0)
 // is consumed in that case, and FE is responsible for reclaiming the remaining
 // preallocated tablet ids.
+//
+// colocate_column_count > 0 enables colocate-aware boundary canonicalization (see
+// calculate_range_split_boundaries). A malformed FE that sends colocate_column_count
+// larger than the sort-key arity returns Status::InvalidArgument here, which triggers
+// the same identical-tablet fallback as "no boundaries" — preserves the publish loop
+// instead of hard-failing.
 Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
-                               int32_t split_count, std::vector<TabletRangeInfo>* split_ranges) {
+                               int32_t split_count, std::vector<TabletRangeInfo>* split_ranges,
+                               int32_t colocate_column_count) {
     if (split_count < 2) {
         return Status::InvalidArgument("Invalid split count, it is less than 2");
+    }
+    if (colocate_column_count < 0 || colocate_column_count > tablet_metadata->schema().sort_key_idxes_size()) {
+        return Status::InvalidArgument(fmt::format("Invalid colocate_column_count {}, sort key arity is {}",
+                                                   colocate_column_count,
+                                                   tablet_metadata->schema().sort_key_idxes_size()));
     }
 
     std::vector<SegmentSplitInfo> segments;
@@ -592,9 +681,10 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
     }
     int64_t avg_num_rows = std::max<int64_t>(1, total_num_rows / split_count);
 
-    ASSIGN_OR_RETURN(auto split_result, calculate_range_split_boundaries(segments, split_count, avg_num_rows,
-                                                                         /*use_num_rows=*/true,
-                                                                         /*track_sources=*/true, &tablet_range));
+    ASSIGN_OR_RETURN(auto split_result,
+                     calculate_range_split_boundaries(segments, split_count, avg_num_rows,
+                                                      /*use_num_rows=*/true,
+                                                      /*track_sources=*/true, &tablet_range, colocate_column_count));
 
     if (split_result.boundaries.empty()) {
         return Status::InvalidArgument("Not enough split ranges available");
@@ -676,8 +766,10 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     std::unordered_map<int64_t, MutableTabletMetadataPtr> new_metadatas;
 
     std::vector<TabletRangeInfo> split_ranges;
+    // colocate_column_count is carried at the txn level (single split job = single txn) since
+    // every SplittingTabletInfoPB in the same job would carry the same value. See lake_types.proto.
     Status status = get_tablet_split_ranges(tablet_manager, old_tablet_metadata, splitting_tablet.new_tablet_ids_size(),
-                                            &split_ranges);
+                                            &split_ranges, txn_info.colocate_column_count());
     if (!status.ok()) {
         g_tablet_reshard_split_fallback_total << 1;
         LOG(WARNING) << "Failed to get tablet split ranges, will not split this tablet: " << old_tablet_metadata->id()

--- a/be/src/storage/lake/tablet_splitter.h
+++ b/be/src/storage/lake/tablet_splitter.h
@@ -90,10 +90,18 @@ struct RangeSplitResult {
 //
 // Returns RangeSplitResult with boundaries and per-range estimates, or empty boundaries if
 // splitting is not possible (e.g., not enough data or segments).
+//
+// colocate_column_count > 0 enables colocate-aware boundary canonicalization: when the
+// selected boundary crosses a colocate-prefix transition between adjacent candidate ranges,
+// the boundary tuple is replaced with the canonical (prefix(right), NULL, ..., NULL) shape.
+// This lets the FE classify the resulting tablet ranges as Level 1 (new ColocateRange) vs
+// Level 2 (intra-colocate) via syntactic equality on the lower bound.
+// colocate_column_count == 0 (default) preserves the pre-P3 behavior exactly.
 StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<SegmentSplitInfo>& segments,
                                                             int32_t target_split_count, int64_t target_value_per_split,
                                                             bool use_num_rows, bool track_sources = false,
-                                                            const TabletRange* tablet_range = nullptr);
+                                                            const TabletRange* tablet_range = nullptr,
+                                                            int32_t colocate_column_count = 0);
 
 StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
         TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,

--- a/be/src/storage/variant_tuple.h
+++ b/be/src/storage/variant_tuple.h
@@ -53,6 +53,9 @@ public:
 
     int compare(const VariantTuple& other) const;
 
+    bool operator<(const VariantTuple& other) const { return compare(other) < 0; }
+    bool operator==(const VariantTuple& other) const { return compare(other) == 0; }
+
     void to_proto(TuplePB* tuple_pb) const;
 
     Status from_proto(const TuplePB& tuple_pb);

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -594,4 +594,124 @@ TEST(TabletSplitterTest, tablet_range_total_invariant_across_split_counts) {
 // they can be reused by the planned cross-publish (P2) refactor without
 // re-introducing a private split-only header.
 
+namespace {
+
+// Build a 2-column key tuple (k1, k2). Used for colocate-aware splitter tests.
+static VariantTuple make_two_int_tuple(int64_t k1, int64_t k2) {
+    VariantTuple tuple;
+    tuple.append(DatumVariant(get_type_info(LogicalType::TYPE_BIGINT), Datum(k1)));
+    tuple.append(DatumVariant(get_type_info(LogicalType::TYPE_BIGINT), Datum(k2)));
+    return tuple;
+}
+
+static SegmentSplitInfo make_two_col_seg(int64_t lo_k1, int64_t lo_k2, int64_t hi_k1, int64_t hi_k2, int64_t num_rows,
+                                         int64_t data_size, uint32_t source_id) {
+    SegmentSplitInfo s;
+    s.min_key = make_two_int_tuple(lo_k1, lo_k2);
+    s.max_key = make_two_int_tuple(hi_k1, hi_k2);
+    s.num_rows = num_rows;
+    s.data_size = data_size;
+    s.source_id = source_id;
+    return s;
+}
+
+} // namespace
+
+// Three disjoint segments with three distinct k1 values produce candidate
+// ranges between every adjacent pair. With colocate_col_count=1 and a 2-way
+// split, the chosen boundary lands at a k1 transition; canonicalization
+// rewrites the boundary to (right_k1, NULL).
+TEST(TabletSplitterTest, colocate_aware_split_picks_canonical_boundary) {
+    std::vector<SegmentSplitInfo> segs = {make_two_col_seg(/*lo*/ 100, 1, /*hi*/ 100, 999, 100, 1000, /*source_id=*/1),
+                                          make_two_col_seg(/*lo*/ 200, 1, /*hi*/ 200, 999, 100, 1000, /*source_id=*/2),
+                                          make_two_col_seg(/*lo*/ 300, 1, /*hi*/ 300, 999, 100, 1000, /*source_id=*/3)};
+
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/150,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true,
+                                                     /*tablet_range=*/nullptr, /*colocate_column_count=*/1));
+    ASSERT_EQ(1, result.boundaries.size());
+    const auto& b = result.boundaries[0];
+    ASSERT_EQ(2u, b.size());
+    // First column = the right neighbor's k1 (200 or 300, depending on greedy choice).
+    EXPECT_FALSE(b[0].value().is_null()) << "colocate-prefix position must be non-null";
+    // Second column must be NULL (canonical NULL filler).
+    EXPECT_TRUE(b[1].value().is_null()) << "trailing positions must be NULL after canonicalization";
+}
+
+// When all data lives within a single colocate prefix value, the splitter has
+// no transition to canonicalize and falls back to the within-key boundary.
+// The resulting boundary's leading column equals the prefix and trailing
+// columns hold real (non-null) values.
+TEST(TabletSplitterTest, colocate_aware_split_falls_back_within_prefix) {
+    // Two non-overlapping segments, both with k1=100, separated by k2.
+    std::vector<SegmentSplitInfo> segs = {
+            make_two_col_seg(/*lo*/ 100, 1, /*hi*/ 100, 100, 100, 1000, /*source_id=*/1),
+            make_two_col_seg(/*lo*/ 100, 200, /*hi*/ 100, 300, 100, 1000, /*source_id=*/2)};
+
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/100,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true,
+                                                     /*tablet_range=*/nullptr, /*colocate_column_count=*/1));
+    ASSERT_EQ(1, result.boundaries.size());
+    const auto& b = result.boundaries[0];
+    ASSERT_EQ(2u, b.size());
+    // No prefix transition → no canonicalization → trailing position is non-null.
+    EXPECT_FALSE(b[1].value().is_null()) << "within-prefix split must keep the actual k2 boundary";
+}
+
+// colocate_column_count == 0 must reproduce pre-P3 behavior exactly: no
+// canonicalization, boundaries are unchanged data tuples.
+TEST(TabletSplitterTest, colocate_column_count_zero_unchanged) {
+    std::vector<SegmentSplitInfo> segs = {make_two_col_seg(/*lo*/ 100, 1, /*hi*/ 100, 100, 100, 1000, /*source_id=*/1),
+                                          make_two_col_seg(/*lo*/ 200, 1, /*hi*/ 200, 100, 100, 1000, /*source_id=*/2)};
+
+    ASSIGN_OR_ABORT(auto result_with_colocate,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/100,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true,
+                                                     /*tablet_range=*/nullptr, /*colocate_column_count=*/1));
+    ASSIGN_OR_ABORT(auto result_default,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/100,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true,
+                                                     /*tablet_range=*/nullptr, /*colocate_col_count=*/0));
+
+    ASSERT_EQ(1, result_default.boundaries.size());
+    ASSERT_EQ(1, result_with_colocate.boundaries.size());
+    // Default-mode boundary's trailing column is non-null (came from a real key).
+    EXPECT_FALSE(result_default.boundaries[0][1].value().is_null());
+    // Colocate-aware boundary's trailing column IS null (synthesized NULL filler).
+    EXPECT_TRUE(result_with_colocate.boundaries[0][1].value().is_null());
+}
+
+// Regression for the prefix-straddling-segment case. A single segment whose key range crosses a
+// colocate-prefix transition must have its rows distributed across LEFT and RIGHT child groups
+// when the split lands on a canonical boundary inside the segment, rather than being assigned
+// wholly to the right child by the post-pass `range->max.compare(boundary)` walk.
+TEST(TabletSplitterTest, colocate_aware_split_keeps_stats_consistent_across_prefix_boundary) {
+    // s1 spans prefix 100..300 (single segment crossing two prefix transitions).
+    // s2 sits at prefix 400 to drive a 2-way split.
+    std::vector<SegmentSplitInfo> segs = {make_two_col_seg(/*lo*/ 100, 0, /*hi*/ 300, 50, 200, 2000, /*source_id=*/1),
+                                          make_two_col_seg(/*lo*/ 400, 0, /*hi*/ 400, 999, 100, 1000, /*source_id=*/2)};
+    ASSIGN_OR_ABORT(auto result,
+                    calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/150,
+                                                     /*use_num_rows=*/true, /*track_sources=*/true,
+                                                     /*tablet_range=*/nullptr, /*colocate_column_count=*/1));
+    ASSERT_EQ(1, result.boundaries.size());
+    // Boundary must be canonical so FE classifies the split as Level 1.
+    EXPECT_TRUE(result.boundaries[0][1].value().is_null())
+            << "boundary trailing column must be NULL after canonicalization";
+    // Σ children must equal Σ inputs.
+    int64_t total_rows = result.range_num_rows[0] + result.range_num_rows[1];
+    int64_t total_bytes = result.range_data_sizes[0] + result.range_data_sizes[1];
+    EXPECT_EQ(300, total_rows);
+    EXPECT_EQ(3000, total_bytes);
+    // The straddling-segment's rows must be partly attributed to the LEFT child — the bug was
+    // assigning them entirely to RIGHT when the canonical boundary sorts before range->max.
+    auto left_it = result.range_source_stats[0].find(1);
+    ASSERT_NE(result.range_source_stats[0].end(), left_it)
+            << "rows from the prefix-crossing segment must contribute to the LEFT child";
+    EXPECT_GT(left_it->second.first, 0);
+    EXPECT_GT(left_it->second.second, 0);
+}
+
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -16,8 +16,14 @@ package com.starrocks.alter.reshard;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
+import com.staros.proto.PlacementPolicy;
 import com.starrocks.alter.reshard.ReshardingPhysicalPartition.PublishResult;
 import com.starrocks.alter.reshard.ReshardingPhysicalPartition.PublishState;
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateRangeMgr;
+import com.starrocks.catalog.ColocateRangeUtils;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
@@ -28,7 +34,10 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.TabletRange;
+import com.starrocks.catalog.Tuple;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.Range;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.Utils;
@@ -38,6 +47,7 @@ import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletReshardJobsItem;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -46,8 +56,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -267,7 +279,13 @@ public class SplitTabletJob extends TabletReshardJob {
             return;
         }
 
-        // 2. Add the new versions of materialized index to catalog
+        // Splice any canonical colocate-boundary new tablets into ColocateRangeMgr and mark
+        // the group unstable. Legacy / buggy BE outputs that straddle an existing boundary
+        // log a warning and still mark unstable so the scan-time alignment guard catches
+        // transient mis-alignment.
+        applyColocateRangeSplitResult();
+
+        // 3. Add the new versions of materialized index to catalog
         addNewMaterializedIndexes();
 
         // 3. Get end transaction id
@@ -530,6 +548,12 @@ public class SplitTabletJob extends TabletReshardJob {
             txnInfo.commitTime = stateStartedTimeMs / 1000;
             txnInfo.txnType = TxnTypePB.TXN_TABLET_RESHARD;
             txnInfo.gtid = gtid;
+            // Carry the table's colocate column count once at the txn level (single split job =
+            // single txn). 0 = non-colocate range table, BE keeps pre-P3 splitter behavior.
+            ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+            ColocateTableIndex.GroupId rangeGroupId = idx.getRangeColocateGroupId(tableId);
+            txnInfo.colocateColumnCount = rangeGroupId == null
+                    ? 0 : idx.getGroupSchema(rangeGroupId).getColocateColumnCount();
 
             Map<Long, TabletRange> tabletRange = new HashMap<>();
             List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
@@ -541,6 +565,104 @@ public class SplitTabletJob extends TabletReshardJob {
         } catch (Exception e) {
             LOG.warn("Failed to publish version for tablet reshard job {}. ", this, e);
             throw new TabletReshardException("Failed to publish version: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Splice any canonical colocate-boundary new tablets produced by this split into
+     * {@link ColocateRangeMgr} and mark the group unstable. Skipped for non-range-colocate
+     * tables.
+     *
+     * <p>Three distinct triggers fire applyRangeSplitResult:
+     * <ul>
+     * <li><b>New canonical boundary</b>: a new tablet's lower bound has the canonical
+     *     {@code (k, NULL...)} shape AND that prefix is not yet a boundary in
+     *     {@link ColocateRangeMgr}. Splice + mark unstable.</li>
+     * <li><b>Old tablet straddles an existing boundary</b>: indicates retry-after-partial-commit
+     *     (boundary was already journaled but mark-unstable was lost). The splice is idempotent;
+     *     the mark-unstable record is re-emitted.</li>
+     * <li><b>Non-canonical crossing</b>: a buggy / colocate-unaware BE produced a child whose
+     *     range straddles an existing boundary without canonicalizing. Log a warning, mark
+     *     unstable so the scan-time alignment guard fails closed.</li>
+     * </ul>
+     */
+    private void applyColocateRangeSplitResult() {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateTableIndex.GroupId groupId = colocateTableIndex.getRangeColocateGroupId(tableId);
+        if (groupId == null) {
+            return;
+        }
+        long grpId = groupId.grpId;
+        int colocateColumnCount = colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
+        List<ColocateRange> currentRanges = colocateTableIndex.getColocateRangeMgr().getColocateRanges(grpId);
+
+        Set<Tuple> canonicalLowers = new LinkedHashSet<>();
+        boolean oldStradlesBoundary = false;
+        boolean nonCanonicalCrossing = false;
+
+        try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.READ)) {
+            OlapTable olapTable = lockedTable.get();
+            List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(olapTable);
+
+            for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
+                PhysicalPartition physicalPartition = olapTable
+                        .getPhysicalPartition(reshardingPhysicalPartition.getPhysicalPartitionId());
+                if (physicalPartition == null) {
+                    continue;
+                }
+                for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
+                        .getReshardingIndexes().values()) {
+                    MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
+                    MaterializedIndex oldIndex = physicalPartition.getIndex(reshardingIndex.getMaterializedIndexId());
+                    for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
+                        SplittingTablet splittingTablet = reshardingTablet.getSplittingTablet();
+                        if (splittingTablet == null || splittingTablet.isIdenticalTablet()) {
+                            continue;
+                        }
+                        Tablet oldTablet = oldIndex == null ? null
+                                : oldIndex.getTablet(splittingTablet.getOldTabletId());
+                        if (oldTablet != null && oldTablet.getRange() != null
+                                && !ColocateRangeUtils.isContainedInOwningColocateRange(
+                                        oldTablet.getRange().getRange(),
+                                        currentRanges, sortKeyColumns, colocateColumnCount)) {
+                            oldStradlesBoundary = true;
+                        }
+                        for (Long newTabletId : splittingTablet.getNewTabletIds()) {
+                            Tablet newTablet = newIndex.getTablet(newTabletId);
+                            if (newTablet == null || newTablet.getRange() == null) {
+                                continue;
+                            }
+                            Range<Tuple> newRange = newTablet.getRange().getRange();
+                            boolean canonicalLow = ColocateRangeUtils.hasCanonicalLowerBound(
+                                    newRange, sortKeyColumns, colocateColumnCount);
+                            if (canonicalLow) {
+                                canonicalLowers.add(newRange.getLowerBound());
+                            } else if (!ColocateRangeUtils.isContainedInOwningColocateRange(
+                                    newRange, currentRanges, sortKeyColumns, colocateColumnCount)) {
+                                LOG.warn("New tablet {} range {} crosses an existing ColocateRange boundary "
+                                        + "in colocate group {}; marking group unstable. Verify FE↔BE versions.",
+                                        newTabletId, newRange, grpId);
+                                nonCanonicalCrossing = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        boolean hasNewCanonical = canonicalLowers.stream().anyMatch(lower ->
+                !ColocateRangeMgr.hasBoundaryAt(currentRanges,
+                        new Tuple(lower.getValues().subList(0, colocateColumnCount))));
+        if (!hasNewCanonical && !oldStradlesBoundary && !nonCanonicalCrossing) {
+            return;
+        }
+        try {
+            colocateTableIndex.applyRangeSplitResult(grpId, canonicalLowers, colocateColumnCount,
+                    () -> GlobalStateMgr.getCurrentState().getStarOSAgent().createShardGroup(
+                            dbId, tableId, 0L, 0L, PlacementPolicy.PACK));
+        } catch (DdlException e) {
+            throw new TabletReshardException(
+                    "Failed to apply range split result for grpId " + grpId + ": " + e.getMessage(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -15,6 +15,10 @@
 package com.starrocks.alter.reshard;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateRangeMgr;
+import com.starrocks.catalog.ColocateRangeUtils;
+import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
@@ -25,6 +29,7 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Tuple;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -74,6 +79,15 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         if (!table.isRangeDistribution()) {
             throw new StarRocksException("Unsupported distribution type " + table.getDefaultDistributionInfo().getType()
                     + " in table " + db.getFullName() + '.' + table.getName());
+        }
+
+        // Block re-split while any peer GroupId is unstable: range-colocate group membership is
+        // shared across DBs, so a still-unaligned split would compound the unaligned state.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateTableIndex.GroupId myGroupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
+        if (myGroupId != null && colocateTableIndex.isAnyGroupWithSameGrpIdUnstable(myGroupId.grpId)) {
+            throw new StarRocksException("Cannot split tablets for range-colocate group "
+                    + myGroupId.grpId + ": group is unstable; wait for alignment to complete before retrying");
         }
 
         Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions = createReshardingPhysicalPartitions();
@@ -295,14 +309,50 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
 
     private void createNewShards(Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions)
             throws StarRocksException {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateTableIndex.GroupId groupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
+        // Snapshot colocate ranges once: createShards inside the loop only reads the same
+        // grpId, and the ranges list is stable for the duration of this DDL (the unstable
+        // guard above blocks concurrent splits).
+        List<ColocateRange> colocateRanges = groupId == null ? null
+                : colocateTableIndex.getColocateRangeMgr().getColocateRanges(groupId.grpId);
+        int colocateColumnCount = groupId == null ? 0
+                : colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
+
         for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
             long physicalPartitionId = reshardingPhysicalPartition.getPhysicalPartitionId();
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
             for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
                     .getReshardingIndexes().values()) {
                 MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
+                MaterializedIndex oldIndex = physicalPartition == null
+                        ? null
+                        : physicalPartition.getIndex(reshardingIndex.getMaterializedIndexId());
                 Map<Long, List<Long>> oldToNewTabletIds = new HashMap<>();
+                Map<Long, List<Long>> oldShardIdToGroupIds = new HashMap<>();
                 for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
-                    oldToNewTabletIds.put(reshardingTablet.getFirstOldTabletId(), reshardingTablet.getNewTabletIds());
+                    long oldTabletId = reshardingTablet.getFirstOldTabletId();
+                    oldToNewTabletIds.put(oldTabletId, reshardingTablet.getNewTabletIds());
+                    List<Long> groupIds = new ArrayList<>(2);
+                    groupIds.add(newIndex.getShardGroupId()); // SPREAD group is unchanged
+                    if (colocateRanges != null) {
+                        // Range-colocate invariant (P1): every tablet of a range-colocate table
+                        // has a TabletRange. Fail fast rather than fall back to prefix=null,
+                        // which would silently route new shards into the first ColocateRange's
+                        // PACK group — wrong once the group has multiple ranges.
+                        Preconditions.checkState(oldIndex != null,
+                                "Missing old MaterializedIndex for range-colocate split");
+                        Tablet oldTablet = oldIndex.getTablet(oldTabletId);
+                        Preconditions.checkState(oldTablet != null && oldTablet.getRange() != null,
+                                "Old tablet %s in range-colocate group has no TabletRange", oldTabletId);
+                        Tuple prefix = ColocateRangeUtils.extractColocatePrefix(
+                                oldTablet.getRange().getRange(), colocateColumnCount);
+                        int idx = ColocateRangeMgr.indexOf(colocateRanges, prefix);
+                        Preconditions.checkState(idx >= 0,
+                                "Old tablet %s has no covering ColocateRange", oldTabletId);
+                        groupIds.add(colocateRanges.get(idx).getShardGroupId());
+                    }
+                    oldShardIdToGroupIds.put(oldTabletId, groupIds);
                 }
 
                 Map<String, String> properties = new HashMap<>();
@@ -311,10 +361,10 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                 properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
 
                 GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForSplit(
+                        oldShardIdToGroupIds,
                         oldToNewTabletIds,
                         table.getPartitionFilePathInfo(physicalPartitionId),
                         table.getPartitionFileCacheInfo(physicalPartitionId),
-                        newIndex.getShardGroupId(),
                         properties, WarehouseManager.DEFAULT_RESOURCE);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
@@ -89,16 +89,41 @@ public class ColocateRangeMgr {
      *         group does not exist or the value is not covered
      */
     public int getColocateRangeIndex(long colocateGroupId, Tuple colocateValue) {
-        List<ColocateRange> colocateRanges = colocateGroupToRanges.get(colocateGroupId);
-        if (colocateRanges == null || colocateRanges.isEmpty()) {
+        return indexOf(colocateGroupToRanges.get(colocateGroupId), colocateValue);
+    }
+
+    /**
+     * Binary-search variant of {@link #getColocateRangeIndex} that operates on a caller-supplied
+     * range list. Used when the caller is mutating a working copy in-flight (e.g. splice path)
+     * and cannot consult the live {@code colocateGroupToRanges} map.
+     *
+     * @return the index of the {@link ColocateRange} containing {@code value}, or {@code -1}
+     *         if {@code ranges} is null/empty or the value is not covered. {@code value == null}
+     *         maps to the first range (the global {@code -infinity} sentinel).
+     */
+    public static int indexOf(List<ColocateRange> ranges, Tuple value) {
+        if (ranges == null || ranges.isEmpty()) {
             return -1;
         }
-        if (colocateValue == null) {
+        if (value == null) {
             return 0;
         }
-        Range<Tuple> pointRange = Range.gele(colocateValue, colocateValue);
-        int index = Collections.binarySearch(colocateRanges, pointRange);
+        int index = Collections.binarySearch(ranges, Range.gele(value, value));
         return index >= 0 ? index : -1;
+    }
+
+    /**
+     * Returns true iff the range list has an entry whose lower bound is exactly {@code prefix}
+     * with inclusive lower (i.e. {@code prefix} is already a registered colocate boundary).
+     */
+    public static boolean hasBoundaryAt(List<ColocateRange> ranges, Tuple prefix) {
+        int idx = indexOf(ranges, prefix);
+        if (idx < 0) {
+            return false;
+        }
+        Range<Tuple> range = ranges.get(idx).getRange();
+        return !range.isMinimum() && range.isLowerBoundIncluded()
+                && java.util.Objects.equals(range.getLowerBound(), prefix);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeUtils.java
@@ -122,4 +122,66 @@ public class ColocateRangeUtils {
         // returned Tuple does not retain a reference to the tablet's bound.
         return new Tuple(new ArrayList<>(values.subList(0, colocateColumnCount)));
     }
+
+    /**
+     * Returns true iff {@code range}'s lower bound is a canonical {@code (k, NULL...)} tuple
+     * (i.e. the shape {@link #expandToFullSortKey} produces from a colocate-range bound). The
+     * upper bound is intentionally NOT required to be canonical — in a multi-way split a mid-way
+     * child can have a canonical lower at the colocate boundary and a within-prefix non-canonical
+     * upper. The caller pairs this with old-tablet containment to decide whether the boundary
+     * is genuinely new.
+     */
+    public static boolean hasCanonicalLowerBound(Range<Tuple> range, List<Column> sortKeyColumns,
+                                                  int colocateColumnCount) {
+        Preconditions.checkArgument(colocateColumnCount >= 0
+                        && colocateColumnCount <= sortKeyColumns.size(),
+                "colocateColumnCount %s out of range [0, %s]",
+                colocateColumnCount, sortKeyColumns.size());
+        return !range.isMinimum()
+                && isCanonicalTuple(range.getLowerBound(), sortKeyColumns, colocateColumnCount);
+    }
+
+    private static boolean isCanonicalTuple(Tuple tuple, List<Column> sortKeyColumns,
+                                            int colocateColumnCount) {
+        if (tuple == null) {
+            return false;
+        }
+        List<Variant> values = tuple.getValues();
+        if (values.size() != sortKeyColumns.size()) {
+            return false;
+        }
+        for (int i = colocateColumnCount; i < values.size(); i++) {
+            if (!(values.get(i) instanceof NullVariant)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns true iff {@code tabletRange} is fully contained within the {@link ColocateRange}
+     * that owns the colocate prefix of its lower bound. Used by both the scan-time alignment
+     * guard ({@link com.starrocks.planner.RangeColocateScanDispatch}) and the post-publish
+     * split classifier — both must agree on what "stays inside the colocate range" means so
+     * the post-split classification cannot accept a tablet that the scan-time guard would
+     * reject.
+     *
+     * <p>Returns {@code false} when no {@link ColocateRange} owns the prefix (caller should
+     * treat this as the "missing coverage" defensive case rather than as crossing).
+     */
+    public static boolean isContainedInOwningColocateRange(Range<Tuple> tabletRange,
+                                                          List<ColocateRange> ranges,
+                                                          List<Column> sortKeyColumns,
+                                                          int colocateColumnCount) {
+        Tuple lowerPrefix = colocateColumnCount > 0
+                ? extractColocatePrefix(tabletRange, colocateColumnCount)
+                : null;
+        int idx = ColocateRangeMgr.indexOf(ranges, lowerPrefix);
+        if (idx < 0) {
+            return false;
+        }
+        Range<Tuple> expanded = expandToFullSortKey(
+                ranges.get(idx).getRange(), sortKeyColumns, colocateColumnCount);
+        return expanded.contains(tabletRange);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -46,6 +46,8 @@ import com.google.gson.annotations.SerializedName;
 import com.staros.proto.PlacementPolicy;
 import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.Range;
+import com.starrocks.common.ThrowingSupplier;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.ColocatePropertyInfo;
 import com.starrocks.common.util.LogUtil;
@@ -511,6 +513,26 @@ public class ColocateTableIndex implements Writable {
         }
     }
 
+    /**
+     * Returns the table's {@link GroupId} iff the table participates in a range-colocate group,
+     * or {@code null} otherwise. Wraps the {@code isColocateTable + getGroup + isRangeColocateGroup}
+     * triple under a single read lock.
+     */
+    @javax.annotation.Nullable
+    public GroupId getRangeColocateGroupId(long tableId) {
+        readLock();
+        try {
+            GroupId groupId = table2Group.get(tableId);
+            if (groupId == null) {
+                return null;
+            }
+            ColocateGroupSchema schema = group2Schema.get(groupId);
+            return (schema != null && schema.isRangeColocate()) ? groupId : null;
+        } finally {
+            readUnlock();
+        }
+    }
+
     public boolean isGroupExist(GroupId groupId) {
         readLock();
         try {
@@ -754,6 +776,124 @@ public class ColocateTableIndex implements Writable {
             writeUnlock();
         }
     }
+
+    /**
+     * Mark every {@link GroupId} that shares the given colocate {@code grpId} as unstable.
+     * Range colocate groups are keyed in {@link ColocateRangeMgr} by {@code grpId} alone, so a
+     * range-mgr mutation in one database affects every peer database that joined the same group;
+     * marking only the caller's own GroupId would leave peer DBs claiming "stable" while their
+     * tablets are mid-migration, allowing colocate joins to run against an unaligned layout.
+     */
+    public void markAllGroupsWithSameGrpIdUnstable(long grpId, boolean needEditLog) {
+        writeLock();
+        try {
+            // markGroupUnstable / isGroupUnstable re-acquire the lock; ReentrantReadWriteLock
+            // is reentrant for the same thread.
+            group2Schema.keySet().stream()
+                    .filter(g -> Objects.equals(g.grpId, grpId))
+                    .collect(Collectors.toList())
+                    .forEach(peer -> markGroupUnstable(peer, needEditLog));
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    /**
+     * Returns true iff any {@link GroupId} sharing the given colocate {@code grpId} is unstable.
+     */
+    public boolean isAnyGroupWithSameGrpIdUnstable(long grpId) {
+        readLock();
+        try {
+            return group2Schema.keySet().stream()
+                    .filter(g -> Objects.equals(g.grpId, grpId))
+                    .anyMatch(this::isGroupUnstable);
+        } finally {
+            readUnlock();
+        }
+    }
+
+    /**
+     * Splice canonical-lower-bound boundaries into the colocate range manager and mark all peer
+     * GroupIds unstable. Idempotent on retry: if all observed boundaries already exist (e.g. a
+     * prior leader committed {@code OP_COLOCATE_RANGE_UPDATE} but crashed before
+     * {@code OP_COLOCATE_MARK_UNSTABLE_V2}), no new range update is journaled but the
+     * mark-unstable record is still emitted.
+     *
+     * @param packShardGroupSupplier called once per missing boundary to allocate a new PACK
+     *                               shard group; the same {@link ThrowingSupplier} pattern as
+     *                               other catalog → StarOS code paths so {@code DdlException}
+     *                               flows naturally.
+     */
+    public void applyRangeSplitResult(long grpId, Set<Tuple> observedCanonicalLowers,
+                                      int colocateColumnCount,
+                                      ThrowingSupplier<Long> packShardGroupSupplier) throws DdlException {
+        writeLock();
+        try {
+            List<ColocateRange> currentRanges = colocateRangeMgr.getColocateRanges(grpId);
+            List<ColocateRange> newRanges = spliceMissingBoundaries(
+                    currentRanges, observedCanonicalLowers, colocateColumnCount, packShardGroupSupplier);
+            if (!newRanges.equals(currentRanges)) {
+                GlobalStateMgr.getCurrentState().getEditLog().logColocateRangeUpdate(
+                        ColocateRangePersistInfo.create(grpId, newRanges),
+                        wal -> colocateRangeMgr.setColocateRanges(grpId, newRanges));
+            }
+            markAllGroupsWithSameGrpIdUnstable(grpId, /* needEditLog */ true);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    /**
+     * Splice missing canonical boundaries into a working copy of {@code currentRanges}.
+     * Returns the working copy; if no boundary was missing the returned list is
+     * {@code equals()} to the input so the caller can skip the journal write.
+     *
+     * <p>The supplier is invoked only when a boundary actually needs allocation.
+     */
+    private List<ColocateRange> spliceMissingBoundaries(List<ColocateRange> currentRanges,
+                                                        Set<Tuple> observedCanonicalLowers,
+                                                        int colocateColumnCount,
+                                                        ThrowingSupplier<Long> packShardGroupSupplier)
+            throws DdlException {
+        if (observedCanonicalLowers.isEmpty()) {
+            return currentRanges;
+        }
+        List<ColocateRange> working = new ArrayList<>(currentRanges);
+        for (Tuple canonicalLower : observedCanonicalLowers) {
+            Tuple prefix = new Tuple(canonicalLower.getValues().subList(0, colocateColumnCount));
+            int idx = ColocateRangeMgr.indexOf(working, prefix);
+            if (idx < 0) {
+                // Prefix not covered — defensive; ColocateRangeMgr's contiguity invariant
+                // makes this unreachable in production.
+                continue;
+            }
+            if (ColocateRangeMgr.hasBoundaryAt(working, prefix)) {
+                // Boundary already present — idempotent skip.
+                continue;
+            }
+            ColocateRange owner = working.get(idx);
+            long newPackShardGroupId;
+            try {
+                newPackShardGroupId = packShardGroupSupplier.get();
+            } catch (DdlException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new DdlException("Failed to allocate PACK shard group: " + e.getMessage(), e);
+            }
+            ColocateRange leftPart = new ColocateRange(
+                    Range.of(owner.getRange().getLowerBound(), prefix,
+                            owner.getRange().isLowerBoundIncluded(), false),
+                    owner.getShardGroupId());
+            ColocateRange rightPart = new ColocateRange(
+                    Range.of(prefix, owner.getRange().getUpperBound(),
+                            true, owner.getRange().isUpperBoundIncluded()),
+                    newPackShardGroupId);
+            working.set(idx, leftPart);
+            working.add(idx + 1, rightPart);
+        }
+        return working;
+    }
+
 
     // only for test
     public void clear() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -624,22 +624,27 @@ public class StarOSAgent {
         return shardInfos.stream().map(ShardInfo::getShardId).collect(Collectors.toList());
     }
 
-    public void createShards(Map<Long, List<Long>> oldToNewShardIds, FilePathInfo pathInfo, FileCacheInfo cacheInfo,
-            long groupId, @NotNull Map<String, String> properties, ComputeResource computeResource)
-            throws DdlException {
-        createShardsForSplit(oldToNewShardIds, pathInfo, cacheInfo, groupId, properties, computeResource);
-    }
-
-    public void createShardsForSplit(Map<Long, List<Long>> oldToNewShardIds, FilePathInfo pathInfo,
-            FileCacheInfo cacheInfo, long groupId, @NotNull Map<String, String> properties,
-            ComputeResource computeResource) throws DdlException {
+    /**
+     * Create shards for a tablet split.
+     *
+     * <p>{@code oldShardIdToGroupIds} carries one entry per old tablet, mapping that old tablet's
+     * id to the list of group ids each new shard spawned from it should join. For non-colocate
+     * range tables this is a single-element list with the SPREAD shard group; for range-colocate
+     * tables it is {@code [SPREAD, <old-tablet's PACK shard group>]} per old tablet, and the PACK
+     * group differs per old tablet once the colocate group has multiple ranges.
+     */
+    public void createShardsForSplit(Map<Long, List<Long>> oldShardIdToGroupIds,
+                                     Map<Long, List<Long>> oldToNewShardIds,
+                                     FilePathInfo pathInfo,
+                                     FileCacheInfo cacheInfo,
+                                     @NotNull Map<String, String> properties,
+                                     ComputeResource computeResource) throws DdlException {
         long workerGroupId = computeResource.getWorkerGroupId();
         prepare();
         List<ShardInfo> shardInfos = null;
         try {
             CreateShardInfo.Builder builder = CreateShardInfo.newBuilder();
             builder.setReplicaCount(1)
-                    .addGroupIds(groupId)
                     .setPathInfo(pathInfo)
                     .setCacheInfo(cacheInfo)
                     .putAllShardProperties(properties)
@@ -648,6 +653,11 @@ public class StarOSAgent {
             List<CreateShardInfo> createShardInfoList = new ArrayList<>(oldToNewShardIds.size() * 2);
             for (Map.Entry<Long, List<Long>> entry : oldToNewShardIds.entrySet()) {
                 builder.clearPlacementPreferences();
+                builder.clearGroupIds();
+                List<Long> groupIds = oldShardIdToGroupIds.get(entry.getKey());
+                Preconditions.checkArgument(groupIds != null && !groupIds.isEmpty(),
+                        "Missing group ids for old shard " + entry.getKey());
+                builder.addAllGroupIds(groupIds);
                 PlacementPreference preference = PlacementPreference.newBuilder()
                         .setPlacementPolicy(PlacementPolicy.PACK)
                         .setPlacementRelationship(PlacementRelationship.WITH_SHARD)

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -1863,6 +1863,16 @@ public class EditLog {
         logJsonObject(OperationType.OP_COLOCATE_RANGE_UPDATE, info);
     }
 
+    /**
+     * WAL-applier overload: the supplied applier runs after the journal record is durable,
+     * so the in-memory mutation matches the persisted state on both leader and follower.
+     * Used by the SplitTabletJob post-publish path so the ColocateRangeMgr update is
+     * sequenced with the same semantics as markGroupUnstable.
+     */
+    public void logColocateRangeUpdate(ColocateRangePersistInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_COLOCATE_RANGE_UPDATE, info, walApplier);
+    }
+
     public void logHeartbeat(HbPackage hbPackage) {
         logJsonObject(OperationType.OP_HEARTBEAT_V2, hbPackage);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
@@ -1,0 +1,434 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.google.common.collect.Multimap;
+import com.staros.proto.PlacementPolicy;
+import com.starrocks.catalog.ColocateGroupSchema;
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateRangeMgr;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Config;
+import com.starrocks.common.Range;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.proto.AggregatePublishVersionRequest;
+import com.starrocks.proto.PublishVersionRequest;
+import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.ReshardingTabletInfoPB;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.proto.TabletRangePB;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.SplitTabletClause;
+import com.starrocks.sql.ast.TabletList;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.MockedBackend.MockLakeService;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Exercises the post-split colocate-range classification path on a range-colocate table.
+ * Mocks the BE response via MockLakeService.publishVersion to return tablet ranges in the
+ * specified canonical (Level 1) or within-prefix (Level 2) shape, then asserts ColocateRangeMgr
+ * convergence and unstable-mark state.
+ */
+public class SplitTabletJobColocateTest {
+
+    protected static ConnectContext connectContext;
+    protected static StarRocksAssert starRocksAssert;
+    private static Database db;
+
+    private OlapTable table;
+    private ColocateTableIndex.GroupId groupId;
+    private static int tableSeq = 0;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        Config.enable_range_distribution = true;
+
+        starRocksAssert.withDatabase("p3_split_test").useDatabase("p3_split_test");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("p3_split_test");
+
+        new MockUp<ThreadPoolExecutor>() {
+            @Mock
+            public <T> Future<T> submit(Callable<T> task) throws Exception {
+                return CompletableFuture.completedFuture(task.call());
+            }
+        };
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Each test creates its own table so ColocateRangeMgr state from a prior test does not
+        // leak across tests; the cluster shares a single ColocateTableIndex instance.
+        String tableName = "t_p3_" + (++tableSeq);
+        String sql = "create table " + tableName + " (k1 int, k2 int)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1', 'colocate_with' = 'p3_grp_" + tableSeq + ":k1');";
+        starRocksAssert.withTable(sql);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName);
+        groupId = GlobalStateMgr.getCurrentState().getColocateTableIndex().getGroup(table.getId());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // The cluster shares one ColocateTableIndex; restore stable so the unstable bit from
+        // a Level-1 or unstable-guard test does not leak into the next case.
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        if (groupId != null && idx.isGroupUnstable(groupId)) {
+            idx.markGroupStable(groupId, /* needEditLog */ false);
+        }
+    }
+
+    @Test
+    public void testLevelTwoSplitDoesNotChangeColocateRangeMgr() throws Exception {
+        ColocateRangeMgr rangeMgr = GlobalStateMgr.getCurrentState().getColocateTableIndex().getColocateRangeMgr();
+        Assertions.assertEquals(1, rangeMgr.getColocateRanges(groupId.grpId).size());
+
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            // Two new tablets, both with WITHIN-PREFIX (non-canonical) lower bounds —
+            // a Level 2 split that does NOT cross any colocate boundary.
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0),
+                    new TabletRange(Range.lt(makeTwoColTuple(100, 50))).toProto());
+            result.put(newTabletIds.get(1),
+                    new TabletRange(Range.ge(makeTwoColTuple(100, 50))).toProto());
+            return result;
+        });
+
+        runSplitJob();
+
+        Assertions.assertEquals(1, rangeMgr.getColocateRanges(groupId.grpId).size(),
+                "Level 2 split must not add a ColocateRange entry");
+        Assertions.assertFalse(GlobalStateMgr.getCurrentState().getColocateTableIndex().isGroupUnstable(groupId),
+                "Level 2 split must leave the group stable");
+    }
+
+    @Test
+    public void testLevelOneSplitAddsCanonicalBoundary() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateRangeMgr rangeMgr = idx.getColocateRangeMgr();
+        Assertions.assertEquals(1, rangeMgr.getColocateRanges(groupId.grpId).size());
+
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            // Canonical (k, NULL) lower bound on the second child marks the boundary at 100 as
+            // a valid Level 1 boundary that splices into ColocateRangeMgr.
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0),
+                    new TabletRange(Range.lt(makeCanonicalTuple(100))).toProto());
+            result.put(newTabletIds.get(1),
+                    new TabletRange(Range.ge(makeCanonicalTuple(100))).toProto());
+            return result;
+        });
+
+        runSplitJob();
+
+        List<ColocateRange> ranges = rangeMgr.getColocateRanges(groupId.grpId);
+        Assertions.assertEquals(2, ranges.size(), "Level 1 split must splice a new ColocateRange");
+        Assertions.assertTrue(idx.isGroupUnstable(groupId),
+                "Level 1 split must mark the group unstable");
+    }
+
+    @Test
+    public void testCannotSplitWhileUnstable() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        idx.markGroupUnstable(groupId, /* needEditLog */ false);
+
+        Assertions.assertThrows(StarRocksException.class, this::createTabletReshardJob);
+    }
+
+    /**
+     * Models a leader crash between {@code OP_COLOCATE_RANGE_UPDATE} and
+     * {@code OP_COLOCATE_MARK_UNSTABLE_V2}: ColocateRangeMgr already has the canonical boundary,
+     * but the unstable bit was never persisted. Retrying must re-mark unstable without
+     * re-allocating PACK shard groups.
+     */
+    @Test
+    public void testApplyRangeSplitResultRemarksUnstableOnRetry() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long grpId = groupId.grpId;
+        Set<Tuple> canonicalLowers = new LinkedHashSet<>();
+        canonicalLowers.add(makeCanonicalTuple(100));
+
+        idx.applyRangeSplitResult(grpId, canonicalLowers, 1,
+                () -> GlobalStateMgr.getCurrentState().getStarOSAgent().createShardGroup(
+                        db.getId(), table.getId(), 0L, 0L, PlacementPolicy.PACK));
+        Assertions.assertEquals(2, idx.getColocateRangeMgr().getColocateRanges(grpId).size());
+        Assertions.assertTrue(idx.isGroupUnstable(groupId));
+
+        // Simulate the lost mark-unstable record.
+        idx.markGroupStable(groupId, /* needEditLog */ false);
+        Assertions.assertFalse(idx.isGroupUnstable(groupId));
+
+        // Retry: the supplier must NOT be invoked because the boundary already exists.
+        idx.applyRangeSplitResult(grpId, canonicalLowers, 1, () -> {
+            throw new IllegalStateException("supplier must not run when boundary already exists");
+        });
+        Assertions.assertEquals(2, idx.getColocateRangeMgr().getColocateRanges(grpId).size());
+        Assertions.assertTrue(idx.isGroupUnstable(groupId), "retry must re-emit OP_COLOCATE_MARK_UNSTABLE_V2");
+    }
+
+    /**
+     * Multi-way Level 1 split: BE produces three children where the boundary-touching middle child
+     * has a canonical lower {@code (k, NULL)} but a non-canonical upper {@code (k, x)}. The
+     * boundary at {@code k} must still be detected and spliced into ColocateRangeMgr.
+     */
+    @Test
+    public void testMultiWaySplitDetectsCanonicalLowerWithNonCanonicalUpper() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateRangeMgr rangeMgr = idx.getColocateRangeMgr();
+        long grpId = groupId.grpId;
+        Assertions.assertEquals(1, rangeMgr.getColocateRanges(grpId).size());
+
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            // 3-way split crossing the boundary at colocate prefix 100. The MIDDLE child has
+            // canonical (100, NULL) lower but a within-prefix (100, 50) upper — codex's case.
+            //   Child 0: [-inf,        (100, NULL))
+            //   Child 1: [(100, NULL), (100, 50))    <- canonical lower, non-canonical upper
+            //   Child 2: [(100, 50),   +inf)
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0),
+                    new TabletRange(Range.lt(makeCanonicalTuple(100))).toProto());
+            result.put(newTabletIds.get(1),
+                    new TabletRange(Range.gelt(makeCanonicalTuple(100), makeTwoColTuple(100, 50))).toProto());
+            result.put(newTabletIds.get(2),
+                    new TabletRange(Range.ge(makeTwoColTuple(100, 50))).toProto());
+            return result;
+        });
+
+        runSplitJob(-3);
+
+        Assertions.assertEquals(2, rangeMgr.getColocateRanges(grpId).size(),
+                "boundary at 100 must be spliced into ColocateRangeMgr");
+        Assertions.assertTrue(idx.isGroupUnstable(groupId),
+                "multi-way Level 1 split must mark the group unstable");
+    }
+
+    /**
+     * Cross-DB colocate: tables in different databases sharing the same {@code grpId} must all be
+     * marked unstable when one of them triggers a Level 1 split. Otherwise a peer DB would claim
+     * "stable" while its tablets are mid-migration.
+     */
+    @Test
+    public void testCrossDbPeerGroupsMarkedUnstable() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long grpId = groupId.grpId;
+        long peerDbId = db.getId() + 100_000;
+        long peerTableId = table.getId() + 100_000;
+        ColocateTableIndex.GroupId peerGroupId = new ColocateTableIndex.GroupId(peerDbId, grpId);
+        String peerName = peerDbId + "_p3_peer";
+
+        Map<ColocateTableIndex.GroupId, ColocateGroupSchema> group2Schema =
+                Deencapsulation.getField(idx, "group2Schema");
+        Multimap<ColocateTableIndex.GroupId, Long> group2Tables =
+                Deencapsulation.getField(idx, "group2Tables");
+        Map<Long, ColocateTableIndex.GroupId> table2Group = Deencapsulation.getField(idx, "table2Group");
+        Map<String, ColocateTableIndex.GroupId> groupName2Id = Deencapsulation.getField(idx, "groupName2Id");
+
+        group2Schema.put(peerGroupId, idx.getGroupSchema(groupId));
+        group2Tables.put(peerGroupId, peerTableId);
+        table2Group.put(peerTableId, peerGroupId);
+        groupName2Id.put(peerName, peerGroupId);
+        try {
+            Assertions.assertFalse(idx.isGroupUnstable(groupId));
+            Assertions.assertFalse(idx.isGroupUnstable(peerGroupId));
+
+            Set<Tuple> canonicalLowers = new LinkedHashSet<>();
+            canonicalLowers.add(makeCanonicalTuple(100));
+            idx.applyRangeSplitResult(grpId, canonicalLowers, 1,
+                    () -> GlobalStateMgr.getCurrentState().getStarOSAgent().createShardGroup(
+                            db.getId(), table.getId(), 0L, 0L, PlacementPolicy.PACK));
+
+            Assertions.assertTrue(idx.isGroupUnstable(groupId), "primary GroupId must be unstable");
+            Assertions.assertTrue(idx.isGroupUnstable(peerGroupId), "peer DB GroupId must be unstable too");
+        } finally {
+            // Restore stable state on the peer; @AfterEach handles the primary.
+            if (idx.isGroupUnstable(peerGroupId)) {
+                idx.markGroupStable(peerGroupId, /* needEditLog */ false);
+            }
+            group2Schema.remove(peerGroupId);
+            group2Tables.removeAll(peerGroupId);
+            table2Group.remove(peerTableId);
+            groupName2Id.remove(peerName);
+        }
+    }
+
+    /**
+     * BE returns a non-canonical tablet range that straddles an existing ColocateRange boundary —
+     * the most likely cause is a colocate-unaware BE. Classification must mark the group unstable
+     * (so the scan-time alignment guard fails closed) without adding any new boundary.
+     */
+    @Test
+    public void testNonCanonicalCrossingMarksUnstable() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long grpId = groupId.grpId;
+        ColocateRangeMgr rangeMgr = idx.getColocateRangeMgr();
+
+        // Seed two ColocateRanges with a boundary at colocate-prefix (100).
+        long firstShardGroupId = rangeMgr.getColocateRanges(grpId).get(0).getShardGroupId();
+        long secondShardGroupId = GlobalStateMgr.getCurrentState().getStarOSAgent().createShardGroup(
+                db.getId(), table.getId(), 0L, 0L, PlacementPolicy.PACK);
+        Tuple boundaryPrefix = new Tuple(Arrays.asList(Variant.of(IntegerType.INT, "100")));
+        rangeMgr.setColocateRanges(grpId, Arrays.asList(
+                new ColocateRange(Range.lt(boundaryPrefix), firstShardGroupId),
+                new ColocateRange(Range.ge(boundaryPrefix), secondShardGroupId)));
+
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            // First child range non-canonically straddles the existing boundary at 100.
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0),
+                    new TabletRange(Range.gelt(makeTwoColTuple(50, 0), makeTwoColTuple(150, 0))).toProto());
+            result.put(newTabletIds.get(1),
+                    new TabletRange(Range.ge(makeTwoColTuple(150, 0))).toProto());
+            return result;
+        });
+
+        runSplitJob();
+
+        Assertions.assertTrue(idx.isGroupUnstable(groupId),
+                "non-canonical range crossing existing boundary must mark unstable");
+        Assertions.assertEquals(2, rangeMgr.getColocateRanges(grpId).size(),
+                "non-canonical crossing must not add a ColocateRange entry");
+    }
+
+    private static Tuple makeCanonicalTuple(int k1) {
+        // (k1, NULL) — second sort-key column NULL-padded to match the canonical shape that
+        // ColocateRangeUtils.expandToFullSortKey produces from a colocate-range bound.
+        return new Tuple(Arrays.asList(
+                Variant.of(IntegerType.INT, String.valueOf(k1)),
+                Variant.nullVariant(IntegerType.INT)));
+    }
+
+    private static Tuple makeTwoColTuple(int k1, int k2) {
+        return new Tuple(Arrays.asList(
+                Variant.of(IntegerType.INT, String.valueOf(k1)),
+                Variant.of(IntegerType.INT, String.valueOf(k2))));
+    }
+
+    private interface RangeProducer {
+        Map<Long, TabletRangePB> produce(long oldTabletId, List<Long> newTabletIds);
+    }
+
+    private static Map<Long, TabletRangePB> applyProducer(List<ReshardingTabletInfoPB> infos,
+                                                          RangeProducer producer) {
+        Map<Long, TabletRangePB> result = new HashMap<>();
+        if (infos == null) {
+            return result;
+        }
+        for (ReshardingTabletInfoPB info : infos) {
+            if (info.splittingTabletInfo == null) {
+                continue;
+            }
+            result.putAll(producer.produce(
+                    info.splittingTabletInfo.oldTabletId,
+                    info.splittingTabletInfo.newTabletIds));
+        }
+        return result;
+    }
+
+    private static PublishVersionResponse okResponse() {
+        PublishVersionResponse response = new PublishVersionResponse();
+        response.status = new StatusPB();
+        response.status.statusCode = TStatusCode.OK.getValue();
+        return response;
+    }
+
+    private static void installLakeServiceMockReturning(RangeProducer producer) {
+        new MockUp<MockLakeService>() {
+            @Mock
+            public Future<PublishVersionResponse> publishVersion(PublishVersionRequest request) {
+                PublishVersionResponse response = okResponse();
+                response.tabletRanges = applyProducer(request.reshardingTabletInfos, producer);
+                return CompletableFuture.completedFuture(response);
+            }
+
+            @Mock
+            public Future<PublishVersionResponse> aggregatePublishVersion(AggregatePublishVersionRequest request) {
+                PublishVersionResponse response = okResponse();
+                response.tabletRanges = new HashMap<>();
+                for (PublishVersionRequest pubReq : request.publishReqs) {
+                    response.tabletRanges.putAll(applyProducer(pubReq.reshardingTabletInfos, producer));
+                }
+                return CompletableFuture.completedFuture(response);
+            }
+        };
+    }
+
+    private TabletReshardJob createTabletReshardJob() throws Exception {
+        return createTabletReshardJob(-2);
+    }
+
+    private TabletReshardJob createTabletReshardJob(long targetSize) throws Exception {
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex idx = physicalPartition.getLatestBaseIndex();
+        long tabletId = idx.getTablets().get(0).getId();
+        TabletList tabletList = new TabletList(List.of(tabletId));
+        Map<String, String> properties = Map.of(PropertyAnalyzer.PROPERTIES_TABLET_RESHARD_TARGET_SIZE,
+                String.valueOf(targetSize));
+        SplitTabletClause clause = new SplitTabletClause(null, tabletList, properties);
+        clause.setTabletReshardTargetSize(targetSize);
+        TabletReshardJobFactory factory = new SplitTabletJobFactory(db, table, clause);
+        return factory.createTabletReshardJob();
+    }
+
+    private void runSplitJob() throws Exception {
+        runSplitJob(-2);
+    }
+
+    private void runSplitJob(long targetSize) throws Exception {
+        TabletReshardJob job = createTabletReshardJob(targetSize);
+        job.run();
+        Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, job.getJobState());
+        // The classification we care about runs in the next transition (RUNNING → CLEANING).
+        job.run();
+        // Drain remaining states so the table returns to NORMAL.
+        for (int i = 0; i < 5 && job.getJobState() != TabletReshardJob.JobState.FINISHED; i++) {
+            job.run();
+        }
+    }
+}

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -412,6 +412,16 @@ message TxnInfoPB {
     optional bool rebuild_pindex = 6;
     optional int64 gtid = 7 [default=0];
     repeated PUniqueId load_ids = 8;
+    // Number of leading sort-key columns that participate in the table's range
+    // colocate group. Only used by tablet split (TXN_TABLET_RESHARD with split
+    // direction). 0 (default) = legacy / non-colocate-aware split. BE uses this
+    // to prefer canonical colocate-prefix boundaries over within-prefix data-
+    // distribution candidates; FE classifies the resulting tablet ranges as
+    // Level 1 (new ColocateRange) vs Level 2 (intra-colocate).
+    // Carried at the txn level (not per SplittingTabletInfoPB) because the value
+    // is table-level metadata: every SplittingTabletInfoPB in one txn would
+    // carry the same value.
+    optional int32 colocate_column_count = 9;
 }
 
 message SplittingTabletInfoPB {


### PR DESCRIPTION
## Why I'm doing:

Range distribution colocate (next phase after #71860 / #72278 / #72900) needs the BE splitter to produce canonical colocate-prefix boundaries and the FE to update `ColocateRangeMgr` after splits. Without this, post-split tablets miss PACK shard group membership and cross-table colocate joins fail.

## What I'm doing:

- Carry the table's colocate column count once at the txn level (`TxnInfoPB.colocate_column_count`). When set, BE's `calculate_range_split_boundaries` synthesizes canonical `(k, NULL, ..., NULL)` boundary tuples at every observed colocate-prefix transition during boundary collection (step 1), so candidate ranges are pre-split at canonical points. The greedy boundary selection then naturally picks a canonical boundary when it wants to split at a prefix transition, and the post-pass per-rowset stats walk stays correct because each candidate range is fully on one side of any canonical.
- FE classifies each new tablet by its lower-bound shape. Canonical lower (regardless of upper shape) → Level 1 candidate; non-canonical that doesn't cross an existing `ColocateRange` → Level 2 (no metadata change). The Level 1 trigger is `hasNewCanonical || oldStradlesBoundary || nonCanonicalCrossing` — the `oldStradlesBoundary` signal handles retry-after-partial-commit (where the canonical lower already exists in the manager but the unstable bit was lost), and prevents false positives on Level 2 first-child inheritance.
- Level 1 path: `ColocateTableIndex.applyRangeSplitResult` splices new `ColocateRange` entries via the WAL-applier overload of `OP_COLOCATE_RANGE_UPDATE`, allocates fresh PACK shard groups, and marks every peer `GroupId` (cross-DB grpId share) unstable. The scan-time `RangeColocateScanDispatch` alignment guard fails closed until alignment runs (P4-part-2 daemon, future PR). `SplitTabletJobFactory` blocks new splits while any peer is unstable so transient unaligned state cannot compound.
- `StarOSAgent.createShardsForSplit` now takes per-old-tablet group ids so each new shard joins `{SPREAD, old-tablet's PACK group}`. Removed the dead `StarOSAgent.createShards(Map<>)` wrapper.
- Tests cover Level 1 / Level 2 / multi-way Level 1 with non-canonical upper / Level 2 first-child inheriting canonical lower / Level 2 last-child ending at canonical upper / re-split-while-unstable rejection / retry idempotency / cross-DB peer unstable propagation / non-canonical-crosses-boundary diagnostic. BE tests cover canonical boundary selection, within-prefix fallback, default-mode unchanged, and the prefix-straddling-segment stats-consistency case.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4