### PR TITLE
[Tool] fix weekly review deploy: use ubuntu linuxdistro and latest inspection package

### DIFF
--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -158,7 +158,7 @@ jobs:
         timeout-minutes: 30
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
-          ./bin/elastic-cluster.sh --template ci-admit
+          ./bin/elastic-cluster.sh --template ci-admit --linuxdistro ubuntu
           _oss="/var/local/env/ossutil64 --config-file /root/.ossutilconfig"
           _base="oss://starrocks-ci-release/${BRANCH}/Release/inspection/pr/ubuntu"
           # Sort by modification time (line starts with date), take latest BE to get the commit SHA
@@ -170,7 +170,7 @@ jobs:
           echo "Inspection commit: ${LATEST_SHA}"
           echo "BE: ${BE_OUTPUT_TAR}"
           echo "FE: ${FE_OUTPUT_TAR}"
-          export BE_OUTPUT_TAR FE_OUTPUT_TAR
+          export BE_OUTPUT_TAR FE_OUTPUT_TAR LINUX_DISTRO=ubuntu
           ./bin/deploy-cluster.sh -c ci-admit
           echo "cluster_name=ci-admit" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Why I'm doing:

Weekly Review deploy fails with two issues:
1. No PR-specific build artifact on OSS → `Merged tar package not found!`
2. `elastic-cluster.sh` defaults to centos7 machines which lack JDK17, but main branch requires JDK17+

## What I'm doing:

- Pass `--linuxdistro ubuntu` to `elastic-cluster.sh` to provision ubuntu machines (which have JDK17)
- Export `LINUX_DISTRO=ubuntu` so `deploy-cluster.sh` uses the correct JDK path
- Look up the latest inspection build artifacts from OSS (`oss://starrocks-ci-release/{branch}/Release/inspection/pr/ubuntu/`), extract commit SHA from the latest BE tar to ensure FE and BE come from the same build, then export `BE_OUTPUT_TAR` / `FE_OUTPUT_TAR`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4