### PR TITLE
[Enhancement] Install type_checker_config.xml under be/lib/

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -1018,8 +1018,11 @@ install(FILES
     ${BASE_DIR}/../conf/udf_security.policy
     ${BASE_DIR}/../conf/core-site.xml
     ${BASE_DIR}/../conf/asan_suppressions.conf
-    ${BASE_DIR}/../conf/type_checker_config.xml
     DESTINATION ${OUTPUT_DIR}/conf)
+
+install(FILES
+    ${BASE_DIR}/../conf/type_checker_config.xml
+    DESTINATION ${OUTPUT_DIR}/lib)
 
 install(DIRECTORY
     ${BASE_DIR}/../webroot/be/

--- a/be/src/types/checker/type_checker.h
+++ b/be/src/types/checker/type_checker.h
@@ -21,7 +21,7 @@
  * 1. XML Configuration-based Type Mapping (Recommended)
  *    - Type mappings can be defined in XML configuration files
  *    - Location specified via STARROCKS_TYPE_CHECKER_CONFIG environment variable
- *    - Default location: $STARROCKS_HOME/conf/type_checker_config.xml
+ *    - Default location: $STARROCKS_HOME/lib/type_checker_config.xml
  *    - Provides dynamic type registration without recompilation
  *    - See type_checker_xml_loader.h for XML format details
  * 

--- a/be/src/types/type_checker_manager.cpp
+++ b/be/src/types/type_checker_manager.cpp
@@ -63,16 +63,15 @@ TypeCheckerManager& TypeCheckerManager::getInstance() {
 }
 
 void TypeCheckerManager::init() {
-    // Load type checkers from XML configuration file
-    // Location: conf/type_checker_config.xml (relative to BE home)
+    // Installed under lib/ so package upgrades always overwrite it
+    // (conf/ may be preserved for user customizations).
     std::string xml_path;
 
     const char* be_home = std::getenv("STARROCKS_HOME");
     if (be_home != nullptr) {
-        xml_path = std::string(be_home) + "/conf/type_checker_config.xml";
+        xml_path = std::string(be_home) + "/lib/type_checker_config.xml";
     } else {
-        // Use relative path as fallback
-        xml_path = "conf/type_checker_config.xml";
+        xml_path = "lib/type_checker_config.xml";
     }
 
     // Load from XML configuration - this is now mandatory

--- a/be/src/types/type_checker_manager.cpp
+++ b/be/src/types/type_checker_manager.cpp
@@ -15,6 +15,7 @@
 #include "types/type_checker_manager.h"
 
 #include <cstdlib>
+#include <filesystem>
 
 #include "checker/type_checker.h"
 #include "checker/type_checker_xml_loader.h"
@@ -64,17 +65,14 @@ TypeCheckerManager& TypeCheckerManager::getInstance() {
 
 void TypeCheckerManager::init() {
     // Installed under lib/ so package upgrades always overwrite it
-    // (conf/ may be preserved for user customizations).
-    std::string xml_path;
-
+    // (conf/ may be preserved for user customizations). Fall back to conf/
+    // so the BE can still find the file when running from the source tree.
     const char* be_home = std::getenv("STARROCKS_HOME");
-    if (be_home != nullptr) {
-        xml_path = std::string(be_home) + "/lib/type_checker_config.xml";
-    } else {
-        xml_path = "lib/type_checker_config.xml";
-    }
+    std::string base = be_home != nullptr ? std::string(be_home) : std::string(".");
+    std::string lib_path = base + "/lib/type_checker_config.xml";
+    std::string conf_path = base + "/conf/type_checker_config.xml";
 
-    // Load from XML configuration - this is now mandatory
+    std::string xml_path = std::filesystem::exists(lib_path) ? lib_path : conf_path;
     if (try_load_from_xml(xml_path)) {
         LOG(INFO) << "TypeCheckerManager initialized from XML configuration: " << xml_path;
     } else {

--- a/build.sh
+++ b/build.sh
@@ -709,7 +709,7 @@ if [ ${BUILD_BE} -eq 1 ]; then
     cp -r -p ${STARROCKS_HOME}/be/output/conf/hadoop_env.sh ${STARROCKS_OUTPUT}/be/conf/
     cp -r -p ${STARROCKS_HOME}/be/output/conf/log4j2.properties ${STARROCKS_OUTPUT}/be/conf/
     cp -r -p ${STARROCKS_HOME}/be/output/conf/core-site.xml ${STARROCKS_OUTPUT}/be/conf/
-    cp -r -p ${STARROCKS_HOME}/be/output/conf/type_checker_config.xml ${STARROCKS_OUTPUT}/be/conf/
+    cp -r -p ${STARROCKS_HOME}/be/output/lib/type_checker_config.xml ${STARROCKS_OUTPUT}/be/lib/
 
     if [ "${BUILD_TYPE}" == "ASAN" ]; then
         cp -r -p ${STARROCKS_HOME}/be/output/conf/asan_suppressions.conf ${STARROCKS_OUTPUT}/be/conf/

--- a/docs/en/developers/type_checker_xml_configuration.md
+++ b/docs/en/developers/type_checker_xml_configuration.md
@@ -17,13 +17,13 @@ The StarRocks Type Checker system uses **mandatory** XML-based configuration for
 
 The type checker configuration is loaded from the following location:
 
-1. **Default Location**: `$STARROCKS_HOME/conf/type_checker_config.xml`
+1. **Default Location**: `$STARROCKS_HOME/lib/type_checker_config.xml`
    ```bash
    export STARROCKS_HOME=/opt/starrocks
-   # Configuration will be loaded from /opt/starrocks/conf/type_checker_config.xml
+   # Configuration will be loaded from /opt/starrocks/lib/type_checker_config.xml
    ```
 
-2. **Relative Fallback**: `conf/type_checker_config.xml` (if `STARROCKS_HOME` is not set)
+2. **Relative Fallback**: `lib/type_checker_config.xml` (if `STARROCKS_HOME` is not set)
 
 **IMPORTANT**: XML configuration is **mandatory**. The configuration file must exist at one of the above locations. If the file is not found or fails to parse, the system will log errors and continue with an empty checker map (default checker handles unknown types).
 
@@ -118,7 +118,7 @@ The following StarRocks logical types can be used in type rules:
 
 ## Default Type Mappings
 
-The default `conf/type_checker_config.xml` includes mappings for:
+The default `lib/type_checker_config.xml` includes mappings for:
 
 - **Java Primitives**: Byte, Short, Integer, Long, Boolean, Float, Double
 - **Java Objects**: String, BigInteger, BigDecimal
@@ -126,25 +126,25 @@ The default `conf/type_checker_config.xml` includes mappings for:
 - **Binary Types**: byte[], [B, java.util.UUID
 - **Database-Specific**: Oracle (TIMESTAMP, TIMESTAMPLTZ, TIMESTAMPTZ, OracleBlob), SQL Server (DateTimeOffset), ClickHouse (UnsignedByte, UnsignedShort, UnsignedInteger, UnsignedLong)
 
-See `conf/type_checker_config.xml` for the complete configuration.
+See `lib/type_checker_config.xml` for the complete configuration.
 
 ## Usage
 
 ### For Administrators
 
 1. **Using Default Configuration**
-   - The default configuration is provided at `conf/type_checker_config.xml`
+   - The default configuration is provided at `lib/type_checker_config.xml`
    - Ensure this file exists before starting StarRocks BE
    - No additional setup required if using standard type mappings
 
 2. **Custom Configuration**
    ```bash
    # Edit the configuration file
-   vim $STARROCKS_HOME/conf/type_checker_config.xml
+   vim $STARROCKS_HOME/lib/type_checker_config.xml
    
    # Or copy to a different location and symlink
-   cp conf/type_checker_config.xml /path/to/custom_config.xml
-   ln -s /path/to/custom_config.xml $STARROCKS_HOME/conf/type_checker_config.xml
+   cp lib/type_checker_config.xml /path/to/custom_config.xml
+   ln -s /path/to/custom_config.xml $STARROCKS_HOME/lib/type_checker_config.xml
    
    # Start StarRocks BE
    ./bin/start_be.sh
@@ -247,9 +247,9 @@ Run the type checker tests:
 2. Verify loading:
 ```bash
 # Place your test XML at the default location
-cp /tmp/test_config.xml $STARROCKS_HOME/conf/type_checker_config.xml
+cp /tmp/test_config.xml $STARROCKS_HOME/lib/type_checker_config.xml
 # Or without STARROCKS_HOME
-cp /tmp/test_config.xml conf/type_checker_config.xml
+cp /tmp/test_config.xml lib/type_checker_config.xml
 # Start BE and check logs
 ```
 
@@ -257,7 +257,7 @@ cp /tmp/test_config.xml conf/type_checker_config.xml
 
 To add a new type mapping:
 
-1. Edit your XML configuration file (or `conf/type_checker_config.xml`)
+1. Edit your XML configuration file (or `lib/type_checker_config.xml`)
 2. Add a new `<type-mapping>` element with appropriate type rules:
    ```xml
    <type-mapping java_class="com.example.CustomType" display_name="CustomType">
@@ -290,16 +290,16 @@ To add a new type mapping:
 
 2. Verify file exists and has correct permissions:
    ```bash
-   ls -la $STARROCKS_HOME/conf/type_checker_config.xml
+   ls -la $STARROCKS_HOME/lib/type_checker_config.xml
    # Or if STARROCKS_HOME is not set
-   ls -la conf/type_checker_config.xml
+   ls -la lib/type_checker_config.xml
    ```
 
 3. Check BE logs for error messages
 
 4. Validate XML syntax:
    ```bash
-   xmllint --noout conf/type_checker_config.xml
+   xmllint --noout lib/type_checker_config.xml
    ```
 
 ### Type Checker Not Working
@@ -315,13 +315,13 @@ To add a new type mapping:
 1. Ensure XML is well-formed (matching open/close tags)
 2. Verify all attributes are properly quoted
 3. Check for special characters that need escaping
-4. Use XML validator: `xmllint conf/type_checker_config.xml`
+4. Use XML validator: `xmllint lib/type_checker_config.xml`
 
 ## Migration from Previous Versions
 
 If you're upgrading from a version with hardcoded type checkers:
 
-1. **XML Configuration is Now Mandatory**: Ensure `conf/type_checker_config.xml` exists
+1. **XML Configuration is Now Mandatory**: Ensure `lib/type_checker_config.xml` exists
 2. **No Hardcoded Fallback**: The system will not fall back to hardcoded configuration
 3. **New XML Format**: Update any custom XML to use `<type-rule>` elements instead of `checker` attribute
 4. **Verify Configuration**: Test your XML configuration before deployment
@@ -355,6 +355,6 @@ All type validation logic is now data-driven via XML configuration, eliminating 
 - Type Checker Implementation: `be/src/types/checker/type_checker.h`
 - XML Loader: `be/src/types/checker/type_checker_xml_loader.h`
 - Type Checker Manager: `be/src/types/type_checker_manager.h`
-- Default Configuration: `conf/type_checker_config.xml`
+- Default Configuration: `lib/type_checker_config.xml`
 - Unit Tests: `be/test/types/type_checker_test.cpp`, `be/test/types/type_checker_xml_loader_test.cpp`
 


### PR DESCRIPTION

## Why I'm doing:

Move the install destination of type_checker_config.xml from be/conf/ to be/lib/. Package upgrades preserve conf/ to keep user customizations but always overwrite lib/, so installing the file under lib/ avoids stale configurations after upgrades.

The source file remains at conf/type_checker_config.xml in the repo; only the install destination and the BE runtime lookup path change.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4