### PR TITLE
[BugFix] Fix race condition of PipelineTimerTask doRun and unscheduling during query context destruction

### DIFF
--- a/be/src/common/bthread_timer.cpp
+++ b/be/src/common/bthread_timer.cpp
@@ -26,7 +26,7 @@ void BthreadTimerTask::waitUtilFinished() {
     _latch.wait();
 }
 
-void BthreadTimerTask::unschedule(BthreadTimer* timer) {
+void BthreadTimerTask::unschedule_and_join(BthreadTimer* timer) {
     int rc = timer->unschedule(this);
     if (rc == 1) {
         waitUtilFinished();

--- a/be/src/common/bthread_timer.h
+++ b/be/src/common/bthread_timer.h
@@ -54,13 +54,13 @@ public:
         _latch.count_down();
     }
 
-    void unschedule(BthreadTimer* timer);
+    void unschedule_and_join(BthreadTimer* timer);
 
     void set_tid(BthreadTimerTaskId tid) { _tid = tid; }
     BthreadTimerTaskId tid() const { return _tid; }
 
 private:
-    // Only call when unschedule returns that the task is running.
+    // Only call when BthreadTimer::unschedule returns that the task is running.
     void waitUtilFinished();
 
 protected:

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -441,14 +441,14 @@ void FragmentContext::clear_pipeline_timer() {
         if (!_rf_timeout_tasks.empty()) {
             for (auto& [ignore, task] : _rf_timeout_tasks) {
                 if (task) {
-                    task->unschedule(_pipeline_timer);
+                    task->unschedule_and_join(_pipeline_timer);
                     task.reset();
                 }
             }
             _rf_timeout_tasks.clear();
         }
         if (_timeout_task) {
-            _timeout_task->unschedule(_pipeline_timer);
+            _timeout_task->unschedule_and_join(_pipeline_timer);
             _timeout_task.reset();
         }
     }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -855,7 +855,7 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
     _update_driver_level_timer();
 
     if (_global_rf_timer != nullptr) {
-        _fragment_ctx->pipeline_timer()->unschedule(_global_rf_timer.get());
+        _global_rf_timer->unschedule_and_join(_fragment_ctx->pipeline_timer());
     }
 
     // Acquire the pointer to avoid be released when removing query

--- a/be/src/exec/pipeline/schedule/pipeline_timer.h
+++ b/be/src/exec/pipeline/schedule/pipeline_timer.h
@@ -30,7 +30,7 @@ class PipelineTimerTask : public BthreadTimerTask {
 public:
     virtual ~PipelineTimerTask() = default;
 
-    void unschedule(PipelineTimer* timer);
+    void unschedule_and_join(PipelineTimer* timer);
 };
 
 class PipelineTimer : public BthreadTimer {
@@ -39,7 +39,7 @@ public:
     ~PipelineTimer() noexcept = default;
 };
 
-inline void PipelineTimerTask::unschedule(PipelineTimer* timer) {
-    BthreadTimerTask::unschedule(timer);
+inline void PipelineTimerTask::unschedule_and_join(PipelineTimer* timer) {
+    BthreadTimerTask::unschedule_and_join(timer);
 }
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/wait_operator.cpp
+++ b/be/src/exec/pipeline/wait_operator.cpp
@@ -43,7 +43,7 @@ Status WaitSourceOperator::prepare(RuntimeState* state) {
 
 void WaitSourceOperator::close(RuntimeState* state) {
     if (_wait_timer_task != nullptr) {
-        state->fragment_ctx()->pipeline_timer()->unschedule(_wait_timer_task.get());
+        _wait_timer_task->unschedule_and_join(state->fragment_ctx()->pipeline_timer());
         _wait_timer_task = nullptr;
     }
 }
@@ -92,7 +92,7 @@ Status WaitSinkOperator::prepare(RuntimeState* state) {
 
 void WaitSinkOperator::close(RuntimeState* state) {
     if (_wait_timer_task != nullptr) {
-        state->fragment_ctx()->pipeline_timer()->unschedule(_wait_timer_task.get());
+        _wait_timer_task->unschedule_and_join(state->fragment_ctx()->pipeline_timer());
         _wait_timer_task = nullptr;
     }
 }

--- a/be/test/exec/pipeline/schedule/observer_test.cpp
+++ b/be/test/exec/pipeline/schedule/observer_test.cpp
@@ -126,7 +126,7 @@ TEST(TimerThreadTest, test) {
         // schedule a expired task
         ASSERT_OK(timer.schedule(noop.get(), s1));
         s.acquire();
-        noop->unschedule(&timer);
+        noop->unschedule_and_join(&timer);
         ASSERT_TRUE(changed);
 
         timespec s2 = abstime;
@@ -135,7 +135,7 @@ TEST(TimerThreadTest, test) {
         changed = false;
         ASSERT_OK(timer.schedule(noop.get(), s2));
         sleep(1);
-        noop->unschedule(&timer);
+        noop->unschedule_and_join(&timer);
         ASSERT_FALSE(changed);
     }
     {
@@ -160,7 +160,7 @@ TEST(TimerThreadTest, test) {
         ASSERT_OK(timer.schedule(noop.get(), s1));
         s.acquire();
         // will wait util timer finished
-        noop->unschedule(&timer);
+        noop->unschedule_and_join(&timer);
         ASSERT_TRUE(changed);
     }
 }

--- a/be/test/exec/pipeline/schedule/pipeline_timer_test.cpp
+++ b/be/test/exec/pipeline/schedule/pipeline_timer_test.cpp
@@ -94,10 +94,10 @@ TEST_F(PipelineTimerTaskTest, runs_when_due_and_unschedule_after_done_does_not_b
         std::this_thread::yield();
     }
 
-    // task.unschedule drives waitUtilFinished only when rc == 1 (running).
+    // task.unschedule_and_join drives waitUtilFinished only when rc == 1 (running).
     // Either way, the call must not deadlock.
     auto start = std::chrono::steady_clock::now();
-    task->unschedule(&timer);
+    task->unschedule_and_join(&timer);
     auto elapsed = std::chrono::steady_clock::now() - start;
     EXPECT_LT(elapsed, std::chrono::seconds(5));
     EXPECT_TRUE(task->ran.load(std::memory_order_acquire));
@@ -117,7 +117,7 @@ TEST_F(PipelineTimerTaskTest, unschedule_pending_task_removes_without_wait) {
 }
 
 // When Run is in progress, unschedule reports TIMER_TASK_RUNNING and
-// PipelineTimerTask::unschedule blocks inside waitUtilFinished until Run returns.
+// PipelineTimerTask::unschedule_and_join blocks inside waitUtilFinished until Run returns.
 TEST_F(PipelineTimerTaskTest, wait_util_finished_blocks_until_run_returns) {
     auto task = std::make_shared<ProbeTask>();
     task->block_until_released = true;
@@ -155,8 +155,8 @@ TEST_F(PipelineTimerTaskTest, wait_util_finished_returns_immediately_when_alread
     ASSERT_OK(timer.schedule(task.get(), past_abstime()));
     task->run_enter.acquire();
 
-    // Drain post-Run state by asking unschedule to synchronize.
-    task->unschedule(&timer);
+    // Drain post-Run state by asking unschedule_and_join to synchronize.
+    task->unschedule_and_join(&timer);
 
     auto start = std::chrono::steady_clock::now();
     task->waitUtilFinished();
@@ -165,7 +165,7 @@ TEST_F(PipelineTimerTaskTest, wait_util_finished_returns_immediately_when_alread
 }
 
 // Dekker / lost-wakeup stress. Each iteration creates a fresh task, schedules it
-// with a past abstime and immediately calls PipelineTimerTask::unschedule. This
+// with a past abstime and immediately calls PipelineTimerTask::unschedule_and_join. This
 // races the waiter's store of _has_consumer against doRun()'s _finished store +
 // _has_consumer load. A regression on the memory ordering (or on mutex + CV
 // coordination) will manifest as a permanent hang here; the watchdog bounds
@@ -192,11 +192,11 @@ TEST_F(PipelineTimerTaskTest, dekker_synchronization_stress) {
     for (int i = 0; i < kIterations; ++i) {
         auto task = std::make_shared<ProbeTask>();
         ASSERT_OK(timer.schedule(task.get(), past_abstime()));
-        // unschedule drives the race: may see TIMER_TASK_REMOVED (we got there
+        // unschedule_and_join drives the race: may see TIMER_TASK_REMOVED (we got there
         // first), TIMER_TASK_RUNNING (bthread already popped it) or -1 (finished
         // before we looked). Only the "running" case exercises waitUtilFinished,
         // but all three must terminate quickly.
-        task->unschedule(&timer);
+        task->unschedule_and_join(&timer);
         completed.store(i + 1, std::memory_order_release);
     }
 
@@ -233,7 +233,7 @@ TEST_F(PipelineTimerTaskTest, batched_tasks_all_unblock_eventually) {
     waiters.reserve(kTasks);
     for (auto& t : tasks) {
         waiters.emplace_back([&, raw = t.get()] {
-            raw->unschedule(&timer);
+            raw->unschedule_and_join(&timer);
             finished.fetch_add(1, std::memory_order_acq_rel);
         });
     }


### PR DESCRIPTION
## Why I'm doing:

BE crashes with stack trace
```
*** Aborted at 1778462420 (unix time) try "date -d @1778462420" if you are using GNU date ***
PC: @     0x7a98d9e9eb2c pthread_kill
*** SIGABRT (@0x3e800109240) received by PID 1086016 (TID 0x7a98513d46c0) LWP(1086891) from PID 1086016; stack trace: ***
    @     0x7a98d9ea1ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x10207f49 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7a98d9e45330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7a98d9e9eb2c pthread_kill
    @     0x7a98d9e4527e gsignal
    @     0x7a98d9e288ff abort
    @         0x14180943 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @         0x1417ef5c __cxxabiv1::__terminate(void (*)())
    @         0x1417efc7 std::terminate()
    @         0x1417fbd5 __cxa_pure_virtual
    @          0x96a3dc6 starrocks::pipeline::RunTimerTask(void*)
    @         0x10425a96 bthread::TimerThread::Task::run_and_delete()
    @         0x104264cb bthread::TimerThread::run()
    @         0x10426f75 bthread::TimerThread::run_this(void*)
    @     0x7a98d9e9caa4 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa3)
    @     0x7a98d9f29c6c (/usr/lib/x86_64-linux-gnu/libc.so.6+0x129c6b)
```

Root cause
Two version of unschedule method provides for pipeline to unregistor an untriggered PipelineTimerTask:
1. PipelineTimer::unschedule(PipelineTimerTask*); after unregister the task then return immediately. 
2. PipelineTimerTask::unschedule(PipelineTimer*); unregister the task then wait the task to finish doRun invocation if the task has been already fired.

The former one has race condition with PipelineTimerTask::doRun, while the latter has not. When finalizing the PipelineDriver, the former one is misused instead of the latter one, which leads query context are released before PipelineTimerTask::doRun accesses the dereference the references that points to already deallocated objects owned by query context.


## What I'm doing:
1. rename PipelineTimerTask::unschedule(PipelineTimer*) to PipelineTimerTask::unschedule_and_wait(PipelineTimer*); 
2. use PipelineTimerTask::unschedule_and_wait instead of PipelineTimer::unschedule(PipelineTimerTask*).
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
