### PR TITLE
[Enhancement] Recover unstable range-colocate groups via alignment checker

### DIFF
--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -286,19 +286,26 @@ StatusOr<TabletRangePB> TabletRangeHelper::convert_t_range_to_pb_range(const TTa
     return pb_range;
 }
 
-// Helper for validate_new_tablet_ranges: compare two range bounds (TuplePB)
-// for byte-for-byte equality, treating "neither has bound" as equal.
+// Structural (proto byte-for-byte) equality of two TuplePB messages. Used by
+// validate_new_tablet_ranges to detect zero-width and adjacency-tile mismatches.
 namespace {
+bool tuple_pb_equal(const TuplePB& lhs, const TuplePB& rhs) {
+    return google::protobuf::util::MessageDifferencer::Equals(lhs, rhs);
+}
+
+// Same as tuple_pb_equal but treats "neither side has the bound" as equal —
+// used at the first.lower / last.upper endpoint checks where the parent range
+// may be unbounded.
 bool tuple_bound_equal(bool lhs_has, const TuplePB& lhs, bool rhs_has, const TuplePB& rhs) {
     if (lhs_has != rhs_has) return false;
     if (!lhs_has) return true;
-    return google::protobuf::util::MessageDifferencer::Equals(lhs, rhs);
+    return tuple_pb_equal(lhs, rhs);
 }
 } // namespace
 
 Status TabletRangeHelper::validate_new_tablet_ranges(
         const TabletRangePB& old_tablet_range,
-        const ::google::protobuf::RepeatedPtrField<TabletRangePB>& new_tablet_ranges) {
+        const google::protobuf::RepeatedPtrField<TabletRangePB>& new_tablet_ranges) {
     if (new_tablet_ranges.empty()) {
         return Status::InvalidArgument("validate_new_tablet_ranges: new_tablet_ranges is empty");
     }
@@ -316,8 +323,7 @@ Status TabletRangeHelper::validate_new_tablet_ranges(
     //    the tablet schema).
     for (const auto& r : new_tablet_ranges) {
         RETURN_IF_ERROR(validate_tablet_range(r));
-        if (r.has_lower_bound() && r.has_upper_bound() &&
-            google::protobuf::util::MessageDifferencer::Equals(r.lower_bound(), r.upper_bound())) {
+        if (r.has_lower_bound() && r.has_upper_bound() && tuple_pb_equal(r.lower_bound(), r.upper_bound())) {
             return Status::InvalidArgument(
                     "validate_new_tablet_ranges: range with lower_bound == upper_bound (zero-width)");
         }
@@ -346,19 +352,19 @@ Status TabletRangeHelper::validate_new_tablet_ranges(
     // 4. Adjacent ranges must tile exactly: ranges[i].upper == ranges[i+1].lower,
     //    upper exclusive on the left, lower inclusive on the right.
     for (int i = 0; i + 1 < new_tablet_ranges.size(); ++i) {
-        const auto& cur = new_tablet_ranges[i];
-        const auto& nxt = new_tablet_ranges[i + 1];
-        if (!cur.has_upper_bound() || !nxt.has_lower_bound()) {
+        const auto& current_range = new_tablet_ranges[i];
+        const auto& next_range = new_tablet_ranges[i + 1];
+        if (!current_range.has_upper_bound() || !next_range.has_lower_bound()) {
             return Status::InvalidArgument(
                     fmt::format("validate_new_tablet_ranges: gap at boundary {} (interior bounds must be set)", i));
         }
-        if (cur.upper_bound_included() || !nxt.lower_bound_included()) {
+        if (current_range.upper_bound_included() || !next_range.lower_bound_included()) {
             return Status::InvalidArgument(
                     fmt::format("validate_new_tablet_ranges: invalid bound flags at boundary {} "
                                 "(left must be exclusive, right must be inclusive)",
                                 i));
         }
-        if (!google::protobuf::util::MessageDifferencer::Equals(cur.upper_bound(), nxt.lower_bound())) {
+        if (!tuple_pb_equal(current_range.upper_bound(), next_range.lower_bound())) {
             return Status::InvalidArgument(
                     fmt::format("validate_new_tablet_ranges: gap or overlap at boundary {} "
                                 "(ranges[i].upper_bound != ranges[i+1].lower_bound)",

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/tablet_range_helper.h"
 
+#include <google/protobuf/util/message_differencer.h>
+
 #include <memory>
 
 #include "column/binary_column.h"
@@ -78,7 +80,7 @@ static StatusOr<Datum> datum_from_type_min(LogicalType type) {
     }
 }
 
-Status TabletRangeHelper::_validate_tablet_range(const TabletRangePB& tablet_range_pb) {
+Status TabletRangeHelper::validate_tablet_range(const TabletRangePB& tablet_range_pb) {
     if (!tablet_range_pb.has_lower_bound() && !tablet_range_pb.has_upper_bound()) {
         return Status::OK();
     }
@@ -108,7 +110,7 @@ StatusOr<SeekRange> TabletRangeHelper::create_seek_range_from(const TabletRangeP
                                                               const TabletSchemaCSPtr& tablet_schema,
                                                               MemPool* mem_pool) {
     SeekRange tablet_range;
-    RETURN_IF_ERROR(_validate_tablet_range(tablet_range_pb));
+    RETURN_IF_ERROR(validate_tablet_range(tablet_range_pb));
     if (!tablet_range_pb.has_lower_bound() && !tablet_range_pb.has_upper_bound()) {
         // (-inf, +inf)
         return tablet_range;
@@ -158,7 +160,7 @@ StatusOr<SeekRange> TabletRangeHelper::create_seek_range_from(const TabletRangeP
 StatusOr<SstSeekRange> TabletRangeHelper::create_sst_seek_range_from(const TabletRangePB& tablet_range_pb,
                                                                      const TabletSchemaCSPtr& tablet_schema) {
     SstSeekRange sst_seek_range;
-    RETURN_IF_ERROR(_validate_tablet_range(tablet_range_pb));
+    RETURN_IF_ERROR(validate_tablet_range(tablet_range_pb));
     if (!tablet_range_pb.has_lower_bound() && !tablet_range_pb.has_upper_bound()) {
         // (-inf, +inf)
         return sst_seek_range;
@@ -282,6 +284,89 @@ StatusOr<TabletRangePB> TabletRangeHelper::convert_t_range_to_pb_range(const TTa
         pb_range.set_upper_bound_included(t_range.upper_bound_included);
     }
     return pb_range;
+}
+
+// Helper for validate_new_tablet_ranges: compare two range bounds (TuplePB)
+// for byte-for-byte equality, treating "neither has bound" as equal.
+namespace {
+bool tuple_bound_equal(bool lhs_has, const TuplePB& lhs, bool rhs_has, const TuplePB& rhs) {
+    if (lhs_has != rhs_has) return false;
+    if (!lhs_has) return true;
+    return google::protobuf::util::MessageDifferencer::Equals(lhs, rhs);
+}
+} // namespace
+
+Status TabletRangeHelper::validate_new_tablet_ranges(
+        const TabletRangePB& old_tablet_range,
+        const ::google::protobuf::RepeatedPtrField<TabletRangePB>& new_tablet_ranges) {
+    if (new_tablet_ranges.empty()) {
+        return Status::InvalidArgument("validate_new_tablet_ranges: new_tablet_ranges is empty");
+    }
+
+    // 0. The old tablet's own range must be well-formed too — otherwise our
+    //    "first.lower matches old.lower" / "last.upper matches old.upper"
+    //    checks below could be comparing against a malformed reference.
+    RETURN_IF_ERROR(validate_tablet_range(old_tablet_range));
+
+    // 1. Each new-tablet range must be individually well-formed, and the two
+    //    bounds (when both set) must not be byte-equal (catches zero-width
+    //    children). Strict semantic ordering (lower < upper) requires a
+    //    schema for type-aware comparison and is the caller's responsibility
+    //    (e.g., compute_split_ranges_from_external_boundaries compares via
+    //    the tablet schema).
+    for (const auto& r : new_tablet_ranges) {
+        RETURN_IF_ERROR(validate_tablet_range(r));
+        if (r.has_lower_bound() && r.has_upper_bound() &&
+            google::protobuf::util::MessageDifferencer::Equals(r.lower_bound(), r.upper_bound())) {
+            return Status::InvalidArgument(
+                    "validate_new_tablet_ranges: range with lower_bound == upper_bound (zero-width)");
+        }
+    }
+
+    // 2. First range's lower bound must match the old tablet's lower bound.
+    const auto& first = new_tablet_ranges[0];
+    if (!tuple_bound_equal(first.has_lower_bound(), first.lower_bound(), old_tablet_range.has_lower_bound(),
+                           old_tablet_range.lower_bound())) {
+        return Status::InvalidArgument("validate_new_tablet_ranges: first.lower_bound != old_tablet_range.lower_bound");
+    }
+    if (first.has_lower_bound() && !first.lower_bound_included()) {
+        return Status::InvalidArgument("validate_new_tablet_ranges: first.lower_bound must be inclusive when set");
+    }
+
+    // 3. Last range's upper bound must match the old tablet's upper bound.
+    const auto& last = new_tablet_ranges[new_tablet_ranges.size() - 1];
+    if (!tuple_bound_equal(last.has_upper_bound(), last.upper_bound(), old_tablet_range.has_upper_bound(),
+                           old_tablet_range.upper_bound())) {
+        return Status::InvalidArgument("validate_new_tablet_ranges: last.upper_bound != old_tablet_range.upper_bound");
+    }
+    if (last.has_upper_bound() && last.upper_bound_included()) {
+        return Status::InvalidArgument("validate_new_tablet_ranges: last.upper_bound must be exclusive when set");
+    }
+
+    // 4. Adjacent ranges must tile exactly: ranges[i].upper == ranges[i+1].lower,
+    //    upper exclusive on the left, lower inclusive on the right.
+    for (int i = 0; i + 1 < new_tablet_ranges.size(); ++i) {
+        const auto& cur = new_tablet_ranges[i];
+        const auto& nxt = new_tablet_ranges[i + 1];
+        if (!cur.has_upper_bound() || !nxt.has_lower_bound()) {
+            return Status::InvalidArgument(
+                    fmt::format("validate_new_tablet_ranges: gap at boundary {} (interior bounds must be set)", i));
+        }
+        if (cur.upper_bound_included() || !nxt.lower_bound_included()) {
+            return Status::InvalidArgument(
+                    fmt::format("validate_new_tablet_ranges: invalid bound flags at boundary {} "
+                                "(left must be exclusive, right must be inclusive)",
+                                i));
+        }
+        if (!google::protobuf::util::MessageDifferencer::Equals(cur.upper_bound(), nxt.lower_bound())) {
+            return Status::InvalidArgument(
+                    fmt::format("validate_new_tablet_ranges: gap or overlap at boundary {} "
+                                "(ranges[i].upper_bound != ranges[i+1].lower_bound)",
+                                i));
+        }
+    }
+
+    return Status::OK();
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_range_helper.h
+++ b/be/src/storage/lake/tablet_range_helper.h
@@ -62,7 +62,7 @@ public:
     // exactly: old range itself is well-formed; each new range is
     // well-formed and non-zero-width (lower != upper by byte equality);
     // adjacent ranges meet exactly with no gaps or overlaps; first.lower
-    // matches old.lower; last.upper matches old.upper. Used by the PSPS
+    // matches old.lower; last.upper matches old.upper. Used by the external boundaries
     // pre-split path to validate FE-supplied ranges before BE commits to
     // writing K new tablets.
     //
@@ -72,7 +72,7 @@ public:
     // checks.
     static Status validate_new_tablet_ranges(
             const TabletRangePB& old_tablet_range,
-            const ::google::protobuf::RepeatedPtrField<TabletRangePB>& new_tablet_ranges);
+            const google::protobuf::RepeatedPtrField<TabletRangePB>& new_tablet_ranges);
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_range_helper.h
+++ b/be/src/storage/lake/tablet_range_helper.h
@@ -52,9 +52,27 @@ public:
 
     static StatusOr<TabletRangePB> convert_t_range_to_pb_range(const TTabletRange& t_range);
 
-private:
-    // check if the tablet range is closedOpen
-    static Status _validate_tablet_range(const TabletRangePB& tablet_range_pb);
+    // Check that a single tablet range is well-formed: closed-open semantics
+    // (lower_bound inclusive when set, upper_bound exclusive when set), with
+    // the corresponding `*_bound_included` flag explicitly present.
+    // Either or both bounds may be absent (unbounded).
+    static Status validate_tablet_range(const TabletRangePB& tablet_range_pb);
+
+    // Check that a list of new-tablet ranges tiles the old tablet range
+    // exactly: old range itself is well-formed; each new range is
+    // well-formed and non-zero-width (lower != upper by byte equality);
+    // adjacent ranges meet exactly with no gaps or overlaps; first.lower
+    // matches old.lower; last.upper matches old.upper. Used by the PSPS
+    // pre-split path to validate FE-supplied ranges before BE commits to
+    // writing K new tablets.
+    //
+    // Note: strict semantic ordering (lower < upper, ranges monotonically
+    // increasing) requires a schema for type-aware comparison and is the
+    // caller's responsibility. This helper only does schema-free structural
+    // checks.
+    static Status validate_new_tablet_ranges(
+            const TabletRangePB& old_tablet_range,
+            const ::google::protobuf::RepeatedPtrField<TabletRangePB>& new_tablet_ranges);
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -41,6 +41,7 @@ bvar::Adder<int64_t> g_tablet_reshard_split_failed("tablet_reshard_split_failed"
 bvar::LatencyRecorder g_tablet_reshard_split_latency("tablet_reshard_split");
 bvar::Adder<int64_t> g_tablet_reshard_split_output_tablet_count("tablet_reshard_split_output_tablet_count");
 bvar::Adder<int64_t> g_tablet_reshard_split_fallback_total("tablet_reshard_split_fallback_total");
+bvar::Adder<int64_t> g_tablet_reshard_split_psps_fallback_total("tablet_reshard_split_psps_fallback_total");
 
 // Layer 2: Merge metrics
 bvar::Adder<int64_t> g_tablet_reshard_merge_total("tablet_reshard_merge_total");

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -41,7 +41,8 @@ bvar::Adder<int64_t> g_tablet_reshard_split_failed("tablet_reshard_split_failed"
 bvar::LatencyRecorder g_tablet_reshard_split_latency("tablet_reshard_split");
 bvar::Adder<int64_t> g_tablet_reshard_split_output_tablet_count("tablet_reshard_split_output_tablet_count");
 bvar::Adder<int64_t> g_tablet_reshard_split_fallback_total("tablet_reshard_split_fallback_total");
-bvar::Adder<int64_t> g_tablet_reshard_split_psps_fallback_total("tablet_reshard_split_psps_fallback_total");
+bvar::Adder<int64_t> g_tablet_reshard_split_external_boundaries_fallback_total(
+        "tablet_reshard_split_external_boundaries_fallback_total");
 
 // Layer 2: Merge metrics
 bvar::Adder<int64_t> g_tablet_reshard_merge_total("tablet_reshard_merge_total");

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -24,11 +24,15 @@
 #include "common/logging.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/update_manager.h"
 #include "storage/tablet_range.h"
+#include "storage/tablet_schema.h"
+#include "types/type_descriptor.h"
 
 extern bvar::Adder<int64_t> g_tablet_reshard_split_fallback_total;
+extern bvar::Adder<int64_t> g_tablet_reshard_split_psps_fallback_total;
 
 namespace starrocks::lake {
 
@@ -494,16 +498,8 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
 
 namespace {
 
-struct Statistic {
-    int64_t num_rows = 0;
-    int64_t data_size = 0;
-    int64_t num_dels = 0;
-};
-
-struct TabletRangeInfo {
-    TabletRangePB range;
-    std::unordered_map<uint32_t, Statistic> rowset_stats;
-};
+// Statistic and TabletRangeInfo are declared in tablet_splitter.h (the PSPS
+// path returns vector<TabletRangeInfo> through that header for testability).
 
 // Per-rowset anchor totals taken from the parent's recorded metadata. Used to
 // renormalize per-split-group estimates so Σ children equals parent exactly,
@@ -635,9 +631,9 @@ void apply_rowset_anchor(const std::unordered_map<uint32_t, RowsetAnchor>& ancho
 // larger than the sort-key arity returns Status::InvalidArgument here, which triggers
 // the same identical-tablet fallback as "no boundaries" — preserves the publish loop
 // instead of hard-failing.
-Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
-                               int32_t split_count, std::vector<TabletRangeInfo>* split_ranges,
-                               int32_t colocate_column_count) {
+Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
+                                    int32_t split_count, std::vector<TabletRangeInfo>* split_ranges,
+                                    int32_t colocate_column_count) {
     if (split_count < 2) {
         return Status::InvalidArgument("Invalid split count, it is less than 2");
     }
@@ -743,58 +739,421 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
     return Status::OK();
 }
 
-} // namespace
+// Builds a single new-tablet metadata that is "identical" to the old tablet —
+// inherits rowsets / delvec_meta / sstable_meta / dcg_meta / rowset_to_schema as-is,
+// only rebinds id / version / commit_time / gtid and clears the per-version
+// transient fields (compaction_inputs, orphan_files, prev_garbage_version).
+//
+// Used by split_tablet's symmetric identical-fallback path. Both the
+// data-driven branch (when get_tablet_split_ranges fails) and the PSPS
+// branch (when compute_split_ranges_from_external_boundaries fails) call
+// this helper with new_tablet_ids[0] to materialize a single identical
+// new tablet rather than the requested K new tablets.
+//
+// In both cases the old tablet may be non-empty; the identical new tablet
+// must inherit its data so the load can write into it without data loss.
+MutableTabletMetadataPtr make_identical_new_tablet_metadata(const TabletMetadataPtr& old_tablet_metadata,
+                                                            int64_t new_id, int64_t new_version,
+                                                            const TxnInfoPB& txn_info) {
+    auto new_tablet_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_metadata);
+    new_tablet_metadata->set_id(new_id);
+    new_tablet_metadata->set_version(new_version);
+    new_tablet_metadata->set_commit_time(txn_info.commit_time());
+    new_tablet_metadata->set_gtid(txn_info.gtid());
+    new_tablet_metadata->clear_compaction_inputs();
+    new_tablet_metadata->clear_orphan_files();
+    new_tablet_metadata->clear_prev_garbage_version();
+    return new_tablet_metadata;
+}
 
-StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
-        TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
-        const SplittingTabletInfoPB& splitting_tablet, int64_t new_version, const TxnInfoPB& txn_info) {
-    if (tablet_metadata == nullptr) {
-        return Status::InvalidArgument("tablet metadata is null");
+// PSPS peer of get_tablet_split_ranges: produces a vector<TabletRangeInfo>
+// from FE-supplied boundaries instead of computing them from segment
+// distribution. Reuses distribute_segment_to_ranges, build_rowset_anchor, and
+// apply_rowset_anchor so the per-rowset stat math is identical to the
+// data-driven path.
+//
+// Non-OK return is caller-handled (split_tablet) by routing to the symmetric
+// identical-fallback path with the PSPS bvar bumped. The helper does NOT
+// fall back internally; it surfaces the precise reason via Status::message.
+//
+// Algorithm (high level):
+//   1a. Size match.
+//   1b. Structural well-formedness of external_ranges (schema-free byte check).
+//   1c. Schema-aware validation: each TuplePB matches the tablet's sort key
+//       in arity and per-column type. Required because DatumVariant::compare
+//       only DCHECKs matching types and would silently mis-compare in release.
+//   2.  Seed K TabletRangeInfo from external_ranges (rowset_stats empty).
+//   3.  Parse FE bounds into VariantTuple + track explicit-presence per side.
+//       "Explicit" means the bound was supplied on the external range OR
+//       inherited from a present parent bound. Only first.lo / last.hi can
+//       ever be non-explicit (== ±infinity, per structural validation).
+//       3a. Per-range strict check: parsed[i].lo >= parsed[i].hi (when both
+//           explicit) -> reject. Strict '>=' covers semantic zero-width that
+//           the byte-level structural check cannot detect.
+//       3b. Adjacent monotonic check: parsed[i].hi > parsed[i+1].lo -> reject.
+//           Interior bounds are always explicit per structural validation.
+//       Runs BEFORE the empty fast-path so empty PSPS tablets get the same
+//       semantic guarantees as non-empty ones.
+//   4.  Empty old tablet fast-path: K empty new-tablets fall out naturally.
+//   5.  Build SegmentSplitInfo from rowsets (same as get_tablet_split_ranges).
+//   6.  Compute segment envelope and effective envelope (intersection with
+//       parent's range). Empty / degenerate-point envelope -> InvalidArgument.
+//   7.  Build distribution vector covering the FULL segment envelope:
+//       [optional left_sink, K (or fewer, after clipping) active slots,
+//        optional right_sink]. Sinks absorb out-of-parent-range segment data
+//       from shared rowsets (prior-split residual). Non-explicit ±infinity
+//       sides clip to effective envelope edge.
+//   8.  Distribute segments into the full vector.
+//   9.  Build anchor; sanity-check that every rowset with anchor totals > 0
+//       has positive active weight on the matching (rows or bytes) axis.
+//       Otherwise allocate_proportionally would uniformly fabricate stats.
+//  10.  Synthesize a RangeSplitResult and apply anchor; output is K
+//       TabletRangeInfo in *split_ranges with normalized rowset_stats.
+Status compute_split_ranges_from_external_boundaries_impl(
+        TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,
+        const ::google::protobuf::RepeatedPtrField<TabletRangePB>& external_ranges, int32_t expected_new_tablet_count,
+        std::vector<TabletRangeInfo>* split_ranges) {
+    DCHECK(split_ranges != nullptr);
+    DCHECK(split_ranges->empty());
+
+    // 1a. Size match. Inside the helper so size-mismatch goes through the
+    //     same PSPS fallback path as other validation failures.
+    if (external_ranges.size() != expected_new_tablet_count) {
+        return Status::InvalidArgument(fmt::format("new_tablet_ranges.size={} != new_tablet_ids.size={}",
+                                                   external_ranges.size(), expected_new_tablet_count));
     }
-    if (splitting_tablet.new_tablet_ids_size() <= 0) {
-        return Status::InvalidArgument("splitting tablet has no new tablet");
+
+    // 1b. Structural validation (schema-free): closed-open per range, no
+    //     byte-equal zero-width child, first.lower matches parent.lower,
+    //     last.upper matches parent.upper, adjacent ranges meet exactly.
+    RETURN_IF_ERROR(TabletRangeHelper::validate_new_tablet_ranges(old_tablet_metadata->range(), external_ranges));
+
+    // 1c. Schema-aware validation of FE-supplied TuplePB bounds. Without
+    //     this, DatumVariant::compare's DCHECK-only type guard means
+    //     release builds silently mis-compare malformed FE input.
+    //     For decimal-family columns, also validate precision/scale exactly:
+    //     DecimalTypeInfo compares raw unscaled values, so a bound with the
+    //     same LogicalType but different scale than the schema would
+    //     mis-order against schema-derived segment bounds.
+    auto tablet_schema = TabletSchema::create(old_tablet_metadata->schema());
+    const auto& sort_key_idxes = tablet_schema->sort_key_idxes();
+    if (sort_key_idxes.empty()) {
+        return Status::InvalidArgument("tablet has no sort key columns; PSPS path requires a sort key");
+    }
+    auto validate_tuple_against_schema = [&](const TuplePB& t, int range_idx, std::string_view side) -> Status {
+        if (t.values_size() != static_cast<int>(sort_key_idxes.size())) {
+            return Status::InvalidArgument(fmt::format("new_tablet_ranges[{}].{}: tuple arity {} != sort_key arity {}",
+                                                       range_idx, side, t.values_size(), sort_key_idxes.size()));
+        }
+        for (int j = 0; j < t.values_size(); ++j) {
+            const auto& var = t.values(j);
+            // PSPS sort-key bounds are scalar values only — tablet sort
+            // keys are restricted to scalar types (no ARRAY/MAP/STRUCT).
+            // Enforce a single SCALAR PTypeNode with scalar_type set so
+            // malformed FE input cannot reach the underlying
+            // TypeDescriptor PTypeNode constructor, which DCHECKs and
+            // does unguarded types.Get() on complex-type child indices
+            // (be/src/types/type_descriptor.cpp:158-204).
+            if (!var.has_type() || var.type().types_size() != 1) {
+                return Status::InvalidArgument(
+                        fmt::format("new_tablet_ranges[{}].{}: column[{}] variant must have exactly one type node "
+                                    "(got types_size={})",
+                                    range_idx, side, j, var.type().types_size()));
+            }
+            const auto& node = var.type().types(0);
+            if (static_cast<TTypeNodeType::type>(node.type()) != TTypeNodeType::SCALAR || !node.has_scalar_type()) {
+                return Status::InvalidArgument(
+                        fmt::format("new_tablet_ranges[{}].{}: column[{}] variant must be a scalar type "
+                                    "(got node_type={}, has_scalar_type={})",
+                                    range_idx, side, j, node.type(), node.has_scalar_type()));
+            }
+            const int col_idx = sort_key_idxes[j];
+            const auto& col = tablet_schema->column(col_idx);
+            const LogicalType col_type = col.type();
+            const auto var_type_desc = TypeDescriptor::from_protobuf(var.type());
+            if (var_type_desc.type != col_type) {
+                return Status::InvalidArgument(
+                        fmt::format("new_tablet_ranges[{}].{}: column[{}] variant type {} != schema type {}", range_idx,
+                                    side, j, static_cast<int>(var_type_desc.type), static_cast<int>(col_type)));
+            }
+            if (var_type_desc.is_decimal_type()) {
+                const int schema_precision = static_cast<int>(col.precision());
+                const int schema_scale = static_cast<int>(col.scale());
+                if (var_type_desc.precision != schema_precision || var_type_desc.scale != schema_scale) {
+                    return Status::InvalidArgument(
+                            fmt::format("new_tablet_ranges[{}].{}: column[{}] decimal precision/scale "
+                                        "({}, {}) != schema ({}, {})",
+                                        range_idx, side, j, var_type_desc.precision, var_type_desc.scale,
+                                        schema_precision, schema_scale));
+                }
+            }
+        }
+        return Status::OK();
+    };
+    for (int i = 0; i < external_ranges.size(); ++i) {
+        const auto& er = external_ranges[i];
+        if (er.has_lower_bound()) {
+            RETURN_IF_ERROR(validate_tuple_against_schema(er.lower_bound(), i, "lower"));
+        }
+        if (er.has_upper_bound()) {
+            RETURN_IF_ERROR(validate_tuple_against_schema(er.upper_bound(), i, "upper"));
+        }
     }
 
-    // Flush the parent's PK-index memtable into sstables before propagating
-    // metadata to the children, so every child inherits an sstable_meta that
-    // already covers its rowsets' live data. This is the pre-split half of
-    // the "reshard inputs must have full sstable coverage" invariant; merge
-    // does the post-split half in merge_sstables.
-    ASSIGN_OR_RETURN(TabletMetadataPtr old_tablet_metadata,
-                     tablet_manager->update_mgr()->flush_pk_memtable(tablet_metadata));
-
-    std::unordered_map<int64_t, MutableTabletMetadataPtr> new_metadatas;
-
-    std::vector<TabletRangeInfo> split_ranges;
-    // colocate_column_count is carried at the txn level (single split job = single txn) since
-    // every SplittingTabletInfoPB in the same job would carry the same value. See lake_types.proto.
-    Status status = get_tablet_split_ranges(tablet_manager, old_tablet_metadata, splitting_tablet.new_tablet_ids_size(),
-                                            &split_ranges, txn_info.colocate_column_count());
-    if (!status.ok()) {
-        g_tablet_reshard_split_fallback_total << 1;
-        LOG(WARNING) << "Failed to get tablet split ranges, will not split this tablet: " << old_tablet_metadata->id()
-                     << ", version: " << old_tablet_metadata->version() << ", txn_id: " << txn_info.txn_id()
-                     << ", status: " << status;
-        auto new_tablet_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_metadata);
-        new_tablet_metadata->set_id(splitting_tablet.new_tablet_ids(0));
-        new_tablet_metadata->set_version(new_version);
-        new_tablet_metadata->set_commit_time(txn_info.commit_time());
-        new_tablet_metadata->set_gtid(txn_info.gtid());
-        new_tablet_metadata->clear_compaction_inputs();
-        new_tablet_metadata->clear_orphan_files();
-        new_tablet_metadata->clear_prev_garbage_version();
-        new_metadatas.emplace(new_tablet_metadata->id(), std::move(new_tablet_metadata));
-        return new_metadatas;
+    // 2. Seed K TabletRangeInfo from external_ranges; rowset_stats stays empty
+    //    for now (filled by apply_rowset_anchor in step 10).
+    split_ranges->reserve(external_ranges.size());
+    for (const auto& er : external_ranges) {
+        auto& tri = split_ranges->emplace_back();
+        tri.range = er;
     }
 
-    // Defense-in-depth: get_tablet_split_ranges guarantees
-    // split_ranges.size() == new_tablet_ids_size() on OK, but a runtime check
-    // here prevents OOB reads into split_ranges[i] if the contract is ever
+    // 3. Parse FE bounds into VariantTuple + track explicit-presence. An
+    //    unset side (only possible at first.lo / last.hi per structural
+    //    validation) means ±infinity and is excluded from the per-range
+    //    inversion check at step 3a. Adjacent (3b) bounds are always
+    //    explicit (interior boundaries are required to be set).
+    struct ParsedBounds {
+        VariantTuple lo;
+        VariantTuple hi;
+        bool lo_explicit = false;
+        bool hi_explicit = false;
+    };
+    std::vector<ParsedBounds> parsed(external_ranges.size());
+    for (int i = 0; i < external_ranges.size(); ++i) {
+        const auto& er = external_ranges[i];
+        if (er.has_lower_bound()) {
+            RETURN_IF_ERROR(parsed[i].lo.from_proto(er.lower_bound()));
+            parsed[i].lo_explicit = true;
+        } else if (old_tablet_metadata->range().has_lower_bound()) {
+            RETURN_IF_ERROR(parsed[i].lo.from_proto(old_tablet_metadata->range().lower_bound()));
+            parsed[i].lo_explicit = true;
+        }
+        if (er.has_upper_bound()) {
+            RETURN_IF_ERROR(parsed[i].hi.from_proto(er.upper_bound()));
+            parsed[i].hi_explicit = true;
+        } else if (old_tablet_metadata->range().has_upper_bound()) {
+            RETURN_IF_ERROR(parsed[i].hi.from_proto(old_tablet_metadata->range().upper_bound()));
+            parsed[i].hi_explicit = true;
+        }
+    }
+
+    // 3a. Per-range strict semantic check. '>=' catches inversion AND
+    //     semantic zero-width (e.g., byte-distinct but same value under
+    //     schema-aware comparison). Skip when either side is ±infinity.
+    for (int i = 0; i < external_ranges.size(); ++i) {
+        if (!parsed[i].lo_explicit || !parsed[i].hi_explicit) continue;
+        if (parsed[i].lo.compare(parsed[i].hi) >= 0) {
+            return Status::InvalidArgument(
+                    fmt::format("new_tablet_ranges[{}] semantically inverted/zero-width (lower >= upper)", i));
+        }
+    }
+
+    // 3b. Adjacent monotonic check. Interior bounds are always explicit.
+    for (int i = 0; i + 1 < external_ranges.size(); ++i) {
+        if (parsed[i].hi.compare(parsed[i + 1].lo) > 0) {
+            return Status::InvalidArgument(fmt::format("new_tablet_ranges[{}/{}] semantically out of order", i, i + 1));
+        }
+    }
+
+    // 4. Empty old tablet fast-path: no rowsets to distribute, K
+    //    TabletRangeInfo with empty rowset_stats is the correct output.
+    //    build_new_tablets_from_split_ranges will produce K new tablets with
+    //    no rowsets. Runs AFTER FE-input validation so empty PSPS tablets
+    //    cannot accept semantically-invalid ranges either.
+    if (old_tablet_metadata->rowsets_size() == 0) {
+        return Status::OK();
+    }
+
+    // 5. Build SegmentSplitInfo from rowsets. Same logic as
+    //    get_tablet_split_ranges; shared via copy because the segment-load
+    //    error handling differs slightly here (we return PSPS-shaped errors).
+    std::vector<SegmentSplitInfo> segments;
+    for (const auto& rowset : old_tablet_metadata->rowsets()) {
+        if (rowset.segments_size() != rowset.segment_size_size() ||
+            rowset.segments_size() != rowset.segment_metas_size()) {
+            return Status::InvalidArgument("Segment metadata is inconsistent with segment list");
+        }
+        for (int32_t i = 0; i < rowset.segments_size(); ++i) {
+            SegmentSplitInfo seg;
+            seg.source_id = rowset.id();
+            const auto& sm = rowset.segment_metas(i);
+            RETURN_IF_ERROR(seg.min_key.from_proto(sm.sort_key_min()));
+            RETURN_IF_ERROR(seg.max_key.from_proto(sm.sort_key_max()));
+            seg.num_rows = sm.num_rows();
+            seg.data_size = rowset.segment_size(i);
+            RETURN_IF_ERROR(seg.load_sort_key_samples(sm));
+            segments.push_back(std::move(seg));
+        }
+    }
+    // rowsets present but no segments derived -> corruption. Matches the
+    // data-driven path's "No segments found" error (get_tablet_split_ranges).
+    if (segments.empty()) {
+        return Status::InvalidArgument("rowsets present but no segments derived (possibly corrupt metadata)");
+    }
+
+    // 6. Compute segment envelope and effective envelope.
+    VariantTuple seg_min = segments.front().min_key;
+    VariantTuple seg_max = segments.front().max_key;
+    for (const auto& s : segments) {
+        if (s.min_key.compare(seg_min) < 0) seg_min = s.min_key;
+        if (s.max_key.compare(seg_max) > 0) seg_max = s.max_key;
+    }
+    VariantTuple effective_lo = seg_min;
+    VariantTuple effective_hi = seg_max;
+    if (old_tablet_metadata->range().has_lower_bound()) {
+        VariantTuple parent_lo;
+        RETURN_IF_ERROR(parent_lo.from_proto(old_tablet_metadata->range().lower_bound()));
+        if (parent_lo.compare(effective_lo) > 0) effective_lo = parent_lo;
+    }
+    if (old_tablet_metadata->range().has_upper_bound()) {
+        VariantTuple parent_hi;
+        RETURN_IF_ERROR(parent_hi.from_proto(old_tablet_metadata->range().upper_bound()));
+        if (parent_hi.compare(effective_hi) < 0) effective_hi = parent_hi;
+    }
+    // '>=' covers both empty (lo > hi) and degenerate-point (lo == hi)
+    // envelopes. Half-open range math cannot K-way split a point; for P0
+    // both cases return InvalidArgument and the caller falls back.
+    if (effective_lo.compare(effective_hi) >= 0) {
+        return Status::InvalidArgument(
+                "effective envelope empty or degenerate-point (segments don't overlap parent's range or collapse to a "
+                "single key)");
+    }
+
+    // 7. Build distribution vector covering the FULL segment envelope.
+    //    dist_to_final[j] == -1 for sinks, otherwise the index into split_ranges.
+    //    Non-explicit ±infinity sides clip to the effective envelope edge.
+    std::vector<RangeInfo> dist_ranges;
+    std::vector<int> dist_to_final;
+    dist_ranges.reserve(external_ranges.size() + 2);
+    dist_to_final.reserve(external_ranges.size() + 2);
+    if (seg_min.compare(effective_lo) < 0) {
+        RangeInfo sink;
+        sink.min = seg_min;
+        sink.max = effective_lo;
+        dist_ranges.push_back(std::move(sink));
+        dist_to_final.push_back(-1);
+    }
+    for (int i = 0; i < external_ranges.size(); ++i) {
+        const VariantTuple clipped_lo =
+                parsed[i].lo_explicit ? ((parsed[i].lo.compare(effective_lo) < 0) ? effective_lo : parsed[i].lo)
+                                      : effective_lo;
+        const VariantTuple clipped_hi =
+                parsed[i].hi_explicit ? ((parsed[i].hi.compare(effective_hi) > 0) ? effective_hi : parsed[i].hi)
+                                      : effective_hi;
+        // Skip on '>=' (zero-width too): [x,x) cannot contain any row under
+        // closed-open semantics; including would risk closed-last-range edge.
+        if (clipped_lo.compare(clipped_hi) >= 0) continue;
+        RangeInfo ri;
+        ri.min = clipped_lo;
+        ri.max = clipped_hi;
+        dist_ranges.push_back(std::move(ri));
+        dist_to_final.push_back(i);
+    }
+    if (seg_max.compare(effective_hi) > 0) {
+        RangeInfo sink;
+        sink.min = effective_hi;
+        sink.max = seg_max;
+        dist_ranges.push_back(std::move(sink));
+        dist_to_final.push_back(-1);
+    }
+    // Defense-in-depth: should be unreachable under v20 invariants (envelope
+    // check at step 5 ensures effective_lo < effective_hi; FE ranges tile
+    // parent's range; at least one FE range must overlap effective envelope).
+    // Asserted at runtime so a future regression in invariants doesn't OOB
+    // find_overlapping_ranges' last_range_index = size()-1.
+    if (dist_ranges.empty()) {
+        return Status::InvalidArgument("distribution vector empty (degenerate envelope or all active slots skipped)");
+    }
+
+    // 8. Distribute segments into the full distribution vector. Out-of-parent
+    //    data flows into sink buckets; sink stats are discarded at step 10.
+    for (const auto& seg : segments) {
+        distribute_segment_to_ranges(seg, dist_ranges, /*track_sources=*/true);
+    }
+
+    // 9. Build anchor BEFORE the sanity check. anchor's per-rowset totals
+    //    fall back to summing segment_metas when rowset-level num_rows /
+    //    data_size are absent on legacy metadata, so the sanity check below
+    //    using anchor totals catches legacy rowsets that direct
+    //    rowset.num_rows() access would miss.
+    auto anchor = build_rowset_anchor(*old_tablet_metadata, tablet_manager);
+
+    // 10. Per-axis all-zero sanity check. For each rowset where anchor totals
+    //     are positive, require Σ over active slots > 0 on the matching axis.
+    //     allocate_proportionally falls back to uniform allocation when all
+    //     weights are zero, which would silently invent stats.
+    for (const auto& [rowset_id, ra] : anchor) {
+        const bool need_row_weight = (ra.num_rows > 0);
+        const bool need_byte_weight = (ra.data_size > 0);
+        if (!need_row_weight && !need_byte_weight) continue;
+        int64_t active_rows_w = 0;
+        int64_t active_bytes_w = 0;
+        for (size_t j = 0; j < dist_ranges.size(); ++j) {
+            if (dist_to_final[j] < 0) continue; // skip sinks
+            auto it = dist_ranges[j].source_stats.find(rowset_id);
+            if (it != dist_ranges[j].source_stats.end()) {
+                active_rows_w += it->second.first;
+                active_bytes_w += it->second.second;
+            }
+        }
+        if (need_row_weight && active_rows_w == 0) {
+            return Status::InvalidArgument(fmt::format(
+                    "rowset id={} has anchor.num_rows={} but no active row weight (possibly corrupt metadata)",
+                    rowset_id, ra.num_rows));
+        }
+        if (need_byte_weight && active_bytes_w == 0) {
+            return Status::InvalidArgument(fmt::format(
+                    "rowset id={} has anchor.data_size={} but no active byte weight (possibly corrupt metadata)",
+                    rowset_id, ra.data_size));
+        }
+    }
+
+    // 11. Synthesize RangeSplitResult with K slots; active slots get their
+    //     accumulated source_stats, sinks discarded, skipped slots stay empty.
+    RangeSplitResult fake_result;
+    fake_result.range_source_stats.resize(external_ranges.size());
+    for (size_t j = 0; j < dist_ranges.size(); ++j) {
+        if (dist_to_final[j] < 0) continue;
+        fake_result.range_source_stats[dist_to_final[j]] = dist_ranges[j].source_stats;
+    }
+
+    // 12. Anchor: Σ children stat == parent stat exactly for num_rows /
+    //     data_size / num_dels. Writes split_ranges[i].rowset_stats.
+    apply_rowset_anchor(anchor, fake_result, split_ranges);
+
+    return Status::OK();
+}
+
+// Build K new-tablet metadata entries from a pre-computed split_ranges vector.
+// Source-agnostic: the caller decides how split_ranges was produced (data-driven
+// boundary search, FE-supplied PSPS boundaries, or any future variant). Each
+// new tablet inherits the old tablet's schema/config, gets a fresh
+// id/version/commit_time/gtid/range, has per-version transient fields cleared,
+// and its rowset list is restricted to the new range with per-rowset stats
+// applied from split_ranges[i].rowset_stats.
+//
+// Precondition: split_ranges.size() == splitting_tablet.new_tablet_ids_size().
+// Per-rowset stats are honored when present in split_ranges[i].rowset_stats;
+// otherwise the rowset is preserved in the new tablet's metadata (still
+// referencing the same shared segment files) but with num_rows / data_size /
+// num_dels set to 0, signaling "rowset is visible in this child's metadata
+// but contributes no rows here under the child's range".
+StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablets_from_split_ranges(
+        const TabletMetadataPtr& old_tablet_metadata, const SplittingTabletInfoPB& splitting_tablet,
+        int64_t new_version, const TxnInfoPB& txn_info, const std::vector<TabletRangeInfo>& split_ranges) {
+    // Defense-in-depth: callers (get_tablet_split_ranges and PSPS helper) are
+    // contracted to return split_ranges.size() == new_tablet_ids_size() on OK,
+    // but a runtime check here prevents OOB reads if the contract is ever
     // broken by a future refactor (Release builds strip DCHECK).
     if (split_ranges.size() != static_cast<size_t>(splitting_tablet.new_tablet_ids_size())) {
         return Status::InternalError(fmt::format("split_ranges size mismatch: expected={}, actual={}",
                                                  splitting_tablet.new_tablet_ids_size(), split_ranges.size()));
     }
+
+    std::unordered_map<int64_t, MutableTabletMetadataPtr> new_metadatas;
+    new_metadatas.reserve(splitting_tablet.new_tablet_ids_size());
+
     for (int32_t i = 0; i < splitting_tablet.new_tablet_ids_size(); ++i) {
         auto new_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_metadata);
         new_tablet_new_metadata->set_id(splitting_tablet.new_tablet_ids(i));
@@ -830,6 +1189,91 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     }
 
     return new_metadatas;
+}
+
+} // namespace
+
+// Public wrapper for the anon-namespace implementation. Exposed via
+// tablet_splitter.h so unit tests can drive the validation paths directly
+// without spinning up a TabletManager/filesystem fixture.
+Status compute_split_ranges_from_external_boundaries(
+        TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,
+        const ::google::protobuf::RepeatedPtrField<TabletRangePB>& external_ranges, int32_t expected_new_tablet_count,
+        std::vector<TabletRangeInfo>* split_ranges) {
+    return compute_split_ranges_from_external_boundaries_impl(tablet_manager, old_tablet_metadata, external_ranges,
+                                                              expected_new_tablet_count, split_ranges);
+}
+
+// Public wrapper for the data-driven split-ranges helper. Exposed for parity
+// testing against compute_split_ranges_from_external_boundaries; production
+// call site is split_tablet().
+Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
+                               int32_t split_count, std::vector<TabletRangeInfo>* split_ranges,
+                               int32_t colocate_column_count) {
+    return get_tablet_split_ranges_impl(tablet_manager, tablet_metadata, split_count, split_ranges,
+                                        colocate_column_count);
+}
+
+StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
+        TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
+        const SplittingTabletInfoPB& splitting_tablet, int64_t new_version, const TxnInfoPB& txn_info) {
+    if (tablet_metadata == nullptr) {
+        return Status::InvalidArgument("tablet metadata is null");
+    }
+    if (splitting_tablet.new_tablet_ids_size() <= 0) {
+        return Status::InvalidArgument("splitting tablet has no new tablet");
+    }
+
+    // Flush the parent's PK-index memtable into sstables before propagating
+    // metadata to the children, so every child inherits an sstable_meta that
+    // already covers its rowsets' live data. This is the pre-split half of
+    // the "reshard inputs must have full sstable coverage" invariant; merge
+    // does the post-split half in merge_sstables.
+    ASSIGN_OR_RETURN(TabletMetadataPtr old_tablet_metadata,
+                     tablet_manager->update_mgr()->flush_pk_memtable(tablet_metadata));
+
+    // Dispatch on FE-supplied new_tablet_ranges. When set, FE has computed the
+    // K-1 boundaries externally (PSPS / Pre-Sample & Pre-Split); BE computes
+    // per-rowset stats only. When unset, fall back to the existing
+    // data-driven boundary search via get_tablet_split_ranges.
+    //
+    // Symmetric identical-fallback: either path's non-OK Status routes through
+    // make_identical_new_tablet_metadata to produce a single identical new
+    // tablet that inherits parent's data. Distinct bvar counters distinguish
+    // the failure root cause for ops alerting.
+    std::vector<TabletRangeInfo> split_ranges;
+    // colocate_column_count is carried at the txn level (single split job = single txn) since
+    // every SplittingTabletInfoPB in the same job would carry the same value. See lake_types.proto.
+    // PSPS path skips boundary computation entirely (FE-supplied), so it does not consume the
+    // colocate_column_count signal.
+    const bool is_psps = splitting_tablet.new_tablet_ranges_size() > 0;
+    Status status = is_psps ? compute_split_ranges_from_external_boundaries(
+                                      tablet_manager, old_tablet_metadata, splitting_tablet.new_tablet_ranges(),
+                                      splitting_tablet.new_tablet_ids_size(), &split_ranges)
+                            : get_tablet_split_ranges(tablet_manager, old_tablet_metadata,
+                                                      splitting_tablet.new_tablet_ids_size(), &split_ranges,
+                                                      txn_info.colocate_column_count());
+    if (!status.ok()) {
+        if (is_psps) {
+            g_tablet_reshard_split_psps_fallback_total << 1;
+            LOG(WARNING) << "PSPS validation/compute failed; identical fallback. "
+                         << "tablet_id=" << old_tablet_metadata->id() << ", version=" << old_tablet_metadata->version()
+                         << ", txn_id=" << txn_info.txn_id() << ", status=" << status;
+        } else {
+            g_tablet_reshard_split_fallback_total << 1;
+            LOG(WARNING) << "Failed to get tablet split ranges, will not split this tablet: "
+                         << old_tablet_metadata->id() << ", version: " << old_tablet_metadata->version()
+                         << ", txn_id: " << txn_info.txn_id() << ", status: " << status;
+        }
+        auto new_tablet_metadata = make_identical_new_tablet_metadata(
+                old_tablet_metadata, splitting_tablet.new_tablet_ids(0), new_version, txn_info);
+        std::unordered_map<int64_t, MutableTabletMetadataPtr> new_metadatas;
+        new_metadatas.emplace(new_tablet_metadata->id(), std::move(new_tablet_metadata));
+        return new_metadatas;
+    }
+
+    return build_new_tablets_from_split_ranges(old_tablet_metadata, splitting_tablet, new_version, txn_info,
+                                               split_ranges);
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -29,12 +29,15 @@
 #include "storage/lake/update_manager.h"
 #include "storage/tablet_range.h"
 #include "storage/tablet_schema.h"
+#include "types/logical_type.h"
 #include "types/type_descriptor.h"
 
 extern bvar::Adder<int64_t> g_tablet_reshard_split_fallback_total;
-extern bvar::Adder<int64_t> g_tablet_reshard_split_psps_fallback_total;
+extern bvar::Adder<int64_t> g_tablet_reshard_split_external_boundaries_fallback_total;
 
 namespace starrocks::lake {
+
+using google::protobuf::RepeatedPtrField;
 
 Status SegmentSplitInfo::load_sort_key_samples(const SegmentMetadataPB& segment_meta) {
     if (segment_meta.sort_key_samples_size() == 0 || !segment_meta.has_sort_key_sample_row_interval()) {
@@ -498,9 +501,6 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
 
 namespace {
 
-// Statistic and TabletRangeInfo are declared in tablet_splitter.h (the PSPS
-// path returns vector<TabletRangeInfo> through that header for testability).
-
 // Per-rowset anchor totals taken from the parent's recorded metadata. Used to
 // renormalize per-split-group estimates so Σ children equals parent exactly,
 // preserving stat conservation across re-splits regardless of how the
@@ -616,6 +616,33 @@ void apply_rowset_anchor(const std::unordered_map<uint32_t, RowsetAnchor>& ancho
     }
 }
 
+// Build SegmentSplitInfo[] from a tablet's rowsets. Rejects per-rowset segment
+// metadata that is internally inconsistent (segments / segment_size /
+// segment_metas array sizes diverge). Does NOT enforce "segments non-empty" —
+// the data-driven and external-boundaries callers have different semantics on empty (one
+// errors, the other treats it as a no-op fast path) and own that check.
+Status build_segments_from_rowsets(const RepeatedPtrField<RowsetMetadataPB>& rowsets,
+                                   std::vector<SegmentSplitInfo>* segments) {
+    for (const auto& rowset : rowsets) {
+        if (rowset.segments_size() != rowset.segment_size_size() ||
+            rowset.segments_size() != rowset.segment_metas_size()) {
+            return Status::InvalidArgument("Segment metadata is inconsistent with segment list");
+        }
+        for (int32_t i = 0; i < rowset.segments_size(); ++i) {
+            SegmentSplitInfo segment;
+            segment.source_id = rowset.id();
+            const auto& segment_meta = rowset.segment_metas(i);
+            RETURN_IF_ERROR(segment.min_key.from_proto(segment_meta.sort_key_min()));
+            RETURN_IF_ERROR(segment.max_key.from_proto(segment_meta.sort_key_max()));
+            segment.num_rows = segment_meta.num_rows();
+            segment.data_size = rowset.segment_size(i);
+            RETURN_IF_ERROR(segment.load_sort_key_samples(segment_meta));
+            segments->push_back(std::move(segment));
+        }
+    }
+    return Status::OK();
+}
+
 // Compute split_count tablet ranges covering the tablet's key space.
 //
 // Postcondition on Status::OK: split_ranges->size() == split_count.
@@ -644,25 +671,7 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     }
 
     std::vector<SegmentSplitInfo> segments;
-
-    for (const auto& rowset : tablet_metadata->rowsets()) {
-        if (rowset.segments_size() != rowset.segment_size_size() ||
-            rowset.segments_size() != rowset.segment_metas_size()) {
-            return Status::InvalidArgument("Segment metadata is inconsistent with segment list");
-        }
-        for (int32_t i = 0; i < rowset.segments_size(); ++i) {
-            SegmentSplitInfo segment;
-            segment.source_id = rowset.id();
-            const auto& segment_meta = rowset.segment_metas(i);
-            RETURN_IF_ERROR(segment.min_key.from_proto(segment_meta.sort_key_min()));
-            RETURN_IF_ERROR(segment.max_key.from_proto(segment_meta.sort_key_max()));
-            segment.num_rows = segment_meta.num_rows();
-            segment.data_size = rowset.segment_size(i);
-            RETURN_IF_ERROR(segment.load_sort_key_samples(segment_meta));
-            segments.push_back(std::move(segment));
-        }
-    }
-
+    RETURN_IF_ERROR(build_segments_from_rowsets(tablet_metadata->rowsets(), &segments));
     if (segments.empty()) {
         return Status::InvalidArgument("No segments found in tablet metadata");
     }
@@ -745,7 +754,7 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
 // transient fields (compaction_inputs, orphan_files, prev_garbage_version).
 //
 // Used by split_tablet's symmetric identical-fallback path. Both the
-// data-driven branch (when get_tablet_split_ranges fails) and the PSPS
+// data-driven branch (when get_tablet_split_ranges fails) and the external boundaries
 // branch (when compute_split_ranges_from_external_boundaries fails) call
 // this helper with new_tablet_ids[0] to materialize a single identical
 // new tablet rather than the requested K new tablets.
@@ -766,146 +775,126 @@ MutableTabletMetadataPtr make_identical_new_tablet_metadata(const TabletMetadata
     return new_tablet_metadata;
 }
 
-// PSPS peer of get_tablet_split_ranges: produces a vector<TabletRangeInfo>
+// external-boundaries peer of get_tablet_split_ranges: produces a vector<TabletRangeInfo>
 // from FE-supplied boundaries instead of computing them from segment
 // distribution. Reuses distribute_segment_to_ranges, build_rowset_anchor, and
 // apply_rowset_anchor so the per-rowset stat math is identical to the
-// data-driven path.
+// data-driven path. Inline numbered step tags document each phase.
 //
 // Non-OK return is caller-handled (split_tablet) by routing to the symmetric
-// identical-fallback path with the PSPS bvar bumped. The helper does NOT
+// identical-fallback path with the external-boundaries bvar bumped. The helper does NOT
 // fall back internally; it surfaces the precise reason via Status::message.
-//
-// Algorithm (high level):
-//   1a. Size match.
-//   1b. Structural well-formedness of external_ranges (schema-free byte check).
-//   1c. Schema-aware validation: each TuplePB matches the tablet's sort key
-//       in arity and per-column type. Required because DatumVariant::compare
-//       only DCHECKs matching types and would silently mis-compare in release.
-//   2.  Seed K TabletRangeInfo from external_ranges (rowset_stats empty).
-//   3.  Parse FE bounds into VariantTuple + track explicit-presence per side.
-//       "Explicit" means the bound was supplied on the external range OR
-//       inherited from a present parent bound. Only first.lo / last.hi can
-//       ever be non-explicit (== ±infinity, per structural validation).
-//       3a. Per-range strict check: parsed[i].lo >= parsed[i].hi (when both
-//           explicit) -> reject. Strict '>=' covers semantic zero-width that
-//           the byte-level structural check cannot detect.
-//       3b. Adjacent monotonic check: parsed[i].hi > parsed[i+1].lo -> reject.
-//           Interior bounds are always explicit per structural validation.
-//       Runs BEFORE the empty fast-path so empty PSPS tablets get the same
-//       semantic guarantees as non-empty ones.
-//   4.  Empty old tablet fast-path: K empty new-tablets fall out naturally.
-//   5.  Build SegmentSplitInfo from rowsets (same as get_tablet_split_ranges).
-//   6.  Compute segment envelope and effective envelope (intersection with
-//       parent's range). Empty / degenerate-point envelope -> InvalidArgument.
-//   7.  Build distribution vector covering the FULL segment envelope:
-//       [optional left_sink, K (or fewer, after clipping) active slots,
-//        optional right_sink]. Sinks absorb out-of-parent-range segment data
-//       from shared rowsets (prior-split residual). Non-explicit ±infinity
-//       sides clip to effective envelope edge.
-//   8.  Distribute segments into the full vector.
-//   9.  Build anchor; sanity-check that every rowset with anchor totals > 0
-//       has positive active weight on the matching (rows or bytes) axis.
-//       Otherwise allocate_proportionally would uniformly fabricate stats.
-//  10.  Synthesize a RangeSplitResult and apply anchor; output is K
-//       TabletRangeInfo in *split_ranges with normalized rowset_stats.
-Status compute_split_ranges_from_external_boundaries_impl(
-        TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,
-        const ::google::protobuf::RepeatedPtrField<TabletRangePB>& external_ranges, int32_t expected_new_tablet_count,
-        std::vector<TabletRangeInfo>* split_ranges) {
+Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_manager,
+                                                          const TabletMetadataPtr& old_tablet_metadata,
+                                                          const RepeatedPtrField<TabletRangePB>& external_ranges,
+                                                          std::vector<TabletRangeInfo>* split_ranges) {
     DCHECK(split_ranges != nullptr);
     DCHECK(split_ranges->empty());
 
-    // 1a. Size match. Inside the helper so size-mismatch goes through the
-    //     same PSPS fallback path as other validation failures.
-    if (external_ranges.size() != expected_new_tablet_count) {
-        return Status::InvalidArgument(fmt::format("new_tablet_ranges.size={} != new_tablet_ids.size={}",
-                                                   external_ranges.size(), expected_new_tablet_count));
-    }
-
-    // 1b. Structural validation (schema-free): closed-open per range, no
+    // 1a. Structural validation (schema-free): closed-open per range, no
     //     byte-equal zero-width child, first.lower matches parent.lower,
     //     last.upper matches parent.upper, adjacent ranges meet exactly.
     RETURN_IF_ERROR(TabletRangeHelper::validate_new_tablet_ranges(old_tablet_metadata->range(), external_ranges));
 
-    // 1c. Schema-aware validation of FE-supplied TuplePB bounds. Without
+    // 1b. Schema-aware validation of FE-supplied TuplePB bounds. Without
     //     this, DatumVariant::compare's DCHECK-only type guard means
     //     release builds silently mis-compare malformed FE input.
     //     For decimal-family columns, also validate precision/scale exactly:
     //     DecimalTypeInfo compares raw unscaled values, so a bound with the
     //     same LogicalType but different scale than the schema would
     //     mis-order against schema-derived segment bounds.
-    auto tablet_schema = TabletSchema::create(old_tablet_metadata->schema());
-    const auto& sort_key_idxes = tablet_schema->sort_key_idxes();
+    //     Reads schema metadata directly from TabletSchemaPB to avoid the
+    //     heavy TabletSchema::create allocation; only sort-key columns'
+    //     type / precision / scale are needed.
+    const TabletSchemaPB& schema_pb = old_tablet_metadata->schema();
+    const auto& sort_key_idxes = schema_pb.sort_key_idxes();
     if (sort_key_idxes.empty()) {
-        return Status::InvalidArgument("tablet has no sort key columns; PSPS path requires a sort key");
+        return Status::InvalidArgument("tablet has no sort key columns; external-boundaries path requires a sort key");
     }
-    auto validate_tuple_against_schema = [&](const TuplePB& t, int range_idx, std::string_view side) -> Status {
-        if (t.values_size() != static_cast<int>(sort_key_idxes.size())) {
+    // Precompute sort-key column metadata once (constant per call); the per-tuple
+    // validation runs 2K times (K boundaries × {lower, upper}) and each call would
+    // otherwise rerun string_to_logical_type and re-read col_pb fields.
+    struct SortKeyColumnMeta {
+        LogicalType type;
+        int precision;
+        int scale;
+        bool is_decimal;
+    };
+    std::vector<SortKeyColumnMeta> sort_key_meta;
+    sort_key_meta.reserve(sort_key_idxes.size());
+    for (int column_index : sort_key_idxes) {
+        // ColumnPB.frac is the scale field (legacy naming).
+        const auto& column_pb = schema_pb.column(column_index);
+        const LogicalType type = string_to_logical_type(column_pb.type());
+        const bool is_decimal = (type == TYPE_DECIMAL || type == TYPE_DECIMALV2 || is_decimalv3_field_type(type));
+        sort_key_meta.push_back({type, column_pb.precision(), column_pb.frac(), is_decimal});
+    }
+    auto validate_tuple_against_schema = [&](const TuplePB& tuple, int range_index, std::string_view side) -> Status {
+        if (tuple.values_size() != sort_key_idxes.size()) {
             return Status::InvalidArgument(fmt::format("new_tablet_ranges[{}].{}: tuple arity {} != sort_key arity {}",
-                                                       range_idx, side, t.values_size(), sort_key_idxes.size()));
+                                                       range_index, side, tuple.values_size(), sort_key_idxes.size()));
         }
-        for (int j = 0; j < t.values_size(); ++j) {
-            const auto& var = t.values(j);
-            // PSPS sort-key bounds are scalar values only — tablet sort
+        for (int j = 0; j < tuple.values_size(); ++j) {
+            const auto& variant = tuple.values(j);
+            // external sort-key bounds are scalar values only — tablet sort
             // keys are restricted to scalar types (no ARRAY/MAP/STRUCT).
             // Enforce a single SCALAR PTypeNode with scalar_type set so
             // malformed FE input cannot reach the underlying
             // TypeDescriptor PTypeNode constructor, which DCHECKs and
             // does unguarded types.Get() on complex-type child indices
             // (be/src/types/type_descriptor.cpp:158-204).
-            if (!var.has_type() || var.type().types_size() != 1) {
+            if (!variant.has_type() || variant.type().types_size() != 1) {
                 return Status::InvalidArgument(
                         fmt::format("new_tablet_ranges[{}].{}: column[{}] variant must have exactly one type node "
                                     "(got types_size={})",
-                                    range_idx, side, j, var.type().types_size()));
+                                    range_index, side, j, variant.type().types_size()));
             }
-            const auto& node = var.type().types(0);
+            const auto& node = variant.type().types(0);
             if (static_cast<TTypeNodeType::type>(node.type()) != TTypeNodeType::SCALAR || !node.has_scalar_type()) {
                 return Status::InvalidArgument(
                         fmt::format("new_tablet_ranges[{}].{}: column[{}] variant must be a scalar type "
                                     "(got node_type={}, has_scalar_type={})",
-                                    range_idx, side, j, node.type(), node.has_scalar_type()));
+                                    range_index, side, j, node.type(), node.has_scalar_type()));
             }
-            const int col_idx = sort_key_idxes[j];
-            const auto& col = tablet_schema->column(col_idx);
-            const LogicalType col_type = col.type();
-            const auto var_type_desc = TypeDescriptor::from_protobuf(var.type());
-            if (var_type_desc.type != col_type) {
-                return Status::InvalidArgument(
-                        fmt::format("new_tablet_ranges[{}].{}: column[{}] variant type {} != schema type {}", range_idx,
-                                    side, j, static_cast<int>(var_type_desc.type), static_cast<int>(col_type)));
+            // Read variant type directly from the validated scalar_type instead of
+            // constructing a full TypeDescriptor; saves the per-tuple allocation.
+            const auto& scalar_type = node.scalar_type();
+            const LogicalType variant_type = thrift_to_type(static_cast<TPrimitiveType::type>(scalar_type.type()));
+            const auto& meta = sort_key_meta[j];
+            if (variant_type != meta.type) {
+                return Status::InvalidArgument(fmt::format(
+                        "new_tablet_ranges[{}].{}: column[{}] variant type {} != schema type {}", range_index, side, j,
+                        logical_type_to_string(variant_type), logical_type_to_string(meta.type)));
             }
-            if (var_type_desc.is_decimal_type()) {
-                const int schema_precision = static_cast<int>(col.precision());
-                const int schema_scale = static_cast<int>(col.scale());
-                if (var_type_desc.precision != schema_precision || var_type_desc.scale != schema_scale) {
-                    return Status::InvalidArgument(
-                            fmt::format("new_tablet_ranges[{}].{}: column[{}] decimal precision/scale "
-                                        "({}, {}) != schema ({}, {})",
-                                        range_idx, side, j, var_type_desc.precision, var_type_desc.scale,
-                                        schema_precision, schema_scale));
+            if (meta.is_decimal) {
+                const int variant_precision = scalar_type.has_precision() ? scalar_type.precision() : -1;
+                const int variant_scale = scalar_type.has_scale() ? scalar_type.scale() : -1;
+                if (variant_precision != meta.precision || variant_scale != meta.scale) {
+                    return Status::InvalidArgument(fmt::format(
+                            "new_tablet_ranges[{}].{}: column[{}] decimal precision/scale "
+                            "({}, {}) != schema ({}, {})",
+                            range_index, side, j, variant_precision, variant_scale, meta.precision, meta.scale));
                 }
             }
         }
         return Status::OK();
     };
     for (int i = 0; i < external_ranges.size(); ++i) {
-        const auto& er = external_ranges[i];
-        if (er.has_lower_bound()) {
-            RETURN_IF_ERROR(validate_tuple_against_schema(er.lower_bound(), i, "lower"));
+        const auto& external_range = external_ranges[i];
+        if (external_range.has_lower_bound()) {
+            RETURN_IF_ERROR(validate_tuple_against_schema(external_range.lower_bound(), i, "lower"));
         }
-        if (er.has_upper_bound()) {
-            RETURN_IF_ERROR(validate_tuple_against_schema(er.upper_bound(), i, "upper"));
+        if (external_range.has_upper_bound()) {
+            RETURN_IF_ERROR(validate_tuple_against_schema(external_range.upper_bound(), i, "upper"));
         }
     }
 
     // 2. Seed K TabletRangeInfo from external_ranges; rowset_stats stays empty
     //    for now (filled by apply_rowset_anchor in step 10).
     split_ranges->reserve(external_ranges.size());
-    for (const auto& er : external_ranges) {
-        auto& tri = split_ranges->emplace_back();
-        tri.range = er;
+    for (const auto& external_range : external_ranges) {
+        auto& range_info = split_ranges->emplace_back();
+        range_info.range = external_range;
     }
 
     // 3. Parse FE bounds into VariantTuple + track explicit-presence. An
@@ -919,21 +908,19 @@ Status compute_split_ranges_from_external_boundaries_impl(
         bool lo_explicit = false;
         bool hi_explicit = false;
     };
+    // validate_new_tablet_ranges already enforces that first.has_lower_bound() ==
+    // parent.has_lower_bound() and last.has_upper_bound() == parent.has_upper_bound(),
+    // and that interior bounds are always set. So an absent external bound here means
+    // parent is unbounded on that side too — no parent inheritance is ever needed.
     std::vector<ParsedBounds> parsed(external_ranges.size());
     for (int i = 0; i < external_ranges.size(); ++i) {
-        const auto& er = external_ranges[i];
-        if (er.has_lower_bound()) {
-            RETURN_IF_ERROR(parsed[i].lo.from_proto(er.lower_bound()));
-            parsed[i].lo_explicit = true;
-        } else if (old_tablet_metadata->range().has_lower_bound()) {
-            RETURN_IF_ERROR(parsed[i].lo.from_proto(old_tablet_metadata->range().lower_bound()));
+        const auto& external_range = external_ranges[i];
+        if (external_range.has_lower_bound()) {
+            RETURN_IF_ERROR(parsed[i].lo.from_proto(external_range.lower_bound()));
             parsed[i].lo_explicit = true;
         }
-        if (er.has_upper_bound()) {
-            RETURN_IF_ERROR(parsed[i].hi.from_proto(er.upper_bound()));
-            parsed[i].hi_explicit = true;
-        } else if (old_tablet_metadata->range().has_upper_bound()) {
-            RETURN_IF_ERROR(parsed[i].hi.from_proto(old_tablet_metadata->range().upper_bound()));
+        if (external_range.has_upper_bound()) {
+            RETURN_IF_ERROR(parsed[i].hi.from_proto(external_range.upper_bound()));
             parsed[i].hi_explicit = true;
         }
     }
@@ -959,35 +946,17 @@ Status compute_split_ranges_from_external_boundaries_impl(
     // 4. Empty old tablet fast-path: no rowsets to distribute, K
     //    TabletRangeInfo with empty rowset_stats is the correct output.
     //    build_new_tablets_from_split_ranges will produce K new tablets with
-    //    no rowsets. Runs AFTER FE-input validation so empty PSPS tablets
+    //    no rowsets. Runs AFTER FE-input validation so empty tablets via external boundaries
     //    cannot accept semantically-invalid ranges either.
     if (old_tablet_metadata->rowsets_size() == 0) {
         return Status::OK();
     }
 
-    // 5. Build SegmentSplitInfo from rowsets. Same logic as
-    //    get_tablet_split_ranges; shared via copy because the segment-load
-    //    error handling differs slightly here (we return PSPS-shaped errors).
+    // 5. Build SegmentSplitInfo from rowsets via shared helper. Empty-segments
+    //    here is corruption (we already short-circuited the empty-rowsets case
+    //    at step 4); external boundaries uses a distinct error message vs the data-driven path.
     std::vector<SegmentSplitInfo> segments;
-    for (const auto& rowset : old_tablet_metadata->rowsets()) {
-        if (rowset.segments_size() != rowset.segment_size_size() ||
-            rowset.segments_size() != rowset.segment_metas_size()) {
-            return Status::InvalidArgument("Segment metadata is inconsistent with segment list");
-        }
-        for (int32_t i = 0; i < rowset.segments_size(); ++i) {
-            SegmentSplitInfo seg;
-            seg.source_id = rowset.id();
-            const auto& sm = rowset.segment_metas(i);
-            RETURN_IF_ERROR(seg.min_key.from_proto(sm.sort_key_min()));
-            RETURN_IF_ERROR(seg.max_key.from_proto(sm.sort_key_max()));
-            seg.num_rows = sm.num_rows();
-            seg.data_size = rowset.segment_size(i);
-            RETURN_IF_ERROR(seg.load_sort_key_samples(sm));
-            segments.push_back(std::move(seg));
-        }
-    }
-    // rowsets present but no segments derived -> corruption. Matches the
-    // data-driven path's "No segments found" error (get_tablet_split_ranges).
+    RETURN_IF_ERROR(build_segments_from_rowsets(old_tablet_metadata->rowsets(), &segments));
     if (segments.empty()) {
         return Status::InvalidArgument("rowsets present but no segments derived (possibly corrupt metadata)");
     }
@@ -1127,7 +1096,7 @@ Status compute_split_ranges_from_external_boundaries_impl(
 
 // Build K new-tablet metadata entries from a pre-computed split_ranges vector.
 // Source-agnostic: the caller decides how split_ranges was produced (data-driven
-// boundary search, FE-supplied PSPS boundaries, or any future variant). Each
+// boundary search, FE-supplied external boundaries, or any future variant). Each
 // new tablet inherits the old tablet's schema/config, gets a fresh
 // id/version/commit_time/gtid/range, has per-version transient fields cleared,
 // and its rowset list is restricted to the new range with per-rowset stats
@@ -1142,7 +1111,7 @@ Status compute_split_ranges_from_external_boundaries_impl(
 StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablets_from_split_ranges(
         const TabletMetadataPtr& old_tablet_metadata, const SplittingTabletInfoPB& splitting_tablet,
         int64_t new_version, const TxnInfoPB& txn_info, const std::vector<TabletRangeInfo>& split_ranges) {
-    // Defense-in-depth: callers (get_tablet_split_ranges and PSPS helper) are
+    // Defense-in-depth: callers (get_tablet_split_ranges and external-boundaries helper) are
     // contracted to return split_ranges.size() == new_tablet_ids_size() on OK,
     // but a runtime check here prevents OOB reads if the contract is ever
     // broken by a future refactor (Release builds strip DCHECK).
@@ -1196,12 +1165,12 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablet
 // Public wrapper for the anon-namespace implementation. Exposed via
 // tablet_splitter.h so unit tests can drive the validation paths directly
 // without spinning up a TabletManager/filesystem fixture.
-Status compute_split_ranges_from_external_boundaries(
-        TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,
-        const ::google::protobuf::RepeatedPtrField<TabletRangePB>& external_ranges, int32_t expected_new_tablet_count,
-        std::vector<TabletRangeInfo>* split_ranges) {
+Status compute_split_ranges_from_external_boundaries(TabletManager* tablet_manager,
+                                                     const TabletMetadataPtr& old_tablet_metadata,
+                                                     const RepeatedPtrField<TabletRangePB>& external_ranges,
+                                                     std::vector<TabletRangeInfo>* split_ranges) {
     return compute_split_ranges_from_external_boundaries_impl(tablet_manager, old_tablet_metadata, external_ranges,
-                                                              expected_new_tablet_count, split_ranges);
+                                                              split_ranges);
 }
 
 // Public wrapper for the data-driven split-ranges helper. Exposed for parity
@@ -1233,7 +1202,7 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
                      tablet_manager->update_mgr()->flush_pk_memtable(tablet_metadata));
 
     // Dispatch on FE-supplied new_tablet_ranges. When set, FE has computed the
-    // K-1 boundaries externally (PSPS / Pre-Sample & Pre-Split); BE computes
+    // K-1 boundaries externally (external boundaries / external boundaries); BE computes
     // per-rowset stats only. When unset, fall back to the existing
     // data-driven boundary search via get_tablet_split_ranges.
     //
@@ -1244,19 +1213,27 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     std::vector<TabletRangeInfo> split_ranges;
     // colocate_column_count is carried at the txn level (single split job = single txn) since
     // every SplittingTabletInfoPB in the same job would carry the same value. See lake_types.proto.
-    // PSPS path skips boundary computation entirely (FE-supplied), so it does not consume the
+    // external-boundaries path skips boundary computation entirely (FE-supplied), so it does not consume the
     // colocate_column_count signal.
-    const bool is_psps = splitting_tablet.new_tablet_ranges_size() > 0;
-    Status status = is_psps ? compute_split_ranges_from_external_boundaries(
-                                      tablet_manager, old_tablet_metadata, splitting_tablet.new_tablet_ranges(),
-                                      splitting_tablet.new_tablet_ids_size(), &split_ranges)
-                            : get_tablet_split_ranges(tablet_manager, old_tablet_metadata,
-                                                      splitting_tablet.new_tablet_ids_size(), &split_ranges,
-                                                      txn_info.colocate_column_count());
+    const bool is_external_boundaries = splitting_tablet.new_tablet_ranges_size() > 0;
+    // For external boundaries, FE supplies two parallel lists (new_tablet_ids and new_tablet_ranges);
+    // they must agree in size, since downstream code zips them per index.
+    Status status;
+    if (is_external_boundaries && splitting_tablet.new_tablet_ranges_size() != splitting_tablet.new_tablet_ids_size()) {
+        status = Status::InvalidArgument(fmt::format("new_tablet_ranges.size={} != new_tablet_ids.size={}",
+                                                     splitting_tablet.new_tablet_ranges_size(),
+                                                     splitting_tablet.new_tablet_ids_size()));
+    } else if (is_external_boundaries) {
+        status = compute_split_ranges_from_external_boundaries(tablet_manager, old_tablet_metadata,
+                                                               splitting_tablet.new_tablet_ranges(), &split_ranges);
+    } else {
+        status = get_tablet_split_ranges(tablet_manager, old_tablet_metadata, splitting_tablet.new_tablet_ids_size(),
+                                         &split_ranges, txn_info.colocate_column_count());
+    }
     if (!status.ok()) {
-        if (is_psps) {
-            g_tablet_reshard_split_psps_fallback_total << 1;
-            LOG(WARNING) << "PSPS validation/compute failed; identical fallback. "
+        if (is_external_boundaries) {
+            g_tablet_reshard_split_external_boundaries_fallback_total << 1;
+            LOG(WARNING) << "external-boundaries validation/compute failed; identical fallback. "
                          << "tablet_id=" << old_tablet_metadata->id() << ", version=" << old_tablet_metadata->version()
                          << ", txn_id=" << txn_info.txn_id() << ", status=" << status;
         } else {

--- a/be/src/storage/lake/tablet_splitter.h
+++ b/be/src/storage/lake/tablet_splitter.h
@@ -107,7 +107,7 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
         TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,
         const SplittingTabletInfoPB& splitting_tablet, int64_t new_version, const TxnInfoPB& txn_info);
 
-// Per-rowset estimated stats; used by the PSPS split path's per-range output.
+// Per-rowset estimated stats; used by the external boundaries split path's per-range output.
 struct Statistic {
     int64_t num_rows = 0;
     int64_t data_size = 0;
@@ -123,7 +123,7 @@ struct TabletRangeInfo {
 // Data-driven peer of compute_split_ranges_from_external_boundaries:
 // computes K-1 boundaries from the old tablet's segment distribution and
 // emits K TabletRangeInfo with per-rowset anchored stats. Exposed for unit
-// testing (parity comparison with the PSPS path); the production call site
+// testing (parity comparison with the external-boundaries path); the production call site
 // is in split_tablet().
 //
 // `tablet_manager` is only dereferenced by build_rowset_anchor's primary-key
@@ -133,7 +133,7 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
                                int32_t split_count, std::vector<TabletRangeInfo>* split_ranges,
                                int32_t colocate_column_count = 0);
 
-// PSPS peer of get_tablet_split_ranges: produces a vector<TabletRangeInfo>
+// external-boundaries peer of get_tablet_split_ranges: produces a vector<TabletRangeInfo>
 // from FE-supplied boundaries instead of computing them from segment
 // distribution. Exposed for unit testing of the validation paths; the
 // production call site is in split_tablet().
@@ -143,7 +143,7 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
 // `tablet_manager` may be nullptr.
 Status compute_split_ranges_from_external_boundaries(
         TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,
-        const ::google::protobuf::RepeatedPtrField<TabletRangePB>& external_ranges, int32_t expected_new_tablet_count,
+        const google::protobuf::RepeatedPtrField<TabletRangePB>& external_ranges,
         std::vector<TabletRangeInfo>* split_ranges);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_splitter.h
+++ b/be/src/storage/lake/tablet_splitter.h
@@ -107,4 +107,43 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
         TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,
         const SplittingTabletInfoPB& splitting_tablet, int64_t new_version, const TxnInfoPB& txn_info);
 
+// Per-rowset estimated stats; used by the PSPS split path's per-range output.
+struct Statistic {
+    int64_t num_rows = 0;
+    int64_t data_size = 0;
+    int64_t num_dels = 0;
+};
+
+// A new-tablet range plus the per-rowset stats that should be carried into it.
+struct TabletRangeInfo {
+    TabletRangePB range;
+    std::unordered_map<uint32_t, Statistic> rowset_stats;
+};
+
+// Data-driven peer of compute_split_ranges_from_external_boundaries:
+// computes K-1 boundaries from the old tablet's segment distribution and
+// emits K TabletRangeInfo with per-rowset anchored stats. Exposed for unit
+// testing (parity comparison with the PSPS path); the production call site
+// is in split_tablet().
+//
+// `tablet_manager` is only dereferenced by build_rowset_anchor's primary-key
+// delvec fallback. For tests using DUP_KEYS metadata with num_dels populated
+// directly, `tablet_manager` may be nullptr.
+Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
+                               int32_t split_count, std::vector<TabletRangeInfo>* split_ranges,
+                               int32_t colocate_column_count = 0);
+
+// PSPS peer of get_tablet_split_ranges: produces a vector<TabletRangeInfo>
+// from FE-supplied boundaries instead of computing them from segment
+// distribution. Exposed for unit testing of the validation paths; the
+// production call site is in split_tablet().
+//
+// `tablet_manager` is only dereferenced when the old tablet has rowsets
+// (build_rowset_anchor at step 9). For empty-tablet validation tests
+// `tablet_manager` may be nullptr.
+Status compute_split_ranges_from_external_boundaries(
+        TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,
+        const ::google::protobuf::RepeatedPtrField<TabletRangePB>& external_ranges, int32_t expected_new_tablet_count,
+        std::vector<TabletRangeInfo>* split_ranges);
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -30,6 +30,8 @@
 
 namespace starrocks::lake {
 
+using google::protobuf::RepeatedPtrField;
+
 namespace {
 
 static VariantTuple make_int_tuple(int32_t value) {
@@ -813,6 +815,149 @@ TEST(TabletRangeHelperTest, test_sst_seek_range_null_as_min_unsupported_type) {
     ASSERT_FALSE(res.ok());
     ASSERT_TRUE(res.status().is_not_supported());
     ASSERT_THAT(res.status().to_string(), testing::HasSubstr("unsupported type for PK min datum"));
+}
+
+// =============================================================================
+// validate_new_tablet_ranges: structural (schema-free) validator used by the
+// external-boundaries path. These tests exercise every rejection branch directly so coverage
+// does not rely on routing through compute_split_ranges_from_external_boundaries.
+// =============================================================================
+
+namespace {
+
+// Builds a closed-open [lower, upper) range with INT bounds. nullopt skips
+// the corresponding bound — used to construct half-bounded edge ranges.
+static TabletRangePB make_int_range_pb(std::optional<int32_t> lower, std::optional<int32_t> upper) {
+    TabletRangePB r;
+    if (lower.has_value()) {
+        *r.mutable_lower_bound() = make_int_tuple_pb(*lower);
+        r.set_lower_bound_included(true);
+    }
+    if (upper.has_value()) {
+        *r.mutable_upper_bound() = make_int_tuple_pb(*upper);
+        r.set_upper_bound_included(false);
+    }
+    return r;
+}
+
+static RepeatedPtrField<TabletRangePB> as_pb_list(std::initializer_list<TabletRangePB> ranges) {
+    RepeatedPtrField<TabletRangePB> out;
+    for (const auto& r : ranges) {
+        *out.Add() = r;
+    }
+    return out;
+}
+
+} // namespace
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_empty_list_rejected) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    auto ranges = as_pb_list({});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_invalid_argument()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("new_tablet_ranges is empty"));
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_zero_width_range_rejected) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    // Synthesize a single range whose lower and upper bounds are byte-equal.
+    TabletRangePB r;
+    *r.mutable_lower_bound() = make_int_tuple_pb(50);
+    *r.mutable_upper_bound() = make_int_tuple_pb(50);
+    r.set_lower_bound_included(true);
+    r.set_upper_bound_included(false);
+    auto ranges = as_pb_list({r});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("zero-width"));
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_first_lower_must_be_inclusive) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    TabletRangePB r = make_int_range_pb(0, 100);
+    r.set_lower_bound_included(false); // Violation: first.lower must be inclusive when set.
+    auto ranges = as_pb_list({r});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("first.lower_bound must be inclusive"));
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_first_lower_mismatch_rejected) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    TabletRangePB r = make_int_range_pb(10, 100); // first.lower=10 != parent.lower=0
+    auto ranges = as_pb_list({r});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("first.lower_bound != old_tablet_range.lower_bound"));
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_last_upper_mismatch_rejected) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    TabletRangePB r = make_int_range_pb(0, 99); // last.upper=99 != parent.upper=100
+    auto ranges = as_pb_list({r});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("last.upper_bound != old_tablet_range.upper_bound"));
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_last_upper_must_be_exclusive) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    TabletRangePB r = make_int_range_pb(0, 100);
+    r.set_upper_bound_included(true); // Violation: last.upper must be exclusive when set.
+    auto ranges = as_pb_list({r});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("last.upper_bound must be exclusive"));
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_interior_gap_missing_bound_rejected) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    TabletRangePB first = make_int_range_pb(0, 50);
+    TabletRangePB second = make_int_range_pb(std::nullopt, 100); // missing lower
+    auto ranges = as_pb_list({first, second});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("gap at boundary 0"));
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_interior_bound_flags_rejected) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    TabletRangePB first = make_int_range_pb(0, 50);
+    first.set_upper_bound_included(true); // Violation: left boundary must be exclusive.
+    TabletRangePB second = make_int_range_pb(50, 100);
+    auto ranges = as_pb_list({first, second});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("invalid bound flags"));
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_adjacency_gap_rejected) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    TabletRangePB first = make_int_range_pb(0, 40);
+    TabletRangePB second = make_int_range_pb(50, 100); // gap: first.upper=40 != second.lower=50
+    auto ranges = as_pb_list({first, second});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("gap or overlap at boundary 0"));
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_happy_path_two_adjacent_ranges) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    TabletRangePB first = make_int_range_pb(0, 50);
+    TabletRangePB second = make_int_range_pb(50, 100);
+    auto ranges = as_pb_list({first, second});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_TRUE(s.ok()) << s;
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_happy_path_unbounded_parent) {
+    // Parent is (-inf, +inf); 3-way split with explicit interior boundaries.
+    TabletRangePB parent;
+    auto ranges = as_pb_list(
+            {make_int_range_pb(std::nullopt, 50), make_int_range_pb(50, 100), make_int_range_pb(100, std::nullopt)});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_TRUE(s.ok()) << s;
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -880,7 +880,9 @@ TEST(TabletRangeHelperTest, validate_new_tablet_ranges_first_lower_must_be_inclu
     auto ranges = as_pb_list({r});
     auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
     ASSERT_FALSE(s.ok());
-    ASSERT_THAT(s.to_string(), testing::HasSubstr("first.lower_bound must be inclusive"));
+    // The per-range guard (validate_tablet_range) fires before the positional
+    // "first.lower_bound must be inclusive" check and emits the generic message.
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("Lower bound is exclusive"));
 }
 
 TEST(TabletRangeHelperTest, validate_new_tablet_ranges_first_lower_mismatch_rejected) {
@@ -908,7 +910,9 @@ TEST(TabletRangeHelperTest, validate_new_tablet_ranges_last_upper_must_be_exclus
     auto ranges = as_pb_list({r});
     auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
     ASSERT_FALSE(s.ok());
-    ASSERT_THAT(s.to_string(), testing::HasSubstr("last.upper_bound must be exclusive"));
+    // The per-range guard (validate_tablet_range) fires before the positional
+    // "last.upper_bound must be exclusive" check and emits the generic message.
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("Upper bound is inclusive"));
 }
 
 TEST(TabletRangeHelperTest, validate_new_tablet_ranges_interior_gap_missing_bound_rejected) {
@@ -929,7 +933,9 @@ TEST(TabletRangeHelperTest, validate_new_tablet_ranges_interior_bound_flags_reje
     auto ranges = as_pb_list({first, second});
     auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
     ASSERT_FALSE(s.ok());
-    ASSERT_THAT(s.to_string(), testing::HasSubstr("invalid bound flags"));
+    // The per-range guard (validate_tablet_range) fires before the positional
+    // "invalid bound flags" check and emits the generic message.
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("Upper bound is inclusive"));
 }
 
 TEST(TabletRangeHelperTest, validate_new_tablet_ranges_adjacency_gap_rejected) {

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -22,9 +22,13 @@
 #include "base/testutil/assert.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/tablet_range.h"
+#include "types/logical_type.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::lake {
+
+using google::protobuf::RepeatedPtrField;
+using google::protobuf::util::MessageDifferencer;
 
 namespace {
 
@@ -599,8 +603,8 @@ TEST(TabletSplitterTest, tablet_range_total_invariant_across_split_counts) {
 // re-introducing a private split-only header.
 
 // Helpers below serve two test groups: colocate-aware data-driven splitter
-// tests (TabletSplitterTest.colocate_*) and PSPS external-boundaries tests
-// (TabletSplitterPspsTest.*). Kept in one anonymous namespace to avoid
+// tests (TabletSplitterTest.colocate_*) and external boundaries external-boundaries tests
+// (TabletSplitterExternalBoundariesTest.*). Kept in one anonymous namespace to avoid
 // duplicate-symbol churn.
 namespace {
 
@@ -624,7 +628,7 @@ static SegmentSplitInfo make_two_col_seg(int64_t lo_k1, int64_t lo_k2, int64_t h
 }
 
 // =============================================================================
-// PSPS (Pre-Sample & Pre-Split) external-boundaries path helpers
+// external boundaries external-boundaries path helpers
 // =============================================================================
 //
 // These exercise compute_split_ranges_from_external_boundaries' validation
@@ -677,74 +681,92 @@ static TabletRangePB make_bigint_range_pb(std::optional<int64_t> lower, std::opt
     return r;
 }
 
-// Build a minimal empty TabletMetadataPtr with a single BIGINT sort-key column
-// and the requested parent range. Used by every PSPS validation test that
-// expects the function to return before touching segments/anchors.
+// Builds a minimal empty TabletMetadataPtr with a single sort-key column of
+// the given LogicalType and the requested parent range. Used by every external boundaries
+// validation test that expects the function to return before touching
+// segments/anchors. precision/scale/length are populated only when non-zero
+// (relevant for decimal sort keys).
+struct SortKeyColumnSpec {
+    LogicalType type;
+    int precision = 0;
+    int scale = 0;
+    int length = 0;
+};
+
+static TabletMetadataPtr make_empty_metadata_with_sort_key(const SortKeyColumnSpec& col_spec,
+                                                           const TabletRangePB& parent_range) {
+    auto m = std::make_shared<TabletMetadataPB>();
+    m->set_id(1);
+    m->set_version(1);
+
+    auto* schema = m->mutable_schema();
+    schema->set_keys_type(PRIMARY_KEYS);
+    schema->set_id(100);
+    auto* col = schema->add_column();
+    col->set_unique_id(0);
+    col->set_name("k1");
+    col->set_type(logical_type_to_string(col_spec.type));
+    col->set_is_key(true);
+    col->set_is_nullable(false);
+    if (col_spec.precision > 0) col->set_precision(col_spec.precision);
+    if (col_spec.scale > 0) col->set_frac(col_spec.scale); // ColumnPB.frac is the scale field
+    if (col_spec.length > 0) col->set_length(col_spec.length);
+    schema->add_sort_key_idxes(0);
+
+    *m->mutable_range() = parent_range;
+    return m;
+}
+
 static TabletMetadataPtr make_empty_metadata_bigint_key(std::optional<int64_t> parent_lower,
                                                         std::optional<int64_t> parent_upper) {
-    auto m = std::make_shared<TabletMetadataPB>();
-    m->set_id(1);
-    m->set_version(1);
-
-    auto* schema = m->mutable_schema();
-    schema->set_keys_type(PRIMARY_KEYS);
-    schema->set_id(100);
-    auto* col = schema->add_column();
-    col->set_unique_id(0);
-    col->set_name("k1");
-    col->set_type("BIGINT");
-    col->set_is_key(true);
-    col->set_is_nullable(false);
-    schema->add_sort_key_idxes(0);
-
-    *m->mutable_range() = make_bigint_range_pb(parent_lower, parent_upper);
-    return m;
+    return make_empty_metadata_with_sort_key({.type = TYPE_BIGINT}, make_bigint_range_pb(parent_lower, parent_upper));
 }
 
-// Same shape but with a DECIMAL64(precision, scale) sort key.
 static TabletMetadataPtr make_empty_metadata_decimal64_key(int precision, int scale) {
-    auto m = std::make_shared<TabletMetadataPB>();
-    m->set_id(1);
-    m->set_version(1);
-
-    auto* schema = m->mutable_schema();
-    schema->set_keys_type(PRIMARY_KEYS);
-    schema->set_id(100);
-    auto* col = schema->add_column();
-    col->set_unique_id(0);
-    col->set_name("k1");
-    col->set_type("DECIMAL64");
-    col->set_is_key(true);
-    col->set_is_nullable(false);
-    col->set_precision(precision);
-    col->set_frac(scale); // ColumnPB.frac is the scale field
-    col->set_length(8);
-    schema->add_sort_key_idxes(0);
-
     // Decimal parent range: cover [10000, 100000) raw to keep tests simple.
     // (raw value space; the unit-test rationale doesn't depend on the human value)
-    auto* pr = m->mutable_range();
-    auto* lo = pr->mutable_lower_bound();
-    *lo->add_values() = make_decimal64_variant_pb(precision, scale, 10000);
-    pr->set_lower_bound_included(true);
-    auto* hi = pr->mutable_upper_bound();
-    *hi->add_values() = make_decimal64_variant_pb(precision, scale, 100000);
-    pr->set_upper_bound_included(false);
-    return m;
+    TabletRangePB parent_range;
+    *parent_range.mutable_lower_bound()->add_values() = make_decimal64_variant_pb(precision, scale, 10000);
+    parent_range.set_lower_bound_included(true);
+    *parent_range.mutable_upper_bound()->add_values() = make_decimal64_variant_pb(precision, scale, 100000);
+    parent_range.set_upper_bound_included(false);
+    return make_empty_metadata_with_sort_key(
+            {.type = TYPE_DECIMAL64, .precision = precision, .scale = scale, .length = 8}, parent_range);
 }
 
-static google::protobuf::RepeatedPtrField<TabletRangePB> make_ranges(std::initializer_list<TabletRangePB> ranges) {
-    google::protobuf::RepeatedPtrField<TabletRangePB> r;
+static RepeatedPtrField<TabletRangePB> make_ranges(std::initializer_list<TabletRangePB> ranges) {
+    RepeatedPtrField<TabletRangePB> r;
     for (const auto& range : ranges) {
         *r.Add() = range;
     }
     return r;
 }
 
+// Build a closed-open DECIMAL64 range with explicit raw values on both bounds.
+static TabletRangePB make_decimal64_range_pb(int precision, int scale, int64_t lo_raw, int64_t hi_raw) {
+    TabletRangePB r;
+    *r.mutable_lower_bound()->add_values() = make_decimal64_variant_pb(precision, scale, lo_raw);
+    r.set_lower_bound_included(true);
+    *r.mutable_upper_bound()->add_values() = make_decimal64_variant_pb(precision, scale, hi_raw);
+    r.set_upper_bound_included(false);
+    return r;
+}
+
+// external-boundaries validation test helper: invokes compute_split_ranges_from_external_boundaries
+// and asserts the call rejected with an InvalidArgument. Used by every test that
+// expects the function to fail early before touching segments/anchors.
+static void expect_external_boundaries_rejected(const TabletMetadataPtr& m,
+                                                const RepeatedPtrField<TabletRangePB>& ranges) {
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(/*tablet_manager=*/nullptr, m, ranges, &out);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+}
+
 } // namespace
 
 // Three disjoint segments with three distinct k1 values produce candidate
-// ranges between every adjacent pair. With colocate_col_count=1 and a 2-way
+// ranges between every adjacent pair. With colocate_column_count=1 and a 2-way
 // split, the chosen boundary lands at a k1 transition; canonicalization
 // rewrites the boundary to (right_k1, NULL).
 TEST(TabletSplitterTest, colocate_aware_split_picks_canonical_boundary) {
@@ -799,7 +821,7 @@ TEST(TabletSplitterTest, colocate_column_count_zero_unchanged) {
     ASSIGN_OR_ABORT(auto result_default,
                     calculate_range_split_boundaries(segs, /*target_split_count=*/2, /*target_value_per_split=*/100,
                                                      /*use_num_rows=*/true, /*track_sources=*/true,
-                                                     /*tablet_range=*/nullptr, /*colocate_col_count=*/0));
+                                                     /*tablet_range=*/nullptr, /*colocate_column_count=*/0));
 
     ASSERT_EQ(1, result_default.boundaries.size());
     ASSERT_EQ(1, result_with_colocate.boundaries.size());
@@ -843,12 +865,11 @@ TEST(TabletSplitterTest, colocate_aware_split_keeps_stats_consistent_across_pref
 // -----------------------------------------------------------------------------
 // Happy path: empty tablet, K=2 well-formed ranges covering parent.
 // -----------------------------------------------------------------------------
-TEST(TabletSplitterPspsTest, empty_tablet_happy_path_k2) {
+TEST(TabletSplitterExternalBoundariesTest, empty_tablet_happy_path_k2) {
     auto m = make_empty_metadata_bigint_key(0, 100);
     auto ranges = make_ranges({make_bigint_range_pb(0, 50), make_bigint_range_pb(50, 100)});
     std::vector<TabletRangeInfo> out;
-    auto status = compute_split_ranges_from_external_boundaries(/*tablet_manager=*/nullptr, m, ranges,
-                                                                /*expected_new_tablet_count=*/2, &out);
+    auto status = compute_split_ranges_from_external_boundaries(/*tablet_manager=*/nullptr, m, ranges, &out);
     ASSERT_TRUE(status.ok()) << status;
     ASSERT_EQ(2, out.size());
     EXPECT_TRUE(out[0].rowset_stats.empty());
@@ -856,23 +877,9 @@ TEST(TabletSplitterPspsTest, empty_tablet_happy_path_k2) {
 }
 
 // -----------------------------------------------------------------------------
-// 1a: size mismatch (K=3 ranges but expected_new_tablet_count=2)
+// 1a: tuple arity mismatch (2-column tuple for a 1-column sort key)
 // -----------------------------------------------------------------------------
-TEST(TabletSplitterPspsTest, size_mismatch_is_rejected) {
-    auto m = make_empty_metadata_bigint_key(0, 100);
-    auto ranges =
-            make_ranges({make_bigint_range_pb(0, 33), make_bigint_range_pb(33, 66), make_bigint_range_pb(66, 100)});
-    std::vector<TabletRangeInfo> out;
-    auto status = compute_split_ranges_from_external_boundaries(/*tablet_manager=*/nullptr, m, ranges,
-                                                                /*expected_new_tablet_count=*/2, &out);
-    ASSERT_FALSE(status.ok());
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
-}
-
-// -----------------------------------------------------------------------------
-// 1c: tuple arity mismatch (2-column tuple for a 1-column sort key)
-// -----------------------------------------------------------------------------
-TEST(TabletSplitterPspsTest, tuple_arity_mismatch_is_rejected) {
+TEST(TabletSplitterExternalBoundariesTest, tuple_arity_mismatch_is_rejected) {
     auto m = make_empty_metadata_bigint_key(0, 100);
     TabletRangePB r0;
     auto* lo = r0.mutable_lower_bound();
@@ -881,105 +888,67 @@ TEST(TabletSplitterPspsTest, tuple_arity_mismatch_is_rejected) {
     r0.set_lower_bound_included(true);
     *r0.mutable_upper_bound() = make_bigint_tuple_pb(50);
     r0.set_upper_bound_included(false);
-    auto ranges = make_ranges({r0, make_bigint_range_pb(50, 100)});
-    std::vector<TabletRangeInfo> out;
-    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
-    ASSERT_FALSE(status.ok());
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
+    expect_external_boundaries_rejected(m, make_ranges({r0, make_bigint_range_pb(50, 100)}));
 }
 
 // -----------------------------------------------------------------------------
-// 1c: variant type mismatch (VARCHAR variant for BIGINT sort key)
+// 1b: variant type mismatch (VARCHAR variant for BIGINT sort key)
 // -----------------------------------------------------------------------------
-TEST(TabletSplitterPspsTest, tuple_type_mismatch_is_rejected) {
+TEST(TabletSplitterExternalBoundariesTest, tuple_type_mismatch_is_rejected) {
     auto m = make_empty_metadata_bigint_key(0, 100);
     TabletRangePB r0 = make_bigint_range_pb(0, 50);
     // Replace upper bound with a VARCHAR variant.
     r0.mutable_upper_bound()->clear_values();
     *r0.mutable_upper_bound()->add_values() = make_varchar_variant_pb("50");
-    auto ranges = make_ranges({r0, make_bigint_range_pb(50, 100)});
-    std::vector<TabletRangeInfo> out;
-    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
-    ASSERT_FALSE(status.ok());
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
+    expect_external_boundaries_rejected(m, make_ranges({r0, make_bigint_range_pb(50, 100)}));
 }
 
 // -----------------------------------------------------------------------------
-// 1c: decimal precision mismatch (schema DECIMAL64(10,2), bound DECIMAL64(11,2))
+// 1b: decimal precision mismatch (schema DECIMAL64(10,2), bound DECIMAL64(11,2))
 // -----------------------------------------------------------------------------
-TEST(TabletSplitterPspsTest, decimal_precision_mismatch_is_rejected) {
+TEST(TabletSplitterExternalBoundariesTest, decimal_precision_mismatch_is_rejected) {
     auto m = make_empty_metadata_decimal64_key(10, 2);
-    // Build two adjacent ranges spanning parent [10000, 100000) but with
-    // bound precision 11 instead of 10.
-    auto make_decimal_range = [](int precision, int scale, int64_t lo_raw, int64_t hi_raw) {
-        TabletRangePB r;
-        *r.mutable_lower_bound()->add_values() = make_decimal64_variant_pb(precision, scale, lo_raw);
-        r.set_lower_bound_included(true);
-        *r.mutable_upper_bound()->add_values() = make_decimal64_variant_pb(precision, scale, hi_raw);
-        r.set_upper_bound_included(false);
-        return r;
-    };
-    auto ranges = make_ranges({make_decimal_range(11, 2, 10000, 50000), make_decimal_range(11, 2, 50000, 100000)});
-    std::vector<TabletRangeInfo> out;
-    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
-    ASSERT_FALSE(status.ok());
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
+    // Build two adjacent ranges spanning parent [10000, 100000) but with bound
+    // precision 11 instead of 10.
+    expect_external_boundaries_rejected(m, make_ranges({make_decimal64_range_pb(11, 2, 10000, 50000),
+                                                        make_decimal64_range_pb(11, 2, 50000, 100000)}));
 }
 
 // -----------------------------------------------------------------------------
-// 1c: decimal scale mismatch (schema DECIMAL64(10,2), bound DECIMAL64(10,3))
+// 1b: decimal scale mismatch (schema DECIMAL64(10,2), bound DECIMAL64(10,3))
 // -----------------------------------------------------------------------------
-TEST(TabletSplitterPspsTest, decimal_scale_mismatch_is_rejected) {
+TEST(TabletSplitterExternalBoundariesTest, decimal_scale_mismatch_is_rejected) {
     auto m = make_empty_metadata_decimal64_key(10, 2);
-    auto make_decimal_range = [](int precision, int scale, int64_t lo_raw, int64_t hi_raw) {
-        TabletRangePB r;
-        *r.mutable_lower_bound()->add_values() = make_decimal64_variant_pb(precision, scale, lo_raw);
-        r.set_lower_bound_included(true);
-        *r.mutable_upper_bound()->add_values() = make_decimal64_variant_pb(precision, scale, hi_raw);
-        r.set_upper_bound_included(false);
-        return r;
-    };
-    auto ranges = make_ranges({make_decimal_range(10, 3, 10000, 50000), make_decimal_range(10, 3, 50000, 100000)});
-    std::vector<TabletRangeInfo> out;
-    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
-    ASSERT_FALSE(status.ok());
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
+    expect_external_boundaries_rejected(m, make_ranges({make_decimal64_range_pb(10, 3, 10000, 50000),
+                                                        make_decimal64_range_pb(10, 3, 50000, 100000)}));
 }
 
 // -----------------------------------------------------------------------------
-// 1c: variant has no `type` field
+// 1b: variant has no `type` field
 // -----------------------------------------------------------------------------
-TEST(TabletSplitterPspsTest, variant_missing_type_is_rejected) {
+TEST(TabletSplitterExternalBoundariesTest, variant_missing_type_is_rejected) {
     auto m = make_empty_metadata_bigint_key(0, 100);
     TabletRangePB r0 = make_bigint_range_pb(0, 50);
     // Drop the `type` field on the upper bound's variant.
     r0.mutable_upper_bound()->mutable_values(0)->clear_type();
-    auto ranges = make_ranges({r0, make_bigint_range_pb(50, 100)});
-    std::vector<TabletRangeInfo> out;
-    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
-    ASSERT_FALSE(status.ok());
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
+    expect_external_boundaries_rejected(m, make_ranges({r0, make_bigint_range_pb(50, 100)}));
 }
 
 // -----------------------------------------------------------------------------
-// 1c: variant has `type` but PTypeDesc.types is empty
+// 1b: variant has `type` but PTypeDesc.types is empty
 // -----------------------------------------------------------------------------
-TEST(TabletSplitterPspsTest, variant_empty_ptypedesc_is_rejected) {
+TEST(TabletSplitterExternalBoundariesTest, variant_empty_ptypedesc_is_rejected) {
     auto m = make_empty_metadata_bigint_key(0, 100);
     TabletRangePB r0 = make_bigint_range_pb(0, 50);
     r0.mutable_upper_bound()->mutable_values(0)->mutable_type()->clear_types();
-    auto ranges = make_ranges({r0, make_bigint_range_pb(50, 100)});
-    std::vector<TabletRangeInfo> out;
-    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
-    ASSERT_FALSE(status.ok());
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
+    expect_external_boundaries_rejected(m, make_ranges({r0, make_bigint_range_pb(50, 100)}));
 }
 
 // -----------------------------------------------------------------------------
-// 1c: variant uses a non-SCALAR PTypeNode (ARRAY) — must reject before
+// 1b: variant uses a non-SCALAR PTypeNode (ARRAY) — must reject before
 // TypeDescriptor::from_protobuf reaches unsafe child-node access.
 // -----------------------------------------------------------------------------
-TEST(TabletSplitterPspsTest, variant_non_scalar_node_is_rejected) {
+TEST(TabletSplitterExternalBoundariesTest, variant_non_scalar_node_is_rejected) {
     auto m = make_empty_metadata_bigint_key(0, 100);
     TabletRangePB r0 = make_bigint_range_pb(0, 50);
     // Mutate the single PTypeNode on the upper bound's variant to look like
@@ -987,11 +956,7 @@ TEST(TabletSplitterPspsTest, variant_non_scalar_node_is_rejected) {
     auto* var = r0.mutable_upper_bound()->mutable_values(0);
     var->mutable_type()->mutable_types(0)->set_type(static_cast<int32_t>(TTypeNodeType::ARRAY));
     var->mutable_type()->mutable_types(0)->clear_scalar_type();
-    auto ranges = make_ranges({r0, make_bigint_range_pb(50, 100)});
-    std::vector<TabletRangeInfo> out;
-    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
-    ASSERT_FALSE(status.ok());
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
+    expect_external_boundaries_rejected(m, make_ranges({r0, make_bigint_range_pb(50, 100)}));
 }
 
 // -----------------------------------------------------------------------------
@@ -999,7 +964,7 @@ TEST(TabletSplitterPspsTest, variant_non_scalar_node_is_rejected) {
 // also reject this (the fix that moved the semantic check before the empty
 // fast-path).
 // -----------------------------------------------------------------------------
-TEST(TabletSplitterPspsTest, empty_tablet_rejects_semantic_inversion) {
+TEST(TabletSplitterExternalBoundariesTest, empty_tablet_rejects_semantic_inversion) {
     auto m = make_empty_metadata_bigint_key(0, 100);
     // 3 ranges that tile structurally (first.lower==0, last.upper==100, byte
     // adjacencies hold), but the middle range is semantically inverted:
@@ -1008,16 +973,12 @@ TEST(TabletSplitterPspsTest, empty_tablet_rejects_semantic_inversion) {
     // ranges[1].upper == ranges[2].lower byte-wise (40==40).
     // Structural validation accepts; step 3a semantic check rejects on the
     // middle range's lower(50) >= upper(40).
-    auto ranges =
-            make_ranges({make_bigint_range_pb(0, 50), make_bigint_range_pb(50, 40), make_bigint_range_pb(40, 100)});
-    std::vector<TabletRangeInfo> out;
-    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 3, &out);
-    ASSERT_FALSE(status.ok()) << "empty tablet must reject semantically-invalid PSPS ranges (W1 fix)";
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
+    expect_external_boundaries_rejected(
+            m, make_ranges({make_bigint_range_pb(0, 50), make_bigint_range_pb(50, 40), make_bigint_range_pb(40, 100)}));
 }
 
 // =============================================================================
-// Parity: PSPS path produces the same per-range output as the data-driven path
+// Parity: external-boundaries path produces the same per-range output as the data-driven path
 // when given the same K-1 boundaries.
 // =============================================================================
 //
@@ -1026,7 +987,7 @@ TEST(TabletSplitterPspsTest, empty_tablet_rejects_semantic_inversion) {
 // rowset stats). This test:
 //   1. Runs the data-driven path on a synthetic 2-rowset tablet.
 //   2. Extracts the K-1 boundary it picked.
-//   3. Feeds the same boundary back through the PSPS path.
+//   3. Feeds the same boundary back through the external-boundaries path.
 //   4. Asserts the resulting K TabletRangeInfo entries are byte-equal.
 //
 // DUP_KEYS + explicit rowset-level num_dels lets us pass tablet_manager =
@@ -1037,9 +998,11 @@ namespace {
 // Build a DUP_KEYS tablet with N rowsets at disjoint integer key ranges. Each
 // rowset gets one segment populated with sort_key_min/max + num_rows; the
 // rowset-level num_rows/data_size/num_dels are set explicitly to skip the
-// build_rowset_anchor PK-fallback path.
+// build_rowset_anchor PK-fallback path. {@code parent_range} is an explicit
+// closed-open parent range; pass an empty TabletRangePB for Range.all() parent.
 static TabletMetadataPtr make_dup_keys_metadata_with_rowsets(
-        std::initializer_list<std::tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>> rowsets) {
+        std::initializer_list<std::tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>> rowsets,
+        const TabletRangePB& parent_range = {}) {
     auto m = std::make_shared<TabletMetadataPB>();
     m->set_id(1);
     m->set_version(1);
@@ -1053,7 +1016,7 @@ static TabletMetadataPtr make_dup_keys_metadata_with_rowsets(
     col->set_is_key(true);
     col->set_is_nullable(false);
     schema->add_sort_key_idxes(0);
-    // Parent range left as Range.all().
+    *m->mutable_range() = parent_range;
 
     for (const auto& [id, lo, hi, num_rows, data_size] : rowsets) {
         auto* r = m->add_rowsets();
@@ -1073,7 +1036,40 @@ static TabletMetadataPtr make_dup_keys_metadata_with_rowsets(
 
 } // namespace
 
-TEST(TabletSplitterParityTest, psps_matches_data_driven_when_fed_same_boundaries) {
+TEST(TabletSplitterExternalBoundariesTest, parent_envelope_clips_effective_lo_hi) {
+    // Parent [0, 100). Two rowsets fully within parent at [10, 40] and [60, 90].
+    // external boundaries K=2 split at 50. Exercises the effective-envelope branches that read
+    // parent.lower_bound / parent.upper_bound (otherwise unreachable from the
+    // Range.all()-parent parity test).
+    auto m = make_dup_keys_metadata_with_rowsets(
+            {
+                    std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(1, 10, 40, 100, 1000),
+                    std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(2, 60, 90, 100, 1000),
+            },
+            make_bigint_range_pb(0, 100));
+
+    auto ranges = make_ranges({make_bigint_range_pb(0, 50), make_bigint_range_pb(50, 100)});
+    std::vector<TabletRangeInfo> out;
+    auto s = compute_split_ranges_from_external_boundaries(/*tablet_manager=*/nullptr, m, ranges, &out);
+    ASSERT_TRUE(s.ok()) << s;
+    ASSERT_EQ(2u, out.size());
+    // Each rowset's stats must sum to the parent's totals (anchor conservation).
+    for (uint32_t rowset_id : {1u, 2u}) {
+        int64_t sum_rows = 0;
+        int64_t sum_size = 0;
+        for (const auto& tri : out) {
+            auto it = tri.rowset_stats.find(rowset_id);
+            if (it != tri.rowset_stats.end()) {
+                sum_rows += it->second.num_rows;
+                sum_size += it->second.data_size;
+            }
+        }
+        EXPECT_EQ(100, sum_rows) << "rowset " << rowset_id;
+        EXPECT_EQ(1000, sum_size) << "rowset " << rowset_id;
+    }
+}
+
+TEST(TabletSplitterParityTest, external_boundaries_matches_data_driven_when_fed_same_boundaries) {
     // Two disjoint rowsets at [0,50] and [60,100], 100 rows each. Data-driven
     // will pick a boundary somewhere in the gap (50..60) for K=2.
     auto m = make_dup_keys_metadata_with_rowsets({
@@ -1090,13 +1086,13 @@ TEST(TabletSplitterParityTest, psps_matches_data_driven_when_fed_same_boundaries
     ASSERT_TRUE(split_data_driven[1].range.has_lower_bound());
     // Byte-equality of the interior boundary (data-driven emits one tuple,
     // not two — same TuplePB on both sides).
-    ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(split_data_driven[0].range.upper_bound(),
-                                                                   split_data_driven[1].range.lower_bound()))
+    ASSERT_TRUE(MessageDifferencer::Equals(split_data_driven[0].range.upper_bound(),
+                                           split_data_driven[1].range.lower_bound()))
             << "data-driven path's interior boundary must be a single TuplePB on both sides";
 
-    // Build PSPS external_ranges from the data-driven boundary, mirroring the
+    // Build external boundaries external_ranges from the data-driven boundary, mirroring the
     // parent Range.all() (first.lower unset, last.upper unset).
-    google::protobuf::RepeatedPtrField<TabletRangePB> external_ranges;
+    RepeatedPtrField<TabletRangePB> external_ranges;
     {
         auto* r0 = external_ranges.Add();
         *r0->mutable_upper_bound() = split_data_driven[0].range.upper_bound();
@@ -1108,26 +1104,26 @@ TEST(TabletSplitterParityTest, psps_matches_data_driven_when_fed_same_boundaries
         r1->set_lower_bound_included(true);
     }
 
-    std::vector<TabletRangeInfo> split_psps;
+    std::vector<TabletRangeInfo> split_external_boundaries;
     s = compute_split_ranges_from_external_boundaries(/*tablet_manager=*/nullptr, m, external_ranges,
-                                                      /*expected_new_tablet_count=*/2, &split_psps);
+                                                      &split_external_boundaries);
     ASSERT_TRUE(s.ok()) << s;
-    ASSERT_EQ(2u, split_psps.size());
+    ASSERT_EQ(2u, split_external_boundaries.size());
 
     // Ranges must be byte-equal proto messages.
     for (size_t i = 0; i < split_data_driven.size(); ++i) {
-        EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(split_data_driven[i].range, split_psps[i].range))
+        EXPECT_TRUE(MessageDifferencer::Equals(split_data_driven[i].range, split_external_boundaries[i].range))
                 << "range[" << i << "] differs between paths";
     }
 
     // Per-rowset stats must match field-by-field.
     for (size_t i = 0; i < split_data_driven.size(); ++i) {
-        EXPECT_EQ(split_data_driven[i].rowset_stats.size(), split_psps[i].rowset_stats.size())
+        EXPECT_EQ(split_data_driven[i].rowset_stats.size(), split_external_boundaries[i].rowset_stats.size())
                 << "rowset_stats size differs at range " << i;
         for (const auto& [rowset_id, stats_dd] : split_data_driven[i].rowset_stats) {
-            auto it = split_psps[i].rowset_stats.find(rowset_id);
-            ASSERT_NE(it, split_psps[i].rowset_stats.end())
-                    << "rowset " << rowset_id << " missing in PSPS output at range " << i;
+            auto it = split_external_boundaries[i].rowset_stats.find(rowset_id);
+            ASSERT_NE(it, split_external_boundaries[i].rowset_stats.end())
+                    << "rowset " << rowset_id << " missing in external boundaries output at range " << i;
             EXPECT_EQ(stats_dd.num_rows, it->second.num_rows)
                     << "range[" << i << "] rowset[" << rowset_id << "] num_rows differs";
             EXPECT_EQ(stats_dd.data_size, it->second.data_size)

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -14,9 +14,13 @@
 
 #include "storage/lake/tablet_splitter.h"
 
+#include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
 
+#include <optional>
+
 #include "base/testutil/assert.h"
+#include "gen_cpp/lake_types.pb.h"
 #include "storage/tablet_range.h"
 #include "types/type_descriptor.h"
 
@@ -594,6 +598,10 @@ TEST(TabletSplitterTest, tablet_range_total_invariant_across_split_counts) {
 // they can be reused by the planned cross-publish (P2) refactor without
 // re-introducing a private split-only header.
 
+// Helpers below serve two test groups: colocate-aware data-driven splitter
+// tests (TabletSplitterTest.colocate_*) and PSPS external-boundaries tests
+// (TabletSplitterPspsTest.*). Kept in one anonymous namespace to avoid
+// duplicate-symbol churn.
 namespace {
 
 // Build a 2-column key tuple (k1, k2). Used for colocate-aware splitter tests.
@@ -613,6 +621,124 @@ static SegmentSplitInfo make_two_col_seg(int64_t lo_k1, int64_t lo_k2, int64_t h
     s.data_size = data_size;
     s.source_id = source_id;
     return s;
+}
+
+// =============================================================================
+// PSPS (Pre-Sample & Pre-Split) external-boundaries path helpers
+// =============================================================================
+//
+// These exercise compute_split_ranges_from_external_boundaries' validation
+// layers (1a/1b/1c/3a/3b). Empty tablets are used throughout so the production
+// path returns at the empty fast-path (step 4) without needing a real
+// TabletManager. tablet_manager = nullptr is safe in that regime.
+
+static VariantPB make_bigint_variant_pb(int64_t value) {
+    DatumVariant dv(get_type_info(LogicalType::TYPE_BIGINT), Datum(value));
+    VariantPB pb;
+    dv.to_proto(&pb);
+    return pb;
+}
+
+static VariantPB make_varchar_variant_pb(const std::string& value) {
+    auto type_info = get_type_info(LogicalType::TYPE_VARCHAR);
+    DatumVariant dv(type_info, Datum(Slice(value)));
+    VariantPB pb;
+    dv.to_proto(&pb);
+    return pb;
+}
+
+static VariantPB make_decimal64_variant_pb(int precision, int scale, int64_t raw_value) {
+    auto type_desc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, precision, scale);
+    auto type_info = get_type_info(type_desc);
+    DatumVariant dv(type_info, Datum(raw_value));
+    VariantPB pb;
+    dv.to_proto(&pb);
+    return pb;
+}
+
+static TuplePB make_bigint_tuple_pb(int64_t value) {
+    TuplePB t;
+    *t.add_values() = make_bigint_variant_pb(value);
+    return t;
+}
+
+// Build a closed-open [lower, upper) range. Either side may be absent (nullopt)
+// for unbounded ±infinity semantics.
+static TabletRangePB make_bigint_range_pb(std::optional<int64_t> lower, std::optional<int64_t> upper) {
+    TabletRangePB r;
+    if (lower.has_value()) {
+        *r.mutable_lower_bound() = make_bigint_tuple_pb(*lower);
+        r.set_lower_bound_included(true);
+    }
+    if (upper.has_value()) {
+        *r.mutable_upper_bound() = make_bigint_tuple_pb(*upper);
+        r.set_upper_bound_included(false);
+    }
+    return r;
+}
+
+// Build a minimal empty TabletMetadataPtr with a single BIGINT sort-key column
+// and the requested parent range. Used by every PSPS validation test that
+// expects the function to return before touching segments/anchors.
+static TabletMetadataPtr make_empty_metadata_bigint_key(std::optional<int64_t> parent_lower,
+                                                        std::optional<int64_t> parent_upper) {
+    auto m = std::make_shared<TabletMetadataPB>();
+    m->set_id(1);
+    m->set_version(1);
+
+    auto* schema = m->mutable_schema();
+    schema->set_keys_type(PRIMARY_KEYS);
+    schema->set_id(100);
+    auto* col = schema->add_column();
+    col->set_unique_id(0);
+    col->set_name("k1");
+    col->set_type("BIGINT");
+    col->set_is_key(true);
+    col->set_is_nullable(false);
+    schema->add_sort_key_idxes(0);
+
+    *m->mutable_range() = make_bigint_range_pb(parent_lower, parent_upper);
+    return m;
+}
+
+// Same shape but with a DECIMAL64(precision, scale) sort key.
+static TabletMetadataPtr make_empty_metadata_decimal64_key(int precision, int scale) {
+    auto m = std::make_shared<TabletMetadataPB>();
+    m->set_id(1);
+    m->set_version(1);
+
+    auto* schema = m->mutable_schema();
+    schema->set_keys_type(PRIMARY_KEYS);
+    schema->set_id(100);
+    auto* col = schema->add_column();
+    col->set_unique_id(0);
+    col->set_name("k1");
+    col->set_type("DECIMAL64");
+    col->set_is_key(true);
+    col->set_is_nullable(false);
+    col->set_precision(precision);
+    col->set_frac(scale); // ColumnPB.frac is the scale field
+    col->set_length(8);
+    schema->add_sort_key_idxes(0);
+
+    // Decimal parent range: cover [10000, 100000) raw to keep tests simple.
+    // (raw value space; the unit-test rationale doesn't depend on the human value)
+    auto* pr = m->mutable_range();
+    auto* lo = pr->mutable_lower_bound();
+    *lo->add_values() = make_decimal64_variant_pb(precision, scale, 10000);
+    pr->set_lower_bound_included(true);
+    auto* hi = pr->mutable_upper_bound();
+    *hi->add_values() = make_decimal64_variant_pb(precision, scale, 100000);
+    pr->set_upper_bound_included(false);
+    return m;
+}
+
+static google::protobuf::RepeatedPtrField<TabletRangePB> make_ranges(std::initializer_list<TabletRangePB> ranges) {
+    google::protobuf::RepeatedPtrField<TabletRangePB> r;
+    for (const auto& range : ranges) {
+        *r.Add() = range;
+    }
+    return r;
 }
 
 } // namespace
@@ -712,6 +838,320 @@ TEST(TabletSplitterTest, colocate_aware_split_keeps_stats_consistent_across_pref
             << "rows from the prefix-crossing segment must contribute to the LEFT child";
     EXPECT_GT(left_it->second.first, 0);
     EXPECT_GT(left_it->second.second, 0);
+}
+
+// -----------------------------------------------------------------------------
+// Happy path: empty tablet, K=2 well-formed ranges covering parent.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterPspsTest, empty_tablet_happy_path_k2) {
+    auto m = make_empty_metadata_bigint_key(0, 100);
+    auto ranges = make_ranges({make_bigint_range_pb(0, 50), make_bigint_range_pb(50, 100)});
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(/*tablet_manager=*/nullptr, m, ranges,
+                                                                /*expected_new_tablet_count=*/2, &out);
+    ASSERT_TRUE(status.ok()) << status;
+    ASSERT_EQ(2, out.size());
+    EXPECT_TRUE(out[0].rowset_stats.empty());
+    EXPECT_TRUE(out[1].rowset_stats.empty());
+}
+
+// -----------------------------------------------------------------------------
+// 1a: size mismatch (K=3 ranges but expected_new_tablet_count=2)
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterPspsTest, size_mismatch_is_rejected) {
+    auto m = make_empty_metadata_bigint_key(0, 100);
+    auto ranges =
+            make_ranges({make_bigint_range_pb(0, 33), make_bigint_range_pb(33, 66), make_bigint_range_pb(66, 100)});
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(/*tablet_manager=*/nullptr, m, ranges,
+                                                                /*expected_new_tablet_count=*/2, &out);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+}
+
+// -----------------------------------------------------------------------------
+// 1c: tuple arity mismatch (2-column tuple for a 1-column sort key)
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterPspsTest, tuple_arity_mismatch_is_rejected) {
+    auto m = make_empty_metadata_bigint_key(0, 100);
+    TabletRangePB r0;
+    auto* lo = r0.mutable_lower_bound();
+    *lo->add_values() = make_bigint_variant_pb(0);
+    *lo->add_values() = make_bigint_variant_pb(0); // extra column
+    r0.set_lower_bound_included(true);
+    *r0.mutable_upper_bound() = make_bigint_tuple_pb(50);
+    r0.set_upper_bound_included(false);
+    auto ranges = make_ranges({r0, make_bigint_range_pb(50, 100)});
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+}
+
+// -----------------------------------------------------------------------------
+// 1c: variant type mismatch (VARCHAR variant for BIGINT sort key)
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterPspsTest, tuple_type_mismatch_is_rejected) {
+    auto m = make_empty_metadata_bigint_key(0, 100);
+    TabletRangePB r0 = make_bigint_range_pb(0, 50);
+    // Replace upper bound with a VARCHAR variant.
+    r0.mutable_upper_bound()->clear_values();
+    *r0.mutable_upper_bound()->add_values() = make_varchar_variant_pb("50");
+    auto ranges = make_ranges({r0, make_bigint_range_pb(50, 100)});
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+}
+
+// -----------------------------------------------------------------------------
+// 1c: decimal precision mismatch (schema DECIMAL64(10,2), bound DECIMAL64(11,2))
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterPspsTest, decimal_precision_mismatch_is_rejected) {
+    auto m = make_empty_metadata_decimal64_key(10, 2);
+    // Build two adjacent ranges spanning parent [10000, 100000) but with
+    // bound precision 11 instead of 10.
+    auto make_decimal_range = [](int precision, int scale, int64_t lo_raw, int64_t hi_raw) {
+        TabletRangePB r;
+        *r.mutable_lower_bound()->add_values() = make_decimal64_variant_pb(precision, scale, lo_raw);
+        r.set_lower_bound_included(true);
+        *r.mutable_upper_bound()->add_values() = make_decimal64_variant_pb(precision, scale, hi_raw);
+        r.set_upper_bound_included(false);
+        return r;
+    };
+    auto ranges = make_ranges({make_decimal_range(11, 2, 10000, 50000), make_decimal_range(11, 2, 50000, 100000)});
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+}
+
+// -----------------------------------------------------------------------------
+// 1c: decimal scale mismatch (schema DECIMAL64(10,2), bound DECIMAL64(10,3))
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterPspsTest, decimal_scale_mismatch_is_rejected) {
+    auto m = make_empty_metadata_decimal64_key(10, 2);
+    auto make_decimal_range = [](int precision, int scale, int64_t lo_raw, int64_t hi_raw) {
+        TabletRangePB r;
+        *r.mutable_lower_bound()->add_values() = make_decimal64_variant_pb(precision, scale, lo_raw);
+        r.set_lower_bound_included(true);
+        *r.mutable_upper_bound()->add_values() = make_decimal64_variant_pb(precision, scale, hi_raw);
+        r.set_upper_bound_included(false);
+        return r;
+    };
+    auto ranges = make_ranges({make_decimal_range(10, 3, 10000, 50000), make_decimal_range(10, 3, 50000, 100000)});
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+}
+
+// -----------------------------------------------------------------------------
+// 1c: variant has no `type` field
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterPspsTest, variant_missing_type_is_rejected) {
+    auto m = make_empty_metadata_bigint_key(0, 100);
+    TabletRangePB r0 = make_bigint_range_pb(0, 50);
+    // Drop the `type` field on the upper bound's variant.
+    r0.mutable_upper_bound()->mutable_values(0)->clear_type();
+    auto ranges = make_ranges({r0, make_bigint_range_pb(50, 100)});
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+}
+
+// -----------------------------------------------------------------------------
+// 1c: variant has `type` but PTypeDesc.types is empty
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterPspsTest, variant_empty_ptypedesc_is_rejected) {
+    auto m = make_empty_metadata_bigint_key(0, 100);
+    TabletRangePB r0 = make_bigint_range_pb(0, 50);
+    r0.mutable_upper_bound()->mutable_values(0)->mutable_type()->clear_types();
+    auto ranges = make_ranges({r0, make_bigint_range_pb(50, 100)});
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+}
+
+// -----------------------------------------------------------------------------
+// 1c: variant uses a non-SCALAR PTypeNode (ARRAY) — must reject before
+// TypeDescriptor::from_protobuf reaches unsafe child-node access.
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterPspsTest, variant_non_scalar_node_is_rejected) {
+    auto m = make_empty_metadata_bigint_key(0, 100);
+    TabletRangePB r0 = make_bigint_range_pb(0, 50);
+    // Mutate the single PTypeNode on the upper bound's variant to look like
+    // ARRAY (TTypeNodeType::ARRAY == 1) and remove its scalar_type payload.
+    auto* var = r0.mutable_upper_bound()->mutable_values(0);
+    var->mutable_type()->mutable_types(0)->set_type(static_cast<int32_t>(TTypeNodeType::ARRAY));
+    var->mutable_type()->mutable_types(0)->clear_scalar_type();
+    auto ranges = make_ranges({r0, make_bigint_range_pb(50, 100)});
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 2, &out);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+}
+
+// -----------------------------------------------------------------------------
+// 3b: adjacent ranges out of order semantically. Important: empty tablets must
+// also reject this (the fix that moved the semantic check before the empty
+// fast-path).
+// -----------------------------------------------------------------------------
+TEST(TabletSplitterPspsTest, empty_tablet_rejects_semantic_inversion) {
+    auto m = make_empty_metadata_bigint_key(0, 100);
+    // 3 ranges that tile structurally (first.lower==0, last.upper==100, byte
+    // adjacencies hold), but the middle range is semantically inverted:
+    //   [0, 50) [50, 40) [40, 100)
+    // ranges[0].upper == ranges[1].lower byte-wise (50==50).
+    // ranges[1].upper == ranges[2].lower byte-wise (40==40).
+    // Structural validation accepts; step 3a semantic check rejects on the
+    // middle range's lower(50) >= upper(40).
+    auto ranges =
+            make_ranges({make_bigint_range_pb(0, 50), make_bigint_range_pb(50, 40), make_bigint_range_pb(40, 100)});
+    std::vector<TabletRangeInfo> out;
+    auto status = compute_split_ranges_from_external_boundaries(nullptr, m, ranges, 3, &out);
+    ASSERT_FALSE(status.ok()) << "empty tablet must reject semantically-invalid PSPS ranges (W1 fix)";
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+}
+
+// =============================================================================
+// Parity: PSPS path produces the same per-range output as the data-driven path
+// when given the same K-1 boundaries.
+// =============================================================================
+//
+// Both paths share build_rowset_anchor + apply_rowset_anchor downstream, so
+// equivalent boundary inputs SHOULD yield equivalent outputs (ranges + per-
+// rowset stats). This test:
+//   1. Runs the data-driven path on a synthetic 2-rowset tablet.
+//   2. Extracts the K-1 boundary it picked.
+//   3. Feeds the same boundary back through the PSPS path.
+//   4. Asserts the resulting K TabletRangeInfo entries are byte-equal.
+//
+// DUP_KEYS + explicit rowset-level num_dels lets us pass tablet_manager =
+// nullptr (no PK delvec fallback).
+
+namespace {
+
+// Build a DUP_KEYS tablet with N rowsets at disjoint integer key ranges. Each
+// rowset gets one segment populated with sort_key_min/max + num_rows; the
+// rowset-level num_rows/data_size/num_dels are set explicitly to skip the
+// build_rowset_anchor PK-fallback path.
+static TabletMetadataPtr make_dup_keys_metadata_with_rowsets(
+        std::initializer_list<std::tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>> rowsets) {
+    auto m = std::make_shared<TabletMetadataPB>();
+    m->set_id(1);
+    m->set_version(1);
+    auto* schema = m->mutable_schema();
+    schema->set_keys_type(DUP_KEYS);
+    schema->set_id(100);
+    auto* col = schema->add_column();
+    col->set_unique_id(0);
+    col->set_name("k1");
+    col->set_type("BIGINT");
+    col->set_is_key(true);
+    col->set_is_nullable(false);
+    schema->add_sort_key_idxes(0);
+    // Parent range left as Range.all().
+
+    for (const auto& [id, lo, hi, num_rows, data_size] : rowsets) {
+        auto* r = m->add_rowsets();
+        r->set_id(id);
+        r->set_num_rows(num_rows);
+        r->set_data_size(data_size);
+        r->set_num_dels(0); // explicit to skip the PK delvec fallback in build_rowset_anchor.
+        r->add_segments("seg" + std::to_string(id));
+        r->add_segment_size(data_size);
+        auto* sm = r->add_segment_metas();
+        sm->set_num_rows(num_rows);
+        *sm->mutable_sort_key_min() = make_bigint_tuple_pb(lo);
+        *sm->mutable_sort_key_max() = make_bigint_tuple_pb(hi);
+    }
+    return m;
+}
+
+} // namespace
+
+TEST(TabletSplitterParityTest, psps_matches_data_driven_when_fed_same_boundaries) {
+    // Two disjoint rowsets at [0,50] and [60,100], 100 rows each. Data-driven
+    // will pick a boundary somewhere in the gap (50..60) for K=2.
+    auto m = make_dup_keys_metadata_with_rowsets({
+            std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(1, 0, 50, 100, 1000),
+            std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(2, 60, 100, 100, 1000),
+    });
+
+    std::vector<TabletRangeInfo> split_data_driven;
+    auto s = get_tablet_split_ranges(/*tablet_manager=*/nullptr, m, /*split_count=*/2, &split_data_driven,
+                                     /*colocate_column_count=*/0);
+    ASSERT_TRUE(s.ok()) << s;
+    ASSERT_EQ(2u, split_data_driven.size());
+    ASSERT_TRUE(split_data_driven[0].range.has_upper_bound());
+    ASSERT_TRUE(split_data_driven[1].range.has_lower_bound());
+    // Byte-equality of the interior boundary (data-driven emits one tuple,
+    // not two — same TuplePB on both sides).
+    ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(split_data_driven[0].range.upper_bound(),
+                                                                   split_data_driven[1].range.lower_bound()))
+            << "data-driven path's interior boundary must be a single TuplePB on both sides";
+
+    // Build PSPS external_ranges from the data-driven boundary, mirroring the
+    // parent Range.all() (first.lower unset, last.upper unset).
+    google::protobuf::RepeatedPtrField<TabletRangePB> external_ranges;
+    {
+        auto* r0 = external_ranges.Add();
+        *r0->mutable_upper_bound() = split_data_driven[0].range.upper_bound();
+        r0->set_upper_bound_included(false);
+    }
+    {
+        auto* r1 = external_ranges.Add();
+        *r1->mutable_lower_bound() = split_data_driven[1].range.lower_bound();
+        r1->set_lower_bound_included(true);
+    }
+
+    std::vector<TabletRangeInfo> split_psps;
+    s = compute_split_ranges_from_external_boundaries(/*tablet_manager=*/nullptr, m, external_ranges,
+                                                      /*expected_new_tablet_count=*/2, &split_psps);
+    ASSERT_TRUE(s.ok()) << s;
+    ASSERT_EQ(2u, split_psps.size());
+
+    // Ranges must be byte-equal proto messages.
+    for (size_t i = 0; i < split_data_driven.size(); ++i) {
+        EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equals(split_data_driven[i].range, split_psps[i].range))
+                << "range[" << i << "] differs between paths";
+    }
+
+    // Per-rowset stats must match field-by-field.
+    for (size_t i = 0; i < split_data_driven.size(); ++i) {
+        EXPECT_EQ(split_data_driven[i].rowset_stats.size(), split_psps[i].rowset_stats.size())
+                << "rowset_stats size differs at range " << i;
+        for (const auto& [rowset_id, stats_dd] : split_data_driven[i].rowset_stats) {
+            auto it = split_psps[i].rowset_stats.find(rowset_id);
+            ASSERT_NE(it, split_psps[i].rowset_stats.end())
+                    << "rowset " << rowset_id << " missing in PSPS output at range " << i;
+            EXPECT_EQ(stats_dd.num_rows, it->second.num_rows)
+                    << "range[" << i << "] rowset[" << rowset_id << "] num_rows differs";
+            EXPECT_EQ(stats_dd.data_size, it->second.data_size)
+                    << "range[" << i << "] rowset[" << rowset_id << "] data_size differs";
+            EXPECT_EQ(stats_dd.num_dels, it->second.num_dels)
+                    << "range[" << i << "] rowset[" << rowset_id << "] num_dels differs";
+        }
+    }
+
+    // Sanity: anchored stats sum to parent totals (the property both paths
+    // claim). Aggregate per rowset across the two child ranges.
+    for (uint32_t rowset_id : {1u, 2u}) {
+        int64_t sum_rows = 0;
+        int64_t sum_size = 0;
+        for (const auto& s : split_data_driven) {
+            auto it = s.rowset_stats.find(rowset_id);
+            if (it != s.rowset_stats.end()) {
+                sum_rows += it->second.num_rows;
+                sum_size += it->second.data_size;
+            }
+        }
+        EXPECT_EQ(100, sum_rows) << "rowset " << rowset_id << ": Σ children num_rows must equal parent";
+        EXPECT_EQ(1000, sum_size) << "rowset " << rowset_id << ": Σ children data_size must equal parent";
+    }
 }
 
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -1,0 +1,255 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.catalog.ColocateGroupSchema;
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.planner.RangeColocateScanDispatch;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.common.MetaUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Colocate checker — drives every unstable range-colocate group toward range alignment
+ * with {@link com.starrocks.catalog.ColocateRangeMgr}'s expected ranges and marks every
+ * peer GroupId stable once aligned.
+ *
+ * <h3>Architecture</h3>
+ * Stateless component owned by {@link TabletReshardJobMgr} and invoked from that manager's
+ * existing scheduler tick. Every {@link #runOneCycle} call walks
+ * {@link ColocateTableIndex#getUnstableGroupIds} and either does work or fast-returns when the
+ * unstable set is empty (the steady-state). Shares the manager's
+ * {@code tablet_reshard_job_scheduler_interval_ms} cadence; no separate thread, timer, or
+ * config. Eliminates the second worker thread and the leader-state reconcile loop that the
+ * previous {@code LeaderDaemon} ownership shape required.
+ *
+ * <p>Leader-state is gated at the manager level: {@code TabletReshardJobMgr} is only started
+ * inside {@code GlobalStateMgr.startLeaderOnlyDaemonThreads}, so the checker never runs on a
+ * brand-new follower. For the demoted-leader edge case, the per-RPC
+ * {@link GlobalStateMgr#isLeaderWorkAdmissionOpen() admission} check inside
+ * {@link SplitTabletJobFactory#forColocateAlignment} (and inside {@link
+ * ColocateTableIndex#markAllGroupsWithSameColocateGroupIdStable}'s journal write) is the
+ * safety net.
+ *
+ * <h3>What a cycle does</h3>
+ * Iterates every unstable range-colocate {@code colocateGroupId}; for each peer {@link
+ * ColocateTableIndex.GroupId}, every {@code NORMAL}-state table, every visible
+ * {@link MaterializedIndex}; per misaligned tablet, computes the FE-supplied per-new-tablet
+ * {@link TabletRange} list via {@link RangeColocateScanDispatch#computeAlignedTabletRanges}
+ * and batches all misaligned tuples in a table into ONE {@link SplitTabletJob} (one job per
+ * table per cycle — see {@link SplitTabletJobFactory#forColocateAlignment}). When every peer
+ * is range-aligned, {@link ColocateTableIndex#markAllGroupsWithSameColocateGroupIdStable}
+ * fires across peers in lock-step.
+ */
+public class ColocateChecker {
+    private static final Logger LOG = LogManager.getLogger(ColocateChecker.class);
+
+    /**
+     * Invoked from {@link TabletReshardJobMgr#runAfterCatalogReady} on every scheduler tick.
+     * Fast-returns when there's no work to do; otherwise iterates unstable range-colocate
+     * groups and reconciles each one toward stable. The steady-state fast-path is O(1).
+     */
+    public void runOneCycle() {
+        if (!RunMode.isSharedDataMode()) {
+            return;
+        }
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        // Steady-state fast-path: no unstable groups → cheap read-lock empty-check, no allocation.
+        if (!colocateTableIndex.hasUnstableGroups()) {
+            return;
+        }
+        Set<Long> processedColocateGroupIds = new HashSet<>();
+        for (ColocateTableIndex.GroupId groupId : colocateTableIndex.getUnstableGroupIds()) {
+            if (!colocateTableIndex.isRangeColocateGroup(groupId)) {
+                continue;
+            }
+            // Peer GroupIds (cross-DB) share the same colocateGroupId; processGroup handles all
+            // peers in one pass, so only run once per unique colocateGroupId.
+            if (!processedColocateGroupIds.add(groupId.grpId)) {
+                continue;
+            }
+            try {
+                processGroup(colocateTableIndex, groupId.grpId);
+            } catch (Exception e) {
+                LOG.warn("failed to process colocate group id {}", groupId.grpId, e);
+            }
+        }
+    }
+
+    /**
+     * Drive one {@code colocateGroupId} toward stability: iterate every peer GroupId × table ×
+     * partition × visible index; fire an alignment {@link SplitTabletJob} for every table
+     * with at least one misaligned tablet; if and only if every peer is fully aligned, mark
+     * every peer GroupId stable in lock-step.
+     */
+    private void processGroup(ColocateTableIndex colocateTableIndex, long colocateGroupId) {
+        List<ColocateRange> expectedRanges =
+                colocateTableIndex.getColocateRangeMgr().getColocateRanges(colocateGroupId);
+        if (expectedRanges.isEmpty()) {
+            return;
+        }
+        List<ColocateTableIndex.GroupId> peers =
+                colocateTableIndex.getAllGroupIdsWithSameColocateGroupId(colocateGroupId);
+        if (peers.isEmpty()) {
+            return;
+        }
+        ColocateGroupSchema schema = colocateTableIndex.getGroupSchema(peers.get(0));
+        if (schema == null) {
+            return;
+        }
+        int colocateColumnCount = schema.getColocateColumnCount();
+
+        boolean allAligned = true;
+        for (ColocateTableIndex.GroupId peerGroupId : peers) {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(peerGroupId.dbId);
+            if (db == null) {
+                continue;
+            }
+            for (long tableId : colocateTableIndex.getAllTableIds(peerGroupId)) {
+                if (!alignTableIfApplicable(db, tableId, expectedRanges, colocateColumnCount, colocateGroupId)) {
+                    allAligned = false;
+                }
+            }
+        }
+
+        if (allAligned) {
+            colocateTableIndex.markAllGroupsWithSameColocateGroupIdStable(colocateGroupId, true);
+            LOG.info("marked colocate group id {} stable across {} peer GroupIds",
+                    colocateGroupId, peers.size());
+        }
+    }
+
+    /**
+     * Per-table dispatch for {@link #processGroup}: looks up the table, filters out non-OlapTable
+     * entries (still considered "aligned" — alignment isn't applicable), defers tables not in
+     * {@code NORMAL} state, and otherwise hands off to {@link #processTable}.
+     *
+     * @return {@code true} iff the table contributed no obstacle to marking the colocate group
+     *         stable this cycle (already aligned, or not an OlapTable). {@code false} when work
+     *         is still needed (misaligned tablets, in-flight alter, lookup failure).
+     */
+    private boolean alignTableIfApplicable(Database db, long tableId, List<ColocateRange> expectedRanges,
+                                            int colocateColumnCount, long colocateGroupId) {
+        Table fetchedTable;
+        try {
+            fetchedTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        } catch (Exception e) {
+            LOG.debug("table {} lookup failed in db {}, skipping", tableId, db.getId(), e);
+            return false;
+        }
+        if (!(fetchedTable instanceof OlapTable olapTable)) {
+            return true;
+        }
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+            // In-flight alter / reshard job — skip this cycle, revisit next. Avoids the
+            // SplitTabletJob.setTableState(NORMAL -> TABLET_RESHARD) race when two jobs
+            // target the same table.
+            return false;
+        }
+        try {
+            return processTable(db, olapTable, expectedRanges, colocateColumnCount);
+        } catch (Exception e) {
+            LOG.warn("alignment failed for table {}.{} in colocate group id {}",
+                    db.getFullName(), olapTable.getName(), colocateGroupId, e);
+            return false;
+        }
+    }
+
+    /**
+     * Inspects every visible materialized index in every physical partition of {@code table};
+     * if any tablet is not range-aligned with {@code expectedRanges}, builds the per-tablet
+     * forced-boundaries map and fires a single alignment {@link SplitTabletJob} for the table.
+     *
+     * @return {@code true} iff every tablet in every visible index was already aligned (no job
+     *         fired); {@code false} otherwise — the caller leaves the colocate group unstable.
+     */
+    private boolean processTable(Database db, OlapTable table, List<ColocateRange> expectedRanges,
+                                  int colocateColumnCount) throws StarRocksException {
+        // physicalPartitionId -> indexId -> oldTabletId -> per-new-tablet ranges that tile the
+        // old tablet's range. Empty map means every tablet in every visible index is already
+        // aligned against expectedRanges.
+        Map<Long, Map<Long, Map<Long, List<TabletRange>>>> alignmentMap = new HashMap<>();
+        boolean alignedSoFar = true;
+        List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(table);
+
+        try (AutoCloseableLock lock = new AutoCloseableLock(db.getId(), table.getId(), LockType.READ)) {
+            for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+                for (MaterializedIndex index :
+                        physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
+                    if (RangeColocateScanDispatch.isTabletRangesAligned(
+                            index, sortKeyColumns, expectedRanges, colocateColumnCount)) {
+                        continue;
+                    }
+                    alignedSoFar = false;
+                    for (Tablet tablet : index.getTablets()) {
+                        if (tablet.getRange() == null) {
+                            continue;
+                        }
+                        List<TabletRange> newRanges = RangeColocateScanDispatch.computeAlignedTabletRanges(
+                                tablet.getRange().getRange(), sortKeyColumns, expectedRanges, colocateColumnCount);
+                        if (newRanges.isEmpty()) {
+                            continue;
+                        }
+                        alignmentMap
+                                .computeIfAbsent(physicalPartition.getId(), k -> new HashMap<>())
+                                .computeIfAbsent(index.getId(), k -> new HashMap<>())
+                                .put(tablet.getId(), newRanges);
+                    }
+                }
+            }
+        }
+
+        if (alignmentMap.isEmpty()) {
+            return alignedSoFar;
+        }
+
+        // Re-validate leader admission immediately before the side-effecting factory call:
+        // forColocateAlignment creates StarOS shards BEFORE addTabletReshardJob writes the
+        // admission-guarded journal record. If demotion started since the cycle began,
+        // proceeding would leak external shards.
+        if (!GlobalStateMgr.getCurrentState().isLeaderWorkAdmissionOpen()) {
+            LOG.info("leader admission closed before submitting alignment job for {}.{}, "
+                            + "deferring to next cycle", db.getFullName(), table.getName());
+            return false;
+        }
+
+        TabletReshardJob job = SplitTabletJobFactory.forColocateAlignment(db, table, alignmentMap);
+        GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().addTabletReshardJob(job);
+        LOG.info("submitted SplitTabletJob {} for table {}.{} covering {} partitions",
+                job.getJobId(), db.getFullName(), table.getName(), alignmentMap.size());
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -32,6 +32,7 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.common.Config;
+import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -87,7 +88,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         // shared across DBs, so a still-unaligned split would compound the unaligned state.
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
         ColocateTableIndex.GroupId myGroupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
-        if (myGroupId != null && colocateTableIndex.isAnyGroupWithSameGrpIdUnstable(myGroupId.grpId)) {
+        if (myGroupId != null && colocateTableIndex.isAnyGroupWithSameColocateGroupIdUnstable(myGroupId.grpId)) {
             throw new StarRocksException("Cannot split tablets for range-colocate group "
                     + myGroupId.grpId + ": group is unstable; wait for alignment to complete before retrying");
         }
@@ -105,7 +106,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
     }
 
     /*
-     * PSPS (Pre-Sample & Pre-Split) entry point. Build a TabletReshardJob
+     * external boundaries entry point. Build a TabletReshardJob
      * that splits exactly one tablet using FE-supplied K-1 boundaries
      * instead of letting BE compute boundaries from segment distribution.
      *
@@ -126,20 +127,20 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                     + " in table " + db.getFullName() + '.' + table.getName());
         }
         Preconditions.checkArgument(newTabletRanges != null && newTabletRanges.size() >= 2,
-                "PSPS requires at least 2 new-tablet ranges (got %s)",
+                "External-boundaries split requires at least 2 new-tablet ranges (got %s)",
                 newTabletRanges == null ? "null" : newTabletRanges.size());
         // Mirror the upper bound that TabletReshardUtils.calcSplitCount applies on the
-        // data-driven path. PSPS bypasses calcSplitCount, so enforce the cap here so
+        // data-driven path. External boundaries bypass calcSplitCount, so enforce the cap here so
         // a bad caller cannot allocate an unbounded number of new tablets/shards.
         Preconditions.checkArgument(newTabletRanges.size() <= Config.tablet_reshard_max_split_count,
-                "PSPS new-tablet count %s exceeds tablet_reshard_max_split_count %s",
+                "external new-tablet count %s exceeds tablet_reshard_max_split_count %s",
                 newTabletRanges.size(), Config.tablet_reshard_max_split_count);
 
         // Mirror the data-driven path's range-colocate unstable-group guard:
-        // refuse to start a PSPS split while any peer GroupId is unstable.
+        // refuse to start an external-boundaries split while any peer GroupId is unstable.
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
         ColocateTableIndex.GroupId myGroupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
-        if (myGroupId != null && colocateTableIndex.isAnyGroupWithSameGrpIdUnstable(myGroupId.grpId)) {
+        if (myGroupId != null && colocateTableIndex.isAnyGroupWithSameColocateGroupIdUnstable(myGroupId.grpId)) {
             throw new StarRocksException("Cannot split tablets for range-colocate group "
                     + myGroupId.grpId + ": group is unstable; wait for alignment to complete before retrying");
         }
@@ -189,7 +190,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
 
             SplittingTablet splittingTablet = createSplittingTablet(oldTabletId, newTabletRanges);
 
-            // Build the full resharding-tablet list: PSPS for the chosen
+            // Build the full resharding-tablet list: external boundaries for the chosen
             // tablet, IdenticalTablet for siblings in the same index.
             List<ReshardingTablet> reshardingTablets = new ArrayList<>();
             for (Tablet sibling : index.getTablets()) {
@@ -433,7 +434,6 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         int colocateColumnCount = groupId == null ? 0
                 : colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
 
-
         for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
             long physicalPartitionId = reshardingPhysicalPartition.getPhysicalPartitionId();
             PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
@@ -494,7 +494,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         return new SplittingTablet(oldTabletId, newTabletIds);
     }
 
-    // PSPS overload: allocate K new tablet ids matching K FE-supplied ranges
+    // external-boundaries overload: allocate K new tablet ids matching K FE-supplied ranges
     // and forward both into SplittingTablet so the BE dispatches to the
     // external-boundaries path on publish.
     private static SplittingTablet createSplittingTablet(long oldTabletId, List<TabletRange> newTabletRanges) {
@@ -509,5 +509,205 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
     private static IdenticalTablet createIdenticalTablet(long oldTabletId) {
         long newTabletId = GlobalStateMgr.getCurrentState().getNextId();
         return new IdenticalTablet(oldTabletId, newTabletId);
+    }
+
+    /**
+     * Checker-only entry for {@link ColocateChecker}. Builds one
+     * {@link SplitTabletJob} covering every misaligned (partition, visible index, tablet)
+     * tuple in {@code alignmentMap}, using FE-supplied per-new-tablet ranges so the BE
+     * dispatches to the external boundaries external-boundaries path on publish.
+     *
+     * <p>Differs from the user-facing {@link #createTabletReshardJob} and the load-time
+     * external boundaries {@link #forExternalBoundaries} entries in two ways:
+     * <ul>
+     * <li><b>Unstable-guard bypass.</b> The checker IS the unstable-state resolver — if it
+     *     refused to act on unstable groups, the group would stay unstable forever.</li>
+     * <li><b>Per-new-tablet PACK assignment.</b> Each child of an alignment split lands in
+     *     a different {@link ColocateRange} (that's the whole point of the alignment), so
+     *     its PACK shard group differs from its siblings'. Uses the per-new-shard StarOS
+     *     overload {@link com.starrocks.lake.StarOSAgent#createShardsForSplitPerNewShard}
+     *     instead of the per-old-shard {@code createShardsForSplit} that the user-facing
+     *     and load-time paths use.</li>
+     * </ul>
+     *
+     * @param alignmentMap {@code physicalPartitionId → indexId → oldTabletId → ranges that
+     *                     tile the old tablet's range exactly}. Caller ensures every range
+     *                     list has size ≥ 2 (otherwise no work is needed for that tablet)
+     *                     and tiles the old tablet range exactly.
+     */
+    public static TabletReshardJob forColocateAlignment(Database db, OlapTable table,
+            Map<Long, Map<Long, Map<Long, List<TabletRange>>>> alignmentMap) throws StarRocksException {
+        Preconditions.checkArgument(alignmentMap != null && !alignmentMap.isEmpty(),
+                "alignmentMap must be non-empty");
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            throw new StarRocksException("Unsupported table type " + table.getType()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+        if (!table.isRangeDistribution()) {
+            throw new StarRocksException("Unsupported distribution type "
+                    + table.getDefaultDistributionInfo().getType()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+
+        Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions = new HashMap<>();
+        try (AutoCloseableLock lock = new AutoCloseableLock(db.getId(), table.getId(), LockType.READ)) {
+            if (table.getState() != OlapTable.OlapTableState.NORMAL) {
+                throw new StarRocksException("Unexpected table state " + table.getState()
+                        + " in table " + db.getFullName() + '.' + table.getName());
+            }
+            for (Map.Entry<Long, Map<Long, Map<Long, List<TabletRange>>>> partitionEntry : alignmentMap.entrySet()) {
+                long physicalPartitionId = partitionEntry.getKey();
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                if (physicalPartition == null) {
+                    // Partition dropped between checker snapshot and factory build; skip.
+                    continue;
+                }
+                Map<Long, ReshardingMaterializedIndex> reshardingIndexes = new HashMap<>();
+                for (Map.Entry<Long, Map<Long, List<TabletRange>>> indexEntry : partitionEntry.getValue().entrySet()) {
+                    long indexId = indexEntry.getKey();
+                    MaterializedIndex oldIndex = physicalPartition.getIndex(indexId);
+                    if (oldIndex == null || oldIndex.getState() != IndexState.NORMAL) {
+                        continue;
+                    }
+                    Map<Long, List<TabletRange>> tabletToRanges = indexEntry.getValue();
+                    if (tabletToRanges.isEmpty()) {
+                        continue;
+                    }
+                    List<ReshardingTablet> reshardingTablets = new ArrayList<>();
+                    for (Tablet sibling : oldIndex.getTablets()) {
+                        List<TabletRange> newRanges = tabletToRanges.get(sibling.getId());
+                        if (newRanges != null && newRanges.size() >= 2) {
+                            reshardingTablets.add(createSplittingTablet(sibling.getId(), newRanges));
+                        } else {
+                            reshardingTablets.add(createIdenticalTablet(sibling.getId()));
+                        }
+                    }
+                    reshardingIndexes.put(oldIndex.getId(),
+                            new ReshardingMaterializedIndex(oldIndex.getId(),
+                                    createMaterializedIndex(oldIndex, reshardingTablets),
+                                    reshardingTablets));
+                }
+                if (reshardingIndexes.isEmpty()) {
+                    continue;
+                }
+                reshardingPhysicalPartitions.put(physicalPartitionId,
+                        new ReshardingPhysicalPartition(physicalPartitionId, reshardingIndexes));
+            }
+        }
+
+        if (reshardingPhysicalPartitions.isEmpty()) {
+            throw new StarRocksException("No tablets need alignment in table "
+                    + db.getFullName() + '.' + table.getName());
+        }
+
+        createNewShardsForColocateAlignment(table, reshardingPhysicalPartitions);
+
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
+    }
+
+    /**
+     * Alignment-path variant of {@link #createNewShards}: each new tablet's PACK shard
+     * group is derived from the lower bound of its assigned range (looked up in
+     * {@link ColocateRangeMgr}) — sibling children of the same old tablet can land in
+     * different PACK groups when the alignment split crosses a colocate boundary.
+     *
+     * <p>Identical tablets inherit the old tablet's PACK group via the same prefix lookup,
+     * matching how user-driven splits keep identical tablets in their existing groups.
+     */
+    private static void createNewShardsForColocateAlignment(OlapTable table,
+            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) throws StarRocksException {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateTableIndex.GroupId groupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
+        Preconditions.checkState(groupId != null,
+                "alignment split called for non-range-colocate table %s", table.getName());
+        List<ColocateRange> colocateRanges =
+                colocateTableIndex.getColocateRangeMgr().getColocateRanges(groupId.grpId);
+        int colocateColumnCount = colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
+
+        for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
+            long physicalPartitionId = reshardingPhysicalPartition.getPhysicalPartitionId();
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+            if (physicalPartition == null) {
+                continue;
+            }
+            for (ReshardingMaterializedIndex reshardingIndex :
+                    reshardingPhysicalPartition.getReshardingIndexes().values()) {
+                MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
+                MaterializedIndex oldIndex = physicalPartition.getIndex(reshardingIndex.getMaterializedIndexId());
+                if (oldIndex == null) {
+                    continue;
+                }
+                Map<Long, Long> newToOldShardId = new HashMap<>();
+                Map<Long, List<Long>> newShardIdToGroupIds = new HashMap<>();
+                for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
+                    long firstOldTabletId = reshardingTablet.getFirstOldTabletId();
+                    Tablet oldTablet = oldIndex.getTablet(firstOldTabletId);
+                    Preconditions.checkState(oldTablet != null && oldTablet.getRange() != null,
+                            "old tablet %s missing range during alignment", firstOldTabletId);
+                    SplittingTablet splittingTablet = reshardingTablet.getSplittingTablet();
+                    if (splittingTablet == null) {
+                        // IdenticalTablet — single new shard, inherits old tablet's PACK group.
+                        long newTabletId = reshardingTablet.getFirstNewTabletId();
+                        List<Long> groupIds = findPlacementGroupIdsForRange(
+                                colocateRanges, newIndex.getShardGroupId(),
+                                oldTablet.getRange().getRange(), colocateColumnCount);
+                        newToOldShardId.put(newTabletId, firstOldTabletId);
+                        newShardIdToGroupIds.put(newTabletId, groupIds);
+                        continue;
+                    }
+                    List<TabletRange> newRanges = splittingTablet.getNewTabletRanges();
+                    List<Long> newTabletIds = splittingTablet.getNewTabletIds();
+                    Preconditions.checkState(!newRanges.isEmpty()
+                                    && newRanges.size() == newTabletIds.size(),
+                            "alignment splitting tablet %s has %s ranges but %s ids",
+                            firstOldTabletId, newRanges.size(), newTabletIds.size());
+                    for (int i = 0; i < newTabletIds.size(); i++) {
+                        long newTabletId = newTabletIds.get(i);
+                        List<Long> groupIds = findPlacementGroupIdsForRange(
+                                colocateRanges, newIndex.getShardGroupId(),
+                                newRanges.get(i).getRange(), colocateColumnCount);
+                        newToOldShardId.put(newTabletId, firstOldTabletId);
+                        newShardIdToGroupIds.put(newTabletId, groupIds);
+                    }
+                }
+                if (newToOldShardId.isEmpty()) {
+                    continue;
+                }
+                // Defense-in-depth: re-validate leader admission immediately before each StarOS
+                // RPC. The checker already gated at submit time, but the loop spans many
+                // partitions / indexes and demotion can fire mid-iteration.
+                if (!GlobalStateMgr.getCurrentState().isLeaderWorkAdmissionOpen()) {
+                    throw new StarRocksException(
+                            "leader work admission closed mid-alignment; aborting before StarOS shard creation");
+                }
+                Map<String, String> properties = new HashMap<>();
+                properties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(table.getId()));
+                properties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
+                properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
+                GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForSplitPerNewShard(
+                        newToOldShardId,
+                        newShardIdToGroupIds,
+                        table.getPartitionFilePathInfo(physicalPartitionId),
+                        table.getPartitionFileCacheInfo(physicalPartitionId),
+                        properties, WarehouseManager.DEFAULT_RESOURCE);
+            }
+        }
+    }
+
+    /**
+     * Returns the {@code [SPREAD, PACK]} placement group ids for the {@link ColocateRange}
+     * that owns the colocate prefix of {@code range}'s lower bound. The SPREAD group is shared
+     * across all new shards of an index; the PACK group is looked up from {@link ColocateRangeMgr}
+     * so each new shard joins the PACK group of its target {@link ColocateRange}.
+     */
+    private static List<Long> findPlacementGroupIdsForRange(List<ColocateRange> colocateRanges, long spreadGroupId,
+                                                     Range<Tuple> range,
+                                                     int colocateColumnCount) {
+        Tuple prefix = ColocateRangeUtils.extractColocatePrefix(range, colocateColumnCount);
+        int rangeIndex = ColocateRangeMgr.indexOf(colocateRanges, prefix);
+        Preconditions.checkState(rangeIndex >= 0,
+                "alignment child has no covering ColocateRange for prefix %s", prefix);
+        return List.of(spreadGroupId, colocateRanges.get(rangeIndex).getShardGroupId());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -29,7 +29,9 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
+import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -96,7 +98,119 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                     + db.getFullName() + '.' + table.getName());
         }
 
-        createNewShards(reshardingPhysicalPartitions);
+        createNewShards(table, reshardingPhysicalPartitions);
+
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
+    }
+
+    /*
+     * PSPS (Pre-Sample & Pre-Split) entry point. Build a TabletReshardJob
+     * that splits exactly one tablet using FE-supplied K-1 boundaries
+     * instead of letting BE compute boundaries from segment distribution.
+     *
+     * The new-tablet count is implied by {@code newTabletRanges.size()} and
+     * must be >= 2. FE owns range validity at this layer; BE re-validates
+     * structural and schema-aware invariants and falls back to an identical
+     * tablet on any mismatch.
+     */
+    public static TabletReshardJob forExternalBoundaries(Database db, OlapTable table, long oldTabletId,
+            List<TabletRange> newTabletRanges) throws StarRocksException {
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            throw new StarRocksException("Unsupported table type " + table.getType()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+        if (!table.isRangeDistribution()) {
+            throw new StarRocksException("Unsupported distribution type "
+                    + table.getDefaultDistributionInfo().getType()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+        Preconditions.checkArgument(newTabletRanges != null && newTabletRanges.size() >= 2,
+                "PSPS requires at least 2 new-tablet ranges (got %s)",
+                newTabletRanges == null ? "null" : newTabletRanges.size());
+        // Mirror the upper bound that TabletReshardUtils.calcSplitCount applies on the
+        // data-driven path. PSPS bypasses calcSplitCount, so enforce the cap here so
+        // a bad caller cannot allocate an unbounded number of new tablets/shards.
+        Preconditions.checkArgument(newTabletRanges.size() <= Config.tablet_reshard_max_split_count,
+                "PSPS new-tablet count %s exceeds tablet_reshard_max_split_count %s",
+                newTabletRanges.size(), Config.tablet_reshard_max_split_count);
+
+        // Mirror the data-driven path's range-colocate unstable-group guard:
+        // refuse to start a PSPS split while any peer GroupId is unstable.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateTableIndex.GroupId myGroupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
+        if (myGroupId != null && colocateTableIndex.isAnyGroupWithSameGrpIdUnstable(myGroupId.grpId)) {
+            throw new StarRocksException("Cannot split tablets for range-colocate group "
+                    + myGroupId.grpId + ": group is unstable; wait for alignment to complete before retrying");
+        }
+
+        Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions = new HashMap<>();
+
+        try (AutoCloseableLock lock = new AutoCloseableLock(db.getId(), table.getId(), LockType.READ)) {
+            if (table.getState() != OlapTable.OlapTableState.NORMAL) {
+                throw new StarRocksException("Unexpected table state " + table.getState()
+                        + " in table " + db.getFullName() + '.' + table.getName());
+            }
+
+            TabletMeta tabletMeta = GlobalStateMgr.getCurrentState().getTabletInvertedIndex()
+                    .getTabletMeta(oldTabletId);
+            // getTabletMeta returns null (raw map miss) when the tablet is
+            // unknown — distinct from getTabletMetaList's NOT_EXIST sentinel.
+            if (tabletMeta == null || tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META
+                    || tabletMeta.getTableId() != table.getId()) {
+                throw new StarRocksException("Cannot find tablet " + oldTabletId
+                        + " in inverted index in table " + db.getFullName() + '.' + table.getName());
+            }
+
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(tabletMeta.getPhysicalPartitionId());
+            if (physicalPartition == null) {
+                throw new StarRocksException("Cannot find physical partition "
+                        + tabletMeta.getPhysicalPartitionId()
+                        + " in table " + db.getFullName() + '.' + table.getName());
+            }
+
+            MaterializedIndex index = physicalPartition.getIndex(tabletMeta.getIndexId());
+            if (index == null) {
+                throw new StarRocksException("Cannot find materialized index " + tabletMeta.getIndexId()
+                        + " in physical partition " + physicalPartition.getId()
+                        + " in table " + db.getFullName() + '.' + table.getName());
+            }
+            if (index.getState() != IndexState.NORMAL) {
+                throw new StarRocksException("Not a normal state materialized index " + tabletMeta.getIndexId()
+                        + " in physical partition " + physicalPartition.getId()
+                        + " in table " + db.getFullName() + '.' + table.getName());
+            }
+            if (index.getTablet(oldTabletId) == null) {
+                throw new StarRocksException("Cannot find tablet " + oldTabletId
+                        + " in materialized index " + tabletMeta.getIndexId()
+                        + " in physical partition " + physicalPartition.getId()
+                        + " in table " + db.getFullName() + '.' + table.getName());
+            }
+
+            SplittingTablet splittingTablet = createSplittingTablet(oldTabletId, newTabletRanges);
+
+            // Build the full resharding-tablet list: PSPS for the chosen
+            // tablet, IdenticalTablet for siblings in the same index.
+            List<ReshardingTablet> reshardingTablets = new ArrayList<>();
+            for (Tablet sibling : index.getTablets()) {
+                if (sibling.getId() == oldTabletId) {
+                    reshardingTablets.add(splittingTablet);
+                } else {
+                    reshardingTablets.add(createIdenticalTablet(sibling.getId()));
+                }
+            }
+
+            Map<Long, ReshardingMaterializedIndex> reshardingIndexes = new HashMap<>();
+            reshardingIndexes.put(index.getId(),
+                    new ReshardingMaterializedIndex(index.getId(),
+                            createMaterializedIndex(index, reshardingTablets),
+                            reshardingTablets));
+
+            reshardingPhysicalPartitions.put(physicalPartition.getId(),
+                    new ReshardingPhysicalPartition(physicalPartition.getId(), reshardingIndexes));
+        }
+
+        createNewShards(table, reshardingPhysicalPartitions);
 
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
@@ -290,7 +404,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         return reshardingTablets;
     }
 
-    private MaterializedIndex createMaterializedIndex(MaterializedIndex oldIndex,
+    private static MaterializedIndex createMaterializedIndex(MaterializedIndex oldIndex,
             List<ReshardingTablet> reshardingTablets) {
         MaterializedIndex newIndex = new MaterializedIndex(GlobalStateMgr.getCurrentState().getNextId(), oldIndex.getMetaId(),
                 IndexState.NORMAL, oldIndex.getShardGroupId());
@@ -307,8 +421,8 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         return newIndex;
     }
 
-    private void createNewShards(Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions)
-            throws StarRocksException {
+    private static void createNewShards(OlapTable table,
+            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) throws StarRocksException {
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
         ColocateTableIndex.GroupId groupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
         // Snapshot colocate ranges once: createShards inside the loop only reads the same
@@ -318,6 +432,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                 : colocateTableIndex.getColocateRangeMgr().getColocateRanges(groupId.grpId);
         int colocateColumnCount = groupId == null ? 0
                 : colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
+
 
         for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
             long physicalPartitionId = reshardingPhysicalPartition.getPhysicalPartitionId();
@@ -377,6 +492,18 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
             newTabletIds.add(globalStateMgr.getNextId());
         }
         return new SplittingTablet(oldTabletId, newTabletIds);
+    }
+
+    // PSPS overload: allocate K new tablet ids matching K FE-supplied ranges
+    // and forward both into SplittingTablet so the BE dispatches to the
+    // external-boundaries path on publish.
+    private static SplittingTablet createSplittingTablet(long oldTabletId, List<TabletRange> newTabletRanges) {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        List<Long> newTabletIds = new ArrayList<>(newTabletRanges.size());
+        for (int j = 0; j < newTabletRanges.size(); ++j) {
+            newTabletIds.add(globalStateMgr.getNextId());
+        }
+        return new SplittingTablet(oldTabletId, newTabletIds, newTabletRanges);
     }
 
     private static IdenticalTablet createIdenticalTablet(long oldTabletId) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
@@ -16,13 +16,25 @@ package com.starrocks.alter.reshard;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.proto.ReshardingTabletInfoPB;
 import com.starrocks.proto.SplittingTabletInfoPB;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /*
- * SplittingTablet saves the old tablet id and the new tablets during a tablet splitting
+ * SplittingTablet saves the old tablet id and the new tablets during a tablet splitting.
+ *
+ * When `newTabletRanges` is empty the BE follows the data-driven split path
+ * (segment distribution computes the K-1 boundaries). When non-empty, the
+ * PSPS (Pre-Sample & Pre-Split) path applies on the BE: the FE-supplied
+ * boundaries are honored verbatim and `newTabletRanges.size()` must equal
+ * `newTabletIds.size()`. BE re-validates structural and schema-aware
+ * invariants before committing.
  */
 public class SplittingTablet implements ReshardingTablet {
 
@@ -32,9 +44,27 @@ public class SplittingTablet implements ReshardingTablet {
     @SerializedName(value = "newTabletIds")
     protected final List<Long> newTabletIds;
 
+    @SerializedName(value = "newTabletRanges")
+    protected final List<TabletRange> newTabletRanges;
+
     public SplittingTablet(long oldTabletId, List<Long> newTabletIds) {
+        this(oldTabletId, newTabletIds, Collections.emptyList());
+    }
+
+    public SplittingTablet(long oldTabletId, List<Long> newTabletIds, List<TabletRange> newTabletRanges) {
         this.oldTabletId = oldTabletId;
         this.newTabletIds = newTabletIds;
+        Preconditions.checkNotNull(newTabletRanges, "newTabletRanges must not be null");
+        Preconditions.checkArgument(newTabletRanges.stream().allMatch(Objects::nonNull),
+                "newTabletRanges must not contain null elements");
+        // Always wrap in a mutable ArrayList: fallbackToIdenticalTablet() clears
+        // this list after a BE-side fallback, mirroring how newTabletIds is
+        // mutated via subList(...).clear().
+        this.newTabletRanges = new ArrayList<>(newTabletRanges);
+        Preconditions.checkState(this.newTabletRanges.isEmpty()
+                        || this.newTabletRanges.size() == newTabletIds.size(),
+                "newTabletRanges.size=%s must equal newTabletIds.size=%s when set",
+                this.newTabletRanges.size(), newTabletIds.size());
     }
 
     @Override
@@ -76,6 +106,10 @@ public class SplittingTablet implements ReshardingTablet {
         return newTabletIds;
     }
 
+    public List<TabletRange> getNewTabletRanges() {
+        return newTabletRanges;
+    }
+
     @Override
     public long getParallelTablets() {
         return newTabletIds.size();
@@ -87,12 +121,20 @@ public class SplittingTablet implements ReshardingTablet {
         reshardingTabletInfoPB.splittingTabletInfo = new SplittingTabletInfoPB();
         reshardingTabletInfoPB.splittingTabletInfo.oldTabletId = oldTabletId;
         reshardingTabletInfoPB.splittingTabletInfo.newTabletIds = newTabletIds;
+        if (!newTabletRanges.isEmpty()) {
+            reshardingTabletInfoPB.splittingTabletInfo.newTabletRanges =
+                    newTabletRanges.stream().map(TabletRange::toProto).collect(Collectors.toList());
+        }
         return reshardingTabletInfoPB;
     }
 
     public void fallbackToIdenticalTablet() {
         Preconditions.checkState(!newTabletIds.isEmpty());
         newTabletIds.subList(1, newTabletIds.size()).clear();
+        // Drop stale FE-supplied ranges. After BE's identical fallback there is
+        // a single inherited new tablet, not the K originally requested, so
+        // the PSPS-style range list would be both mis-sized and meaningless.
+        newTabletRanges.clear();
     }
 
     public boolean isIdenticalTablet() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  *
  * When `newTabletRanges` is empty the BE follows the data-driven split path
  * (segment distribution computes the K-1 boundaries). When non-empty, the
- * PSPS (Pre-Sample & Pre-Split) path applies on the BE: the FE-supplied
+ * external boundaries path applies on the BE: the FE-supplied
  * boundaries are honored verbatim and `newTabletRanges.size()` must equal
  * `newTabletIds.size()`. BE re-validates structural and schema-aware
  * invariants before committing.
@@ -44,8 +44,22 @@ public class SplittingTablet implements ReshardingTablet {
     @SerializedName(value = "newTabletIds")
     protected final List<Long> newTabletIds;
 
+    // Defaulted to empty list in the no-arg Gson constructor below so legacy
+    // SplittingTablet records persisted before this field existed deserialize
+    // to an empty list instead of null. Gson invokes the no-arg constructor
+    // (when one exists, as here) and then reflection-sets only the fields
+    // present in the JSON, so toProto / fallbackToIdenticalTablet never see
+    // null even on an in-flight reshard job replayed from a pre-PR snapshot.
     @SerializedName(value = "newTabletRanges")
     protected final List<TabletRange> newTabletRanges;
+
+    // Used only by Gson deserialization; delegates to the validated 3-arg
+    // constructor so the same wrapping / preconditions apply. Gson then
+    // reflection-sets each field present in the JSON, leaving newTabletRanges
+    // at the empty default for legacy records that predate the field.
+    private SplittingTablet() {
+        this(0, Collections.emptyList(), Collections.emptyList());
+    }
 
     public SplittingTablet(long oldTabletId, List<Long> newTabletIds) {
         this(oldTabletId, newTabletIds, Collections.emptyList());
@@ -133,7 +147,7 @@ public class SplittingTablet implements ReshardingTablet {
         newTabletIds.subList(1, newTabletIds.size()).clear();
         // Drop stale FE-supplied ranges. After BE's identical fallback there is
         // a single inherited new tablet, not the K originally requested, so
-        // the PSPS-style range list would be both mis-sized and meaningless.
+        // the external-boundaries-style range list would be both mis-sized and meaningless.
         newTabletRanges.clear();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -51,6 +51,12 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
     // Original tablet id -> resharding tablet info
     protected final Map<Long, ReshardingTabletInfo> reshardingTabletInfos = Maps.newConcurrentMap();
 
+    // Colocate checker: stateless, invoked from this manager's tick. Owns no
+    // thread of its own — shares this manager's scheduler cadence
+    // ({@code tablet_reshard_job_scheduler_interval_ms}) and self-gates on shared-data-mode,
+    // leader status, and empty unstable-groups before doing any real work.
+    private final ColocateChecker colocateChecker = new ColocateChecker();
+
     public TabletReshardJobMgr() {
         super("tablet-reshard-job-mgr", Config.tablet_reshard_job_scheduler_interval_ms);
     }
@@ -166,6 +172,7 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
 
     @Override
     protected void runAfterCatalogReady() {
+        colocateChecker.runOneCycle();
         runTabletReshardJobs();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -563,6 +563,20 @@ public class ColocateTableIndex implements Writable {
         }
     }
 
+    /**
+     * Cheap empty-check counterpart to {@link #getUnstableGroupIds()} that avoids the
+     * snapshot allocation. Intended for hot-path callers (e.g. {@code ColocateChecker})
+     * that want to fast-return when no unstable groups exist.
+     */
+    public boolean hasUnstableGroups() {
+        readLock();
+        try {
+            return !unstableGroups.isEmpty();
+        } finally {
+            readUnlock();
+        }
+    }
+
     public GroupId getGroup(long tableId) {
         readLock();
         try {
@@ -778,38 +792,74 @@ public class ColocateTableIndex implements Writable {
     }
 
     /**
-     * Mark every {@link GroupId} that shares the given colocate {@code grpId} as unstable.
-     * Range colocate groups are keyed in {@link ColocateRangeMgr} by {@code grpId} alone, so a
-     * range-mgr mutation in one database affects every peer database that joined the same group;
-     * marking only the caller's own GroupId would leave peer DBs claiming "stable" while their
-     * tablets are mid-migration, allowing colocate joins to run against an unaligned layout.
+     * Mark every {@link GroupId} that shares the given {@code colocateGroupId} as unstable.
+     * Range colocate groups are keyed in {@link ColocateRangeMgr} by {@code colocateGroupId}
+     * alone, so a range-mgr mutation in one database affects every peer database that joined
+     * the same group; marking only the caller's own GroupId would leave peer DBs claiming
+     * "stable" while their tablets are mid-migration, allowing colocate joins to run against
+     * an unaligned layout.
      */
-    public void markAllGroupsWithSameGrpIdUnstable(long grpId, boolean needEditLog) {
+    public void markAllGroupsWithSameColocateGroupIdUnstable(long colocateGroupId, boolean needEditLog) {
         writeLock();
         try {
             // markGroupUnstable / isGroupUnstable re-acquire the lock; ReentrantReadWriteLock
             // is reentrant for the same thread.
-            group2Schema.keySet().stream()
-                    .filter(g -> Objects.equals(g.grpId, grpId))
-                    .collect(Collectors.toList())
-                    .forEach(peer -> markGroupUnstable(peer, needEditLog));
+            peersOfColocateGroup(colocateGroupId).forEach(peer -> markGroupUnstable(peer, needEditLog));
         } finally {
             writeUnlock();
         }
     }
 
     /**
-     * Returns true iff any {@link GroupId} sharing the given colocate {@code grpId} is unstable.
+     * Symmetric counterpart to {@link #markAllGroupsWithSameColocateGroupIdUnstable}. Marks every
+     * {@link GroupId} that shares the given {@code colocateGroupId} as stable. Used by the
+     * colocate checker once every peer GroupId's tablet layout matches
+     * {@link ColocateRangeMgr#getColocateRanges} — marking only one peer GroupId would leave
+     * the others claiming unstable while the cluster is actually aligned.
      */
-    public boolean isAnyGroupWithSameGrpIdUnstable(long grpId) {
+    public void markAllGroupsWithSameColocateGroupIdStable(long colocateGroupId, boolean needEditLog) {
+        writeLock();
+        try {
+            peersOfColocateGroup(colocateGroupId).forEach(peer -> markGroupStable(peer, needEditLog));
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    /**
+     * Returns every {@link GroupId} that shares the given {@code colocateGroupId}, as a snapshot
+     * under the read lock. Useful for the colocate checker which needs to iterate cross-DB peers
+     * without holding the catalog lock for the duration of the cycle.
+     */
+    public List<GroupId> getAllGroupIdsWithSameColocateGroupId(long colocateGroupId) {
         readLock();
         try {
-            return group2Schema.keySet().stream()
-                    .filter(g -> Objects.equals(g.grpId, grpId))
-                    .anyMatch(this::isGroupUnstable);
+            return peersOfColocateGroup(colocateGroupId);
         } finally {
             readUnlock();
         }
+    }
+
+    /**
+     * Returns true iff any {@link GroupId} sharing the given {@code colocateGroupId} is unstable.
+     */
+    public boolean isAnyGroupWithSameColocateGroupIdUnstable(long colocateGroupId) {
+        readLock();
+        try {
+            return peersOfColocateGroup(colocateGroupId).stream().anyMatch(this::isGroupUnstable);
+        } finally {
+            readUnlock();
+        }
+    }
+
+    /**
+     * Snapshot of every {@link GroupId} that shares the given {@code colocateGroupId}. Caller
+     * is responsible for holding the appropriate lock (read for queries, write for mutations).
+     */
+    private List<GroupId> peersOfColocateGroup(long colocateGroupId) {
+        return group2Schema.keySet().stream()
+                .filter(g -> Objects.equals(g.grpId, colocateGroupId))
+                .collect(Collectors.toList());
     }
 
     /**
@@ -837,7 +887,7 @@ public class ColocateTableIndex implements Writable {
                         ColocateRangePersistInfo.create(grpId, newRanges),
                         wal -> colocateRangeMgr.setColocateRanges(grpId, newRanges));
             }
-            markAllGroupsWithSameGrpIdUnstable(grpId, /* needEditLog */ true);
+            markAllGroupsWithSameColocateGroupIdUnstable(grpId, /* needEditLog */ true);
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4359,7 +4359,8 @@ public class Config extends ConfigBase {
     /**
      * The default scheduler interval for tablet reshard jobs.
      */
-    @ConfField(mutable = false, comment = "The default scheduler interval for tablet reshard jobs.")
+    @ConfField(mutable = false, comment = "The default scheduler interval for tablet reshard jobs. "
+            + "Also drives the colocate checker's tick cadence on shared-data clusters.")
     public static long tablet_reshard_job_scheduler_interval_ms = 10;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -677,6 +677,58 @@ public class StarOSAgent {
         }
     }
 
+    /**
+     * Per-new-shard variant of {@link #createShardsForSplit} used by the colocate checker.
+     * Each new shard joins its own list of group ids (PACK group per
+     * colocate range), while still pinning placement to its old shard via
+     * {@code PlacementRelationship.WITH_SHARD}.
+     *
+     * <p>{@code newToOldShardId} maps each new shard id to its parent old shard id.
+     * {@code newShardIdToGroupIds} maps each new shard id to its target group ids
+     * (typically {@code [SPREAD, PACK-for-this-shard's-ColocateRange]}). Both maps must
+     * have the same key set; the call fails if a new shard has no group assignment.
+     */
+    public void createShardsForSplitPerNewShard(Map<Long, Long> newToOldShardId,
+                                                 Map<Long, List<Long>> newShardIdToGroupIds,
+                                                 FilePathInfo pathInfo,
+                                                 FileCacheInfo cacheInfo,
+                                                 @NotNull Map<String, String> properties,
+                                                 ComputeResource computeResource) throws DdlException {
+        long workerGroupId = computeResource.getWorkerGroupId();
+        prepare();
+        try {
+            CreateShardInfo.Builder builder = CreateShardInfo.newBuilder();
+            builder.setReplicaCount(1)
+                    .setPathInfo(pathInfo)
+                    .setCacheInfo(cacheInfo)
+                    .putAllShardProperties(properties)
+                    .setScheduleToWorkerGroup(workerGroupId);
+            List<CreateShardInfo> createShardInfoList = new ArrayList<>(newToOldShardId.size());
+            for (Map.Entry<Long, Long> entry : newToOldShardId.entrySet()) {
+                long newShardId = entry.getKey();
+                long oldShardId = entry.getValue();
+                List<Long> groupIds = newShardIdToGroupIds.get(newShardId);
+                Preconditions.checkArgument(groupIds != null && !groupIds.isEmpty(),
+                        "Missing group ids for new shard " + newShardId);
+                builder.clearPlacementPreferences();
+                builder.clearGroupIds();
+                builder.addAllGroupIds(groupIds);
+                builder.addPlacementPreferences(PlacementPreference.newBuilder()
+                        .setPlacementPolicy(PlacementPolicy.PACK)
+                        .setPlacementRelationship(PlacementRelationship.WITH_SHARD)
+                        .setRelationshipTargetId(oldShardId)
+                        .build());
+                builder.setShardId(newShardId);
+                createShardInfoList.add(builder.build());
+            }
+            List<ShardInfo> shardInfos = client.createShard(serviceId, createShardInfoList);
+            Preconditions.checkState(shardInfos.size() == createShardInfoList.size());
+            LOG.debug("Create per-new-shard split shards success. shard infos: {}", shardInfos);
+        } catch (Exception e) {
+            throw new DdlException("Failed to create per-new-shard split shards. error: " + e.getMessage());
+        }
+    }
+
     public void createShardsForMerge(Map<Long, List<Long>> newToOldShardIds, FilePathInfo pathInfo,
             FileCacheInfo cacheInfo, long groupId, @NotNull Map<String, String> properties,
             ComputeResource computeResource) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/internal/RuntimeTypeAdapterTypes.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/internal/RuntimeTypeAdapterTypes.java
@@ -86,7 +86,10 @@ import com.starrocks.catalog.LargeIntVariant;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaxVariant;
+import com.starrocks.catalog.MinVariant;
 import com.starrocks.catalog.MysqlTable;
+import com.starrocks.catalog.NullVariant;
 import com.starrocks.catalog.OdbcCatalogResource;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
@@ -445,7 +448,13 @@ public class RuntimeTypeAdapterTypes {
                         .registerSubtype(IntVariant.class, "IntVariant")
                         .registerSubtype(LargeIntVariant.class, "LargeIntVariant")
                         .registerSubtype(StringVariant.class, "StringVariant")
-                        .registerSubtype(DateVariant.class, "DateVariant");
+                        .registerSubtype(DateVariant.class, "DateVariant")
+                        // Canonical colocate boundaries serialized via SplittingTablet contain
+                        // NullVariant suffixes; MinVariant / MaxVariant cover the unbounded
+                        // sentinel cases observed in ColocateRange persistence.
+                        .registerSubtype(NullVariant.class, "NullVariant")
+                        .registerSubtype(MinVariant.class, "MinVariant")
+                        .registerSubtype(MaxVariant.class, "MaxVariant");
         CLAZZ_TO_RUNTIME_TYPE_ADAPTOR_FACTORIES.put(Variant.class, variant_runtime_type_adapter_factory);
 
         final RuntimeTypeAdapterFactory<TvrVersionRange> tvr_delta_runtime_type_adapter_factory =

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
@@ -26,12 +26,14 @@ import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.common.Range;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.MetaUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -134,6 +136,124 @@ public final class RangeColocateScanDispatch {
                         colocateGroupId, physicalPartition.getId()));
             }
         }
+    }
+
+    /**
+     * Static counterpart to {@link #computeBucketSeq} that just returns the aligned /
+     * not-aligned boolean. Used by {@link com.starrocks.alter.reshard.ColocateChecker}
+     * to decide whether a partition / index needs an alignment split.
+     *
+     * <p>Same rules as the dispatch path's transient-state detection: every tablet's range
+     * must be contained in exactly one expanded {@link ColocateRange}, and every
+     * {@link ColocateRange} must have at least one covering tablet. Caller passes in the
+     * snapshot of {@code expectedRanges} so a single cycle of the checker sees a stable
+     * view across all peers.
+     */
+    public static boolean isTabletRangesAligned(MaterializedIndex selectedIndex, List<Column> sortKeyColumns,
+                                                 List<ColocateRange> expectedRanges, int colocateColumnCount) {
+        Preconditions.checkArgument(!expectedRanges.isEmpty(),
+                "expectedRanges must not be empty for range colocate alignment check");
+        List<Range<Tuple>> expandedRanges = new ArrayList<>(expectedRanges.size());
+        for (ColocateRange colocateRange : expectedRanges) {
+            expandedRanges.add(ColocateRangeUtils.expandToFullSortKey(
+                    colocateRange.getRange(), sortKeyColumns, colocateColumnCount));
+        }
+        Set<Integer> coveredBucketSeqs = new HashSet<>();
+        for (Tablet tablet : selectedIndex.getTablets()) {
+            if (tablet.getRange() == null) {
+                // P0/P1 invariant: every tablet of a range-colocate table has a TabletRange.
+                // A missing range is a deeper bug than misalignment — return false so the
+                // checker does not try to fix it and the dispatch guard still fires.
+                return false;
+            }
+            Range<Tuple> tabletRange = tablet.getRange().getRange();
+            Tuple prefix = ColocateRangeUtils.extractColocatePrefix(tabletRange, colocateColumnCount);
+            int bucketSeq = ColocateRangeMgr.indexOf(expectedRanges, prefix);
+            if (bucketSeq < 0 || !expandedRanges.get(bucketSeq).contains(tabletRange)) {
+                return false;
+            }
+            coveredBucketSeqs.add(bucketSeq);
+        }
+        return coveredBucketSeqs.size() == expectedRanges.size();
+    }
+
+    /**
+     * Returns the canonical colocate boundaries strictly inside {@code tabletRange} (i.e.
+     * the {@link ColocateRange} lower bounds, expanded to full sort key, that fall between
+     * the tablet's lower and upper bounds, exclusive on both sides). These are the
+     * boundaries an alignment split of this tablet must use.
+     *
+     * <p>If the returned list is empty, the tablet either is already aligned to the colocate
+     * range topology or is contained in a single {@link ColocateRange} — caller decides which
+     * by composing with {@link #isTabletRangesAligned}.
+     */
+    public static List<Tuple> computeForcedAlignmentBoundaries(Range<Tuple> tabletRange, List<Column> sortKeyColumns,
+                                                                List<ColocateRange> expectedRanges,
+                                                                int colocateColumnCount) {
+        List<Tuple> boundaries = new ArrayList<>();
+        for (ColocateRange colocateRange : expectedRanges) {
+            Range<Tuple> cr = colocateRange.getRange();
+            if (cr.isMinimum()) {
+                continue; // No canonical boundary at -inf.
+            }
+            // ColocateRangeMgr canonicalizes every non-minimum range to inclusive lower; a
+            // non-inclusive lower here means upstream constructed an unsupported range and
+            // the alignment math would silently drop boundaries, leaving the group livelocked.
+            Preconditions.checkState(cr.isLowerBoundIncluded(),
+                    "ColocateRange with non-inclusive lower bound is not supported: %s", cr);
+            Range<Tuple> expanded = ColocateRangeUtils.expandToFullSortKey(cr, sortKeyColumns, colocateColumnCount);
+            Tuple canonicalLower = expanded.getLowerBound();
+            // Strictly inside tabletRange: tablet lower < boundary < tablet upper.
+            boolean strictlyAboveLower = tabletRange.isMinimum()
+                    || tabletRange.getLowerBound().compareTo(canonicalLower) < 0
+                    || (tabletRange.getLowerBound().equals(canonicalLower) && !tabletRange.isLowerBoundIncluded());
+            boolean strictlyBelowUpper = tabletRange.isMaximum()
+                    || canonicalLower.compareTo(tabletRange.getUpperBound()) < 0;
+            if (strictlyAboveLower && strictlyBelowUpper) {
+                boundaries.add(canonicalLower);
+            }
+        }
+        return boundaries;
+    }
+
+    /**
+     * Converts the canonical-boundary list returned by {@link #computeForcedAlignmentBoundaries}
+     * into the per-new-tablet {@link TabletRange} list that the external boundaries
+     * {@code SplitTabletJobFactory.forExternalBoundaries} family of entries consumes
+     * (or, for colocate alignment, the checker's per-new-tablet PACK assignment path).
+     *
+     * <p>For an old tablet with range {@code [lower, upper)} and K-1 canonical boundaries
+     * {@code [b[0], ..., b[K-2]]} (strictly inside the old range, strictly increasing), the
+     * children tile the old range as:
+     * <pre>
+     *   child 0     : [lower, b[0])
+     *   child i ∈ (0, K-1) : [b[i-1], b[i])
+     *   child K-1   : [b[K-2], upper)  (preserves old upper-bound inclusion)
+     * </pre>
+     * Returns {@link Collections#emptyList()} when no boundary is supplied — caller treats this
+     * as "tablet already aligned, no split needed".
+     */
+    public static List<TabletRange> computeAlignedTabletRanges(Range<Tuple> tabletRange,
+                                                                List<Column> sortKeyColumns,
+                                                                List<ColocateRange> expectedRanges,
+                                                                int colocateColumnCount) {
+        List<Tuple> boundaries = computeForcedAlignmentBoundaries(
+                tabletRange, sortKeyColumns, expectedRanges, colocateColumnCount);
+        if (boundaries.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<TabletRange> result = new ArrayList<>(boundaries.size() + 1);
+        Tuple prevLower = tabletRange.isMinimum() ? null : tabletRange.getLowerBound();
+        boolean prevLowerInc = !tabletRange.isMinimum() && tabletRange.isLowerBoundIncluded();
+        for (Tuple boundary : boundaries) {
+            result.add(new TabletRange(Range.of(prevLower, boundary, prevLowerInc, false)));
+            prevLower = boundary;
+            prevLowerInc = true;
+        }
+        Tuple oldUpper = tabletRange.isMaximum() ? null : tabletRange.getUpperBound();
+        boolean oldUpperInc = !tabletRange.isMaximum() && tabletRange.isUpperBoundIncluded();
+        result.add(new TabletRange(Range.of(prevLower, oldUpper, prevLowerInc, oldUpperInc)));
+        return result;
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
@@ -1,0 +1,211 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.staros.proto.PlacementPolicy;
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateRangeMgr;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.Range;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Exercises {@link ColocateChecker}'s core decision paths:
+ *   - unstable + already-aligned group is marked stable in one cycle;
+ *   - unstable + misaligned partition triggers an alignment {@link SplitTabletJob};
+ *   - no unstable groups => no work.
+ *
+ * <p>Calls {@link ColocateChecker#runOneCycle()} directly so the tests focus on the
+ * checking body rather than the host {@link TabletReshardJobMgr}'s scheduler.
+ */
+public class ColocateCheckerTest {
+
+    protected static ConnectContext connectContext;
+    protected static StarRocksAssert starRocksAssert;
+    private static Database db;
+
+    private OlapTable table;
+    private ColocateTableIndex.GroupId groupId;
+    private static final AtomicInteger NEXT_TABLE_SEQ = new AtomicInteger();
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        Config.enable_range_distribution = true;
+
+        starRocksAssert.withDatabase("p4_align_test").useDatabase("p4_align_test");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("p4_align_test");
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Each test gets a fresh colocate group so prior tests' ColocateRangeMgr mutations do
+        // not leak across tests; the cluster shares one ColocateTableIndex instance.
+        int seq = NEXT_TABLE_SEQ.incrementAndGet();
+        String tableName = "t_p4_align_" + seq;
+        String sql = "create table " + tableName + " (k1 int, k2 int)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1', 'colocate_with' = 'p4_align_grp_" + seq + ":k1');";
+        starRocksAssert.withTable(sql);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName);
+        groupId = GlobalStateMgr.getCurrentState().getColocateTableIndex().getGroup(table.getId());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        if (groupId != null && colocateTableIndex.isGroupUnstable(groupId)) {
+            colocateTableIndex.markGroupStable(groupId, /* needEditLog */ false);
+        }
+    }
+
+    @Test
+    public void testAlignedUnstableGroupBecomesStable() throws Exception {
+        // The freshly-created table has one tablet covering the single default ColocateRange
+        // [MIN, MAX) -> already aligned. Marking the group unstable then running the checker
+        // must find every partition aligned and mark every peer GroupId stable.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+        Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId));
+
+        ColocateChecker checker = new ColocateChecker();
+        checker.runOneCycle();
+
+        Assertions.assertFalse(colocateTableIndex.isGroupUnstable(groupId),
+                "aligned + unstable group must be marked stable after one cycle");
+    }
+
+    @Test
+    public void testMisalignedTabletTriggersAlignmentJob() throws Exception {
+        // Splice a synthetic second ColocateRange entry at colocate-prefix 100 to create
+        // misalignment: the table's single tablet spans [MIN, MAX) but two ColocateRanges now exist.
+        // The checker must (a) detect misalignment, (b) compute the canonical boundary at k1=100,
+        // and (c) submit one alignment SplitTabletJob.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        spliceSecondColocateRangeAt100AndMarkUnstable();
+
+        ColocateChecker checker = new ColocateChecker();
+        checker.runOneCycle();
+
+        // Filter by this test's table id: the host TabletReshardJobMgr scheduler may have
+        // ticked concurrently and submitted its own alignment job for the same unstable group,
+        // so the total job count can be >= 1 — assert at least one alignment job exists for
+        // *our* table, which is sufficient evidence the checker did its work.
+        Assertions.assertTrue(countAlignmentJobsForTable(table.getId()) >= 1,
+                "misaligned partition must trigger at least one alignment SplitTabletJob");
+
+        // Group must remain unstable: alignment job is pending; only after every peer is aligned
+        // does the checker mark stable. Submitting the job is not enough.
+        Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
+                "group must remain unstable until the alignment job actually publishes");
+    }
+
+    @Test
+    public void testTableInNonNormalStateIsSkipped() throws Exception {
+        // A misaligned partition would normally trigger an alignment job, but if the table
+        // is mid-alter (state != NORMAL) the checker must skip it this cycle to avoid the
+        // SplitTabletJob.setTableState(NORMAL -> TABLET_RESHARD) precondition failure, and
+        // must leave the group unstable so a later cycle retries.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        spliceSecondColocateRangeAt100AndMarkUnstable();
+
+        OlapTable.OlapTableState originalState = table.getState();
+        table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+        try {
+            long ourJobsBefore = countAlignmentJobsForTable(table.getId());
+
+            ColocateChecker checker = new ColocateChecker();
+            checker.runOneCycle();
+
+            long ourJobsAfter = countAlignmentJobsForTable(table.getId());
+            Assertions.assertEquals(ourJobsBefore, ourJobsAfter,
+                    "non-NORMAL table state must skip alignment job submission");
+            Assertions.assertTrue(colocateTableIndex.isGroupUnstable(groupId),
+                    "group must remain unstable so a later cycle retries once state returns to NORMAL");
+        } finally {
+            table.setState(originalState);
+        }
+    }
+
+    private static long countAlignmentJobsForTable(long tableId) {
+        return GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJobs().values().stream()
+                .filter(j -> j.getJobType() == TabletReshardJob.JobType.SPLIT_TABLET)
+                .filter(j -> j instanceof SplitTabletJob)
+                .map(j -> (SplitTabletJob) j)
+                .filter(j -> j.getTableId() == tableId)
+                .count();
+    }
+
+    /**
+     * Synthetically splices a second {@link ColocateRange} entry at colocate-prefix 100 and
+     * marks the group unstable. The table starts with a single tablet spanning {@code [MIN, MAX)}
+     * — afterwards there are two ColocateRanges {@code [MIN, 100)} / {@code [100, MAX)} but the
+     * tablet still spans the whole space, so the layout is misaligned against the group's
+     * expected ranges.
+     */
+    private void spliceSecondColocateRangeAt100AndMarkUnstable() throws DdlException {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateRangeMgr rangeMgr = colocateTableIndex.getColocateRangeMgr();
+        long colocateGroupId = groupId.grpId;
+        long firstShardGroupId = rangeMgr.getColocateRanges(colocateGroupId).get(0).getShardGroupId();
+        long secondShardGroupId = GlobalStateMgr.getCurrentState().getStarOSAgent().createShardGroup(
+                db.getId(), table.getId(), 0L, 0L, PlacementPolicy.PACK);
+        Tuple boundaryPrefix = new Tuple(Arrays.asList(Variant.of(IntegerType.INT, "100")));
+        rangeMgr.setColocateRanges(colocateGroupId, Arrays.asList(
+                new ColocateRange(Range.lt(boundaryPrefix), firstShardGroupId),
+                new ColocateRange(Range.ge(boundaryPrefix), secondShardGroupId)));
+        colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
+    }
+
+    @Test
+    public void testNoUnstableGroupNoOp() throws Exception {
+        // With no unstable groups, the checker must produce no work even with the table present.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        Assertions.assertFalse(colocateTableIndex.isGroupUnstable(groupId));
+
+        int jobsBefore = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr()
+                .getTabletReshardJobs().size();
+
+        ColocateChecker checker = new ColocateChecker();
+        checker.runOneCycle();
+
+        Assertions.assertFalse(colocateTableIndex.isGroupUnstable(groupId));
+        Assertions.assertEquals(jobsBefore,
+                GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJobs().size(),
+                "no unstable groups => no alignment jobs submitted");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -403,6 +403,210 @@ public class SplitTabletJobTest {
         }
     }
 
+    // -------------------------------------------------------------------------
+    // PSPS (Pre-Sample & Pre-Split) end-to-end driver.
+    //
+    // Drives SplitTabletJobFactory.forExternalBoundaries(...) through PENDING
+    // -> RUNNING -> FINISHED with a mocked BE that echoes the FE-supplied
+    // ranges back verbatim (the BE contract: "external boundaries honored
+    // verbatim"). Asserts the SplittingTablet carries newTabletRanges all the
+    // way through toProto(), and that the resulting new tablets land with the
+    // FE-supplied ranges.
+    // -------------------------------------------------------------------------
+    @Test
+    public void testRunPspsTabletReshardJob() throws Exception {
+        new MockUp<MockLakeService>() {
+            @Mock
+            public Future<PublishVersionResponse> publishVersion(PublishVersionRequest request) {
+                PublishVersionResponse response = new PublishVersionResponse();
+                response.status = new StatusPB();
+                response.status.statusCode = TStatusCode.OK.getValue();
+                if (request.reshardingTabletInfos == null) {
+                    return CompletableFuture.completedFuture(response);
+                }
+                response.tabletRanges = new HashMap<>();
+                for (ReshardingTabletInfoPB info : request.reshardingTabletInfos) {
+                    addEchoedRanges(info, response.tabletRanges);
+                }
+                return CompletableFuture.completedFuture(response);
+            }
+
+            @Mock
+            public Future<PublishVersionResponse> aggregatePublishVersion(AggregatePublishVersionRequest request) {
+                PublishVersionResponse response = new PublishVersionResponse();
+                response.status = new StatusPB();
+                response.status.statusCode = TStatusCode.OK.getValue();
+                response.tabletRanges = new HashMap<>();
+                for (PublishVersionRequest publishRequest : request.publishReqs) {
+                    if (publishRequest.reshardingTabletInfos == null) {
+                        continue;
+                    }
+                    for (ReshardingTabletInfoPB info : publishRequest.reshardingTabletInfos) {
+                        addEchoedRanges(info, response.tabletRanges);
+                    }
+                }
+                return CompletableFuture.completedFuture(response);
+            }
+        };
+
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex materializedIndex = physicalPartition.getLatestBaseIndex();
+        Tablet oldTablet = materializedIndex.getTablets().get(0);
+        long oldTabletId = oldTablet.getId();
+        long oldVersion = physicalPartition.getVisibleVersion();
+        int oldTabletCount = materializedIndex.getTablets().size();
+
+        // Tests in this class share a single static table, and earlier @Test
+        // methods can leave the latest index's tablets with bounded ranges.
+        // Reset the chosen old tablet to Range.all() so the K=3 PSPS ranges
+        // below — built for a Range.all() parent — are deterministically
+        // valid regardless of test order.
+        oldTablet.setRange(new TabletRange());
+
+        // K=3 PSPS ranges that satisfy the BE-side structural validator on a
+        // Range.all() parent: first.lower absent, last.upper absent, interior
+        // boundaries set with closed-lower / open-upper, adjacent ranges meet
+        // exactly. This mirrors the contract enforced in
+        // TabletRangeHelper::validate_new_tablet_ranges (BE).
+        List<TabletRange> newTabletRanges = List.of(
+                tabletRangeUpperOnly(100),
+                tabletRange(100, 200),
+                tabletRangeLowerOnly(200));
+
+        TabletReshardJob tabletReshardJob = SplitTabletJobFactory.forExternalBoundaries(
+                db, table, oldTabletId, newTabletRanges);
+        Assertions.assertNotNull(tabletReshardJob);
+
+        // The SplittingTablet inside the job must carry the FE-supplied
+        // ranges, and toProto() must serialize them into the wire shape that
+        // BE's split_tablet dispatches on.
+        SplittingTablet splittingTablet = findSplittingTablet(tabletReshardJob, oldTabletId);
+        Assertions.assertEquals(newTabletRanges.size(), splittingTablet.getNewTabletIds().size());
+        Assertions.assertEquals(newTabletRanges.size(), splittingTablet.getNewTabletRanges().size());
+
+        ReshardingTabletInfoPB pb = splittingTablet.toProto();
+        Assertions.assertNotNull(pb.splittingTabletInfo.newTabletRanges,
+                "newTabletRanges must be present on the wire so BE dispatches to PSPS");
+        Assertions.assertEquals(newTabletRanges.size(), pb.splittingTabletInfo.newTabletRanges.size());
+
+        Assertions.assertEquals(TabletReshardJob.JobState.PENDING, tabletReshardJob.getJobState());
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+
+        tabletReshardJob.run();
+        Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, tabletReshardJob.getJobState());
+        Assertions.assertEquals(OlapTable.OlapTableState.TABLET_RESHARD, table.getState());
+
+        tabletReshardJob.run();
+        Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, tabletReshardJob.getJobState());
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        Assertions.assertEquals(oldVersion + 1, physicalPartition.getVisibleVersion());
+
+        // Net effect: the index gained K-1 tablets; the chosen old tablet is
+        // gone; the K new tablets carry the FE-supplied ranges (echoed by the
+        // mocked BE).
+        MaterializedIndex newMaterializedIndex = physicalPartition.getLatestBaseIndex();
+        Assertions.assertEquals(oldTabletCount + (newTabletRanges.size() - 1),
+                newMaterializedIndex.getTablets().size());
+        Assertions.assertNull(GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getTabletMeta(oldTabletId));
+
+        // TabletRangePB (generated jprotobuf class) has no equals override;
+        // compare the underlying Range<Tuple> which does. The values must
+        // match the FE-supplied PSPS ranges position-for-position.
+        List<Long> ids = splittingTablet.getNewTabletIds();
+        for (int idx = 0; idx < ids.size(); idx++) {
+            Tablet newTablet = newMaterializedIndex.getTablet(ids.get(idx));
+            Assertions.assertNotNull(newTablet);
+            Assertions.assertNotNull(newTablet.getRange());
+            Assertions.assertEquals(newTabletRanges.get(idx).getRange(), newTablet.getRange().getRange(),
+                    "new tablet range must match the FE-supplied PSPS range exactly (idx=" + idx + ")");
+        }
+    }
+
+    // forExternalBoundaries rejects non-PSPS-shaped input.
+    @Test
+    public void testForExternalBoundariesRejectsTooFewRanges() {
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        long oldTabletId = physicalPartition.getLatestBaseIndex().getTablets().get(0).getId();
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, oldTabletId,
+                        List.of(tabletRange(0, 100))));
+    }
+
+    @Test
+    public void testForExternalBoundariesRejectsUnknownTablet() {
+        Assertions.assertThrows(com.starrocks.common.StarRocksException.class,
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, /*oldTabletId=*/Long.MAX_VALUE,
+                        List.of(tabletRange(0, 100), tabletRange(100, 200))));
+    }
+
+    // PSPS must respect the tablet_reshard_max_split_count cap that the
+    // data-driven path enforces via TabletReshardUtils.calcSplitCount.
+    @Test
+    public void testForExternalBoundariesRejectsTooManyRanges() {
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        long oldTabletId = physicalPartition.getLatestBaseIndex().getTablets().get(0).getId();
+
+        int oversize = Config.tablet_reshard_max_split_count + 1;
+        List<TabletRange> tooMany = new ArrayList<>(oversize);
+        for (int i = 0; i < oversize; i++) {
+            tooMany.add(tabletRange(i * 100, (i + 1) * 100));
+        }
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, oldTabletId, tooMany));
+    }
+
+    // Mock helper: BE echo of the FE-supplied PSPS ranges, plus identical-tablet
+    // siblings retaining their original ranges. This matches the BE's success
+    // contract — newTabletRanges honored verbatim into K new tablets.
+    private void addEchoedRanges(ReshardingTabletInfoPB info, Map<Long, TabletRangePB> out) {
+        if (info.splittingTabletInfo != null) {
+            List<Long> newTabletIds = info.splittingTabletInfo.newTabletIds;
+            List<TabletRangePB> ranges = info.splittingTabletInfo.newTabletRanges;
+            if (ranges != null && ranges.size() == newTabletIds.size()) {
+                for (int i = 0; i < newTabletIds.size(); i++) {
+                    out.put(newTabletIds.get(i), ranges.get(i));
+                }
+            } else {
+                // Data-driven path fallback (no PSPS ranges on the wire).
+                out.putAll(createSplitTabletRanges(info.splittingTabletInfo.oldTabletId, newTabletIds));
+            }
+        }
+        if (info.identicalTabletInfo != null) {
+            Long oldId = info.identicalTabletInfo.oldTabletId;
+            Long newId = info.identicalTabletInfo.newTabletId;
+            out.put(newId, createTabletRangePBFromOldTablet(oldId));
+        }
+    }
+
+    private static SplittingTablet findSplittingTablet(TabletReshardJob job, long oldTabletId) {
+        SplitTabletJob splitJob = (SplitTabletJob) job;
+        for (ReshardingPhysicalPartition rpp : splitJob.getReshardingPhysicalPartitions().values()) {
+            for (ReshardingMaterializedIndex rmi : rpp.getReshardingIndexes().values()) {
+                for (ReshardingTablet rt : rmi.getReshardingTablets()) {
+                    SplittingTablet st = rt.getSplittingTablet();
+                    if (st != null && st.getOldTabletId() == oldTabletId) {
+                        return st;
+                    }
+                }
+            }
+        }
+        throw new AssertionError("SplittingTablet for old tablet " + oldTabletId + " not found");
+    }
+
+    private static TabletRange tabletRange(int lowerValue, int upperValue) {
+        return new TabletRange(Range.of(createTuple(lowerValue), createTuple(upperValue), true, false));
+    }
+
+    // First range of a PSPS list that splits a Range.all() parent: (-inf, upperValue).
+    private static TabletRange tabletRangeUpperOnly(int upperValue) {
+        return new TabletRange(Range.lt(createTuple(upperValue)));
+    }
+
+    // Last range of a PSPS list that splits a Range.all() parent: [lowerValue, +inf).
+    private static TabletRange tabletRangeLowerOnly(int lowerValue) {
+        return new TabletRange(Range.ge(createTuple(lowerValue)));
+    }
+
     private static Tuple createTuple(int value) {
         return new Tuple(Arrays.asList(Variant.of(IntegerType.INT, String.valueOf(value))));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
 import com.starrocks.common.Range;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.lake.Utils;
 import com.starrocks.proto.AggregatePublishVersionRequest;
@@ -64,6 +65,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 
 public class SplitTabletJobTest {
     protected static ConnectContext connectContext;
@@ -98,68 +100,7 @@ public class SplitTabletJobTest {
 
     @Test
     public void testRunTabletReshardJob() throws Exception {
-        new MockUp<MockLakeService>() {
-            @Mock
-            public Future<PublishVersionResponse> publishVersion(PublishVersionRequest request) {
-                PublishVersionResponse response = new PublishVersionResponse();
-                response.status = new StatusPB();
-                response.status.statusCode = TStatusCode.OK.getValue();
-                if (request.reshardingTabletInfos == null) {
-                    return CompletableFuture.completedFuture(response);
-                }
-
-                response.tabletRanges = new HashMap<>();
-                for (ReshardingTabletInfoPB reshardingTabletInfoPB : request.reshardingTabletInfos) {
-                    if (reshardingTabletInfoPB.splittingTabletInfo != null) {
-                        // For splitting tablets, get the old tablet's range and split it into
-                        // contiguous sub-ranges
-                        Long oldTabletId = reshardingTabletInfoPB.splittingTabletInfo.oldTabletId;
-                        List<Long> newTabletIds = reshardingTabletInfoPB.splittingTabletInfo.newTabletIds;
-                        response.tabletRanges.putAll(createSplitTabletRanges(oldTabletId, newTabletIds));
-                    }
-                    if (reshardingTabletInfoPB.identicalTabletInfo != null) {
-                        // For identical tablets, the new tablet has the same range as the old tablet
-                        Long oldTabletId = reshardingTabletInfoPB.identicalTabletInfo.oldTabletId;
-                        Long newTabletId = reshardingTabletInfoPB.identicalTabletInfo.newTabletId;
-                        response.tabletRanges.put(newTabletId, createTabletRangePBFromOldTablet(oldTabletId));
-                    }
-                }
-
-                return CompletableFuture.completedFuture(response);
-            }
-
-            @Mock
-            public Future<PublishVersionResponse> aggregatePublishVersion(AggregatePublishVersionRequest request) {
-                PublishVersionResponse response = new PublishVersionResponse();
-                response.status = new StatusPB();
-                response.status.statusCode = TStatusCode.OK.getValue();
-                response.tabletRanges = new HashMap<>();
-
-                for (PublishVersionRequest publishRequest : request.publishReqs) {
-                    if (publishRequest.reshardingTabletInfos == null) {
-                        continue;
-                    }
-
-                    for (ReshardingTabletInfoPB reshardingTabletInfoPB : publishRequest.reshardingTabletInfos) {
-                        if (reshardingTabletInfoPB.splittingTabletInfo != null) {
-                            // For splitting tablets, get the old tablet's range and split it into
-                            // contiguous sub-ranges
-                            Long oldTabletId = reshardingTabletInfoPB.splittingTabletInfo.oldTabletId;
-                            List<Long> newTabletIds = reshardingTabletInfoPB.splittingTabletInfo.newTabletIds;
-                            response.tabletRanges.putAll(createSplitTabletRanges(oldTabletId, newTabletIds));
-                        }
-                        if (reshardingTabletInfoPB.identicalTabletInfo != null) {
-                            // For identical tablets, the new tablet has the same range as the old tablet
-                            Long oldTabletId = reshardingTabletInfoPB.identicalTabletInfo.oldTabletId;
-                            Long newTabletId = reshardingTabletInfoPB.identicalTabletInfo.newTabletId;
-                            response.tabletRanges.put(newTabletId, createTabletRangePBFromOldTablet(oldTabletId));
-                        }
-                    }
-                }
-
-                return CompletableFuture.completedFuture(response);
-            }
-        };
+        installLakeServiceMock(this::addDataDrivenRanges);
 
         PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
         MaterializedIndex materializedIndex = physicalPartition.getLatestBaseIndex();
@@ -204,58 +145,7 @@ public class SplitTabletJobTest {
 
     @Test
     public void testFallbackToIdenticalTablet() throws Exception {
-        new MockUp<MockLakeService>() {
-            @Mock
-            public Future<PublishVersionResponse> publishVersion(PublishVersionRequest request) {
-                PublishVersionResponse response = new PublishVersionResponse();
-                response.status = new StatusPB();
-                response.status.statusCode = TStatusCode.OK.getValue();
-                if (request.reshardingTabletInfos == null) {
-                    return CompletableFuture.completedFuture(response);
-                }
-
-                response.tabletRanges = new HashMap<>();
-                for (ReshardingTabletInfoPB reshardingTabletInfoPB : request.reshardingTabletInfos) {
-                    if (reshardingTabletInfoPB.splittingTabletInfo == null) {
-                        continue;
-                    }
-                    // Only return range for the first tablet (fallback to identical tablet).
-                    // The range should be the same as the old tablet's range.
-                    Long oldTabletId = reshardingTabletInfoPB.splittingTabletInfo.oldTabletId;
-                    Long firstTabletId = reshardingTabletInfoPB.splittingTabletInfo.newTabletIds.get(0);
-                    response.tabletRanges.put(firstTabletId, createTabletRangePBFromOldTablet(oldTabletId));
-                }
-
-                return CompletableFuture.completedFuture(response);
-            }
-
-            @Mock
-            public Future<PublishVersionResponse> aggregatePublishVersion(AggregatePublishVersionRequest request) {
-                PublishVersionResponse response = new PublishVersionResponse();
-                response.status = new StatusPB();
-                response.status.statusCode = TStatusCode.OK.getValue();
-                response.tabletRanges = new HashMap<>();
-
-                for (PublishVersionRequest publishRequest : request.publishReqs) {
-                    if (publishRequest.reshardingTabletInfos == null) {
-                        continue;
-                    }
-
-                    for (ReshardingTabletInfoPB reshardingTabletInfoPB : publishRequest.reshardingTabletInfos) {
-                        if (reshardingTabletInfoPB.splittingTabletInfo == null) {
-                            continue;
-                        }
-                        // Only return range for the first tablet (fallback to identical tablet).
-                        // The range should be the same as the old tablet's range.
-                        Long oldTabletId = reshardingTabletInfoPB.splittingTabletInfo.oldTabletId;
-                        Long firstTabletId = reshardingTabletInfoPB.splittingTabletInfo.newTabletIds.get(0);
-                        response.tabletRanges.put(firstTabletId, createTabletRangePBFromOldTablet(oldTabletId));
-                    }
-                }
-
-                return CompletableFuture.completedFuture(response);
-            }
-        };
+        installLakeServiceMock(this::addFallbackToIdenticalRanges);
 
         PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
         MaterializedIndex materializedIndex = physicalPartition.getLatestBaseIndex();
@@ -404,7 +294,7 @@ public class SplitTabletJobTest {
     }
 
     // -------------------------------------------------------------------------
-    // PSPS (Pre-Sample & Pre-Split) end-to-end driver.
+    // external boundaries end-to-end driver.
     //
     // Drives SplitTabletJobFactory.forExternalBoundaries(...) through PENDING
     // -> RUNNING -> FINISHED with a mocked BE that echoes the FE-supplied
@@ -414,40 +304,8 @@ public class SplitTabletJobTest {
     // FE-supplied ranges.
     // -------------------------------------------------------------------------
     @Test
-    public void testRunPspsTabletReshardJob() throws Exception {
-        new MockUp<MockLakeService>() {
-            @Mock
-            public Future<PublishVersionResponse> publishVersion(PublishVersionRequest request) {
-                PublishVersionResponse response = new PublishVersionResponse();
-                response.status = new StatusPB();
-                response.status.statusCode = TStatusCode.OK.getValue();
-                if (request.reshardingTabletInfos == null) {
-                    return CompletableFuture.completedFuture(response);
-                }
-                response.tabletRanges = new HashMap<>();
-                for (ReshardingTabletInfoPB info : request.reshardingTabletInfos) {
-                    addEchoedRanges(info, response.tabletRanges);
-                }
-                return CompletableFuture.completedFuture(response);
-            }
-
-            @Mock
-            public Future<PublishVersionResponse> aggregatePublishVersion(AggregatePublishVersionRequest request) {
-                PublishVersionResponse response = new PublishVersionResponse();
-                response.status = new StatusPB();
-                response.status.statusCode = TStatusCode.OK.getValue();
-                response.tabletRanges = new HashMap<>();
-                for (PublishVersionRequest publishRequest : request.publishReqs) {
-                    if (publishRequest.reshardingTabletInfos == null) {
-                        continue;
-                    }
-                    for (ReshardingTabletInfoPB info : publishRequest.reshardingTabletInfos) {
-                        addEchoedRanges(info, response.tabletRanges);
-                    }
-                }
-                return CompletableFuture.completedFuture(response);
-            }
-        };
+    public void testRunExternalBoundariesTabletReshardJob() throws Exception {
+        installLakeServiceMock(this::addEchoedRanges);
 
         PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
         MaterializedIndex materializedIndex = physicalPartition.getLatestBaseIndex();
@@ -458,12 +316,12 @@ public class SplitTabletJobTest {
 
         // Tests in this class share a single static table, and earlier @Test
         // methods can leave the latest index's tablets with bounded ranges.
-        // Reset the chosen old tablet to Range.all() so the K=3 PSPS ranges
+        // Reset the chosen old tablet to Range.all() so the K=3 external boundaries ranges
         // below — built for a Range.all() parent — are deterministically
         // valid regardless of test order.
         oldTablet.setRange(new TabletRange());
 
-        // K=3 PSPS ranges that satisfy the BE-side structural validator on a
+        // K=3 external boundaries ranges that satisfy the BE-side structural validator on a
         // Range.all() parent: first.lower absent, last.upper absent, interior
         // boundaries set with closed-lower / open-upper, adjacent ranges meet
         // exactly. This mirrors the contract enforced in
@@ -486,7 +344,7 @@ public class SplitTabletJobTest {
 
         ReshardingTabletInfoPB pb = splittingTablet.toProto();
         Assertions.assertNotNull(pb.splittingTabletInfo.newTabletRanges,
-                "newTabletRanges must be present on the wire so BE dispatches to PSPS");
+                "newTabletRanges must be present on the wire so BE dispatches to external boundaries");
         Assertions.assertEquals(newTabletRanges.size(), pb.splittingTabletInfo.newTabletRanges.size());
 
         Assertions.assertEquals(TabletReshardJob.JobState.PENDING, tabletReshardJob.getJobState());
@@ -511,18 +369,18 @@ public class SplitTabletJobTest {
 
         // TabletRangePB (generated jprotobuf class) has no equals override;
         // compare the underlying Range<Tuple> which does. The values must
-        // match the FE-supplied PSPS ranges position-for-position.
+        // match the FE-supplied external boundaries ranges position-for-position.
         List<Long> ids = splittingTablet.getNewTabletIds();
         for (int idx = 0; idx < ids.size(); idx++) {
             Tablet newTablet = newMaterializedIndex.getTablet(ids.get(idx));
             Assertions.assertNotNull(newTablet);
             Assertions.assertNotNull(newTablet.getRange());
             Assertions.assertEquals(newTabletRanges.get(idx).getRange(), newTablet.getRange().getRange(),
-                    "new tablet range must match the FE-supplied PSPS range exactly (idx=" + idx + ")");
+                    "new tablet range must match the FE-supplied external boundaries range exactly (idx=" + idx + ")");
         }
     }
 
-    // forExternalBoundaries rejects non-PSPS-shaped input.
+    // forExternalBoundaries rejects non-external boundaries-shaped input.
     @Test
     public void testForExternalBoundariesRejectsTooFewRanges() {
         PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
@@ -534,12 +392,12 @@ public class SplitTabletJobTest {
 
     @Test
     public void testForExternalBoundariesRejectsUnknownTablet() {
-        Assertions.assertThrows(com.starrocks.common.StarRocksException.class,
+        Assertions.assertThrows(StarRocksException.class,
                 () -> SplitTabletJobFactory.forExternalBoundaries(db, table, /*oldTabletId=*/Long.MAX_VALUE,
                         List.of(tabletRange(0, 100), tabletRange(100, 200))));
     }
 
-    // PSPS must respect the tablet_reshard_max_split_count cap that the
+    // external boundaries must respect the tablet_reshard_max_split_count cap that the
     // data-driven path enforces via TabletReshardUtils.calcSplitCount.
     @Test
     public void testForExternalBoundariesRejectsTooManyRanges() {
@@ -555,7 +413,73 @@ public class SplitTabletJobTest {
                 () -> SplitTabletJobFactory.forExternalBoundaries(db, table, oldTabletId, tooMany));
     }
 
-    // Mock helper: BE echo of the FE-supplied PSPS ranges, plus identical-tablet
+    // Installs a MockUp on MockLakeService that intercepts both publishVersion and
+    // aggregatePublishVersion, populating the response's tabletRanges by applying
+    // {@code rangeBuilder} to every ReshardingTabletInfoPB in the request(s). The
+    // status is always OK; null reshardingTabletInfos are short-circuited.
+    private void installLakeServiceMock(BiConsumer<ReshardingTabletInfoPB, Map<Long, TabletRangePB>> rangeBuilder) {
+        new MockUp<MockLakeService>() {
+            @Mock
+            public Future<PublishVersionResponse> publishVersion(PublishVersionRequest request) {
+                PublishVersionResponse response = new PublishVersionResponse();
+                response.status = new StatusPB();
+                response.status.statusCode = TStatusCode.OK.getValue();
+                if (request.reshardingTabletInfos == null) {
+                    return CompletableFuture.completedFuture(response);
+                }
+                response.tabletRanges = new HashMap<>();
+                for (ReshardingTabletInfoPB info : request.reshardingTabletInfos) {
+                    rangeBuilder.accept(info, response.tabletRanges);
+                }
+                return CompletableFuture.completedFuture(response);
+            }
+
+            @Mock
+            public Future<PublishVersionResponse> aggregatePublishVersion(AggregatePublishVersionRequest request) {
+                PublishVersionResponse response = new PublishVersionResponse();
+                response.status = new StatusPB();
+                response.status.statusCode = TStatusCode.OK.getValue();
+                response.tabletRanges = new HashMap<>();
+                for (PublishVersionRequest publishRequest : request.publishReqs) {
+                    if (publishRequest.reshardingTabletInfos == null) {
+                        continue;
+                    }
+                    for (ReshardingTabletInfoPB info : publishRequest.reshardingTabletInfos) {
+                        rangeBuilder.accept(info, response.tabletRanges);
+                    }
+                }
+                return CompletableFuture.completedFuture(response);
+            }
+        };
+    }
+
+    // Mock helper: data-driven BE response. Splitting tablets get evenly-distributed
+    // sub-ranges of the old tablet; identical tablets retain the old tablet's range.
+    private void addDataDrivenRanges(ReshardingTabletInfoPB info, Map<Long, TabletRangePB> out) {
+        if (info.splittingTabletInfo != null) {
+            Long oldTabletId = info.splittingTabletInfo.oldTabletId;
+            List<Long> newTabletIds = info.splittingTabletInfo.newTabletIds;
+            out.putAll(createSplitTabletRanges(oldTabletId, newTabletIds));
+        }
+        if (info.identicalTabletInfo != null) {
+            Long oldTabletId = info.identicalTabletInfo.oldTabletId;
+            Long newTabletId = info.identicalTabletInfo.newTabletId;
+            out.put(newTabletId, createTabletRangePBFromOldTablet(oldTabletId));
+        }
+    }
+
+    // Mock helper: BE-side fallback to identical tablet. Only the first new tablet
+    // is published, with the old tablet's range (no actual split happened).
+    private void addFallbackToIdenticalRanges(ReshardingTabletInfoPB info, Map<Long, TabletRangePB> out) {
+        if (info.splittingTabletInfo == null) {
+            return;
+        }
+        Long oldTabletId = info.splittingTabletInfo.oldTabletId;
+        Long firstTabletId = info.splittingTabletInfo.newTabletIds.get(0);
+        out.put(firstTabletId, createTabletRangePBFromOldTablet(oldTabletId));
+    }
+
+    // Mock helper: BE echo of the FE-supplied external boundaries ranges, plus identical-tablet
     // siblings retaining their original ranges. This matches the BE's success
     // contract — newTabletRanges honored verbatim into K new tablets.
     private void addEchoedRanges(ReshardingTabletInfoPB info, Map<Long, TabletRangePB> out) {
@@ -567,7 +491,7 @@ public class SplitTabletJobTest {
                     out.put(newTabletIds.get(i), ranges.get(i));
                 }
             } else {
-                // Data-driven path fallback (no PSPS ranges on the wire).
+                // Data-driven path fallback (no external boundaries ranges on the wire).
                 out.putAll(createSplitTabletRanges(info.splittingTabletInfo.oldTabletId, newTabletIds));
             }
         }
@@ -597,12 +521,12 @@ public class SplitTabletJobTest {
         return new TabletRange(Range.of(createTuple(lowerValue), createTuple(upperValue), true, false));
     }
 
-    // First range of a PSPS list that splits a Range.all() parent: (-inf, upperValue).
+    // First range of a external boundaries list that splits a Range.all() parent: (-inf, upperValue).
     private static TabletRange tabletRangeUpperOnly(int upperValue) {
         return new TabletRange(Range.lt(createTuple(upperValue)));
     }
 
-    // Last range of a PSPS list that splits a Range.all() parent: [lowerValue, +inf).
+    // Last range of a external boundaries list that splits a Range.all() parent: [lowerValue, +inf).
     private static TabletRange tabletRangeLowerOnly(int lowerValue) {
         return new TabletRange(Range.ge(createTuple(lowerValue)));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplittingTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplittingTabletTest.java
@@ -1,0 +1,102 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.proto.SplittingTabletInfoPB;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.starrocks.persist.gson.GsonUtils.GSON;
+
+public class SplittingTabletTest {
+
+    @Test
+    public void testJsonRoundTripPreservesEmptyRanges() {
+        // Data-driven-path round-trip: empty newTabletRanges remains empty.
+        SplittingTablet original = new SplittingTablet(2, new ArrayList<>(List.of(21L, 22L)));
+        String json = GSON.toJson(original);
+        SplittingTablet copy = GSON.fromJson(json, SplittingTablet.class);
+
+        Assertions.assertNotNull(copy.getNewTabletRanges());
+        Assertions.assertTrue(copy.getNewTabletRanges().isEmpty());
+        Assertions.assertNull(copy.toProto().splittingTabletInfo.newTabletRanges);
+    }
+
+    @Test
+    public void testConstructorRejectsNullList() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new SplittingTablet(2, List.of(21L, 22L), null));
+    }
+
+    @Test
+    public void testConstructorRejectsNullElements() {
+        // An internal PSPS caller passing a list with a null entry must fail
+        // at construction with context, not later in the toProto() stream.
+        List<TabletRange> ranges = Arrays.asList(new TabletRange(), null);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new SplittingTablet(2, List.of(21L, 22L), ranges));
+    }
+
+    @Test
+    public void testConstructorRejectsSizeMismatch() {
+        List<TabletRange> ranges = List.of(new TabletRange(), new TabletRange(), new TabletRange());
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> new SplittingTablet(2, List.of(21L, 22L), ranges));
+    }
+
+    @Test
+    public void testConstructorAcceptsEmptyRangesList() {
+        SplittingTablet t = new SplittingTablet(2, new ArrayList<>(List.of(21L, 22L)),
+                Collections.emptyList());
+        Assertions.assertTrue(t.getNewTabletRanges().isEmpty());
+    }
+
+    @Test
+    public void testFallbackClearsBothListsForPspsPath() {
+        // PSPS-shaped SplittingTablet with K=3 ranges. After fallback, only
+        // the first new tablet survives and the K-entry ranges list must be
+        // cleared to keep invariants consistent.
+        List<TabletRange> ranges = new ArrayList<>(List.of(new TabletRange(), new TabletRange(), new TabletRange()));
+        SplittingTablet t = new SplittingTablet(2, new ArrayList<>(List.of(21L, 22L, 23L)), ranges);
+
+        Assertions.assertFalse(t.isIdenticalTablet());
+        Assertions.assertEquals(3, t.getNewTabletRanges().size());
+
+        t.fallbackToIdenticalTablet();
+
+        Assertions.assertTrue(t.isIdenticalTablet());
+        Assertions.assertEquals(1, t.getNewTabletIds().size());
+        Assertions.assertTrue(t.getNewTabletRanges().isEmpty(),
+                "fallback must clear stale FE-supplied ranges along with the trailing new tablet ids");
+    }
+
+    @Test
+    public void testToProtoSerializesNonEmptyRanges() {
+        List<TabletRange> ranges = List.of(new TabletRange(), new TabletRange());
+        SplittingTablet t = new SplittingTablet(2, new ArrayList<>(List.of(21L, 22L)), ranges);
+
+        SplittingTabletInfoPB pb = t.toProto().splittingTabletInfo;
+        Assertions.assertEquals(Long.valueOf(2), pb.oldTabletId);
+        Assertions.assertEquals(List.of(21L, 22L), pb.newTabletIds);
+        Assertions.assertNotNull(pb.newTabletRanges);
+        Assertions.assertEquals(2, pb.newTabletRanges.size());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplittingTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplittingTabletTest.java
@@ -48,8 +48,8 @@ public class SplittingTabletTest {
 
     @Test
     public void testConstructorRejectsNullElements() {
-        // An internal PSPS caller passing a list with a null entry must fail
-        // at construction with context, not later in the toProto() stream.
+        // An internal external-boundaries caller passing a list with a null entry must
+        // fail at construction with context, not later in the toProto() stream.
         List<TabletRange> ranges = Arrays.asList(new TabletRange(), null);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> new SplittingTablet(2, List.of(21L, 22L), ranges));
@@ -70,10 +70,10 @@ public class SplittingTabletTest {
     }
 
     @Test
-    public void testFallbackClearsBothListsForPspsPath() {
-        // PSPS-shaped SplittingTablet with K=3 ranges. After fallback, only
-        // the first new tablet survives and the K-entry ranges list must be
-        // cleared to keep invariants consistent.
+    public void testFallbackClearsBothListsForExternalBoundariesPath() {
+        // External-boundaries-shaped SplittingTablet with K=3 ranges. After
+        // fallback, only the first new tablet survives and the K-entry ranges
+        // list must be cleared to keep invariants consistent.
         List<TabletRange> ranges = new ArrayList<>(List.of(new TabletRange(), new TabletRange(), new TabletRange()));
         SplittingTablet t = new SplittingTablet(2, new ArrayList<>(List.of(21L, 22L, 23L)), ranges);
 
@@ -86,6 +86,23 @@ public class SplittingTabletTest {
         Assertions.assertEquals(1, t.getNewTabletIds().size());
         Assertions.assertTrue(t.getNewTabletRanges().isEmpty(),
                 "fallback must clear stale FE-supplied ranges along with the trailing new tablet ids");
+    }
+
+    @Test
+    public void testLegacyJsonWithoutNewTabletRangesDeserializesToEmptyList() {
+        // Rolling-upgrade hazard: a SplittingTablet serialized before the
+        // newTabletRanges field existed will lack the key entirely. Gson must
+        // invoke the no-arg constructor and let the field initializer leave the
+        // list non-null so toProto / fallbackToIdenticalTablet do not NPE.
+        String legacyJson = "{\"oldTabletId\":2,\"newTabletIds\":[21,22]}";
+        SplittingTablet copy = GSON.fromJson(legacyJson, SplittingTablet.class);
+
+        Assertions.assertNotNull(copy.getNewTabletRanges(), "legacy record must yield a non-null ranges list");
+        Assertions.assertTrue(copy.getNewTabletRanges().isEmpty());
+        // The fallback path must work even on a legacy record carried through
+        // a state transition post-upgrade.
+        copy.fallbackToIdenticalTablet();
+        Assertions.assertTrue(copy.isIdenticalTablet());
     }
 
     @Test

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -427,7 +427,7 @@ message TxnInfoPB {
 message SplittingTabletInfoPB {
     optional int64 old_tablet_id = 1;
     repeated int64 new_tablet_ids = 2;
-    // FE-supplied new-tablet ranges (PSPS / Pre-Sample & Pre-Split path).
+    // FE-supplied new-tablet ranges (external-boundaries path).
     // When non-empty:
     //   - BE skips data-driven boundary computation in `split_tablet` and
     //     dispatches to `compute_split_ranges_from_external_boundaries`

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -427,6 +427,18 @@ message TxnInfoPB {
 message SplittingTabletInfoPB {
     optional int64 old_tablet_id = 1;
     repeated int64 new_tablet_ids = 2;
+    // FE-supplied new-tablet ranges (PSPS / Pre-Sample & Pre-Split path).
+    // When non-empty:
+    //   - BE skips data-driven boundary computation in `split_tablet` and
+    //     dispatches to `compute_split_ranges_from_external_boundaries`
+    //     instead, which honors these ranges verbatim.
+    //   - Size MUST equal new_tablet_ids.size.
+    //   - Ranges MUST cover the old tablet's range exactly with no gaps/overlaps.
+    //   - Each range uses [lower, upper) (upper_bound_included=false).
+    // Upgrade ordering policy: BE is upgraded before FE, so any FE that
+    // populates this field is guaranteed to be talking to BEs that consume
+    // it; no separate capability flag is needed.
+    repeated TabletRangePB new_tablet_ranges = 3;
 }
 
 message MergingTabletInfoPB {

--- a/test/sql/test_colocate_range/R/test_colocate_range_basic_create
+++ b/test/sql/test_colocate_range/R/test_colocate_range_basic_create
@@ -1,26 +1,43 @@
 -- name: test_colocate_range_basic_create @cloud @sequential
--- SQL integration: basic CREATE / DROP of range-colocate tables.
--- Verifies two tables can join the same colocate group without error.
 set enable_range_distribution = true;
-
+-- result:
+-- !result
 create database db_${uuid0};
+-- result:
+-- !result
 use db_${uuid0};
-
+-- result:
+-- !result
 create table t1 (k1 int, k2 int)
     order by(k1, k2)
     properties('replication_num' = '1', 'colocate_with' = 'grp_basic_${uuid0}:k1');
-
+-- result:
+-- !result
 create table t2 (k1 int, k2 int)
     order by(k1, k2)
     properties('replication_num' = '1', 'colocate_with' = 'grp_basic_${uuid0}:k1');
-
--- Both tables should accept inserts; result is checkable without uuid dependency.
+-- result:
+-- !result
 insert into t1 values (1, 10), (2, 20);
+-- result:
+-- !result
 insert into t2 values (1, 100), (2, 200);
-
+-- result:
+-- !result
 select count(*) from t1;
+-- result:
+2
+-- !result
 select count(*) from t2;
-
+-- result:
+2
+-- !result
 drop table t2;
+-- result:
+-- !result
 drop table t1;
+-- result:
+-- !result
 drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_colocate_range/R/test_colocate_range_cross_db_group
+++ b/test/sql/test_colocate_range/R/test_colocate_range_cross_db_group
@@ -1,0 +1,42 @@
+-- name: test_colocate_range_cross_db_group @cloud @sequential
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0}_a;
+-- result:
+-- !result
+create database db_${uuid0}_b;
+-- result:
+-- !result
+create table db_${uuid0}_a.t_left (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_xdb_${uuid0}:k1');
+-- result:
+-- !result
+create table db_${uuid0}_b.t_right (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_xdb_${uuid0}:k1');
+-- result:
+-- !result
+insert into db_${uuid0}_a.t_left values (1, 10), (2, 20), (3, 30);
+-- result:
+-- !result
+insert into db_${uuid0}_b.t_right values (1, 100), (2, 200), (3, 300);
+-- result:
+-- !result
+select count(*) from db_${uuid0}_a.t_left l join db_${uuid0}_b.t_right r on l.k1 = r.k1;
+-- result:
+3
+-- !result
+drop table db_${uuid0}_a.t_left;
+-- result:
+-- !result
+drop table db_${uuid0}_b.t_right;
+-- result:
+-- !result
+drop database db_${uuid0}_a;
+-- result:
+-- !result
+drop database db_${uuid0}_b;
+-- result:
+-- !result

--- a/test/sql/test_colocate_range/R/test_colocate_range_cross_table_join
+++ b/test/sql/test_colocate_range/R/test_colocate_range_cross_table_join
@@ -1,27 +1,39 @@
 -- name: test_colocate_range_cross_table_join @cloud @sequential
--- SQL integration: colocate join across two tables in the same range-colocate group.
--- Verifies the plan uses COLOCATE join (not SHUFFLE / BROADCAST) when both sides
--- share the same grpId. Tablet ids in EXPLAIN are uuid-dependent so the result
--- assertion focuses on the join semantics, while plan-shape is covered by FE
--- optimizer plan tests (see ColocateCheckerTest / RangeColocateJoinTest).
 set enable_range_distribution = true;
-
+-- result:
+-- !result
 create database db_${uuid0};
+-- result:
+-- !result
 use db_${uuid0};
-
+-- result:
+-- !result
 create table tenants (tenant_id int, created_time int, id int)
     order by(tenant_id, created_time, id)
     properties('replication_num' = '1', 'colocate_with' = 'grp_join_${uuid0}:tenant_id');
-
+-- result:
+-- !result
 create table events (tenant_id int, created_time int, event_id int)
     order by(tenant_id, created_time, event_id)
     properties('replication_num' = '1', 'colocate_with' = 'grp_join_${uuid0}:tenant_id');
-
+-- result:
+-- !result
 insert into tenants values (1, 100, 1), (2, 200, 2), (3, 300, 3);
+-- result:
+-- !result
 insert into events values (1, 100, 11), (2, 200, 22), (3, 300, 33);
-
+-- result:
+-- !result
 select count(*) from tenants t join events e on t.tenant_id = e.tenant_id;
-
+-- result:
+3
+-- !result
 drop table events;
+-- result:
+-- !result
 drop table tenants;
+-- result:
+-- !result
 drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_colocate_range/R/test_colocate_range_dml_roundtrip
+++ b/test/sql/test_colocate_range/R/test_colocate_range_dml_roundtrip
@@ -1,0 +1,50 @@
+-- name: test_colocate_range_dml_roundtrip @cloud @sequential
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (k1 int, k2 int, v int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_dml_${uuid0}:k1');
+-- result:
+-- !result
+insert into t values
+    (1, 10, 100), (1, 11, 110),
+    (2, 20, 200), (2, 21, 210),
+    (3, 30, 300), (3, 31, 310);
+-- result:
+-- !result
+select count(*) from t;
+-- result:
+6
+-- !result
+select sum(v) from t;
+-- result:
+1230
+-- !result
+delete from t where k1 = 2;
+-- result:
+-- !result
+select count(*) from t;
+-- result:
+4
+-- !result
+select sum(v) from t;
+-- result:
+820
+-- !result
+select count(distinct k1) from t;
+-- result:
+2
+-- !result
+drop table t;
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_colocate_range/R/test_colocate_range_group_by_prefix
+++ b/test/sql/test_colocate_range/R/test_colocate_range_group_by_prefix
@@ -1,0 +1,43 @@
+-- name: test_colocate_range_group_by_prefix @cloud @sequential
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (k1 int, k2 int, v int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_agg_${uuid0}:k1');
+-- result:
+-- !result
+insert into t (k1, k2, v)
+select cast(x % 4 as int), x, x from table(generate_series(1, 40)) as g(x);
+-- result:
+-- !result
+select k1, count(*) from t group by k1 order by k1;
+-- result:
+0	10
+1	10
+2	10
+3	10
+-- !result
+select k1, sum(v) from t group by k1 order by k1;
+-- result:
+0	220
+1	190
+2	200
+3	210
+-- !result
+select count(*) from t;
+-- result:
+40
+-- !result
+drop table t;
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_colocate_range/R/test_colocate_range_intra_partition_split
+++ b/test/sql/test_colocate_range/R/test_colocate_range_intra_partition_split
@@ -1,0 +1,30 @@
+-- name: test_colocate_range_intra_partition_split @cloud @sequential
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (k1 int, k2 int, v int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_intra_${uuid0}:k1');
+-- result:
+-- !result
+insert into t (k1, k2, v)
+select 100, x, x from table(generate_series(1, 1000)) as g(x);
+-- result:
+-- !result
+[UC]alter table t split tablet properties('tablet_reshard_target_size' = '1024');
+select count(*) from t a join t b on a.k1 = b.k1;
+-- result:
+1000000
+-- !result
+drop table t;
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_colocate_range/R/test_colocate_range_self_join_on_prefix
+++ b/test/sql/test_colocate_range/R/test_colocate_range_self_join_on_prefix
@@ -1,0 +1,33 @@
+-- name: test_colocate_range_self_join_on_prefix @cloud @sequential
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (k1 int, k2 int, v int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_self_${uuid0}:k1');
+-- result:
+-- !result
+insert into t (k1, k2, v)
+select x % 50, x, x from table(generate_series(1, 100)) as g(x);
+-- result:
+-- !result
+select count(*) from t a join t b on a.k1 = b.k1;
+-- result:
+200
+-- !result
+select count(*) from t a join t b on a.k1 = b.k1 where a.v >= 0;
+-- result:
+200
+-- !result
+drop table t;
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_colocate_range/R/test_colocate_range_three_way_join
+++ b/test/sql/test_colocate_range/R/test_colocate_range_three_way_join
@@ -1,0 +1,54 @@
+-- name: test_colocate_range_three_way_join @cloud @sequential
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table a (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_three_${uuid0}:k1');
+-- result:
+-- !result
+create table b (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_three_${uuid0}:k1');
+-- result:
+-- !result
+create table c (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_three_${uuid0}:k1');
+-- result:
+-- !result
+insert into a values (1, 10), (2, 20), (3, 30);
+-- result:
+-- !result
+insert into b values (1, 100), (2, 200), (3, 300);
+-- result:
+-- !result
+insert into c values (1, 1000), (2, 2000), (3, 3000);
+-- result:
+-- !result
+select count(*) from a join b on a.k1 = b.k1 join c on a.k1 = c.k1;
+-- result:
+3
+-- !result
+select count(*) from a join b on a.k1 = b.k1 join c on b.k1 = c.k1;
+-- result:
+3
+-- !result
+drop table c;
+-- result:
+-- !result
+drop table b;
+-- result:
+-- !result
+drop table a;
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_colocate_range/README.md
+++ b/test/sql/test_colocate_range/README.md
@@ -1,0 +1,9 @@
+## test_colocate_range tests
+
+Colocate-checker SQL integration tests. T/ files exist; R/ recordings
+are absent — they require a real BE in shared-data mode and are recorded via TSP.
+
+The fail-closed-then-recover scenarios (Level-1 split observed before scanner
+converges) need a millisecond-scale pause that the scanner does not currently
+expose, so those cases are covered by FE unit tests
+(`ColocateCheckerTest`) instead and not duplicated here.

--- a/test/sql/test_colocate_range/T/test_colocate_range_basic_create
+++ b/test/sql/test_colocate_range/T/test_colocate_range_basic_create
@@ -1,0 +1,24 @@
+-- name: test_colocate_range_basic_create @cloud @sequential
+-- SQL integration: basic CREATE / DROP of range-colocate tables.
+-- TSP-recorded R/ file pending; case definition lives here so the checker coverage
+-- can be regression-tracked once the test cluster supports range distribution.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1 (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_basic_${uuid0}:k1');
+
+show create table t1;
+
+create table t2 (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_basic_${uuid0}:k1');
+
+show create table t2;
+
+drop table t2;
+drop table t1;
+drop database db_${uuid0};

--- a/test/sql/test_colocate_range/T/test_colocate_range_cross_db_group
+++ b/test/sql/test_colocate_range/T/test_colocate_range_cross_db_group
@@ -1,0 +1,28 @@
+-- name: test_colocate_range_cross_db_group @cloud @sequential
+-- SQL integration: same colocate group across two databases. Verifies the
+-- ColocateTableIndex peer-GroupId resolution works when two tables in
+-- different DBs share the same colocateGroupId. The cross-DB join uses
+-- fully-qualified names; the result count is deterministic.
+set enable_range_distribution = true;
+
+create database db_${uuid0}_a;
+create database db_${uuid0}_b;
+
+create table db_${uuid0}_a.t_left (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_xdb_${uuid0}:k1');
+
+create table db_${uuid0}_b.t_right (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_xdb_${uuid0}:k1');
+
+insert into db_${uuid0}_a.t_left values (1, 10), (2, 20), (3, 30);
+insert into db_${uuid0}_b.t_right values (1, 100), (2, 200), (3, 300);
+
+-- cross-DB colocate join on the colocate-prefix column
+select count(*) from db_${uuid0}_a.t_left l join db_${uuid0}_b.t_right r on l.k1 = r.k1;
+
+drop table db_${uuid0}_a.t_left;
+drop table db_${uuid0}_b.t_right;
+drop database db_${uuid0}_a;
+drop database db_${uuid0}_b;

--- a/test/sql/test_colocate_range/T/test_colocate_range_cross_table_join
+++ b/test/sql/test_colocate_range/T/test_colocate_range_cross_table_join
@@ -1,0 +1,27 @@
+-- name: test_colocate_range_cross_table_join @cloud @sequential
+-- SQL integration: colocate join across two tables in the same range-colocate group.
+-- Verifies the plan picks COLOCATE join (not SHUFFLE) when both sides share the same grpId.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table tenants (tenant_id int, created_time int, id int)
+    order by(tenant_id, created_time, id)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_join_${uuid0}:tenant_id');
+
+create table events (tenant_id int, created_time int, event_id int)
+    order by(tenant_id, created_time, event_id)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_join_${uuid0}:tenant_id');
+
+insert into tenants values (1, 100, 1), (2, 200, 2), (3, 300, 3);
+insert into events values (1, 100, 11), (2, 200, 22), (3, 300, 33);
+
+-- Both sides join on the full colocate-prefix (tenant_id); plan must show COLOCATE.
+explain select count(*) from tenants t join events e on t.tenant_id = e.tenant_id;
+
+select count(*) from tenants t join events e on t.tenant_id = e.tenant_id;
+
+drop table events;
+drop table tenants;
+drop database db_${uuid0};

--- a/test/sql/test_colocate_range/T/test_colocate_range_dml_roundtrip
+++ b/test/sql/test_colocate_range/T/test_colocate_range_dml_roundtrip
@@ -1,0 +1,29 @@
+-- name: test_colocate_range_dml_roundtrip @cloud @sequential
+-- SQL integration: insert / delete / select round-trip on a range-colocate
+-- table. Verifies write paths stay correct after the colocate-group setup.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (k1 int, k2 int, v int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_dml_${uuid0}:k1');
+
+insert into t values
+    (1, 10, 100), (1, 11, 110),
+    (2, 20, 200), (2, 21, 210),
+    (3, 30, 300), (3, 31, 310);
+
+select count(*) from t;
+select sum(v) from t;
+
+-- delete one k1 partition's worth of rows
+delete from t where k1 = 2;
+
+select count(*) from t;
+select sum(v) from t;
+select count(distinct k1) from t;
+
+drop table t;
+drop database db_${uuid0};

--- a/test/sql/test_colocate_range/T/test_colocate_range_group_by_prefix
+++ b/test/sql/test_colocate_range/T/test_colocate_range_group_by_prefix
@@ -1,0 +1,25 @@
+-- name: test_colocate_range_group_by_prefix @cloud @sequential
+-- SQL integration: GROUP BY on the colocate-prefix column. Verifies aggregate
+-- results are correct on a range-colocate table.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (k1 int, k2 int, v int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_agg_${uuid0}:k1');
+
+-- 4 keys × 10 rows each = 40 rows; per-group sum is deterministic.
+insert into t (k1, k2, v)
+select cast(x % 4 as int), x, x from table(generate_series(1, 40)) as g(x);
+
+-- count per colocate-prefix value
+select k1, count(*) from t group by k1 order by k1;
+-- sum per colocate-prefix value
+select k1, sum(v) from t group by k1 order by k1;
+-- total
+select count(*) from t;
+
+drop table t;
+drop database db_${uuid0};

--- a/test/sql/test_colocate_range/T/test_colocate_range_intra_partition_split
+++ b/test/sql/test_colocate_range/T/test_colocate_range_intra_partition_split
@@ -1,0 +1,26 @@
+-- name: test_colocate_range_intra_partition_split @cloud @sequential
+-- SQL integration: Level-2 (intra-colocate) tablet split. Children stay inside
+-- the same ColocateRange so ColocateRangeMgr is unchanged and the group stays stable.
+-- No checker-pause needed: Level-2 never produces an unstable group, so the colocate
+-- checker finds no work and does not interfere with the assertions.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (k1 int, k2 int, v int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_intra_${uuid0}:k1');
+
+-- Seed enough rows in a single colocate prefix (k1=100) to make a Level-2 split meaningful.
+insert into t (k1, k2, v)
+select 100, x, x from generate_series(1, 1000) as g(x);
+
+-- Manual split inside a single colocate prefix. Children stay in the same ColocateRange.
+alter table t split tablet properties('tablet_reshard_target_size' = '1024');
+
+-- Group must remain stable (no canonical boundary crossed).
+select count(*) from t a join t b on a.k1 = b.k1;
+
+drop table t;
+drop database db_${uuid0};

--- a/test/sql/test_colocate_range/T/test_colocate_range_intra_partition_split
+++ b/test/sql/test_colocate_range/T/test_colocate_range_intra_partition_split
@@ -1,8 +1,13 @@
 -- name: test_colocate_range_intra_partition_split @cloud @sequential
 -- SQL integration: Level-2 (intra-colocate) tablet split. Children stay inside
--- the same ColocateRange so ColocateRangeMgr is unchanged and the group stays stable.
--- No checker-pause needed: Level-2 never produces an unstable group, so the colocate
--- checker finds no work and does not interfere with the assertions.
+-- the same ColocateRange so ColocateRangeMgr is unchanged and the group stays
+-- stable. No checker-pause needed: Level-2 never produces an unstable group, so
+-- the colocate checker finds no work and does not interfere with the assertions.
+--
+-- Note: with a tiny seed dataset the FE may decide no split is needed; the test
+-- still validates that the join result remains correct whether or not a split
+-- actually fires. Use [UC] on the alter to avoid asserting on a uuid-bearing
+-- error string.
 set enable_range_distribution = true;
 
 create database db_${uuid0};
@@ -12,14 +17,17 @@ create table t (k1 int, k2 int, v int)
     order by(k1, k2)
     properties('replication_num' = '1', 'colocate_with' = 'grp_intra_${uuid0}:k1');
 
--- Seed enough rows in a single colocate prefix (k1=100) to make a Level-2 split meaningful.
+-- Seed enough rows in a single colocate prefix (k1=100) to make a Level-2 split
+-- meaningful when the threshold is met.
 insert into t (k1, k2, v)
-select 100, x, x from generate_series(1, 1000) as g(x);
+select 100, x, x from table(generate_series(1, 1000)) as g(x);
 
--- Manual split inside a single colocate prefix. Children stay in the same ColocateRange.
-alter table t split tablet properties('tablet_reshard_target_size' = '1024');
+-- Manual split inside a single colocate prefix. Children stay in the same
+-- ColocateRange. [UC] avoids asserting on the (uuid-bearing) "no tablets need
+-- to split" message that surfaces when the tablet is below the size threshold.
+[UC]alter table t split tablet properties('tablet_reshard_target_size' = '1024');
 
--- Group must remain stable (no canonical boundary crossed).
+-- Group must remain stable (no canonical boundary crossed) and result correct.
 select count(*) from t a join t b on a.k1 = b.k1;
 
 drop table t;

--- a/test/sql/test_colocate_range/T/test_colocate_range_self_join_on_prefix
+++ b/test/sql/test_colocate_range/T/test_colocate_range_self_join_on_prefix
@@ -1,0 +1,29 @@
+-- name: test_colocate_range_self_join_on_prefix @cloud @sequential
+-- SQL integration: self-join on the colocate-prefix column. Both sides of the
+-- join read from the same table, so the partition layout matches by
+-- construction; verifies the result count and that no shuffle is required.
+-- The count assertion is deterministic regardless of the underlying tablet
+-- layout (sharded or single).
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (k1 int, k2 int, v int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_self_${uuid0}:k1');
+
+-- two rows per k1 across 50 distinct k1 values.
+insert into t (k1, k2, v)
+select x % 50, x, x from table(generate_series(1, 100)) as g(x);
+
+-- self join on k1: for each k1 with 2 rows, the join produces 4 rows; with
+-- 50 distinct k1 values → 50 * 4 = 200 rows.
+select count(*) from t a join t b on a.k1 = b.k1;
+
+-- equivalent join with an extra non-prefix predicate that doesn't change the
+-- semantic answer; verifies the predicate plumbing didn't break colocate.
+select count(*) from t a join t b on a.k1 = b.k1 where a.v >= 0;
+
+drop table t;
+drop database db_${uuid0};

--- a/test/sql/test_colocate_range/T/test_colocate_range_three_way_join
+++ b/test/sql/test_colocate_range/T/test_colocate_range_three_way_join
@@ -1,0 +1,34 @@
+-- name: test_colocate_range_three_way_join @cloud @sequential
+-- SQL integration: three tables in the same range-colocate group joined on the
+-- shared colocate-prefix column. Verifies the optimizer can chain three
+-- colocate joins without falling back to shuffle/broadcast and that the result
+-- count is preserved through the chain.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table a (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_three_${uuid0}:k1');
+
+create table b (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_three_${uuid0}:k1');
+
+create table c (k1 int, k2 int)
+    order by(k1, k2)
+    properties('replication_num' = '1', 'colocate_with' = 'grp_three_${uuid0}:k1');
+
+insert into a values (1, 10), (2, 20), (3, 30);
+insert into b values (1, 100), (2, 200), (3, 300);
+insert into c values (1, 1000), (2, 2000), (3, 3000);
+
+-- chain three colocate-aligned joins; each pair shares the same partition layout.
+select count(*) from a join b on a.k1 = b.k1 join c on a.k1 = c.k1;
+select count(*) from a join b on a.k1 = b.k1 join c on b.k1 = c.k1;
+
+drop table c;
+drop table b;
+drop table a;
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

After a Level-1 colocate-boundary split splices a new `ColocateRange` and PACK shard group, every other partition / table / DB in the same colocate group is left mid-aligned: `RangeColocateScanDispatch` fails closed on the misalignment, and `SplitTabletJobFactory` blocks new user-driven splits while any peer GroupId is unstable. Without an auto-recovery mechanism, a single Level-1 split puts the colocate group in a permanently broken state.

## What I'm doing:

This PR bundles two layers, structured as two commits:

**Commit 1 — External-boundaries path for tablet split.** Substrate for splitting a tablet by FE-supplied boundaries instead of BE-computed segment-distribution boundaries. FE pre-computes K-1 sort-key boundaries and passes them on the publish RPC; BE honors the boundaries verbatim while computing per-rowset stats internally. Symmetric identical-fallback on either path's validation failure.

**Commit 2 — Leader-only `ColocateChecker`.** Drives every unstable range-colocate `colocateGroupId` × table × visible index toward range alignment with `ColocateRangeMgr`'s expected ranges. Uses the external-boundaries substrate from commit 1: per-tablet canonical boundaries are converted to per-new-tablet `TabletRange` lists and submitted via `SplittingTablet.newTabletRanges`, so BE dispatches to `compute_split_ranges_from_external_boundaries` on publish.

### External-boundaries layer (commit 1)

- **Proto** (`gensrc/proto/lake_types.proto`): `SplittingTabletInfoPB.new_tablet_ranges` (repeated `TabletRangePB`) on the publish RPC.
- **BE** (`tablet_splitter.cpp`): `compute_split_ranges_from_external_boundaries` produces `vector<TabletRangeInfo>` from `external_ranges`, reusing `distribute_segment_to_ranges` / `build_rowset_anchor` / `apply_rowset_anchor` so per-rowset stat math is identical to the data-driven path. Distinct bvar counters distinguish external-boundaries vs data-driven fallback sources.
- **BE** (`tablet_range_helper.cpp`): `TabletRangeHelper::validate_new_tablet_ranges` — schema-free structural validator: closed-open per range, no byte-equal zero-width child, first.lower / last.upper match parent, adjacent ranges tile exactly via `tuple_pb_equal` (`MessageDifferencer::Equals` wrapper).
- **BE schema-aware bound validation**: reads `TabletSchemaPB` directly (no `TabletSchema::create` allocation); precomputes sort-key column metadata once per call; rejects type mismatches and decimal precision/scale mismatches with readable error messages.
- **Refactors**: `make_identical_new_tablet_metadata` helper + `build_new_tablets_from_split_ranges` helper + `build_segments_from_rowsets` shared between data-driven and external-boundaries paths.
- **FE**: `SplittingTablet.newTabletRanges` field + Gson journaling; `SplitTabletJobFactory.forExternalBoundaries` entry accepts a caller-supplied range list.

### Alignment-checker layer (commit 2)

- **`ColocateChecker`** — stateless POJO held by `TabletReshardJobMgr`. No thread of its own, no Config, no `isLeader` check, no interrupt machinery: `runOneCycle()` invoked from the manager's `runAfterCatalogReady` tick and self-gates on shared-data mode + empty unstable-groups before doing any real work via `ColocateTableIndex.hasUnstableGroups()`. The manager is started only via `startLeaderOnlyDaemonThreads`, so leader-only-ness is inherited.
- Cycle iterates every unstable range-colocate `colocateGroupId`; for each peer `GroupId`, every `NORMAL`-state table, every visible `MaterializedIndex`; per misaligned tablet, computes canonical boundaries strictly inside its range, expands them to per-new-tablet `TabletRange`s via `RangeColocateScanDispatch.computeAlignedTabletRanges`, and batches all misaligned tuples in a table into **one** `SplitTabletJob` (one job per table per cycle). When every peer is range-aligned, `markAllGroupsWithSameColocateGroupIdStable` fires across peers in lock-step.
- **`SplitTabletJobFactory.forColocateAlignment`** — checker-only entry. Bypasses the unstable-guard (checker IS the resolver). Per-new-tablet PACK assignment via `StarOSAgent.createShardsForSplitPerNewShard` (additive new overload) so each alignment-split child joins its target `ColocateRange`'s PACK group. Re-validates leader admission immediately before each StarOS shard-creation RPC.
- **`ColocateTableIndex.markAllGroupsWithSameColocateGroupIdStable` + `getAllGroupIdsWithSameColocateGroupId` + `hasUnstableGroups`** — symmetric to the existing `markAllGroupsWithSameColocateGroupIdUnstable` and friends; share a private `peersOfColocateGroup` helper.
- **`RangeColocateScanDispatch.isTabletRangesAligned` + `computeForcedAlignmentBoundaries` + `computeAlignedTabletRanges`** — static helpers shared with the checker. The last converts the canonical-boundary list into the per-new-tablet `TabletRange` list the BE consumes. Rejects non-inclusive lower bounds via `Preconditions.checkState` (would otherwise silently livelock the alignment loop).
- **`RuntimeTypeAdapterTypes`** — register `NullVariant` / `MinVariant` / `MaxVariant` so canonical `(k, NULL, ..., NULL)` tuples on `SplittingTablet.newTabletRanges` survive Gson journaling.

**Stable gate semantic**: every tablet's range is contained in exactly one `ColocateRange` and every `ColocateRange` has at least one covering tablet. PACK-shard-group physical placement of the originating-partition split-children is a tracked follow-up gated on a new staros shard-group-reassignment API.

**Known follow-ups (intentionally out of scope):**
- Production leader-demotion path needs to call `beginLeaderDemotion()` before `stopLeaderOnlyDaemonThreads()`; the checker's `isLeaderWorkAdmissionOpen()` check is forward-compatible and will start fencing as soon as that lands.
- Multi-RPC torn state during demotion has the same pattern as the user-driven split path. Needs either batched StarOS calls or a rollback API.
- Shard-creation ordering: `forColocateAlignment` creates StarOS shards before `addTabletReshardJob` writes the journal record and runs its cap check, so a cap-rejection or duplicate-id throw can leak shards. Same shape as the user-driven split path. Architecturally the fix is to move StarOS shard creation from job-creation time into the job's PENDING → PREPARING transition so it sits under the journaled state machine and inherits its retry / cleanup semantics. Tracked as a separate PR.
- MV / rollup index with reduced sort-key arity falls back to identical-tablet on strict schema validation, leaving the group permanently unstable. Per-index arity handling in `computeAlignedTabletRanges` is the fix; tracked separately.

### Testing

- **BE external-boundaries**: ~30 tests in `tablet_splitter_test.cpp` covering structural / schema / semantic validation paths + parity vs data-driven path + envelope-clipping happy path; ~10 direct `validate_new_tablet_ranges` tests in `tablet_range_helper_test.cpp` covering every rejection branch in the structural validator.
- **FE external-boundaries**: `SplitTabletJobTest` covers `forExternalBoundaries` end-to-end with a mocked `MockLakeService` that echoes ranges back; `SplittingTabletTest` covers Gson round-trip of `newTabletRanges`.
- **FE alignment-checker**: 4 `ColocateCheckerTest` cases (aligned-unstable → stable, misaligned → alignment job, table in non-NORMAL state skipped, no-unstable → no-op).
- **SQL integration**: 3 T-files in `test/sql/test_colocate_range/` (`@cloud @sequential` tagged; R recordings deferred to TSP follow-up).
- **End-to-end validation on TSP shared-data cluster**: 9 scenarios validated — basic Level-1 + recovery, sparse-partition forced-boundary, cross-DB peer alignment, unstable-guard rejection, multi-boundary Level-1 (3 prefixes), Level-2 stays stable, concurrent unstable groups, DROP table during unstable, TRUNCATE during unstable. All scenarios converged within 1-2 manager ticks.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes
- [ ] Parameter changes
- [ ] Policy changes
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
