### PR TITLE
[Enhancement] Skip redundant partition key expr build on add_partition_value dedup hit

### DIFF
--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -383,6 +383,16 @@ StatusOr<TPartitionMap*> HiveTableDescriptor::deserialize_partition_map(
 
 Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, ObjectPool* pool, int64_t id,
                                                 const THdfsPartition& thrift_partition) {
+    // Produce a uniform mismatch error so that callers see the same wording and
+    // fields regardless of which branch (fast-path shared-lock hit, or slow-path
+    // emplace() race loss) actually detected the conflict.
+    auto mismatch_status = [&](const HdfsPartitionDescriptor* old_partition) {
+        return Status::InternalError(fmt::format(
+                "Partition id {} already exists with different partition_key_exprs. "
+                "new partition (thrift) = {}, old_partition = {}",
+                id, apache::thrift::ThriftDebugString(thrift_partition), old_partition->debug_string()));
+    };
+
     // Fast path: shared-lock lookup. If the partition is already registered, skip
     // building a new HdfsPartitionDescriptor and the expensive create_part_key_exprs
     // (ExprFactory + prepare + open). This is the common case when many scan ranges
@@ -393,10 +403,7 @@ Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, Obj
         if (it != _partition_id_to_desc_map.end()) {
             auto* old_partition = it->second;
             if (thrift_partition.partition_key_exprs != old_partition->thrift_partition_key_exprs()) {
-                return Status::InternalError(fmt::format(
-                        "Partition id {} already exists with different partition_key_exprs. "
-                        "new partition (thrift) = {}, old_partition = {}",
-                        id, apache::thrift::ThriftDebugString(thrift_partition), old_partition->debug_string()));
+                return mismatch_status(old_partition);
             }
             return Status::OK();
         }
@@ -413,10 +420,8 @@ Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, Obj
     auto [it, inserted] = _partition_id_to_desc_map.emplace(id, partition);
     if (!inserted) {
         auto* old_partition = it->second;
-        if (partition->thrift_partition_key_exprs() != old_partition->thrift_partition_key_exprs()) {
-            return Status::InternalError(
-                    fmt::format("Partition id {} already exists. new partition = {}, old_partition = {}", id,
-                                partition->debug_string(), old_partition->debug_string()));
+        if (thrift_partition.partition_key_exprs != old_partition->thrift_partition_key_exprs()) {
+            return mismatch_status(old_partition);
         }
         // The newly built `partition` is unreferenced; it will be freed when `pool` dies.
     }

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -393,8 +393,10 @@ Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, Obj
         if (it != _partition_id_to_desc_map.end()) {
             auto* old_partition = it->second;
             if (thrift_partition.partition_key_exprs != old_partition->thrift_partition_key_exprs()) {
-                return Status::InternalError(
-                        fmt::format("Partition id {} already exists with different partition_key_exprs.", id));
+                return Status::InternalError(fmt::format(
+                        "Partition id {} already exists with different partition_key_exprs. "
+                        "new partition (thrift) = {}, old_partition = {}",
+                        id, apache::thrift::ThriftDebugString(thrift_partition), old_partition->debug_string()));
             }
             return Status::OK();
         }

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -387,10 +387,10 @@ Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, Obj
     // fields regardless of which branch (fast-path shared-lock hit, or slow-path
     // emplace() race loss) actually detected the conflict.
     auto mismatch_status = [&](const HdfsPartitionDescriptor* old_partition) {
-        return Status::InternalError(fmt::format(
-                "Partition id {} already exists with different partition_key_exprs. "
-                "new partition (thrift) = {}, old_partition = {}",
-                id, apache::thrift::ThriftDebugString(thrift_partition), old_partition->debug_string()));
+        return Status::InternalError(
+                fmt::format("Partition id {} already exists with different partition_key_exprs. "
+                            "new partition (thrift) = {}, old_partition = {}",
+                            id, apache::thrift::ThriftDebugString(thrift_partition), old_partition->debug_string()));
     };
 
     // Fast path: shared-lock lookup. If the partition is already registered, skip

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -383,21 +383,40 @@ StatusOr<TPartitionMap*> HiveTableDescriptor::deserialize_partition_map(
 
 Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, ObjectPool* pool, int64_t id,
                                                 const THdfsPartition& thrift_partition) {
-    auto* partition = pool->add(new HdfsPartitionDescriptor(thrift_partition, _mr));
-    RETURN_IF_ERROR(partition->create_part_key_exprs(runtime_state, pool));
+    // Fast path: shared-lock lookup. If the partition is already registered, skip
+    // building a new HdfsPartitionDescriptor and the expensive create_part_key_exprs
+    // (ExprFactory + prepare + open). This is the common case when many scan ranges
+    // share the same partition_id.
     {
-        std::unique_lock lock(_map_mutex);
+        std::shared_lock lock(_map_mutex);
         const auto it = _partition_id_to_desc_map.find(id);
         if (it != _partition_id_to_desc_map.end()) {
             auto* old_partition = it->second;
-            if (partition->thrift_partition_key_exprs() != old_partition->thrift_partition_key_exprs()) {
+            if (thrift_partition.partition_key_exprs != old_partition->thrift_partition_key_exprs()) {
                 return Status::InternalError(
-                        fmt::format("Partition id {} already exists. new partition = {}, old_partition = {}", id,
-                                    partition->debug_string(), old_partition->debug_string()));
+                        fmt::format("Partition id {} already exists with different partition_key_exprs.", id));
             }
-        } else {
-            _partition_id_to_desc_map[id] = partition;
+            return Status::OK();
         }
+    }
+
+    // Slow path: build a new HdfsPartitionDescriptor and its key exprs outside any
+    // lock so that create_part_key_exprs (prepare/open) is not serialized.
+    auto* partition = pool->add(new HdfsPartitionDescriptor(thrift_partition, _mr));
+    RETURN_IF_ERROR(partition->create_part_key_exprs(runtime_state, pool));
+
+    // Insert under a write lock; another caller may have inserted the same id while
+    // we were building, so double-check and tolerate the race.
+    std::unique_lock lock(_map_mutex);
+    auto [it, inserted] = _partition_id_to_desc_map.emplace(id, partition);
+    if (!inserted) {
+        auto* old_partition = it->second;
+        if (partition->thrift_partition_key_exprs() != old_partition->thrift_partition_key_exprs()) {
+            return Status::InternalError(
+                    fmt::format("Partition id {} already exists. new partition = {}, old_partition = {}", id,
+                                partition->debug_string(), old_partition->debug_string()));
+        }
+        // The newly built `partition` is unreferenced; it will be freed when `pool` dies.
     }
     return Status::OK();
 }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -269,6 +269,7 @@ set(EXEC_FILES
         ./exec/data_sinks/arrow_result_writer_test.cpp
         ./runtime/buffer_control_block_test.cpp
         ./runtime/data_stream_mgr_test.cpp
+        ./runtime/descriptors_test.cpp
         ./runtime/diagnose_daemon_test.cpp
         ./runtime/external_scan_context_mgr_test.cpp
         ./runtime/fragment_mgr_test.cpp

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -1,0 +1,188 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/descriptors.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include "base/testutil/assert.h"
+#include "common/object_pool.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "runtime/descriptors_ext.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+class HiveTableDescriptorAddPartitionTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _exec_env = ExecEnv::GetInstance();
+        _pool = std::make_unique<ObjectPool>();
+
+        TTableDescriptor tdesc;
+        tdesc.id = 1;
+        tdesc.tableType = TTableType::HDFS_TABLE;
+        _table_desc = _pool->add(new HdfsTableDescriptor(tdesc, _pool.get()));
+
+        _runtime_state = _make_runtime_state();
+    }
+
+    std::shared_ptr<RuntimeState> _make_runtime_state() {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        auto rs = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, _exec_env);
+        TUniqueId query_id;
+        rs->init_mem_trackers(query_id);
+        return rs;
+    }
+
+    // Build a minimal THdfsPartition. partition_key_exprs is left empty by default;
+    // callers can override with custom thrift to exercise the dedup-conflict branch.
+    static THdfsPartition _make_partition(std::vector<TExpr> partition_key_exprs = {}) {
+        THdfsPartition p;
+        p.file_format = THdfsFileFormat::TEXT;
+        p.location.suffix = "";
+        p.partition_key_exprs = std::move(partition_key_exprs);
+        return p;
+    }
+
+    // Returns a TExpr that is non-equal under thrift `!=` to a default-constructed TExpr.
+    // We just give it one synthetic node so the vector comparison detects a difference.
+    static TExpr _make_distinct_thrift_expr() {
+        TExpr e;
+        TExprNode node;
+        node.node_type = TExprNodeType::INT_LITERAL;
+        node.num_children = 0;
+        e.nodes.push_back(node);
+        return e;
+    }
+
+protected:
+    ExecEnv* _exec_env = nullptr;
+    std::unique_ptr<ObjectPool> _pool;
+    HdfsTableDescriptor* _table_desc = nullptr;
+    std::shared_ptr<RuntimeState> _runtime_state;
+};
+
+// First call inserts a new partition descriptor; get_partition returns it.
+TEST_F(HiveTableDescriptorAddPartitionTest, FirstCallInsertsNewEntry) {
+    constexpr int64_t partition_id = 1;
+    THdfsPartition thrift = _make_partition();
+
+    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift));
+
+    HdfsPartitionDescriptor* desc = _table_desc->get_partition(partition_id);
+    ASSERT_NE(nullptr, desc);
+    ASSERT_EQ(thrift.partition_key_exprs, desc->thrift_partition_key_exprs());
+}
+
+// Second call with the same partition_id and same thrift is a dedup hit on the fast
+// path. The previously inserted descriptor must remain in the map (no replacement).
+TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdSameThriftIsDedupHit) {
+    constexpr int64_t partition_id = 2;
+    THdfsPartition thrift = _make_partition();
+
+    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift));
+    HdfsPartitionDescriptor* first = _table_desc->get_partition(partition_id);
+    ASSERT_NE(nullptr, first);
+
+    // Same thrift: must succeed and must NOT replace the existing entry.
+    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift));
+    HdfsPartitionDescriptor* second = _table_desc->get_partition(partition_id);
+    ASSERT_EQ(first, second);
+}
+
+// Second call with the same partition_id but different thrift must fail.
+TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdDifferentThriftFails) {
+    constexpr int64_t partition_id = 3;
+    THdfsPartition base = _make_partition();
+    THdfsPartition conflict = _make_partition({_make_distinct_thrift_expr()});
+
+    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, base));
+
+    Status s = _table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, conflict);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_internal_error()) << s.to_string();
+
+    // Existing entry must be unchanged.
+    HdfsPartitionDescriptor* desc = _table_desc->get_partition(partition_id);
+    ASSERT_NE(nullptr, desc);
+    ASSERT_EQ(base.partition_key_exprs, desc->thrift_partition_key_exprs());
+}
+
+// Different partition_ids should produce independent descriptors.
+TEST_F(HiveTableDescriptorAddPartitionTest, DifferentPartitionIdsCoexist) {
+    THdfsPartition p1 = _make_partition();
+    THdfsPartition p2 = _make_partition({_make_distinct_thrift_expr()});
+
+    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), 10, p1));
+    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), 11, p2));
+
+    HdfsPartitionDescriptor* d10 = _table_desc->get_partition(10);
+    HdfsPartitionDescriptor* d11 = _table_desc->get_partition(11);
+    ASSERT_NE(nullptr, d10);
+    ASSERT_NE(nullptr, d11);
+    ASSERT_NE(d10, d11);
+}
+
+// Many sequential dedup-hits on the same partition_id must all succeed and never
+// replace the original entry. Exercises the shared_lock fast path.
+TEST_F(HiveTableDescriptorAddPartitionTest, RepeatedDedupHitsKeepFirstEntry) {
+    constexpr int64_t partition_id = 42;
+    THdfsPartition thrift = _make_partition();
+
+    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift));
+    HdfsPartitionDescriptor* first = _table_desc->get_partition(partition_id);
+
+    for (int i = 0; i < 100; ++i) {
+        ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift));
+    }
+    ASSERT_EQ(first, _table_desc->get_partition(partition_id));
+}
+
+// Concurrent add_partition_value with the same id + same thrift from many threads
+// must yield exactly one descriptor in the map. The races between the shared_lock
+// fast path miss and the unique_lock slow path insert must all resolve to the same
+// surviving entry without errors.
+TEST_F(HiveTableDescriptorAddPartitionTest, ConcurrentInsertSameIdConvergesToOne) {
+    constexpr int64_t partition_id = 7;
+    THdfsPartition thrift = _make_partition();
+
+    constexpr int kThreads = 8;
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    std::vector<Status> statuses(kThreads);
+
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([&, i]() {
+            statuses[i] = _table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift);
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+    for (const auto& s : statuses) {
+        ASSERT_OK(s);
+    }
+
+    HdfsPartitionDescriptor* desc = _table_desc->get_partition(partition_id);
+    ASSERT_NE(nullptr, desc);
+    ASSERT_EQ(thrift.partition_key_exprs, desc->thrift_partition_key_exprs());
+}
+
+} // namespace starrocks

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -107,7 +107,9 @@ TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdSameThriftIsDedupHit)
     ASSERT_EQ(first, second);
 }
 
-// Second call with the same partition_id but different thrift must fail.
+// Second call with the same partition_id but different thrift must fail, and the
+// error message must surface enough context (both the new thrift and the existing
+// partition's debug string) to help diagnose the mismatch.
 TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdDifferentThriftFails) {
     constexpr int64_t partition_id = 3;
     THdfsPartition base = _make_partition();
@@ -118,6 +120,11 @@ TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdDifferentThriftFails)
     Status s = _table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, conflict);
     ASSERT_FALSE(s.ok());
     ASSERT_TRUE(s.is_internal_error()) << s.to_string();
+
+    const std::string msg = s.to_string();
+    EXPECT_NE(std::string::npos, msg.find(std::to_string(partition_id))) << msg;
+    EXPECT_NE(std::string::npos, msg.find("partition_key_exprs")) << msg;
+    EXPECT_NE(std::string::npos, msg.find("old_partition")) << msg;
 
     // Existing entry must be unchanged.
     HdfsPartitionDescriptor* desc = _table_desc->get_partition(partition_id);

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -132,9 +132,13 @@ TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdDifferentThriftFails)
     ASSERT_FALSE(s.ok());
     ASSERT_TRUE(s.is_internal_error()) << s.to_string();
 
+    // The mismatch error must include id, both descriptors, and explicitly mention
+    // partition_key_exprs. The format is unified across fast-path and slow-path race
+    // branches, so this assertion is deterministic regardless of which branch fires.
     const std::string msg = s.to_string();
     EXPECT_NE(std::string::npos, msg.find(std::to_string(partition_id))) << msg;
     EXPECT_NE(std::string::npos, msg.find("partition_key_exprs")) << msg;
+    EXPECT_NE(std::string::npos, msg.find("new partition (thrift)")) << msg;
     EXPECT_NE(std::string::npos, msg.find("old_partition")) << msg;
 
     // Existing entry must be unchanged.

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -21,9 +21,11 @@
 #include "base/testutil/assert.h"
 #include "common/object_pool.h"
 #include "gen_cpp/Descriptors_types.h"
+#include "gen_cpp/Exprs_types.h"
 #include "runtime/descriptors_ext.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
+#include "types/logical_type.h"
 
 namespace starrocks {
 
@@ -61,13 +63,22 @@ public:
         return p;
     }
 
-    // Returns a TExpr that is non-equal under thrift `!=` to a default-constructed TExpr.
-    // We just give it one synthetic node so the vector comparison detects a difference.
-    static TExpr _make_distinct_thrift_expr() {
-        TExpr e;
+    // Returns a TExpr describing a valid INT_LITERAL so it can survive both the
+    // thrift inequality check on the fast path and a real ExprFactory::create_expr_trees
+    // call on the slow path. The literal value is parameterised so callers can produce
+    // distinct-but-valid exprs.
+    static TExpr _make_int_literal_thrift_expr(int64_t value) {
         TExprNode node;
         node.node_type = TExprNodeType::INT_LITERAL;
+        node.type = gen_type_desc(TPrimitiveType::INT);
         node.num_children = 0;
+        node.is_nullable = false;
+        node.has_nullable_child = false;
+        TIntLiteral lit;
+        lit.value = value;
+        node.__set_int_literal(lit);
+
+        TExpr e;
         e.nodes.push_back(node);
         return e;
     }
@@ -113,7 +124,7 @@ TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdSameThriftIsDedupHit)
 TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdDifferentThriftFails) {
     constexpr int64_t partition_id = 3;
     THdfsPartition base = _make_partition();
-    THdfsPartition conflict = _make_partition({_make_distinct_thrift_expr()});
+    THdfsPartition conflict = _make_partition({_make_int_literal_thrift_expr(1)});
 
     ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, base));
 
@@ -135,7 +146,7 @@ TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdDifferentThriftFails)
 // Different partition_ids should produce independent descriptors.
 TEST_F(HiveTableDescriptorAddPartitionTest, DifferentPartitionIdsCoexist) {
     THdfsPartition p1 = _make_partition();
-    THdfsPartition p2 = _make_partition({_make_distinct_thrift_expr()});
+    THdfsPartition p2 = _make_partition({_make_int_literal_thrift_expr(42)});
 
     ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), 10, p1));
     ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), 11, p2));


### PR DESCRIPTION
## Why I'm doing:

This first pr for: https://github.com/StarRocks/starrocks/issues/73136

HiveTableDescriptor::add_partition_value is invoked once per scan range carrying a partition_value (in _prepare_exec_plan and the incremental scan-range RPC path). For HDFS/Hive/Iceberg tables it is common to have many scan ranges sharing the same partition_id — for example, one Hive partition typically backs multiple data files / scan ranges. Every such call would hit the dedup branch and discard the new descriptor.
The old implementation does the expensive work unconditionally before checking the map:

```
auto* partition = pool->add(new HdfsPartitionDescriptor(thrift_partition, _mr));
RETURN_IF_ERROR(partition->create_part_key_exprs(runtime_state, pool));   // ExprFactory + prepare + open
{
    std::unique_lock lock(_map_mutex);
    if (map.find(id) exists) { /* dedup, throw away the work above */ }
    else { map[id] = partition; }
}
```

So on a dedup hit it pays for:

- one new HdfsPartitionDescriptor (thrift copy)
- ExprFactory::create_expr_trees → ExprExecutor::prepare → ExprExecutor::open
- a write lock on _map_mutex

All wasted, on every same-partition scan range. With thousands of scan ranges per partition (large Hive/Iceberg tables) this shows up as a few–tens of ms of unnecessary work in fragment prepare, plus serialized writer-lock contention across fragments concurrently registering partitions.
The intent of the original "build before locking" ordering was to keep the critical section small — but it conflated "build cheap thrift copy" with "build ExprContexts and run prepare/open", paying the expensive cost even on the dedup-hit path.


## What I'm doing:

Skip redundant partition key expr build on add_partition_value dedup hit

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
