### PR TITLE
[Tool] fix weekly review deploy: use latest daily build instead of missing PR artifact

### DIFF
--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -159,6 +159,18 @@ jobs:
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
           ./bin/elastic-cluster.sh --template ci-admit
+          _oss="/var/local/env/ossutil64 --config-file /root/.ossutilconfig"
+          _base="oss://starrocks-ci-release/${BRANCH}/Release/inspection/pr/ubuntu"
+          # Sort by modification time (line starts with date), take latest BE to get the commit SHA
+          LATEST_SHA=$(${_oss} ls "${_base}/" | grep "\-BE\.tar\.gz" | sort -r | head -1 | awk '{print $NF}' | grep -oE '[a-f0-9]{40}')
+          [[ -z "${LATEST_SHA}" ]] && echo "::error::No inspection package found for branch ${BRANCH}" && exit 1
+          SHORT_SHA=${LATEST_SHA:0:7}
+          BE_OUTPUT_TAR="${_base}/${LATEST_SHA}/be/StarRocks-${SHORT_SHA}-BE.tar.gz"
+          FE_OUTPUT_TAR="${_base}/${LATEST_SHA}/fe/StarRocks-${SHORT_SHA}-FE.tar.gz"
+          echo "Inspection commit: ${LATEST_SHA}"
+          echo "BE: ${BE_OUTPUT_TAR}"
+          echo "FE: ${FE_OUTPUT_TAR}"
+          export BE_OUTPUT_TAR FE_OUTPUT_TAR
           ./bin/deploy-cluster.sh -c ci-admit
           echo "cluster_name=ci-admit" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Why I'm doing:

Weekly Review has no PR-specific build artifact on OSS. `deploy-cluster.sh` looks for a package under `oss://starrocks-ci-release/{branch}/Release/pr/ubuntu/{COMMIT_SHA}/`, which does not exist for weekly review runs, causing:
```
Error: Merged tar package not found!
```

## What I'm doing:

Before calling `deploy-cluster.sh`, look up the latest inspection build artifacts:
1. List `oss://starrocks-ci-release/{branch}/Release/inspection/pr/ubuntu/`, sort by modification time, take the latest BE tar
2. Extract the commit SHA from the path to ensure FE and BE are from the same build
3. Export `BE_OUTPUT_TAR` and `FE_OUTPUT_TAR` so `deploy-cluster.sh` uses them directly, bypassing the PR artifact lookup

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4