### PR TITLE
[BugFix] Allow state_union to accept compatible string types in IVM

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.rule.ivm.common;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -160,8 +161,10 @@ public class IvmOpUtils {
     public static ScalarOperator buildStateUnionScalarOperator(CallOperator aggFunc,
                                                                 ScalarOperator intermediateAggScalarOp,
                                                                 ScalarOperator aggStateAggStateColumnRef) {
-        Preconditions.checkArgument(intermediateAggScalarOp.getType().equals(aggStateAggStateColumnRef.getType()),
-                "The type of intermediateAggScalarOp and aggStateTableRowIdScalarOp must be the same");
+        Preconditions.checkArgument(
+                typesCompatibleForStateUnion(intermediateAggScalarOp.getType(), aggStateAggStateColumnRef.getType()),
+                "intermediateAggScalarOp type %s is incompatible with MV state column type %s",
+                intermediateAggScalarOp.getType(), aggStateAggStateColumnRef.getType());
         Type[] argTypes = new Type[] {intermediateAggScalarOp.getType(), aggStateAggStateColumnRef.getType()};
         String origAggFuncName = AggStateUtils.getAggFuncNameOfCombinator(aggFunc.getFnName());
         String stateUnionFunctionName = AggStateUtils.stateUnionFunctionName(origAggFuncName);
@@ -181,5 +184,21 @@ public class IvmOpUtils {
         specializedFunc.setAggStateDesc(inputAggStateDesc.clone());
         return new CallOperator(stateUnionFunctionName, intermediateAggScalarOp.getType(),
                 List.of(intermediateAggScalarOp, aggStateAggStateColumnRef), specializedFunc);
+    }
+
+    @VisibleForTesting
+    static boolean typesCompatibleForStateUnion(Type intermediate, Type mvColumn) {
+        if (intermediate.equals(mvColumn)) {
+            return true;
+        }
+        // MaterializedViewAnalyzer caps VARCHAR length at OlapMaxVarcharLength (65533)
+        // when persisting MV column types, so the delta side's narrower VARCHAR(N) is
+        // semantically compatible with the MV side's wider VARCHAR(65533). Same logic
+        // applies to other string types sharing a primitive kind.
+        if (intermediate.isStringType() && mvColumn.isStringType()
+                && intermediate.getPrimitiveType() == mvColumn.getPrimitiveType()) {
+            return true;
+        }
+        return false;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtilsTest.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm.common;
+
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link IvmOpUtils#typesCompatibleForStateUnion(Type, Type)}.
+ *
+ * Documents the cases the helper accepts (equal types and string types
+ * with the same primitive kind, e.g. VARCHAR with different lengths) and
+ * the cases it rejects (different primitive kinds, mismatched decimals).
+ */
+public class IvmOpUtilsTest {
+
+    @Test
+    public void equalTypesAreCompatible() {
+        ScalarType a = TypeFactory.createVarcharType(100);
+        ScalarType b = TypeFactory.createVarcharType(100);
+        Assertions.assertTrue(IvmOpUtils.typesCompatibleForStateUnion(a, b));
+    }
+
+    @Test
+    public void varcharDifferentLengthsAreCompatible() {
+        // Motivating case: delta-side VARCHAR(N) vs MV-side VARCHAR(65533)
+        // after AnalyzerUtils.transformTableColumnType widens the MV column.
+        ScalarType narrow = TypeFactory.createVarcharType(50);
+        ScalarType wide = TypeFactory.createVarcharType(65533);
+        Assertions.assertTrue(IvmOpUtils.typesCompatibleForStateUnion(narrow, wide));
+        Assertions.assertTrue(IvmOpUtils.typesCompatibleForStateUnion(wide, narrow));
+    }
+
+    @Test
+    public void charAndVarcharAreNotCompatible() {
+        // CHAR and VARCHAR are both string types but have different
+        // primitive kinds; the helper must not widen across them.
+        ScalarType charType = TypeFactory.createCharType(10);
+        ScalarType varcharType = TypeFactory.createVarcharType(10);
+        Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(charType, varcharType));
+        Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(varcharType, charType));
+    }
+
+    @Test
+    public void varcharAndIntAreNotCompatible() {
+        ScalarType varcharType = TypeFactory.createVarcharType(10);
+        Type intType = IntegerType.INT;
+        Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(varcharType, intType));
+        Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(intType, varcharType));
+    }
+
+    @Test
+    public void decimalSamePrecisionScaleEqual() {
+        ScalarType a = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2);
+        ScalarType b = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2);
+        Assertions.assertTrue(IvmOpUtils.typesCompatibleForStateUnion(a, b));
+    }
+
+    @Test
+    public void decimalDifferentScaleNotCompatible() {
+        // The helper only widens for string types; decimals must match
+        // exactly via equals (precision + scale).
+        ScalarType a = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2);
+        ScalarType b = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 3);
+        Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(a, b));
+        Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(b, a));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

IVM refresh over an Iceberg MV containing `MIN(varchar_col)` or `MAX(varchar_col)` fails during planning with a `Preconditions.checkArgument` violation in `IvmOpUtils.buildStateUnionScalarOperator`. The delta-side intermediate aggregate carries the original `VARCHAR(N)` type, while the MV-side AGG_STATE column ref carries `VARCHAR(65533)` — `MaterializedViewAnalyzer.genMaterializedViewColumns` runs every persisted column type through `AnalyzerUtils.transformTableColumnType`, which caps VARCHAR at `OlapMaxVarcharLength = 65533`. The strict type-equality precondition then rejects an otherwise compatible pair.

## What I'm doing:

Replace the strict `equals` precondition in `IvmOpUtils.buildStateUnionScalarOperator` with a new `typesCompatibleForStateUnion` helper that additionally accepts two STRING types sharing the same primitive kind. Unblocks MIN/MAX over VARCHAR/CHAR columns without weakening type safety for non-string paths.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4