### PR TITLE
[Refactor] Move storage metrics out of AgentMetrics

### DIFF
--- a/be/src/agent/agent_metrics.cpp
+++ b/be/src/agent/agent_metrics.cpp
@@ -102,13 +102,7 @@ void AgentMetrics::install(MetricRegistry* registry) {
     registry->register_metric("engine_requests_total", MetricLabels().add("type", #type).add("status", #status), \
                               &metric)
 
-    REGISTER_ENGINE_REQUEST_METRIC(create_tablet, total, create_tablet_requests_total);
-    REGISTER_ENGINE_REQUEST_METRIC(create_tablet, failed, create_tablet_requests_failed);
-    REGISTER_ENGINE_REQUEST_METRIC(drop_tablet, total, drop_tablet_requests_total);
-
-    REGISTER_ENGINE_REQUEST_METRIC(report_all_tablets, total, report_all_tablets_requests_total);
     REGISTER_ENGINE_REQUEST_METRIC(report_all_tablets, failed, report_all_tablets_requests_failed);
-    REGISTER_ENGINE_REQUEST_METRIC(report_tablet, total, report_tablet_requests_total);
     REGISTER_ENGINE_REQUEST_METRIC(report_tablet, failed, report_tablet_requests_failed);
     REGISTER_ENGINE_REQUEST_METRIC(report_disk, total, report_disk_requests_total);
     REGISTER_ENGINE_REQUEST_METRIC(report_disk, failed, report_disk_requests_failed);
@@ -117,8 +111,6 @@ void AgentMetrics::install(MetricRegistry* registry) {
 
     REGISTER_ENGINE_REQUEST_METRIC(schema_change, total, schema_change_requests_total);
     REGISTER_ENGINE_REQUEST_METRIC(schema_change, failed, schema_change_requests_failed);
-    REGISTER_ENGINE_REQUEST_METRIC(create_rollup, total, create_rollup_requests_total);
-    REGISTER_ENGINE_REQUEST_METRIC(create_rollup, failed, create_rollup_requests_failed);
     REGISTER_ENGINE_REQUEST_METRIC(clone, total, clone_requests_total);
     REGISTER_ENGINE_REQUEST_METRIC(clone, failed, clone_requests_failed);
 

--- a/be/src/agent/agent_metrics.h
+++ b/be/src/agent/agent_metrics.h
@@ -49,13 +49,7 @@ public:
                           int64_t data_used_capacity, int64_t state);
     void register_thread_pool_metrics(const std::string& name, ThreadPool* threadpool);
 
-    METRIC_DEFINE_INT_COUNTER(create_tablet_requests_total, MetricUnit::REQUESTS);
-    METRIC_DEFINE_INT_COUNTER(create_tablet_requests_failed, MetricUnit::REQUESTS);
-    METRIC_DEFINE_INT_COUNTER(drop_tablet_requests_total, MetricUnit::REQUESTS);
-
-    METRIC_DEFINE_INT_COUNTER(report_all_tablets_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(report_all_tablets_requests_failed, MetricUnit::REQUESTS);
-    METRIC_DEFINE_INT_COUNTER(report_tablet_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(report_tablet_requests_failed, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(report_disk_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(report_disk_requests_failed, MetricUnit::REQUESTS);
@@ -70,8 +64,6 @@ public:
 
     METRIC_DEFINE_INT_COUNTER(schema_change_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(schema_change_requests_failed, MetricUnit::REQUESTS);
-    METRIC_DEFINE_INT_COUNTER(create_rollup_requests_total, MetricUnit::REQUESTS);
-    METRIC_DEFINE_INT_COUNTER(create_rollup_requests_failed, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(clone_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(clone_requests_failed, MetricUnit::REQUESTS);
 

--- a/be/src/exec/data_sinks/tablet_sink.cpp
+++ b/be/src/exec/data_sinks/tablet_sink.cpp
@@ -39,7 +39,6 @@
 #include <sstream>
 #include <utility>
 
-#include "agent/utils.h"
 #include "base/compression/compression_utils.h"
 #include "base/simd/simd.h"
 #include "base/uid_util.h"

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -20,8 +20,6 @@
 #include <filesystem>
 #include <set>
 
-#include "agent/agent_server.h"
-#include "agent/task_signatures_manager.h"
 #include "base/string/string_parser.hpp"
 #include "base/utility/defer_op.h"
 #include "common/config_http_fwd.h"

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -20,8 +20,6 @@
 #include <filesystem>
 #include <set>
 
-#include "agent/agent_server.h"
-#include "agent/task_signatures_manager.h"
 #include "base/string/string_parser.hpp"
 #include "base/utility/defer_op.h"
 #include "common/config_http_fwd.h"

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -50,7 +50,6 @@
 #include <utility>
 #include <vector>
 
-#include "agent/status.h"
 #include "common/status.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/BackendService_types.h"

--- a/be/src/storage/storage_metrics.cpp
+++ b/be/src/storage/storage_metrics.cpp
@@ -144,6 +144,13 @@ void StorageMetrics::install(MetricRegistry* registry) {
     REGISTER_STORAGE_METRIC(blocks_open_writing);
 
     REGISTER_ENGINE_REQUEST_METRIC(storage_migrate, total, storage_migrate_requests_total);
+    REGISTER_ENGINE_REQUEST_METRIC(create_tablet, total, create_tablet_requests_total);
+    REGISTER_ENGINE_REQUEST_METRIC(create_tablet, failed, create_tablet_requests_failed);
+    REGISTER_ENGINE_REQUEST_METRIC(drop_tablet, total, drop_tablet_requests_total);
+    REGISTER_ENGINE_REQUEST_METRIC(report_all_tablets, total, report_all_tablets_requests_total);
+    REGISTER_ENGINE_REQUEST_METRIC(report_tablet, total, report_tablet_requests_total);
+    REGISTER_ENGINE_REQUEST_METRIC(create_rollup, total, create_rollup_requests_total);
+    REGISTER_ENGINE_REQUEST_METRIC(create_rollup, failed, create_rollup_requests_failed);
     REGISTER_ENGINE_REQUEST_METRIC(delete, total, delete_requests_total);
     REGISTER_ENGINE_REQUEST_METRIC(delete, failed, delete_requests_failed);
     REGISTER_ENGINE_REQUEST_METRIC(base_compaction, total, base_compaction_request_total);

--- a/be/src/storage/storage_metrics.h
+++ b/be/src/storage/storage_metrics.h
@@ -94,6 +94,13 @@ public:
     METRIC_DEFINE_UINT_GAUGE(unused_rowsets_count, MetricUnit::ROWSETS);
 
     METRIC_DEFINE_INT_COUNTER(storage_migrate_requests_total, MetricUnit::REQUESTS);
+    METRIC_DEFINE_INT_COUNTER(create_tablet_requests_total, MetricUnit::REQUESTS);
+    METRIC_DEFINE_INT_COUNTER(create_tablet_requests_failed, MetricUnit::REQUESTS);
+    METRIC_DEFINE_INT_COUNTER(drop_tablet_requests_total, MetricUnit::REQUESTS);
+    METRIC_DEFINE_INT_COUNTER(report_all_tablets_requests_total, MetricUnit::REQUESTS);
+    METRIC_DEFINE_INT_COUNTER(report_tablet_requests_total, MetricUnit::REQUESTS);
+    METRIC_DEFINE_INT_COUNTER(create_rollup_requests_total, MetricUnit::REQUESTS);
+    METRIC_DEFINE_INT_COUNTER(create_rollup_requests_failed, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(delete_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(delete_requests_failed, MetricUnit::REQUESTS);
 

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -41,7 +41,6 @@
 #include <ctime>
 #include <memory>
 
-#include "agent/agent_metrics.h"
 #include "base/format.h"
 #include "base/path/path_util.h"
 #include "base/testutil/sync_point.h"
@@ -188,7 +187,7 @@ Status TabletManager::_update_tablet_map_and_partition_info(const TabletSharedPt
 }
 
 Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector<DataDir*> stores) {
-    AgentMetrics::instance()->create_tablet_requests_total.increment(1);
+    StorageMetrics::instance()->create_tablet_requests_total.increment(1);
 
     int64_t tablet_id = request.tablet_id;
     int32_t schema_hash = request.tablet_schema.schema_hash;
@@ -227,7 +226,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
     if (tablet != nullptr && tablet->tablet_state() != TABLET_SHUTDOWN) {
         return Status::OK();
     } else if (tablet != nullptr) {
-        AgentMetrics::instance()->create_tablet_requests_failed.increment(1);
+        StorageMetrics::instance()->create_tablet_requests_failed.increment(1);
         DCHECK_EQ(TABLET_SHUTDOWN, tablet->tablet_state());
         return Status::InternalError("tablet still resident in shutdown queue");
     }
@@ -243,7 +242,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
                          << "new_tablet_id=" << tablet_id << " new_schema_hash=" << schema_hash
                          << " base_tablet_id=" << request.base_tablet_id
                          << " base_schema_hash=" << request.base_schema_hash;
-            AgentMetrics::instance()->create_tablet_requests_failed.increment(1);
+            StorageMetrics::instance()->create_tablet_requests_failed.increment(1);
             return Status::InternalError("base tablet not exist");
         }
         // If we are doing schema-change, we should use the same data dir
@@ -258,7 +257,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
                                               base_tablet.get(), stores);
     if (tablet == nullptr) {
         LOG(WARNING) << "Fail to create tablet " << request.tablet_id;
-        AgentMetrics::instance()->create_tablet_requests_failed.increment(1);
+        StorageMetrics::instance()->create_tablet_requests_failed.increment(1);
         return Status::InternalError("fail to create tablet");
     }
 
@@ -406,7 +405,7 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
     TabletSharedPtr dropped_tablet = nullptr;
     {
         std::unique_lock wlock(_get_tablets_shard_lock(tablet_id));
-        AgentMetrics::instance()->drop_tablet_requests_total.increment(1);
+        StorageMetrics::instance()->drop_tablet_requests_total.increment(1);
 
         if (flag != kDeleteFiles && flag != kMoveFilesToTrash && flag != kKeepMetaAndFiles) {
             return Status::InvalidArgument(fmt::format("invalid TabletDropFlag {}", (int)flag));
@@ -1012,7 +1011,7 @@ Status TabletManager::load_tablet_from_dir(DataDir* store, TTabletId tablet_id, 
 }
 
 Status TabletManager::report_tablet_info(TTabletInfo* tablet_info) {
-    AgentMetrics::instance()->report_tablet_requests_total.increment(1);
+    StorageMetrics::instance()->report_tablet_requests_total.increment(1);
 
     TabletSharedPtr tablet = get_tablet(tablet_info->tablet_id, false);
     if (tablet == nullptr) {
@@ -1039,7 +1038,7 @@ Status TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* tabl
         LOG(INFO) << "Found " << expire_txn_map.size() << " expired tablet transactions";
     }
 
-    AgentMetrics::instance()->report_all_tablets_requests_total.increment(1);
+    StorageMetrics::instance()->report_all_tablets_requests_total.increment(1);
 
     size_t max_tablet_rowset_num = 0;
     TTabletId max_tablet_id = 0;
@@ -1574,7 +1573,7 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
 }
 
 Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag flag) {
-    AgentMetrics::instance()->drop_tablet_requests_total.increment(1);
+    StorageMetrics::instance()->drop_tablet_requests_total.increment(1);
 
     if (flag != kMoveFilesToTrash && flag != kKeepMetaAndFiles) {
         return Status::InvalidArgument(fmt::format("invalid TabletDropFlag {}", (int)flag));

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -45,7 +45,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "agent/status.h"
 #include "base/concurrency/spinlock.h"
 #include "base/statusor.h"
 #include "common/status.h"

--- a/be/src/storage/task/engine_alter_tablet_task.cpp
+++ b/be/src/storage/task/engine_alter_tablet_task.cpp
@@ -34,7 +34,6 @@
 
 #include "storage/task/engine_alter_tablet_task.h"
 
-#include "agent/agent_metrics.h"
 #include "base/utility/defer_op.h"
 #include "common/config_storage_fwd.h"
 #include "io/core/io_profiler.h"
@@ -42,6 +41,7 @@
 #include "runtime/exec_env.h"
 #include "storage/lake/schema_change.h"
 #include "storage/schema_change.h"
+#include "storage/storage_metrics.h"
 
 namespace starrocks {
 
@@ -58,7 +58,7 @@ Status EngineAlterTabletTask::execute() {
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_mem_tracker.get());
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
-    AgentMetrics::instance()->create_rollup_requests_total.increment(1);
+    StorageMetrics::instance()->create_rollup_requests_total.increment(1);
 
     auto scope = IOProfiler::scope(IOProfiler::TAG_ALTER, _alter_tablet_req.new_tablet_id);
 
@@ -79,7 +79,7 @@ Status EngineAlterTabletTask::execute() {
         LOG(WARNING) << alter_msg_header << "failed to do alter task. status=" << res.to_string()
                      << " detail run msg: " << '\n'
                      << task_detail_msg;
-        AgentMetrics::instance()->create_rollup_requests_failed.increment(1);
+        StorageMetrics::instance()->create_rollup_requests_failed.increment(1);
         return res;
     }
 

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -51,7 +51,6 @@
 #include <utility>
 #include <vector>
 
-#include "agent/status.h"
 #include "base/concurrency/countdown_latch.h"
 #include "base/container/lru_cache.h"
 #include "base/time/time.h"

--- a/be/test/agent/agent_metrics_test.cpp
+++ b/be/test/agent/agent_metrics_test.cpp
@@ -45,9 +45,9 @@ TEST(AgentMetricsTest, InstallRegistersEngineRequestMetrics) {
     MetricRegistry registry("test_registry");
     metrics.install(&registry);
 
-    metrics.create_tablet_requests_total.increment(3);
+    metrics.report_disk_requests_total.increment(3);
     assert_metric_value(&registry, "engine_requests_total",
-                        MetricLabels().add("type", "create_tablet").add("status", "total"), "3");
+                        MetricLabels().add("type", "report_disk").add("status", "total"), "3");
 
     metrics.report_task_requests_failed.increment(4);
     assert_metric_value(&registry, "engine_requests_total",

--- a/be/test/storage/storage_metrics_test.cpp
+++ b/be/test/storage/storage_metrics_test.cpp
@@ -64,6 +64,34 @@ TEST(StorageMetricsTest, InstallRegistersLoadMetrics) {
     assert_metric_value(&registry, "engine_requests_total",
                         MetricLabels().add("type", "storage_migrate").add("status", "total"), "8");
 
+    metrics.create_tablet_requests_total.increment(37);
+    assert_metric_value(&registry, "engine_requests_total",
+                        MetricLabels().add("type", "create_tablet").add("status", "total"), "37");
+
+    metrics.create_tablet_requests_failed.increment(38);
+    assert_metric_value(&registry, "engine_requests_total",
+                        MetricLabels().add("type", "create_tablet").add("status", "failed"), "38");
+
+    metrics.drop_tablet_requests_total.increment(39);
+    assert_metric_value(&registry, "engine_requests_total",
+                        MetricLabels().add("type", "drop_tablet").add("status", "total"), "39");
+
+    metrics.report_tablet_requests_total.increment(40);
+    assert_metric_value(&registry, "engine_requests_total",
+                        MetricLabels().add("type", "report_tablet").add("status", "total"), "40");
+
+    metrics.report_all_tablets_requests_total.increment(41);
+    assert_metric_value(&registry, "engine_requests_total",
+                        MetricLabels().add("type", "report_all_tablets").add("status", "total"), "41");
+
+    metrics.create_rollup_requests_total.increment(42);
+    assert_metric_value(&registry, "engine_requests_total",
+                        MetricLabels().add("type", "create_rollup").add("status", "total"), "42");
+
+    metrics.create_rollup_requests_failed.increment(43);
+    assert_metric_value(&registry, "engine_requests_total",
+                        MetricLabels().add("type", "create_rollup").add("status", "failed"), "43");
+
     metrics.delete_requests_failed.increment(9);
     assert_metric_value(&registry, "engine_requests_total",
                         MetricLabels().add("type", "delete").add("status", "failed"), "9");

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -243,28 +243,28 @@ TEST_F(BackendMetricsTest, Normal) {
     }
     // engine request
     {
-        agent_metrics->create_tablet_requests_total.increment(15);
+        storage_metrics->create_tablet_requests_total.increment(15);
         auto metric = metrics->get_metric("engine_requests_total",
                                           MetricLabels().add("type", "create_tablet").add("status", "total"));
         ASSERT_TRUE(metric != nullptr);
         ASSERT_STREQ("15", metric->to_string().c_str());
     }
     {
-        agent_metrics->drop_tablet_requests_total.increment(16);
+        storage_metrics->drop_tablet_requests_total.increment(16);
         auto metric = metrics->get_metric("engine_requests_total",
                                           MetricLabels().add("type", "drop_tablet").add("status", "total"));
         ASSERT_TRUE(metric != nullptr);
         ASSERT_STREQ("16", metric->to_string().c_str());
     }
     {
-        agent_metrics->report_all_tablets_requests_total.increment(17);
+        storage_metrics->report_all_tablets_requests_total.increment(17);
         auto metric = metrics->get_metric("engine_requests_total",
                                           MetricLabels().add("type", "report_all_tablets").add("status", "total"));
         ASSERT_TRUE(metric != nullptr);
         ASSERT_STREQ("17", metric->to_string().c_str());
     }
     {
-        agent_metrics->report_tablet_requests_total.increment(18);
+        storage_metrics->report_tablet_requests_total.increment(18);
         auto metric = metrics->get_metric("engine_requests_total",
                                           MetricLabels().add("type", "report_tablet").add("status", "total"));
         ASSERT_TRUE(metric != nullptr);
@@ -278,7 +278,7 @@ TEST_F(BackendMetricsTest, Normal) {
         ASSERT_STREQ("19", metric->to_string().c_str());
     }
     {
-        agent_metrics->create_rollup_requests_total.increment(20);
+        storage_metrics->create_rollup_requests_total.increment(20);
         auto metric = metrics->get_metric("engine_requests_total",
                                           MetricLabels().add("type", "create_rollup").add("status", "total"));
         ASSERT_TRUE(metric != nullptr);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
