### PR TITLE
[Refactor] Tidy row id reuse in segment iterator OR-MATCH fallback

### DIFF
--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <utility>
 
 #include "exprs/expr.h"

--- a/be/src/storage/column_predicate_inverted_index_fallback.cpp
+++ b/be/src/storage/column_predicate_inverted_index_fallback.cpp
@@ -32,16 +32,19 @@ InvertedIndexFallbackPredicate::InvertedIndexFallbackPredicate(const ColumnExprP
 
 Status InvertedIndexFallbackPredicate::evaluate(const Column* column, uint8_t* selection, uint16_t from,
                                                 uint16_t to) const {
-    // Does not support range evaluation
+    // The rowid buffer is populated in chunk-row order during the scan; rowid
+    // for chunk row i lives at (*_rowid_buffer)[i]. We evaluate the chunk-row
+    // range [from, to), which must fit inside the captured rowids.
     DCHECK(from == 0);
+    DCHECK_LE(to, _rowid_buffer->size());
 
-    // Use bitmap for fallback evaluation
     const bool is_negated = is_negated_expr();
     const uint8_t hit_value = is_negated ? 0 : 1;
     const uint8_t miss_value = is_negated ? 1 : 0;
     roaring::BulkContext ctx;
-    for (size_t i = 0; i < _rowid_buffer->size(); i++) {
-        selection[i] = _bitmap.containsBulk(ctx, (*_rowid_buffer)[i]) ? hit_value : miss_value;
+    const auto& rowids = *_rowid_buffer;
+    for (uint16_t i = from; i < to; i++) {
+        selection[i] = _bitmap.containsBulk(ctx, rowids[i]) ? hit_value : miss_value;
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/or_match_fallback_visitor.h
+++ b/be/src/storage/rowset/or_match_fallback_visitor.h
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "common/object_pool.h"
+#include "common/status.h"
+#include "gutil/casts.h"
+#include "runtime/descriptors.h" // SlotDescriptor::col_name() is called below
+#include "storage/column_expr_predicate.h"
+#include "storage/column_predicate.h"
+#include "storage/column_predicate_inverted_index_fallback.h"
+#include "storage/index/inverted/inverted_index_iterator.h"
+#include "storage/olap_common.h"
+#include "storage/predicate_tree/predicate_tree.h"
+
+namespace starrocks {
+
+// Walks an OR subtree of a predicate tree and replaces every MATCH-style
+// ColumnExprPredicate it finds with an InvertedIndexFallbackPredicate that
+// carries the segment-local rowid bitmap pre-loaded from the inverted index.
+//
+// Lives in a header (rather than as a function-local class) for two reasons:
+//   1. C++ forbids member function templates inside function-local classes,
+//      and the compound-node overload here is a template on CompoundNodeType.
+//   2. Unit tests can construct it directly to exercise the early-return
+//      branches without standing up a full SegmentIterator.
+//
+// The visitor's lifetime is bounded by a single
+// SegmentIterator::_wrap_or_match_predicates_for_fallback() call; references
+// it holds (iterators, pool, rowid_buffer, has_fallback_predicates) must
+// outlive that call.
+struct OrMatchFallbackVisitor {
+    const std::vector<InvertedIndexIterator*>& iterators;
+    ObjectPool& pool;
+    const std::vector<rowid_t>* rowid_buffer;
+    bool* has_fallback_predicates;
+
+    Status operator()(PredicateColumnNode& node) const {
+        const auto* pred = node.col_pred();
+        if (pred->type() != PredicateType::kExpr) {
+            return Status::OK();
+        }
+        const auto* expr_pred = down_cast<const ColumnExprPredicate*>(pred);
+        if (!expr_pred->is_match_expr()) {
+            return Status::OK();
+        }
+        InvertedIndexIterator* iter = iterators[pred->column_id()];
+        if (iter == nullptr) {
+            return Status::OK();
+        }
+        ASSIGN_OR_RETURN(auto bitmap_opt, expr_pred->read_inverted_index(expr_pred->slot_desc()->col_name(), iter));
+        if (!bitmap_opt.has_value()) {
+            bitmap_opt.emplace(); // empty bitmap => no matches in this segment
+        }
+        auto* wrapper = pool.add(new InvertedIndexFallbackPredicate(expr_pred, std::move(*bitmap_opt), rowid_buffer));
+        node.set_col_pred(wrapper);
+        *has_fallback_predicates = true;
+        return Status::OK();
+    }
+
+    template <CompoundNodeType Type>
+    Status operator()(PredicateCompoundNode<Type>& node) const {
+        for (auto child : node.children()) {
+            RETURN_IF_ERROR(child.visit(*this));
+        }
+        return Status::OK();
+    }
+};
+
+} // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -68,6 +68,7 @@
 #include "storage/rowset/default_value_column_iterator.h"
 #include "storage/rowset/dictcode_column_iterator.h"
 #include "storage/rowset/fill_subfield_iterator.h"
+#include "storage/rowset/or_match_fallback_visitor.h"
 #include "storage/rowset/rowid_column_iterator.h"
 #include "storage/rowset/segment.h"
 #include "storage/rowset/short_key_range_option.h"
@@ -322,6 +323,11 @@ private:
         std::vector<InvertedIndexIterator*> inverted_index_iterators;
         std::unordered_set<ColumnId> prune_cols_candidate_by_inverted_index;
 
+        // Reusable buffer of segment-level rowids captured during scan. Owned
+        // here because `InvertedIndexFallbackPredicate` holds a stable pointer
+        // to it and reads rowids[i] for chunk row i during evaluate().
+        std::vector<rowid_t> rowid_buffer;
+
         // Cleanup method to properly delete iterators
         void cleanup() {
             for (auto* iter : inverted_index_iterators) {
@@ -432,6 +438,10 @@ private:
     Status _init_inverted_index_iterators();
 
     Status _apply_inverted_index();
+    // Wrap MATCH predicates living inside OR subtrees of the predicate tree
+    // with `InvertedIndexFallbackPredicate`, so OR evaluation can fall back to
+    // a per-row bitmap lookup using the rowid captured during scan.
+    Status _wrap_or_match_predicates_for_fallback();
 
     Status _read(Chunk* chunk, vector<rowid_t>* rowid, size_t n, bool predicate_col_late_materialize_read);
 
@@ -555,9 +565,6 @@ private:
 
     // Inverted index context - only created when needed
     std::unique_ptr<InvertedIndexContext> _inverted_index_ctx;
-
-    // Reusable buffer for rowids to avoid repeated allocations
-    std::vector<rowid_t> _rowid_buffer;
 
     bool _enable_predicate_col_late_materialize;
 };
@@ -2125,12 +2132,17 @@ Status SegmentIterator::do_get_next(Chunk* chunk) {
     DCHECK_EQ(0, chunk->num_rows());
 
     Status st;
-    const bool need_rowids = (_vector_index_ctx && _vector_index_ctx->always_build_rowid()) ||
-                             (_inverted_index_ctx && _inverted_index_ctx->has_fallback_predicates);
-    if (need_rowids) {
-        _rowid_buffer.clear(); // Reuse existing capacity
+    std::vector<rowid_t> local_rowids;
+    std::vector<rowid_t>* p_rowids = nullptr;
+    // The OR-MATCH fallback path requires capturing into the buffer that the
+    // InvertedIndexFallbackPredicate already holds a pointer to. The vector
+    // index path just needs rowids; a per-call local is fine.
+    if (_inverted_index_ctx && _inverted_index_ctx->has_fallback_predicates) {
+        _inverted_index_ctx->rowid_buffer.clear();
+        p_rowids = &_inverted_index_ctx->rowid_buffer;
+    } else if (_vector_index_ctx && _vector_index_ctx->always_build_rowid()) {
+        p_rowids = &local_rowids;
     }
-    std::vector<uint32_t>* p_rowids = need_rowids ? &_rowid_buffer : nullptr;
     do {
         st = _do_get_next(chunk, p_rowids);
     } while (st.ok() && chunk->num_rows() == 0);
@@ -2165,15 +2177,21 @@ Status SegmentIterator::do_get_next(Chunk* chunk, vector<uint64_t>* rssid_rowids
     DCHECK_EQ(0, chunk->num_rows());
 
     Status st;
-    _rowid_buffer.clear(); // Reuse existing capacity
+    std::vector<rowid_t> local_rowids;
+    // When OR-MATCH fallback predicates are active, capture into the context
+    // buffer so the predicate's stored pointer stays valid.
+    std::vector<rowid_t>* p_rowids = &local_rowids;
+    if (_inverted_index_ctx && _inverted_index_ctx->has_fallback_predicates) {
+        _inverted_index_ctx->rowid_buffer.clear();
+        p_rowids = &_inverted_index_ctx->rowid_buffer;
+    }
     do {
-        st = _do_get_next(chunk, &_rowid_buffer);
+        st = _do_get_next(chunk, p_rowids);
     } while (st.ok() && chunk->num_rows() == 0);
     if (st.ok()) {
-        // encode rssid with rowid
-        // | rssid (32bit) | rowid (32bit) |
+        // encode rssid with rowid: | rssid (32bit) | rowid (32bit) |
         uint64_t rssid_shift = (uint64_t)(_opts.rowset_id + segment_id()) << 32;
-        for (uint32_t rowid : _rowid_buffer) {
+        for (uint32_t rowid : *p_rowids) {
             rssid_rowids->push_back(rssid_shift | rowid);
         }
     }
@@ -3655,63 +3673,22 @@ Status SegmentIterator::_init_inverted_index_iterators() {
     return Status::OK();
 }
 
-// Visitor for wrapping MATCH predicates in OR queries with InvertedIndexFallbackPredicate
-// Only wraps predicates that are inside OR nodes (non-immediate children of root)
-struct InvertedIndexFallbackVisitor {
-    Status operator()(PredicateColumnNode& node) const {
-        const auto* pred = node.col_pred();
-
-        // Only wrap ColumnExprPredicate with MATCH expressions
-        if (pred->type() != PredicateType::kExpr) {
-            return Status::OK();
-        }
-
-        const auto* expr_pred = static_cast<const ColumnExprPredicate*>(pred);
-        if (!expr_pred->is_match_expr()) {
-            return Status::OK();
-        }
-
-        // Get the inverted index iterator for this column
-        const ColumnId cid = pred->column_id();
-        InvertedIndexIterator* inverted_iter = inverted_index_iterators[cid];
-        if (inverted_iter == nullptr) {
-            return Status::OK();
-        }
-
-        // Read the bitmap from inverted index using the column name from SlotDescriptor
-        const auto column_name = expr_pred->slot_desc()->col_name();
-        ASSIGN_OR_RETURN(auto roaring_opt, expr_pred->read_inverted_index(column_name, inverted_iter));
-        if (!roaring_opt.has_value()) {
-            // use empty bitmap (no matches)
-            roaring_opt.emplace();
-        }
-
-        // Create the fallback wrapper with segment-specific bitmap and rowid buffer pointer
-        auto* wrapper = new InvertedIndexFallbackPredicate(expr_pred, std::move(roaring_opt.value()), rowid_buffer);
-        pool->add(wrapper);
-
-        // Replace the predicate in the tree
-        node.set_col_pred(wrapper);
-
-        // Mark that we have fallback predicates (need rowids during scan)
-        *has_fallback_predicates = true;
+Status SegmentIterator::_wrap_or_match_predicates_for_fallback() {
+    // Only OR subtrees need the per-row fallback. Immediate AND-children of the
+    // root keep the normal inverted-index filtering path.
+    if (!_opts.pred_tree.has_or_predicate()) {
         return Status::OK();
     }
 
-    template <CompoundNodeType Type>
-    Status operator()(PredicateCompoundNode<Type>& node) const {
-        // Recursively visit all children
-        for (auto child : node.children()) {
-            RETURN_IF_ERROR(child.visit(*this));
-        }
-        return Status::OK();
+    OrMatchFallbackVisitor visitor{_inverted_index_ctx->inverted_index_iterators, _obj_pool,
+                                   &_inverted_index_ctx->rowid_buffer, &_inverted_index_ctx->has_fallback_predicates};
+    auto root = _opts.pred_tree.release_root();
+    for (auto& or_child : root.compound_children()) {
+        RETURN_IF_ERROR(or_child.visit(visitor));
     }
-
-    std::vector<InvertedIndexIterator*>& inverted_index_iterators;
-    bool* has_fallback_predicates;
-    ObjectPool* pool;
-    const std::vector<rowid_t>* rowid_buffer;
-};
+    _opts.pred_tree = PredicateTree::create(std::move(root));
+    return Status::OK();
+}
 
 Status SegmentIterator::_apply_inverted_index() {
     RETURN_IF(_scan_range.empty(), Status::OK());
@@ -3723,23 +3700,7 @@ Status SegmentIterator::_apply_inverted_index() {
     }
     SCOPED_RAW_TIMER(&_opts.stats->gin_index_filter_ns);
 
-    // For OR queries: wrap MATCH predicates with InvertedIndexFallbackPredicate
-    _inverted_index_ctx->has_fallback_predicates = false;
-    const bool gin_fallback_enabled = _opts.pred_tree.has_or_predicate();
-    if (gin_fallback_enabled) {
-        // Walk the OR nodes (non-immediate children) and wrap MATCH predicates
-        auto root = _opts.pred_tree.release_root();
-        InvertedIndexFallbackVisitor visitor{_inverted_index_ctx->inverted_index_iterators,
-                                             &_inverted_index_ctx->has_fallback_predicates, &_obj_pool, &_rowid_buffer};
-
-        // Only visit OR nodes (compound children of root)
-        // Immediate children of root use the normal inverted index filtering path
-        for (auto& or_child : root.compound_children()) {
-            RETURN_IF_ERROR(or_child.visit(visitor));
-        }
-
-        _opts.pred_tree = PredicateTree::create(std::move(root));
-    }
+    RETURN_IF_ERROR(_wrap_or_match_predicates_for_fallback());
 
     roaring::Roaring row_bitmap = range2roaring(_scan_range);
     size_t input_rows = row_bitmap.cardinality();

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -409,6 +409,7 @@ SET(DW_TEST_FILES
     ./storage/column_and_predicate_test.cpp
     ./storage/column_or_predicate_test.cpp
     ./storage/column_predicate_test.cpp
+    ./storage/column_predicate_inverted_index_fallback_test.cpp
     ./storage/compaction_manager_test.cpp
     ./storage/compaction_parallelization_test.cpp
     ./storage/compaction_utils_test.cpp

--- a/be/test/storage/column_predicate_inverted_index_fallback_test.cpp
+++ b/be/test/storage/column_predicate_inverted_index_fallback_test.cpp
@@ -1,0 +1,345 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/column_predicate_inverted_index_fallback.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "common/object_pool.h"
+#include "roaring/roaring.hh"
+#include "storage/column_expr_predicate.h"
+#include "storage/column_predicate.h"
+#include "storage/index/inverted/inverted_index_iterator.h"
+#include "storage/olap_common.h"
+#include "storage/predicate_tree/predicate_tree.h"
+#include "storage/rowset/or_match_fallback_visitor.h"
+#include "storage/types.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+// Verifies that InvertedIndexFallbackPredicate, which is the wrapper introduced
+// by the OR-MATCH fallback path, evaluates correctly against its segment-local
+// rowid bitmap. The wrapped ColumnExprPredicate carries no real expression
+// context here (passing nullptr expr_ctx is a documented no-op), so calls into
+// the wrapped predicate that depend on the AST (is_negated_expr, is_match_expr)
+// return the safe defaults. That is precisely the surface we want to exercise:
+// the bitmap-vs-rowid loop and the [from, to) bounds contract.
+class InvertedIndexFallbackPredicateTest : public ::testing::Test {
+protected:
+    static ColumnExprPredicate* make_wrapped(ColumnId cid = 0) {
+        auto status_or =
+                ColumnExprPredicate::make_column_expr_predicate(get_type_info(TYPE_VARCHAR), cid, /*state=*/nullptr,
+                                                                /*expr_ctx=*/nullptr, /*slot_desc=*/nullptr);
+        EXPECT_TRUE(status_or.ok());
+        return status_or.value();
+    }
+
+    static std::string render(const std::vector<uint8_t>& v, size_t n) {
+        std::string s;
+        s.reserve(n * 2);
+        for (size_t i = 0; i < n; i++) {
+            if (i > 0) s.push_back(',');
+            s.push_back(v[i] ? '1' : '0');
+        }
+        return s;
+    }
+};
+
+TEST_F(InvertedIndexFallbackPredicateTest, evaluate_all_hits) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
+    roaring::Roaring bitmap;
+    bitmap.add(10);
+    bitmap.add(20);
+    bitmap.add(30);
+    std::vector<rowid_t> rowids{10, 20, 30};
+
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+    std::vector<uint8_t> sel(3, 0);
+    ASSERT_OK(pred.evaluate(/*column=*/nullptr, sel.data(), 0, 3));
+    EXPECT_EQ("1,1,1", render(sel, 3));
+}
+
+TEST_F(InvertedIndexFallbackPredicateTest, evaluate_all_misses) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
+    // empty bitmap simulates "no matches in this segment"
+    roaring::Roaring bitmap;
+    std::vector<rowid_t> rowids{1, 2, 3};
+
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+    std::vector<uint8_t> sel(3, 1);
+    ASSERT_OK(pred.evaluate(/*column=*/nullptr, sel.data(), 0, 3));
+    EXPECT_EQ("0,0,0", render(sel, 3));
+}
+
+TEST_F(InvertedIndexFallbackPredicateTest, evaluate_mixed) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
+    roaring::Roaring bitmap;
+    bitmap.add(10);
+    bitmap.add(30);
+    // rowids monotonic, matching how _read() appends from SparseRange
+    std::vector<rowid_t> rowids{5, 10, 20, 30, 40};
+
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+    std::vector<uint8_t> sel(5, 0xAA); // pre-fill with sentinel
+    ASSERT_OK(pred.evaluate(/*column=*/nullptr, sel.data(), 0, 5));
+    EXPECT_EQ("0,1,0,1,0", render(sel, 5));
+}
+
+// Regression: the original implementation looped to _rowid_buffer->size()
+// ignoring `to`, which could overwrite past the selection or read past the
+// buffer if the two ever diverged. The refactor switched to honoring [from,
+// to). This test wires the rowid buffer to be larger than `to` and asserts
+// we only touch sel[0..to).
+TEST_F(InvertedIndexFallbackPredicateTest, evaluate_honors_to_bound) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
+    roaring::Roaring bitmap;
+    bitmap.add(100);
+    bitmap.add(200);
+    bitmap.add(300);
+    bitmap.add(400);
+    std::vector<rowid_t> rowids{100, 200, 300, 400}; // 4 rowids captured
+
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+    // Evaluate only the first two rows; trailing two sentinel bytes must
+    // survive untouched.
+    std::vector<uint8_t> sel(4, 0x55);
+    ASSERT_OK(pred.evaluate(/*column=*/nullptr, sel.data(), 0, 2));
+    EXPECT_EQ(1, sel[0]);
+    EXPECT_EQ(1, sel[1]);
+    EXPECT_EQ(0x55, sel[2]);
+    EXPECT_EQ(0x55, sel[3]);
+}
+
+TEST_F(InvertedIndexFallbackPredicateTest, evaluate_empty_range_is_noop) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
+    roaring::Roaring bitmap;
+    bitmap.add(7);
+    std::vector<rowid_t> rowids{7};
+
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+    std::vector<uint8_t> sel(1, 0x42);
+    ASSERT_OK(pred.evaluate(/*column=*/nullptr, sel.data(), 0, 0));
+    EXPECT_EQ(0x42, sel[0]); // untouched
+}
+
+// evaluate_and clears (ANDs in zeros) where the bitmap misses.
+TEST_F(InvertedIndexFallbackPredicateTest, evaluate_and_combines) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
+    roaring::Roaring bitmap;
+    bitmap.add(10);
+    bitmap.add(30);
+    std::vector<rowid_t> rowids{10, 20, 30, 40};
+
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+    std::vector<uint8_t> sel{1, 1, 1, 0}; // last row already filtered out
+    ASSERT_OK(pred.evaluate_and(/*column=*/nullptr, sel.data(), 0, 4));
+    // row 10 hits -> 1&1=1; row 20 misses -> 1&0=0; row 30 hits -> 1&1=1;
+    // row 40 misses but selection already 0 -> 0&0=0
+    EXPECT_EQ("1,0,1,0", render(sel, 4));
+}
+
+// evaluate_or sets bits where the bitmap hits; pre-set selection bits stay set.
+TEST_F(InvertedIndexFallbackPredicateTest, evaluate_or_combines) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
+    roaring::Roaring bitmap;
+    bitmap.add(20);
+    bitmap.add(40);
+    std::vector<rowid_t> rowids{10, 20, 30, 40};
+
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+    std::vector<uint8_t> sel{1, 0, 0, 0}; // first row already matched by sibling OR-arm
+    ASSERT_OK(pred.evaluate_or(/*column=*/nullptr, sel.data(), 0, 4));
+    EXPECT_EQ("1,1,0,1", render(sel, 4));
+}
+
+// evaluate_and / evaluate_or must respect [from, to) too: the temp buffer they
+// allocate is sized to (to - from). If evaluate ignored `to` and instead used
+// _rowid_buffer->size(), this case would write past the temp buffer.
+TEST_F(InvertedIndexFallbackPredicateTest, evaluate_and_honors_to_bound) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
+    roaring::Roaring bitmap;
+    bitmap.add(1);
+    bitmap.add(2);
+    bitmap.add(3);
+    std::vector<rowid_t> rowids{1, 2, 3}; // 3 rowids captured
+
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+    std::vector<uint8_t> sel{1, 1, 0xCC}; // pre-existing 0xCC must survive
+    ASSERT_OK(pred.evaluate_and(/*column=*/nullptr, sel.data(), 0, 2));
+    EXPECT_EQ(1, sel[0]);
+    EXPECT_EQ(1, sel[1]);
+    EXPECT_EQ(0xCC, sel[2]); // untouched
+}
+
+// Construction must inherit index_filter_only / is_expr_predicate from the
+// wrapped predicate so that the rest of the storage pipeline treats the
+// wrapper consistently.
+TEST_F(InvertedIndexFallbackPredicateTest, inherits_wrapped_attributes) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped(/*cid=*/7));
+    wrapped->set_index_filter_only(true);
+
+    roaring::Roaring bitmap;
+    std::vector<rowid_t> rowids;
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+
+    EXPECT_TRUE(pred.is_index_filter_only());
+    EXPECT_TRUE(pred.is_expr_predicate());
+    EXPECT_EQ(PredicateType::kGinFallback, pred.type());
+    EXPECT_EQ(7u, pred.column_id());
+}
+
+// Calling seek_inverted_index on a fallback wrapper is a programming error:
+// fallback predicates already carry their pre-loaded segment bitmap.
+TEST_F(InvertedIndexFallbackPredicateTest, seek_inverted_index_is_rejected) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
+    roaring::Roaring bitmap;
+    std::vector<rowid_t> rowids;
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+
+    roaring::Roaring out;
+    auto st = pred.seek_inverted_index("c0", /*iterator=*/nullptr, &out);
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_internal_error());
+}
+
+// is_negated_expr() forwards to the wrapped predicate; with an empty expr ctx
+// chain the wrapped predicate reports false, so hits stay 1 and misses stay 0.
+// This is the same expectation as evaluate_mixed, just exercised through the
+// is_negated_expr() forwarding code path explicitly.
+TEST_F(InvertedIndexFallbackPredicateTest, non_negated_uses_hit_one) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
+    EXPECT_FALSE(wrapped->is_negated_expr());
+
+    roaring::Roaring bitmap;
+    bitmap.add(50);
+    std::vector<rowid_t> rowids{50, 60};
+
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
+    EXPECT_FALSE(pred.is_negated_expr());
+
+    std::vector<uint8_t> sel(2, 0);
+    ASSERT_OK(pred.evaluate(/*column=*/nullptr, sel.data(), 0, 2));
+    EXPECT_EQ("1,0", render(sel, 2));
+}
+
+// ---------------------------------------------------------------------------
+// OrMatchFallbackVisitor tests
+// ---------------------------------------------------------------------------
+//
+// Coverage scope: the visitor's reachable branches when wrapping doesn't fire
+// (non-Expr predicate, non-MATCH Expr predicate) and the compound-node
+// template overload that recurses through OR-subtrees.
+//
+// The "MATCH wrap" path (load bitmap, allocate InvertedIndexFallbackPredicate,
+// set_col_pred) is reachable only with a real MATCH expression whose AST
+// satisfies ColumnExprPredicate::read_inverted_index's structural checks
+// (MATCH_EXPR root with slot_ref + string_literal children). Standing up that
+// expression machinery at the BE unit-test level is significantly heavier than
+// the surface it would cover. End-to-end coverage of that path, plus the
+// SegmentIterator::do_get_next() branches that flip on
+// _inverted_index_ctx->has_fallback_predicates, comes from the SQL-tester
+// integration suite under test/sql/test_inverted_index.
+
+class OrMatchFallbackVisitorTest : public ::testing::Test {
+protected:
+    bool has_fallback = false;
+    std::vector<InvertedIndexIterator*> iterators{16, nullptr};
+    ObjectPool pool;
+    std::vector<rowid_t> rowid_buffer;
+
+    OrMatchFallbackVisitor make_visitor() {
+        return OrMatchFallbackVisitor{iterators, pool, &rowid_buffer, &has_fallback};
+    }
+};
+
+// A predicate column node whose underlying predicate is NOT a ColumnExprPredicate
+// must short-circuit at the kExpr type check; the visitor is a no-op.
+TEST_F(OrMatchFallbackVisitorTest, skips_non_expr_predicate) {
+    std::unique_ptr<ColumnPredicate> eq(new_column_eq_predicate(get_type_info(TYPE_INT), /*cid=*/0, "1"));
+    PredicateColumnNode node(eq.get());
+    const auto* original = node.col_pred();
+
+    auto visitor = make_visitor();
+    ASSERT_OK(visitor(node));
+
+    EXPECT_FALSE(has_fallback);
+    EXPECT_EQ(original, node.col_pred()); // not swapped for a wrapper
+}
+
+// An Expr predicate that is NOT a MATCH predicate (here: empty expr-ctx chain,
+// is_match_expr() returns false) must also short-circuit, after the down_cast
+// runs. Covers the `pred->type() == kExpr` -> `!is_match_expr()` branch.
+TEST_F(OrMatchFallbackVisitorTest, skips_non_match_expr_predicate) {
+    auto status_or = ColumnExprPredicate::make_column_expr_predicate(get_type_info(TYPE_VARCHAR), /*cid=*/0,
+                                                                     /*state=*/nullptr,
+                                                                     /*expr_ctx=*/nullptr, /*slot_desc=*/nullptr);
+    ASSERT_TRUE(status_or.ok());
+    std::unique_ptr<ColumnExprPredicate> expr_pred(status_or.value());
+    ASSERT_EQ(PredicateType::kExpr, expr_pred->type());
+    ASSERT_FALSE(expr_pred->is_match_expr());
+
+    PredicateColumnNode node(expr_pred.get());
+    auto visitor = make_visitor();
+    ASSERT_OK(visitor(node));
+
+    EXPECT_FALSE(has_fallback);
+    EXPECT_EQ(expr_pred.get(), node.col_pred());
+}
+
+// The compound-node template overload must invoke the column-node operator on
+// every leaf reachable through children(). Build an OR node holding two
+// non-Expr column children; the visitor walks both without wrapping anything.
+TEST_F(OrMatchFallbackVisitorTest, recurses_into_compound_children) {
+    std::unique_ptr<ColumnPredicate> eq0(new_column_eq_predicate(get_type_info(TYPE_INT), /*cid=*/0, "1"));
+    std::unique_ptr<ColumnPredicate> eq1(new_column_eq_predicate(get_type_info(TYPE_INT), /*cid=*/1, "2"));
+
+    PredicateOrNode or_node;
+    or_node.add_child(PredicateColumnNode(eq0.get()));
+    or_node.add_child(PredicateColumnNode(eq1.get()));
+    ASSERT_EQ(2u, or_node.num_children());
+
+    auto visitor = make_visitor();
+    ASSERT_OK(visitor(or_node));
+
+    EXPECT_FALSE(has_fallback);
+}
+
+// Nested compound traversal: OR( AND( col, col ), col ). The OR-overload
+// recurses into the AND-overload, which in turn dispatches to the
+// column-node overload for each leaf.
+TEST_F(OrMatchFallbackVisitorTest, recurses_through_nested_compound) {
+    std::unique_ptr<ColumnPredicate> eq0(new_column_eq_predicate(get_type_info(TYPE_INT), /*cid=*/0, "1"));
+    std::unique_ptr<ColumnPredicate> eq1(new_column_eq_predicate(get_type_info(TYPE_INT), /*cid=*/1, "2"));
+    std::unique_ptr<ColumnPredicate> eq2(new_column_eq_predicate(get_type_info(TYPE_INT), /*cid=*/2, "3"));
+
+    PredicateAndNode and_node;
+    and_node.add_child(PredicateColumnNode(eq0.get()));
+    and_node.add_child(PredicateColumnNode(eq1.get()));
+
+    PredicateOrNode or_node;
+    or_node.add_child(std::move(and_node));
+    or_node.add_child(PredicateColumnNode(eq2.get()));
+
+    auto visitor = make_visitor();
+    ASSERT_OK(visitor(or_node));
+
+    EXPECT_FALSE(has_fallback);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

The OR-MATCH PR hooked the inverted-index fallback path into SegmentIterator by sprinkling rowid plumbing across several methods. Clean it up:

* Replace the free InvertedIndexFallbackVisitor struct (four raw pointer/reference fields) with a private member function _wrap_or_match_predicates_for_fallback() that contains a tightly scoped local visitor.
* Sink _rowid_buffer from a SegmentIterator member into InvertedIndexContext::rowid_buffer, where it lives next to its only long-lived consumer (the InvertedIndexFallbackPredicate that stores a pointer into it). The vector index and rssid_rowids paths fall back to per-call local std::vector<rowid_t> buffers, restoring the pre-OR-MATCH style.
* Drop the redundant has_fallback_predicates reset in _apply_inverted_index() — cleanup() and default-init already handle it.
* Fix InvertedIndexFallbackPredicate::evaluate() to honor the predicate contract by iterating [from, to) instead of _rowid_buffer->size(). This removes a latent out-of-bounds write in evaluate_and / evaluate_or, whose _tmp_select buffer is sized to (to - from).

Adds a focused unit test that exercises the fallback wrapper directly: fully-hit / fully-miss / mixed bitmaps, the [from, to) bounds contract (regression for the bound fix), evaluate_and / evaluate_or combine semantics, empty range no-op, inherited attributes, and the rejection of seek_inverted_index on an already-loaded wrapper.

No behavior change for callers; OR-MATCH semantics are preserved.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
