### PR TITLE
[Tool] fix weekly review: stop re-copying ci-tool in backup_log step

### DIFF
--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Backup logs
         if: always()
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
+          cd ci-tool && source lib/init.sh
           ./bin/backup_log_cores.sh || true
 
       - name: Clean MySQL ECI


### PR DESCRIPTION
## Why I'm doing:

After #73029 merged deploy/sql-tester/teardown into a single job, the backup_log step still does \`rm -rf ./ci-tool && cp -rf /var/lib/ci-tool\`. This overwrites \`ci-tool/conf/starrocks_deploy.conf\` (written by \`elastic-cluster.sh\` in the deploy step) with the pre-installed version. The delete step then reads empty/stale conf and **fails to delete any ECS machines**, causing resource leaks.

## What I'm doing:

Change backup_log step from re-copying ci-tool to reusing the existing one. All steps run on the same runner in the same job - ci-tool only needs to be copied once (in the deploy step).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4