### PR TITLE
[BugFix] Replace non-thread-safe std::gmtime with gmtime_r

### DIFF
--- a/be/src/types/variant.cpp
+++ b/be/src/types/variant.cpp
@@ -22,6 +22,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <charconv>
 #include <cstdint>
+#include <ctime>
 #include <iomanip>
 #include <string_view>
 
@@ -646,10 +647,13 @@ StatusOr<VariantValue> VariantValue::get_element_at_index(const VariantMetadata&
 }
 
 static std::string epoch_day_to_date(int32_t epoch_days) {
-    std::time_t raw_time = epoch_days * 86400; // to seconds
-    std::tm* ptm = std::gmtime(&raw_time);     // to UTC
+    std::time_t raw_time = static_cast<std::time_t>(epoch_days) * 86400; // to seconds
+    std::tm tm_buf{};
+    if (gmtime_r(&raw_time, &tm_buf) == nullptr) {
+        return {};
+    }
     char buffer[11];
-    std::strftime(buffer, sizeof(buffer), "%Y-%m-%d", ptm);
+    std::strftime(buffer, sizeof(buffer), "%Y-%m-%d", &tm_buf);
     return buffer;
 }
 

--- a/be/test/formats/parquet/parquet_variant_test.cpp
+++ b/be/test/formats/parquet/parquet_variant_test.cpp
@@ -293,10 +293,13 @@ TEST_F(ParquetVariantTest, TimestampValue) {
 }
 
 std::string epoch_day_to_date(int32_t epoch_days) {
-    std::time_t raw_time = epoch_days * 86400; // to seconds
-    std::tm* ptm = std::gmtime(&raw_time);     // to UTC
+    std::time_t raw_time = static_cast<std::time_t>(epoch_days) * 86400; // to seconds
+    std::tm tm_buf{};
+    if (gmtime_r(&raw_time, &tm_buf) == nullptr) {
+        return {};
+    }
     char buffer[11];
-    std::strftime(buffer, sizeof(buffer), "%Y-%m-%d", ptm);
+    std::strftime(buffer, sizeof(buffer), "%Y-%m-%d", &tm_buf);
     return buffer;
 }
 


### PR DESCRIPTION


## Why I'm doing:

std::gmtime returns a pointer to a shared static buffer, which makes concurrent calls racy and may corrupt the returned std::tm. Use the reentrant gmtime_r variant with a stack-local std::tm, and widen the seconds computation to std::time_t to avoid signed overflow on extreme epoch_days values.
```
// Run:   ./gmtime_race

#include <atomic>
#include <chrono>
#include <cstdio>
#include <ctime>
#include <thread>
#include <vector>

int main() {
    constexpr int kThreads        = 8;
    constexpr int kItersPerThread = 200000;

    // Eight well-separated time points; each thread is pinned to one of them.
    // If gmtime were thread-safe, the tm read back must match this input.
    const std::time_t inputs[kThreads] = {
        0,                  // 1970-01-01 UTC -> year=70
        100000000,          // 1973           -> year=73
        500000000,          // 1985           -> year=85
        1000000000,         // 2001           -> year=101
        1500000000,         // 2017           -> year=117
        1700000000,         // 2023           -> year=123
        1800000000,         // 2027           -> year=127
        1900000000,         // 2030           -> year=130
    };

    // Used to verify that all threads receive the same static-buffer pointer.
    std::atomic<const std::tm*> shared_ptr{nullptr};
    std::atomic<bool>           same_pointer_across_threads{true};

    // Number of times we actually caught the data race in the act.
    std::atomic<long> mismatch_count{0};
    std::atomic<long> total_calls{0};

    std::vector<std::thread> threads;
    threads.reserve(kThreads);

    auto t0 = std::chrono::steady_clock::now();

    for (int tid = 0; tid < kThreads; ++tid) {
        threads.emplace_back([&, tid]() {
            const std::time_t my_time = inputs[tid];

            // Compute the "correct" answer once, with no contention.
            int expected_year;
            int expected_mon;
            int expected_mday;
            {
                std::tm tmp = *std::gmtime(&my_time);
                expected_year = tmp.tm_year;
                expected_mon  = tmp.tm_mon;
                expected_mday = tmp.tm_mday;
            }

            long local_mismatch = 0;

            for (int i = 0; i < kItersPerThread; ++i) {
                const std::tm* p = std::gmtime(&my_time);

                // Check 1: do all threads see the same static pointer?
                const std::tm* expected = shared_ptr.load(std::memory_order_relaxed);
                if (expected == nullptr) {
                    shared_ptr.compare_exchange_strong(expected, p);
                } else if (expected != p) {
                    same_pointer_across_threads.store(false, std::memory_order_relaxed);
                }

                // Check 2: simulate real code that reads multiple fields off
                // the returned pointer to build a string; another thread can
                // overwrite the buffer inside that window.
                int year = p->tm_year;
                int mon  = p->tm_mon;
                for (volatile int k = 0; k < 5; ++k) {} // widen the window
                int mday = p->tm_mday;

                if (year != expected_year || mon != expected_mon || mday != expected_mday) {
                    ++local_mismatch;
                }
            }

            mismatch_count.fetch_add(local_mismatch, std::memory_order_relaxed);
            total_calls.fetch_add(kItersPerThread, std::memory_order_relaxed);
        });
    }

    for (auto& th : threads) th.join();

    auto t1 = std::chrono::steady_clock::now();
    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();

    std::printf("threads             = %d\n", kThreads);
    std::printf("calls per thread    = %d\n", kItersPerThread);
    std::printf("total calls         = %ld\n", total_calls.load());
    std::printf("elapsed             = %lld ms\n", (long long)ms);
    std::printf("all threads got the SAME tm* pointer ? %s\n",
                same_pointer_across_threads.load() ? "YES (shared static buffer)" : "no");
    std::printf("data-race induced mismatches = %ld  (%.4f %%)\n",
                mismatch_count.load(),
                100.0 * mismatch_count.load() / total_calls.load());

    if (mismatch_count.load() > 0) {
        std::printf("\n=> CONFIRMED: std::gmtime is NOT thread-safe.\n");
        std::printf("   Fix: use gmtime_r(&t, &tm_out) on POSIX,\n");
        std::printf("        or gmtime_s(&tm_out, &t) on Windows.\n");
        return 1;
    } else {
        std::printf("\n=> No field mismatch observed in this run (race is timing-dependent),\n");
        std::printf("   but the shared-pointer check above already proves the buffer is shared.\n");
        return 0;
    }
}
```
```
threads             = 8
calls per thread    = 200000
total calls         = 1600000
elapsed             = 302 ms
all threads got the SAME tm* pointer ? YES (shared static buffer)
data-race induced mismatches = 427305  (26.7066 %)

=> CONFIRMED: std::gmtime is NOT thread-safe.
   Fix: use gmtime_r(&t, &tm_out) on POSIX,
        or gmtime_s(&tm_out, &t) on Windows.
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
