### PR TITLE
[BugFix] Allocate Hive/Iceberg partition descriptors from query-level pool to avoid UAF

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -396,9 +396,16 @@ static std::unordered_set<int32_t> collect_broadcast_join_right_offsprings(
 
 // there will be partition values used by this batch of scan ranges and maybe following scan ranges
 // so before process this batch of scan ranges, we have to put partition values into the table associated with.
-static Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
-                                               const std::vector<TScanRangeParams>& scan_ranges) {
-    auto* obj_pool = runtime_state->obj_pool();
+// Exposed (non-static) so that unit tests can pin the contract that this helper allocates partition
+// descriptors from the query-level pool, not the per-fragment pool.
+Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
+                                        const std::vector<TScanRangeParams>& scan_ranges) {
+    // HiveTableDescriptor is shared across fragment instances of the same query, so the
+    // partition descriptors it owns must outlive any single fragment. Use the query-level
+    // ObjectPool instead of runtime_state->obj_pool() (which is per fragment instance) to
+    // avoid a heap-use-after-free when one fragment finishes while another is still
+    // referencing the entry in _partition_id_to_desc_map.
+    auto* obj_pool = runtime_state->global_obj_pool();
     const DescriptorTbl& desc_tbl = runtime_state->desc_tbl();
     TTableId cache_table_id = -1;
     TableDescriptor* table = nullptr;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -398,8 +398,7 @@ static std::unordered_set<int32_t> collect_broadcast_join_right_offsprings(
 // so before process this batch of scan ranges, we have to put partition values into the table associated with.
 // Exposed (non-static) so that unit tests can pin the contract that this helper allocates partition
 // descriptors from the query-level pool, not the per-fragment pool.
-Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
-                                        const std::vector<TScanRangeParams>& scan_ranges) {
+Status add_scan_ranges_partition_values(RuntimeState* runtime_state, const std::vector<TScanRangeParams>& scan_ranges) {
     // HiveTableDescriptor is shared across fragment instances of the same query, so the
     // partition descriptors it owns must outlive any single fragment. Use the query-level
     // ObjectPool instead of runtime_state->obj_pool() (which is per fragment instance) to

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -405,7 +405,7 @@ Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
     // ObjectPool instead of runtime_state->obj_pool() (which is per fragment instance) to
     // avoid a heap-use-after-free when one fragment finishes while another is still
     // referencing the entry in _partition_id_to_desc_map.
-    auto* obj_pool = runtime_state->global_obj_pool();
+    auto* obj_pool = RuntimeStateHelper::global_obj_pool(runtime_state);
     const DescriptorTbl& desc_tbl = runtime_state->desc_tbl();
     TTableId cache_table_id = -1;
     TableDescriptor* table = nullptr;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -57,22 +57,12 @@
 namespace starrocks {
 
 // for ut only
-RuntimeState::RuntimeState() : _obj_pool(new ObjectPool()) {}
+RuntimeState::RuntimeState() : _obj_pool(std::make_shared<ObjectPool>()) {}
 
 RuntimeState::RuntimeState(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,
                            const TQueryGlobals& query_globals, const QueryExecutionServices* query_execution_services,
                            ExecEnv* exec_env)
-        : _exec_env(exec_env),
-          _obj_pool(new ObjectPool()),
-          _is_cancelled(false),
-          _per_fragment_instance_idx(0),
-          _num_rows_load_total_from_source(0),
-          _num_bytes_load_from_source(0),
-          _num_rows_load_sink(0),
-          _num_bytes_load_sink(0),
-          _num_rows_load_filtered(0),
-          _num_rows_load_unselected(0),
-          _num_print_error_rows(0) {
+        : _exec_env(exec_env), _obj_pool(new ObjectPool()) {
     _profile = std::make_shared<RuntimeProfile>("Fragment " + print_id(fragment_instance_id));
     _load_channel_profile = std::make_shared<RuntimeProfile>("LoadChannel");
     _init(fragment_instance_id, query_options, query_globals, query_execution_services);
@@ -87,17 +77,7 @@ RuntimeState::RuntimeState(const TUniqueId& fragment_instance_id, const TQueryOp
 RuntimeState::RuntimeState(const TUniqueId& query_id, const TUniqueId& fragment_instance_id,
                            const TQueryOptions& query_options, const TQueryGlobals& query_globals,
                            const QueryExecutionServices* query_execution_services, ExecEnv* exec_env)
-        : _query_id(query_id),
-          _exec_env(exec_env),
-          _obj_pool(new ObjectPool()),
-          _per_fragment_instance_idx(0),
-          _num_rows_load_total_from_source(0),
-          _num_bytes_load_from_source(0),
-          _num_rows_load_sink(0),
-          _num_bytes_load_sink(0),
-          _num_rows_load_filtered(0),
-          _num_rows_load_unselected(0),
-          _num_print_error_rows(0) {
+        : _query_id(query_id), _exec_env(exec_env), _obj_pool(new ObjectPool()) {
     _profile = std::make_shared<RuntimeProfile>("Fragment " + print_id(fragment_instance_id));
     _load_channel_profile = std::make_shared<RuntimeProfile>("LoadChannel");
     _init(fragment_instance_id, query_options, query_globals, query_execution_services);
@@ -108,8 +88,7 @@ RuntimeState::RuntimeState(const TUniqueId& query_id, const TUniqueId& fragment_
         : RuntimeState(query_id, fragment_instance_id, query_options, query_globals,
                        static_cast<const QueryExecutionServices*>(nullptr), exec_env) {}
 
-RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
-        : _obj_pool(new ObjectPool()), _is_cancelled(false), _per_fragment_instance_idx(0) {
+RuntimeState::RuntimeState(const TQueryGlobals& query_globals) : _obj_pool(new ObjectPool()) {
     _profile = std::make_shared<RuntimeProfile>("<unnamed>");
     _load_channel_profile = std::make_shared<RuntimeProfile>("<unnamed>");
     _query_options.batch_size = DEFAULT_CHUNK_SIZE;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -664,7 +664,7 @@ private:
     // if true, execution should stop with a CANCELLED status
     std::atomic<bool> _is_cancelled{false};
 
-    int _per_fragment_instance_idx;
+    int _per_fragment_instance_idx = 0;
     int _num_per_fragment_instances = 0;
 
     // used as send id

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -82,6 +82,7 @@ set(EXEC_FILES
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/pipeline/exec_group_test.cpp
         ./exec/pipeline/glm_manager_tablet_adaptor_test.cpp
+        ./exec/pipeline/fragment_executor_test.cpp
         ./exec/pipeline/scan/physical_split_morsel_queue_test.cpp
         ./exec/query_cache/query_cache_test.cpp
         ./exec/query_cache/transform_operator.cpp
@@ -269,6 +270,7 @@ set(EXEC_FILES
         ./exec/data_sinks/arrow_result_writer_test.cpp
         ./runtime/buffer_control_block_test.cpp
         ./runtime/data_stream_mgr_test.cpp
+        ./runtime/descriptors_test.cpp
         ./runtime/diagnose_daemon_test.cpp
         ./runtime/external_scan_context_mgr_test.cpp
         ./runtime/fragment_mgr_test.cpp

--- a/be/test/exec/pipeline/fragment_executor_test.cpp
+++ b/be/test/exec/pipeline/fragment_executor_test.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include "base/testutil/assert.h"
 #include "common/config.h"
 #include "exec/pipeline/query_context.h"
 #include "gen_cpp/Descriptors_types.h"
@@ -24,15 +25,13 @@
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "runtime/runtime_state_helper.h"
-#include "testutil/assert.h"
 
 namespace starrocks::pipeline {
 
 // Forward declaration: the helper lives in fragment_executor.cpp. It is non-static so
 // this test can call it directly and pin the contract that partition descriptors are
 // allocated from the query-level ObjectPool (so they outlive any single fragment).
-Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
-                                        const std::vector<TScanRangeParams>& scan_ranges);
+Status add_scan_ranges_partition_values(RuntimeState* runtime_state, const std::vector<TScanRangeParams>& scan_ranges);
 
 class FragmentExecutorPartitionTest : public ::testing::Test {
 public:

--- a/be/test/exec/pipeline/fragment_executor_test.cpp
+++ b/be/test/exec/pipeline/fragment_executor_test.cpp
@@ -22,6 +22,7 @@
 #include "gen_cpp/PlanNodes_types.h"
 #include "gutil/casts.h"
 #include "runtime/descriptors.h"
+#include "runtime/descriptors_ext.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "runtime/runtime_state_helper.h"

--- a/be/test/exec/pipeline/fragment_executor_test.cpp
+++ b/be/test/exec/pipeline/fragment_executor_test.cpp
@@ -23,6 +23,7 @@
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
+#include "runtime/runtime_state_helper.h"
 #include "testutil/assert.h"
 
 namespace starrocks::pipeline {
@@ -79,7 +80,8 @@ protected:
 // leaving dangling pointers. A sibling fragment then hit UAF on the duplicate-check
 // comparison `partition->thrift_partition_key_exprs() != old_partition->...`.
 //
-// The fix switched to `runtime_state->global_obj_pool()` (per-query). This test
+// The fix switched to `RuntimeStateHelper::global_obj_pool(runtime_state)`
+// (per-query). This test
 // asserts that contract: after a fragment-level RuntimeState (and its per-fragment
 // pool) is destroyed, the partition descriptor it inserted remains alive in the
 // query-level pool. Under ASAN, reading the descriptor's heap fields after the
@@ -126,7 +128,7 @@ TEST_F(FragmentExecutorPartitionTest, PartitionDescriptorOutlivesFragmentPool) {
         // Sanity check: the contract being asserted only holds when the two pools
         // really differ. If a future refactor unified them, the assertion below
         // wouldn't tell us anything useful, so guard it.
-        ASSERT_NE(rs->obj_pool(), rs->global_obj_pool());
+        ASSERT_NE(rs->obj_pool(), RuntimeStateHelper::global_obj_pool(rs.get()));
 
         ASSERT_OK(add_scan_ranges_partition_values(rs.get(), scan_ranges));
     }

--- a/be/test/exec/pipeline/fragment_executor_test.cpp
+++ b/be/test/exec/pipeline/fragment_executor_test.cpp
@@ -1,0 +1,142 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+#include "exec/pipeline/query_context.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "gen_cpp/InternalService_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gutil/casts.h"
+#include "runtime/descriptors.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+
+namespace starrocks::pipeline {
+
+// Forward declaration: the helper lives in fragment_executor.cpp. It is non-static so
+// this test can call it directly and pin the contract that partition descriptors are
+// allocated from the query-level ObjectPool (so they outlive any single fragment).
+Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
+                                        const std::vector<TScanRangeParams>& scan_ranges);
+
+class FragmentExecutorPartitionTest : public ::testing::Test {
+public:
+    void SetUp() override { _exec_env = ExecEnv::GetInstance(); }
+
+    std::shared_ptr<RuntimeState> _make_runtime_state(QueryContext* query_ctx, DescriptorTbl* desc_tbl) {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        auto rs = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, _exec_env);
+        TUniqueId query_id;
+        rs->init_mem_trackers(query_id);
+        rs->set_query_ctx(query_ctx);
+        rs->set_desc_tbl(desc_tbl);
+        return rs;
+    }
+
+    static TScanRangeParams _make_scan_range(TTableId table_id, int64_t partition_id) {
+        TScanRangeParams params;
+        TScanRange& sr = params.scan_range;
+        sr.__isset.hdfs_scan_range = true;
+        sr.hdfs_scan_range.__isset.table_id = true;
+        sr.hdfs_scan_range.table_id = table_id;
+        sr.hdfs_scan_range.__isset.partition_id = true;
+        sr.hdfs_scan_range.partition_id = partition_id;
+        sr.hdfs_scan_range.__isset.partition_value = true;
+        sr.hdfs_scan_range.partition_value.file_format = THdfsFileFormat::TEXT;
+        sr.hdfs_scan_range.partition_value.location.suffix = "";
+        return params;
+    }
+
+protected:
+    ExecEnv* _exec_env = nullptr;
+};
+
+// Regression test for a heap-use-after-free in add_scan_ranges_partition_values.
+//
+// HiveTableDescriptor::_partition_id_to_desc_map is shared across all fragment
+// instances of the same query. The partition descriptors stored in that map must
+// therefore outlive any single fragment instance.
+//
+// Before the fix, add_scan_ranges_partition_values allocated partition descriptors
+// from `runtime_state->obj_pool()` (per-fragment). When one fragment finished and its
+// pool destructed, the descriptors it inserted into the shared map were freed,
+// leaving dangling pointers. A sibling fragment then hit UAF on the duplicate-check
+// comparison `partition->thrift_partition_key_exprs() != old_partition->...`.
+//
+// The fix switched to `runtime_state->global_obj_pool()` (per-query). This test
+// asserts that contract: after a fragment-level RuntimeState (and its per-fragment
+// pool) is destroyed, the partition descriptor it inserted remains alive in the
+// query-level pool. Under ASAN, reading the descriptor's heap fields after the
+// fragment's pool dies would otherwise be reported as heap-use-after-free.
+TEST_F(FragmentExecutorPartitionTest, PartitionDescriptorOutlivesFragmentPool) {
+    constexpr TTableId kTableId = 100;
+    constexpr int64_t kPartitionId = 42;
+
+    // Build a TDescriptorTable that contains a single HDFS table descriptor.
+    TDescriptorTable thrift_tbl;
+    {
+        TTableDescriptor tt;
+        tt.id = kTableId;
+        tt.tableType = TTableType::HDFS_TABLE;
+        thrift_tbl.tableDescriptors.push_back(tt);
+    }
+
+    // The QueryContext owns the per-query ObjectPool; the partition descriptor must
+    // ultimately end up here so it survives fragment teardown.
+    auto query_ctx = std::make_shared<QueryContext>();
+
+    // Build the DescriptorTbl in the query-level pool, matching the production path
+    // taken by FragmentExecutor._prepare_runtime_state for is_cached==false.
+    DescriptorTbl* desc_tbl = nullptr;
+    {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        RuntimeState bootstrap_rs(fragment_id, query_options, query_globals, _exec_env);
+        ASSERT_OK(DescriptorTbl::create(&bootstrap_rs, query_ctx->object_pool(), thrift_tbl, &desc_tbl,
+                                        config::vector_chunk_size));
+    }
+
+    auto* table_desc = desc_tbl->get_table_descriptor(kTableId);
+    ASSERT_NE(nullptr, table_desc);
+    auto* hive_table = down_cast<HiveTableDescriptor*>(table_desc);
+
+    std::vector<TScanRangeParams> scan_ranges = {_make_scan_range(kTableId, kPartitionId)};
+
+    // Run add_scan_ranges_partition_values inside a fragment-level scope. The
+    // RuntimeState (and its per-fragment obj_pool) is destroyed when the scope exits.
+    {
+        auto rs = _make_runtime_state(query_ctx.get(), desc_tbl);
+        // Sanity check: the contract being asserted only holds when the two pools
+        // really differ. If a future refactor unified them, the assertion below
+        // wouldn't tell us anything useful, so guard it.
+        ASSERT_NE(rs->obj_pool(), rs->global_obj_pool());
+
+        ASSERT_OK(add_scan_ranges_partition_values(rs.get(), scan_ranges));
+    }
+
+    // After the fragment is gone, the partition descriptor must still be accessible
+    // and its heap-owned fields must not have been freed.
+    HdfsPartitionDescriptor* partition = hive_table->get_partition(kPartitionId);
+    ASSERT_NE(nullptr, partition);
+    // Touching the vector trips ASAN if the descriptor backing memory was freed.
+    (void)partition->thrift_partition_key_exprs().size();
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -19,6 +19,7 @@
 #include "base/testutil/assert.h"
 #include "common/object_pool.h"
 #include "gen_cpp/Descriptors_types.h"
+#include "runtime/descriptors_ext.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_state.h"

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -16,12 +16,12 @@
 
 #include <gtest/gtest.h>
 
+#include "base/testutil/assert.h"
 #include "common/object_pool.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_state.h"
-#include "testutil/assert.h"
 
 namespace starrocks {
 

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -1,0 +1,106 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/descriptors.h"
+
+#include <gtest/gtest.h>
+
+#include "common/object_pool.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class HiveTableDescriptorTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _exec_env = ExecEnv::GetInstance();
+        _query_pool = std::make_unique<ObjectPool>();
+
+        TTableDescriptor tdesc;
+        tdesc.id = 1;
+        tdesc.tableType = TTableType::HDFS_TABLE;
+        _table_desc = _query_pool->add(new HdfsTableDescriptor(tdesc, _query_pool.get()));
+    }
+
+    std::shared_ptr<RuntimeState> _make_runtime_state() {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        auto rs = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, _exec_env);
+        TUniqueId query_id;
+        rs->init_mem_trackers(query_id);
+        return rs;
+    }
+
+    static THdfsPartition _make_partition_value() {
+        THdfsPartition p;
+        p.file_format = THdfsFileFormat::TEXT;
+        p.location.suffix = "";
+        return p;
+    }
+
+protected:
+    ExecEnv* _exec_env = nullptr;
+    std::unique_ptr<ObjectPool> _query_pool;
+    HdfsTableDescriptor* _table_desc = nullptr;
+};
+
+// Regression test for a heap-use-after-free in HiveTableDescriptor::add_partition_value.
+//
+// When two fragment instances of the same query share one HiveTableDescriptor (e.g. a
+// Hive/Iceberg table referenced multiple times via CTE), each fragment instance calls
+// add_partition_value, which stores the partition descriptor pointer in the
+// HiveTableDescriptor::_partition_id_to_desc_map shared across fragments.
+//
+// The previous implementation used `runtime_state->obj_pool()` (per-fragment) to allocate
+// the descriptor. When fragment A finished and its pool destructed, the inserted
+// descriptor was freed, but the pointer remained in the shared map. Fragment B then read
+// the dangling pointer in the duplicate-check comparison, causing UAF.
+//
+// The fix uses `runtime_state->global_obj_pool()` (per-query) so the descriptor's
+// lifetime matches the shared map. This test simulates that fixed behavior: both
+// fragments share the same query-level ObjectPool, so dropping a fragment's
+// RuntimeState does not free the partition descriptor. Under ASAN this exercises the
+// memory paths and must complete without errors.
+TEST_F(HiveTableDescriptorTest, AddPartitionValueLifetimeAcrossPools) {
+    constexpr int64_t partition_id = 42;
+    THdfsPartition thrift_partition = _make_partition_value();
+
+    {
+        // Fragment instance A: allocate from the shared query-level pool, then finish.
+        auto rs_a = _make_runtime_state();
+        ASSERT_OK(_table_desc->add_partition_value(rs_a.get(), _query_pool.get(), partition_id, thrift_partition));
+    }
+    // rs_a is destroyed here. Because the partition descriptor was allocated from
+    // _query_pool (the long-lived per-query pool), the map entry remains valid.
+
+    {
+        // Fragment instance B: same partition_id. add_partition_value finds the existing
+        // entry, compares thrift_partition_key_exprs against the (still-alive) old entry,
+        // and returns OK without inserting a duplicate.
+        auto rs_b = _make_runtime_state();
+        ASSERT_OK(_table_desc->add_partition_value(rs_b.get(), _query_pool.get(), partition_id, thrift_partition));
+    }
+
+    // The partition descriptor must still be accessible after both fragment instances
+    // have been destroyed; it is owned by the query-level pool.
+    HdfsPartitionDescriptor* partition = _table_desc->get_partition(partition_id);
+    ASSERT_NE(nullptr, partition);
+}
+
+} // namespace starrocks

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -72,7 +72,7 @@ protected:
 // descriptor was freed, but the pointer remained in the shared map. Fragment B then read
 // the dangling pointer in the duplicate-check comparison, causing UAF.
 //
-// The fix uses `runtime_state->global_obj_pool()` (per-query) so the descriptor's
+// The fix uses `RuntimeStateHelper::global_obj_pool(runtime_state)` (per-query) so the descriptor's
 // lifetime matches the shared map. This test simulates that fixed behavior: both
 // fragments share the same query-level ObjectPool, so dropping a fragment's
 // RuntimeState does not free the partition descriptor. Under ASAN this exercises the


### PR DESCRIPTION
## Why I'm doing:

```
*** SIGABRT (@0x3e80000176b) received by PID 5995 (TID 0xf6255b4efa80) LWP(6802) from PID 5995; stack trace: ***
    @     0xf625f20babdc (/usr/lib/aarch64-linux-gnu/libc.so.6+0x8abdb)
    @         0x10ce5818 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0xf625f388ba60 ([vdso]+0xa5f)
    @     0xf625f20b7608 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x87607)
    @     0xf625f206cb3c gsignal
    @     0xf625f2057e00 abort
    @         0x137401ec __gnu_cxx::__verbose_terminate_handler()
    @         0x1373e4cc __cxxabiv1::__terminate(void (*)())
    @         0x1373e530 std::terminate()
    @         0x1373e6c4 __cxa_throw
    @          0xd8ca168 __wrap___cxa_throw
    @         0x1373ebd8 operator new(unsigned long)
    @          0x9e98f40 starrocks::Expr::debug_string[abi:cxx11](std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const&)
    @          0xd48a248 starrocks::HdfsPartitionDescriptor::debug_string[abi:cxx11]() const
    @          0xd48d2a8 starrocks::HiveTableDescriptor::add_partition_value(starrocks::RuntimeState*, starrocks::ObjectPool*, long, starrocks::THdfsPartition const&)
    @          0xd5d3808 starrocks::pipeline::add_scan_ranges_partition_values(starrocks::RuntimeState*, std::vector<starrocks::TScanRangeParams, std::allocator<starrocks::TScanRangeParams> > const&)
    @          0xd5d9390 starrocks::pipeline::FragmentExecutor::_prepare_exec_plan(starrocks::ExecEnv*, starrocks::pipeline::UnifiedExecPlanFragmentParams const&)
    @          0xd5da900 starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0xd73fcec starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0xd743a14 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*)
    @          0xd749004 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFramentResult*, google::protobuf::Closure*)
    @          0xd4a6168 starrocks::PriorityThreadPool::work_thread(int)
    @         0x10c9fbd8 thread_proxy
    @     0xf625f20b595c (/usr/lib/aarch64-linux-gnu/libc.so.6+0x8595b)
    @     0xf625f211bb4c (/usr/lib/aarch64-linux-gnu/libc.so.6+0xebb4b)
```

```==120969==ERROR: AddressSanitizer: heap-use-after-free on address 0x60800012c9d8 at pc 0x000021b12db5 bp 0x14e1381fe3f0 sp 0x14e1381fe3e0
READ of size 8 at 0x60800012c9d8 thread T366
    #0 0x21b12db4 in std::vector<starrocks::TExpr, std::allocator<starrocks::TExpr> >::size() const /usr/include/c++/12/bits/stl_vector.h:988
    #1 0x2ef0c29d in bool std::operator==<starrocks::TExpr, std::allocator<starrocks::TExpr> >(std::vector<starrocks::TExpr, std::allocator<starrocks::TExpr> > const&, std::vector<starrocks::TExpr, std::allocator<starrocks::TExpr> > const&) /usr/include/c++/12/bits/stl_vector.h:2036
    #2 0x2eeff7fa in starrocks::HiveTableDescriptor::add_partition_value(starrocks::RuntimeState*, starrocks::ObjectPool*, long, starrocks::THdfsPartition const&) be/src/runtime/descriptors.cpp:503
    #3 0x2f3a29f5 in add_scan_ranges_partition_values be/src/exec/pipeline/fragment_executor.cpp:428
    #4 0x2f3a5a03 in starrocks::pipeline::FragmentExecutor::_prepare_exec_plan(starrocks::ExecEnv*, starrocks::pipeline::UnifiedExecPlanFragmentParams const&) be/src/exec/pipeline/fragment_executor.cpp:580
    #5 0x2f3b0d36 in starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/exec/pipeline/fragment_executor.cpp:971
    #6 0x2fbcc728 in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/service/internal_service.cpp:597
    #7 0x2fbcc05a in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*) be/src/service/internal_service.cpp:578
    #8 0x2fbc1c22 in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*) be/src/service/internal_service.cpp:310
    #9 0x2fbd4a57 in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}::operator()() const be/src/service/internal_service.cpp:290
    #10 0x2fbe78f5 in void std::__invoke_impl<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>(std::__invoke_other, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&) /usr/include/c++/12/bits/invoke.h:61
    #11 0x2fbe3e2b in std::enable_if<is_invocable_r_v<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>(starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&) /usr/include/c++/12/bits/invoke.h:111
    #12 0x2fbdddea in std::_Function_handler<void (), starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}>::_M_invoke(std::_Any_data const&) /usr/include/c++/12/bits/std_function.h:290
    #13 0x1a028941 in std::function<void ()>::operator()() const /usr/include/c++/12/bits/std_function.h:591
    #14 0x2ef51b31 in starrocks::PriorityThreadPool::work_thread(int) be/src/util/priority_thread_pool.hpp:198
    #15 0x2ef94a72 in void std::__invoke_impl<void, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(std::__invoke_memfun_deref, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&) /usr/include/c++/12/bits/invoke.h:74
    #16 0x2ef948a8 in std::__invoke_result<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>::type std::__invoke<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&) /usr/include/c++/12/bits/invoke.h:96
    #17 0x2ef9483c in decltype (__invoke((*this)._M_pmf, (forward<starrocks::PriorityThreadPool*&>)({parm#1}), (forward<int&>)({parm#1}))) std::_Mem_fn_base<void (starrocks::PriorityThreadPool::*)(int), true>::operator()<starrocks::PriorityThreadPool*&, int&>(starrocks::PriorityThreadPool*&, int&) const /usr/include/c++/12/functional:167
    #18 0x2ef947a9 in void std::__invoke_impl<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>(std::__invoke_other, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&) /usr/include/c++/12/bits/invoke.h:61
    #19 0x2ef946fe in std::enable_if<is_invocable_r_v<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>, void>::type std::__invoke_r<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>(std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&) /usr/include/c++/12/bits/invoke.h:111
    #20 0x2ef933e8 in void std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /usr/include/c++/12/functional:643
    #21 0x2ef8ff32 in void std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>::operator()<>() /usr/include/c++/12/functional:702
    #22 0x2ef8e26b in boost::detail::thread_data<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)> >::run() /var/local/thirdparty/installed/include/boost/thread/detail/thread.hpp:120
    #23 0x347bb6ea in thread_proxy libs/thread/src/pthread/thread.cpp:179
    #24 0x14e1e633cac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    #25 0x14e1e63ce8cf  (/lib/x86_64-linux-gnu/libc.so.6+0x1268cf)

0x60800012c9d8 is located 56 bytes inside of 96-byte region [0x60800012c9a0,0x60800012ca00)
freed by thread T365 here:
    #0 0x19d13aa8 in operator delete(void*) (/home/disk1/sr/be/lib/starrocks_be+0x19d13aa8)
    #1 0x2ef0ce63 in starrocks::ObjectPool::add<starrocks::HdfsPartitionDescriptor>(starrocks::HdfsPartitionDescriptor*)::{lambda(void*)#1}::operator()(void*) const be/src/common/object_pool.h:47
    #2 0x2ef0ce8b in starrocks::ObjectPool::add<starrocks::HdfsPartitionDescriptor>(starrocks::HdfsPartitionDescriptor*)::{lambda(void*)#1}::_FUN(void*) be/src/common/object_pool.h:47
    #3 0x215598d3 in starrocks::ObjectPool::clear() be/src/common/object_pool.h:55
    #4 0x21559759 in starrocks::ObjectPool::~ObjectPool() be/src/common/object_pool.h:35
    #5 0x2f288244 in std::_Sp_counted_ptr<starrocks::ObjectPool*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/include/c++/12/bits/shared_ptr_base.h:428
    #6 0x19d6392f in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/12/bits/shared_ptr_base.h:346
    #7 0x19d77195 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/12/bits/shared_ptr_base.h:1071
    #8 0x2f265e45 in std::__shared_ptr<starrocks::ObjectPool, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/12/bits/shared_ptr_base.h:1524
    #9 0x2f265e65 in std::shared_ptr<starrocks::ObjectPool>::~shared_ptr() /usr/include/c++/12/bits/shared_ptr.h:175
    #10 0x2f25af6e in starrocks::RuntimeState::~RuntimeState() be/src/runtime/runtime_state.cpp:159
    #11 0x2e122fcb in std::default_delete<starrocks::RuntimeState>::operator()(starrocks::RuntimeState*) const /usr/include/c++/12/bits/unique_ptr.h:95
    #12 0x2f3e0daa in std::_Sp_counted_deleter<starrocks::RuntimeState*, std::default_delete<starrocks::RuntimeState>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/include/c++/12/bits/shared_ptr_base.h:527
    #13 0x19d6392f in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/12/bits/shared_ptr_base.h:346
    #14 0x19d77195 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/12/bits/shared_ptr_base.h:1071
    #15 0x28373987 in std::__shared_ptr<starrocks::RuntimeState, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/12/bits/shared_ptr_base.h:1524
    #16 0x283739a7 in std::shared_ptr<starrocks::RuntimeState>::~shared_ptr() /usr/include/c++/12/bits/shared_ptr.h:175
    #17 0x2835f595 in starrocks::pipeline::FragmentContext::~FragmentContext() be/src/exec/pipeline/fragment_context.cpp:56
    #18 0x2f3e12b1 in void std::destroy_at<starrocks::pipeline::FragmentContext>(starrocks::pipeline::FragmentContext*) /usr/include/c++/12/bits/stl_construct.h:88
    #19 0x2f3e11ce in void std::_Destroy<starrocks::pipeline::FragmentContext>(starrocks::pipeline::FragmentContext*) /usr/include/c++/12/bits/stl_construct.h:149
    #20 0x2f3e0fb3 in void std::allocator_traits<std::allocator<void> >::destroy<starrocks::pipeline::FragmentContext>(std::allocator<void>&, starrocks::pipeline::FragmentContext*) /usr/include/c++/12/bits/alloc_traits.h:648
    #21 0x2f3e05c2 in std::_Sp_counted_ptr_inplace<starrocks::pipeline::FragmentContext, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/include/c++/12/bits/shared_ptr_base.h:613
    #22 0x19d6392f in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/12/bits/shared_ptr_base.h:346
    #23 0x19d77195 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/12/bits/shared_ptr_base.h:1071
    #24 0x2837671b in std::__shared_ptr<starrocks::pipeline::FragmentContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/12/bits/shared_ptr_base.h:1524
    #25 0x2f3c804f in std::__shared_ptr<starrocks::pipeline::FragmentContext, (__gnu_cxx::_Lock_policy)2>::reset() /usr/include/c++/12/bits/shared_ptr_base.h:1642
    #26 0x2f3b3017 in starrocks::pipeline::FragmentExecutor::_fail_cleanup(bool) be/src/exec/pipeline/fragment_executor.cpp:1032
    #27 0x2f3aed10 in operator() be/src/exec/pipeline/fragment_executor.cpp:942
    #28 0x2f3b7ec9 in ~DeferOp be/src/util/defer_op.h:49
    #29 0x2f3b14d2 in starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/exec/pipeline/fragment_executor.cpp:991

previously allocated by thread T365 here:
    #0 0x19d12f48 in operator new(unsigned long) (/home/disk1/sr/be/lib/starrocks_be+0x19d12f48)
    #1 0x2eeff300 in starrocks::HiveTableDescriptor::add_partition_value(starrocks::RuntimeState*, starrocks::ObjectPool*, long, starrocks::THdfsPartition const&) be/src/runtime/descriptors.cpp:493
    #2 0x2f3a29f5 in add_scan_ranges_partition_values be/src/exec/pipeline/fragment_executor.cpp:428
    #3 0x2f3a5a03 in starrocks::pipeline::FragmentExecutor::_prepare_exec_plan(starrocks::ExecEnv*, starrocks::pipeline::UnifiedExecPlanFragmentParams const&) be/src/exec/pipeline/fragment_executor.cpp:580
    #4 0x2f3b0d36 in starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/exec/pipeline/fragment_executor.cpp:971
    #5 0x2fbcc728 in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/service/internal_service.cpp:597
    #6 0x2fbcc05a in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*) be/src/service/internal_service.cpp:578
    #7 0x2fbc1c22 in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*) be/src/service/internal_service.cpp:310
    #8 0x2fbd4a57 in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}::operator()() const be/src/service/internal_service.cpp:290
    #9 0x2fbe78f5 in void std::__invoke_impl<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>(std::__invoke_other, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&) /usr/include/c++/12/bits/invoke.h:61
    #10 0x2fbe3e2b in std::enable_if<is_invocable_r_v<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>(starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&) /usr/include/c++/12/bits/invoke.h:111
    #11 0x2fbdddea in std::_Function_handler<void (), starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}>::_M_invoke(std::_Any_data const&) /usr/include/c++/12/bits/std_function.h:290
    #12 0x1a028941 in std::function<void ()>::operator()() const /usr/include/c++/12/bits/std_function.h:591
    #13 0x2ef51b31 in starrocks::PriorityThreadPool::work_thread(int) be/src/util/priority_thread_pool.hpp:198
    #14 0x2ef94a72 in void std::__invoke_impl<void, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(std::__invoke_memfun_deref, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&) /usr/include/c++/12/bits/invoke.h:74
    #15 0x2ef948a8 in std::__invoke_result<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>::type std::__invoke<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&) /usr/include/c++/12/bits/invoke.h:96
    #16 0x2ef9483c in decltype (__invoke((*this)._M_pmf, (forward<starrocks::PriorityThreadPool*&>)({parm#1}), (forward<int&>)({parm#1}))) std::_Mem_fn_base<void (starrocks::PriorityThreadPool::*)(int), true>::operator()<starrocks::PriorityThreadPool*&, int&>(starrocks::PriorityThreadPool*&, int&) const /usr/include/c++/12/functional:167
    #17 0x2ef947a9 in void std::__invoke_impl<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>(std::__invoke_other, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&) /usr/include/c++/12/bits/invoke.h:61
    #18 0x2ef946fe in std::enable_if<is_invocable_r_v<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>, void>::type std::__invoke_r<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>(std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&) /usr/include/c++/12/bits/invoke.h:111
    #19 0x2ef933e8 in void std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /usr/include/c++/12/functional:643
    #20 0x2ef8ff32 in void std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>::operator()<>() /usr/include/c++/12/functional:702
    #21 0x2ef8e26b in boost::detail::thread_data<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)> >::run() /var/local/thirdparty/installed/include/boost/thread/detail/thread.hpp:120
    #22 0x347bb6ea in thread_proxy libs/thread/src/pthread/thread.cpp:179
```

## What I'm doing:

HiveTableDescriptor::_partition_id_to_desc_map is shared at the query level, not the fragment-instance level: multiple fragment instances of the same query read from and write into the same partition descriptor map. However, add_scan_ranges_partition_values previously allocated partition descriptors from runtime_state->obj_pool(), whose lifetime is tied to a single fragment instance.

The consequence: once any one fragment instance finishes and tears down its obj_pool, other still-running fragment instances of the same query keep reaching the freed descriptors through _partition_id_to_desc_map, triggering a heap-use-after-free. Under stress / ASan this shows up as sporadic crashes or dirty reads in Iceberg scans.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
