### PR TITLE
[UT] fix persistent_index_sstable mem leak while fault injection

### DIFF
--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -63,13 +63,13 @@ Status PersistentIndexSstable::init(std::unique_ptr<RandomAccessFile> rf, const 
         options.filter_policy = _filter_policy.get();
     }
     options.block_cache = cache;
-    sstable::Table* table;
-    auto open_st = sstable::Table::Open(options, rf.get(), sstable_pb.filesize(), &table);
+    std::unique_ptr<sstable::Table> table;
+    auto open_st = sstable::Table::Open(options, rf.get(), sstable_pb.filesize(), table);
     TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::init:table_open_error", &open_st);
     if (open_st.is_corruption()) {
         auto drop_status = drop_corrupted_sstable_cache(rf->filename());
         if (drop_status.ok()) {
-            delete table;
+            table.reset();
             if (tablet_mgr == nullptr) {
                 return Status::InvalidArgument("tablet_mgr is null when loading sst file");
             }
@@ -80,7 +80,7 @@ Status PersistentIndexSstable::init(std::unique_ptr<RandomAccessFile> rf, const 
             }
             ASSIGN_OR_RETURN(rf, fs::new_random_access_file(
                                          opts, tablet_mgr->sst_location(metadata->id(), sstable_pb.filename())));
-            open_st = sstable::Table::Open(options, rf.get(), sstable_pb.filesize(), &table);
+            open_st = sstable::Table::Open(options, rf.get(), sstable_pb.filesize(), table);
             TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::init:table_open_retry_error", &open_st);
         }
     }
@@ -89,7 +89,7 @@ Status PersistentIndexSstable::init(std::unique_ptr<RandomAccessFile> rf, const 
         LOG(WARNING) << "Failed to open PersistentIndex SST file: " << sstable_pb.filename() << ", error: " << open_st;
         return open_st;
     }
-    _sst.reset(table);
+    _sst = std::move(table);
     _rf = std::move(rf);
     _sstable_pb.CopyFrom(sstable_pb);
     // load delvec

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -69,7 +69,6 @@ Status PersistentIndexSstable::init(std::unique_ptr<RandomAccessFile> rf, const 
     if (open_st.is_corruption()) {
         auto drop_status = drop_corrupted_sstable_cache(rf->filename());
         if (drop_status.ok()) {
-            table.reset();
             if (tablet_mgr == nullptr) {
                 return Status::InvalidArgument("tablet_mgr is null when loading sst file");
             }

--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -43,8 +43,8 @@ struct Table::Rep {
     Block* index_block = nullptr;
 };
 
-Status Table::Open(const Options& options, RandomAccessFile* file, uint64_t size, Table** table) {
-    *table = nullptr;
+Status Table::Open(const Options& options, RandomAccessFile* file, uint64_t size, std::unique_ptr<Table>& table) {
+    table.reset();
     if (size < Footer::kEncodedLength) {
         return Status::Corruption("file is too short to be an sstable");
     }
@@ -81,8 +81,8 @@ Status Table::Open(const Options& options, RandomAccessFile* file, uint64_t size
         rep->cache_id = (options.block_cache ? options.block_cache->new_id() : 0);
         rep->filter_data = nullptr;
         rep->filter = nullptr;
-        *table = new Table(rep);
-        (*table)->ReadMeta(footer);
+        table.reset(new Table(rep));
+        table->ReadMeta(footer);
     }
 
     return s;

--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -44,7 +44,6 @@ struct Table::Rep {
 };
 
 Status Table::Open(const Options& options, RandomAccessFile* file, uint64_t size, std::unique_ptr<Table>& table) {
-    table.reset();
     if (size < Footer::kEncodedLength) {
         return Status::Corruption("file is too short to be an sstable");
     }

--- a/be/src/storage/sstable/table.h
+++ b/be/src/storage/sstable/table.h
@@ -3,6 +3,8 @@
 // (https://developers.google.com/open-source/licenses/bsd)
 #pragma once
 
+#include <memory>
+
 #include "common/status.h"
 
 namespace starrocks {
@@ -25,15 +27,14 @@ public:
     // of "file", and read the metadata entries necessary to allow
     // retrieving data from the table.
     //
-    // If successful, returns ok and sets "*table" to the newly opened
-    // table.  The client should delete "*table" when no longer needed.
-    // If there was an error while initializing the table, sets "*table"
-    // to nullptr and returns a non-ok status.  Does not take ownership of
-    // "*source", but the client must ensure that "source" remains live
-    // for the duration of the returned table's lifetime.
+    // If successful, returns ok and sets "table" to the newly opened table.
+    // If there was an error, returns a non-ok status and resets "table" to nullptr.
     //
-    // *file must remain live while this Table is in use.
-    static Status Open(const Options& options, RandomAccessFile* file, uint64_t file_size, Table** table);
+    // Does not take ownership of "file", but the caller must ensure
+    // that "file" remains live for the duration of the returned table's
+    // lifetime.
+    static Status Open(const Options& options, RandomAccessFile* file, uint64_t file_size,
+                       std::unique_ptr<Table>& table);
 
     Table(const Table&) = delete;
     Table& operator=(const Table&) = delete;

--- a/be/src/storage/sstable/table.h
+++ b/be/src/storage/sstable/table.h
@@ -28,7 +28,8 @@ public:
     // retrieving data from the table.
     //
     // If successful, returns ok and sets "table" to the newly opened table.
-    // If there was an error, returns a non-ok status and resets "table" to nullptr.
+    // The caller may only use "table" when the returned Status is OK.
+    // On failure, "table" is left in an unspecified state and must not be used.
     //
     // Does not take ownership of "file", but the caller must ensure
     // that "file" remains live for the duration of the returned table's

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -384,17 +384,16 @@ void dump_lake_persistent_index_sst(const std::string& file_name, const starrock
 
     // Open the table via the official API for full KV iteration.
     Options tbl_opts;
-    Table* table = nullptr;
-    st = Table::Open(tbl_opts, file.get(), file_size, &table);
+    std::unique_ptr<Table> table;
+    st = Table::Open(tbl_opts, file.get(), file_size, table);
     if (!st.ok()) {
         std::cerr << "open SST table for iteration failed: " << st << std::endl;
         return;
     }
-    std::unique_ptr<Table> table_guard(table);
 
     ReadOptions iter_opts;
     iter_opts.fill_cache = false;
-    auto* iter = table_guard->NewIterator(iter_opts);
+    auto* iter = table->NewIterator(iter_opts);
     std::unique_ptr<Iterator> iter_guard(iter);
 
     // Dump all key-value entries.

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -140,7 +140,7 @@ TEST_F(PersistentIndexSstableTest, test_merge) {
     std::vector<std::unique_ptr<sstable::Table>> sstable_ptrs(3);
     for (int i = 0; i < 3; ++i) {
         std::unique_ptr<sstable::Table> sstable;
-    CHECK_OK(sstable::Table::Open(options, read_files[i].get(), fileszs[i], sstable));
+        CHECK_OK(sstable::Table::Open(options, read_files[i].get(), fileszs[i], sstable));
         sstable::Iterator* iter = sstable->NewIterator(read_options);
         list.emplace_back(iter);
         sstable_ptrs[i] = std::move(sstable);
@@ -464,7 +464,7 @@ TEST_F(PersistentIndexSstableTest, test_ioerror_inject) {
         // scan & check
         ASSIGN_OR_ABORT(auto read_file, fs::new_random_access_file(lake::join_path(kTestDir, filename)));
         std::unique_ptr<sstable::Table> sstable;
-    CHECK_OK(sstable::Table::Open(options, read_file.get(), filesz, sstable));
+        CHECK_OK(sstable::Table::Open(options, read_file.get(), filesz, sstable));
         sstable::ReadOptions read_options;
         sstable::Iterator* iter = sstable->NewIterator(read_options);
         for (iter->SeekToFirst(); iter->Valid() && iter->status().ok(); iter->Next()) {

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -65,9 +65,9 @@ TEST_F(PersistentIndexSstableTest, test_generate_sst_scan_and_check) {
     CHECK_OK(builder.Finish());
     uint64_t filesz = builder.FileSize();
     // scan & check
-    sstable::Table* sstable = nullptr;
     ASSIGN_OR_ABORT(auto read_file, fs::new_random_access_file(lake::join_path(kTestDir, filename)));
-    CHECK_OK(sstable::Table::Open(options, read_file.get(), filesz, &sstable));
+    std::unique_ptr<sstable::Table> sstable;
+    CHECK_OK(sstable::Table::Open(options, read_file.get(), filesz, sstable));
     sstable::ReadOptions read_options;
     int count = 0;
     sstable::Iterator* iter = sstable->NewIterator(read_options);
@@ -80,7 +80,6 @@ TEST_F(PersistentIndexSstableTest, test_generate_sst_scan_and_check) {
     }
     ASSERT_TRUE(count == N);
     delete iter;
-    delete sstable;
 }
 
 TEST_F(PersistentIndexSstableTest, test_generate_sst_seek_and_check) {
@@ -97,9 +96,9 @@ TEST_F(PersistentIndexSstableTest, test_generate_sst_seek_and_check) {
     CHECK_OK(builder.Finish());
     uint64_t filesz = builder.FileSize();
     // seek & check
-    sstable::Table* sstable = nullptr;
     ASSIGN_OR_ABORT(auto read_file, fs::new_random_access_file(lake::join_path(kTestDir, filename)));
-    CHECK_OK(sstable::Table::Open(options, read_file.get(), filesz, &sstable));
+    std::unique_ptr<sstable::Table> sstable;
+    CHECK_OK(sstable::Table::Open(options, read_file.get(), filesz, sstable));
     sstable::ReadOptions read_options;
     sstable::Iterator* iter = sstable->NewIterator(read_options);
     for (int i = 0; i < 100; i++) {
@@ -112,7 +111,6 @@ TEST_F(PersistentIndexSstableTest, test_generate_sst_seek_and_check) {
         ASSERT_TRUE(exp_val == cur_val);
     }
     delete iter;
-    delete sstable;
 }
 
 TEST_F(PersistentIndexSstableTest, test_merge) {
@@ -141,11 +139,11 @@ TEST_F(PersistentIndexSstableTest, test_merge) {
     sstable::ReadOptions read_options;
     std::vector<std::unique_ptr<sstable::Table>> sstable_ptrs(3);
     for (int i = 0; i < 3; ++i) {
-        sstable::Table* sstable = nullptr;
-        CHECK_OK(sstable::Table::Open(options, read_files[i].get(), fileszs[i], &sstable));
+        std::unique_ptr<sstable::Table> sstable;
+    CHECK_OK(sstable::Table::Open(options, read_files[i].get(), fileszs[i], sstable));
         sstable::Iterator* iter = sstable->NewIterator(read_options);
         list.emplace_back(iter);
-        sstable_ptrs[i].reset(sstable);
+        sstable_ptrs[i] = std::move(sstable);
     }
 
     phmap::btree_map<std::string, std::string> map;
@@ -180,9 +178,9 @@ TEST_F(PersistentIndexSstableTest, test_merge) {
     }
     CHECK_OK(builder.Finish());
     uint64_t filesz = builder.FileSize();
-    sstable::Table* sstable = nullptr;
     ASSIGN_OR_ABORT(auto read_file, fs::new_random_access_file(lake::join_path(kTestDir, filename)));
-    CHECK_OK(sstable::Table::Open(options, read_file.get(), filesz, &sstable));
+    std::unique_ptr<sstable::Table> sstable;
+    CHECK_OK(sstable::Table::Open(options, read_file.get(), filesz, sstable));
     sstable::Iterator* iter = sstable->NewIterator(read_options);
     for (int i = 0; i < 100; i++) {
         int r = rand() % N;
@@ -196,7 +194,6 @@ TEST_F(PersistentIndexSstableTest, test_merge) {
     list.clear();
     read_files.clear();
     delete iter;
-    delete sstable;
     sstable_ptrs.clear();
 }
 
@@ -465,16 +462,15 @@ TEST_F(PersistentIndexSstableTest, test_ioerror_inject) {
     uint64_t filesz = builder.FileSize();
     if (st.ok()) {
         // scan & check
-        sstable::Table* sstable = nullptr;
         ASSIGN_OR_ABORT(auto read_file, fs::new_random_access_file(lake::join_path(kTestDir, filename)));
-        CHECK_OK(sstable::Table::Open(options, read_file.get(), filesz, &sstable));
+        std::unique_ptr<sstable::Table> sstable;
+    CHECK_OK(sstable::Table::Open(options, read_file.get(), filesz, sstable));
         sstable::ReadOptions read_options;
         sstable::Iterator* iter = sstable->NewIterator(read_options);
         for (iter->SeekToFirst(); iter->Valid() && iter->status().ok(); iter->Next()) {
         }
         ASSERT_TRUE(iter->status().ok());
         delete iter;
-        delete sstable;
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

After `TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::init:table_open_error", &open_st);`, the status change to false, but leave table leak.

Only while run BE UT has this problem.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
