### PR TITLE
[UT] Suffix per-process PID to flaky BE test directories

### DIFF
--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -16,6 +16,7 @@
 
 #include <bthread/bthread.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #include <random>
 #include <thread>
@@ -86,7 +87,8 @@ protected:
 
     void do_block_merger(bool use_profile);
 
-    constexpr static const char* const kTestDirectory = "test_lake_async_delta_writer";
+    // Suffix with PID so concurrent processes (e.g. gtest-parallel) never share this dir.
+    inline static const std::string kTestDirectory = "test_lake_async_delta_writer_" + std::to_string(getpid());
 
     int64_t _partition_id;
     std::shared_ptr<TabletMetadata> _tablet_metadata;

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #include <random>
 
@@ -171,7 +172,8 @@ public:
     }
 
 protected:
-    constexpr static const char* const kTestGroupPath = "test_lake_primary_key";
+    // Suffix with PID so concurrent processes (e.g. gtest-parallel) never share this dir.
+    inline static const std::string kTestGroupPath = "test_lake_primary_key_" + std::to_string(getpid());
     constexpr static const int kChunkSize = 12;
 
     std::shared_ptr<TabletMetadata> _tablet_metadata;

--- a/be/test/storage/persistent_index_consistency_test.cpp
+++ b/be/test/storage/persistent_index_consistency_test.cpp
@@ -14,6 +14,7 @@
 
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #include <cassert>
 #include <cstdlib>
@@ -66,7 +67,8 @@ struct TestParams {
     bool print_debug_info = false;
 };
 
-static const std::string kTestDirectory = "./test_persistent_index_consistency";
+// Suffix with PID so concurrent processes (e.g. gtest-parallel) never share this dir.
+static const std::string kTestDirectory = "./test_persistent_index_consistency_" + std::to_string(getpid());
 
 template <typename T>
 class PersistentIndexWrapper {


### PR DESCRIPTION
## Why I'm doing:

Three BE unit tests are flaky in CI:

- `LakeAsyncDeltaWriterTest.test_block_merger_running_while_close`
- `LakePrimaryKeyPublishTest.test_recover_with_multi_reason`
- `PersistentIndexConsistencyTestTest.test_local_persistent_index`

Each fixture uses a hardcoded relative test directory (e.g. `test_lake_primary_key`, `test_lake_async_delta_writer`, `./test_persistent_index_consistency`). When gtest-parallel runs multiple test functions of the same binary in separate processes (each parameterised case is a separate process), the processes share CWD and the same directory. `SetUp`/`TearDown` then call `fs::remove_all` on that path, wiping data the sibling process is still using.

Repro: 8 parallel workers running each test reliably reproduced many `FAILED` outcomes in `test_recover_with_multi_reason` and `test_block_merger_running_while_close` (e.g. `delta_writer.cpp:776` / `:904` `RETURN_IF_ERROR`).

## What I'm doing:

Suffix the test directory with `getpid()` so each process gets its own isolated path. The constant is changed from a `constexpr const char*` to an `inline static const std::string` initialised once per process.

Affected fixtures / paths:

- `LakeAsyncDeltaWriterTest` → `test_lake_async_delta_writer_<pid>`
- `LakePrimaryKeyPublishTest` → `test_lake_primary_key_<pid>`
- `PersistentIndexConsistencyTestTest` → `./test_persistent_index_consistency_<pid>`

Verification (in dev-env-ubuntu ASAN build): with the fix applied, 0 failures across 720+ parallel invocations (`block_merger` + `recover_with_multi_reason` under 8 workers × 15 iters × 5 params) and 8 parallel `test_local_persistent_index` invocations.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Test plan
- [ ] BE unit tests pass: `LakeAsyncDeltaWriterTest.test_block_merger_running_while_close`
- [ ] BE unit tests pass: `LakePrimaryKeyPublishTest.test_recover_with_multi_reason/*`
- [ ] BE unit tests pass: `PersistentIndexConsistencyTestTest.test_local_persistent_index`
- [ ] No regression in concurrent gtest-parallel runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)