### PR TITLE
[Enhancement] Replace inet_ntoa with thread-safe inet_ntop

### DIFF
--- a/be/src/base/network/network_util.cpp
+++ b/be/src/base/network/network_util.cpp
@@ -162,7 +162,14 @@ Status hostname_to_ipv4(const std::string& host, std::string& ip) {
     }
 
     addr.s_addr = ((sockaddr_in*)(res->ai_addr))->sin_addr.s_addr;
-    ip = inet_ntoa(addr);
+    char ipv4_str[INET_ADDRSTRLEN];
+    if (inet_ntop(AF_INET, &addr, ipv4_str, sizeof(ipv4_str)) == nullptr) {
+        std::string err_msg = strings::Substitute("failed to convert ipv4 for host: $0, errno: $1", host, errno);
+        LOG(WARNING) << err_msg;
+        freeaddrinfo(res);
+        return Status::InternalError(err_msg);
+    }
+    ip = ipv4_str;
 
     freeaddrinfo(res);
     return Status::OK();


### PR DESCRIPTION
## Why I'm doing:

inet_ntoa returns a pointer to a static buffer and is not thread-safe. Use inet_ntop, which writes into a caller-provided buffer and matches the convention already used elsewhere in this file for both IPv4 and IPv6 conversion paths.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
