### PR TITLE
[BugFix] Add missing Service/ServiceBE link group for gold linker

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -544,6 +544,8 @@ set(STARROCKS_LINK_LIBS
     Formats
     HttpClient
     IO
+    Service
+    ServiceBE
     Storage
     Rowset
     Runtime

--- a/be/src/service/CMakeLists.txt
+++ b/be/src/service/CMakeLists.txt
@@ -51,7 +51,6 @@ if ((NOT ${MAKE_TEST} STREQUAL "ON") AND (NOT BUILD_FORMAT_LIB))
     # set_target_properties(starrocks_be PROPERTIES LINK_FLAGS -pthread)
 
     target_link_libraries(starrocks_be
-        ServiceBE
         ${STARROCKS_LINK_LIBS}
         )
     STARROCKS_FORCE_LOAD_LIBS(starrocks_be Exprs ExprCore)


### PR DESCRIPTION
## Why I'm doing:

PR #73055 extracted `Service` and `ServiceBE` from the `--start-group/--end-group` block in `be/CMakeLists.txt` and linked `ServiceBE` before `STARROCKS_LINK_LIBS` in `service/CMakeLists.txt`. This causes link failures when building with the GNU `gold` linker (used on CentOS with glibc < 2.29 and GCC >= 14):

```
be/src/service/daemon.cpp:217: error: undefined reference to 'starrocks::SystemMetrics::instance()'
be/src/service/daemon.cpp:353: error: undefined reference to 'starrocks::mlock_modules()'
be/src/service/internal_service.cpp:1313: error: undefined reference to 'starrocks::ShortCircuitExecutor::ShortCircuitExecutor(starrocks::ExecEnv*)'
be/src/service/internal_service.cpp:1260: error: undefined reference to 'starrocks::execute_command(...)'
be/src/service/backend_metrics_initializer.cpp:282: error: undefined reference to 'starrocks::JVMMetrics::instance()'
be/src/common/util/minidump.cpp:162: error: undefined reference to 'my_strlen'
be/src/common/util/minidump.cpp:54: error: undefined reference to 'google_breakpad::ExceptionHandler::ExceptionHandler(...)'
```

The CI (Ubuntu, `lld` linker) passes because `lld` resolves symbols globally across all `--start-group/--end-group` boundaries, while `gold` strictly respects group scoping — it does not backtrack into a later `--start-group` to resolve symbols from libraries that precede it.

## What I'm doing:

Move `Service` and `ServiceBE` back into the `--start-group/--end-group` block so their dependencies on `Util`, `Exec`, `Runtime`, and thirdparty libraries (breakpad, mysql) are resolved correctly under the `gold` linker. Remove the now-redundant standalone `ServiceBE` from the `starrocks_be` target link line.

Introduced in #73055

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4