### PR TITLE
[Enhancement] Migrate tier-2 leader daemons to LeaderDaemon

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -77,7 +77,9 @@ public abstract class AlterHandler extends LeaderDaemon {
      */
     protected ReentrantLock lock = new ReentrantLock();
 
-    protected ThreadPoolExecutor executor;
+    // Not final: shutdownNow() in onStopped() interrupts in-flight AlterReplicaTask
+    // submissions; start() rebuilds the pool when the next leader takes over.
+    protected volatile ThreadPoolExecutor executor;
 
     protected void lock() {
         lock.lock();
@@ -89,9 +91,13 @@ public abstract class AlterHandler extends LeaderDaemon {
 
     public AlterHandler(String name) {
         super(name, Config.alter_scheduler_interval_millisecond);
-        executor = ThreadPoolManager
-                .newDaemonCacheThreadPool(Config.alter_max_worker_threads, Config.alter_max_worker_queue_size,
-                        name + "_pool", true);
+        executor = newExecutor();
+    }
+
+    private ThreadPoolExecutor newExecutor() {
+        return ThreadPoolManager.newDaemonCacheThreadPool(
+                Config.alter_max_worker_threads, Config.alter_max_worker_queue_size,
+                getName() + "_pool", true);
     }
 
 
@@ -195,16 +201,28 @@ public abstract class AlterHandler extends LeaderDaemon {
         setInterval(Config.alter_scheduler_interval_millisecond);
     }
 
-    // alterJobsV2 is persistent (saved/loaded via image and replayed on followers via editlog),
-    // so it must NOT be cleared on demotion - the next leader resumes those jobs from the same
-    // map. The owned 'executor' thread pool also stays alive across leader sessions; in-flight
-    // AlterReplicaTask submissions complete on their own. Subclasses can override onStopped()
-    // to drop derived caches (e.g. tableNotFinalStateJobMap, lastRecycleBinCheckTime) that are
-    // recomputable from alterJobsV2 / cluster state.
-
     @Override
     public synchronized void start() {
+        // Rebuild the executor if a previous demotion shut it down so handleFinishAlterTask
+        // submissions accepted by the new leader run on a fresh pool.
+        if (executor == null || executor.isShutdown()) {
+            executor = newExecutor();
+        }
         super.start();
+    }
+
+    @Override
+    protected void onStopped() {
+        // alterJobsV2 is persistent (saved/loaded via image and replayed on followers via
+        // editlog), so it must NOT be cleared on demotion - the next leader resumes those
+        // jobs from the same map. Subclasses can override onStopped() to drop derived caches
+        // (e.g. tableNotFinalStateJobMap) that are recomputable from alterJobsV2; just
+        // remember to call super.onStopped() so the executor shutdown still runs.
+        // shutdownNow() interrupts in-flight AlterReplicaTask submissions so threads exit
+        // promptly; no awaitTermination because the drain is bounded.
+        if (executor != null && !executor.isShutdown()) {
+            executor.shutdownNow();
+        }
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -41,7 +41,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.ThreadPoolManager;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.RemoveAlterJobV2OperationLog;
 import com.starrocks.qe.ShowResultSet;
@@ -64,7 +64,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.locks.ReentrantLock;
 
-public abstract class AlterHandler extends FrontendDaemon {
+public abstract class AlterHandler extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(AlterHandler.class);
     protected ConcurrentMap<Long, AlterJobV2> alterJobsV2 = Maps.newConcurrentMap();
 
@@ -190,10 +190,17 @@ public abstract class AlterHandler extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         clearExpireFinishedOrCancelledAlterJobsV2();
         setInterval(Config.alter_scheduler_interval_millisecond);
     }
+
+    // alterJobsV2 is persistent (saved/loaded via image and replayed on followers via editlog),
+    // so it must NOT be cleared on demotion - the next leader resumes those jobs from the same
+    // map. The owned 'executor' thread pool also stays alive across leader sessions; in-flight
+    // AlterReplicaTask submissions complete on their own. Subclasses can override onStopped()
+    // to drop derived caches (e.g. tableNotFinalStateJobMap, lastRecycleBinCheckTime) that are
+    // recomputable from alterJobsV2 / cluster state.
 
     @Override
     public synchronized void start() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -203,6 +203,16 @@ public abstract class AlterHandler extends LeaderDaemon {
 
     @Override
     public synchronized void start() {
+        // Refuse to overlap with a previous pool that has not finished draining. Mirrors the
+        // pattern used by BatchWriteMgr / RoutineLoadTaskScheduler / CoordinatorBackendAssigner:
+        // shutdownNow() in onStopped() is best-effort, so a worker thread that ignores the
+        // interrupt momentarily may still be alive when start() runs. Spinning up a fresh pool
+        // would put two AlterReplicaTask submission workers against the same alterJobsV2 +
+        // handler state.
+        if (executor != null && executor.isShutdown() && !executor.isTerminated()) {
+            throw new IllegalStateException(
+                    "AlterHandler " + getName() + " executor has not terminated; refuse to restart");
+        }
         // Rebuild the executor if a previous demotion shut it down so handleFinishAlterTask
         // submissions accepted by the new leader run on a fresh pool.
         if (executor == null || executor.isShutdown()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -143,6 +143,29 @@ public class AlterJobMgr {
         clusterHandler.setStop();
     }
 
+    /**
+     * Coordinated stop for leader demotion: drain each handler so onStopped() runs and the
+     * worker threads exit cleanly. Wraps each handler call in its own try-catch so a
+     * misbehaving handler cannot abort the remaining handlers' drain.
+     */
+    public void stopGracefully(long timeoutMs) {
+        try {
+            schemaChangeHandler.stopGracefully(timeoutMs);
+        } catch (Throwable t) {
+            LOG.warn("stop schemaChangeHandler failed", t);
+        }
+        try {
+            materializedViewHandler.stopGracefully(timeoutMs);
+        } catch (Throwable t) {
+            LOG.warn("stop materializedViewHandler failed", t);
+        }
+        try {
+            clusterHandler.stopGracefully(timeoutMs);
+        } catch (Throwable t) {
+            LOG.warn("stop clusterHandler failed", t);
+        }
+    }
+
     public void processDropMaterializedView(DropMaterializedViewStmt stmt) throws DdlException, MetaNotFoundException {
         // check db
         String dbName = stmt.getDbName();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -844,8 +844,8 @@ public class MaterializedViewHandler extends AlterHandler {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
-        super.runAfterCatalogReady();
+    protected void runAfterLeaseValid() {
+        super.runAfterLeaseValid();
         runAlterJobV2();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2000,7 +2000,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
         if (RunMode.isSharedDataMode()) {
             // check warehouse
-            this.computeResource = connectContext != null ?
+            final ComputeResource computeResource = connectContext != null ?
                     connectContext.getCurrentComputeResource() : WarehouseManager.DEFAULT_RESOURCE;
             final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
             if (!warehouseManager.isResourceAvailable(computeResource)) {
@@ -2029,8 +2029,8 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
-        super.runAfterCatalogReady();
+    protected void runAfterLeaseValid() {
+        super.runAfterLeaseValid();
         runAlterJobV2();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
@@ -250,8 +250,8 @@ public class SystemHandler extends AlterHandler {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
-        super.runAfterCatalogReady();
+    protected void runAfterLeaseValid() {
+        super.runAfterLeaseValid();
 
         // check all decommissioned backends, if there is no tablet on that backend, drop it.
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -232,6 +232,14 @@ public class BackupHandler extends LeaderDaemon implements Writable, MemoryTrack
         // drop the per-leader-session init flag so the new leader re-validates backup/restore
         // tmp directories before resuming jobs.
         isInit = false;
+        // repoMgr was started by start(); stop its ping loop so it does not keep talking to
+        // remote storage after demotion. The same instance is reused on re-election; its
+        // persisted repo maps remain intact across the stop/start cycle.
+        try {
+            repoMgr.stopGracefully(Config.leader_demotion_drain_timeout_sec * 1000L);
+        } catch (Throwable t) {
+            LOG.warn("stop repoMgr failed", t);
+        }
     }
 
     // handle create repository stmt

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -63,7 +63,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Writable;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.memory.MemoryTrackable;
@@ -115,7 +115,7 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.scheduler.MVActiveChecker.MV_BACKUP_INACTIVE_REASON;
 
-public class BackupHandler extends FrontendDaemon implements Writable, MemoryTrackable {
+public class BackupHandler extends LeaderDaemon implements Writable, MemoryTrackable {
 
     private static final Logger LOG = LogManager.getLogger(BackupHandler.class);
 
@@ -150,7 +150,9 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
     private GlobalStateMgr globalStateMgr;
 
     public BackupHandler() {
-        // for persist
+        // for persist - LeaderDaemon requires a name; the worker thread is never started for
+        // the deserialization-only instance (start() requires globalStateMgr to be non-null).
+        super("backup-handler", 3000L);
     }
 
     public BackupHandler(GlobalStateMgr globalStateMgr) {
@@ -210,7 +212,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         if (!isInit) {
             if (!init()) {
                 return;
@@ -221,6 +223,15 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
             job.setGlobalStateMgr(globalStateMgr);
             job.run();
         }
+    }
+
+    @Override
+    protected void onStopped() {
+        // dbIdToBackupOrRestoreJob is persistent state (saved/loaded via image and replayed
+        // through the editlog) - the next leader resumes those jobs from the same map. Only
+        // drop the per-leader-session init flag so the new leader re-validates backup/restore
+        // tmp directories before resuming jobs.
+        isInit = false;
     }
 
     // handle create repository stmt

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RepositoryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RepositoryMgr.java
@@ -39,7 +39,7 @@ import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.backup.Status.ErrCode;
 import com.starrocks.common.io.Writable;
-import com.starrocks.common.util.Daemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
@@ -51,9 +51,14 @@ import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 /*
- * A manager to manage all backup repositories
+ * A manager to manage all backup repositories.
+ *
+ * Extends {@link LeaderDaemon} so the ping loop is bound to the leader session: when this FE is
+ * demoted the worker is stopped (via {@link BackupHandler}'s lifecycle), and when re-elected the
+ * same singleton can be started again. The persisted state ({@link #repoNameMap}) is preserved
+ * across stop/start cycles because the manager instance is reused.
  */
-public class RepositoryMgr extends Daemon implements Writable, GsonPostProcessable {
+public class RepositoryMgr extends LeaderDaemon implements Writable, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(RepositoryMgr.class);
 
     // all key should be in lower case
@@ -68,7 +73,7 @@ public class RepositoryMgr extends Daemon implements Writable, GsonPostProcessab
     }
 
     @Override
-    protected void runOneCycle() {
+    protected void runAfterLeaseValid() {
         for (Repository repo : repoNameMap.values()) {
             if (!repo.ping()) {
                 LOG.warn("Failed to connect repository {}. msg: {}", repo.getName(), repo.getErrorMsg());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -51,7 +51,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.io.Writable;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.persist.ImageWriter;
@@ -86,7 +86,7 @@ import javax.validation.constraints.NotNull;
 import static com.starrocks.server.GlobalStateMgr.isCheckpointThread;
 import static java.lang.Math.max;
 
-public class CatalogRecycleBin extends FrontendDaemon implements Writable, MemoryTrackable {
+public class CatalogRecycleBin extends LeaderDaemon implements Writable, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(CatalogRecycleBin.class);
 
     private final Map<Long, RecycleDatabaseInfo> idToDatabase;
@@ -1218,7 +1218,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         long currentTimeMs = System.currentTimeMillis();
         // Must follow the partition -> table -> db order for two reasons:
         // 1. Avoid dangling references: partition(table) should be erased before its parent table(db).

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -55,7 +55,7 @@ import com.starrocks.clone.TabletSchedCtx.Priority;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.persist.ColocatePersistInfo;
@@ -81,7 +81,7 @@ import java.util.stream.IntStream;
 /**
  * ColocateTableBalancer is responsible for tablets' repair and balance of colocated tables.
  */
-public class ColocateTableBalancer extends FrontendDaemon {
+public class ColocateTableBalancer extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(ColocateTableBalancer.class);
 
     private static final long CHECK_INTERVAL_MS = 20 * 1000L; // 20 second
@@ -250,13 +250,24 @@ public class ColocateTableBalancer extends FrontendDaemon {
      *   Otherwise, mark the group as stable
      */
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         if (!Config.tablet_sched_disable_colocate_balance && isSystemStable(GlobalStateMgr
                 .getCurrentState().getNodeMgr().getClusterInfo())) {
             relocateAndBalancePerGroup();
             relocateAndBalanceAllGroups();
         }
         matchGroups();
+    }
+
+    @Override
+    protected void onStopped() {
+        // aliveBackendIds and systemStableStartTime are leader-session watermarks used to gate
+        // balancing on cluster stability. Reset both so the next leader re-observes BE liveness
+        // and re-times the stability window from scratch instead of trusting the demoted
+        // leader's view. group2ColocateRelocationInfo is left as-is: it tracks in-progress
+        // relocation decisions tied to ColocateTableIndex and is reused on re-election.
+        aliveBackendIds = new HashSet<>();
+        systemStableStartTime = -1L;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -54,7 +54,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DynamicPartitionUtil;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.RangeUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.Util;
@@ -97,7 +97,7 @@ import java.util.Set;
  * Config.dynamic_partition_enable determine whether this feature is enable, Config.dynamic_partition_check_interval_seconds
  * determine how often the task is performed
  */
-public class DynamicPartitionScheduler extends FrontendDaemon {
+public class DynamicPartitionScheduler extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(DynamicPartitionScheduler.class);
     public static final String LAST_SCHEDULER_TIME = "lastSchedulerTime";
     public static final String LAST_UPDATE_TIME = "lastUpdateTime";
@@ -502,11 +502,11 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
 
     @VisibleForTesting
     public void runOnceForTest() {
-        runAfterCatalogReady();
+        runAfterLeaseValid();
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         // Find all tables that need to be scheduled.
         long now = System.currentTimeMillis();
         long checkIntervalMs = Config.dynamic_partition_check_interval_seconds * 1000L;
@@ -528,5 +528,16 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
         // partition_ttl_number and partition_ttl work for mv with
         // single column range partitioning(including expr partitioning).
         ttlPartitionScheduler.scheduleTTLPartition();
+    }
+
+    @Override
+    protected void onStopped() {
+        // The schedulable-table set and the lastFindingTime watermark are leader-session
+        // bookkeeping; findSchedulableTables() walks dbs/tables and re-registers when the next
+        // leader activates, so leftover entries can be dropped here without losing tables that
+        // were registered through SQL on this leader.
+        dynamicPartitionTableInfo.clear();
+        ttlPartitionScheduler.getTtlPartitionInfo().clear();
+        lastFindingTime = -1;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -58,7 +58,7 @@ import com.starrocks.common.CloseableLock;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.qe.ConnectContext;
@@ -88,7 +88,7 @@ import java.util.stream.Collectors;
  * This checker is responsible for checking all unhealthy tablets.
  * It does not responsible for any scheduler of tablet repairing or balance
  */
-public class TabletChecker extends FrontendDaemon {
+public class TabletChecker extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(TabletChecker.class);
 
     private static final long LOG_PRINT_INTERVAL = 60000L;
@@ -215,7 +215,7 @@ public class TabletChecker extends FrontendDaemon {
      * If a tablet is not healthy, a TabletInfo will be created and sent to TabletScheduler for repairing.
      */
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         int pendingNum = tabletScheduler.getPendingNum();
         int runningNum = tabletScheduler.getRunningNum();
         if (pendingNum > Config.tablet_sched_max_scheduling_tablets
@@ -231,6 +231,18 @@ public class TabletChecker extends FrontendDaemon {
 
         stat.counterTabletCheckRound.incrementAndGet();
         LOG.info(stat.incrementalBrief());
+    }
+
+    @Override
+    protected void onStopped() {
+        // urgentTable is leader-session bookkeeping populated by ADMIN REPAIR TABLE on this
+        // leader; the operator must re-issue ADMIN REPAIR after a re-election if they still
+        // want priority repair. lastLogPrintTime is reset so the next leader's first cycle
+        // logs immediately. stat is intentionally left as-is - it's a process-wide counter.
+        synchronized (urgentTable) {
+            urgentTable.clear();
+        }
+        lastLogPrintTime = -1L;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
@@ -86,6 +87,13 @@ public class BatchWriteMgr extends LeaderDaemon {
 
     @Override
     public synchronized void start() {
+        // Refuse to overlap with a previous worker that did not drain in onStopped(): if the
+        // pool is shutdown but not yet terminated, in-flight merge-commit submissions from the
+        // previous leader session are still running.
+        if (threadPoolExecutor != null && threadPoolExecutor.isShutdown() && !threadPoolExecutor.isTerminated()) {
+            throw new IllegalStateException(
+                    "BatchWriteMgr threadPoolExecutor has not terminated; refuse to restart");
+        }
         if (threadPoolExecutor == null || threadPoolExecutor.isShutdown()) {
             threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
                     Config.merge_commit_executor_threads_num, "merge-commit", true);
@@ -130,9 +138,20 @@ public class BatchWriteMgr extends LeaderDaemon {
             LOG.warn("stop coordinatorBackendAssigner failed", t);
         }
         if (threadPoolExecutor != null && !threadPoolExecutor.isShutdown()) {
-            // shutdownNow() interrupts in-flight merge-commit submissions; we do not
-            // awaitTermination here - the demotion drain is bounded and tasks are leader-only.
+            // shutdownNow() interrupts in-flight merge-commit submissions; wait boundedly so a
+            // subsequent start() does not race a still-alive worker against a freshly created
+            // pool. If termination times out start() will refuse to rebuild.
             threadPoolExecutor.shutdownNow();
+            try {
+                if (!threadPoolExecutor.awaitTermination(
+                        Config.leader_demotion_drain_timeout_sec, TimeUnit.SECONDS)) {
+                    LOG.error("BatchWriteMgr threadPoolExecutor did not terminate within {}s",
+                            Config.leader_demotion_drain_timeout_sec);
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                LOG.warn("Interrupted while waiting for BatchWriteMgr threadPoolExecutor to terminate");
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
@@ -65,10 +65,13 @@ public class BatchWriteMgr extends LeaderDaemon {
     // An assigner that manages the assignment of coordinator backends.
     private final CoordinatorBackendAssigner coordinatorBackendAssigner;
 
-    // A thread pool executor for executing batch write tasks.
-    private final ThreadPoolExecutor threadPoolExecutor;
+    // A thread pool executor for executing batch write tasks. Not final: shutdownNow() in
+    // onStopped() and rebuilt by start() so leader-side worker threads exit promptly on
+    // demotion and a fresh pool is available after re-election.
+    private volatile ThreadPoolExecutor threadPoolExecutor;
 
-    private final TxnStateDispatcher txnStateDispatcher;
+    // Rebuilt together with threadPoolExecutor so it never holds a reference to a shut down pool.
+    private volatile TxnStateDispatcher txnStateDispatcher;
 
     public BatchWriteMgr() {
         super("merge-commit-mgr", Config.merge_commit_gc_check_interval_ms);
@@ -83,6 +86,11 @@ public class BatchWriteMgr extends LeaderDaemon {
 
     @Override
     public synchronized void start() {
+        if (threadPoolExecutor == null || threadPoolExecutor.isShutdown()) {
+            threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
+                    Config.merge_commit_executor_threads_num, "merge-commit", true);
+            txnStateDispatcher = new TxnStateDispatcher(threadPoolExecutor);
+        }
         super.start();
         this.coordinatorBackendAssigner.start();
         LOG.info("Start batch write manager");
@@ -99,8 +107,9 @@ public class BatchWriteMgr extends LeaderDaemon {
         // mergeCommitJobs and the per-table backend-assigner registrations are leader-session
         // bookkeeping: BE coordinators are picked again when the next leader sees the next
         // request. Drop the registrations so a new leader does not inherit assignments made
-        // against a sealed editlog. threadPoolExecutor / coordinatorBackendAssigner are not
-        // shut down here because they are owned by this singleton across leader sessions.
+        // against a sealed editlog. The owned thread pool and the coordinator assigner are
+        // shut down so their worker threads exit promptly during demotion drain; both are
+        // rebuilt by start() on re-election.
         lock.writeLock().lock();
         try {
             for (MergeCommitJob job : mergeCommitJobs.values()) {
@@ -114,6 +123,16 @@ public class BatchWriteMgr extends LeaderDaemon {
             MergeCommitMetricRegistry.getInstance().setJobNum(0);
         } finally {
             lock.writeLock().unlock();
+        }
+        try {
+            coordinatorBackendAssigner.stop();
+        } catch (Throwable t) {
+            LOG.warn("stop coordinatorBackendAssigner failed", t);
+        }
+        if (threadPoolExecutor != null && !threadPoolExecutor.isShutdown()) {
+            // shutdownNow() interrupts in-flight merge-commit submissions; we do not
+            // awaitTermination here - the demotion drain is bounded and tasks are leader-only.
+            threadPoolExecutor.shutdownNow();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.ThreadPoolManager;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.load.streamload.StreamLoadKvParams;
 import com.starrocks.server.GlobalStateMgr;
@@ -49,7 +49,7 @@ import static com.starrocks.server.WarehouseManager.DEFAULT_WAREHOUSE_NAME;
 /**
  * Manages batch write operations.
  */
-public class BatchWriteMgr extends FrontendDaemon {
+public class BatchWriteMgr extends LeaderDaemon {
 
     private static final Logger LOG = LoggerFactory.getLogger(BatchWriteMgr.class);
 
@@ -89,9 +89,32 @@ public class BatchWriteMgr extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         setInterval(Config.merge_commit_gc_check_interval_ms);
         cleanupInactiveJobs();
+    }
+
+    @Override
+    protected void onStopped() {
+        // mergeCommitJobs and the per-table backend-assigner registrations are leader-session
+        // bookkeeping: BE coordinators are picked again when the next leader sees the next
+        // request. Drop the registrations so a new leader does not inherit assignments made
+        // against a sealed editlog. threadPoolExecutor / coordinatorBackendAssigner are not
+        // shut down here because they are owned by this singleton across leader sessions.
+        lock.writeLock().lock();
+        try {
+            for (MergeCommitJob job : mergeCommitJobs.values()) {
+                try {
+                    coordinatorBackendAssigner.unregisterBatchWrite(job.getId());
+                } catch (Throwable t) {
+                    LOG.warn("unregister batch write {} failed", job.getId(), t);
+                }
+            }
+            mergeCommitJobs.clear();
+            MergeCommitMetricRegistry.getInstance().setJobNum(0);
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssigner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssigner.java
@@ -31,6 +31,13 @@ public interface CoordinatorBackendAssigner {
     void start();
 
     /**
+     * Stops the backend assigner, interrupting its internal scheduler so the worker thread
+     * exits promptly during leader demotion. Implementations should make this idempotent
+     * and tolerate being followed by another {@link #start()} after re-election.
+     */
+    void stop();
+
+    /**
      * Registers a batch write with the specified parameters.
      *
      * @param id The ID of the batch write operation.

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
@@ -71,7 +71,9 @@ public final class CoordinatorBackendAssignerImpl implements CoordinatorBackendA
 
     private final AtomicLong taskIdAllocator;
     private final PriorityBlockingQueue<Task> taskPriorityQueue;
-    private final ExecutorService singleExecutor;
+    // Not final: recreated by {@link #start()} if a previous {@link #stop()} shut it down,
+    // so the assigner is reusable across leader demotion / re-election cycles.
+    private volatile ExecutorService singleExecutor;
 
     // Registered load. load id -> LoadMeta
     private final ConcurrentHashMap<Long, LoadMeta> registeredLoadMetas;
@@ -103,9 +105,24 @@ public final class CoordinatorBackendAssignerImpl implements CoordinatorBackendA
     }
 
     @Override
-    public void start() {
-        this.singleExecutor.submit(this::runSchedule);
+    public synchronized void start() {
+        if (singleExecutor == null || singleExecutor.isShutdown()) {
+            singleExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
+                    1, "coordinator-be-assigner", true);
+        }
+        singleExecutor.submit(this::runSchedule);
         LOG.info("Start coordinator be assigner");
+    }
+
+    @Override
+    public synchronized void stop() {
+        // shutdownNow() interrupts the runSchedule worker so its blocking poll() returns;
+        // runSchedule treats InterruptedException as an exit signal. No awaitTermination is
+        // performed here - the demotion drain is bounded by leader_demotion_drain_timeout_sec
+        // and a fresh executor is created on the next start().
+        if (singleExecutor != null && !singleExecutor.isShutdown()) {
+            singleExecutor.shutdownNow();
+        }
     }
 
     /**
@@ -127,6 +144,12 @@ public final class CoordinatorBackendAssignerImpl implements CoordinatorBackendA
                     LOG.debug("Set schedule interval to {} ms", checkIntervalMs);
                 }
                 task = taskPriorityQueue.poll(checkIntervalMs, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException ie) {
+                // shutdownNow() interrupts this thread on leader demotion; exit the schedule
+                // loop so the worker can be replaced by a fresh one on the next start().
+                Thread.currentThread().interrupt();
+                LOG.info("Coordinator be assigner interrupted, exiting");
+                return;
             } catch (Throwable throwable) {
                 LOG.warn("Failed to poll task queue", throwable);
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
@@ -149,6 +149,17 @@ public final class CoordinatorBackendAssignerImpl implements CoordinatorBackendA
                 return;
             }
         }
+        // Now that the schedule loop has terminated, drop the leader-session state it owned.
+        // BatchWriteMgr.onStopped() pushes async UNREGISTER_LOAD tasks for each merge-commit
+        // job before calling stop(), but those tasks are discarded by shutdownNow(); without
+        // an explicit clear here, warehouseMetas / registeredLoadMetas / taskPriorityQueue
+        // would survive into the next leader session and let stale load ownership leak into
+        // new backend assignments. Safe to mutate without further locking because the only
+        // writer (runSchedule) has just terminated.
+        taskPriorityQueue.clear();
+        registeredLoadMetas.clear();
+        warehouseMetas.clear();
+        numPendingTasksForDetectUnavailableNodes.set(0);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
@@ -95,8 +95,7 @@ public final class CoordinatorBackendAssignerImpl implements CoordinatorBackendA
     public CoordinatorBackendAssignerImpl() {
         this.taskIdAllocator = new AtomicLong(0);
         this.taskPriorityQueue = new PriorityBlockingQueue<>(32, TaskComparator.INSTANCE);
-        this.singleExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
-                1, "coordinator-be-assigner", true);
+        this.singleExecutor = null;
         this.registeredLoadMetas = new ConcurrentHashMap<>();
         this.warehouseMetas = new HashMap<>();
         this.numPendingTasksForDetectUnavailableNodes = new AtomicLong(0);
@@ -106,10 +105,19 @@ public final class CoordinatorBackendAssignerImpl implements CoordinatorBackendA
 
     @Override
     public synchronized void start() {
-        if (singleExecutor == null || singleExecutor.isShutdown()) {
-            singleExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
-                    1, "coordinator-be-assigner", true);
+        if (singleExecutor != null && !singleExecutor.isShutdown()) {
+            LOG.warn("CoordinatorBackendAssigner already running, skip duplicate start()");
+            return;
         }
+        // Refuse to overlap with a previous worker that did not drain. After {@link #stop()}
+        // succeeds the executor is both shutdown and terminated; if it is only shutdown we may
+        // still have a live worker from the previous leader session.
+        if (singleExecutor != null && !singleExecutor.isTerminated()) {
+            throw new IllegalStateException(
+                    "CoordinatorBackendAssigner previous worker has not terminated; refuse to start a new one");
+        }
+        singleExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
+                1, "coordinator-be-assigner", true);
         singleExecutor.submit(this::runSchedule);
         LOG.info("Start coordinator be assigner");
     }
@@ -117,11 +125,29 @@ public final class CoordinatorBackendAssignerImpl implements CoordinatorBackendA
     @Override
     public synchronized void stop() {
         // shutdownNow() interrupts the runSchedule worker so its blocking poll() returns;
-        // runSchedule treats InterruptedException as an exit signal. No awaitTermination is
-        // performed here - the demotion drain is bounded by leader_demotion_drain_timeout_sec
-        // and a fresh executor is created on the next start().
+        // runSchedule treats InterruptedException as an exit signal. Wait boundedly for the
+        // worker to actually exit so a subsequent start() does not race a still-alive worker
+        // against a freshly created one.
         if (singleExecutor != null && !singleExecutor.isShutdown()) {
             singleExecutor.shutdownNow();
+        }
+        if (singleExecutor != null) {
+            boolean terminated = false;
+            try {
+                terminated = singleExecutor.awaitTermination(
+                        Config.leader_demotion_drain_timeout_sec, TimeUnit.SECONDS);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                LOG.warn("Interrupted while waiting for coordinator-be-assigner to terminate");
+            }
+            if (!terminated) {
+                // The executor remains shutdown-but-not-terminated, so a subsequent start()
+                // refuses to spin up a parallel worker; the stuck worker plus a new one would
+                // corrupt warehouseMetas.
+                LOG.error("CoordinatorBackendAssigner worker did not exit within {}s; refusing future restart",
+                        Config.leader_demotion_drain_timeout_sec);
+                return;
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJobScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJobScheduler.java
@@ -40,7 +40,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DuplicatedRequestException;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.LoadException;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.load.FailMsg;
@@ -57,7 +57,7 @@ import java.util.concurrent.RejectedExecutionException;
  * The function of execute will be called in LoadScheduler.
  * The status of LoadJob will be changed to loading after LoadScheduler.
  */
-public class LoadJobScheduler extends FrontendDaemon {
+public class LoadJobScheduler extends LeaderDaemon {
 
     private static final Logger LOG = LogManager.getLogger(LoadJobScheduler.class);
 
@@ -68,12 +68,20 @@ public class LoadJobScheduler extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         try {
             process();
         } catch (Throwable e) {
             LOG.warn("Failed to process one round of LoadJobScheduler with error message {}", e.getMessage(), e);
         }
+    }
+
+    @Override
+    protected void onStopped() {
+        // The pending LoadJob refs are leader-session bookkeeping; LoadMgr.prepareJobs() re-queues
+        // unfinished jobs from persistent state when the next leader activates, so dropping them
+        // here avoids double-scheduling on re-election.
+        needScheduleJobs.clear();
     }
 
     private void process() throws InterruptedException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.history.TableKeeper;
 import com.starrocks.server.GlobalStateMgr;
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.Logger;
 
 /**
  */
-public class LoadsHistorySyncer extends FrontendDaemon {
+public class LoadsHistorySyncer extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(LoadsHistorySyncer.class);
 
     public static final String LOADS_HISTORY_DB_NAME = "_statistics_";
@@ -116,7 +116,7 @@ public class LoadsHistorySyncer extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         if (FeConstants.runningUnitTest) {
             return;
         }
@@ -138,6 +138,15 @@ public class LoadsHistorySyncer extends FrontendDaemon {
         } catch (Throwable e) {
             LOG.warn("Failed to process one round of LoadJobScheduler with error message {}", e.getMessage(), e);
         }
+    }
+
+    @Override
+    protected void onStopped() {
+        // Reset leader-session bookkeeping: firstSync re-arms the "wait one cycle for table
+        // keeper" warm-up, and syncedLoadFinishTime resets so the next leader does not skip
+        // syncing rows whose finish times pre-date its activation.
+        firstSync = true;
+        syncedLoadFinishTime = -1L;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
@@ -39,7 +39,7 @@ import com.google.common.collect.Sets;
 import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.server.GlobalStateMgr;
@@ -48,7 +48,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-public class RoutineLoadScheduler extends FrontendDaemon {
+public class RoutineLoadScheduler extends LeaderDaemon {
 
     private static final Logger LOG = LogManager.getLogger(RoutineLoadScheduler.class);
 
@@ -56,7 +56,7 @@ public class RoutineLoadScheduler extends FrontendDaemon {
 
     @VisibleForTesting
     public RoutineLoadScheduler() {
-        super();
+        super("routine-load-scheduler", Config.routine_load_scheduler_interval_millisecond);
         routineLoadManager = GlobalStateMgr.getCurrentState().getRoutineLoadMgr();
     }
 
@@ -66,7 +66,7 @@ public class RoutineLoadScheduler extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         try {
             process();
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -43,7 +43,7 @@ import com.starrocks.common.LoadException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.DebugUtil;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.load.routineload.RoutineLoadJob.JobState;
@@ -73,7 +73,7 @@ import java.util.concurrent.TimeUnit;
  * <p>
  * The scheduler will be blocked in step3 till the queue receive a new task
  */
-public class RoutineLoadTaskScheduler extends FrontendDaemon {
+public class RoutineLoadTaskScheduler extends LeaderDaemon {
 
     private static final Logger LOG = LogManager.getLogger(RoutineLoadTaskScheduler.class);
 
@@ -100,12 +100,24 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         try {
             process();
         } catch (Throwable e) {
             LOG.warn("Failed to process one round of RoutineLoadTaskScheduler", e);
         }
+    }
+
+    @Override
+    protected void onStopped() {
+        // The task queue holds RoutineLoadTaskInfo refs that are leader-session bookkeeping;
+        // RoutineLoadMgr re-divides routine load jobs into tasks when the next leader activates.
+        // The slot watermark is reset so the next leader re-queries BE slot capacity.
+        needScheduleTasksQueue.clear();
+        lastBackendSlotUpdateTime = -1;
+        // scheduledExecutorService and threadPool are not shut down here - they are owned by
+        // this singleton and live across leader sessions; in-flight submissions complete on
+        // their own. Tier 3 may revisit this once executors become re-creatable.
     }
 
     private void process() throws InterruptedException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -83,8 +83,11 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
 
     private final RoutineLoadMgr routineLoadManager;
     private final LinkedBlockingQueue<RoutineLoadTaskInfo> needScheduleTasksQueue = Queues.newLinkedBlockingQueue();
-    private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-    private final ExecutorService threadPool = Executors.newCachedThreadPool();
+    // Not final: shutdownNow() in onStopped() interrupts the delay-scheduler / dispatch pool
+    // so their worker threads exit promptly on demotion; both are rebuilt by start() on
+    // re-election.
+    private volatile ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    private volatile ExecutorService threadPool = Executors.newCachedThreadPool();
 
     private long lastBackendSlotUpdateTime = -1;
 
@@ -97,6 +100,17 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
     public RoutineLoadTaskScheduler(RoutineLoadMgr routineLoadManager) {
         super("routine-load-task-scheduler", 0);
         this.routineLoadManager = routineLoadManager;
+    }
+
+    @Override
+    public synchronized void start() {
+        if (scheduledExecutorService.isShutdown()) {
+            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        }
+        if (threadPool.isShutdown()) {
+            threadPool = Executors.newCachedThreadPool();
+        }
+        super.start();
     }
 
     @Override
@@ -115,9 +129,12 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
         // The slot watermark is reset so the next leader re-queries BE slot capacity.
         needScheduleTasksQueue.clear();
         lastBackendSlotUpdateTime = -1;
-        // scheduledExecutorService and threadPool are not shut down here - they are owned by
-        // this singleton and live across leader sessions; in-flight submissions complete on
-        // their own. Tier 3 may revisit this once executors become re-creatable.
+        // shutdownNow() interrupts the delay-scheduler / dispatch workers so they exit even
+        // if blocked on metadata locks (which become interruptible in a later PR). We do not
+        // awaitTermination - the demotion drain is bounded and a fresh pool is built by
+        // start() on re-election.
+        scheduledExecutorService.shutdownNow();
+        threadPool.shutdownNow();
     }
 
     private void process() throws InterruptedException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -104,6 +105,17 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
 
     @Override
     public synchronized void start() {
+        // Refuse to overlap with a previous worker that did not drain. The previous {@link
+        // #onStopped()} both shutdownNow()s and awaitTermination()s; if a pool is shutdown but
+        // not terminated we still have live workers from the previous leader session.
+        if (scheduledExecutorService.isShutdown() && !scheduledExecutorService.isTerminated()) {
+            throw new IllegalStateException(
+                    "RoutineLoadTaskScheduler scheduledExecutorService has not terminated; refuse to restart");
+        }
+        if (threadPool.isShutdown() && !threadPool.isTerminated()) {
+            throw new IllegalStateException(
+                    "RoutineLoadTaskScheduler threadPool has not terminated; refuse to restart");
+        }
         if (scheduledExecutorService.isShutdown()) {
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
         }
@@ -130,11 +142,28 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
         needScheduleTasksQueue.clear();
         lastBackendSlotUpdateTime = -1;
         // shutdownNow() interrupts the delay-scheduler / dispatch workers so they exit even
-        // if blocked on metadata locks (which become interruptible in a later PR). We do not
-        // awaitTermination - the demotion drain is bounded and a fresh pool is built by
-        // start() on re-election.
+        // if blocked on metadata locks. Wait boundedly for both pools to actually terminate so
+        // a subsequent start() does not rebuild and run new workers in parallel with the old
+        // ones - that would race on routineLoadManager state and BE slot accounting. If a pool
+        // does not terminate within the timeout, start() will refuse to restart this scheduler.
         scheduledExecutorService.shutdownNow();
         threadPool.shutdownNow();
+        long timeoutMs = Config.leader_demotion_drain_timeout_sec * 1000L;
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        awaitTermination("scheduledExecutorService", scheduledExecutorService, deadline);
+        awaitTermination("threadPool", threadPool, deadline);
+    }
+
+    private static void awaitTermination(String name, java.util.concurrent.ExecutorService pool, long deadlineMs) {
+        long remainingMs = Math.max(1L, deadlineMs - System.currentTimeMillis());
+        try {
+            if (!pool.awaitTermination(remainingMs, TimeUnit.MILLISECONDS)) {
+                LOG.error("RoutineLoadTaskScheduler {} did not terminate within drain timeout", name);
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while waiting for RoutineLoadTaskScheduler {} to terminate", name);
+        }
     }
 
     private void process() throws InterruptedException {
@@ -182,23 +211,47 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
         if (msg != null) {
             routineLoadTaskInfo.setMsg(msg, true);
         }
-        scheduledExecutorService.schedule(() -> {
-            try {
-                needScheduleTasksQueue.put(routineLoadTaskInfo);
-            } catch (InterruptedException exception) {
-                LOG.warn("put task to queue failed", exception);
-            }
-        }, 1L, TimeUnit.SECONDS);
+        if (isStopped() || scheduledExecutorService.isShutdown()) {
+            LOG.info("RoutineLoadTaskScheduler is stopped, skip delayPutToQueue for task {}",
+                    routineLoadTaskInfo.getId());
+            return;
+        }
+        try {
+            scheduledExecutorService.schedule(() -> {
+                try {
+                    needScheduleTasksQueue.put(routineLoadTaskInfo);
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    LOG.warn("put task to queue failed", exception);
+                }
+            }, 1L, TimeUnit.SECONDS);
+        } catch (RejectedExecutionException e) {
+            // Race with onStopped(): scheduler was shut down between the guard above and
+            // schedule(). Safe to drop - the next leader will re-divide the routine load.
+            LOG.info("RoutineLoadTaskScheduler scheduler shut down, drop delayPutToQueue for task {}",
+                    routineLoadTaskInfo.getId());
+        }
     }
 
     private void submitToSchedule(RoutineLoadTaskInfo routineLoadTaskInfo) {
-        threadPool.submit(() -> {
-            try {
-                scheduleOneTask(routineLoadTaskInfo);
-            } catch (Exception e) {
-                LOG.warn("schedule routine load task failed", e);
-            }
-        });
+        if (isStopped() || threadPool.isShutdown()) {
+            LOG.info("RoutineLoadTaskScheduler is stopped, skip submitToSchedule for task {}",
+                    routineLoadTaskInfo.getId());
+            return;
+        }
+        try {
+            threadPool.submit(() -> {
+                try {
+                    scheduleOneTask(routineLoadTaskInfo);
+                } catch (Exception e) {
+                    LOG.warn("schedule routine load task failed", e);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            // Race with onStopped(): pool was shut down between the guard above and submit().
+            LOG.info("RoutineLoadTaskScheduler threadPool shut down, drop submitToSchedule for task {}",
+                    routineLoadTaskInfo.getId());
+        }
     }
 
     void scheduleOneTask(RoutineLoadTaskInfo routineLoadTaskInfo) throws Exception {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -136,11 +136,6 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
 
     @Override
     protected void onStopped() {
-        // The task queue holds RoutineLoadTaskInfo refs that are leader-session bookkeeping;
-        // RoutineLoadMgr re-divides routine load jobs into tasks when the next leader activates.
-        // The slot watermark is reset so the next leader re-queries BE slot capacity.
-        needScheduleTasksQueue.clear();
-        lastBackendSlotUpdateTime = -1;
         // shutdownNow() interrupts the delay-scheduler / dispatch workers so they exit even
         // if blocked on metadata locks. Wait boundedly for both pools to actually terminate so
         // a subsequent start() does not rebuild and run new workers in parallel with the old
@@ -152,6 +147,16 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
         long deadline = System.currentTimeMillis() + timeoutMs;
         awaitTermination("scheduledExecutorService", scheduledExecutorService, deadline);
         awaitTermination("threadPool", threadPool, deadline);
+        // Clear AFTER both pools have terminated: a delay-runnable scheduled by the previous
+        // leader can fire mid-onStopped() and call needScheduleTasksQueue.put() before the
+        // interrupt from shutdownNow() lands. Clearing before the pools drain would leave any
+        // such stale put in the queue, where the next leader would poll it as if it were its
+        // own work.
+        // The task queue holds RoutineLoadTaskInfo refs that are leader-session bookkeeping;
+        // RoutineLoadMgr re-divides routine load jobs into tasks when the next leader activates.
+        // The slot watermark is reset so the next leader re-queries BE slot capacity.
+        needScheduleTasksQueue.clear();
+        lastBackendSlotUpdateTime = -1;
     }
 
     private static void awaitTermination(String name, java.util.concurrent.ExecutorService pool, long deadlineMs) {

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
@@ -21,7 +21,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -43,7 +43,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-public class ReplicationMgr extends FrontendDaemon {
+public class ReplicationMgr extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(ReplicationMgr.class);
 
     @SerializedName(value = "runningJobs")
@@ -60,10 +60,14 @@ public class ReplicationMgr extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         runRunningJobs();
         clearExpiredJobs();
     }
+
+    // runningJobs / committedJobs / abortedJobs are persistent state (saved/loaded via image,
+    // updated on followers via editlog replay). They must NOT be cleared on demotion - the
+    // next leader resumes those jobs from the same maps. So no onStopped() override is needed.
 
     public void addReplicationJob(TTableReplicationRequest request) throws StarRocksException {
         LOG.debug("Add replication job, database id: {}, table id: {}, job id: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1660,23 +1660,38 @@ public class GlobalStateMgr {
         stopOne("reportHandler", () -> reportHandler.stopGracefully(timeoutMs));
         stopOne("temporaryTableCleaner", () -> temporaryTableCleaner.stopGracefully(timeoutMs));
         stopOne("metaRecoveryDaemon", () -> metaRecoveryDaemon.stopGracefully(timeoutMs));
+        stopOne("replicationMgr", () -> replicationMgr.stopGracefully(timeoutMs));
         stopOne("safeModeChecker", () -> safeModeChecker.stopGracefully(timeoutMs));
         stopOne("spmAutoCapturer", () -> spmAutoCapturer.stopGracefully(timeoutMs));
         stopOne("mvActiveChecker", () -> mvActiveChecker.stopGracefully(timeoutMs));
+        stopOne("statisticAutoCollector", () -> statisticAutoCollector.stopGracefully(timeoutMs));
+        stopOne("statisticsMetaManager", () -> statisticsMetaManager.stopGracefully(timeoutMs));
         stopOne("updateDbUsedDataQuotaDaemon", () -> updateDbUsedDataQuotaDaemon.stopGracefully(timeoutMs));
+        stopOne("dynamicPartitionScheduler", () -> dynamicPartitionScheduler.stopGracefully(timeoutMs));
+        stopOne("batchWriteMgr", () -> batchWriteMgr.stopGracefully(timeoutMs));
+        stopOne("routineLoadTaskScheduler", () -> routineLoadTaskScheduler.stopGracefully(timeoutMs));
+        stopOne("routineLoadScheduler", () -> routineLoadScheduler.stopGracefully(timeoutMs));
         if (timePrinter != null) {
             stopOne("timePrinter", () -> timePrinter.stopGracefully(timeoutMs));
         }
+        stopOne("recycleBin", () -> getRecycleBin().stopGracefully(timeoutMs));
+        stopOne("backupHandler", () -> getBackupHandler().stopGracefully(timeoutMs));
         stopOne("consistencyChecker", () -> consistencyChecker.stopGracefully(timeoutMs));
+        stopOne("alterJobMgr", () -> getAlterJobMgr().stopGracefully(timeoutMs));
         if (txnTimeoutChecker != null) {
             stopOne("txnTimeoutChecker", () -> txnTimeoutChecker.stopGracefully(timeoutMs));
         }
         stopOne("publishVersionDaemon", () -> publishVersionDaemon.stopGracefully(timeoutMs));
         stopOne("loadLoadingChecker", () -> loadLoadingChecker.stopGracefully(timeoutMs));
         stopOne("loadEtlChecker", () -> loadEtlChecker.stopGracefully(timeoutMs));
+        stopOne("loadsHistorySyncer", () -> loadsHistorySyncer.stopGracefully(timeoutMs));
         stopOne("loadTimeoutChecker", () -> loadTimeoutChecker.stopGracefully(timeoutMs));
+        stopOne("loadJobScheduler", () -> loadJobScheduler.stopGracefully(timeoutMs));
         if (!RunMode.isSharedDataMode()) {
+            stopOne("colocateTableBalancer",
+                    () -> ColocateTableBalancer.getInstance().stopGracefully(timeoutMs));
             stopOne("tabletScheduler", () -> tabletScheduler.stopGracefully(timeoutMs));
+            stopOne("tabletChecker", () -> tabletChecker.stopGracefully(timeoutMs));
         }
         stopOne("heartbeatMgr", () -> heartbeatMgr.stopGracefully(timeoutMs));
         stopOne("keyRotationDaemon", () -> keyRotationDaemon.stopGracefully(timeoutMs));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -20,7 +20,7 @@ import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class StatisticAutoCollector extends FrontendDaemon {
+public class StatisticAutoCollector extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(StatisticAutoCollector.class);
 
     private static final StatisticExecutor STATISTIC_EXECUTOR = new StatisticExecutor();
@@ -50,7 +50,7 @@ public class StatisticAutoCollector extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         // update interval
         if (getInterval() != Config.statistic_collect_interval_sec * 1000) {
             setInterval(Config.statistic_collect_interval_sec * 1000);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -26,7 +26,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.AutoInferUtil;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.load.pipe.filelist.RepoCreator;
 import com.starrocks.qe.ConnectContext;
@@ -76,7 +76,7 @@ import static com.starrocks.type.FloatType.DOUBLE;
 import static com.starrocks.type.IntegerType.BIGINT;
 import static com.starrocks.type.JsonType.JSON;
 
-public class StatisticsMetaManager extends FrontendDaemon {
+public class StatisticsMetaManager extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(StatisticsMetaManager.class);
 
     public StatisticsMetaManager() {
@@ -575,7 +575,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         // To make UT pass, some UT will create database and table
         trySleep(Config.statistic_manager_sleep_time_sec * 1000);
         while (!checkDatabaseExist()) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -454,12 +454,16 @@ public class StatisticsMetaManager extends LeaderDaemon {
         }
     }
 
-    private void trySleep(long millis) {
-        try {
-            Thread.sleep(millis);
-        } catch (InterruptedException e) {
-            LOG.warn(e.getMessage(), e);
-        }
+    /**
+     * Sleep for {@code millis} ms. Re-throws {@link InterruptedException} so the caller can stop
+     * the current leader-session cycle promptly. Callers running inside {@link #runAfterLeaseValid}
+     * must propagate the exception (or otherwise return) instead of swallowing it, so that
+     * {@link LeaderDaemon#stopGracefully(long)} can drain the worker on demotion. The interrupt
+     * flag is intentionally cleared by {@link Thread#sleep}; we let the exception itself signal
+     * stop.
+     */
+    private void trySleep(long millis) throws InterruptedException {
+        Thread.sleep(millis);
     }
 
     private boolean createTable(String tableName) {
@@ -487,7 +491,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
         }
     }
 
-    public boolean alterTable(String tableName) {
+    public boolean alterTable(String tableName) throws InterruptedException {
         ConnectContext context = StatisticUtils.buildConnectContext();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(STATISTICS_DB_NAME);
         Table table =  GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
@@ -500,7 +504,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
         }
     }
 
-    public boolean alterFullStatisticsTable(ConnectContext context, Table table) {
+    public boolean alterFullStatisticsTable(ConnectContext context, Table table) throws InterruptedException {
         for (String columnName : FULL_STATISTICS_COMPATIBLE_COLUMNS) {
             if (table.getColumn(columnName) == null) {
                 if (columnName.equalsIgnoreCase("collection_size")) {
@@ -526,6 +530,9 @@ public class StatisticsMetaManager extends LeaderDaemon {
                     }
 
                     while (table.getColumn(columnName) == null) {
+                        if (isStopped()) {
+                            return false;
+                        }
                         // `alter table` may be sync in the shared-nothing cluster. So we need to check if job is done.
                         // TODO(stephen): This check is not robust because we can't get job handle here.
                         List<AlterJobV2> unfinishedAlterJobs = GlobalStateMgr.getCurrentState().getAlterJobMgr()
@@ -553,19 +560,22 @@ public class StatisticsMetaManager extends LeaderDaemon {
         return true;
     }
 
-    private void refreshStatisticsTable(String tableName) {
-        while (!checkTableExist(tableName)) {
+    private void refreshStatisticsTable(String tableName) throws InterruptedException {
+        while (!isStopped() && !checkTableExist(tableName)) {
             if (createTable(tableName)) {
                 break;
             }
             LOG.warn("create statistics table " + tableName + " failed");
             trySleep(10000);
         }
+        if (isStopped()) {
+            return;
+        }
         if (checkTableExist(tableName)) {
             StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName);
         }
 
-        while (!checkTableCompatible(tableName)) {
+        while (!isStopped() && !checkTableCompatible(tableName)) {
             if (alterTable(tableName)) {
                 break;
             }
@@ -575,14 +585,17 @@ public class StatisticsMetaManager extends LeaderDaemon {
     }
 
     @Override
-    protected void runAfterLeaseValid() {
+    protected void runAfterLeaseValid() throws InterruptedException {
         // To make UT pass, some UT will create database and table
         trySleep(Config.statistic_manager_sleep_time_sec * 1000);
-        while (!checkDatabaseExist()) {
+        while (!isStopped() && !checkDatabaseExist()) {
             if (createDatabase()) {
                 break;
             }
             trySleep(10000);
+        }
+        if (isStopped()) {
+            return;
         }
 
         refreshStatisticsTable(SAMPLE_STATISTICS_TABLE_NAME);
@@ -593,6 +606,9 @@ public class StatisticsMetaManager extends LeaderDaemon {
         refreshStatisticsTable(MULTI_COLUMN_STATISTICS_TABLE_NAME);
         refreshStatisticsTable(SPM_BASELINE_TABLE_NAME);
         refreshStatisticsTable(QUERY_HISTORY_TABLE_NAME);
+        if (isStopped()) {
+            return;
+        }
 
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().clearStatisticFromDroppedPartition();
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().clearStatisticFromDroppedTable();
@@ -603,25 +619,30 @@ public class StatisticsMetaManager extends LeaderDaemon {
     }
 
     public void createStatisticsTablesForTest() {
-        while (!checkDatabaseExist()) {
-            if (createDatabase()) {
-                break;
+        try {
+            while (!checkDatabaseExist()) {
+                if (createDatabase()) {
+                    break;
+                }
+                trySleep(1);
             }
-            trySleep(1);
-        }
 
-        boolean existsSample = false;
-        boolean existsFull = false;
-        while (!existsSample || !existsFull) {
-            existsSample = checkTableExist(SAMPLE_STATISTICS_TABLE_NAME);
-            existsFull = checkTableExist(FULL_STATISTICS_TABLE_NAME);
-            if (!existsSample) {
-                createTable(SAMPLE_STATISTICS_TABLE_NAME);
+            boolean existsSample = false;
+            boolean existsFull = false;
+            while (!existsSample || !existsFull) {
+                existsSample = checkTableExist(SAMPLE_STATISTICS_TABLE_NAME);
+                existsFull = checkTableExist(FULL_STATISTICS_TABLE_NAME);
+                if (!existsSample) {
+                    createTable(SAMPLE_STATISTICS_TABLE_NAME);
+                }
+                if (!existsFull) {
+                    createTable(FULL_STATISTICS_TABLE_NAME);
+                }
+                trySleep(1);
             }
-            if (!existsFull) {
-                createTable(FULL_STATISTICS_TABLE_NAME);
-            }
-            trySleep(1);
+        } catch (InterruptedException e) {
+            // Test helper: just restore the interrupt flag and return.
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerTest.java
@@ -232,6 +232,33 @@ public class AlterHandlerTest {
     }
 
     /**
+     * start() must refuse to spin up a fresh pool when the previous one is shutdown but has
+     * not actually terminated yet - otherwise two AlterReplicaTask submission workers could
+     * race on alterJobsV2 during a fast demote/re-elect cycle.
+     */
+    @Test
+    public void testStartRefusesToRestartBeforePreviousPoolTerminates() throws Exception {
+        java.util.concurrent.ThreadPoolExecutor blockedPool = new java.util.concurrent.ThreadPoolExecutor(
+                1, 1, 0L, java.util.concurrent.TimeUnit.MILLISECONDS,
+                new java.util.concurrent.ArrayBlockingQueue<>(1));
+        blockedPool.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedPool.shutdown();
+        org.apache.commons.lang3.reflect.FieldUtils.writeField(handler, "executor", blockedPool, true);
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, handler::start);
+        } finally {
+            blockedPool.shutdownNow();
+        }
+    }
+
+    /**
      * Helper method to create a mock AlterJobV2 with specified properties.
      */
     private AlterJobV2 createMockJob(long jobId, long tableId, long txnId, AlterJobV2.JobState state) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerTest.java
@@ -208,6 +208,30 @@ public class AlterHandlerTest {
     }
 
     /**
+     * After onStopped() shuts down the AlterReplicaTask executor, a subsequent start() must
+     * rebuild it so that handleFinishAlterTask submissions accepted by the next leader land
+     * on a fresh pool rather than throwing RejectedExecutionException forever.
+     */
+    @Test
+    public void testStartRebuildsExecutorAfterOnStopped() throws Exception {
+        java.util.concurrent.ThreadPoolExecutor poolBeforeStop =
+                (java.util.concurrent.ThreadPoolExecutor) org.apache.commons.lang3.reflect.FieldUtils
+                        .readField(handler, "executor", true);
+        org.apache.commons.lang3.reflect.MethodUtils.invokeMethod(handler, true, "onStopped");
+        Assertions.assertTrue(poolBeforeStop.isShutdown(),
+                "executor must be shut down on demotion so AlterReplicaTask workers exit");
+
+        handler.start();
+        java.util.concurrent.ThreadPoolExecutor poolAfterRestart =
+                (java.util.concurrent.ThreadPoolExecutor) org.apache.commons.lang3.reflect.FieldUtils
+                        .readField(handler, "executor", true);
+        Assertions.assertNotSame(poolBeforeStop, poolAfterRestart,
+                "start() must rebuild the executor after demotion");
+        Assertions.assertFalse(poolAfterRestart.isShutdown());
+        handler.setStop();
+    }
+
+    /**
      * Helper method to create a mock AlterJobV2 with specified properties.
      */
     private AlterJobV2 createMockJob(long jobId, long tableId, long txnId, AlterJobV2.JobState state) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrTest.java
@@ -90,6 +90,78 @@ public class AlterJobMgrTest {
         Assertions.assertEquals((Long) 1L, result.get(2L));
     }
 
+    @Test
+    public void testStopGracefullyDrainsAllHandlers() {
+        // AlterJobMgr is an aggregator; stopGracefully(timeoutMs) must reach every wired
+        // handler so each one's worker thread exits and onStopped() runs. LeaderDaemon's
+        // stopGracefully is final, so we observe the contract via the onStopped() hook
+        // it invokes for an unstarted daemon (worker=null path).
+        boolean[] schemaChangeStopped = new boolean[1];
+        boolean[] mvStopped = new boolean[1];
+        boolean[] systemStopped = new boolean[1];
+
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler() {
+            @Override
+            protected void onStopped() {
+                schemaChangeStopped[0] = true;
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler() {
+            @Override
+            protected void onStopped() {
+                mvStopped[0] = true;
+            }
+        };
+        SystemHandler systemHandler = new SystemHandler() {
+            @Override
+            protected void onStopped() {
+                systemStopped[0] = true;
+            }
+        };
+        AlterJobMgr alterJobMgr = new AlterJobMgr(schemaChangeHandler, materializedViewHandler, systemHandler);
+
+        alterJobMgr.stopGracefully(1000L);
+
+        Assertions.assertTrue(schemaChangeStopped[0], "schemaChangeHandler must be stopped");
+        Assertions.assertTrue(mvStopped[0], "materializedViewHandler must be stopped");
+        Assertions.assertTrue(systemStopped[0], "clusterHandler must be stopped");
+    }
+
+    @Test
+    public void testStopGracefullyContinuesWhenOneHandlerThrows() {
+        // A misbehaving handler must not abort the demotion drain; the remaining handlers
+        // still need to be stopped. setStop() runs before stopGracefully's internal
+        // try/catch around onStopped, so a throwing setStop propagates - AlterJobMgr's
+        // own per-handler try/catch is the safety net we exercise here.
+        boolean[] mvStopped = new boolean[1];
+        boolean[] systemStopped = new boolean[1];
+
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler() {
+            @Override
+            public void setStop() {
+                throw new RuntimeException("simulated handler stop failure");
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler() {
+            @Override
+            protected void onStopped() {
+                mvStopped[0] = true;
+            }
+        };
+        SystemHandler systemHandler = new SystemHandler() {
+            @Override
+            protected void onStopped() {
+                systemStopped[0] = true;
+            }
+        };
+        AlterJobMgr alterJobMgr = new AlterJobMgr(schemaChangeHandler, materializedViewHandler, systemHandler);
+
+        alterJobMgr.stopGracefully(1000L);
+
+        Assertions.assertTrue(mvStopped[0], "materializedViewHandler must still be stopped");
+        Assertions.assertTrue(systemStopped[0], "clusterHandler must still be stopped");
+    }
+
     private RollupJobV2 buildRollupJob(long id) {
         return new RollupJobV2(id, 20001, 30001, "test", 3600000,
                 0, 0, "test", "test", 1,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrTest.java
@@ -162,6 +162,59 @@ public class AlterJobMgrTest {
         Assertions.assertTrue(systemStopped[0], "clusterHandler must still be stopped");
     }
 
+    @Test
+    public void testStopGracefullyContinuesWhenMaterializedViewHandlerThrows() {
+        // Mirror of the previous test, but the middle handler is the one that misbehaves.
+        // Covers the materializedViewHandler-specific try/catch arm in stopGracefully so a
+        // failure there does not skip the SystemHandler drain.
+        boolean[] schemaChangeStopped = new boolean[1];
+        boolean[] systemStopped = new boolean[1];
+
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler() {
+            @Override
+            protected void onStopped() {
+                schemaChangeStopped[0] = true;
+            }
+        };
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler() {
+            @Override
+            public void setStop() {
+                throw new RuntimeException("simulated materializedView stop failure");
+            }
+        };
+        SystemHandler systemHandler = new SystemHandler() {
+            @Override
+            protected void onStopped() {
+                systemStopped[0] = true;
+            }
+        };
+        AlterJobMgr alterJobMgr = new AlterJobMgr(schemaChangeHandler, materializedViewHandler, systemHandler);
+
+        alterJobMgr.stopGracefully(1000L);
+
+        Assertions.assertTrue(schemaChangeStopped[0], "schemaChangeHandler must still be stopped");
+        Assertions.assertTrue(systemStopped[0], "clusterHandler must still be stopped");
+    }
+
+    @Test
+    public void testStopGracefullyTolerantsClusterHandlerThrowing() {
+        // The last handler in the fan-out is SystemHandler (a.k.a. clusterHandler). Its
+        // try/catch arm has no successor to verify, so we just assert the call completes
+        // without propagating the exception - the safety net must absorb it.
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        SystemHandler systemHandler = new SystemHandler() {
+            @Override
+            public void setStop() {
+                throw new RuntimeException("simulated cluster stop failure");
+            }
+        };
+        AlterJobMgr alterJobMgr = new AlterJobMgr(schemaChangeHandler, materializedViewHandler, systemHandler);
+
+        // Should not throw - the SystemHandler-arm catch swallows.
+        Assertions.assertDoesNotThrow(() -> alterJobMgr.stopGracefully(1000L));
+    }
+
     private RollupJobV2 buildRollupJob(long id) {
         return new RollupJobV2(id, 20001, 30001, "test", 3600000,
                 0, 0, "test", "test", 1,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrTest.java
@@ -197,7 +197,7 @@ public class AlterJobMgrTest {
     }
 
     @Test
-    public void testStopGracefullyTolerantsClusterHandlerThrowing() {
+    public void testStopGracefullyToleratesClusterHandlerThrowing() {
         // The last handler in the fan-out is SystemHandler (a.k.a. clusterHandler). Its
         // try/catch arm has no successor to verify, so we just assert the call completes
         // without propagating the exception - the safety net must absorb it.

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeFastSchemaChangeTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeFastSchemaChangeTestBase.java
@@ -769,21 +769,21 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
 
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
         job1.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
-        schemaChangeHandler.runAfterCatalogReady();
+        schemaChangeHandler.runAfterLeaseValid();
         Assertions.assertSame(job1, schemaChangeHandler.getAlterJobsV2().get(job1.getJobId()));
         Assertions.assertFalse(getHistorySchema(job1).isExpired());
         GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), runningTxn1, "fail1");
-        schemaChangeHandler.runAfterCatalogReady();
+        schemaChangeHandler.runAfterLeaseValid();
         Assertions.assertNull(schemaChangeHandler.getAlterJobsV2().get(job1.getJobId()));
 
         GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), runningTxn2, "fail2");
-        schemaChangeHandler.runAfterCatalogReady();
+        schemaChangeHandler.runAfterLeaseValid();
         Assertions.assertSame(job2, schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
         Assertions.assertTrue(historySchema2.isExpired());
         Assertions.assertNull(historySchema2.getSchemaByIndexMetaId(baseIndexMetaId).orElse(null));
         Assertions.assertNull(historySchema2.getSchemaBySchemaId(preAlterIndexMeta2.getSchemaId()).orElse(null));
         job2.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
-        schemaChangeHandler.runAfterCatalogReady();
+        schemaChangeHandler.runAfterLeaseValid();
         Assertions.assertNull(schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -73,8 +73,8 @@ public class LakeRollupJobTest {
     @BeforeAll
     public static void setUp() throws Exception {
         new MockUp<MaterializedViewHandler>() {
-            @Mock protected void runAfterCatalogReady() {
-                System.out.println("Mocked MaterializedViewHandler.runAfterCatalogReady() called");
+            @Mock protected void runAfterLeaseValid() {
+                System.out.println("Mocked MaterializedViewHandler.runAfterLeaseValid() called");
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
@@ -78,7 +78,7 @@ public class RollupJobV2Test extends DDLTestBase {
     public static void beforeAll() {
         new MockUp<MaterializedViewHandler>() {
             @Mock
-            protected void runAfterCatalogReady() {
+            protected void runAfterLeaseValid() {
                 // do nothing
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
@@ -530,22 +530,22 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
 
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
         job1.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
-        schemaChangeHandler.runAfterCatalogReady();
+        schemaChangeHandler.runAfterLeaseValid();
         Assertions.assertSame(job1, schemaChangeHandler.getAlterJobsV2().get(job1.getJobId()));
         Assertions.assertFalse(job1.getHistorySchema().orElse(null).isExpired());
         GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), runningTxn1, "fail1");
-        schemaChangeHandler.runAfterCatalogReady();
+        schemaChangeHandler.runAfterLeaseValid();
         Assertions.assertNull(schemaChangeHandler.getAlterJobsV2().get(job1.getJobId()));
 
         GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), runningTxn2, "fail2");
-        schemaChangeHandler.runAfterCatalogReady();
+        schemaChangeHandler.runAfterLeaseValid();
         Assertions.assertSame(job2, schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
         Assertions.assertTrue(job2.getHistorySchema().orElse(null).isExpired());
         Assertions.assertNull(job2.getHistorySchema().orElse(null).getSchemaByIndexMetaId(baseIndexMetaId).orElse(null));
         Assertions.assertNull(job2.getHistorySchema().orElse(null)
                 .getSchemaBySchemaId(preAlterIndexMeta2.getSchemaId()).orElse(null));
         job2.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
-        schemaChangeHandler.runAfterCatalogReady();
+        schemaChangeHandler.runAfterLeaseValid();
         Assertions.assertNull(schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -165,7 +165,7 @@ public class BackupHandlerTest {
     @Test
     public void testInit() {
         BackupHandler handler = new BackupHandler(GlobalStateMgr.getCurrentState());
-        handler.runAfterCatalogReady();
+        handler.runAfterLeaseValid();
 
         File backupDir = new File(BackupHandler.BACKUP_ROOT_DIR.toString());
         Assertions.assertTrue(backupDir.exists());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -194,6 +194,26 @@ public class BackupHandlerTest {
     }
 
     @Test
+    public void testOnStoppedSwallowsRepoMgrStopFailure() throws Exception {
+        // The per-handler try/catch around repoMgr.stopGracefully must absorb any failure so
+        // a misbehaving RepositoryMgr cannot abort the leader-demotion drain (which would
+        // leave the FE in a half-demoted state). stopGracefully is final on LeaderDaemon;
+        // observe the safety net by making setStop() throw - stopGracefully calls setStop()
+        // before its own try/catch, so the exception bubbles up into BackupHandler's catch.
+        TestBackupHandler handler = new TestBackupHandler(GlobalStateMgr.getCurrentState());
+        RepositoryMgr throwingRepoMgr = new RepositoryMgr() {
+            @Override
+            public void setStop() {
+                throw new RuntimeException("simulated repo stop failure");
+            }
+        };
+        org.apache.commons.lang3.reflect.FieldUtils.writeField(handler, "repoMgr", throwingRepoMgr, true);
+
+        Assertions.assertDoesNotThrow(handler::callOnStopped,
+                "onStopped must absorb a throwing repoMgr.stopGracefully");
+    }
+
+    @Test
     public void testCreateAndDropRepository(@Mocked BrokerMgr brokerMgr) throws Exception {
         setUpMocker();
 

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -119,6 +119,16 @@ public class BackupHandlerTest {
 
     private String brokerName = "broker";
 
+    private static class TestBackupHandler extends BackupHandler {
+        TestBackupHandler(GlobalStateMgr globalStateMgr) {
+            super(globalStateMgr);
+        }
+
+        void callOnStopped() {
+            super.onStopped();
+        }
+    }
+
     @BeforeEach
     public void setup() throws Exception {
         UtFrameUtils.setUpForPersistTest();
@@ -169,6 +179,18 @@ public class BackupHandlerTest {
 
         File backupDir = new File(BackupHandler.BACKUP_ROOT_DIR.toString());
         Assertions.assertTrue(backupDir.exists());
+    }
+
+    @Test
+    public void testOnStoppedStopsRepositoryMgr() {
+        TestBackupHandler handler = new TestBackupHandler(GlobalStateMgr.getCurrentState());
+        RepositoryMgr repoMgr = handler.getRepoMgr();
+
+        Assertions.assertFalse(repoMgr.isStopped());
+
+        handler.callOnStopped();
+
+        Assertions.assertTrue(repoMgr.isStopped(), "repository ping loop must stop on leader demotion");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RepositoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RepositoryTest.java
@@ -178,6 +178,26 @@ public class RepositoryTest {
     }
 
     @Test
+    public void testRepositoryMgrRunAfterLeaseValidPingsRepositories() {
+        new Expectations() {
+            {
+                storage.checkPathExist(anyString);
+                times = 2;
+                result = Status.OK;
+            }
+        };
+
+        repo = new Repository(10000, "repo", false, location, storage);
+        RepositoryMgr repositoryMgr = new RepositoryMgr();
+        repositoryMgr.replayAddRepo(repo);
+
+        repositoryMgr.runAfterLeaseValid();
+
+        Assertions.assertTrue(repo.ping());
+        Assertions.assertNull(repo.getErrorMsg());
+    }
+
+    @Test
     public void testListSnapshots() {
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -71,6 +71,8 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -108,26 +110,26 @@ public class ColocateTableBalancerTest {
     public static void beforeClass() throws Exception {
         new MockUp<ColocateTableBalancer>() {
             @Mock
-            protected void runAfterCatalogReady() {
-                System.out.println("Mocked ColocateTableBalancer.runAfterCatalogReady() called");
+            protected void runAfterLeaseValid() {
+                System.out.println("Mocked ColocateTableBalancer.runAfterLeaseValid() called");
             }
         };
         new MockUp<SystemHandler>() {
             @Mock
-            protected void runAfterCatalogReady() {
-                System.out.println("Mocked SystemHandler.runAfterCatalogReady() called");
+            protected void runAfterLeaseValid() {
+                System.out.println("Mocked SystemHandler.runAfterLeaseValid() called");
             }
         };
         new MockUp<RoutineLoadTaskScheduler>() {
             @Mock
-            protected void runAfterCatalogReady() {
+            protected void runAfterLeaseValid() {
                 // the interval is 0, so skip log printing to prevent too many logs
             }
         };
         new MockUp<TabletChecker>() {
             @Mock
-            protected void runAfterCatalogReady() {
-                System.out.println("Mocked TabletChecker.runAfterCatalogReady() called");
+            protected void runAfterLeaseValid() {
+                System.out.println("Mocked TabletChecker.runAfterLeaseValid() called");
             }
         };
 
@@ -1101,5 +1103,25 @@ public class ColocateTableBalancerTest {
         System.out.println("after sleep, time: " + System.currentTimeMillis()
                     + "alive backend is: " + infoService.getBackendIds(true));
         Assertions.assertTrue(balancer.isSystemStable(infoService));
+    }
+
+    @Test
+    public void testOnStoppedResetsStabilityWatermarks() throws Exception {
+        // aliveBackendIds and systemStableStartTime are leader-session watermarks used to gate
+        // colocate balancing on cluster stability. After demotion the next leader must
+        // re-observe BE liveness and re-time the stability window from scratch.
+        ColocateTableBalancer balancer = ColocateTableBalancer.getInstance();
+
+        FieldUtils.writeField(balancer, "aliveBackendIds",
+                new HashSet<>(Arrays.asList(7L, 8L)), true);
+        FieldUtils.writeField(balancer, "systemStableStartTime", 123456789L, true);
+
+        MethodUtils.invokeMethod(balancer, true, "onStopped");
+
+        @SuppressWarnings("unchecked")
+        Set<Long> aliveBackendIds = (Set<Long>) FieldUtils.readField(balancer, "aliveBackendIds", true);
+        long systemStableStartTime = (long) FieldUtils.readField(balancer, "systemStableStartTime", true);
+        Assertions.assertTrue(aliveBackendIds.isEmpty(), "aliveBackendIds must be reset on demotion");
+        Assertions.assertEquals(-1L, systemStableStartTime, "systemStableStartTime must be reset on demotion");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
@@ -236,7 +236,7 @@ public class DynamicPartitionSchedulerTest extends StarRocksTestBase {
         tbl.getTableProperty().setPartitionTTLNumber(3);
 
         dynamicPartitionScheduler.registerTtlPartitionTable(db.getId(), tbl.getId());
-        dynamicPartitionScheduler.runAfterCatalogReady();
+        dynamicPartitionScheduler.runAfterLeaseValid();
 
         Assertions.assertEquals(3, tbl.getPartitions().size());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
@@ -33,11 +33,14 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -495,5 +498,36 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
         assertFalse(result2.isOk());
         assertEquals(TStatusCode.INVALID_ARGUMENT, result2.getStatus().getStatus_code());
         assertTrue(result2.getStatus().getError_msgs().get(0).contains("does not match"));
+    }
+
+    @Test
+    public void testOnStoppedClearsLeaderSessionState() throws Exception {
+        // mergeCommitJobs holds in-flight merge-commit jobs created on this leader. After
+        // demotion the next leader picks fresh coordinator backends per table, so leftover
+        // entries here would otherwise confuse those decisions. The owned threadPoolExecutor
+        // is intentionally NOT shut down by onStopped() because LeaderDaemon.start() is
+        // idempotent and the executor field is final - that lifecycle is left to Tier 3.
+        @SuppressWarnings("unchecked")
+        Map<BatchWriteId, MergeCommitJob> jobs = (Map<BatchWriteId, MergeCommitJob>)
+                FieldUtils.readField(batchWriteMgr, "mergeCommitJobs", true);
+
+        StreamLoadKvParams params = new StreamLoadKvParams(new HashMap<>() {
+            {
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "1000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "1");
+                put(HTTP_FORMAT, "json");
+            }
+        });
+        // Seed one job through the public API so the registration with
+        // CoordinatorBackendAssigner mirrors production usage.
+        RequestCoordinatorBackendResult seeded = batchWriteMgr.requestCoordinatorBackends(
+                tableId1, params, new UserIdentity("root", "%"));
+        if (seeded.isOk()) {
+            assertEquals(1, jobs.size(), "precondition: a merge-commit job is registered");
+        }
+
+        MethodUtils.invokeMethod(batchWriteMgr, true, "onStopped");
+
+        assertTrue(jobs.isEmpty(), "mergeCommitJobs must be cleared on demotion");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
@@ -501,33 +501,30 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
     }
 
     @Test
-    public void testOnStoppedClearsLeaderSessionState() throws Exception {
-        // mergeCommitJobs holds in-flight merge-commit jobs created on this leader. After
-        // demotion the next leader picks fresh coordinator backends per table, so leftover
-        // entries here would otherwise confuse those decisions. The owned threadPoolExecutor
-        // is intentionally NOT shut down by onStopped() because LeaderDaemon.start() is
-        // idempotent and the executor field is final - that lifecycle is left to Tier 3.
+    public void testOnStoppedClearsLeaderSessionStateAndShutsDownPools() throws Exception {
+        // mergeCommitJobs holds in-flight merge-commit jobs created on this leader; after
+        // demotion the next leader picks fresh coordinator backends per table. The owned
+        // threadPoolExecutor and coordinatorBackendAssigner are shut down so their worker
+        // threads exit promptly during the drain, and start() rebuilds them on re-election.
         @SuppressWarnings("unchecked")
         Map<BatchWriteId, MergeCommitJob> jobs = (Map<BatchWriteId, MergeCommitJob>)
                 FieldUtils.readField(batchWriteMgr, "mergeCommitJobs", true);
-
-        StreamLoadKvParams params = new StreamLoadKvParams(new HashMap<>() {
-            {
-                put(HTTP_BATCH_WRITE_INTERVAL_MS, "1000");
-                put(HTTP_BATCH_WRITE_PARALLEL, "1");
-                put(HTTP_FORMAT, "json");
-            }
-        });
-        // Seed one job through the public API so the registration with
-        // CoordinatorBackendAssigner mirrors production usage.
-        RequestCoordinatorBackendResult seeded = batchWriteMgr.requestCoordinatorBackends(
-                tableId1, params, new UserIdentity("root", "%"));
-        if (seeded.isOk()) {
-            assertEquals(1, jobs.size(), "precondition: a merge-commit job is registered");
-        }
+        java.util.concurrent.ThreadPoolExecutor poolBeforeStop =
+                (java.util.concurrent.ThreadPoolExecutor) FieldUtils.readField(
+                        batchWriteMgr, "threadPoolExecutor", true);
 
         MethodUtils.invokeMethod(batchWriteMgr, true, "onStopped");
 
         assertTrue(jobs.isEmpty(), "mergeCommitJobs must be cleared on demotion");
+        assertTrue(poolBeforeStop.isShutdown(),
+                "threadPoolExecutor must be shut down on demotion so workers can exit");
+
+        // A subsequent start() must rebuild the pool so the daemon is reusable.
+        batchWriteMgr.start();
+        java.util.concurrent.ThreadPoolExecutor poolAfterRestart =
+                (java.util.concurrent.ThreadPoolExecutor) FieldUtils.readField(
+                        batchWriteMgr, "threadPoolExecutor", true);
+        assertFalse(poolAfterRestart.isShutdown(),
+                "threadPoolExecutor must be rebuilt on re-election");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
@@ -42,7 +42,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_INTERVAL_MS;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_PARALLEL;
@@ -52,6 +55,7 @@ import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_WAREHOUSE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BatchWriteMgrTest extends BatchWriteTestBase {
@@ -526,5 +530,26 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                         batchWriteMgr, "threadPoolExecutor", true);
         assertFalse(poolAfterRestart.isShutdown(),
                 "threadPoolExecutor must be rebuilt on re-election");
+    }
+
+    @Test
+    public void testStartRefusesToRestartBeforePreviousPoolTerminates() throws Exception {
+        ThreadPoolExecutor blockedPool = new ThreadPoolExecutor(
+                1, 1, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(1));
+        blockedPool.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedPool.shutdown();
+        FieldUtils.writeField(batchWriteMgr, "threadPoolExecutor", blockedPool, true);
+
+        try {
+            assertThrows(IllegalStateException.class, batchWriteMgr::start);
+        } finally {
+            blockedPool.shutdownNow();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
@@ -513,6 +513,24 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
         @SuppressWarnings("unchecked")
         Map<BatchWriteId, MergeCommitJob> jobs = (Map<BatchWriteId, MergeCommitJob>)
                 FieldUtils.readField(batchWriteMgr, "mergeCommitJobs", true);
+        // Seed two jobs through the public API so onStopped() actually walks the map and
+        // calls coordinatorBackendAssigner.unregisterBatchWrite for each entry.
+        StreamLoadKvParams params1 = new StreamLoadKvParams(new HashMap<>() {
+            {
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "1000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "1");
+            }
+        });
+        StreamLoadKvParams params2 = new StreamLoadKvParams(new HashMap<>() {
+            {
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "10000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "1");
+            }
+        });
+        assertTrue(batchWriteMgr.requestCoordinatorBackends(tableId1, params1, UserIdentity.ROOT).isOk());
+        assertTrue(batchWriteMgr.requestCoordinatorBackends(tableId2, params2, UserIdentity.ROOT).isOk());
+        assertEquals(2, jobs.size(), "precondition: two merge-commit jobs registered");
+
         java.util.concurrent.ThreadPoolExecutor poolBeforeStop =
                 (java.util.concurrent.ThreadPoolExecutor) FieldUtils.readField(
                         batchWriteMgr, "threadPoolExecutor", true);
@@ -530,6 +548,46 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                         batchWriteMgr, "threadPoolExecutor", true);
         assertFalse(poolAfterRestart.isShutdown(),
                 "threadPoolExecutor must be rebuilt on re-election");
+    }
+
+    @Test
+    public void testOnStoppedSwallowsAssignerStopFailure() throws Exception {
+        // The per-handler try/catch around coordinatorBackendAssigner.stop() must absorb
+        // any failure so the rest of the drain (mergeCommitJobs clear and threadPoolExecutor
+        // shutdown) still runs.
+        CoordinatorBackendAssigner throwingAssigner = new CoordinatorBackendAssigner() {
+            @Override
+            public void start() {
+            }
+
+            @Override
+            public void stop() {
+                throw new RuntimeException("simulated assigner stop failure");
+            }
+
+            @Override
+            public void registerBatchWrite(long id, ComputeResource computeResource, TableId tableId, int expectParallel) {
+            }
+
+            @Override
+            public void unregisterBatchWrite(long id) {
+            }
+
+            @Override
+            public Optional<List<ComputeNode>> getBackends(long id) {
+                return Optional.empty();
+            }
+        };
+        FieldUtils.writeField(batchWriteMgr, "coordinatorBackendAssigner", throwingAssigner, true);
+
+        ThreadPoolExecutor poolBeforeStop = (ThreadPoolExecutor)
+                FieldUtils.readField(batchWriteMgr, "threadPoolExecutor", true);
+
+        // Should not throw despite assigner.stop() throwing.
+        MethodUtils.invokeMethod(batchWriteMgr, true, "onStopped");
+
+        assertTrue(poolBeforeStop.isShutdown(),
+                "threadPoolExecutor must still be shut down even when assigner.stop() throws");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerTest.java
@@ -28,6 +28,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -37,8 +39,10 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -274,6 +278,79 @@ public class CoordinatorBackendAssignerTest extends BatchWriteTestBase {
         assertSame(task2, queue.poll());
         assertSame(task3, queue.poll());
         assertSame(task4, queue.poll());
+    }
+
+    @Test
+    public void testDuplicateStartIsNoOp() throws Exception {
+        // Calling start() while the worker is already running must short-circuit on the
+        // "already running" guard instead of spawning a second worker thread that would
+        // race the first against taskPriorityQueue and warehouseMetas.
+        ExecutorService poolBefore = readSingleExecutor();
+        assigner.start();
+        ExecutorService poolAfter = readSingleExecutor();
+        assertSame(poolBefore, poolAfter, "duplicate start() must not replace the running executor");
+    }
+
+    @Test
+    public void testStopShutsDownExecutorAndStartRebuilds() throws Exception {
+        // stop() interrupts the scheduler worker so its blocking poll() returns and
+        // runSchedule exits; the executor must terminate within the drain timeout. A
+        // subsequent start() then creates a fresh executor for the re-elected leader.
+        ExecutorService originalExecutor = readSingleExecutor();
+        assigner.stop();
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).until(originalExecutor::isTerminated);
+
+        assigner.start();
+        ExecutorService rebuiltExecutor = readSingleExecutor();
+        assertNotNull(rebuiltExecutor);
+        assertNotSame(originalExecutor, rebuiltExecutor,
+                "stop() then start() must rebuild the executor");
+        assertFalse(rebuiltExecutor.isShutdown());
+    }
+
+    @Test
+    public void testStartRefusesWhenPreviousWorkerNotTerminated() throws Exception {
+        // Inject a shutdown-but-not-terminated executor to mimic a stop() that timed out
+        // because the worker was stuck. start() must refuse rather than spinning up a
+        // parallel worker, which would corrupt warehouseMetas.
+        ExecutorService blockedExecutor = Executors.newSingleThreadExecutor();
+        blockedExecutor.submit(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedExecutor.shutdown();
+
+        // Tear down the @BeforeEach pool first so it doesn't race the test.
+        ExecutorService before = readSingleExecutor();
+        assigner.stop();
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).until(before::isTerminated);
+
+        // Now plant the blocked executor and call start() - it must throw because the
+        // injected executor is shutdown-but-not-terminated.
+        writeSingleExecutor(blockedExecutor);
+
+        try {
+            assertThrows(IllegalStateException.class, () -> assigner.start());
+        } finally {
+            blockedExecutor.shutdownNow();
+        }
+    }
+
+    private ExecutorService readSingleExecutor() throws ReflectiveOperationException {
+        java.lang.reflect.Field field =
+                CoordinatorBackendAssignerImpl.class.getDeclaredField("singleExecutor");
+        field.setAccessible(true);
+        return (ExecutorService) field.get(assigner);
+    }
+
+    private void writeSingleExecutor(ExecutorService executor) throws ReflectiveOperationException {
+        java.lang.reflect.Field field =
+                CoordinatorBackendAssignerImpl.class.getDeclaredField("singleExecutor");
+        field.setAccessible(true);
+        field.set(assigner, executor);
     }
 
     private boolean containsLoadMeta(long loadId, long warehouseId) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerTest.java
@@ -309,6 +309,43 @@ public class CoordinatorBackendAssignerTest extends BatchWriteTestBase {
     }
 
     @Test
+    public void testStopClearsAssignerStateForLeaderHandoff() throws Exception {
+        // BatchWriteMgr.onStopped() pushes async UNREGISTER_LOAD tasks for each merge-commit
+        // job, but stop() then drops the queue via shutdownNow() before they run. To keep
+        // leader-session load ownership from leaking into the next leader, stop() must
+        // synchronously clear warehouseMetas / registeredLoadMetas / taskPriorityQueue after
+        // the worker terminates.
+        registerBatchWrite(1L, 1, new TableId(DB_NAME_1, TABLE_NAME_1_1), 1);
+        registerBatchWrite(2L, 1, new TableId(DB_NAME_1, TABLE_NAME_1_2), 1);
+        Awaitility.await().timeout(5, TimeUnit.SECONDS)
+                .until(() -> assigner.getBackends(1L).isPresent()
+                        && assigner.getBackends(2L).isPresent());
+        assertNotNull(getWarehouseMeta(1));
+
+        assigner.stop();
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).until(readSingleExecutor()::isTerminated);
+
+        // After stop returns, all leader-session collections must be empty so a freshly
+        // re-elected leader starts with a clean assigner.
+        @SuppressWarnings("unchecked")
+        java.util.Map<Long, ?> registeredLoadMetas =
+                (java.util.Map<Long, ?>) readPrivateField("registeredLoadMetas");
+        java.util.Map<?, ?> warehouseMetasMap =
+                (java.util.Map<?, ?>) readPrivateField("warehouseMetas");
+        java.util.concurrent.PriorityBlockingQueue<?> queue =
+                (java.util.concurrent.PriorityBlockingQueue<?>) readPrivateField("taskPriorityQueue");
+        assertTrue(registeredLoadMetas.isEmpty(), "registeredLoadMetas must be cleared on stop");
+        assertTrue(warehouseMetasMap.isEmpty(), "warehouseMetas must be cleared on stop");
+        assertTrue(queue.isEmpty(), "taskPriorityQueue must be cleared on stop");
+    }
+
+    private Object readPrivateField(String name) throws Exception {
+        java.lang.reflect.Field field = CoordinatorBackendAssignerImpl.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(assigner);
+    }
+
+    @Test
     public void testStartRefusesWhenPreviousWorkerNotTerminated() throws Exception {
         // Inject a shutdown-but-not-terminated executor to mimic a stop() that timed out
         // because the worker was stuck. start() must refuse rather than spinning up a

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
@@ -41,7 +41,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.LoadException;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.load.RoutineLoadDesc;
 import com.starrocks.planner.StreamLoadPlanner;
@@ -57,7 +56,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 public class RoutineLoadSchedulerTest {
 
@@ -115,7 +113,7 @@ public class RoutineLoadSchedulerTest {
 
         RoutineLoadScheduler routineLoadScheduler = new RoutineLoadScheduler();
         Deencapsulation.setField(routineLoadScheduler, "routineLoadManager", routineLoadManager);
-        routineLoadScheduler.runAfterCatalogReady();
+        routineLoadScheduler.runAfterLeaseValid();
 
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList =
                 Deencapsulation.getField(kafkaRoutineLoadJob, "routineLoadTaskInfoList");
@@ -140,7 +138,7 @@ public class RoutineLoadSchedulerTest {
                 times = 1;
             }
         };
-        routineLoadTaskScheduler.runAfterCatalogReady();
+        routineLoadTaskScheduler.runAfterLeaseValid();
     }
 
     public void functionTest(@Mocked GlobalStateMgr globalStateMgr,
@@ -180,10 +178,11 @@ public class RoutineLoadSchedulerTest {
         RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler();
         routineLoadTaskScheduler.setInterval(5000);
 
-        ExecutorService executorService =
-                ThreadPoolManager.newDaemonFixedThreadPool(2, 2, "routine-load-task-scheduler", false);
-        executorService.submit(routineLoadScheduler);
-        executorService.submit(routineLoadTaskScheduler);
+        // LeaderDaemon manages its own worker thread; .start() spawns a daemon thread that
+        // runs the loop. The previous ExecutorService.submit() pattern relied on the old
+        // FrontendDaemon implementing Runnable, which LeaderDaemon does not.
+        routineLoadScheduler.start();
+        routineLoadTaskScheduler.start();
 
         KafkaRoutineLoadJob kafkaRoutineLoadJob1 = new KafkaRoutineLoadJob(1L, "test_custom_partition",
                  1L, 1L, "xxx", "test_1");

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
@@ -57,7 +57,11 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class RoutineLoadTaskSchedulerTest {
@@ -288,6 +292,49 @@ public class RoutineLoadTaskSchedulerTest {
             Assertions.assertTrue(e instanceof MetaNotFoundException);
             Assertions.assertEquals("database 1 does not exist", e.getMessage());
             Assertions.assertEquals(RoutineLoadJob.JobState.CANCELLED, routineLoadJob.state);
+        }
+    }
+
+    @Test
+    public void testStartRefusesToRestartBeforeScheduledExecutorTerminates() {
+        RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler();
+        ScheduledExecutorService blockedScheduler = Executors.newSingleThreadScheduledExecutor();
+        blockedScheduler.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedScheduler.shutdown();
+        Deencapsulation.setField(routineLoadTaskScheduler, "scheduledExecutorService", blockedScheduler);
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, routineLoadTaskScheduler::start);
+        } finally {
+            blockedScheduler.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testStartRefusesToRestartBeforeThreadPoolTerminates() {
+        RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler();
+        ThreadPoolExecutor blockedPool = new ThreadPoolExecutor(
+                1, 1, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(1));
+        blockedPool.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedPool.shutdown();
+        Deencapsulation.setField(routineLoadTaskScheduler, "threadPool", blockedPool);
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, routineLoadTaskScheduler::start);
+        } finally {
+            blockedPool.shutdownNow();
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
@@ -127,7 +127,7 @@ public class RoutineLoadTaskSchedulerTest {
 
         RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler();
         Deencapsulation.setField(routineLoadTaskScheduler, "needScheduleTasksQueue", routineLoadTaskInfoQueue);
-        routineLoadTaskScheduler.runAfterCatalogReady();
+        routineLoadTaskScheduler.runAfterLeaseValid();
 
         // The task was submitted to the thread pool waiting for execution, it could be some delay the task didn't get
         // executed at all when main thread thought the testing is done.

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
@@ -60,6 +60,7 @@ import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -370,6 +371,40 @@ public class RoutineLoadTaskSchedulerTest {
         Assertions.assertFalse(rebuiltThreadPool.isShutdown());
 
         scheduler.setStop();
+    }
+
+    @Test
+    public void testOnStoppedClearsQueueAfterPoolsTerminate() {
+        // Race fix: a delay-runnable scheduled by the previous leader can fire mid-onStopped()
+        // and call needScheduleTasksQueue.put() before the interrupt from shutdownNow() lands.
+        // If clear() runs before the pools drain, that stale put survives demotion and the
+        // next leader polls it. Pin the invariant by routing the production clear() through a
+        // queue subclass that records whether both pools were already terminated at the
+        // moment clear() ran.
+        RoutineLoadTaskScheduler scheduler = new RoutineLoadTaskScheduler();
+        ScheduledExecutorService sched = Deencapsulation.getField(scheduler, "scheduledExecutorService");
+        ExecutorService pool = Deencapsulation.getField(scheduler, "threadPool");
+        boolean[] schedTerminatedAtClear = {false};
+        boolean[] poolTerminatedAtClear = {false};
+        LinkedBlockingQueue<RoutineLoadTaskInfo> trackingQueue = new LinkedBlockingQueue<RoutineLoadTaskInfo>() {
+            @Override
+            public void clear() {
+                schedTerminatedAtClear[0] = sched.isTerminated();
+                poolTerminatedAtClear[0] = pool.isTerminated();
+                super.clear();
+            }
+        };
+        Deencapsulation.setField(scheduler, "needScheduleTasksQueue", trackingQueue);
+
+        Deencapsulation.invoke(scheduler, "onStopped");
+
+        Assertions.assertTrue(schedTerminatedAtClear[0],
+                "scheduledExecutorService must be terminated before clear() runs");
+        Assertions.assertTrue(poolTerminatedAtClear[0],
+                "threadPool must be terminated before clear() runs");
+        Long watermark = Deencapsulation.getField(scheduler, "lastBackendSlotUpdateTime");
+        Assertions.assertEquals(-1L, watermark.longValue(),
+                "slot watermark must be reset for the next leader");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
@@ -337,4 +337,72 @@ public class RoutineLoadTaskSchedulerTest {
             blockedPool.shutdownNow();
         }
     }
+
+    @Test
+    public void testOnStoppedShutsDownPoolsAndStartRebuildsThem() {
+        // onStopped() must shutdownNow() both executors so their worker threads exit promptly
+        // during the drain. A subsequent start() must rebuild both pools so the scheduler is
+        // reusable when the FE is re-elected.
+        RoutineLoadTaskScheduler scheduler = new RoutineLoadTaskScheduler();
+        ScheduledExecutorService originalScheduler =
+                Deencapsulation.getField(scheduler, "scheduledExecutorService");
+        ExecutorService originalThreadPool = Deencapsulation.getField(scheduler, "threadPool");
+
+        Deencapsulation.invoke(scheduler, "onStopped");
+
+        Assertions.assertTrue(originalScheduler.isShutdown(),
+                "scheduledExecutorService must be shut down on demotion");
+        Assertions.assertTrue(originalThreadPool.isShutdown(),
+                "threadPool must be shut down on demotion");
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).until(originalScheduler::isTerminated);
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).until(originalThreadPool::isTerminated);
+
+        // The original pools are terminated, so start() should hit the rebuild branches.
+        scheduler.start();
+        ScheduledExecutorService rebuiltScheduler =
+                Deencapsulation.getField(scheduler, "scheduledExecutorService");
+        ExecutorService rebuiltThreadPool = Deencapsulation.getField(scheduler, "threadPool");
+        Assertions.assertNotSame(originalScheduler, rebuiltScheduler,
+                "scheduledExecutorService must be rebuilt on re-election");
+        Assertions.assertNotSame(originalThreadPool, rebuiltThreadPool,
+                "threadPool must be rebuilt on re-election");
+        Assertions.assertFalse(rebuiltScheduler.isShutdown());
+        Assertions.assertFalse(rebuiltThreadPool.isShutdown());
+
+        scheduler.setStop();
+    }
+
+    @Test
+    public void testDelayPutToQueueSkipsWhenStopped() throws Exception {
+        // After onStopped() shuts down scheduledExecutorService, delayPutToQueue must skip
+        // cleanly instead of throwing - the next leader will re-divide the routine load.
+        RoutineLoadTaskScheduler scheduler = new RoutineLoadTaskScheduler();
+        ScheduledExecutorService originalScheduler =
+                Deencapsulation.getField(scheduler, "scheduledExecutorService");
+        Deencapsulation.invoke(scheduler, "onStopped");
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).until(originalScheduler::isTerminated);
+
+        KafkaRoutineLoadJob job = new KafkaRoutineLoadJob(1L, "job1", 1L, 1L, null, "topic1");
+        KafkaTaskInfo taskInfo = new KafkaTaskInfo(new UUID(1, 1), job, 20000,
+                System.currentTimeMillis(), Maps.newHashMap(), Config.routine_load_task_timeout_second * 1000);
+
+        // delayPutToQueue is private; invoke through Deencapsulation. Must not throw.
+        Deencapsulation.invoke(scheduler, "delayPutToQueue", taskInfo, "test-msg");
+    }
+
+    @Test
+    public void testSubmitToScheduleSkipsWhenStopped() throws Exception {
+        // Mirror of the previous test: submitToSchedule's stopped-guard short-circuits when
+        // the threadPool was shut down, preventing RejectedExecutionException leakage.
+        RoutineLoadTaskScheduler scheduler = new RoutineLoadTaskScheduler();
+        ExecutorService originalThreadPool = Deencapsulation.getField(scheduler, "threadPool");
+        Deencapsulation.invoke(scheduler, "onStopped");
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).until(originalThreadPool::isTerminated);
+
+        KafkaRoutineLoadJob job = new KafkaRoutineLoadJob(1L, "job1", 1L, 1L, null, "topic1");
+        KafkaTaskInfo taskInfo = new KafkaTaskInfo(new UUID(1, 1), job, 20000,
+                System.currentTimeMillis(), Maps.newHashMap(), Config.routine_load_task_timeout_second * 1000);
+
+        Deencapsulation.invoke(scheduler, "submitToSchedule", taskInfo);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -121,10 +121,10 @@ public class ReplicationMgrTest {
         Assertions.assertEquals(ReplicationJobState.INITIALIZING.toString(), job.getState().toString());
         Assertions.assertEquals(ReplicationJobState.INITIALIZING.hashCode(), job.getState().hashCode());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
         replicationMgr.replayReplicationJob(job);
@@ -142,7 +142,7 @@ public class ReplicationMgrTest {
             task.toString();
         }
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
         replicationMgr.replayReplicationJob(job);
@@ -158,7 +158,7 @@ public class ReplicationMgrTest {
             task.toString();
         }
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.COMMITTED, job.getState());
 
         Assertions.assertEquals(partition.getDefaultPhysicalPartition().getCommittedVersion(),
@@ -175,7 +175,7 @@ public class ReplicationMgrTest {
         Config.history_job_keep_max_second = -1;
         Assertions.assertTrue(job.isExpired());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertTrue(replicationMgr.getCommittedJobs().isEmpty());
 
         replicationMgr.replayDeleteReplicationJob(job);
@@ -191,7 +191,7 @@ public class ReplicationMgrTest {
         replicationMgr.cancelRunningJobs();
         Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
 
         Assertions.assertTrue(replicationMgr.getRunningJobs().isEmpty());
@@ -202,13 +202,13 @@ public class ReplicationMgrTest {
     public void testSnapshotingCancel() {
         Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
         replicationMgr.cancelRunningJobs();
         Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
 
         Assertions.assertTrue(replicationMgr.getRunningJobs().isEmpty());
@@ -218,7 +218,7 @@ public class ReplicationMgrTest {
         Config.history_job_keep_max_second = -1;
         Assertions.assertTrue(job.isExpired());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertTrue(replicationMgr.getAbortedJobs().isEmpty());
 
         replicationMgr.replayDeleteReplicationJob(job);
@@ -231,7 +231,7 @@ public class ReplicationMgrTest {
     public void testReplicatingCancel() {
         Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
         Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
@@ -242,13 +242,13 @@ public class ReplicationMgrTest {
             replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
         }
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
         replicationMgr.cancelRunningJobs();
         Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
     }
 
@@ -256,10 +256,10 @@ public class ReplicationMgrTest {
     public void testCommittedCancel() {
         Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
         Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
@@ -270,7 +270,7 @@ public class ReplicationMgrTest {
             replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
         }
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
         for (AgentTask task : runningTasks.values()) {
@@ -279,7 +279,7 @@ public class ReplicationMgrTest {
             replicationMgr.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
         }
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.COMMITTED, job.getState());
 
         replicationMgr.cancelRunningJobs();
@@ -290,10 +290,10 @@ public class ReplicationMgrTest {
     public void testSnapshotingFailed() throws Exception {
         Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
         Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
@@ -303,7 +303,7 @@ public class ReplicationMgrTest {
             replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
         }
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
     }
 
@@ -311,10 +311,10 @@ public class ReplicationMgrTest {
     public void testReplicatingFailed() throws Exception {
         Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
         Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
@@ -325,7 +325,7 @@ public class ReplicationMgrTest {
             replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
         }
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
         for (AgentTask task : runningTasks.values()) {
@@ -336,7 +336,7 @@ public class ReplicationMgrTest {
             replicationMgr.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
         }
 
-        replicationMgr.runAfterCatalogReady();
+        replicationMgr.runAfterLeaseValid();
         Assertions.assertEquals(ReplicationJobState.ABORTED, job.getState());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsMetaMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsMetaMgrTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
@@ -77,6 +78,16 @@ public class StatisticsMetaMgrTest extends PlanTestBase  {
         m.alterFullStatisticsTable(connectContext, table);
         Assertions.assertTrue(m.checkTableCompatible(tblName));
         Assertions.assertTrue(m.alterTable(FULL_STATISTICS_TABLE_NAME));
+    }
+
+    @Test
+    public void testRefreshStatisticsTableReturnsWhenStopped() {
+        StatisticsMetaManager m = new StatisticsMetaManager();
+        m.setStop();
+
+        Deencapsulation.invoke(m, "refreshStatisticsTable", FULL_STATISTICS_TABLE_NAME);
+
+        Assertions.assertTrue(m.isStopped());
     }
 
     private TableRef createTableRef(TableName tableName) {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -1558,8 +1558,10 @@ public class UtFrameUtils {
 
     public static void stopBackgroundSchemaChangeHandler(long timeoutMs) throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
-        schemaChangeHandler.setStop();
-        schemaChangeHandler.interrupt();
+        // LeaderDaemon's setStop() already interrupts the worker; stopGracefully joins up to
+        // timeoutMs and runs onStopped(). If the worker did not exit in time, fall through
+        // to the polling loop below so the existing TimeoutException contract is preserved.
+        schemaChangeHandler.stopGracefully(timeoutMs);
         long endTime = System.currentTimeMillis() + timeoutMs;
         while (schemaChangeHandler.isRunning()) {
             if (System.currentTimeMillis() > endTime) {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -1558,10 +1558,11 @@ public class UtFrameUtils {
 
     public static void stopBackgroundSchemaChangeHandler(long timeoutMs) throws Exception {
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
-        // LeaderDaemon's setStop() already interrupts the worker; stopGracefully joins up to
-        // timeoutMs and runs onStopped(). If the worker did not exit in time, fall through
-        // to the polling loop below so the existing TimeoutException contract is preserved.
-        schemaChangeHandler.stopGracefully(timeoutMs);
+        // This UT helper only stops the background schema-change loop so tests can drive
+        // schema-change jobs manually. Do not call stopGracefully() here: it runs the
+        // demotion cleanup hook and shuts down AlterHandler's executor, which prevents
+        // subsequent manual job progress in schema-change tests.
+        schemaChangeHandler.setStop();
         long endTime = System.currentTimeMillis() + timeoutMs;
         while (schemaChangeHandler.isRunning()) {
             if (System.currentTimeMillis() > endTime) {


### PR DESCRIPTION
## Why I'm doing:

Part of safe leader demotion (#63357). The previous LeaderDaemon framework PR added the restartable, lease-aware daemon base and migrated the first representative daemons. The remaining Tier 2 leader-only daemons in the Load/Statistics and DDL/Backup/Balance groups still extend `FrontendDaemon`, so they cannot be drained through the new demotion path and may keep leader-session state alive after this FE steps down.

This PR migrates the Tier 2 A+B scope so demotion can stop these daemons cleanly and release transient leader-session state without relying on process exit.

## What I'm doing:

### Migrate Tier 2 leader-only daemons to `LeaderDaemon`

Load / Statistics:

- `LoadJobScheduler`
- `RoutineLoadScheduler`
- `RoutineLoadTaskScheduler`
- `LoadsHistorySyncer`
- `BatchWriteMgr`
- `DynamicPartitionScheduler`
- `StatisticsMetaManager`
- `StatisticAutoCollector`

DDL / Backup / Balance:

- `AlterHandler`
- `SchemaChangeHandler`
- `MaterializedViewHandler`
- `SystemHandler`
- `BackupHandler`
- `CatalogRecycleBin`
- `ColocateTableBalancer`
- `TabletChecker`
- `ReplicationMgr`

Each migrated daemon now uses `runAfterLeaseValid()` and releases leader-session-only state from `onStopped()` where applicable. Persistent metadata state is intentionally preserved.

### Add DDL stop aggregator

`AlterJobMgr` now exposes `stopGracefully(timeoutMs)` to fan out demotion drain to `SchemaChangeHandler`, `MaterializedViewHandler`, and `SystemHandler`. Each handler is stopped independently so one failure does not prevent the others from being drained.

### Wire demotion stop order

`GlobalStateMgr.stopLeaderOnlyDaemonThreads()` now stops the migrated daemons in reverse of `startLeaderOnlyDaemonThreads()` order, including the shared-nothing guarded daemons.


### Verification

- `./run-fe-ut.sh --test com.starrocks.load.batchwrite.BatchWriteMgrTest`: BUILD SUCCESS
- `mvn -pl fe-core -am test-compile -DskipTests`: BUILD SUCCESS
- `mvn -pl fe-core -am test -Dtest='AlterJobMgrTest,GlobalStateMgrTest,BatchWriteMgrTest,ColocateTableBalancerTest,RoutineLoadSchedulerTest,RoutineLoadTaskSchedulerTest,DynamicPartitionSchedulerTest,LeaderDaemonTest,TabletCollectorTest,ConsistencyCheckerTest,SPMAutoCapturerTest'`: 86 tests passed
- `mvn -pl fe-core -am test -Dtest='BackupHandlerTest,ReplicationMgrTest,BatchWriteMgrTest'`: 27 tests passed
- `mvn -pl fe-core checkstyle:check`: 0 violations

Related to #63357

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Leader demotion now drains the migrated leader-only daemons through `LeaderDaemon.stopGracefully()` instead of leaving them on the old `FrontendDaemon` stop path.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
