### PR TITLE
[Enhancement] Skip TabletMetadataPB deep copy on metacache hit in tablet_id overload

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -530,6 +530,10 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
         return tablet_metadata_or.status();
     }
 
+    // Skip the deep copy when the cached PB already has the right id; set_id below would be a no-op.
+    if (tablet_metadata_or.value()->id() == tablet_id) {
+        return std::move(tablet_metadata_or).value();
+    }
     auto tablet_metadata = std::make_shared<TabletMetadata>(*tablet_metadata_or.value());
     tablet_metadata->set_id(tablet_id);
     return tablet_metadata;


### PR DESCRIPTION
## Why I'm doing:

`TabletManager::get_tablet_metadata(tablet_id, version, ...)` always allocated a fresh `TabletMetadataPB` and deep-copied the cached one just so it could call `set_id(tablet_id)` on the copy. For the dominant code path — single-tablet metadata files (or bundle entries) read at a non-initial version — the cached PB's `id()` already equals `tablet_id`, so the copy is wasted work and the `set_id` is a no-op.

#73002 partially addressed this by routing one caller (`LakeDelvecLoader::load_from_file`) through the path-based overload, which already returns the cached `shared_ptr` without copying. That fixes one hot site but leaves every other `tablet_id`-based caller still paying the copy on every cache hit:

- `storage/lake/transactions.cpp`
- `storage/lake/tablet_reshard.cpp`
- `storage/lake/vacuum.cpp`
- `storage/lake/update_manager.cpp`
- `storage/lake/lake_primary_key_compaction_conflict_resolver.cpp`
- `storage/lake/tablet.cpp`, `vector_index_build_task.cpp`, `tablet_retain_info.cpp`
- `service/service_be/lake_service.cpp`
- `exprs/table_function/list_rowsets.cpp`
- `script/script.cpp`

PK compaction / PK-index rebuild paths in particular issue many `get_tablet_metadata(tablet_id, ...)` calls per tablet, so on cold-start storms with multi-MB metadata this copy cost is non-trivial.

## What I'm doing:

Fix the root cause in the `tablet_id` overload: when the cached PB already carries the right `id()`, return the existing `shared_ptr` directly and skip both `make_shared<TabletMetadata>(*ptr)` and `set_id`. Fall through to the existing copy + `set_id` path for the cases where the cached id can differ — bundle / aggregation-partition entries and the `kInitialVersion` fallback in the path overload (which writes `id` onto the cached PB before caching, so subsequent hits also benefit from the fast path).

Result: every `tablet_id`-based caller now skips the copy on metacache hits without needing to be rewritten to the path overload. The `LakeDelvecLoader` workaround in #73002 could be folded back in a follow-up, but that's left for a separate change to keep this PR focused.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4