### PR TITLE
[Internal/TSP-Validation] Test PR — PR 72827 + flip enable_load_segment_parallel default to true

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -653,7 +653,7 @@ CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
 // The interval for performing stack trace to control the frequency.
 CONF_mInt64(diagnose_stack_trace_interval_ms, "1800000");
 
-CONF_Bool(enable_load_segment_parallel, "false");
+CONF_Bool(enable_load_segment_parallel, "true");
 CONF_Int32(load_segment_thread_pool_num_max, "128");
 CONF_Int32(load_segment_thread_pool_queue_size, "10240");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -657,13 +657,6 @@ CONF_Bool(enable_load_segment_parallel, "false");
 CONF_Int32(load_segment_thread_pool_num_max, "128");
 CONF_Int32(load_segment_thread_pool_queue_size, "10240");
 
-// Construct per-segment iterators in parallel inside
-// Rowset::get_each_segment_iterator_with_delvec. Each task runs SegmentIterator
-// construction on load_segment_thread_pool so the eager delvec / dcg remote reads
-// inside the constructor can overlap across segments. Independent of
-// enable_load_segment_parallel, which only parallelizes segment footer loading.
-CONF_mBool(enable_load_segment_iterator_parallel, "false");
-
 // Enable segment metadata filter for lake tables.
 // When enabled, segments whose sort key range does not intersect with query predicates will be skipped.
 CONF_mBool(enable_lake_segment_metadata_filter, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -657,6 +657,13 @@ CONF_Bool(enable_load_segment_parallel, "false");
 CONF_Int32(load_segment_thread_pool_num_max, "128");
 CONF_Int32(load_segment_thread_pool_queue_size, "10240");
 
+// Construct per-segment iterators in parallel inside
+// Rowset::get_each_segment_iterator_with_delvec. Each task runs SegmentIterator
+// construction on load_segment_thread_pool so the eager delvec / dcg remote reads
+// inside the constructor can overlap across segments. Independent of
+// enable_load_segment_parallel, which only parallelizes segment footer loading.
+CONF_mBool(enable_load_segment_iterator_parallel, "false");
+
 // Enable segment metadata filter for lake tables.
 // When enabled, segments whose sort key range does not intersect with query predicates will be skipped.
 CONF_mBool(enable_lake_segment_metadata_filter, "true");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -401,7 +401,6 @@
         "load_diagnose_rpc_timeout_stack_trace_threshold_ms",
         "load_fp_brpc_timeout_ms",
         "enable_load_segment_parallel",
-        "enable_load_segment_iterator_parallel",
         "write_buffer_size",
         "load_process_max_memory_hard_limit_ratio",
         "enable_new_load_on_memory_limit_exceeded",

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -401,6 +401,7 @@
         "load_diagnose_rpc_timeout_stack_trace_threshold_ms",
         "load_fp_brpc_timeout_ms",
         "enable_load_segment_parallel",
+        "enable_load_segment_iterator_parallel",
         "write_buffer_size",
         "load_process_max_memory_hard_limit_ratio",
         "enable_new_load_on_memory_limit_exceeded",

--- a/be/src/common/config_ingest_fwd.h
+++ b/be/src/common/config_ingest_fwd.h
@@ -125,7 +125,7 @@ CONF_mInt32(load_fp_brpc_timeout_ms, "-1");
 // Used in load fail point. The block time to simulate TabletsChannel::add_chunk spends much time
 CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
 
-CONF_Bool(enable_load_segment_parallel, "false");
+CONF_Bool(enable_load_segment_parallel, "true");
 
 // write buffer size before flush
 CONF_mInt64(write_buffer_size, "104857600");

--- a/be/src/common/config_ingest_fwd.h
+++ b/be/src/common/config_ingest_fwd.h
@@ -127,6 +127,13 @@ CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
 
 CONF_Bool(enable_load_segment_parallel, "false");
 
+// Construct per-segment iterators in parallel inside
+// Rowset::get_each_segment_iterator_with_delvec. Each task runs SegmentIterator
+// construction on load_segment_thread_pool so the eager delvec / dcg remote reads
+// inside the constructor can overlap across segments. Independent of
+// enable_load_segment_parallel, which only parallelizes segment footer loading.
+CONF_mBool(enable_load_segment_iterator_parallel, "false");
+
 // write buffer size before flush
 CONF_mInt64(write_buffer_size, "104857600");
 

--- a/be/src/common/config_ingest_fwd.h
+++ b/be/src/common/config_ingest_fwd.h
@@ -127,13 +127,6 @@ CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
 
 CONF_Bool(enable_load_segment_parallel, "false");
 
-// Construct per-segment iterators in parallel inside
-// Rowset::get_each_segment_iterator_with_delvec. Each task runs SegmentIterator
-// construction on load_segment_thread_pool so the eager delvec / dcg remote reads
-// inside the constructor can overlap across segments. Independent of
-// enable_load_segment_parallel, which only parallelizes segment footer loading.
-CONF_mBool(enable_load_segment_iterator_parallel, "false");
-
 // write buffer size before flush
 CONF_mInt64(write_buffer_size, "104857600");
 

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -519,7 +519,10 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         return opts;
     };
 
-    const bool parallel = config::enable_load_segment_iterator_parallel && segments.size() > 1;
+    // Reuse _parallel_load (initialized from config::enable_load_segment_parallel) so the
+    // segment-range-mode constructor — which forces _parallel_load=false to keep segment
+    // order — keeps the serial path here too.
+    const bool parallel = _parallel_load && segments.size() > 1;
 
     if (!parallel) {
         std::vector<ChunkIteratorPtr> seg_iterators;

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -560,14 +560,13 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         auto task = std::make_shared<std::packaged_task<StatusOr<ChunkIteratorPtr>()>>(
                 [seg_ptr, schema, opts]() { return seg_ptr->new_iterator(schema, opts); });
         auto fut = task->get_future();
-        auto submit_st =
-                ExecEnv::GetInstance()->load_segment_thread_pool()->submit_func([task]() { (*task)(); });
+        auto submit_st = ExecEnv::GetInstance()->load_segment_thread_pool()->submit_func([task]() { (*task)(); });
         if (!submit_st.ok()) {
             // Thread pool busy / shutting down: run inline so we still make forward progress.
             // The future becomes ready as soon as (*task)() returns.
             LOG(WARNING) << "submit_func failed for new_iterator: " << submit_st.code_as_string()
-                         << ", falling back to inline construction, seg_idx: " << i
-                         << ", tablet: " << _tablet_id << ", rowset: " << metadata().id();
+                         << ", falling back to inline construction, seg_idx: " << i << ", tablet: " << _tablet_id
+                         << ", rowset: " << metadata().id();
             (*task)();
         }
         iter_futures.push_back(std::move(fut));

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -488,7 +488,10 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         const std::vector<SparseRangePtr>* rowid_range_per_segment) {
     TRACE_COUNTER_SCOPE_LATENCY_US("get_each_segment_iterator_with_delvec_us");
     std::vector<SegmentPtr> segments;
-    RETURN_IF_ERROR(load_segments(&segments, false));
+    {
+        TRACE_COUNTER_SCOPE_LATENCY_US("load_segments_for_iter_with_delvec_us");
+        RETURN_IF_ERROR(load_segments(&segments, false));
+    }
     auto root_loc = _tablet_mgr->tablet_root_location(tablet_id());
     SegmentReadOptions seg_options_template;
     ASSIGN_OR_RETURN(seg_options_template.fs, FileSystemFactory::CreateSharedFromString(root_loc));
@@ -544,36 +547,39 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         token = ExecEnv::GetInstance()->load_segment_thread_pool()->new_token(ThreadPool::ExecutionMode::CONCURRENT);
     }
 
-    for (int i = 0; i < (int)segments.size(); i++) {
-        auto seg_ptr = segments[i];
-        auto opts = build_per_segment_options(i);
-        auto task = [seg_ptr, schema, opts, &per_segment_iters, &err_mutex, &first_err, i]() {
-            auto res = seg_ptr->new_iterator(schema, opts);
-            if (res.status().is_end_of_file()) {
-                // Leave per_segment_iters[i] as nullptr; the final compaction loop drops nullptrs.
-                return;
-            }
-            if (!res.ok()) {
-                std::lock_guard<std::mutex> lock(err_mutex);
-                first_err.update(res.status());
-                return;
-            }
-            per_segment_iters[i] = std::move(res).value();
-        };
-        if (token) {
-            auto submit_st = token->submit_func(task);
-            if (!submit_st.ok()) {
-                // Thread pool busy / shutting down: run inline so we still make forward progress.
-                LOG(WARNING) << "submit_func failed for new_iterator: " << submit_st.code_as_string()
-                             << ", falling back to inline construction, seg_idx: " << i << ", tablet: " << _tablet_id
-                             << ", rowset: " << metadata().id();
+    {
+        TRACE_COUNTER_SCOPE_LATENCY_US("build_segment_iter_with_delvec_us");
+        for (int i = 0; i < (int)segments.size(); i++) {
+            auto seg_ptr = segments[i];
+            auto opts = build_per_segment_options(i);
+            auto task = [seg_ptr, schema, opts, &per_segment_iters, &err_mutex, &first_err, i]() {
+                auto res = seg_ptr->new_iterator(schema, opts);
+                if (res.status().is_end_of_file()) {
+                    // Leave per_segment_iters[i] as nullptr; the final compaction loop drops nullptrs.
+                    return;
+                }
+                if (!res.ok()) {
+                    std::lock_guard<std::mutex> lock(err_mutex);
+                    first_err.update(res.status());
+                    return;
+                }
+                per_segment_iters[i] = std::move(res).value();
+            };
+            if (token) {
+                auto submit_st = token->submit_func(task);
+                if (!submit_st.ok()) {
+                    // Thread pool busy / shutting down: run inline so we still make forward progress.
+                    LOG(WARNING) << "submit_func failed for new_iterator: " << submit_st.code_as_string()
+                                 << ", falling back to inline construction, seg_idx: " << i
+                                 << ", tablet: " << _tablet_id << ", rowset: " << metadata().id();
+                    task();
+                }
+            } else {
                 task();
             }
-        } else {
-            task();
         }
+        if (token) token->wait();
     }
-    if (token) token->wait();
 
     if (!first_err.ok()) {
         return first_err;

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -521,45 +521,29 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         return opts;
     };
 
-    // Reuse _parallel_load (initialized from config::enable_load_segment_parallel) so the
-    // segment-range-mode constructor — which forces _parallel_load=false to keep segment
-    // order — keeps the serial path here too.
-    const bool parallel = _parallel_load && segments.size() > 1;
-
-    if (!parallel) {
-        std::vector<ChunkIteratorPtr> seg_iterators;
-        seg_iterators.reserve(segments.size());
-        for (int i = 0; i < (int)segments.size(); i++) {
-            auto opts = build_per_segment_options(i);
-            auto res = segments[i]->new_iterator(schema, opts);
-            if (res.status().is_end_of_file()) {
-                continue;
-            }
-            if (!res.ok()) {
-                return res.status();
-            }
-            seg_iterators.push_back(std::move(res).value());
-        }
-        return seg_iterators;
-    }
-
-    // Parallel path: fan out new_iterator calls so the eager delvec / dcg remote reads
-    // inside SegmentIterator's constructor can overlap. Each task captures its own
-    // SegmentReadOptions copy (per-segment fields differ); the shared loaders /
-    // FileSystem are read-only across the parallel section. Stats updates inside the
-    // ctor (get_delvec_ns / get_delta_column_group_ns) are written from worker threads
-    // onto the shared `stats` — these are tracing-only counters, the IO byte/count
-    // fields are not touched until get_next/close runs serially.
+    // Single loop covers both serial and parallel paths. When `_parallel_load` is on
+    // (mirroring config::enable_load_segment_parallel; the segment-range-mode ctor forces
+    // it false to preserve segment order), submit each task to a ThreadPoolToken so the
+    // eager delvec / dcg remote reads inside SegmentIterator's constructor can overlap.
+    // Otherwise — and on submit failure — run the task inline.
     //
-    // Use a ThreadPoolToken for the barrier (token->wait()) instead of a per-segment
-    // future, mirroring UpdateManager::_do_update_with_condition_parallel. Per-segment
-    // outputs are written to a pre-sized vector (each thread owns its own slot, so no
-    // mutex is needed); the first error is captured under a mutex.
+    // Each task writes to its own slot in `per_segment_iters` (independent memory, no
+    // mutex needed). The first error is recorded into `first_err` via Status::update
+    // under a small mutex (rare path).
+    //
+    // Stats updates inside the ctor (get_delvec_ns / get_delta_column_group_ns) are
+    // written from worker threads onto the shared `stats` — these are tracing-only
+    // counters, the IO byte/count fields are not touched until get_next/close runs
+    // serially.
     std::vector<ChunkIteratorPtr> per_segment_iters(segments.size()); // default-init to nullptr
     std::mutex err_mutex;
     Status first_err = Status::OK();
 
-    auto token = ExecEnv::GetInstance()->load_segment_thread_pool()->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    std::unique_ptr<ThreadPoolToken> token;
+    if (_parallel_load && segments.size() > 1) {
+        token = ExecEnv::GetInstance()->load_segment_thread_pool()->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
+    }
 
     for (int i = 0; i < (int)segments.size(); i++) {
         auto seg_ptr = segments[i];
@@ -572,21 +556,25 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
             }
             if (!res.ok()) {
                 std::lock_guard<std::mutex> lock(err_mutex);
-                if (first_err.ok()) first_err = res.status();
+                first_err.update(res.status());
                 return;
             }
             per_segment_iters[i] = std::move(res).value();
         };
-        auto submit_st = token->submit_func(task);
-        if (!submit_st.ok()) {
-            // Thread pool busy / shutting down: run inline so we still make forward progress.
-            LOG(WARNING) << "submit_func failed for new_iterator: " << submit_st.code_as_string()
-                         << ", falling back to inline construction, seg_idx: " << i << ", tablet: " << _tablet_id
-                         << ", rowset: " << metadata().id();
+        if (token) {
+            auto submit_st = token->submit_func(task);
+            if (!submit_st.ok()) {
+                // Thread pool busy / shutting down: run inline so we still make forward progress.
+                LOG(WARNING) << "submit_func failed for new_iterator: " << submit_st.code_as_string()
+                             << ", falling back to inline construction, seg_idx: " << i << ", tablet: " << _tablet_id
+                             << ", rowset: " << metadata().id();
+                task();
+            }
+        } else {
             task();
         }
     }
-    token->wait();
+    if (token) token->wait();
 
     if (!first_err.ok()) {
         return first_err;

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -559,8 +559,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
     std::mutex err_mutex;
     Status first_err = Status::OK();
 
-    auto token = ExecEnv::GetInstance()->load_segment_thread_pool()->new_token(
-            ThreadPool::ExecutionMode::CONCURRENT);
+    auto token = ExecEnv::GetInstance()->load_segment_thread_pool()->new_token(ThreadPool::ExecutionMode::CONCURRENT);
 
     for (int i = 0; i < (int)segments.size(); i++) {
         auto seg_ptr = segments[i];

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <future>
+#include <mutex>
 #include <unordered_set>
 
 #include "base/debug/trace.h"
@@ -24,6 +25,7 @@
 #include "column/datum_convert.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_lake_fwd.h"
+#include "common/thread/threadpool.h"
 #include "fs/fs_factory.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
@@ -548,44 +550,53 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
     // ctor (get_delvec_ns / get_delta_column_group_ns) are written from worker threads
     // onto the shared `stats` — these are tracing-only counters, the IO byte/count
     // fields are not touched until get_next/close runs serially.
-    std::vector<std::future<StatusOr<ChunkIteratorPtr>>> iter_futures;
-    iter_futures.reserve(segments.size());
-    // Outlives futures so the wait-on-destruct fallback runs before futures are torn down.
-    DeferOp wait_iter_futures([&iter_futures]() {
-        for (auto& f : iter_futures) {
-            if (f.valid()) f.wait();
-        }
-    });
+    //
+    // Use a ThreadPoolToken for the barrier (token->wait()) instead of a per-segment
+    // future, mirroring UpdateManager::_do_update_with_condition_parallel. Per-segment
+    // outputs are written to a pre-sized vector (each thread owns its own slot, so no
+    // mutex is needed); the first error is captured under a mutex.
+    std::vector<ChunkIteratorPtr> per_segment_iters(segments.size()); // default-init to nullptr
+    std::mutex err_mutex;
+    Status first_err = Status::OK();
+
+    auto token = ExecEnv::GetInstance()->load_segment_thread_pool()->new_token(
+            ThreadPool::ExecutionMode::CONCURRENT);
 
     for (int i = 0; i < (int)segments.size(); i++) {
         auto seg_ptr = segments[i];
         auto opts = build_per_segment_options(i);
-        auto task = std::make_shared<std::packaged_task<StatusOr<ChunkIteratorPtr>()>>(
-                [seg_ptr, schema, opts]() { return seg_ptr->new_iterator(schema, opts); });
-        auto fut = task->get_future();
-        auto submit_st = ExecEnv::GetInstance()->load_segment_thread_pool()->submit_func([task]() { (*task)(); });
+        auto task = [seg_ptr, schema, opts, &per_segment_iters, &err_mutex, &first_err, i]() {
+            auto res = seg_ptr->new_iterator(schema, opts);
+            if (res.status().is_end_of_file()) {
+                // Leave per_segment_iters[i] as nullptr; the final compaction loop drops nullptrs.
+                return;
+            }
+            if (!res.ok()) {
+                std::lock_guard<std::mutex> lock(err_mutex);
+                if (first_err.ok()) first_err = res.status();
+                return;
+            }
+            per_segment_iters[i] = std::move(res).value();
+        };
+        auto submit_st = token->submit_func(task);
         if (!submit_st.ok()) {
             // Thread pool busy / shutting down: run inline so we still make forward progress.
-            // The future becomes ready as soon as (*task)() returns.
             LOG(WARNING) << "submit_func failed for new_iterator: " << submit_st.code_as_string()
                          << ", falling back to inline construction, seg_idx: " << i << ", tablet: " << _tablet_id
                          << ", rowset: " << metadata().id();
-            (*task)();
+            task();
         }
-        iter_futures.push_back(std::move(fut));
     }
+    token->wait();
 
+    if (!first_err.ok()) {
+        return first_err;
+    }
     std::vector<ChunkIteratorPtr> seg_iterators;
     seg_iterators.reserve(segments.size());
-    for (auto& f : iter_futures) {
-        auto res = f.get();
-        if (res.status().is_end_of_file()) {
-            continue;
-        }
-        if (!res.ok()) {
-            return res.status();
-        }
-        seg_iterators.push_back(std::move(res).value());
+    for (auto& it : per_segment_iters) {
+        if (it == nullptr) continue; // EOF-skipped segment
+        seg_iterators.push_back(std::move(it));
     }
     return seg_iterators;
 }

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -541,8 +541,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
 
     std::unique_ptr<ThreadPoolToken> token;
     if (_parallel_load && segments.size() > 1) {
-        token = ExecEnv::GetInstance()->load_segment_thread_pool()->new_token(
-                ThreadPool::ExecutionMode::CONCURRENT);
+        token = ExecEnv::GetInstance()->load_segment_thread_pool()->new_token(ThreadPool::ExecutionMode::CONCURRENT);
     }
 
     for (int i = 0; i < (int)segments.size(); i++) {

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -488,37 +488,95 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
     std::vector<SegmentPtr> segments;
     RETURN_IF_ERROR(load_segments(&segments, false));
     auto root_loc = _tablet_mgr->tablet_root_location(tablet_id());
-    std::vector<ChunkIteratorPtr> seg_iterators;
-    seg_iterators.reserve(segments.size());
-    SegmentReadOptions seg_options;
-    ASSIGN_OR_RETURN(seg_options.fs, FileSystemFactory::CreateSharedFromString(root_loc));
-    seg_options.stats = stats;
-    seg_options.lake_io_opts.fs = seg_options.fs;
-    seg_options.lake_io_opts.location_provider = _tablet_mgr->location_provider();
-    seg_options.is_primary_keys = true;
-    seg_options.delvec_loader =
-            std::make_shared<LakeDelvecLoader>(_tablet_mgr, builder, true /*fill cache*/, seg_options.lake_io_opts);
-    seg_options.dcg_loader = std::make_shared<LakeDeltaColumnGroupLoader>(_tablet_metadata);
-    seg_options.version = version;
-    seg_options.tablet_id = tablet_id();
-    seg_options.rowset_id = metadata().id();
+    SegmentReadOptions seg_options_template;
+    ASSIGN_OR_RETURN(seg_options_template.fs, FileSystemFactory::CreateSharedFromString(root_loc));
+    seg_options_template.stats = stats;
+    seg_options_template.lake_io_opts.fs = seg_options_template.fs;
+    seg_options_template.lake_io_opts.location_provider = _tablet_mgr->location_provider();
+    seg_options_template.is_primary_keys = true;
+    seg_options_template.delvec_loader = std::make_shared<LakeDelvecLoader>(_tablet_mgr, builder, true /*fill cache*/,
+                                                                            seg_options_template.lake_io_opts);
+    seg_options_template.dcg_loader = std::make_shared<LakeDeltaColumnGroupLoader>(_tablet_metadata);
+    seg_options_template.version = version;
+    seg_options_template.tablet_id = tablet_id();
+    seg_options_template.rowset_id = metadata().id();
 
     ASSIGN_OR_RETURN(auto shared_segment_range, get_seek_range());
 
-    for (int i = 0; i < segments.size(); i++) {
-        auto& seg_ptr = segments[i];
-        seg_options.tablet_range = std::nullopt;
+    auto build_per_segment_options = [&](int i) {
+        SegmentReadOptions opts = seg_options_template;
+        opts.tablet_range = std::nullopt;
         if (i < _metadata->shared_segments_size() && _metadata->shared_segments(i) &&
             shared_segment_range.has_value()) {
-            seg_options.tablet_range = *shared_segment_range;
+            opts.tablet_range = *shared_segment_range;
         }
         // Apply per-segment rowid range if provided
         if (rowid_range_per_segment != nullptr && i < rowid_range_per_segment->size()) {
-            seg_options.rowid_range_option = (*rowid_range_per_segment)[i];
+            opts.rowid_range_option = (*rowid_range_per_segment)[i];
         } else {
-            seg_options.rowid_range_option = nullptr;
+            opts.rowid_range_option = nullptr;
         }
-        auto res = seg_ptr->new_iterator(schema, seg_options);
+        return opts;
+    };
+
+    const bool parallel = config::enable_load_segment_iterator_parallel && segments.size() > 1;
+
+    if (!parallel) {
+        std::vector<ChunkIteratorPtr> seg_iterators;
+        seg_iterators.reserve(segments.size());
+        for (int i = 0; i < (int)segments.size(); i++) {
+            auto opts = build_per_segment_options(i);
+            auto res = segments[i]->new_iterator(schema, opts);
+            if (res.status().is_end_of_file()) {
+                continue;
+            }
+            if (!res.ok()) {
+                return res.status();
+            }
+            seg_iterators.push_back(std::move(res).value());
+        }
+        return seg_iterators;
+    }
+
+    // Parallel path: fan out new_iterator calls so the eager delvec / dcg remote reads
+    // inside SegmentIterator's constructor can overlap. Each task captures its own
+    // SegmentReadOptions copy (per-segment fields differ); the shared loaders /
+    // FileSystem are read-only across the parallel section. Stats updates inside the
+    // ctor (get_delvec_ns / get_delta_column_group_ns) are written from worker threads
+    // onto the shared `stats` — these are tracing-only counters, the IO byte/count
+    // fields are not touched until get_next/close runs serially.
+    std::vector<std::future<StatusOr<ChunkIteratorPtr>>> iter_futures;
+    iter_futures.reserve(segments.size());
+    // Outlives futures so the wait-on-destruct fallback runs before futures are torn down.
+    DeferOp wait_iter_futures([&iter_futures]() {
+        for (auto& f : iter_futures) {
+            if (f.valid()) f.wait();
+        }
+    });
+
+    for (int i = 0; i < (int)segments.size(); i++) {
+        auto seg_ptr = segments[i];
+        auto opts = build_per_segment_options(i);
+        auto task = std::make_shared<std::packaged_task<StatusOr<ChunkIteratorPtr>()>>(
+                [seg_ptr, schema, opts]() { return seg_ptr->new_iterator(schema, opts); });
+        auto fut = task->get_future();
+        auto submit_st =
+                ExecEnv::GetInstance()->load_segment_thread_pool()->submit_func([task]() { (*task)(); });
+        if (!submit_st.ok()) {
+            // Thread pool busy / shutting down: run inline so we still make forward progress.
+            // The future becomes ready as soon as (*task)() returns.
+            LOG(WARNING) << "submit_func failed for new_iterator: " << submit_st.code_as_string()
+                         << ", falling back to inline construction, seg_idx: " << i
+                         << ", tablet: " << _tablet_id << ", rowset: " << metadata().id();
+            (*task)();
+        }
+        iter_futures.push_back(std::move(fut));
+    }
+
+    std::vector<ChunkIteratorPtr> seg_iterators;
+    seg_iterators.reserve(segments.size());
+    for (auto& f : iter_futures) {
+        auto res = f.get();
         if (res.status().is_end_of_file()) {
             continue;
         }

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -875,7 +875,9 @@ TEST_F(LakeRowsetTest, test_get_each_segment_iterator_with_delvec_parallel) {
     set_rowset_shared_segments(rs_meta, true);
     set_tablet_range_int(_tablet_metadata.get(), 10, true, 12, false);
 
-    ConfigResetGuard<bool> guard(&config::enable_load_segment_iterator_parallel, true);
+    // Rowset captures _parallel_load (= enable_load_segment_parallel) at construction time,
+    // so the guard must be in place before the Rowset is created.
+    ConfigResetGuard<bool> guard(&config::enable_load_segment_parallel, true);
 
     auto rowset =
             std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -865,6 +865,29 @@ TEST_F(LakeRowsetTest, test_get_each_segment_iterator_with_delvec_respects_table
     ASSERT_EQ(count_rows_from_iters(seg_iters), 3 * 2);
 }
 
+// Same as the test above, but with parallel iterator construction enabled. Verifies
+// that fan-out via load_segment_thread_pool produces the same per-segment iterators
+// in the same order as the serial path, and that per-segment options (tablet_range)
+// are honored independently per task.
+TEST_F(LakeRowsetTest, test_get_each_segment_iterator_with_delvec_parallel) {
+    create_rowsets_for_testing();
+    auto* rs_meta = _tablet_metadata->mutable_rowsets(0);
+    set_rowset_shared_segments(rs_meta, true);
+    set_tablet_range_int(_tablet_metadata.get(), 10, true, 12, false);
+
+    ConfigResetGuard<bool> guard(&config::enable_load_segment_iterator_parallel, true);
+
+    auto rowset =
+            std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);
+    OlapReaderStatistics stats;
+    auto input_schema = ChunkHelper::convert_schema(_tablet_schema, std::vector<ColumnId>{0});
+    ASSIGN_OR_ABORT(auto seg_iters, rowset->get_each_segment_iterator_with_delvec(input_schema, 1, nullptr, &stats));
+
+    // 3 segments, each contributes keys {10, 11} after tablet range filtering.
+    ASSERT_EQ(seg_iters.size(), 3);
+    ASSERT_EQ(count_rows_from_iters(seg_iters), 3 * 2);
+}
+
 // Test class for segment metadata filter and parallel load with skip_segment_idxs
 class LakeRowsetSegmentMetadataFilterTest : public TestBase {
 public:

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -40,6 +40,7 @@
 #include "storage/lake/versioned_tablet.h"
 #include "storage/lake/vertical_compaction_task.h"
 #include "storage/predicate_tree/predicate_tree.hpp"
+#include "storage/range.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/tablet_schema.h"
 #include "test_util.h"
@@ -865,29 +866,62 @@ TEST_F(LakeRowsetTest, test_get_each_segment_iterator_with_delvec_respects_table
     ASSERT_EQ(count_rows_from_iters(seg_iters), 3 * 2);
 }
 
-// Same as the test above, but with parallel iterator construction enabled. Verifies
-// that fan-out via load_segment_thread_pool produces the same per-segment iterators
-// in the same order as the serial path, and that per-segment options (tablet_range)
-// are honored independently per task.
+// Verify the parallel path (fan-out onto load_segment_thread_pool) returns iterators
+// in the same order as the serial path AND honors per-segment SegmentReadOptions
+// independently. All 3 segments share identical content, so the only way to make
+// per-segment ordering observable is to give each one a distinct rowid_range and
+// check that the returned iterators yield matching row counts in index order.
 TEST_F(LakeRowsetTest, test_get_each_segment_iterator_with_delvec_parallel) {
     create_rowsets_for_testing();
-    auto* rs_meta = _tablet_metadata->mutable_rowsets(0);
-    set_rowset_shared_segments(rs_meta, true);
-    set_tablet_range_int(_tablet_metadata.get(), 10, true, 12, false);
 
-    // Rowset captures _parallel_load (= enable_load_segment_parallel) at construction time,
-    // so the guard must be in place before the Rowset is created.
-    ConfigResetGuard<bool> guard(&config::enable_load_segment_parallel, true);
-
-    auto rowset =
-            std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);
-    OlapReaderStatistics stats;
     auto input_schema = ChunkHelper::convert_schema(_tablet_schema, std::vector<ColumnId>{0});
-    ASSIGN_OR_ABORT(auto seg_iters, rowset->get_each_segment_iterator_with_delvec(input_schema, 1, nullptr, &stats));
 
-    // 3 segments, each contributes keys {10, 11} after tablet range filtering.
-    ASSERT_EQ(seg_iters.size(), 3);
-    ASSERT_EQ(count_rows_from_iters(seg_iters), 3 * 2);
+    // Distinct row counts per segment: 3, 1, 2. Identical-output across segments would
+    // mask ordering bugs, so the counts must all differ.
+    std::vector<SparseRangePtr> per_seg_ranges(3);
+    per_seg_ranges[0] = std::make_shared<SparseRange<>>(0, 3);
+    per_seg_ranges[1] = std::make_shared<SparseRange<>>(0, 1);
+    per_seg_ranges[2] = std::make_shared<SparseRange<>>(0, 2);
+    const std::vector<size_t> expected_per_iter_rows{3, 1, 2};
+
+    auto run_and_count_per_iter = [&](bool parallel) {
+        // Rowset captures enable_load_segment_parallel at construction time, so the guard
+        // must be in place before the Rowset is created.
+        ConfigResetGuard<bool> guard(&config::enable_load_segment_parallel, parallel);
+        auto rowset = std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0,
+                                                     0 /* compaction_segment_limit */);
+        OlapReaderStatistics stats;
+        ASSIGN_OR_ABORT(auto seg_iters, rowset->get_each_segment_iterator_with_delvec(input_schema, 1, nullptr, &stats,
+                                                                                      &per_seg_ranges));
+        std::vector<size_t> per_iter_rows;
+        per_iter_rows.reserve(seg_iters.size());
+        for (const auto& it : seg_iters) {
+            CHECK(it->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
+            CHECK(it->init_output_schema(std::unordered_set<uint32_t>()).ok());
+            auto chunk = ChunkHelper::new_chunk(it->schema(), 1024);
+            size_t rows = 0;
+            while (true) {
+                chunk->reset();
+                auto st = it->get_next(chunk.get());
+                if (st.is_end_of_file()) break;
+                CHECK(st.ok()) << st.to_string();
+                rows += chunk->num_rows();
+            }
+            per_iter_rows.push_back(rows);
+        }
+        return per_iter_rows;
+    };
+
+    auto parallel_rows = run_and_count_per_iter(true);
+    auto serial_rows = run_and_count_per_iter(false);
+
+    // One iterator per segment.
+    ASSERT_EQ(parallel_rows.size(), 3u);
+    ASSERT_EQ(serial_rows.size(), 3u);
+    // Parallel output preserves serial order (vector equality, not just multiset).
+    ASSERT_EQ(parallel_rows, serial_rows);
+    // And per-segment rowid_range options were honored at the matching index.
+    ASSERT_EQ(parallel_rows, expected_per_iter_rows);
 }
 
 // Test class for segment metadata filter and parallel load with skip_segment_idxs


### PR DESCRIPTION
Internal TSP validation PR for PR #72827. Do not merge.

This branch is PR #72827 + a single commit that flips `enable_load_segment_parallel` default to `true`, so a TSP shared-data cluster picks up the parallel iterator-construction path for an apples-to-apples comparison vs base (PR #73163).

Will be closed once measurement is complete.