### PR TITLE
[Refactor] Renumber TxnInfoPB.colocate_column_count from 9 to 11

### DIFF
--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -421,7 +421,7 @@ message TxnInfoPB {
     // Carried at the txn level (not per SplittingTabletInfoPB) because the value
     // is table-level metadata: every SplittingTabletInfoPB in one txn would
     // carry the same value.
-    optional int32 colocate_column_count = 9;
+    optional int32 colocate_column_count = 11;
 }
 
 message SplittingTabletInfoPB {


### PR DESCRIPTION
## Why I'm doing:

Reassign the field number of the recently-added `TxnInfoPB.colocate_column_count` (introduced in #73008) from `9` to `11`.

## What I'm doing:

- `gensrc/proto/lake_types.proto`: change `optional int32 colocate_column_count = 9;` to `optional int32 colocate_column_count = 11;` inside `message TxnInfoPB`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Test plan

- [ ] BE compiles after regenerating protobuf (`cd gensrc && make proto && ./build.sh --be`)
- [ ] FE compiles (`./build.sh --fe`)
- [ ] `python3 build-support/check_gensrc_schema_compatibility.py --mode changed --base origin/main` passes for the changed field

Note: the field `colocate_column_count` was added very recently in #73008 and has not yet shipped in any release, so renumbering does not break existing on-disk data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
