### PR TITLE
[Tool] fix weekly SQL-Tester review: OSS path //centos7 (missing LINUX_DISTRO/BUILD_TYPE)

### DIFF
--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -149,6 +149,8 @@ jobs:
       BRANCH:        ${{ needs.prepare.outputs.BRANCH }}
       PR_NUMBER:     ${{ needs.prepare.outputs.COMMIT_SHA }}
       WEEKLY_REVIEW: 'true'
+      LINUX_DISTRO:  ubuntu
+      BUILD_TYPE:    Release
     outputs:
       sql_oss_path: ${{ steps.run.outputs.sql_oss_path }}
     steps:

--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Backup logs
         if: always()
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
+          cd ci-tool && source lib/init.sh
           ./bin/backup_log_cores.sh || true
 
       - name: Clean MySQL ECI


### PR DESCRIPTION
## Why I'm doing:
The `sql-tester-review` job env did not include `LINUX_DISTRO` or `BUILD_TYPE`. Only the "Apply for ECS" step exported them inside its own bash script — those exports do not carry into the next step. So `run-sql-tester.sh` defaulted `LINUX_DISTRO=centos7` (line 45) and left `BUILD_TYPE` empty, uploading XML to `//centos7/native` while REPORT expected `Release/ubuntu/native`.

## What I'm doing:

Add `LINUX_DISTRO: ubuntu` and `BUILD_TYPE: Release` to the job-level `env:` block so all steps in `sql-tester-review` inherit them.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4