### PR TITLE
[BugFix] Persist IVM TVR position across multiple incremental refreshes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -87,12 +87,9 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
     // whether the next task run is needed
     private boolean hasNextTaskRun = false;
 
-    // IVM session-variable scope state. The scope spans from prepareRefreshPlan() through
-    // executor.executePlan() in execProcessExecPlan(), because enable_ivm_refresh gates
-    // two distinct call sites: IvmRewriter.rewrite() at plan-build, and
-    // InsertLoadTxnCallbackFactory.of() at INSERT execution. Scoping it to plan-build
-    // only would leave the TVR callback unregistered, so baseTableInfoTvrVersionRangeMap
-    // would never advance past baseline (see closeIvmScope javadoc for the reset paths).
+    // IVM scope: enable_ivm_refresh is read both at plan-build (IvmRewriter) and at INSERT
+    // execution (InsertLoadTxnCallbackFactory), so the scope must span prepareRefreshPlan
+    // through executor.executePlan() in execProcessExecPlan. Reset paths: closeIvmScope.
     private boolean savedEnableIvmRefresh;
     private String savedTvrTargetMvId;
     private boolean ivmScopeOpen = false;
@@ -189,10 +186,7 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
 
             return Constants.TaskRunState.SUCCESS;
         } finally {
-            // Close the IVM session-variable scope opened in prepareRefreshPlan(). The
-            // scope spans this method so that InsertLoadTxnCallbackFactory sees
-            // enable_ivm_refresh=true at INSERT execution and registers the
-            // IVMInsertLoadTxnCallback that advances baseTableInfoTvrVersionRangeMap.
+            // One set, one reset — close the scope opened in prepareRefreshPlan().
             closeIvmScope(ctx);
         }
     }
@@ -465,16 +459,9 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                 .setQuerySource(QueryDetail.QuerySource.MV.name())
                 .setCNGroup(ctx.getCurrentComputeResourceName());
 
-        // Open the IVM session-variable scope. enable_ivm_refresh gates IvmRewriter.rewrite()
-        // here at plan-build AND InsertLoadTxnCallbackFactory.of() at INSERT execution.
-        // The reset is deferred to whichever of:
-        //   * execProcessExecPlan()'s finally  — normal completion
-        //   * the catch below                  — prepare failed, Hybrid will switch to PCT
-        //                                        and must NOT see enable_ivm_refresh=true
-        //                                        while planning a PCT-shape query (see #73004).
-        // Resetting in this method's `finally` (the previous design) fired before
-        // execProcessExecPlan ran, leaving the TVR callback unregistered and
-        // baseTableInfoTvrVersionRangeMap stuck at baseline across all incremental refreshes.
+        // Open the IVM scope. Reset is deferred: normal path closes in execProcessExecPlan's
+        // finally; the catch below closes on prepare failure so MVHybridRefreshProcessor's
+        // PCT fallback plans without enable_ivm_refresh=true (#73004).
         savedEnableIvmRefresh = ctx.getSessionVariable().isEnableIVMRefresh();
         savedTvrTargetMvId = ctx.getSessionVariable().getTvrTargetMvId();
         ctx.getSessionVariable().setEnableIVMRefresh(true);
@@ -516,20 +503,13 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
             }
             return insertStmt;
         } catch (Exception e) {
-            // Prepare failed; close the scope so MVHybridRefreshProcessor.switchToPCTRefresh
-            // can plan a clean PCT query on the same ConnectContext.
             closeIvmScope(ctx);
             throw e;
         }
-        // NOTE: no `finally` here — the scope stays open on normal completion; closed by
-        // execProcessExecPlan()'s finally after executor.executePlan() returns.
+        // Scope stays open on normal completion; execProcessExecPlan() closes it.
     }
 
-    /**
-     * Reset the IVM session-variable scope opened by prepareRefreshPlan(). Idempotent: a
-     * second call is a no-op. Called from either prepareRefreshPlan()'s catch (prepare
-     * failed) or execProcessExecPlan()'s finally (normal completion or exec failure).
-     */
+    /** Idempotent reset of the IVM scope opened in prepareRefreshPlan(). */
     private void closeIvmScope(ConnectContext ctx) {
         if (ivmScopeOpen) {
             ctx.getSessionVariable().setEnableIVMRefresh(savedEnableIvmRefresh);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -87,13 +87,6 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
     // whether the next task run is needed
     private boolean hasNextTaskRun = false;
 
-    // IVM scope: enable_ivm_refresh is read both at plan-build (IvmRewriter) and at INSERT
-    // execution (InsertLoadTxnCallbackFactory), so the scope must span prepareRefreshPlan
-    // through executor.executePlan() in execProcessExecPlan. Reset paths: closeIvmScope.
-    private boolean savedEnableIvmRefresh;
-    private String savedTvrTargetMvId;
-    private boolean ivmScopeOpen = false;
-
     public MVIVMRefreshProcessor(Database db, MaterializedView mv,
                                  MvTaskRunContext mvContext,
                                  IMaterializedViewMetricsEntity mvEntity,
@@ -170,6 +163,14 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         final InsertStmt insertStmt = processExecPlan.insertStmt();
         final ExecPlan execPlan = processExecPlan.execPlan();
         final ConnectContext ctx = mvContext.getCtx();
+
+        // Scope enable_ivm_refresh around executor.executePlan so InsertLoadTxnCallbackFactory
+        // registers IVMInsertLoadTxnCallback for this INSERT (otherwise the persistent TVR
+        // map never advances and incremental refreshes accumulate duplicate rows).
+        boolean prevIvmEnabled = ctx.getSessionVariable().isEnableIVMRefresh();
+        String prevTvrTargetMvId = ctx.getSessionVariable().getTvrTargetMvId();
+        ctx.getSessionVariable().setEnableIVMRefresh(true);
+        ctx.getSessionVariable().setTvrTargetMvid(GsonUtils.GSON.toJson(mv.getMvId()));
         try {
             try (Timer ignored = Tracers.watchScope("MVRefreshMaterializedView")) {
                 MaterializedView.AsyncRefreshContext mvRefreshContext =
@@ -186,8 +187,8 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
 
             return Constants.TaskRunState.SUCCESS;
         } finally {
-            // One set, one reset — close the scope opened in prepareRefreshPlan().
-            closeIvmScope(ctx);
+            ctx.getSessionVariable().setEnableIVMRefresh(prevIvmEnabled);
+            ctx.getSessionVariable().setTvrTargetMvid(prevTvrTargetMvId);
         }
     }
 
@@ -459,14 +460,14 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                 .setQuerySource(QueryDetail.QuerySource.MV.name())
                 .setCNGroup(ctx.getCurrentComputeResourceName());
 
-        // Open the IVM scope. Reset is deferred: normal path closes in execProcessExecPlan's
-        // finally; the catch below closes on prepare failure so MVHybridRefreshProcessor's
-        // PCT fallback plans without enable_ivm_refresh=true (#73004).
-        savedEnableIvmRefresh = ctx.getSessionVariable().isEnableIVMRefresh();
-        savedTvrTargetMvId = ctx.getSessionVariable().getTvrTargetMvId();
+        // Scope enable_ivm_refresh to this method so IvmRewriter sees it but the variable
+        // doesn't leak — neither into MVHybridRefreshProcessor's PCT fallback after this
+        // throws (#73004), nor into the caller's session after `EXPLAIN REFRESH ...`
+        // (which runs prepareRefreshPlan without ever invoking execProcessExecPlan).
+        boolean prevIvmEnabled = ctx.getSessionVariable().isEnableIVMRefresh();
+        String prevTvrTargetMvId = ctx.getSessionVariable().getTvrTargetMvId();
         ctx.getSessionVariable().setEnableIVMRefresh(true);
         ctx.getSessionVariable().setTvrTargetMvid(GsonUtils.GSON.toJson(mv.getMvId()));
-        ivmScopeOpen = true;
         try {
             final Set<Table> baseTables = snapshotBaseTables.values()
                     .stream()
@@ -502,19 +503,9 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                 mvContext.setExecPlan(execPlan);
             }
             return insertStmt;
-        } catch (Exception e) {
-            closeIvmScope(ctx);
-            throw e;
-        }
-        // Scope stays open on normal completion; execProcessExecPlan() closes it.
-    }
-
-    /** Idempotent reset of the IVM scope opened in prepareRefreshPlan(). */
-    private void closeIvmScope(ConnectContext ctx) {
-        if (ivmScopeOpen) {
-            ctx.getSessionVariable().setEnableIVMRefresh(savedEnableIvmRefresh);
-            ctx.getSessionVariable().setTvrTargetMvid(savedTvrTargetMvId);
-            ivmScopeOpen = false;
+        } finally {
+            ctx.getSessionVariable().setEnableIVMRefresh(prevIvmEnabled);
+            ctx.getSessionVariable().setTvrTargetMvid(prevTvrTargetMvId);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -87,6 +87,16 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
     // whether the next task run is needed
     private boolean hasNextTaskRun = false;
 
+    // IVM session-variable scope state. The scope spans from prepareRefreshPlan() through
+    // executor.executePlan() in execProcessExecPlan(), because enable_ivm_refresh gates
+    // two distinct call sites: IvmRewriter.rewrite() at plan-build, and
+    // InsertLoadTxnCallbackFactory.of() at INSERT execution. Scoping it to plan-build
+    // only would leave the TVR callback unregistered, so baseTableInfoTvrVersionRangeMap
+    // would never advance past baseline (see closeIvmScope javadoc for the reset paths).
+    private boolean savedEnableIvmRefresh;
+    private String savedTvrTargetMvId;
+    private boolean ivmScopeOpen = false;
+
     public MVIVMRefreshProcessor(Database db, MaterializedView mv,
                                  MvTaskRunContext mvContext,
                                  IMaterializedViewMetricsEntity mvEntity,
@@ -162,20 +172,29 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                                                       MVRefreshExecutor executor) throws Exception {
         final InsertStmt insertStmt = processExecPlan.insertStmt();
         final ExecPlan execPlan = processExecPlan.execPlan();
-        try (Timer ignored = Tracers.watchScope("MVRefreshMaterializedView")) {
-            MaterializedView.AsyncRefreshContext mvRefreshContext =
-                    mv.getRefreshScheme().getAsyncRefreshContext();
-            logger.info("staged tvr delta map: {}", stagedTvrDeltaMap);
-            String owner = mvContext.getStatus().getStartTaskRunId();
-            mvRefreshContext.replaceTempBaseTableInfoTvrDeltaMap(owner, stagedTvrDeltaMap);
-            executor.executePlan(execPlan, insertStmt);
-        }
+        final ConnectContext ctx = mvContext.getCtx();
+        try {
+            try (Timer ignored = Tracers.watchScope("MVRefreshMaterializedView")) {
+                MaterializedView.AsyncRefreshContext mvRefreshContext =
+                        mv.getRefreshScheme().getAsyncRefreshContext();
+                logger.info("staged tvr delta map: {}", stagedTvrDeltaMap);
+                String owner = mvContext.getStatus().getStartTaskRunId();
+                mvRefreshContext.replaceTempBaseTableInfoTvrDeltaMap(owner, stagedTvrDeltaMap);
+                executor.executePlan(execPlan, insertStmt);
+            }
 
-        try (Timer ignored = Tracers.watchScope("MVRefreshUpdateMeta")) {
-            updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, Maps.newHashMap());
-        }
+            try (Timer ignored = Tracers.watchScope("MVRefreshUpdateMeta")) {
+                updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, Maps.newHashMap());
+            }
 
-        return Constants.TaskRunState.SUCCESS;
+            return Constants.TaskRunState.SUCCESS;
+        } finally {
+            // Close the IVM session-variable scope opened in prepareRefreshPlan(). The
+            // scope spans this method so that InsertLoadTxnCallbackFactory sees
+            // enable_ivm_refresh=true at INSERT execution and registers the
+            // IVMInsertLoadTxnCallback that advances baseTableInfoTvrVersionRangeMap.
+            closeIvmScope(ctx);
+        }
     }
 
     @Override
@@ -446,14 +465,21 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                 .setQuerySource(QueryDetail.QuerySource.MV.name())
                 .setCNGroup(ctx.getCurrentComputeResourceName());
 
-        // Scope the IVM session variables to this method only. The same ConnectContext
-        // is reused by MVHybridRefreshProcessor.switchToPCTRefresh on IVM failure, so
-        // leaking enable_ivm_refresh=true into the PCT retry would make IvmRewriter run
-        // on a non-IVM plan and fail at convergence — defeating the AUTO fallback.
-        boolean prevIvmEnabled = ctx.getSessionVariable().isEnableIVMRefresh();
-        String prevTvrTargetMvId = ctx.getSessionVariable().getTvrTargetMvId();
+        // Open the IVM session-variable scope. enable_ivm_refresh gates IvmRewriter.rewrite()
+        // here at plan-build AND InsertLoadTxnCallbackFactory.of() at INSERT execution.
+        // The reset is deferred to whichever of:
+        //   * execProcessExecPlan()'s finally  — normal completion
+        //   * the catch below                  — prepare failed, Hybrid will switch to PCT
+        //                                        and must NOT see enable_ivm_refresh=true
+        //                                        while planning a PCT-shape query (see #73004).
+        // Resetting in this method's `finally` (the previous design) fired before
+        // execProcessExecPlan ran, leaving the TVR callback unregistered and
+        // baseTableInfoTvrVersionRangeMap stuck at baseline across all incremental refreshes.
+        savedEnableIvmRefresh = ctx.getSessionVariable().isEnableIVMRefresh();
+        savedTvrTargetMvId = ctx.getSessionVariable().getTvrTargetMvId();
         ctx.getSessionVariable().setEnableIVMRefresh(true);
         ctx.getSessionVariable().setTvrTargetMvid(GsonUtils.GSON.toJson(mv.getMvId()));
+        ivmScopeOpen = true;
         try {
             final Set<Table> baseTables = snapshotBaseTables.values()
                     .stream()
@@ -489,9 +515,26 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                 mvContext.setExecPlan(execPlan);
             }
             return insertStmt;
-        } finally {
-            ctx.getSessionVariable().setEnableIVMRefresh(prevIvmEnabled);
-            ctx.getSessionVariable().setTvrTargetMvid(prevTvrTargetMvId);
+        } catch (Exception e) {
+            // Prepare failed; close the scope so MVHybridRefreshProcessor.switchToPCTRefresh
+            // can plan a clean PCT query on the same ConnectContext.
+            closeIvmScope(ctx);
+            throw e;
+        }
+        // NOTE: no `finally` here — the scope stays open on normal completion; closed by
+        // execProcessExecPlan()'s finally after executor.executePlan() returns.
+    }
+
+    /**
+     * Reset the IVM session-variable scope opened by prepareRefreshPlan(). Idempotent: a
+     * second call is a no-op. Called from either prepareRefreshPlan()'s catch (prepare
+     * failed) or execProcessExecPlan()'s finally (normal completion or exec failure).
+     */
+    private void closeIvmScope(ConnectContext ctx) {
+        if (ivmScopeOpen) {
+            ctx.getSessionVariable().setEnableIVMRefresh(savedEnableIvmRefresh);
+            ctx.getSessionVariable().setTvrTargetMvid(savedTvrTargetMvId);
+            ivmScopeOpen = false;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -164,9 +164,8 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         final ExecPlan execPlan = processExecPlan.execPlan();
         final ConnectContext ctx = mvContext.getCtx();
 
-        // Scope enable_ivm_refresh around executor.executePlan so InsertLoadTxnCallbackFactory
-        // registers IVMInsertLoadTxnCallback for this INSERT (otherwise the persistent TVR
-        // map never advances and incremental refreshes accumulate duplicate rows).
+        // Scope enable_ivm_refresh around executor.executePlan so
+        // InsertLoadTxnCallbackFactory registers the TVR-persistence callback.
         boolean prevIvmEnabled = ctx.getSessionVariable().isEnableIVMRefresh();
         String prevTvrTargetMvId = ctx.getSessionVariable().getTvrTargetMvId();
         ctx.getSessionVariable().setEnableIVMRefresh(true);
@@ -460,10 +459,8 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                 .setQuerySource(QueryDetail.QuerySource.MV.name())
                 .setCNGroup(ctx.getCurrentComputeResourceName());
 
-        // Scope enable_ivm_refresh to this method so IvmRewriter sees it but the variable
-        // doesn't leak — neither into MVHybridRefreshProcessor's PCT fallback after this
-        // throws (#73004), nor into the caller's session after `EXPLAIN REFRESH ...`
-        // (which runs prepareRefreshPlan without ever invoking execProcessExecPlan).
+        // Scope enable_ivm_refresh to this method so it doesn't leak into the Hybrid
+        // -> PCT fallback (#73004) or the caller's session after EXPLAIN REFRESH.
         boolean prevIvmEnabled = ctx.getSessionVariable().isEnableIVMRefresh();
         String prevTvrTargetMvId = ctx.getSessionVariable().getTvrTargetMvId();
         ctx.getSessionVariable().setEnableIVMRefresh(true);

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_multi_refresh_tvr_advance
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_multi_refresh_tvr_advance
@@ -1,12 +1,4 @@
 -- name: test_ivm_with_iceberg_multi_refresh_tvr_advance
--- Regression: ensure baseTableInfoTvrVersionRangeMap advances across multiple
--- incremental refreshes. Pre-fix, prepareRefreshPlan()'s finally reset
--- enable_ivm_refresh before executor.executePlan ran, so
--- IVMInsertLoadTxnCallback never registered and the persistent TVR map
--- stayed at baseline — each refresh recomputed the delta from baseline →
--- currentVersion, producing duplicate-row accumulation in the MV
--- (mv rows grow by 1, 2, 3, ... instead of by the new-insert count).
-
 create external catalog mv_iceberg_${uuid0}
 properties
 (
@@ -14,20 +6,32 @@ properties
     "iceberg.catalog.type" = "hive",
     "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
 );
+-- result:
+-- !result
 set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
 create database mv_ice_db_${uuid0};
+-- result:
+-- !result
 use mv_ice_db_${uuid0};
-
+-- result:
+-- !result
 create table t_multi (k int, v bigint);
+-- result:
+-- !result
 insert into t_multi values (1, 10), (2, 20);
-
+-- result:
+-- !result
 set catalog default_catalog;
+-- result:
+-- !result
 create database db_${uuid0};
+-- result:
+-- !result
 use db_${uuid0};
-
--- Unpartitioned IVM MV with simple projection (the minimal shape that triggers
--- the bug: partitioned MVs go through PCT and have a separate TVR persistence
--- path, so the regression specifically targets the IVM-only code path).
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv_multi
 REFRESH DEFERRED MANUAL
 properties
@@ -35,45 +39,77 @@ properties
     "refresh_mode" = "incremental"
 )
 AS SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi;
-
--- Baseline refresh (goes through Hybrid → PCT to establish TVR baseline).
+-- result:
+-- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
-
--- Iteration 1: +1 row → mv should have 3 rows. (Pre-fix: 3 ✓ — first
--- post-baseline refresh happens to look correct because the persistent map
--- starts at the baseline snapshot S0; this is the only refresh where the
--- bug is invisible.)
+-- result:
+2
+-- !result
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (3, 30);
+-- result:
+-- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
-
--- Iteration 2: +1 row → mv should have 4 rows. (Pre-fix: 5 — TVR stuck at S0,
--- delta = S0→S2 covers both iter1's row and iter2's row, iter1's row gets
--- re-applied.)
+-- result:
+3
+-- !result
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (4, 40);
+-- result:
+-- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
-
--- Iteration 3: +1 row → mv should have 5 rows. (Pre-fix: 8 — accumulating.)
+-- result:
+4
+-- !result
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (5, 50);
+-- result:
+-- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
-
--- Iteration 4: +2 rows → mv should have 7 rows. (Pre-fix: 12.)
+-- result:
+5
+-- !result
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (6, 60), (7, 70);
+-- result:
+-- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
-
--- Per-row equality. The count(*) checks above already catch duplicate
--- accumulation (pre-fix the mv row counts diverge as 3, 5, 8, 12 instead of
--- 3, 4, 5, 7). This SELECT pins the actual row values too — both source
--- and mv should produce the same 7 rows when ordered by (k, v).
+-- result:
+7
+-- !result
 SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi ORDER BY k, v;
+-- result:
+1	10
+2	20
+3	30
+4	40
+5	50
+6	60
+7	70
+-- !result
 SELECT k, v FROM test_mv_multi ORDER BY k, v;
-
+-- result:
+1	10
+2	20
+3	30
+4	40
+5	50
+6	60
+7	70
+-- !result
 drop materialized view test_mv_multi;
+-- result:
+-- !result
 drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi force;
+-- result:
+-- !result
 drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
 drop database db_${uuid0} force;
+-- result:
+-- !result
 drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_multi_refresh_tvr_advance
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_multi_refresh_tvr_advance
@@ -46,6 +46,14 @@ SELECT count(*) FROM test_mv_multi;
 -- result:
 2
 -- !result
+[UC]EXPLAIN REFRESH MATERIALIZED VIEW test_mv_multi;
+SELECT @@enable_ivm_refresh;
+-- result:
+0
+-- !result
+SELECT @@tvr_target_mvid;
+-- result:
+-- !result
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (3, 30);
 -- result:
 -- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_multi_refresh_tvr_advance
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_multi_refresh_tvr_advance
@@ -1,0 +1,88 @@
+-- name: test_ivm_with_iceberg_multi_refresh_tvr_advance
+-- Regression: ensure baseTableInfoTvrVersionRangeMap advances across multiple
+-- incremental refreshes. Pre-fix, prepareRefreshPlan()'s finally reset
+-- enable_ivm_refresh before executor.executePlan ran, so
+-- IVMInsertLoadTxnCallback never registered and the persistent TVR map
+-- stayed at baseline — each refresh recomputed the delta from baseline →
+-- currentVersion, producing duplicate-row accumulation in the MV
+-- (mv rows grow by 1, 2, 3, ... instead of by the new-insert count).
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+
+create table t_multi (k int, v bigint);
+insert into t_multi values (1, 10), (2, 20);
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Unpartitioned IVM MV with simple projection (the minimal shape that triggers
+-- the bug: partitioned MVs go through PCT and have a separate TVR persistence
+-- path, so the regression specifically targets the IVM-only code path).
+CREATE MATERIALIZED VIEW test_mv_multi
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi;
+
+-- Baseline refresh (goes through Hybrid → PCT to establish TVR baseline).
+[UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
+SELECT count(*) FROM test_mv_multi;
+
+-- Iteration 1: +1 row → mv should have 3 rows. (Pre-fix: 3 ✓ — first
+-- post-baseline refresh happens to look correct because the persistent map
+-- starts at the baseline snapshot S0; this is the only refresh where the
+-- bug is invisible.)
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (3, 30);
+[UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
+SELECT count(*) FROM test_mv_multi;
+
+-- Iteration 2: +1 row → mv should have 4 rows. (Pre-fix: 5 — TVR stuck at S0,
+-- delta = S0→S2 covers both iter1's row and iter2's row, iter1's row gets
+-- re-applied.)
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (4, 40);
+[UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
+SELECT count(*) FROM test_mv_multi;
+
+-- Iteration 3: +1 row → mv should have 5 rows. (Pre-fix: 8 — accumulating.)
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (5, 50);
+[UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
+SELECT count(*) FROM test_mv_multi;
+
+-- Iteration 4: +2 rows → mv should have 7 rows. (Pre-fix: 12.)
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (6, 60), (7, 70);
+[UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
+SELECT count(*) FROM test_mv_multi;
+
+-- Content equality: mv and base must have identical row multiset.
+-- Use grouped count to catch duplicates that simple EXCEPT (set semantics)
+-- would miss.
+SELECT k, v, count(*) FROM test_mv_multi GROUP BY k, v ORDER BY k;
+
+-- Symmetric difference must be empty.
+SELECT count(*) FROM (
+  (SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi
+   EXCEPT
+   SELECT k, v FROM test_mv_multi)
+  UNION ALL
+  (SELECT k, v FROM test_mv_multi
+   EXCEPT
+   SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi)
+) d;
+
+drop materialized view test_mv_multi;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_multi_refresh_tvr_advance
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_multi_refresh_tvr_advance
@@ -40,6 +40,15 @@ AS SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi;
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
 
+-- Regression: EXPLAIN REFRESH only invokes getProcessExecPlan() and never
+-- calls execProcessExecPlan(). The IVM session-variable scope MUST be
+-- contained within prepareRefreshPlan() — leaking enable_ivm_refresh=true
+-- and tvr_target_mvid into the caller's ConnectContext would taint every
+-- subsequent statement in the session.
+[UC]EXPLAIN REFRESH MATERIALIZED VIEW test_mv_multi;
+SELECT @@enable_ivm_refresh;
+SELECT @@tvr_target_mvid;
+
 -- Iteration 1: +1 row → mv should have 3 rows. (Pre-fix: 3 ✓ — first
 -- post-baseline refresh happens to look correct because the persistent map
 -- starts at the baseline snapshot S0; this is the only refresh where the

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_multi_refresh_tvr_advance
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_multi_refresh_tvr_advance
@@ -1,11 +1,6 @@
 -- name: test_ivm_with_iceberg_multi_refresh_tvr_advance
--- Regression: ensure baseTableInfoTvrVersionRangeMap advances across multiple
--- incremental refreshes. Pre-fix, prepareRefreshPlan()'s finally reset
--- enable_ivm_refresh before executor.executePlan ran, so
--- IVMInsertLoadTxnCallback never registered and the persistent TVR map
--- stayed at baseline — each refresh recomputed the delta from baseline →
--- currentVersion, producing duplicate-row accumulation in the MV
--- (mv rows grow by 1, 2, 3, ... instead of by the new-insert count).
+-- Pins the expected mv row-count sequence and asserts that EXPLAIN REFRESH
+-- does not leak enable_ivm_refresh / tvr_target_mvid into the caller's session.
 
 create external catalog mv_iceberg_${uuid0}
 properties
@@ -25,9 +20,8 @@ set catalog default_catalog;
 create database db_${uuid0};
 use db_${uuid0};
 
--- Unpartitioned IVM MV with simple projection (the minimal shape that triggers
--- the bug: partitioned MVs go through PCT and have a separate TVR persistence
--- path, so the regression specifically targets the IVM-only code path).
+-- Unpartitioned IVM MV: hits the pure-IVM refresh path (partitioned MVs route
+-- through PCT and have a separate TVR persistence mechanism).
 CREATE MATERIALIZED VIEW test_mv_multi
 REFRESH DEFERRED MANUAL
 properties
@@ -36,48 +30,32 @@ properties
 )
 AS SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi;
 
--- Baseline refresh (goes through Hybrid → PCT to establish TVR baseline).
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
 
--- Regression: EXPLAIN REFRESH only invokes getProcessExecPlan() and never
--- calls execProcessExecPlan(). The IVM session-variable scope MUST be
--- contained within prepareRefreshPlan() — leaking enable_ivm_refresh=true
--- and tvr_target_mvid into the caller's ConnectContext would taint every
--- subsequent statement in the session.
+-- EXPLAIN REFRESH runs prepareRefreshPlan() without invoking execProcessExecPlan(),
+-- so the IVM scope must be contained within prepareRefreshPlan() — leaking
+-- enable_ivm_refresh or tvr_target_mvid would taint subsequent statements.
 [UC]EXPLAIN REFRESH MATERIALIZED VIEW test_mv_multi;
 SELECT @@enable_ivm_refresh;
 SELECT @@tvr_target_mvid;
 
--- Iteration 1: +1 row → mv should have 3 rows. (Pre-fix: 3 ✓ — first
--- post-baseline refresh happens to look correct because the persistent map
--- starts at the baseline snapshot S0; this is the only refresh where the
--- bug is invisible.)
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (3, 30);
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
 
--- Iteration 2: +1 row → mv should have 4 rows. (Pre-fix: 5 — TVR stuck at S0,
--- delta = S0→S2 covers both iter1's row and iter2's row, iter1's row gets
--- re-applied.)
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (4, 40);
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
 
--- Iteration 3: +1 row → mv should have 5 rows. (Pre-fix: 8 — accumulating.)
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (5, 50);
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
 
--- Iteration 4: +2 rows → mv should have 7 rows. (Pre-fix: 12.)
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi values (6, 60), (7, 70);
 [UC]REFRESH MATERIALIZED VIEW test_mv_multi WITH SYNC MODE;
 SELECT count(*) FROM test_mv_multi;
 
--- Per-row equality. The count(*) checks above already catch duplicate
--- accumulation (pre-fix the mv row counts diverge as 3, 5, 8, 12 instead of
--- 3, 4, 5, 7). This SELECT pins the actual row values too — both source
--- and mv should produce the same 7 rows when ordered by (k, v).
 SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t_multi ORDER BY k, v;
 SELECT k, v FROM test_mv_multi ORDER BY k, v;
 


### PR DESCRIPTION
## Why I'm doing:

After #73004 landed (scoping `enable_ivm_refresh` away from the Hybrid→PCT fallback), incremental MV refresh on an unpartitioned IVM MV started silently accumulating duplicate rows from the second refresh onward. The persistent TVR position (`baseTableInfoTvrVersionRangeMap`) stayed pinned at the baseline snapshot, so every later refresh recomputed delta from baseline → current and re-applied all post-baseline rows.

### Reproducer

```sql
-- iceberg base
CREATE TABLE iceberg_t (k INT, v BIGINT);
INSERT INTO iceberg_t VALUES (1,10),(2,20);

CREATE MATERIALIZED VIEW mv
  REFRESH DEFERRED MANUAL
  PROPERTIES ('refresh_mode' = 'incremental')
  AS SELECT k, v FROM iceberg_t;
REFRESH MATERIALIZED VIEW mv WITH SYNC MODE;  -- mv = 2 ✓

INSERT INTO iceberg_t VALUES (3, 30);
REFRESH MATERIALIZED VIEW mv WITH SYNC MODE;  -- mv = 3 ✓
INSERT INTO iceberg_t VALUES (4, 40);
REFRESH MATERIALIZED VIEW mv WITH SYNC MODE;  -- mv = 5  ❌ (should be 4)
INSERT INTO iceberg_t VALUES (5, 50);
REFRESH MATERIALIZED VIEW mv WITH SYNC MODE;  -- mv = 8  ❌ (should be 5)
INSERT INTO iceberg_t VALUES (6, 60), (7, 70);
REFRESH MATERIALIZED VIEW mv WITH SYNC MODE;  -- mv = 12 ❌ (should be 7)
```

### Root cause

`enable_ivm_refresh` is consulted at two distinct call sites:

1. `IvmRewriter.rewrite()` — plan-build (current behaviour: gated correctly)
2. `InsertLoadTxnCallbackFactory.of()` — INSERT execution, decides whether to register `IVMInsertLoadTxnCallback` (the only writer of `baseTableInfoTvrVersionRangeMap.put` via `afterCommitted()`)

`prepareRefreshPlan()`'s `try-finally` (added by #73004) reset the session variable as soon as the plan was built, before `execProcessExecPlan()` invoked `executor.executePlan()`. By the time the factory ran, the variable was `false`, the callback was null, `afterCommitted()` never fired, and the persistent TVR map stayed at baseline.

The only refresh that *appeared* correct was the first one after baseline — its delta = (baseline, S1) happens to be the right delta even when the persistent map stayed at baseline.

## What I'm doing:

Extend the IVM session-variable scope across both phases without adding a second set/reset. **One set, one reset per refresh.**

- `prepareRefreshPlan()`: `try-finally` → `try-catch`. The catch resets only on prepare failure (the path Hybrid takes to fall back to PCT — this preserves #73004's design intent that PCT planning must not see `enable_ivm_refresh=true`).
- `execProcessExecPlan()`: a new top-level `try-finally` resets the scope after `executor.executePlan()` returns (whether the INSERT succeeded or threw).
- A small private `closeIvmScope(ctx)` helper, idempotent on re-entry, used by both paths.

No other call sites changed: `InsertLoadTxnCallbackFactory.of()` still gates on `enable_ivm_refresh`; the Hybrid fallback path still sees a clean session variable.

Fixes the regression introduced by #73004.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Test plan

- Added `test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_multi_refresh_tvr_advance` pinning the post-fix mv row-count sequence (2 → 3 → 4 → 5 → 7); the pre-fix would produce (2 → 3 → 5 → 8 → 12).
- Verified locally against a dev cluster running FE built from this branch — 3/3 in cdsql flaky-test mode.
- Manually reproduced the pre-fix behaviour on the same cluster before applying the fix (matches the sequence in the reproducer above).