### PR TITLE
[BugFix] Use localtime_r for thread safety in lake vacuum

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1321,7 +1321,9 @@ static StatusOr<std::pair<int64_t, int64_t>> partition_datafile_gc(std::string_v
         transaction_ids.insert(extract_txn_id_prefix(name).value_or(0));
         bytes_to_delete += entry.size.value_or(0);
         std::time_t time = static_cast<std::time_t>(entry.mtime.value_or(0));
-        auto outtime = std::put_time(std::localtime(&time), "%Y-%m-%d %H:%M:%S");
+        std::tm tm_buf{};
+        localtime_r(&time, &tm_buf);
+        auto outtime = std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S");
         ++progress;
         if (audit_ostream) {
             audit_ostream << '(' << progress << '/' << orphan_data_files.size() << ") " << name


### PR DESCRIPTION


## Why I'm doing:

std::localtime returns a pointer to a static internal buffer and is not thread-safe. Replace it with localtime_r writing into a stack-local tm to avoid data races when partition_datafile_gc runs concurrently.

```
#include <atomic>
#include <chrono>
#include <cstdio>
#include <ctime>
#include <thread>
#include <vector>

int main() {
    constexpr int kThreads        = 8;
    constexpr int kItersPerThread = 200000;

    const std::time_t inputs[kThreads] = {
        0,                  // 1970-01-01 00:00:00 UTC  -> year=70
        100000000,          // 1973                      -> year=73
        500000000,          // 1985                      -> year=85
        1000000000,         // 2001                      -> year=101
        1500000000,         // 2017                      -> year=117
        1700000000,         // 2023                      -> year=123
        1800000000,         // 2027                      -> year=127
        1900000000,         // 2030                      -> year=130
    };

    std::atomic<const std::tm*> shared_ptr{nullptr};
    std::atomic<bool>           same_pointer_across_threads{true};

    std::atomic<long> mismatch_count{0};
    std::atomic<long> total_calls{0};

    std::vector<std::thread> threads;
    threads.reserve(kThreads);

    auto t0 = std::chrono::steady_clock::now();

    for (int tid = 0; tid < kThreads; ++tid) {
        threads.emplace_back([&, tid]() {
            const std::time_t my_time = inputs[tid];

            int expected_year;
            {
                std::tm tmp = *std::localtime(&my_time);
                expected_year = tmp.tm_year;
            }

            long local_mismatch = 0;

            for (int i = 0; i < kItersPerThread; ++i) {
                const std::tm* p = std::localtime(&my_time);

                const std::tm* expected = shared_ptr.load(std::memory_order_relaxed);
                if (expected == nullptr) {
                    shared_ptr.compare_exchange_strong(expected, p);
                } else if (expected != p) {
                    same_pointer_across_threads.store(false, std::memory_order_relaxed);
                }

                int year1 = p->tm_year;
                for (volatile int k = 0; k < 5; ++k) {}
                int year2 = p->tm_year;

                if (year1 != expected_year || year2 != expected_year || year1 != year2) {
                    ++local_mismatch;
                }
            }

            mismatch_count.fetch_add(local_mismatch, std::memory_order_relaxed);
            total_calls.fetch_add(kItersPerThread, std::memory_order_relaxed);
        });
    }

    for (auto& th : threads) th.join();

    auto t1 = std::chrono::steady_clock::now();
    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();

    std::printf("threads             = %d\n", kThreads);
    std::printf("calls per thread    = %d\n", kItersPerThread);
    std::printf("total calls         = %ld\n", total_calls.load());
    std::printf("elapsed             = %lld ms\n", (long long)ms);
    std::printf("all threads got the SAME tm* pointer ? %s\n",
                same_pointer_across_threads.load() ? "YES (shared static buffer)" : "no");
    std::printf("data-race induced mismatches = %ld  (%.3f %%)\n",
                mismatch_count.load(),
                100.0 * mismatch_count.load() / total_calls.load());

    if (mismatch_count.load() > 0) {
        std::printf("\n=> CONFIRMED: std::localtime is NOT thread-safe.\n");
        std::printf("   Fix: use localtime_r(&t, &tm_out) on POSIX,\n");
        return 1;
    } else {
        std::printf("\n=> No mismatch observed in this run (race is timing-dependent,\n");
        std::printf("   but the shared-pointer check above already proves the buffer is shared).\n");
        return 0;
    }
}
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
