### PR TITLE
[Internal/TSP-Validation] Test PR — flip enable_load_segment_parallel default to true (base)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -658,7 +658,7 @@ CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
 // The interval for performing stack trace to control the frequency.
 CONF_mInt64(diagnose_stack_trace_interval_ms, "1800000");
 
-CONF_Bool(enable_load_segment_parallel, "false");
+CONF_Bool(enable_load_segment_parallel, "true");
 CONF_Int32(load_segment_thread_pool_num_max, "128");
 CONF_Int32(load_segment_thread_pool_queue_size, "10240");
 

--- a/be/src/common/config_ingest_fwd.h
+++ b/be/src/common/config_ingest_fwd.h
@@ -125,7 +125,7 @@ CONF_mInt32(load_fp_brpc_timeout_ms, "-1");
 // Used in load fail point. The block time to simulate TabletsChannel::add_chunk spends much time
 CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
 
-CONF_Bool(enable_load_segment_parallel, "false");
+CONF_Bool(enable_load_segment_parallel, "true");
 
 // write buffer size before flush
 CONF_mInt64(write_buffer_size, "104857600");


### PR DESCRIPTION
Internal TSP validation PR for PR #72827. Do not merge.

This branch is upstream/main + a single commit that flips `enable_load_segment_parallel` default to `true`, so a TSP shared-data cluster picks up the parallel-load path on the **base** (no parallel iterator construction) for an apples-to-apples comparison vs #72827.

Will be closed once measurement is complete.