### PR TITLE
[BugFix] preserve typed AggStateDesc on IVM avg_state_union scalar

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.AggStateDesc;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarbinaryType;
@@ -169,7 +170,16 @@ public class IvmOpUtils {
         if (newFunc == null) {
             throw new IllegalArgumentException("Function " + stateUnionFunctionName + " not found");
         }
+        // <agg>_state_union overloads share one signature (varbinary, varbinary), so FunctionSet only
+        // keeps the first; its AggStateDesc may not match the real input type. The AGG_STATE column
+        // type carries the typed AggStateDesc from AggStateCombineCombinator.of — use it to specialize.
+        AggStateDesc inputAggStateDesc = intermediateAggScalarOp.getType().getAggStateDesc();
+        Preconditions.checkState(inputAggStateDesc != null,
+                "intermediateAggScalarOp's type must carry an AggStateDesc, got: %s",
+                intermediateAggScalarOp.getType());
+        Function specializedFunc = newFunc.copy();
+        specializedFunc.setAggStateDesc(inputAggStateDesc.clone());
         return new CallOperator(stateUnionFunctionName, intermediateAggScalarOp.getType(),
-                List.of(intermediateAggScalarOp, aggStateAggStateColumnRef), newFunc);
+                List.of(intermediateAggScalarOp, aggStateAggStateColumnRef), specializedFunc);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`AVG(DECIMAL)` in an INCREMENTAL materialized view produces correct results on the **first** refresh but silently produces `0` on every subsequent **incremental** refresh. The problem reproduces on Iceberg base tables (the only IVM-supported source today). `AVG(BIGINT)` / `AVG(INT)` / `AVG(DOUBLE)` IVM all work — only DECIMAL is corrupted.

### Reproduction (verified end-to-end against a dev cluster)

```sql
CREATE EXTERNAL CATALOG ivm_agg PROPERTIES (
  'type'='iceberg', 'iceberg.catalog.type'='hive',
  'hive.metastore.uris'='thrift://...:9083');
CREATE DATABASE ivm_agg.bug;
CREATE TABLE ivm_agg.bug.t (k string, d decimal(10,2), dt date) PARTITION BY (dt);
INSERT INTO ivm_agg.bug.t VALUES
  ('A', 10.50, '2026-01-01'), ('A', 20.50, '2026-01-01'), ('B', 100.00, '2026-01-02');

CREATE DATABASE ivm_mvs;
CREATE MATERIALIZED VIEW ivm_mvs.mv PARTITION BY dt
  REFRESH DEFERRED MANUAL PROPERTIES ('refresh_mode'='incremental')
  AS SELECT k, dt, AVG(d) AS avg_d FROM ivm_agg.bug.t GROUP BY k, dt;
REFRESH MATERIALIZED VIEW ivm_mvs.mv WITH SYNC MODE;

SELECT k, avg_d FROM ivm_mvs.mv ORDER BY k;
-- A  15.50000000  ✓ correct
-- B 100.00000000  ✓ correct

INSERT INTO ivm_agg.bug.t VALUES ('A', 30.50, '2026-01-01'), ('B', 200.00, '2026-01-02');
REFRESH MATERIALIZED VIEW ivm_mvs.mv WITH SYNC MODE;

SELECT k, avg_d FROM ivm_mvs.mv ORDER BY k;
-- A 0.00000000   ✗ should be 20.50
-- B 0.00000000   ✗ should be 150.00
```

`task_runs.STATE = SUCCESS`, no error logged — pure data corruption.

### Root cause

`AVG(d)` is rewritten by `IVMAnalyzer` into a state column `avg_combine(d) AS __AGG_STATE_avg(d)` plus a user-facing `avg_state_merge(__AGG_STATE_avg(d))`. The MV's state column on disk is the binary state of the underlying aggregate.

For DECIMAL inputs the BE picks the typed `decimal_avg(DECIMAL64)` aggregate (via the `func_version > 2` redirect in `aggregate_factory.cpp`), whose serialized state is **24 bytes** = `int128 sum (16B) + int64 count (8B)`. The first refresh writes 24-byte states correctly:

| k | state_len | state_hex |
|---|---|---|
| A | 24 | `1C0C00..00 0200..00` (sum=3100, count=2) |
| B | 24 | `1027..00 0100..00` (sum=10000, count=1) |

For each subsequent refresh, `IvmDeltaAggregateRule.transform` builds a `Project[avg_state_union(intermediate_agg, mv_existing_state)]` whose scalar function is wired by `IvmOpUtils.buildStateUnionScalarOperator`. That helper looks the function up via `ExprUtils.getBuiltinFunction("avg_state_union", [varbinary, varbinary])`.

**The lookup returns the wrong function.** All `<agg>_state_union(intermediate_type, intermediate_type)` overloads share a single signature (e.g. `(varbinary, varbinary)`), so `FunctionSet.addBuiltInFunction` de-duplicates them via `IS_INDISTINGUISHABLE` and only keeps the **first** registered variant. For `avg`, that variant is the `avg(double)` overload, whose `AggStateDesc` says `args=[double]`. That stale `AggStateDesc` rides along on the looked-up function and is what the BE later uses to pick the underlying `merge` / `serialize_to_column` implementation:

- `args=[double]` → no decimal redirect → BE resolves `avg(DOUBLE)`, whose state layout is **16 bytes** (`double sum + int64 count`).
- The BE faithfully serializes a 16-byte state of `avg(DOUBLE)` over column data that was actually `decimal_avg(DECIMAL64)` 24-byte state.

Reading 16 bytes off a 24-byte input:
- `double sum`  = lower 8 bytes of the int128 sum (a denormal-double bit pattern that adds *linearly* for small values, so the sum survives by accident);
- `int64 count` = next 8 bytes — i.e. the **upper** 8 bytes of the int128 sum, which are 0 for any ordinary value.

After the merge BE writes a 16-byte state with `count=0`. The user-facing `avg_state_merge` then computes `sum/count` → 0/0 → column default = 0. The corruption is invisible above the data layer because the BE happily serializes 16 bytes into a `varbinary` column that previously held 24-byte states. Hex dump after one incremental refresh:

| k | state_len | state_hex |
|---|---|---|
| A | **16** | `06180000000000000000000000000000` (sum=6150, count=0) |
| B | **16** | `30750000000000000000000000000000` (sum=30000, count=0) |

Why DOUBLE/INT/BIGINT IVM still works: their underlying AVG uses `ImmediateType=double` and the same 16-byte state layout — interpreting them as `avg(DOUBLE)` round-trips bit-for-bit, so the dedup never bites them.

Why `avg_state_merge` looks fine on the first refresh: `IVMAnalyzer.buildStateMergeFuncExpr` builds an `Expr` (FunctionCallExpr) that goes through `AggStateUtils.getAggStateFunction`, which reads the `AggStateDesc` from the input AGG_STATE column type and rebuilds `StateMergeCombinator.of(argFn)` with the right underlying aggregate. The IVM optimizer rule constructs `CallOperator`s directly and bypasses that analyzer fixup, so the dedup wins for `state_union` only.

## What I'm doing:

The AGG_STATE column type already carries the *correct* `AggStateDesc` (it's set by `AggStateCombineCombinator.of` from the original AVG overload). Mirror what the analyzer does for user-typed `<agg>_state_union(state)` calls: after the FunctionSet lookup, override the looked-up function's stale `AggStateDesc` with the one embedded on the input AGG_STATE column type. The BE then resolves the typed `decimal_avg(DECIMAL64)` correctly and the 24-byte state layout is preserved across incremental refreshes.

```java
// IvmOpUtils.buildStateUnionScalarOperator
AggStateDesc inputAggStateDesc = intermediateAggScalarOp.getType().getAggStateDesc();
Function specializedFunc = newFunc.copy();
specializedFunc.setAggStateDesc(inputAggStateDesc.clone());
```

The fix touches no FE-side combinator code, no BE code paths, and no IVM rule besides the one helper that wires up the scalar.

## Verification

End-to-end on the dev cluster after `cdsql update fe --build`:

```
-- After incremental refresh (with fix):
+------+--------------+-----------+--------------------------------------------------+
| k    | avg_d        | state_len | state_hex                                        |
+------+--------------+-----------+--------------------------------------------------+
| A    |  20.50000000 |        24 | 061800000000000000000000000000000300000000000000 |  -- count=3 ✓
| B    | 150.00000000 |        24 | 307500000000000000000000000000000200000000000000 |  -- count=2 ✓
+------+--------------+-----------+--------------------------------------------------+
```

Sum hex matches expected: 0x1806=6150 (=61.50 = 10.50+20.50+30.50, ✓ A) and 0x7530=30000 (=300.00 = 100+200, ✓ B). State stays 24 bytes; count is preserved across the merge.

No automated test is bundled in the PR — the existing IVM aggregate plan tests (`IVMBasedMvRefreshProcessorIcebergTest.testJoinAndAggregate*`) only assert `state_union` is in the plan string, and there is no DECIMAL column on the mock Iceberg tables; adding one would touch `MockIcebergMetadata` schema, partition schema, and partition transform schema, expanding the change well beyond this fix. Happy to add a focused regression test in a follow-up if reviewers want one.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

(IVM hasn't shipped to a release branch yet, so no version backport labels are checked.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)