### PR TITLE
[Enhancement] Reduce lock contention in CachingIcebergCatalog by switching from catalog-level to table-level locking

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -90,6 +90,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     private final Map<IcebergTableName, Set<String>> metaFileCacheMap = new ConcurrentHashMap<>(); // table -> metadata file paths
     private final Map<IcebergTableName, Long> tableLatestAccessTime = new ConcurrentHashMap<>();
     private final Map<IcebergTableName, Long> tableLatestRefreshTime = new ConcurrentHashMap<>();
+    // Per-table lock strings: avoids catalog-wide serialization during concurrent refresh of different tables.
+    private final ConcurrentHashMap<String, String> tableRefreshLockMap = new ConcurrentHashMap<>();
 
     private final com.github.benmanes.caffeine.cache.LoadingCache<IcebergTableName, Map<String, Partition>> partitionCache;
 
@@ -386,7 +388,16 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     @Override
-    public synchronized void refreshTable(String dbName, String tableName, ConnectContext ctx, ExecutorService executorService) {
+    public void refreshTable(String dbName, String tableName, ConnectContext ctx, ExecutorService executorService) {
+        String lockKey = dbName.toLowerCase(Locale.ROOT) + "." + tableName.toLowerCase(Locale.ROOT);
+        tableRefreshLockMap.putIfAbsent(lockKey, lockKey);
+        String lock = tableRefreshLockMap.get(lockKey);
+        synchronized (lock) {
+            refreshTableUnderLock(dbName, tableName, ctx, executorService);
+        }
+    }
+
+    private void refreshTableUnderLock(String dbName, String tableName, ConnectContext ctx, ExecutorService executorService) {
         IcebergTableName icebergTableName = new IcebergTableName(dbName, tableName);
         Table cachedTable = tables.getIfPresent(icebergTableName);
         if (cachedTable == null) {
@@ -440,9 +451,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         // update tables before refresh partition cache
         // so when refreshing partition cache, `getTables` can return the latest one.
         // another way to fix is to call `delegate.getTables` when refreshing partition cache.
-        synchronized (this) {
-            tables.put(keyWithoutSnap, updatedTable);
-        }
+        tables.put(keyWithoutSnap, updatedTable);
 
         partitionCache.invalidate(baseIcebergTableName);
         partitionCache.get(updatedIcebergTableName);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -55,9 +55,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.HIVE_METASTORE_URIS;
@@ -879,6 +881,132 @@ public class CachingIcebergCatalogTest {
             es.shutdownNow();
             System.out.println("===== test reload async end =====");
         }
+    }
+
+    /**
+     * Two concurrent refreshTable calls on the SAME table must be serialized: the second
+     * waits for the first to finish before entering its critical section.
+     */
+    @Test
+    public void testRefreshTableSameTableIsSerializedNotParallel() throws Exception {
+        AtomicInteger concurrentRefreshes = new AtomicInteger(0);
+        AtomicInteger maxConcurrentRefreshes = new AtomicInteger(0);
+        CountDownLatch firstStarted = new CountDownLatch(1);
+
+        IcebergCatalog delegate = Mockito.mock(IcebergCatalog.class);
+        Mockito.when(delegate.getTable(Mockito.any(), Mockito.eq("db"), Mockito.eq("tbl")))
+                .thenAnswer(inv -> {
+                    int current = concurrentRefreshes.incrementAndGet();
+                    maxConcurrentRefreshes.accumulateAndGet(current, Math::max);
+                    firstStarted.countDown();
+                    Thread.sleep(80);
+                    concurrentRefreshes.decrementAndGet();
+
+                    TableOperations ops = Mockito.mock(TableOperations.class);
+                    TableMetadata meta = Mockito.mock(TableMetadata.class);
+                    Mockito.when(ops.current()).thenReturn(meta);
+                    Mockito.when(meta.metadataFileLocation()).thenReturn("loc-" + UUID.randomUUID());
+                    Snapshot snap = Mockito.mock(Snapshot.class);
+                    Mockito.when(snap.snapshotId()).thenReturn(1L);
+                    Mockito.when(snap.dataManifests(Mockito.any())).thenReturn(List.of());
+                    Mockito.when(meta.currentSnapshot()).thenReturn(snap);
+                    return new BaseTable(ops, "db.tbl");
+                });
+
+        CachingIcebergCatalog catalog = new CachingIcebergCatalog(
+                CATALOG_NAME, delegate, DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+
+        // Populate cache with an initial table so refreshTable enters the update branch.
+        TableOperations initOps = Mockito.mock(TableOperations.class);
+        TableMetadata initMeta = Mockito.mock(TableMetadata.class);
+        Snapshot initSnap = Mockito.mock(Snapshot.class);
+        Mockito.when(initOps.current()).thenReturn(initMeta);
+        Mockito.when(initMeta.metadataFileLocation()).thenReturn("loc-initial");
+        Mockito.when(initMeta.currentSnapshot()).thenReturn(initSnap);
+        Mockito.when(initSnap.snapshotId()).thenReturn(0L);
+        Mockito.when(initSnap.dataManifests(Mockito.any())).thenReturn(List.of());
+        BaseTable initTable = new BaseTable(initOps, "db.tbl");
+        LoadingCache<IcebergTableName, Table> tables1 = Deencapsulation.getField(catalog, "tables");
+        tables1.put(new IcebergTableName("db", "tbl"), initTable);
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        ConnectContext ctx = new ConnectContext();
+
+        pool.submit(() -> catalog.refreshTable("db", "tbl", ctx, null));
+        firstStarted.await(2, TimeUnit.SECONDS);
+        pool.submit(() -> catalog.refreshTable("db", "tbl", ctx, null));
+
+        pool.shutdown();
+        pool.awaitTermination(5, TimeUnit.SECONDS);
+
+        Assertions.assertEquals(1, maxConcurrentRefreshes.get(),
+                "concurrent refreshes on same table must be serialized (max concurrent should be 1)");
+    }
+
+    /**
+     * Two concurrent refreshTable calls on DIFFERENT tables must not block each other:
+     * both should overlap in time.
+     */
+    @Test
+    public void testRefreshTableDifferentTablesRunInParallel() throws Exception {
+        int sleepMs = 150;
+        AtomicInteger maxConcurrent = new AtomicInteger(0);
+        AtomicInteger concurrent = new AtomicInteger(0);
+        CountDownLatch bothStarted = new CountDownLatch(2);
+
+        IcebergCatalog delegate = Mockito.mock(IcebergCatalog.class);
+        Mockito.when(delegate.getTable(Mockito.any(), Mockito.eq("db"), Mockito.anyString()))
+                .thenAnswer(inv -> {
+                    int c = concurrent.incrementAndGet();
+                    maxConcurrent.accumulateAndGet(c, Math::max);
+                    bothStarted.countDown();
+                    Thread.sleep(sleepMs);
+                    concurrent.decrementAndGet();
+
+                    TableOperations ops = Mockito.mock(TableOperations.class);
+                    TableMetadata meta = Mockito.mock(TableMetadata.class);
+                    Mockito.when(ops.current()).thenReturn(meta);
+                    Mockito.when(meta.metadataFileLocation()).thenReturn("loc-" + UUID.randomUUID());
+                    Snapshot snap = Mockito.mock(Snapshot.class);
+                    Mockito.when(snap.snapshotId()).thenReturn(1L);
+                    Mockito.when(snap.dataManifests(Mockito.any())).thenReturn(List.of());
+                    Mockito.when(meta.currentSnapshot()).thenReturn(snap);
+                    return new BaseTable(ops, "db." + inv.getArgument(2));
+                });
+
+        CachingIcebergCatalog catalog = new CachingIcebergCatalog(
+                CATALOG_NAME, delegate, DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+
+        LoadingCache<IcebergTableName, Table> tables2 = Deencapsulation.getField(catalog, "tables");
+        // Pre-populate cache for both tables so refreshTable enters the update branch.
+        for (String tbl : List.of("tbl1", "tbl2")) {
+            TableOperations initOps = Mockito.mock(TableOperations.class);
+            TableMetadata initMeta = Mockito.mock(TableMetadata.class);
+            Snapshot initSnap = Mockito.mock(Snapshot.class);
+            Mockito.when(initOps.current()).thenReturn(initMeta);
+            Mockito.when(initMeta.metadataFileLocation()).thenReturn("loc-initial-" + tbl);
+            Mockito.when(initMeta.currentSnapshot()).thenReturn(initSnap);
+            Mockito.when(initSnap.snapshotId()).thenReturn(0L);
+            Mockito.when(initSnap.dataManifests(Mockito.any())).thenReturn(List.of());
+            tables2.put(new IcebergTableName("db", tbl), new BaseTable(initOps, "db." + tbl));
+        }
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        ConnectContext ctx = new ConnectContext();
+
+        long start = System.currentTimeMillis();
+        pool.submit(() -> catalog.refreshTable("db", "tbl1", ctx, null));
+        pool.submit(() -> catalog.refreshTable("db", "tbl2", ctx, null));
+
+        pool.shutdown();
+        pool.awaitTermination(5, TimeUnit.SECONDS);
+        long elapsed = System.currentTimeMillis() - start;
+
+        Assertions.assertEquals(2, maxConcurrent.get(),
+                "refreshes on different tables should overlap (max concurrent should be 2)");
+        // If they ran sequentially the elapsed time would be >= 2*sleepMs; parallel means < 1.8*sleepMs.
+        Assertions.assertTrue(elapsed < sleepMs * 2 - 50,
+                "different-table refreshes should run in parallel, elapsed=" + elapsed + "ms");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -55,7 +55,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -946,21 +948,43 @@ public class CachingIcebergCatalogTest {
     /**
      * Two concurrent refreshTable calls on DIFFERENT tables must not block each other:
      * both should overlap in time.
+     *
+     * <p>A CyclicBarrier forces both threads to rendezvous inside the mock before either
+     * proceeds, so the "max concurrent" reading is deterministic even under GC pressure.
+     * No wall-clock assertion is used.
      */
     @Test
     public void testRefreshTableDifferentTablesRunInParallel() throws Exception {
-        int sleepMs = 150;
         AtomicInteger maxConcurrent = new AtomicInteger(0);
         AtomicInteger concurrent = new AtomicInteger(0);
-        CountDownLatch bothStarted = new CountDownLatch(2);
+        // Barrier ensures both threads have incremented the counter before either continues.
+        CyclicBarrier barrier = new CyclicBarrier(2);
 
         IcebergCatalog delegate = Mockito.mock(IcebergCatalog.class);
         Mockito.when(delegate.getTable(Mockito.any(), Mockito.eq("db"), Mockito.anyString()))
                 .thenAnswer(inv -> {
                     int c = concurrent.incrementAndGet();
                     maxConcurrent.accumulateAndGet(c, Math::max);
-                    bothStarted.countDown();
-                    Thread.sleep(sleepMs);
+                    // Wait until the other thread also reaches this point, guaranteeing overlap.
+                    //
+                    // Why 5 s: in the happy path both threads reach here in microseconds (the
+                    // code path is a handful of ConcurrentHashMap ops + one synchronized block
+                    // on different lock objects).  The timeout only fires when the lock is
+                    // catalog-wide and permanently blocks the second thread — the regression we
+                    // want to catch.
+                    //
+                    // Trade-off: a shorter timeout reduces false-negative latency when the
+                    // regression is present, but risks a false-positive (flaky failure) under
+                    // extreme GC pressure.  5 s is conservative enough to absorb even a full
+                    // GC pause while still keeping test feedback fast.
+                    try {
+                        barrier.await(5, TimeUnit.SECONDS);
+                    } catch (BrokenBarrierException | java.util.concurrent.TimeoutException e) {
+                        throw new RuntimeException(
+                                "Barrier timed out — second thread never reached the barrier. "
+                                        + "This indicates catalog-wide locking is blocking concurrent "
+                                        + "refreshes of different tables.", e);
+                    }
                     concurrent.decrementAndGet();
 
                     TableOperations ops = Mockito.mock(TableOperations.class);
@@ -994,19 +1018,17 @@ public class CachingIcebergCatalogTest {
         ExecutorService pool = Executors.newFixedThreadPool(2);
         ConnectContext ctx = new ConnectContext();
 
-        long start = System.currentTimeMillis();
         pool.submit(() -> catalog.refreshTable("db", "tbl1", ctx, null));
         pool.submit(() -> catalog.refreshTable("db", "tbl2", ctx, null));
 
         pool.shutdown();
         pool.awaitTermination(5, TimeUnit.SECONDS);
-        long elapsed = System.currentTimeMillis() - start;
 
+        // The barrier above guarantees deterministic overlap: if the lock were catalog-wide,
+        // the second thread would block on synchronized() and the barrier would time out,
+        // causing the test to fail with BrokenBarrierException before reaching this line.
         Assertions.assertEquals(2, maxConcurrent.get(),
                 "refreshes on different tables should overlap (max concurrent should be 2)");
-        // If they ran sequentially the elapsed time would be >= 2*sleepMs; parallel means < 1.8*sleepMs.
-        Assertions.assertTrue(elapsed < sleepMs * 2 - 50,
-                "different-table refreshes should run in parallel, elapsed=" + elapsed + "ms");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
`CachingIcebergCatalog.refreshTable` was annotated with `synchronized`, which puts a single lock on the entire catalog instance. This means that when the background refresh thread cycles through all cached tables, each `refreshTable` call blocks every other one — even for completely unrelated tables. On catalogs with many active tables, this serializes what should be independent I/O-bound operations and can cause refresh lag.

## What I'm doing:
Port the table-level locking pattern from `CachingHiveMetastore` into `CachingIcebergCatalog`.

Instead of one lock for the whole catalog, each table gets its own lock string stored in a `ConcurrentHashMap`:

```
Before (catalog-level):
Thread A: refreshTable("db", "tbl1") ─┐
├─ synchronized(this) → serialized
Thread B: refreshTable("db", "tbl2") ─┘

After (table-level):
Thread A: refreshTable("db", "tbl1") → synchronized("db.tbl1") ─┐ run in parallel
Thread B: refreshTable("db", "tbl2") → synchronized("db.tbl2") ─┘

Thread A: refreshTable("db", "tbl1") ─┐
├─ synchronized("db.tbl1") → still serialized
Thread C: refreshTable("db", "tbl1") ─┘
```

Two threads refreshing the **same** table still serialize (correct), while two threads refreshing **different** tables now run concurrently (improved).

The inner `synchronized(this)` guard around `tables.put()` is also removed — it was made redundant both by the per-table lock now held by the caller, and by Caffeine's own thread-safety guarantees.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
