### PR TITLE
[UT] Stabilize print_hit_materialized_view in transparent MV tests

### DIFF
--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2336,7 +2336,19 @@ class StarrocksSQLApiLib(object):
                 mvs.sort()
                 print("Hit materialized views:", ", ".join(mvs))
                 return mvs
-        return self._with_materialized_view_rewrite(check_mv)
+
+        # Retry the check several times before declaring failure. MV partition
+        # staleness state propagates asynchronously after base-table writes, so
+        # the optimizer may not pick the expected rewrite (e.g. UNION) on the
+        # first explain call right after an INSERT.
+        max_retries = 5
+        for attempt in range(max_retries):
+            result = self._with_materialized_view_rewrite(check_mv)
+            if not isinstance(result, bool) or result:
+                return result
+            if attempt < max_retries - 1:
+                time.sleep(2)
+        return False
 
     def print_hit_materialized_views(self, query) -> str:
         """


### PR DESCRIPTION
## Why I'm doing:

The helper used by test_transparent_mv_union_olap and similar MV tests performed a single explain check after a 1s sleep. After INSERTs into a base table, the MV partition staleness state propagates asynchronously, so the optimizer occasionally fails to pick the expected UNION rewrite on the first explain, producing a flaky 'True' != 'False' diff.

Retry the check up to 5 times with 2s backoff when no expected token is found in the plan. Non-bool results (the list-of-MVs path) are returned unchanged on first attempt.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
