### PR TITLE
[BugFix] Fix BE service static link order

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -536,6 +536,7 @@ endif()
 # Set starrocks libraries
 set(STARROCKS_LINK_LIBS
     ${WL_START_GROUP}
+    Service
     Agent
     Connector
     Exec

--- a/be/src/service/CMakeLists.txt
+++ b/be/src/service/CMakeLists.txt
@@ -32,7 +32,7 @@ ADD_BE_LIB(Service
         ${EXEC_FILES}
 )
 
-target_link_libraries(ServiceBE PUBLIC Service)
+add_dependencies(ServiceBE Service)
 
 # only build starrocks_be when TEST is off
 if ((NOT ${MAKE_TEST} STREQUAL "ON") AND (NOT BUILD_FORMAT_LIB))


### PR DESCRIPTION
Place the Service archive in the BE static library group so service objects can resolve symbols from Util, Runtime, Exec, and related internal libraries during final linking.

```
be/src/service/daemon.cpp:114: error: undefined reference to 'starrocks::SystemMetrics::get_disks_io_time(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, long, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, long> > >*)'
```

**reproduction environment:**
docker image: docker pull starrocks/dev-env-centos7:latest
branch: main

## Why I'm doing:

The BE final link can fail because `libService.a` is emitted after the main static library group. Since service objects reference symbols from internal BE libraries such as `Util`, `Runtime`, `Exec`, `Common`, and `StarOSIntegration`, the static linker may not revisit those earlier archives and reports undefined references.

## What I'm doing:

Move `Service` into `STARROCKS_LINK_LIBS` so it participates in the existing `--start-group/--end-group` static archive resolution, and keep `ServiceBE` dependent on `Service` only for build ordering instead of exporting it as a late transitive link dependency.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
