### PR TITLE
[Enhancement] Migrate tier-3 leader daemons to LeaderDaemon

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -21,7 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.gson.GsonPostProcessable;
@@ -42,7 +42,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.Map;
 
-public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProcessable {
+public class TabletReshardJobMgr extends LeaderDaemon implements GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(TabletReshardJobMgr.class);
 
     @SerializedName(value = "tabletReshardJobs")
@@ -170,8 +170,13 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
         reshardingTabletInfos.remove(tabletId);
     }
 
+    // tabletReshardJobs is persistent (@SerializedName, save/load via image) and
+    // reshardingTabletInfos is also serialized through writer.writeJson(this), so neither
+    // map should be cleared on demotion - the next leader resumes those jobs from the same
+    // maps. Default onStopped() is sufficient.
+
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         colocateChecker.runOneCycle();
         runTabletReshardJobs();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LeaderDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LeaderDaemon.java
@@ -16,6 +16,10 @@ package com.starrocks.common.util;
 
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LeaderLease;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.cngroup.CRAcquireContext;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -49,6 +53,14 @@ public abstract class LeaderDaemon {
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
     private volatile Thread worker;
     private volatile LeaderLease capturedLease = LeaderLease.INVALID;
+
+    /**
+     * Last compute resource the subclass acquired through {@link #acquireBackgroundComputeResource()}.
+     * Mirrors the same-named field on {@code FrontendDaemon} so lake-side leader daemons that
+     * relied on it before migration continue to compile and behave identically. Defaults to
+     * {@link WarehouseManager#DEFAULT_RESOURCE} until the subclass acquires one.
+     */
+    protected ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
 
     protected LeaderDaemon(String name) {
         this(name, DEFAULT_INTERVAL_SECONDS * 1000L);
@@ -227,5 +239,18 @@ public abstract class LeaderDaemon {
     protected void onJoinTimeout() {
         LOG.error("{} did not exit within stop timeout; terminating JVM to avoid concurrent workers", name);
         System.exit(-1);
+    }
+
+    /**
+     * Refresh {@link #computeResource} from the background warehouse. Migrated from the same
+     * helper on {@code FrontendDaemon}; only subclasses that perform background work against a
+     * lake compute group need to call it.
+     */
+    protected void acquireBackgroundComputeResource() {
+        final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        final Warehouse warehouse = warehouseManager.getBackgroundWarehouse();
+        final CRAcquireContext acquireContext = CRAcquireContext.of(warehouse.getId(), computeResource);
+        // check resource before each run
+        this.computeResource = warehouseManager.acquireComputeResource(acquireContext);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -30,7 +30,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.NetUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -62,7 +62,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-public class StarMgrMetaSyncer extends FrontendDaemon {
+public class StarMgrMetaSyncer extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(StarMgrMetaSyncer.class);
 
     private static final LongCounterMetric SHARD_GROUP_DELETE_COUNTER = new LongCounterMetric(
@@ -684,7 +684,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         long newInterval = Config.star_mgr_meta_sync_interval_sec * 1000L;
         if (newInterval > 0 && getInterval() != newInterval) {
             setInterval(newInterval);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletWriteLogHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletWriteLogHistorySyncer.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.history.TableKeeper;
 import com.starrocks.server.GlobalStateMgr;
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class TabletWriteLogHistorySyncer extends FrontendDaemon {
+public class TabletWriteLogHistorySyncer extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(TabletWriteLogHistorySyncer.class);
 
     public static final String DB_NAME = "_statistics_";
@@ -104,7 +104,7 @@ public class TabletWriteLogHistorySyncer extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         if (FeConstants.runningUnitTest) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJobScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJobScheduler.java
@@ -15,7 +15,7 @@
 package com.starrocks.lake.snapshot;
 
 import com.starrocks.common.Pair;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.leader.CheckpointController;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
 
 // ClusterSnapshotJobScheduler daemon is running on master node. Coordinate two checkpoint controller
 // together to finish image checkpoint one by one and upload image for backup
-public class ClusterSnapshotJobScheduler extends FrontendDaemon implements SnapshotJobContext {
+public class ClusterSnapshotJobScheduler extends LeaderDaemon implements SnapshotJobContext {
     public static final Logger LOG = LogManager.getLogger(ClusterSnapshotJobScheduler.class);
     private static int CAPTURE_ID_RETRY_TIME = 10;
 
@@ -85,7 +85,7 @@ public class ClusterSnapshotJobScheduler extends FrontendDaemon implements Snaps
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         // skip first run when the scheduler start
         if (lastAutomatedJobStartTimeMs == 0) {
             GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -462,11 +462,17 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
      * Coordinated stop for leader demotion. ClusterSnapshotMgr is not a daemon itself; it
      * owns an inner LeaderDaemon. Fan out to it so its worker thread exits and onStopped()
      * runs. automatedSnapshotJobs is persistent (saved through gson) so it is NOT cleared.
+     *
+     * The scheduler reference is nulled out after the stop so the next {@link #start()} call
+     * (triggered by re-election) rebuilds it. Without this, start() short-circuits on the
+     * non-null check and snapshot scheduling never resumes; the dangling scheduler would also
+     * keep references to the previous leader session's CheckpointControllers.
      */
     public void stopGracefully(long timeoutMs) {
         ClusterSnapshotJobScheduler scheduler = clusterSnapshotJobScheduler;
         if (scheduler != null) {
             scheduler.stopGracefully(timeoutMs);
+            clusterSnapshotJobScheduler = null;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -458,6 +458,18 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         }
     }
 
+    /**
+     * Coordinated stop for leader demotion. ClusterSnapshotMgr is not a daemon itself; it
+     * owns an inner LeaderDaemon. Fan out to it so its worker thread exits and onStopped()
+     * runs. automatedSnapshotJobs is persistent (saved through gson) so it is NOT cleared.
+     */
+    public void stopGracefully(long timeoutMs) {
+        ClusterSnapshotJobScheduler scheduler = clusterSnapshotJobScheduler;
+        if (scheduler != null) {
+            scheduler.stopGracefully(timeoutMs);
+        }
+    }
+
     public TClusterSnapshotJobsResponse getAllSnapshotJobsInfo() {
         TClusterSnapshotJobsResponse response = new TClusterSnapshotJobsResponse();
         for (ClusterSnapshotJob job : automatedSnapshotJobs.values()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -27,7 +27,7 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeAggregator;
@@ -61,7 +61,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-public class AutovacuumDaemon extends FrontendDaemon {
+public class AutovacuumDaemon extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(AutovacuumDaemon.class);
 
     private static final long MILLISECONDS_PER_SECOND = 1000;
@@ -70,15 +70,42 @@ public class AutovacuumDaemon extends FrontendDaemon {
     private static final long MILLISECONDS_PER_HOUR = MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND;
 
     private final Set<Long> vacuumingPartitions = Sets.newConcurrentHashSet();
-    private final BlockingThreadPoolExecutorService executorService = BlockingThreadPoolExecutorService.newInstance(
-            Config.lake_autovacuum_parallel_partitions, 0, 1, TimeUnit.HOURS, "autovacuum");
+
+    // Not final: shutdownNow() in onStopped() interrupts in-flight vacuum tasks so they
+    // exit promptly even if blocked on metadata locks; start() rebuilds the pool on
+    // re-election.
+    private volatile BlockingThreadPoolExecutorService executorService = newExecutorService();
+
+    private static BlockingThreadPoolExecutorService newExecutorService() {
+        return BlockingThreadPoolExecutorService.newInstance(
+                Config.lake_autovacuum_parallel_partitions, 0, 1, TimeUnit.HOURS, "autovacuum");
+    }
 
     public AutovacuumDaemon() {
         super("auto-vacuum", 2000);
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    public synchronized void start() {
+        if (executorService.isShutdown()) {
+            executorService = newExecutorService();
+        }
+        super.start();
+    }
+
+    @Override
+    protected void onStopped() {
+        // vacuumingPartitions is leader-session bookkeeping: the in-flight executor tasks
+        // remove themselves from this set in a finally block, but shutdownNow() will cancel
+        // queued tasks that have not yet run, so we clear here to avoid stale partition ids
+        // suppressing the next leader's vacuum scan. The executor itself is shut down so
+        // worker threads exit promptly during the drain.
+        executorService.shutdownNow();
+        vacuumingPartitions.clear();
+    }
+
+    @Override
+    protected void runAfterLeaseValid() {
         if (FeConstants.runningUnitTest) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -74,7 +74,9 @@ public class AutovacuumDaemon extends LeaderDaemon {
     // Not final: shutdownNow() in onStopped() interrupts in-flight vacuum tasks so they
     // exit promptly even if blocked on metadata locks; start() rebuilds the pool on
     // re-election.
-    private volatile BlockingThreadPoolExecutorService executorService = newExecutorService();
+    // Package-private so same-package tests can swap in a stuck pool to exercise the
+    // restart guard without reflection.
+    volatile BlockingThreadPoolExecutorService executorService = newExecutorService();
 
     private static BlockingThreadPoolExecutorService newExecutorService() {
         return BlockingThreadPoolExecutorService.newInstance(
@@ -87,6 +89,14 @@ public class AutovacuumDaemon extends LeaderDaemon {
 
     @Override
     public synchronized void start() {
+        // Refuse to overlap with a previous pool that has not finished draining: isShutdown()
+        // becomes true before in-flight vacuum tasks actually exit, so a fast demote/re-elect
+        // can put two vacuum executor generations against the same metadata. Mirrors the
+        // BatchWriteMgr / AlterHandler restart guard.
+        if (executorService.isShutdown() && !executorService.isTerminated()) {
+            throw new IllegalStateException(
+                    "AutovacuumDaemon executorService has not terminated; refuse to restart");
+        }
         if (executorService.isShutdown()) {
             executorService = newExecutorService();
         }
@@ -98,9 +108,20 @@ public class AutovacuumDaemon extends LeaderDaemon {
         // vacuumingPartitions is leader-session bookkeeping: the in-flight executor tasks
         // remove themselves from this set in a finally block, but shutdownNow() will cancel
         // queued tasks that have not yet run, so we clear here to avoid stale partition ids
-        // suppressing the next leader's vacuum scan. The executor itself is shut down so
-        // worker threads exit promptly during the drain.
+        // suppressing the next leader's vacuum scan. The executor itself is shut down and we
+        // wait boundedly for actual termination so a subsequent start() does not race a still-
+        // alive vacuum worker against a freshly created pool against the same metadata; if the
+        // pool does not terminate within the drain budget, start() will refuse to rebuild.
         executorService.shutdownNow();
+        long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
+        try {
+            if (!executorService.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
+                LOG.warn("AutovacuumDaemon executorService did not terminate within drain timeout");
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while waiting for AutovacuumDaemon executorService to terminate");
+        }
         vacuumingPartitions.clear();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -65,7 +65,9 @@ public class FullVacuumDaemon extends LeaderDaemon implements Writable {
 
     // Not final: shutdownNow() in onStopped() interrupts in-flight full-vacuum tasks so
     // they exit promptly; start() rebuilds the pool on re-election.
-    private volatile BlockingThreadPoolExecutorService executorService = newExecutorService();
+    // Package-private so same-package tests can swap in a stuck pool to exercise the
+    // restart guard without reflection.
+    volatile BlockingThreadPoolExecutorService executorService = newExecutorService();
 
     private static BlockingThreadPoolExecutorService newExecutorService() {
         return BlockingThreadPoolExecutorService.newInstance(
@@ -80,6 +82,14 @@ public class FullVacuumDaemon extends LeaderDaemon implements Writable {
 
     @Override
     public synchronized void start() {
+        // Refuse to overlap with a previous pool that has not finished draining: isShutdown()
+        // becomes true before in-flight full-vacuum tasks actually exit, so a fast
+        // demote/re-elect can put two full-vacuum executor generations against the same
+        // metadata / object store. Mirrors the AutovacuumDaemon / BatchWriteMgr restart guard.
+        if (executorService.isShutdown() && !executorService.isTerminated()) {
+            throw new IllegalStateException(
+                    "FullVacuumDaemon executorService has not terminated; refuse to restart");
+        }
         if (executorService.isShutdown()) {
             executorService = newExecutorService();
         }
@@ -89,9 +99,21 @@ public class FullVacuumDaemon extends LeaderDaemon implements Writable {
     @Override
     protected void onStopped() {
         // Same contract as AutovacuumDaemon: shut down the pool so worker threads exit on
-        // demotion, and clear in-flight partition bookkeeping so the next leader does not
-        // skip partitions whose ids stayed in vacuumingPartitions across the boundary.
+        // demotion, clear in-flight partition bookkeeping so the next leader does not skip
+        // partitions whose ids stayed in vacuumingPartitions across the boundary, and wait
+        // boundedly for the pool to actually terminate so a subsequent start() does not race
+        // a still-alive full-vacuum worker against a freshly created pool. If termination
+        // times out, start() will refuse to rebuild.
         executorService.shutdownNow();
+        long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
+        try {
+            if (!executorService.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
+                LOG.warn("FullVacuumDaemon executorService did not terminate within drain timeout");
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while waiting for FullVacuumDaemon executorService to terminate");
+        }
         vacuumingPartitions.clear();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -25,7 +25,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.Writable;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTableHelper;
@@ -56,16 +56,22 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.rpc.LakeService.TIMEOUT_VACUUM_FULL;
 
-public class FullVacuumDaemon extends FrontendDaemon implements Writable {
+public class FullVacuumDaemon extends LeaderDaemon implements Writable {
     private static final Logger LOG = LogManager.getLogger(FullVacuumDaemon.class);
 
     private static final long MILLISECONDS_PER_SECOND = 1000;
 
     private final Set<Long> vacuumingPartitions = Sets.newConcurrentHashSet();
 
-    private final BlockingThreadPoolExecutorService executorService =
-            BlockingThreadPoolExecutorService.newInstance(Config.lake_fullvacuum_parallel_partitions, 0, TIMEOUT_VACUUM_FULL,
-                    TimeUnit.MILLISECONDS, "fullvacuum");
+    // Not final: shutdownNow() in onStopped() interrupts in-flight full-vacuum tasks so
+    // they exit promptly; start() rebuilds the pool on re-election.
+    private volatile BlockingThreadPoolExecutorService executorService = newExecutorService();
+
+    private static BlockingThreadPoolExecutorService newExecutorService() {
+        return BlockingThreadPoolExecutorService.newInstance(
+                Config.lake_fullvacuum_parallel_partitions, 0, TIMEOUT_VACUUM_FULL,
+                TimeUnit.MILLISECONDS, "fullvacuum");
+    }
 
     public FullVacuumDaemon() {
         // Check every minute if we should run a full vacuum
@@ -73,7 +79,24 @@ public class FullVacuumDaemon extends FrontendDaemon implements Writable {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    public synchronized void start() {
+        if (executorService.isShutdown()) {
+            executorService = newExecutorService();
+        }
+        super.start();
+    }
+
+    @Override
+    protected void onStopped() {
+        // Same contract as AutovacuumDaemon: shut down the pool so worker threads exit on
+        // demotion, and clear in-flight partition bookkeeping so the next leader does not
+        // skip partitions whose ids stayed in vacuumingPartitions across the boundary.
+        executorService.shutdownNow();
+        vacuumingPartitions.clear();
+    }
+
+    @Override
+    protected void runAfterLeaseValid() {
         if (!Config.lake_enable_fullvacuum) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vector/VectorIndexBuildScheduler.java
@@ -12,7 +12,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.proto.BuildVectorIndexResponse;
 import com.starrocks.proto.VectorIndexBuildInfoPB;
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
  * builtVersion is stored on {@link LakeTablet} (with @SerializedName) and persisted via checkpoint.
  * Publish path reads builtVersion directly from the tablet object.
  */
-public class VectorIndexBuildScheduler extends FrontendDaemon {
+public class VectorIndexBuildScheduler extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(VectorIndexBuildScheduler.class);
 
     static final int MAX_CONCURRENT_TASKS = 64;
@@ -100,7 +100,7 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         if (!GlobalStateMgr.getCurrentState().isLeader()) {
             recoveryScanDone = false;
             return;
@@ -115,6 +115,20 @@ public class VectorIndexBuildScheduler extends FrontendDaemon {
         checkRunningTaskTimeout();
         cleanupStaleEntries();
         scheduleFromPending();
+    }
+
+    @Override
+    protected void onStopped() {
+        // The four caches and the recovery watermark are all leader-session bookkeeping:
+        // pendingTablets is repopulated by transactions on the next leader, runningTasks /
+        // preferredNodes are rebuilt as new build attempts are dispatched, cooldownUntil is
+        // a transient backoff map, and recoveryScanDone must reset to false so the next
+        // leader rescans tablets whose builtVersion < visibleVersion.
+        pendingTablets.clear();
+        runningTasks.clear();
+        preferredNodes.clear();
+        cooldownUntil.clear();
+        recoveryScanDone = false;
     }
 
     // ========== Public API ==========

--- a/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
@@ -94,8 +94,10 @@ public class CheckpointController extends LeaderDaemon {
     private final String subDir;
     private final boolean belongToGlobalStateMgr;
 
-    private final Set<String> nodesToPushImage;
-    private final Map<String, Long> lastFailedTime = new HashMap<>();
+    // Package-private so same-package tests can assert on the cleared-on-demotion contract
+    // without reflection.
+    final Set<String> nodesToPushImage;
+    final Map<String, Long> lastFailedTime = new HashMap<>();
 
     private volatile String workerNodeName;
     private volatile long workerSelectedTime;

--- a/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
@@ -39,7 +39,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.NetUtils;
 import com.starrocks.http.meta.MetaService;
 import com.starrocks.journal.CheckpointException;
@@ -82,7 +82,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 /**
  * CheckpointController daemon is running on master node. handle the checkpoint work for starrocks.
  */
-public class CheckpointController extends FrontendDaemon {
+public class CheckpointController extends LeaderDaemon {
     public static final Logger LOG = LogManager.getLogger(CheckpointController.class);
     private static final int PUT_TIMEOUT_SECOND = 3600;
     private static final int CONNECT_TIMEOUT_SECOND = 1;
@@ -123,13 +123,40 @@ public class CheckpointController extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         RW_LOCK.readLock().lock();
         try {
             runCheckpointController();
         } finally {
             RW_LOCK.readLock().unlock();
         }
+    }
+
+    /**
+     * Coordinated stop for leader demotion. All three checkpoint phases (createImage,
+     * pushImage, deleteOldJournals) are idempotent at the system level - worker FE
+     * keeps writing the image regardless of this leader's lifecycle, and the next
+     * leader will re-orchestrate pushImage / deleteOldJournals from scratch. So we
+     * only have to release leader-session bookkeeping and ask MetaHelper to break
+     * out of any in-flight HTTP, then let the daemon thread exit.
+     *
+     * Today {@link MetaHelper#cancelInFlight()} is a no-op (see TODO there), so a
+     * push/download stuck in HttpURLConnection.read will block this drain up to its
+     * own connect/read timeout (up to 3600s per node for push). The bookkeeping
+     * fields below are still cleared so the next leader does not inherit stale
+     * "pending push" / "last-failed-worker" state.
+     */
+    @Override
+    protected void onStopped() {
+        MetaHelper.cancelInFlight();
+        // Leader-session bookkeeping: nodesToPushImage tracks pending pushes from the
+        // last createImage round; lastFailedTime drives worker-selection ordering for
+        // the next round. Both must reset so a re-elected leader does not inherit
+        // stale targets. workerNodeName / workerSelectedTime / journalId / result /
+        // clusterSnapshotInfo are per-round volatile fields naturally overwritten by
+        // the next createImage() call - no need to clear here.
+        nodesToPushImage.clear();
+        lastFailedTime.clear();
     }
 
     protected void runCheckpointController() {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
@@ -77,6 +77,26 @@ public class MetaHelper {
         return CHECKPOINT_LIMIT_BYTES;
     }
 
+    /**
+     * Best-effort cancel for any blocking HTTP operation currently issued by MetaHelper on
+     * behalf of leader-only daemons (e.g. CheckpointController push/download). Today this is
+     * a no-op: {@link #httpGet} and {@link #downloadImageFile} use bare {@link HttpURLConnection},
+     * which honors neither {@link Thread#interrupt()} nor any other external cancel signal for
+     * socket reads. The only way a stuck call exits is its own connect/read timeout, which
+     * may be up to an hour for push and {@code MetaService.DOWNLOAD_TIMEOUT_SECOND} for
+     * download.
+     *
+     * TODO(cancel-infra): wire this up to actively disconnect the active {@link HttpURLConnection}
+     * (or switch to a cancellable HTTP client) so leader-demotion {@code onStopped()} can
+     * break out of these calls within the {@code leader_demotion_drain_timeout_sec} budget.
+     * This is tracked alongside the planned {@code Locker.lockInterruptibly} cleanup, since
+     * both block the same goal of making demotion drain deterministic for non-interruptible
+     * blocking operations.
+     */
+    public static void cancelInFlight() {
+        // intentionally empty - see TODO(cancel-infra) above
+    }
+
     // rename the .PART_SUFFIX file to filename
     public static File complete(String filename, File dir) throws IOException {
         File file = new File(dir, filename + MetaHelper.PART_SUFFIX);

--- a/fe/fe-core/src/main/java/com/starrocks/leader/TaskRunStateSynchronizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/TaskRunStateSynchronizer.java
@@ -16,7 +16,7 @@
 package com.starrocks.leader;
 
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunManager;
 import com.starrocks.scheduler.TaskRunScheduler;
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class TaskRunStateSynchronizer extends FrontendDaemon {
+public class TaskRunStateSynchronizer extends LeaderDaemon {
     public static final Logger LOG = LogManager.getLogger(TaskRunStateSynchronizer.class);
     // taskId -> progress
     private Map<Long, Integer> runningTaskRunProgressMap;
@@ -49,7 +49,15 @@ public class TaskRunStateSynchronizer extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void onStopped() {
+        // runningTaskRunProgressMap is leader-session bookkeeping used to detect progress
+        // deltas worth journalling. The next leader rebuilds it from TaskRunScheduler on
+        // activation; leaving stale entries would suppress the first progress edit log.
+        runningTaskRunProgressMap.clear();
+    }
+
+    @Override
+    protected void runAfterLeaseValid() {
         Set<TaskRun> runningTaskRuns = taskRunScheduler.getCopiedRunningTaskRuns();
         Map<Long, Integer> jobProgressMap = new HashMap<>();
         for (TaskRun taskRun : runningTaskRuns) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
@@ -96,8 +96,11 @@ public final class ExportChecker extends LeaderDaemon {
 
     /**
      * Coordinated stop for leader demotion. Drains each checker so onStopped() runs and the
-     * worker thread exits, then closes every owned LeaderTaskExecutor so its internal pools
-     * are shut down with shutdownNow(). The next {@link #init(long)} call (run by the
+     * worker thread exits, then closes every owned LeaderTaskExecutor and blocks up to
+     * {@code timeoutMs} for its internal pools to actually terminate. Without this wait
+     * demotion would return immediately while ExportExportingTask is still blocked in
+     * subTasksDoneSignal.await(getLeftTimeSecond()) and would run concurrently with the
+     * re-elected leader's export work. The next {@link #init(long)} call (run by the
      * re-elected leader) replaces the static maps with fresh instances.
      */
     public static void stopAll(long timeoutMs) {
@@ -108,16 +111,20 @@ public final class ExportChecker extends LeaderDaemon {
                 LOG.warn("stop {} failed", exportChecker.getName(), t);
             }
         }
+        // Split the drain budget across the three executors so the total stopAll() wall time
+        // stays within timeoutMs even when every pool needs the full budget.
+        int executorCount = executors.size() + (exportingSubTaskExecutor != null ? 1 : 0);
+        long perExecutorMs = executorCount > 0 ? Math.max(1L, timeoutMs / executorCount) : 0L;
         for (LeaderTaskExecutor leaderTaskExecutor : executors.values()) {
             try {
-                leaderTaskExecutor.close();
+                leaderTaskExecutor.close(perExecutorMs);
             } catch (Throwable t) {
                 LOG.warn("close export LeaderTaskExecutor failed", t);
             }
         }
         if (exportingSubTaskExecutor != null) {
             try {
-                exportingSubTaskExecutor.close();
+                exportingSubTaskExecutor.close(perExecutorMs);
             } catch (Throwable t) {
                 LOG.warn("close exportingSubTaskExecutor failed", t);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
@@ -37,7 +37,7 @@ package com.starrocks.load;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.load.ExportJob.JobState;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
@@ -51,12 +51,13 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Map;
 
-public final class ExportChecker extends FrontendDaemon {
+public final class ExportChecker extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(ExportChecker.class);
 
-    // checkers for running job state
+    // checkers for running job state. Replaced on every {@link #init(long)} call so a
+    // leader demotion drain followed by re-election creates fresh instances.
     private static Map<JobState, ExportChecker> checkers = Maps.newHashMap();
-    // executors for pending tasks
+    // executors for pending tasks. Same lifecycle as {@link #checkers}.
     private static Map<JobState, LeaderTaskExecutor> executors = Maps.newHashMap();
     private JobState jobState;
 
@@ -93,12 +94,42 @@ public final class ExportChecker extends FrontendDaemon {
         exportingSubTaskExecutor.start();
     }
 
+    /**
+     * Coordinated stop for leader demotion. Drains each checker so onStopped() runs and the
+     * worker thread exits, then closes every owned LeaderTaskExecutor so its internal pools
+     * are shut down with shutdownNow(). The next {@link #init(long)} call (run by the
+     * re-elected leader) replaces the static maps with fresh instances.
+     */
+    public static void stopAll(long timeoutMs) {
+        for (ExportChecker exportChecker : checkers.values()) {
+            try {
+                exportChecker.stopGracefully(timeoutMs);
+            } catch (Throwable t) {
+                LOG.warn("stop {} failed", exportChecker.getName(), t);
+            }
+        }
+        for (LeaderTaskExecutor leaderTaskExecutor : executors.values()) {
+            try {
+                leaderTaskExecutor.close();
+            } catch (Throwable t) {
+                LOG.warn("close export LeaderTaskExecutor failed", t);
+            }
+        }
+        if (exportingSubTaskExecutor != null) {
+            try {
+                exportingSubTaskExecutor.close();
+            } catch (Throwable t) {
+                LOG.warn("close exportingSubTaskExecutor failed", t);
+            }
+        }
+    }
+
     public static LeaderTaskExecutor getExportingSubTaskExecutor() {
         return exportingSubTaskExecutor;
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         LOG.debug("start check export jobs. job state: {}", jobState.name());
         switch (jobState) {
             case PENDING:

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
@@ -597,6 +597,21 @@ public class Pipe implements GsonPostProcessable {
         getPipeSource().getFileListRepo().destroy();
     }
 
+    /**
+     * Reset transient leader-session state so the next leader re-runs
+     * {@link #recovery()} and rebuilds {@code runningTasks} via {@link #buildNewTasks()}.
+     * Pipe metadata itself is persistent; only the in-memory progress flags are dropped.
+     * The PipeTaskDesc handles in {@code runningTasks} were tied to BE RPC bookkeeping on
+     * the old leader, so leaving them around would block buildNewTasks() (it skips when
+     * runningTasks is non-empty) and Pipe.recovery() (it short-circuits when recovered).
+     */
+    public void resetForLeaderHandoff() {
+        try (CloseableLock l = takeWriteLock()) {
+            recovered = false;
+            runningTasks.clear();
+        }
+    }
+
     public boolean isRecovered() {
         return recovered;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeListener.java
@@ -16,7 +16,7 @@ package com.starrocks.load.pipe;
 
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,7 +26,7 @@ import java.util.List;
  * Listen event for the pipe, and generate new tasks
  * TODO: currently it's singe-thread execution, but it's very easy to extend to multi-thread style
  */
-public class PipeListener extends FrontendDaemon {
+public class PipeListener extends LeaderDaemon {
 
     private static final Logger LOG = LogManager.getLogger(PipeListener.class);
 
@@ -38,7 +38,7 @@ public class PipeListener extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         try {
             process();
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeScheduler.java
@@ -15,7 +15,7 @@
 package com.starrocks.load.pipe;
 
 import com.starrocks.common.Config;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.LeaderDaemon;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,7 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
 /**
  * PipeScheduler: get tasks from pipe and execute them
  */
-public class PipeScheduler extends FrontendDaemon {
+public class PipeScheduler extends LeaderDaemon {
 
     private static final Logger LOG = LogManager.getLogger(PipeScheduler.class);
 
@@ -44,12 +44,26 @@ public class PipeScheduler extends FrontendDaemon {
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void runAfterLeaseValid() {
         try {
             process();
         } catch (Throwable e) {
             LOG.warn("Failed to process one round of PipeScheduler", e);
         }
+    }
+
+    @Override
+    protected void onStopped() {
+        // recovered and beSlotMap are leader-session bookkeeping: the next leader must
+        // re-run pipe.recovery() before scheduling, and BE slot reservations made against a
+        // sealed editlog must not leak across sessions.
+        slotLock.lock();
+        try {
+            beSlotMap.clear();
+        } finally {
+            slotLock.unlock();
+        }
+        recovered = false;
     }
 
     private void process() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeScheduler.java
@@ -57,6 +57,12 @@ public class PipeScheduler extends LeaderDaemon {
         // recovered and beSlotMap are leader-session bookkeeping: the next leader must
         // re-run pipe.recovery() before scheduling, and BE slot reservations made against a
         // sealed editlog must not leak across sessions.
+        //
+        // Each Pipe also carries its own transient `recovered` flag and `runningTasks` map.
+        // Pipe.recovery() short-circuits when recovered is true and buildNewTasks() refuses
+        // to enqueue new work while runningTasks is non-empty, so reset both per pipe;
+        // otherwise the re-elected leader thinks every pipe is already recovered and never
+        // schedules another task.
         slotLock.lock();
         try {
             beSlotMap.clear();
@@ -64,6 +70,13 @@ public class PipeScheduler extends LeaderDaemon {
             slotLock.unlock();
         }
         recovered = false;
+        for (Pipe pipe : CollectionUtils.emptyIfNull(pipeManager.getAllPipes())) {
+            try {
+                pipe.resetForLeaderHandoff();
+            } catch (Throwable e) {
+                LOG.warn("Failed to reset pipe {} for leader handoff", pipe, e);
+            }
+        }
     }
 
     private void process() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -99,13 +99,18 @@ public class TaskManager implements MemoryTrackable {
 
     // The periodScheduler is used to generate the corresponding TaskRun on time for the Periodical Task.
     // This scheduler can use the time wheel to optimize later.
-    private final ScheduledExecutorService periodScheduler = Executors.newScheduledThreadPool(1);
+    //
+    // Not final: rebuilt by start() if a previous stop() shut it down so this manager is
+    // reusable across leader demotion / re-election cycles.
+    private volatile ScheduledExecutorService periodScheduler = Executors.newScheduledThreadPool(1);
 
     // The dispatchTaskScheduler is responsible for periodically checking whether the running TaskRun is completed
     // and updating the status. It is also responsible for placing pending TaskRun in the running TaskRun queue.
     // This operation need to consider concurrency.
     // This scheduler can use notify/wait to optimize later.
-    private final ScheduledExecutorService dispatchScheduler = Executors.newScheduledThreadPool(1);
+    //
+    // Not final: same rebuild-on-restart contract as periodScheduler.
+    private volatile ScheduledExecutorService dispatchScheduler = Executors.newScheduledThreadPool(1);
     // Use to concurrency control
     private final QueryableReentrantLock taskLock;
 
@@ -121,6 +126,15 @@ public class TaskManager implements MemoryTrackable {
 
     public void start() {
         if (isStart.compareAndSet(false, true)) {
+            // Rebuild both schedulers if a previous stop() shut them down. periodScheduler also
+            // needs a fresh pool so the futures kept by periodFutureMap (which we cleared in
+            // stop()) cannot reference cancelled futures from the previous leader session.
+            if (periodScheduler.isShutdown()) {
+                periodScheduler = Executors.newScheduledThreadPool(1);
+            }
+            if (dispatchScheduler.isShutdown()) {
+                dispatchScheduler = Executors.newScheduledThreadPool(1);
+            }
             clearUnfinishedTaskRun();
             registerPeriodicalTask();
             dispatchScheduler.scheduleAtFixedRate(() -> {
@@ -141,6 +155,33 @@ public class TaskManager implements MemoryTrackable {
                 }
             }, 0, 1, TimeUnit.SECONDS);
         }
+    }
+
+    /**
+     * Coordinated stop for leader demotion. TaskManager owns two ScheduledExecutorService
+     * instances and is not a LeaderDaemon (its dispatch loop runs inside the executor with
+     * an embedded leader check), so it cannot follow the standard {@code stopGracefully}
+     * contract; this method is the equivalent. After it returns the manager is in a state
+     * where the next {@link #start()} rebuilds both pools and re-registers periodic tasks.
+     * shutdownNow() interrupts in-flight TaskRun checks so they exit promptly even if blocked
+     * in metadata locks.
+     */
+    public void stop() {
+        if (!isStart.compareAndSet(true, false)) {
+            return;
+        }
+        // Cancel periodic futures so a re-registered task on the next leader does not race
+        // a still-firing future against the new periodScheduler.
+        for (ScheduledFuture<?> future : periodFutureMap.values()) {
+            try {
+                future.cancel(true);
+            } catch (Throwable t) {
+                LOG.warn("cancel periodic task future failed", t);
+            }
+        }
+        periodFutureMap.clear();
+        periodScheduler.shutdownNow();
+        dispatchScheduler.shutdownNow();
     }
 
     private void registerPeriodicalTask() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -91,7 +91,9 @@ public class TaskManager implements MemoryTrackable {
     private final Map<Long, Task> idToTaskMap;
     // taskName -> Task, include Manual Task, Periodical Task
     private final Map<String, Task> nameToTaskMap;
-    private final Map<Long, ScheduledFuture<?>> periodFutureMap;
+    // Package-private so same-package tests can assert the cleared-on-stop contract without
+    // reflection.
+    final Map<Long, ScheduledFuture<?>> periodFutureMap;
 
     // include PENDING/RUNNING taskRun;
     private final TaskRunManager taskRunManager;
@@ -102,7 +104,8 @@ public class TaskManager implements MemoryTrackable {
     //
     // Not final: rebuilt by start() if a previous stop() shut it down so this manager is
     // reusable across leader demotion / re-election cycles.
-    private volatile ScheduledExecutorService periodScheduler = Executors.newScheduledThreadPool(1);
+    // Package-private so same-package tests can assert / swap pool state without reflection.
+    volatile ScheduledExecutorService periodScheduler = Executors.newScheduledThreadPool(1);
 
     // The dispatchTaskScheduler is responsible for periodically checking whether the running TaskRun is completed
     // and updating the status. It is also responsible for placing pending TaskRun in the running TaskRun queue.
@@ -110,7 +113,8 @@ public class TaskManager implements MemoryTrackable {
     // This scheduler can use notify/wait to optimize later.
     //
     // Not final: same rebuild-on-restart contract as periodScheduler.
-    private volatile ScheduledExecutorService dispatchScheduler = Executors.newScheduledThreadPool(1);
+    // Package-private for same reasons as periodScheduler above.
+    volatile ScheduledExecutorService dispatchScheduler = Executors.newScheduledThreadPool(1);
     // Use to concurrency control
     private final QueryableReentrantLock taskLock;
 
@@ -126,6 +130,21 @@ public class TaskManager implements MemoryTrackable {
 
     public void start() {
         if (isStart.compareAndSet(false, true)) {
+            // Refuse to overlap with previous schedulers that did not drain in stop():
+            // shutdownNow() does not wait for in-flight TaskRun checks to exit, so a fast
+            // demote/re-elect can put two scheduler generations against the same TaskRunManager
+            // and periodFutureMap. Mirrors the BatchWriteMgr / AlterHandler / LeaderTaskExecutor
+            // restart guard.
+            if (periodScheduler.isShutdown() && !periodScheduler.isTerminated()) {
+                isStart.set(false);
+                throw new IllegalStateException(
+                        "TaskManager periodScheduler has not terminated; refuse to restart");
+            }
+            if (dispatchScheduler.isShutdown() && !dispatchScheduler.isTerminated()) {
+                isStart.set(false);
+                throw new IllegalStateException(
+                        "TaskManager dispatchScheduler has not terminated; refuse to restart");
+            }
             // Rebuild both schedulers if a previous stop() shut them down. periodScheduler also
             // needs a fresh pool so the futures kept by periodFutureMap (which we cleared in
             // stop()) cannot reference cancelled futures from the previous leader session.
@@ -158,15 +177,33 @@ public class TaskManager implements MemoryTrackable {
     }
 
     /**
+     * Non-blocking equivalent of {@link #stop(long)}: shuts down both schedulers without
+     * waiting for in-flight TaskRun checks to actually exit. Prefer {@link #stop(long)} on
+     * the leader demotion drain path so a re-elected leader does not race the old
+     * scheduler generation.
+     */
+    public void stop() {
+        stop(0L);
+    }
+
+    /**
      * Coordinated stop for leader demotion. TaskManager owns two ScheduledExecutorService
      * instances and is not a LeaderDaemon (its dispatch loop runs inside the executor with
      * an embedded leader check), so it cannot follow the standard {@code stopGracefully}
-     * contract; this method is the equivalent. After it returns the manager is in a state
-     * where the next {@link #start()} rebuilds both pools and re-registers periodic tasks.
+     * contract; this method is the equivalent.
+     *
      * shutdownNow() interrupts in-flight TaskRun checks so they exit promptly even if blocked
-     * in metadata locks.
+     * in metadata locks. When {@code timeoutMs > 0}, this method also blocks up to that budget
+     * waiting for both pools to actually terminate so a subsequent {@link #start()} does not
+     * spin up a fresh scheduler against the same TaskRunManager / periodFutureMap as the still-
+     * running old generation. If termination times out, the next {@link #start()} will refuse
+     * to restart (IllegalStateException) rather than overlap pools.
+     *
+     * @param timeoutMs maximum time to wait for both schedulers to drain, in milliseconds. Zero
+     *                  or negative means do not wait (legacy behaviour). The budget is split
+     *                  across the two pools.
      */
-    public void stop() {
+    public void stop(long timeoutMs) {
         if (!isStart.compareAndSet(true, false)) {
             return;
         }
@@ -182,6 +219,22 @@ public class TaskManager implements MemoryTrackable {
         periodFutureMap.clear();
         periodScheduler.shutdownNow();
         dispatchScheduler.shutdownNow();
+        if (timeoutMs > 0L) {
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            try {
+                long remaining = Math.max(1L, deadline - System.currentTimeMillis());
+                if (!periodScheduler.awaitTermination(remaining, TimeUnit.MILLISECONDS)) {
+                    LOG.warn("TaskManager periodScheduler did not terminate within drain timeout");
+                }
+                remaining = Math.max(1L, deadline - System.currentTimeMillis());
+                if (!dispatchScheduler.awaitTermination(remaining, TimeUnit.MILLISECONDS)) {
+                    LOG.warn("TaskManager dispatchScheduler did not terminate within drain timeout");
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                LOG.warn("Interrupted while waiting for TaskManager schedulers to terminate");
+            }
+        }
     }
 
     private void registerPeriodicalTask() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1682,12 +1682,9 @@ public class GlobalStateMgr {
     }
 
     /**
-     * Symmetric counterpart to {@link #startLeaderOnlyDaemonThreads()}. Stops the leader-only
-     * daemons that have been migrated to {@link com.starrocks.common.util.LeaderDaemon}, in reverse
-     * start order, so leader-session state is released promptly during demotion and the FE
-     * singletons become reusable when this node is re-elected.
-     *
-     * TODO: migrate the remaining {@code Daemon}-based leader tasks and add them here.
+     * Symmetric counterpart to {@link #startLeaderOnlyDaemonThreads()}. Stops every leader-only
+     * daemon in reverse start order so leader-session state is released promptly during
+     * demotion and the FE singletons become reusable when this node is re-elected.
      */
     void stopLeaderOnlyDaemonThreads() {
         long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
@@ -1746,6 +1743,8 @@ public class GlobalStateMgr {
         stopOne("loadsHistorySyncer", () -> loadsHistorySyncer.stopGracefully(timeoutMs));
         stopOne("loadTimeoutChecker", () -> loadTimeoutChecker.stopGracefully(timeoutMs));
         stopOne("loadJobScheduler", () -> loadJobScheduler.stopGracefully(timeoutMs));
+        stopOne("loadingLoadTaskScheduler", () -> loadingLoadTaskScheduler.close(timeoutMs));
+        stopOne("pendingLoadTaskScheduler", () -> pendingLoadTaskScheduler.close(timeoutMs));
         if (!RunMode.isSharedDataMode()) {
             stopOne("colocateTableBalancer",
                     () -> ColocateTableBalancer.getInstance().stopGracefully(timeoutMs));
@@ -1754,6 +1753,11 @@ public class GlobalStateMgr {
         }
         stopOne("heartbeatMgr", () -> heartbeatMgr.stopGracefully(timeoutMs));
         stopOne("keyRotationDaemon", () -> keyRotationDaemon.stopGracefully(timeoutMs));
+        stopOne("checkpointController", () -> checkpointController.stopGracefully(timeoutMs));
+        if (RunMode.isSharedDataMode()) {
+            stopOne("starMgrCheckpointController",
+                    () -> StarMgrServer.getCurrentState().stopCheckpointController(timeoutMs));
+        }
     }
 
     private void stopOne(String name, Runnable action) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1717,7 +1717,7 @@ public class GlobalStateMgr {
         if (taskCleaner != null) {
             stopOne("taskCleaner", () -> taskCleaner.stopGracefully(timeoutMs));
         }
-        stopOne("taskManager", () -> taskManager.stop());
+        stopOne("taskManager", () -> taskManager.stop(timeoutMs));
         stopOne("statisticAutoCollector", () -> statisticAutoCollector.stopGracefully(timeoutMs));
         stopOne("statisticsMetaManager", () -> statisticsMetaManager.stopGracefully(timeoutMs));
         stopOne("updateDbUsedDataQuotaDaemon", () -> updateDbUsedDataQuotaDaemon.stopGracefully(timeoutMs));

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -337,7 +337,7 @@ public class GlobalStateMgr {
 
     private FrontendDaemon labelCleaner; // To clean old LabelInfo, ExportJobInfos
     private LeaderDaemon txnTimeoutChecker; // To abort timeout txns
-    private FrontendDaemon taskCleaner;   // To clean expire Task/TaskRun
+    private LeaderDaemon taskCleaner;   // To clean expire Task/TaskRun
     private FrontendDaemon tableKeeper;   // Maintain internal history tables
     private JournalWriter journalWriter; // leader only: write journal log
     private Daemon replayer;
@@ -1692,14 +1692,35 @@ public class GlobalStateMgr {
     void stopLeaderOnlyDaemonThreads() {
         long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
         // Stop in the reverse order of startLeaderOnlyDaemonThreads().
+        if (RunMode.isSharedDataMode()) {
+            stopOne("tabletReshardJobMgr", () -> tabletReshardJobMgr.stopGracefully(timeoutMs));
+        }
         stopOne("tabletCollector", () -> tabletCollector.stopGracefully(timeoutMs));
         stopOne("reportHandler", () -> reportHandler.stopGracefully(timeoutMs));
+        if (RunMode.isSharedDataMode()) {
+            stopOne("clusterSnapshotMgr", () -> clusterSnapshotMgr.stopGracefully(timeoutMs));
+        }
         stopOne("temporaryTableCleaner", () -> temporaryTableCleaner.stopGracefully(timeoutMs));
         stopOne("metaRecoveryDaemon", () -> metaRecoveryDaemon.stopGracefully(timeoutMs));
         stopOne("replicationMgr", () -> replicationMgr.stopGracefully(timeoutMs));
         stopOne("safeModeChecker", () -> safeModeChecker.stopGracefully(timeoutMs));
+        if (RunMode.isSharedDataMode()) {
+            stopOne("vectorIndexBuildScheduler", () -> vectorIndexBuildScheduler.stopGracefully(timeoutMs));
+            stopOne("fullVacuumDaemon", () -> fullVacuumDaemon.stopGracefully(timeoutMs));
+            stopOne("autovacuumDaemon", () -> autovacuumDaemon.stopGracefully(timeoutMs));
+            stopOne("starMgrMetaSyncer", () -> starMgrMetaSyncer.stopGracefully(timeoutMs));
+        }
+        if (taskRunStateSynchronizer != null) {
+            stopOne("taskRunStateSynchronizer", () -> taskRunStateSynchronizer.stopGracefully(timeoutMs));
+        }
         stopOne("spmAutoCapturer", () -> spmAutoCapturer.stopGracefully(timeoutMs));
         stopOne("mvActiveChecker", () -> mvActiveChecker.stopGracefully(timeoutMs));
+        stopOne("pipeScheduler", () -> pipeScheduler.stopGracefully(timeoutMs));
+        stopOne("pipeListener", () -> pipeListener.stopGracefully(timeoutMs));
+        if (taskCleaner != null) {
+            stopOne("taskCleaner", () -> taskCleaner.stopGracefully(timeoutMs));
+        }
+        stopOne("taskManager", () -> taskManager.stop());
         stopOne("statisticAutoCollector", () -> statisticAutoCollector.stopGracefully(timeoutMs));
         stopOne("statisticsMetaManager", () -> statisticsMetaManager.stopGracefully(timeoutMs));
         stopOne("updateDbUsedDataQuotaDaemon", () -> updateDbUsedDataQuotaDaemon.stopGracefully(timeoutMs));
@@ -1718,8 +1739,10 @@ public class GlobalStateMgr {
             stopOne("txnTimeoutChecker", () -> txnTimeoutChecker.stopGracefully(timeoutMs));
         }
         stopOne("publishVersionDaemon", () -> publishVersionDaemon.stopGracefully(timeoutMs));
+        stopOne("exportChecker", () -> ExportChecker.stopAll(timeoutMs));
         stopOne("loadLoadingChecker", () -> loadLoadingChecker.stopGracefully(timeoutMs));
         stopOne("loadEtlChecker", () -> loadEtlChecker.stopGracefully(timeoutMs));
+        stopOne("tabletWriteLogHistorySyncer", () -> tabletWriteLogHistorySyncer.stopGracefully(timeoutMs));
         stopOne("loadsHistorySyncer", () -> loadsHistorySyncer.stopGracefully(timeoutMs));
         stopOne("loadTimeoutChecker", () -> loadTimeoutChecker.stopGracefully(timeoutMs));
         stopOne("loadJobScheduler", () -> loadJobScheduler.stopGracefully(timeoutMs));
@@ -2162,9 +2185,9 @@ public class GlobalStateMgr {
     }
 
     public void createTaskCleaner() {
-        taskCleaner = new FrontendDaemon("TaskCleaner", Config.task_check_interval_second * 1000L) {
+        taskCleaner = new LeaderDaemon("TaskCleaner", Config.task_check_interval_second * 1000L) {
             @Override
-            protected void runAfterCatalogReady() {
+            protected void runAfterLeaseValid() {
                 doTaskBackgroundJob();
                 setInterval(Config.task_check_interval_second * 1000L);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
@@ -52,7 +52,9 @@ public class StarMgrServer {
     private static final Logger LOG = LogManager.getLogger(StarMgrServer.class);
 
     private static StarMgrServer CHECKPOINT = null;
-    private CheckpointController checkpointController = null;
+    // Package-private so same-package tests can inject a mock controller and verify
+    // stopCheckpointController without reflection.
+    CheckpointController checkpointController = null;
     private CheckpointWorker checkpointWorker = null;
     private boolean checkpointWorkerStarted = false;
     private static long checkpointThreadId = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
@@ -229,6 +229,20 @@ public class StarMgrServer {
         checkpointController.start();
     }
 
+    /**
+     * Symmetric counterpart to {@link #startCheckpointController()}. Stops the StarMgr-side
+     * CheckpointController so its daemon thread exits and leader-session bookkeeping is
+     * cleared during leader demotion drain. The field is left as-is because
+     * {@link #startCheckpointController()} unconditionally replaces it with a fresh
+     * instance on re-election; the old one becomes garbage once stopGracefully returns.
+     */
+    public void stopCheckpointController(long timeoutMs) {
+        CheckpointController controller = checkpointController;
+        if (controller != null) {
+            controller.stopGracefully(timeoutMs);
+        }
+    }
+
     private void becomeFollower() {
         getStarMgr().becomeFollower();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -78,6 +78,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -89,7 +90,9 @@ public class HeartbeatMgr extends LeaderDaemon {
     private static final AtomicReference<TMasterInfo> MASTER_INFO = new AtomicReference<>();
 
     private final boolean needRegisterMetric;
-    private volatile ExecutorService executor;
+    // Package-private so same-package tests can swap in a stuck pool to exercise the
+    // restart guard without reflection.
+    volatile ExecutorService executor;
 
     public HeartbeatMgr(boolean needRegisterMetric) {
         super("heartbeat-mgr", Config.heartbeat_timeout_second * 1000L);
@@ -98,6 +101,14 @@ public class HeartbeatMgr extends LeaderDaemon {
 
     @Override
     public synchronized void start() {
+        // Refuse to overlap with a previous pool that has not finished draining: isShutdown()
+        // becomes true before in-flight heartbeat RPCs actually return, so a fast
+        // demote/re-elect can put two heartbeat-sender generations against the same backends.
+        // Mirrors the BatchWriteMgr / AlterHandler restart guard.
+        if (executor != null && executor.isShutdown() && !executor.isTerminated()) {
+            throw new IllegalStateException(
+                    "HeartbeatMgr executor has not terminated; refuse to restart");
+        }
         if (executor == null || executor.isShutdown()) {
             executor = ThreadPoolManager.newDaemonFixedThreadPool(Config.heartbeat_mgr_threads_num,
                     Config.heartbeat_mgr_blocking_queue_size, "heartbeat-mgr-pool", needRegisterMetric);
@@ -107,10 +118,23 @@ public class HeartbeatMgr extends LeaderDaemon {
 
     @Override
     protected synchronized void onStopped() {
+        // shutdownNow() interrupts in-flight heartbeat RPCs, then await termination boundedly
+        // so a subsequent start() does not race a still-alive sender against a freshly created
+        // pool. The executor reference is kept on timeout so the restart guard in start()
+        // fires; on successful drain start() will see isShutdown() and rebuild.
         ExecutorService e = executor;
-        if (e != null) {
-            e.shutdownNow();
-            executor = null;
+        if (e == null) {
+            return;
+        }
+        e.shutdownNow();
+        long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
+        try {
+            if (!e.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
+                LOG.warn("HeartbeatMgr executor did not terminate within drain timeout");
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while waiting for HeartbeatMgr executor to terminate");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
@@ -103,15 +103,43 @@ public class LeaderTaskExecutor {
     }
 
     public void close() {
-        // Use shutdown() not shutdownNow(): the only production caller is ExportChecker, whose
-        // ExportExportingTasks wait inside subTasksDoneSignal.await(timeoutSec). Interrupting
-        // them via shutdownNow() would translate into a TIMEOUT cancel of the underlying export
-        // job (ExportExportingTask treats the InterruptedException from await as a hard
-        // failure) and also skip the job.setDoExportingThread(null) cleanup. The bounded await
-        // already exits within leader_demotion_drain_timeout_sec; we just stop submitting new
-        // work and let in-flight tasks finish.
+        close(0L);
+    }
+
+    /**
+     * Coordinated stop for leader demotion. Uses shutdown() (not shutdownNow()) so in-flight
+     * tasks complete their bounded {@code subTasksDoneSignal.await(timeoutSec)} naturally —
+     * interrupting via shutdownNow() would cause the caller (e.g. ExportExportingTask) to
+     * translate the InterruptedException into a TIMEOUT cancel of a healthy job and skip
+     * the job.setDoExportingThread(null) cleanup.
+     *
+     * If {@code awaitMillis > 0}, also blocks up to that budget waiting for both internal
+     * pools to actually terminate. This is required on the leader demotion drain path so a
+     * re-elected leader does not race the old leader's still-running tasks.
+     *
+     * @param awaitMillis maximum time to wait for both pools to drain, in milliseconds. Zero
+     *                    or negative means do not wait (legacy behaviour). The budget is
+     *                    split across the two internal pools.
+     */
+    public void close(long awaitMillis) {
         scheduledThreadPool.shutdown();
         executor.shutdown();
+        if (awaitMillis > 0L) {
+            long deadline = System.currentTimeMillis() + awaitMillis;
+            try {
+                long remaining = Math.max(1L, deadline - System.currentTimeMillis());
+                if (!scheduledThreadPool.awaitTermination(remaining, TimeUnit.MILLISECONDS)) {
+                    LOG.warn("LeaderTaskExecutor scheduledThreadPool did not terminate within drain timeout");
+                }
+                remaining = Math.max(1L, deadline - System.currentTimeMillis());
+                if (!executor.awaitTermination(remaining, TimeUnit.MILLISECONDS)) {
+                    LOG.warn("LeaderTaskExecutor executor did not terminate within drain timeout");
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                LOG.warn("Interrupted while waiting for LeaderTaskExecutor to terminate");
+            }
+        }
         synchronized (runningTasks) {
             runningTasks.clear();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
@@ -103,12 +103,15 @@ public class LeaderTaskExecutor {
     }
 
     public void close() {
-        // shutdownNow() interrupts in-flight tasks so worker threads exit promptly even if
-        // blocked on metadata locks; this is required for the leader-demotion drain path
-        // bounded by leader_demotion_drain_timeout_sec. Queued tasks are discarded - they
-        // are leader-side work that the new leader will re-issue.
-        scheduledThreadPool.shutdownNow();
-        executor.shutdownNow();
+        // Use shutdown() not shutdownNow(): the only production caller is ExportChecker, whose
+        // ExportExportingTasks wait inside subTasksDoneSignal.await(timeoutSec). Interrupting
+        // them via shutdownNow() would translate into a TIMEOUT cancel of the underlying export
+        // job (ExportExportingTask treats the InterruptedException from await as a hard
+        // failure) and also skip the job.setDoExportingThread(null) cleanup. The bounded await
+        // already exits within leader_demotion_drain_timeout_sec; we just stop submitting new
+        // work and let in-flight tasks finish.
+        scheduledThreadPool.shutdown();
+        executor.shutdown();
         synchronized (runningTasks) {
             runningTasks.clear();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
@@ -103,9 +103,15 @@ public class LeaderTaskExecutor {
     }
 
     public void close() {
-        scheduledThreadPool.shutdown();
-        executor.shutdown();
-        runningTasks.clear();
+        // shutdownNow() interrupts in-flight tasks so worker threads exit promptly even if
+        // blocked on metadata locks; this is required for the leader-demotion drain path
+        // bounded by leader_demotion_drain_timeout_sec. Queued tasks are discarded - they
+        // are leader-side work that the new leader will re-issue.
+        scheduledThreadPool.shutdownNow();
+        executor.shutdownNow();
+        synchronized (runningTasks) {
+            runningTasks.clear();
+        }
     }
 
     public int getTaskNum() {

--- a/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
@@ -51,26 +51,52 @@ import java.util.concurrent.TimeUnit;
 public class LeaderTaskExecutor {
     private static final Logger LOG = LogManager.getLogger(LeaderTaskExecutor.class);
 
-    private ThreadPoolExecutor executor;
+    // Not final: close() shuts down both pools and start() rebuilds them so a singleton
+    // executor instance can survive a leader demote / re-elect cycle.
+    // Package-private so same-package tests can swap in a stuck pool to exercise the
+    // restart guard without reflection.
+    ThreadPoolExecutor executor;
     private Map<Long, Future<?>> runningTasks;
     public ScheduledThreadPoolExecutor scheduledThreadPool;
 
+    // Saved for rebuild on restart - see start().
+    private final String name;
+    private final int threadNum;
+    private final int queueSize;
+    private final boolean needRegisterMetric;
+
     public LeaderTaskExecutor(String name, int threadNum, boolean needRegisterMetric) {
-        executor = ThreadPoolManager
-                .newDaemonFixedThreadPool(threadNum, threadNum * 2, name + "_pool", needRegisterMetric);
-        runningTasks = Maps.newHashMap();
-        scheduledThreadPool =
-                ThreadPoolManager.newDaemonScheduledThreadPool(1, name + "_scheduler_thread_pool", needRegisterMetric);
+        this(name, threadNum, threadNum * 2, needRegisterMetric);
     }
 
     public LeaderTaskExecutor(String name, int threadNum, int queueSize, boolean needRegisterMetric) {
-        executor = ThreadPoolManager.newDaemonFixedThreadPool(threadNum, queueSize, name + "_pool", needRegisterMetric);
+        this.name = name;
+        this.threadNum = threadNum;
+        this.queueSize = queueSize;
+        this.needRegisterMetric = needRegisterMetric;
         runningTasks = Maps.newHashMap();
+        buildPools();
+    }
+
+    private void buildPools() {
+        executor = ThreadPoolManager.newDaemonFixedThreadPool(threadNum, queueSize, name + "_pool", needRegisterMetric);
         scheduledThreadPool =
                 ThreadPoolManager.newDaemonScheduledThreadPool(1, name + "_scheduler_thread_pool", needRegisterMetric);
     }
 
-    public void start() {
+    public synchronized void start() {
+        // Refuse to overlap with a previous worker that did not drain in close(): if the pool
+        // is shutdown but not yet terminated, in-flight submissions from the previous leader
+        // session are still running. Mirrors the BatchWriteMgr / AlterHandler restart guard.
+        if (executor.isShutdown() && !executor.isTerminated()) {
+            throw new IllegalStateException(
+                    "LeaderTaskExecutor " + name + " executor has not terminated; refuse to restart");
+        }
+        // Rebuild the pools if a previous demotion shut them down so subsequent submissions
+        // do not raise RejectedExecutionException on the new leader session.
+        if (executor.isShutdown()) {
+            buildPools();
+        }
         scheduledThreadPool.scheduleAtFixedRate(new TaskChecker(), 0L, 1000L, TimeUnit.MILLISECONDS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
@@ -95,9 +95,42 @@ public class PriorityLeaderTaskExecutor {
     }
 
     public void close() {
+        close(0L);
+    }
+
+    /**
+     * Coordinated stop for leader demotion. Uses shutdown() (not shutdownNow()) so in-flight
+     * priority tasks are not interrupted mid-flight; if {@code awaitMillis > 0}, blocks up to
+     * that budget waiting for both internal pools to actually terminate. This is required on
+     * the leader demotion drain path so a re-elected leader does not race the old leader's
+     * still-running tasks.
+     *
+     * @param awaitMillis maximum time to wait for both pools to drain, in milliseconds. Zero
+     *                    or negative means do not wait (legacy behaviour). The budget is
+     *                    split across the two internal pools.
+     */
+    public void close(long awaitMillis) {
         scheduledThreadPool.shutdown();
         executor.shutdown();
-        runningTasks.clear();
+        if (awaitMillis > 0L) {
+            long deadline = System.currentTimeMillis() + awaitMillis;
+            try {
+                long remaining = Math.max(1L, deadline - System.currentTimeMillis());
+                if (!scheduledThreadPool.awaitTermination(remaining, TimeUnit.MILLISECONDS)) {
+                    LOG.warn("PriorityLeaderTaskExecutor scheduledThreadPool did not terminate within drain timeout");
+                }
+                remaining = Math.max(1L, deadline - System.currentTimeMillis());
+                if (!executor.awaitTermination(remaining, TimeUnit.MILLISECONDS)) {
+                    LOG.warn("PriorityLeaderTaskExecutor executor did not terminate within drain timeout");
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                LOG.warn("Interrupted while waiting for PriorityLeaderTaskExecutor to terminate");
+            }
+        }
+        synchronized (runningTasks) {
+            runningTasks.clear();
+        }
     }
 
     public int getTaskNum() {

--- a/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
@@ -32,19 +32,49 @@ import java.util.concurrent.TimeUnit;
 public class PriorityLeaderTaskExecutor {
     private static final Logger LOG = LogManager.getLogger(PriorityLeaderTaskExecutor.class);
 
-    private PriorityThreadPoolExecutor executor;
+    // Not final: close() shuts down both pools and start() rebuilds them so a singleton
+    // executor instance can survive a leader demote / re-elect cycle.
+    // Package-private so same-package tests can swap in a stuck pool to exercise the
+    // restart guard without reflection.
+    PriorityThreadPoolExecutor executor;
     private Map<Long, PriorityFutureTask<?>> runningTasks;
     public ScheduledThreadPoolExecutor scheduledThreadPool;
 
+    // Saved for rebuild on restart - see start().
+    private final String name;
+    private final int threadNum;
+    private final int queueSize;
+    private final boolean needRegisterMetric;
+
     public PriorityLeaderTaskExecutor(String name, int threadNum, int queueSize, boolean needRegisterMetric) {
+        this.name = name;
+        this.threadNum = threadNum;
+        this.queueSize = queueSize;
+        this.needRegisterMetric = needRegisterMetric;
+        runningTasks = Maps.newHashMap();
+        buildPools();
+    }
+
+    private void buildPools() {
         executor = ThreadPoolManager.newDaemonFixedPriorityThreadPool(threadNum, queueSize, name + "_priority_pool",
                 needRegisterMetric);
-        runningTasks = Maps.newHashMap();
         scheduledThreadPool = ThreadPoolManager.newDaemonScheduledThreadPool(1,
                 name + "_scheduler_priority_thread_pool", needRegisterMetric);
     }
 
-    public void start() {
+    public synchronized void start() {
+        // Refuse to overlap with a previous worker that did not drain in close(): if the pool
+        // is shutdown but not yet terminated, in-flight priority tasks from the previous leader
+        // session are still running. Mirrors the BatchWriteMgr / AlterHandler restart guard.
+        if (executor.isShutdown() && !executor.isTerminated()) {
+            throw new IllegalStateException(
+                    "PriorityLeaderTaskExecutor " + name + " executor has not terminated; refuse to restart");
+        }
+        // Rebuild the pools if a previous demotion shut them down so subsequent submissions
+        // do not raise RejectedExecutionException on the new leader session.
+        if (executor.isShutdown()) {
+            buildPools();
+        }
         scheduledThreadPool.scheduleAtFixedRate(new TaskChecker(), 0L, 1000L, TimeUnit.MILLISECONDS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -89,6 +89,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -110,8 +111,10 @@ public class PublishVersionDaemon extends LeaderDaemon {
     // and modify transaction state on FE
     // for shared-nothing, task executor thread will be responsible for checking publish task
     // result and modify transaction state on FE
-    private ThreadPoolExecutor taskExecutor;
-    private ThreadPoolExecutor deleteTxnLogExecutor;
+    // Package-private so same-package tests can swap in a stuck pool to exercise the
+    // restart guard without reflection.
+    ThreadPoolExecutor taskExecutor;
+    ThreadPoolExecutor deleteTxnLogExecutor;
     // Guards ConfigRefreshDaemon listener registration. Executors are recreated on every
     // leader activation (after onStopped() nulls them), but listeners must be registered
     // only once per daemon instance — otherwise each demote/re-elect cycle leaks a listener.
@@ -254,7 +257,8 @@ public class PublishVersionDaemon extends LeaderDaemon {
         return taskExecutor;
     }
 
-    private @NotNull ThreadPoolExecutor getDeleteTxnLogExecutor() {
+    @NotNull
+    ThreadPoolExecutor getDeleteTxnLogExecutor() {
         if (deleteTxnLogExecutor == null) {
             // Create a new thread for every task if there is no idle threads available.
             // Idle threads will be cleaned after `KEEP_ALIVE_TIME` seconds, which is 60 seconds by default.
@@ -1164,17 +1168,29 @@ public class PublishVersionDaemon extends LeaderDaemon {
      * BE-side PublishVersionTask is idempotent (BE returns success when the requested
      * version is already visible), so dropping in-flight tasks is safe - the new leader
      * will resubmit publish from {@code GlobalTransactionMgr.getReadyToPublishTransactions}.
+     *
+     * shutdownNow() interrupts the publish/delete-txnlog workers, then awaitTermination
+     * blocks boundedly so a re-elected leader does not race the old pool against the
+     * publishingTransactionIds dedup set. On successful drain the executor reference is
+     * nulled so the next call to {@link #getTaskExecutor()} rebuilds a fresh pool; on
+     * timeout the reference is kept so the restart guard in {@link #start()} bails out.
      */
     @Override
     protected void onStopped() {
         ThreadPoolExecutor t = taskExecutor;
+        ThreadPoolExecutor d = deleteTxnLogExecutor;
         if (t != null) {
             t.shutdownNow();
-            taskExecutor = null;
         }
-        ThreadPoolExecutor d = deleteTxnLogExecutor;
         if (d != null) {
             d.shutdownNow();
+        }
+        long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        if (awaitExecutorTermination("taskExecutor", t, deadline)) {
+            taskExecutor = null;
+        }
+        if (awaitExecutorTermination("deleteTxnLogExecutor", d, deadline)) {
             deleteTxnLogExecutor = null;
         }
         if (publishingTransactionIds != null) {
@@ -1183,6 +1199,43 @@ public class PublishVersionDaemon extends LeaderDaemon {
         if (publishingLakeTransactionsBatchTableId != null) {
             publishingLakeTransactionsBatchTableId.clear();
         }
+    }
+
+    private static boolean awaitExecutorTermination(String name, ThreadPoolExecutor pool, long deadlineMs) {
+        if (pool == null) {
+            return true;
+        }
+        long remainingMs = Math.max(1L, deadlineMs - System.currentTimeMillis());
+        try {
+            if (pool.awaitTermination(remainingMs, TimeUnit.MILLISECONDS)) {
+                return true;
+            }
+            LOG.warn("PublishVersionDaemon {} did not terminate within drain timeout", name);
+            return false;
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while waiting for PublishVersionDaemon {} to terminate", name);
+            return false;
+        }
+    }
+
+    @Override
+    public synchronized void start() {
+        // Refuse to overlap with a previous pool that did not drain in onStopped(): a
+        // shutdown-but-not-terminated executor means publish/delete-txnlog workers from
+        // the previous leader session are still running. Mirrors the BatchWriteMgr /
+        // AlterHandler / HeartbeatMgr restart guard. The fields are nulled in onStopped()
+        // on successful drain so the getters lazily rebuild fresh pools on re-election.
+        if (taskExecutor != null && taskExecutor.isShutdown() && !taskExecutor.isTerminated()) {
+            throw new IllegalStateException(
+                    "PublishVersionDaemon taskExecutor has not terminated; refuse to restart");
+        }
+        if (deleteTxnLogExecutor != null && deleteTxnLogExecutor.isShutdown()
+                && !deleteTxnLogExecutor.isTerminated()) {
+            throw new IllegalStateException(
+                    "PublishVersionDaemon deleteTxnLogExecutor has not terminated; refuse to restart");
+        }
+        super.start();
     }
 
     // Transactions that can be published in a batch for a partition of a shadow index

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
@@ -173,7 +173,7 @@ public class TabletReshardJobMgrTest {
         Assertions.assertEquals(normalJob.getParallelTablets() + abnormalJob.getParallelTablets(),
                 jobMgr.getTotalParallelTablets());
 
-        jobMgr.runAfterCatalogReady();
+        jobMgr.runAfterLeaseValid();
 
         Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, normalJob.getJobState());
         Assertions.assertEquals(TabletReshardJob.JobState.ABORTED, abnormalJob.getJobState());
@@ -187,7 +187,7 @@ public class TabletReshardJobMgrTest {
         abnormalJob.finishedTimeMs = 0;
         Assertions.assertTrue(abnormalJob.isExpired());
 
-        jobMgr.runAfterCatalogReady();
+        jobMgr.runAfterLeaseValid();
 
         Assertions.assertEquals(1, jobMgr.getTabletReshardJobs().size());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -301,7 +301,7 @@ public class StarMgrMetaSyncerTest {
             }
         };
 
-        starMgrMetaSyncer.runAfterCatalogReady();
+        starMgrMetaSyncer.runAfterLeaseValid();
         Assertions.assertEquals(1, starOSAgent.listShardGroup().size());
     }
 
@@ -1224,13 +1224,13 @@ public class StarMgrMetaSyncerTest {
 
         long oldConfig = Config.shard_group_clean_threshold_sec;
         Config.shard_group_clean_threshold_sec = 0;
-        syncer.runAfterCatalogReady();
+        syncer.runAfterLeaseValid();
         ClusterSnapshotJob j3 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
         j3.setState(ClusterSnapshotJobState.FINISHED);
-        syncer.runAfterCatalogReady();
+        syncer.runAfterLeaseValid();
         ClusterSnapshotJob j4 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
         j4.setState(ClusterSnapshotJobState.FINISHED);
-        syncer.runAfterCatalogReady();
+        syncer.runAfterLeaseValid();
         Config.shard_group_clean_threshold_sec = oldConfig;
     }
 
@@ -1332,7 +1332,7 @@ public class StarMgrMetaSyncerTest {
             cleanedGroupIds.clear();
             // shardGroupSet1 will be expired
             long begin = System.currentTimeMillis();
-            starMgrMetaSyncer.runAfterCatalogReady();
+            starMgrMetaSyncer.runAfterLeaseValid();
             long elapse = System.currentTimeMillis() - begin;
             LOG.warn("The check takes {}ms", elapse);
             Assertions.assertTrue(elapse < 5000, String.format("The check takes %dms.", elapse));
@@ -1344,7 +1344,7 @@ public class StarMgrMetaSyncerTest {
             cleanedGroupIds.clear();
             // shardGroupSet1 and shardGroupSet2 will be expired
             long begin = System.currentTimeMillis();
-            starMgrMetaSyncer.runAfterCatalogReady();
+            starMgrMetaSyncer.runAfterLeaseValid();
             long elapse = System.currentTimeMillis() - begin;
             LOG.warn("The check takes {}ms", elapse);
             Assertions.assertTrue(elapse < 5000, String.format("The check takes %dms.", elapse));
@@ -1424,7 +1424,7 @@ public class StarMgrMetaSyncerTest {
             Config.shard_group_clean_threshold_sec = 4; // 4 seconds
             cleanedGroupIds.clear();
             long begin = System.currentTimeMillis();
-            starMgrMetaSyncer.runAfterCatalogReady();
+            starMgrMetaSyncer.runAfterLeaseValid();
             long elapse = System.currentTimeMillis() - begin;
             Assertions.assertTrue(elapse >= delayMs.get());
             // Nothing cleaned
@@ -1435,7 +1435,7 @@ public class StarMgrMetaSyncerTest {
             Config.shard_group_clean_threshold_sec = 4; // 4 seconds
             cleanedGroupIds.clear();
             long begin = System.currentTimeMillis();
-            starMgrMetaSyncer.runAfterCatalogReady();
+            starMgrMetaSyncer.runAfterLeaseValid();
             long elapse = System.currentTimeMillis() - begin;
             Assertions.assertTrue(elapse >= delayMs.get());
             // All cleaned
@@ -1547,7 +1547,7 @@ public class StarMgrMetaSyncerTest {
 
         cleanedGroupIds.clear();
         Assertions.assertEquals(0L, groupCounter.get());
-        starMgrMetaSyncer.runAfterCatalogReady();
+        starMgrMetaSyncer.runAfterLeaseValid();
         // all groups should be counted
         Assertions.assertEquals(groupIds.size(), groupCounter.get());
         // Assertions.assertEquals(expectedCleanedGroupIds.size(), cleanedGroupIds.size());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -396,7 +396,7 @@ public class VacuumTest {
         long oldValue2 = Config.lake_fullvacuum_partition_naptime_seconds;
         Config.lake_fullvacuum_parallel_partitions = 1;
         Config.lake_fullvacuum_partition_naptime_seconds = 0;
-        Deencapsulation.invoke(fullVacuumDaemon, "runAfterCatalogReady");
+        Deencapsulation.invoke(fullVacuumDaemon, "runAfterLeaseValid");
         Config.lake_fullvacuum_partition_naptime_seconds = oldValue2;
         Config.lake_fullvacuum_parallel_partitions = oldValue1;
         FeConstants.runningUnitTest = true;
@@ -523,7 +523,7 @@ public class VacuumTest {
         long oldValue2 = Config.lake_fullvacuum_partition_naptime_seconds;
         Config.lake_fullvacuum_parallel_partitions = 1;
         Config.lake_fullvacuum_partition_naptime_seconds = 0;
-        Deencapsulation.invoke(fullVacuumDaemon, "runAfterCatalogReady");
+        Deencapsulation.invoke(fullVacuumDaemon, "runAfterLeaseValid");
         Config.lake_fullvacuum_partition_naptime_seconds = oldValue2;
         Config.lake_fullvacuum_parallel_partitions = oldValue1;
         FeConstants.runningUnitTest = true;
@@ -689,5 +689,47 @@ public class VacuumTest {
             long fullVacuumResult = FullVacuumDaemon.computeMinActiveTxnId(db, olapTable);
             Assertions.assertEquals(50L, fullVacuumResult);
         }
+    }
+
+    @Test
+    public void testAutovacuumDaemonOnStoppedShutsDownExecutorAndStartRebuilds() throws Exception {
+        // The owned BlockingThreadPoolExecutorService is leader-only: shutdownNow() in
+        // onStopped() must interrupt in-flight vacuum tasks so worker threads exit, and
+        // start() must rebuild the pool for the next leader.
+        AutovacuumDaemon daemon = new AutovacuumDaemon();
+        org.apache.hadoop.util.BlockingThreadPoolExecutorService before =
+                (org.apache.hadoop.util.BlockingThreadPoolExecutorService) org.apache.commons.lang3.reflect.FieldUtils
+                        .readField(daemon, "executorService", true);
+
+        org.apache.commons.lang3.reflect.MethodUtils.invokeMethod(daemon, true, "onStopped");
+        Assertions.assertTrue(before.isShutdown(), "executorService must be shut down on demotion");
+
+        daemon.start();
+        org.apache.hadoop.util.BlockingThreadPoolExecutorService after =
+                (org.apache.hadoop.util.BlockingThreadPoolExecutorService) org.apache.commons.lang3.reflect.FieldUtils
+                        .readField(daemon, "executorService", true);
+        Assertions.assertNotSame(before, after, "executorService must be rebuilt on re-election");
+        Assertions.assertFalse(after.isShutdown());
+        daemon.setStop();
+    }
+
+    @Test
+    public void testFullVacuumDaemonOnStoppedShutsDownExecutorAndStartRebuilds() throws Exception {
+        // Same shutdown/rebuild contract as AutovacuumDaemon.
+        FullVacuumDaemon daemon = new FullVacuumDaemon();
+        org.apache.hadoop.util.BlockingThreadPoolExecutorService before =
+                (org.apache.hadoop.util.BlockingThreadPoolExecutorService) org.apache.commons.lang3.reflect.FieldUtils
+                        .readField(daemon, "executorService", true);
+
+        org.apache.commons.lang3.reflect.MethodUtils.invokeMethod(daemon, true, "onStopped");
+        Assertions.assertTrue(before.isShutdown());
+
+        daemon.start();
+        org.apache.hadoop.util.BlockingThreadPoolExecutorService after =
+                (org.apache.hadoop.util.BlockingThreadPoolExecutorService) org.apache.commons.lang3.reflect.FieldUtils
+                        .readField(daemon, "executorService", true);
+        Assertions.assertNotSame(before, after);
+        Assertions.assertFalse(after.isShutdown());
+        daemon.setStop();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
@@ -666,8 +666,8 @@ public class ClusterSnapshotTest {
         long beginTime = scheduler.lastAutomatedJobStartTimeMs;
 
         setAutomatedSnapshotOn(false);
-        scheduler.runAfterCatalogReady();
-        scheduler.runAfterCatalogReady();
+        scheduler.runAfterLeaseValid();
+        scheduler.runAfterLeaseValid();
 
         new MockUp<ClusterSnapshotJobScheduler>() {
             @Mock
@@ -678,7 +678,7 @@ public class ClusterSnapshotTest {
 
         long oldValue = Config.automated_cluster_snapshot_interval_seconds;
         Config.automated_cluster_snapshot_interval_seconds = 0L;
-        scheduler.runAfterCatalogReady();
+        scheduler.runAfterLeaseValid();
         long endTime = scheduler.lastAutomatedJobStartTimeMs;
         Config.automated_cluster_snapshot_interval_seconds = oldValue;
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
@@ -1081,4 +1081,28 @@ public class ClusterSnapshotTest {
         Assertions.assertEquals("boom", err);
     }
 
+    @Test
+    public void testStopGracefullyNullsOutSchedulerSoStartRebuilds() {
+        // After demotion the inner ClusterSnapshotJobScheduler must be nulled out so that the
+        // next start() rebuilds it with fresh CheckpointController references; otherwise the
+        // re-elected leader silently never restarts snapshot scheduling.
+        ClusterSnapshotMgr mgr = new ClusterSnapshotMgr();
+        ClusterSnapshotJobScheduler injected = new ClusterSnapshotJobScheduler(null, null);
+        Deencapsulation.setField(mgr, "clusterSnapshotJobScheduler", injected);
+        Assertions.assertNotNull(Deencapsulation.getField(mgr, "clusterSnapshotJobScheduler"));
+
+        mgr.stopGracefully(1000L);
+
+        Assertions.assertNull(Deencapsulation.getField(mgr, "clusterSnapshotJobScheduler"),
+                "scheduler reference must be cleared so start() rebuilds it on re-election");
+    }
+
+    @Test
+    public void testStopGracefullyIsNoOpWhenSchedulerNeverStarted() {
+        // Followers / non-shared-data clusters never instantiate the scheduler. stopGracefully
+        // must tolerate that and not throw.
+        ClusterSnapshotMgr mgr = new ClusterSnapshotMgr();
+        Assertions.assertDoesNotThrow(() -> mgr.stopGracefully(1000L));
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/vacuum/AutovacuumDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/vacuum/AutovacuumDaemonTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.lake.vacuum;
 
+import com.starrocks.common.Config;
 import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,38 @@ public class AutovacuumDaemonTest {
                     "rebuilt executor must accept new submissions");
         } finally {
             daemon.setStop();
+        }
+    }
+
+    @Test
+    public void testOnStoppedLogsWhenExecutorRefusesToTerminate() {
+        // When a vacuum worker ignores shutdownNow's interrupt long enough to outlast the
+        // drain budget, onStopped must log a warning and proceed rather than block forever.
+        // Covers the LOG.warn / catch branches in onStopped's awaitTermination.
+        AutovacuumDaemon daemon = new AutovacuumDaemon();
+        BlockingThreadPoolExecutorService stuck =
+                BlockingThreadPoolExecutorService.newInstance(1, 0, 1, TimeUnit.HOURS, "autovacuum-stuck-test");
+        stuck.execute(() -> {
+            long deadline = System.currentTimeMillis() + 2000L;
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                    // simulate uninterruptible vacuum work
+                }
+            }
+        });
+        daemon.executorService = stuck;
+        int oldTimeout = Config.leader_demotion_drain_timeout_sec;
+        Config.leader_demotion_drain_timeout_sec = 1;
+        try {
+            daemon.onStopped();
+            // Drain timed out; pool is still shutdown and reference retained for the
+            // restart guard.
+            Assertions.assertTrue(stuck.isShutdown());
+        } finally {
+            Config.leader_demotion_drain_timeout_sec = oldTimeout;
+            stuck.shutdownNow();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/vacuum/AutovacuumDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/vacuum/AutovacuumDaemonTest.java
@@ -1,0 +1,87 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.vacuum;
+
+import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class AutovacuumDaemonTest {
+
+    @Test
+    public void testOnStoppedAwaitsExecutorTermination() {
+        // onStopped() shutdownNow()'s the vacuum executor and then awaits termination so a
+        // subsequent start() on the new leader does not race a still-alive vacuum worker
+        // against a freshly created pool. isTerminated() must be true once onStopped()
+        // returns.
+        AutovacuumDaemon daemon = new AutovacuumDaemon();
+        BlockingThreadPoolExecutorService executor = daemon.executorService;
+
+        daemon.onStopped();
+
+        Assertions.assertTrue(executor.isShutdown(), "executor must be shutdown");
+        Assertions.assertTrue(executor.isTerminated(),
+                "executor must be terminated after onStopped() awaits drain");
+    }
+
+    @Test
+    public void testStartRebuildsExecutorAfterOnStopped() {
+        // After onStopped() drains the previous pool, start() must rebuild it so a re-elected
+        // leader can submit vacuum tasks without RejectedExecutionException.
+        AutovacuumDaemon daemon = new AutovacuumDaemon();
+        BlockingThreadPoolExecutorService originalExecutor = daemon.executorService;
+
+        daemon.onStopped();
+        Assertions.assertTrue(originalExecutor.isTerminated());
+
+        daemon.start();
+        try {
+            Assertions.assertNotSame(originalExecutor, daemon.executorService,
+                    "executor must be rebuilt on re-election");
+            Assertions.assertFalse(daemon.executorService.isShutdown(),
+                    "rebuilt executor must accept new submissions");
+        } finally {
+            daemon.setStop();
+        }
+    }
+
+    @Test
+    public void testStartRefusesToRestartBeforeExecutorTerminates() {
+        // Mirror of BatchWriteMgr / AlterHandler restart guard. If a previous executor is
+        // shutdown but has not yet terminated (in-flight task ignoring interrupt), start()
+        // must throw IllegalStateException rather than spinning up a fresh pool against the
+        // same metadata.
+        AutovacuumDaemon daemon = new AutovacuumDaemon();
+        BlockingThreadPoolExecutorService blockedExecutor =
+                BlockingThreadPoolExecutorService.newInstance(1, 0, 1, TimeUnit.HOURS, "autovacuum-blocked-test");
+        blockedExecutor.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedExecutor.shutdown();
+        daemon.executorService = blockedExecutor;
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, daemon::start);
+        } finally {
+            blockedExecutor.shutdownNow();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/vacuum/FullVacuumDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/vacuum/FullVacuumDaemonTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.lake.vacuum;
 
+import com.starrocks.common.Config;
 import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,35 @@ public class FullVacuumDaemonTest {
                     "rebuilt executor must accept new submissions");
         } finally {
             daemon.setStop();
+        }
+    }
+
+    @Test
+    public void testOnStoppedLogsWhenExecutorRefusesToTerminate() {
+        // When a full-vacuum worker ignores shutdownNow's interrupt long enough to outlast
+        // the drain budget, onStopped must log a warning and proceed rather than block.
+        FullVacuumDaemon daemon = new FullVacuumDaemon();
+        BlockingThreadPoolExecutorService stuck =
+                BlockingThreadPoolExecutorService.newInstance(1, 0, 1, TimeUnit.HOURS, "fullvacuum-stuck-test");
+        stuck.execute(() -> {
+            long deadline = System.currentTimeMillis() + 2000L;
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                    // simulate uninterruptible full-vacuum work
+                }
+            }
+        });
+        daemon.executorService = stuck;
+        int oldTimeout = Config.leader_demotion_drain_timeout_sec;
+        Config.leader_demotion_drain_timeout_sec = 1;
+        try {
+            daemon.onStopped();
+            Assertions.assertTrue(stuck.isShutdown());
+        } finally {
+            Config.leader_demotion_drain_timeout_sec = oldTimeout;
+            stuck.shutdownNow();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/vacuum/FullVacuumDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/vacuum/FullVacuumDaemonTest.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.vacuum;
+
+import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class FullVacuumDaemonTest {
+
+    @Test
+    public void testOnStoppedAwaitsExecutorTermination() {
+        // onStopped() shutdownNow()'s the vacuum executor and then awaits termination so a
+        // subsequent start() on the new leader does not race a still-alive full-vacuum worker
+        // against a freshly created pool. isTerminated() must be true once onStopped() returns.
+        FullVacuumDaemon daemon = new FullVacuumDaemon();
+        BlockingThreadPoolExecutorService executor = daemon.executorService;
+
+        daemon.onStopped();
+
+        Assertions.assertTrue(executor.isShutdown(), "executor must be shutdown");
+        Assertions.assertTrue(executor.isTerminated(),
+                "executor must be terminated after onStopped() awaits drain");
+    }
+
+    @Test
+    public void testStartRebuildsExecutorAfterOnStopped() {
+        // After onStopped() drains the previous pool, start() must rebuild it so a re-elected
+        // leader can submit full-vacuum tasks without RejectedExecutionException.
+        FullVacuumDaemon daemon = new FullVacuumDaemon();
+        BlockingThreadPoolExecutorService originalExecutor = daemon.executorService;
+
+        daemon.onStopped();
+        Assertions.assertTrue(originalExecutor.isTerminated());
+
+        daemon.start();
+        try {
+            Assertions.assertNotSame(originalExecutor, daemon.executorService,
+                    "executor must be rebuilt on re-election");
+            Assertions.assertFalse(daemon.executorService.isShutdown(),
+                    "rebuilt executor must accept new submissions");
+        } finally {
+            daemon.setStop();
+        }
+    }
+
+    @Test
+    public void testStartRefusesToRestartBeforeExecutorTerminates() {
+        // Mirror of BatchWriteMgr / AlterHandler restart guard. If a previous executor is
+        // shutdown but has not yet terminated (in-flight task ignoring interrupt), start()
+        // must throw IllegalStateException rather than spinning up a fresh pool against the
+        // same metadata / object store.
+        FullVacuumDaemon daemon = new FullVacuumDaemon();
+        BlockingThreadPoolExecutorService blockedExecutor =
+                BlockingThreadPoolExecutorService.newInstance(1, 0, 1, TimeUnit.HOURS, "fullvacuum-blocked-test");
+        blockedExecutor.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedExecutor.shutdown();
+        daemon.executorService = blockedExecutor;
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, daemon::start);
+        } finally {
+            blockedExecutor.shutdownNow();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/vector/VectorIndexBuildSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/vector/VectorIndexBuildSchedulerTest.java
@@ -732,7 +732,7 @@ public class VectorIndexBuildSchedulerTest {
         };
 
         java.lang.reflect.Method m =
-                VectorIndexBuildScheduler.class.getDeclaredMethod("runAfterCatalogReady");
+                VectorIndexBuildScheduler.class.getDeclaredMethod("runAfterLeaseValid");
         m.setAccessible(true);
         m.invoke(scheduler);
 
@@ -762,7 +762,7 @@ public class VectorIndexBuildSchedulerTest {
         };
 
         java.lang.reflect.Method m =
-                VectorIndexBuildScheduler.class.getDeclaredMethod("runAfterCatalogReady");
+                VectorIndexBuildScheduler.class.getDeclaredMethod("runAfterLeaseValid");
         m.setAccessible(true);
 
         java.lang.reflect.Field f = VectorIndexBuildScheduler.class.getDeclaredField("recoveryScanDone");
@@ -1004,5 +1004,24 @@ public class VectorIndexBuildSchedulerTest {
         Assertions.assertTrue(getRunningTasks().isEmpty());
         Assertions.assertEquals(20L, latestVersion(tabletId));
         Assertions.assertEquals(15L, latestCompactionVersion(tabletId));
+    }
+
+    @Test
+    public void testOnStoppedClearsLeaderSessionStateAndResetsRecovery() throws Exception {
+        // The four caches and recoveryScanDone are all leader-session bookkeeping: a new
+        // leader rebuilds pendingTablets from transactions, dispatches new builds, and must
+        // rerun recoveryScan() because builtVersion < visibleVersion tablets may have moved.
+        scheduler.addPendingTablet(1L, 5L, false);
+        scheduler.addPendingTablet(2L, 7L, false);
+        getRunningTasks().put(3L, createTaskWithStartTime(3L, 9L, System.currentTimeMillis()));
+        org.apache.commons.lang3.reflect.FieldUtils.writeField(scheduler, "recoveryScanDone", true, true);
+
+        org.apache.commons.lang3.reflect.MethodUtils.invokeMethod(scheduler, true, "onStopped");
+
+        Assertions.assertTrue(getPendingTablets().isEmpty(), "pendingTablets must be cleared on demotion");
+        Assertions.assertTrue(getRunningTasks().isEmpty(), "runningTasks must be cleared on demotion");
+        Assertions.assertFalse(
+                (boolean) org.apache.commons.lang3.reflect.FieldUtils.readField(scheduler, "recoveryScanDone", true),
+                "recoveryScanDone must reset so the next leader rescans tablets");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/leader/CheckpointControllerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/CheckpointControllerTest.java
@@ -15,18 +15,22 @@
 package com.starrocks.leader;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.system.Frontend;
 import com.starrocks.utframe.MockJournal;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -106,6 +110,27 @@ public class CheckpointControllerTest {
         int idx2 = workers.indexOf(follower2);
         assertTrue(idx1 < idx2);
         Config.checkpoint_only_on_leader = oldValue;
+    }
+
+    @Test
+    public void testOnStoppedClearsLeaderSessionBookkeeping() {
+        // onStopped must drop the previous leader's pending-push set and last-failed-worker
+        // map so a re-elected leader does not (a) try to push to nodes that already have
+        // the new image and (b) inherit stale worker-selection bias. Per-round volatile
+        // fields (workerNodeName / journalId / result / clusterSnapshotInfo) are naturally
+        // overwritten by the next createImage() call, so onStopped does not touch them.
+        Set<String> nodesToPushImage = Deencapsulation.getField(controller, "nodesToPushImage");
+        Map<String, Long> lastFailedTime = Deencapsulation.getField(controller, "lastFailedTime");
+        nodesToPushImage.add("follower1");
+        nodesToPushImage.add("follower2");
+        controller.setLastFailedTime("follower1", System.currentTimeMillis());
+
+        Deencapsulation.invoke(controller, "onStopped");
+
+        Assertions.assertTrue(nodesToPushImage.isEmpty(),
+                "nodesToPushImage must be cleared on demotion");
+        Assertions.assertTrue(lastFailedTime.isEmpty(),
+                "lastFailedTime must be cleared on demotion");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/leader/CheckpointControllerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/CheckpointControllerTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.leader;
 
 import com.starrocks.common.Config;
-import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
@@ -29,8 +28,6 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -119,17 +116,15 @@ public class CheckpointControllerTest {
         // the new image and (b) inherit stale worker-selection bias. Per-round volatile
         // fields (workerNodeName / journalId / result / clusterSnapshotInfo) are naturally
         // overwritten by the next createImage() call, so onStopped does not touch them.
-        Set<String> nodesToPushImage = Deencapsulation.getField(controller, "nodesToPushImage");
-        Map<String, Long> lastFailedTime = Deencapsulation.getField(controller, "lastFailedTime");
-        nodesToPushImage.add("follower1");
-        nodesToPushImage.add("follower2");
+        controller.nodesToPushImage.add("follower1");
+        controller.nodesToPushImage.add("follower2");
         controller.setLastFailedTime("follower1", System.currentTimeMillis());
 
-        Deencapsulation.invoke(controller, "onStopped");
+        controller.onStopped();
 
-        Assertions.assertTrue(nodesToPushImage.isEmpty(),
+        Assertions.assertTrue(controller.nodesToPushImage.isEmpty(),
                 "nodesToPushImage must be cleared on demotion");
-        Assertions.assertTrue(lastFailedTime.isEmpty(),
+        Assertions.assertTrue(controller.lastFailedTime.isEmpty(),
                 "lastFailedTime must be cleared on demotion");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
@@ -88,4 +88,56 @@ public class ExportCheckerTest {
         cancelled = (boolean) method.invoke(checker, job);
         Assertions.assertTrue(cancelled);
     }
+
+    @Test
+    public void testStopAllClosesExecutorsAndInitRebuilds() throws Exception {
+        // stopAll must shut down all three LeaderTaskExecutor instances so their worker
+        // threads exit on demotion; a subsequent init() must replace the static maps with
+        // fresh instances for the next leader.
+        ExportChecker.init(1000L);
+        com.starrocks.task.LeaderTaskExecutor pendingBefore = readExecutor(JobState.PENDING);
+        com.starrocks.task.LeaderTaskExecutor exportingBefore = readExecutor(JobState.EXPORTING);
+        com.starrocks.task.LeaderTaskExecutor subTaskBefore = readSubTaskExecutor();
+        Assertions.assertNotNull(pendingBefore);
+        Assertions.assertNotNull(exportingBefore);
+        Assertions.assertNotNull(subTaskBefore);
+
+        ExportChecker.stopAll(1000L);
+        Assertions.assertTrue(readPoolFromExecutor(pendingBefore).isShutdown(),
+                "pending executor pool must be shut down");
+        Assertions.assertTrue(readPoolFromExecutor(exportingBefore).isShutdown(),
+                "exporting executor pool must be shut down");
+        Assertions.assertTrue(readPoolFromExecutor(subTaskBefore).isShutdown(),
+                "sub-task executor pool must be shut down");
+
+        // init() again must produce fresh instances.
+        ExportChecker.init(1000L);
+        Assertions.assertNotSame(pendingBefore, readExecutor(JobState.PENDING));
+        Assertions.assertNotSame(exportingBefore, readExecutor(JobState.EXPORTING));
+        Assertions.assertNotSame(subTaskBefore, readSubTaskExecutor());
+        // Tear down what init() just created so the test does not leak threads.
+        ExportChecker.stopAll(1000L);
+    }
+
+    private com.starrocks.task.LeaderTaskExecutor readExecutor(JobState state) throws Exception {
+        Field field = ExportChecker.class.getDeclaredField("executors");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<JobState, com.starrocks.task.LeaderTaskExecutor> executors =
+                (Map<JobState, com.starrocks.task.LeaderTaskExecutor>) field.get(null);
+        return executors.get(state);
+    }
+
+    private com.starrocks.task.LeaderTaskExecutor readSubTaskExecutor() throws Exception {
+        Field field = ExportChecker.class.getDeclaredField("exportingSubTaskExecutor");
+        field.setAccessible(true);
+        return (com.starrocks.task.LeaderTaskExecutor) field.get(null);
+    }
+
+    private java.util.concurrent.ThreadPoolExecutor readPoolFromExecutor(com.starrocks.task.LeaderTaskExecutor lte)
+            throws Exception {
+        Field field = com.starrocks.task.LeaderTaskExecutor.class.getDeclaredField("executor");
+        field.setAccessible(true);
+        return (java.util.concurrent.ThreadPoolExecutor) field.get(lte);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
@@ -109,6 +109,15 @@ public class ExportCheckerTest {
                 "exporting executor pool must be shut down");
         Assertions.assertTrue(readPoolFromExecutor(subTaskBefore).isShutdown(),
                 "sub-task executor pool must be shut down");
+        // stopAll must block until the pools actually terminate so demotion does not race
+        // with old-leader export work. With idle pools (no in-flight tasks) every executor
+        // should terminate before stopAll returns.
+        Assertions.assertTrue(readPoolFromExecutor(pendingBefore).isTerminated(),
+                "pending executor pool must be terminated before stopAll returns");
+        Assertions.assertTrue(readPoolFromExecutor(exportingBefore).isTerminated(),
+                "exporting executor pool must be terminated before stopAll returns");
+        Assertions.assertTrue(readPoolFromExecutor(subTaskBefore).isTerminated(),
+                "sub-task executor pool must be terminated before stopAll returns");
 
         // init() again must produce fresh instances.
         ExportChecker.init(1000L);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -1454,4 +1454,52 @@ public class TaskManagerTest {
         Assertions.assertTrue(dispatched[0],
                 "Dispatch scheduler should proceed when leader");
     }
+
+    @Test
+    public void testStopShutsDownSchedulersAndStartRebuilds() throws Exception {
+        // TaskManager owns two ScheduledExecutorService instances; stop() must shut both down
+        // so worker threads exit on demotion and start() must rebuild them for re-election.
+        // periodFutureMap holds futures scheduled on the old pool - it must be empty after
+        // stop() so a re-registered periodic task on the new leader does not collide with
+        // stale futures.
+        TaskManager mgr = new TaskManager();
+        mgr.start();
+
+        java.util.concurrent.ScheduledExecutorService periodBefore =
+                (java.util.concurrent.ScheduledExecutorService) org.apache.commons.lang3.reflect.FieldUtils
+                        .readField(mgr, "periodScheduler", true);
+        java.util.concurrent.ScheduledExecutorService dispatchBefore =
+                (java.util.concurrent.ScheduledExecutorService) org.apache.commons.lang3.reflect.FieldUtils
+                        .readField(mgr, "dispatchScheduler", true);
+
+        mgr.stop();
+        Assertions.assertTrue(periodBefore.isShutdown(), "periodScheduler must be shut down by stop()");
+        Assertions.assertTrue(dispatchBefore.isShutdown(), "dispatchScheduler must be shut down by stop()");
+        java.util.Map<?, ?> futureMap = (java.util.Map<?, ?>) org.apache.commons.lang3.reflect.FieldUtils
+                .readField(mgr, "periodFutureMap", true);
+        Assertions.assertTrue(futureMap.isEmpty(), "periodFutureMap must be cleared by stop()");
+
+        // Second start() rebuilds both pools.
+        mgr.start();
+        java.util.concurrent.ScheduledExecutorService periodAfter =
+                (java.util.concurrent.ScheduledExecutorService) org.apache.commons.lang3.reflect.FieldUtils
+                        .readField(mgr, "periodScheduler", true);
+        java.util.concurrent.ScheduledExecutorService dispatchAfter =
+                (java.util.concurrent.ScheduledExecutorService) org.apache.commons.lang3.reflect.FieldUtils
+                        .readField(mgr, "dispatchScheduler", true);
+        Assertions.assertNotSame(periodBefore, periodAfter, "periodScheduler must be rebuilt on re-election");
+        Assertions.assertNotSame(dispatchBefore, dispatchAfter, "dispatchScheduler must be rebuilt on re-election");
+        Assertions.assertFalse(periodAfter.isShutdown());
+        Assertions.assertFalse(dispatchAfter.isShutdown());
+
+        mgr.stop();
+    }
+
+    @Test
+    public void testStopIsNoOpWhenNotStarted() {
+        // stop() guards with isStart.compareAndSet(true, false); a TaskManager that never
+        // started must not throw when stop is called.
+        TaskManager mgr = new TaskManager();
+        Assertions.assertDoesNotThrow(mgr::stop);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -1465,32 +1465,26 @@ public class TaskManagerTest {
         TaskManager mgr = new TaskManager();
         mgr.start();
 
-        java.util.concurrent.ScheduledExecutorService periodBefore =
-                (java.util.concurrent.ScheduledExecutorService) org.apache.commons.lang3.reflect.FieldUtils
-                        .readField(mgr, "periodScheduler", true);
-        java.util.concurrent.ScheduledExecutorService dispatchBefore =
-                (java.util.concurrent.ScheduledExecutorService) org.apache.commons.lang3.reflect.FieldUtils
-                        .readField(mgr, "dispatchScheduler", true);
+        java.util.concurrent.ScheduledExecutorService periodBefore = mgr.periodScheduler;
+        java.util.concurrent.ScheduledExecutorService dispatchBefore = mgr.dispatchScheduler;
 
-        mgr.stop();
+        mgr.stop(5000L);
         Assertions.assertTrue(periodBefore.isShutdown(), "periodScheduler must be shut down by stop()");
         Assertions.assertTrue(dispatchBefore.isShutdown(), "dispatchScheduler must be shut down by stop()");
-        java.util.Map<?, ?> futureMap = (java.util.Map<?, ?>) org.apache.commons.lang3.reflect.FieldUtils
-                .readField(mgr, "periodFutureMap", true);
-        Assertions.assertTrue(futureMap.isEmpty(), "periodFutureMap must be cleared by stop()");
+        Assertions.assertTrue(periodBefore.isTerminated(),
+                "periodScheduler must be terminated after stop(timeoutMs)");
+        Assertions.assertTrue(dispatchBefore.isTerminated(),
+                "dispatchScheduler must be terminated after stop(timeoutMs)");
+        Assertions.assertTrue(mgr.periodFutureMap.isEmpty(), "periodFutureMap must be cleared by stop()");
 
         // Second start() rebuilds both pools.
         mgr.start();
-        java.util.concurrent.ScheduledExecutorService periodAfter =
-                (java.util.concurrent.ScheduledExecutorService) org.apache.commons.lang3.reflect.FieldUtils
-                        .readField(mgr, "periodScheduler", true);
-        java.util.concurrent.ScheduledExecutorService dispatchAfter =
-                (java.util.concurrent.ScheduledExecutorService) org.apache.commons.lang3.reflect.FieldUtils
-                        .readField(mgr, "dispatchScheduler", true);
-        Assertions.assertNotSame(periodBefore, periodAfter, "periodScheduler must be rebuilt on re-election");
-        Assertions.assertNotSame(dispatchBefore, dispatchAfter, "dispatchScheduler must be rebuilt on re-election");
-        Assertions.assertFalse(periodAfter.isShutdown());
-        Assertions.assertFalse(dispatchAfter.isShutdown());
+        Assertions.assertNotSame(periodBefore, mgr.periodScheduler,
+                "periodScheduler must be rebuilt on re-election");
+        Assertions.assertNotSame(dispatchBefore, mgr.dispatchScheduler,
+                "dispatchScheduler must be rebuilt on re-election");
+        Assertions.assertFalse(mgr.periodScheduler.isShutdown());
+        Assertions.assertFalse(mgr.dispatchScheduler.isShutdown());
 
         mgr.stop();
     }
@@ -1500,6 +1494,34 @@ public class TaskManagerTest {
         // stop() guards with isStart.compareAndSet(true, false); a TaskManager that never
         // started must not throw when stop is called.
         TaskManager mgr = new TaskManager();
-        Assertions.assertDoesNotThrow(mgr::stop);
+        Assertions.assertDoesNotThrow(() -> mgr.stop());
+    }
+
+    @Test
+    public void testStartRefusesToRestartBeforeSchedulersTerminate() throws Exception {
+        // Mirror of BatchWriteMgr / AlterHandler / LeaderTaskExecutor restart guard. If
+        // stop() returns but a scheduler has not yet terminated (in-flight task ignoring
+        // interrupt), start() must throw IllegalStateException rather than launching a
+        // parallel scheduler against the same TaskRunManager / periodFutureMap.
+        TaskManager mgr = new TaskManager();
+        mgr.start();
+        java.util.concurrent.ScheduledThreadPoolExecutor blockedPool =
+                new java.util.concurrent.ScheduledThreadPoolExecutor(1);
+        blockedPool.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedPool.shutdown();
+        mgr.stop();
+        mgr.periodScheduler = blockedPool;
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, mgr::start);
+        } finally {
+            blockedPool.shutdownNow();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -1524,4 +1524,63 @@ public class TaskManagerTest {
             blockedPool.shutdownNow();
         }
     }
+
+    @Test
+    public void testStartRefusesToRestartBeforeDispatchSchedulerTerminates() throws Exception {
+        // Mirror of testStartRefusesToRestartBeforeSchedulersTerminate but for the dispatch
+        // scheduler branch. Both guards must short-circuit start() rather than spawning a
+        // second scheduler generation.
+        TaskManager mgr = new TaskManager();
+        mgr.start();
+        java.util.concurrent.ScheduledThreadPoolExecutor blockedPool =
+                new java.util.concurrent.ScheduledThreadPoolExecutor(1);
+        blockedPool.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedPool.shutdown();
+        mgr.stop();
+        // periodScheduler is set to a clean shutdown pool so the first guard does not fire;
+        // dispatchScheduler is set to the blocked pool so the second guard does.
+        mgr.dispatchScheduler = blockedPool;
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, mgr::start);
+        } finally {
+            blockedPool.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testStopWithTimeoutLogsWhenSchedulerRefusesToTerminate() throws Exception {
+        // stop(timeoutMs) must call awaitTermination on both pools; when the await returns
+        // false (a worker ignored shutdownNow's interrupt) it logs a warning and proceeds
+        // rather than blocking forever. This test covers the LOG.warn branches by injecting
+        // a scheduler whose worker ignores interrupts long enough to outlast the budget.
+        TaskManager mgr = new TaskManager();
+        mgr.start();
+        // Replace periodScheduler with a pool whose single worker spins ignoring interrupt.
+        java.util.concurrent.ScheduledThreadPoolExecutor stuckSched =
+                new java.util.concurrent.ScheduledThreadPoolExecutor(1);
+        stuckSched.execute(() -> {
+            long deadline = System.currentTimeMillis() + 2000L;
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                    // simulate uninterruptible work
+                }
+            }
+        });
+        mgr.periodScheduler = stuckSched;
+
+        mgr.stop(50L);
+
+        Assertions.assertTrue(stuckSched.isShutdown(), "scheduler must be shutdown by stop");
+        // worker is still running but stop() returned within budget; cleanup
+        stuckSched.shutdownNow();
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/staros/StarMgrServerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/staros/StarMgrServerTest.java
@@ -19,6 +19,7 @@ import com.staros.exception.StarException;
 import com.staros.manager.StarManagerServer;
 import com.starrocks.common.Config;
 import com.starrocks.journal.bdbje.BDBEnvironment;
+import com.starrocks.leader.CheckpointController;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
@@ -88,5 +89,26 @@ public class StarMgrServerTest {
             }
         };
         server.replayAndGenerateImage(tempFolder.getPath(), 1L);
+    }
+
+    @Test
+    public void testStopCheckpointControllerNullSafe() {
+        // stopCheckpointController must be a no-op when startCheckpointController has not run.
+        StarMgrServer server = new StarMgrServer();
+        Assertions.assertNull(server.checkpointController);
+        Assertions.assertDoesNotThrow(() -> server.stopCheckpointController(1000L));
+    }
+
+    @Test
+    public void testStopCheckpointControllerStopsExistingController() {
+        // stopCheckpointController must forward to LeaderDaemon.stopGracefully on the owned
+        // controller. With a freshly constructed (never started) controller the join is a
+        // no-op and onStopped() runs without side effects, so this exercises the line where
+        // the not-null branch is taken.
+        StarMgrServer server = new StarMgrServer();
+        server.checkpointController = new CheckpointController(
+                "star_os_checkpoint_controller_test", new com.starrocks.utframe.MockJournal(), "");
+
+        Assertions.assertDoesNotThrow(() -> server.stopCheckpointController(1000L));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
@@ -65,9 +65,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class HeartbeatMgrTest {
 
@@ -251,19 +253,70 @@ public class HeartbeatMgrTest {
     }
 
     @Test
-    public void testOnStoppedShutsDownAndClearsExecutor() throws Exception {
+    public void testOnStoppedShutsDownAndAwaitsExecutorTermination() {
         HeartbeatMgr mgr = new HeartbeatMgr(false);
         // start() lazy-inits the executor.
         mgr.start();
-        Field execField = HeartbeatMgr.class.getDeclaredField("executor");
-        execField.setAccessible(true);
-        ExecutorService before = (ExecutorService) execField.get(mgr);
+        ExecutorService before = mgr.executor;
         Assertions.assertNotNull(before, "executor must be initialized after start()");
 
         // protected onStopped() is visible from the same package.
         mgr.onStopped();
 
         Assertions.assertTrue(before.isShutdown(), "previous executor must be shut down");
-        Assertions.assertNull(execField.get(mgr), "executor reference must be nulled for re-init on next start()");
+        Assertions.assertTrue(before.isTerminated(),
+                "previous executor must be terminated after onStopped() awaits drain");
+        // Reference is kept (not nulled) on success so the restart guard in start() can fire
+        // when termination times out; start() rebuilds on isShutdown() so reuse is safe.
+        Assertions.assertSame(before, mgr.executor,
+                "executor reference is retained after successful drain");
+        Assertions.assertNotNull(mgr.executor);
+    }
+
+    @Test
+    public void testStartRebuildsExecutorAfterOnStopped() {
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        mgr.start();
+        ExecutorService originalExecutor = mgr.executor;
+        mgr.onStopped();
+        Assertions.assertTrue(originalExecutor.isTerminated());
+
+        mgr.start();
+        try {
+            Assertions.assertNotSame(originalExecutor, mgr.executor,
+                    "executor must be rebuilt on re-election");
+            Assertions.assertFalse(mgr.executor.isShutdown(),
+                    "rebuilt executor must accept new heartbeats");
+        } finally {
+            mgr.setStop();
+        }
+    }
+
+    @Test
+    public void testStartRefusesToRestartBeforeExecutorTerminates() {
+        // Mirror of BatchWriteMgr / AlterHandler restart guard. If a previous executor is
+        // shutdown but has not yet terminated (heartbeat RPC ignoring interrupt), start()
+        // must throw IllegalStateException rather than spinning up a fresh pool against the
+        // same backends.
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        mgr.start();
+        ThreadPoolExecutor blockedPool = new ThreadPoolExecutor(
+                1, 1, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(1));
+        blockedPool.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedPool.shutdown();
+        mgr.setStop();
+        mgr.executor = blockedPool;
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, mgr::start);
+        } finally {
+            blockedPool.shutdownNow();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
@@ -293,6 +293,37 @@ public class HeartbeatMgrTest {
     }
 
     @Test
+    public void testOnStoppedLogsWhenExecutorRefusesToTerminate() {
+        // When the heartbeat worker pool ignores shutdownNow's interrupt long enough to
+        // outlast the drain budget, onStopped must log a warning and return rather than
+        // blocking forever. Covers the LOG.warn branch in onStopped's awaitTermination.
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        ThreadPoolExecutor stuck = new ThreadPoolExecutor(
+                1, 1, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(1));
+        stuck.execute(() -> {
+            long deadline = System.currentTimeMillis() + 2000L;
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                    // simulate uninterruptible heartbeat RPC
+                }
+            }
+        });
+        mgr.executor = stuck;
+        int oldTimeout = com.starrocks.common.Config.leader_demotion_drain_timeout_sec;
+        com.starrocks.common.Config.leader_demotion_drain_timeout_sec = 1;
+        try {
+            mgr.onStopped();
+            Assertions.assertNotNull(mgr.executor,
+                    "executor reference must be retained when drain timed out so restart guard fires");
+        } finally {
+            com.starrocks.common.Config.leader_demotion_drain_timeout_sec = oldTimeout;
+            stuck.shutdownNow();
+        }
+    }
+
+    @Test
     public void testStartRefusesToRestartBeforeExecutorTerminates() {
         // Mirror of BatchWriteMgr / AlterHandler restart guard. If a previous executor is
         // shutdown but has not yet terminated (heartbeat RPC ignoring interrupt), start()

--- a/fe/fe-core/src/test/java/com/starrocks/task/LeaderTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/LeaderTaskExecutorTest.java
@@ -114,6 +114,31 @@ public class LeaderTaskExecutorTest {
     }
 
     @Test
+    public void testCloseWithTimeoutLogsWhenExecutorRefusesToTerminate() {
+        // close(awaitMillis) returning false from awaitTermination triggers a LOG.warn for
+        // each pool that did not drain. Submit an uninterruptible task and use a very short
+        // timeout budget to hit both LOG.warn branches.
+        LeaderTaskExecutor target =
+                new LeaderTaskExecutor("leader_task_executor_timeout_test", 1, 10, false);
+        target.start();
+        target.executor.execute(() -> {
+            long deadline = System.currentTimeMillis() + 1500L;
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                    // simulate uninterruptible work
+                }
+            }
+        });
+
+        target.close(50L);
+
+        Assertions.assertTrue(target.executor.isShutdown());
+        target.executor.shutdownNow();
+    }
+
+    @Test
     public void testStartRefusesToRestartBeforePoolTerminates() {
         // Mirror of BatchWriteMgr / AlterHandler restart guard. If close() returns but the
         // underlying executor has not yet terminated (in-flight task ignoring interrupt),

--- a/fe/fe-core/src/test/java/com/starrocks/task/LeaderTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/LeaderTaskExecutorTest.java
@@ -17,12 +17,17 @@
 
 package com.starrocks.task;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class LeaderTaskExecutorTest {
     private static final Logger LOG = LoggerFactory.getLogger(LeaderTaskExecutorTest.class);
@@ -77,6 +82,61 @@ public class LeaderTaskExecutorTest {
         Assertions.assertEquals(size + 1, executor.getCorePoolSize());
         executor.setPoolSize(size);
         Assertions.assertEquals(size, executor.getCorePoolSize());
+    }
+
+    @Test
+    public void testStartAfterCloseRebuildsPoolsForReuse() {
+        // close() shuts down both pools so a singleton instance (pendingLoadTaskScheduler,
+        // loadingLoadTaskScheduler in GlobalStateMgr) can be used by the demotion drain. A
+        // subsequent start() on the SAME instance must rebuild both pools so the next leader
+        // session does not get RejectedExecutionException when scheduling tasks.
+        LeaderTaskExecutor target = new LeaderTaskExecutor("leader_task_executor_reuse_test", 1, 10, false);
+        target.start();
+        ThreadPoolExecutor originalExecutor = target.executor;
+        ScheduledThreadPoolExecutor originalSched = target.scheduledThreadPool;
+
+        target.close(5000L);
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).until(originalExecutor::isTerminated);
+
+        target.start();
+
+        Assertions.assertNotSame(originalExecutor, target.executor, "executor must be rebuilt on restart");
+        Assertions.assertNotSame(originalSched, target.scheduledThreadPool,
+                "scheduledThreadPool must be rebuilt on restart");
+        Assertions.assertFalse(target.executor.isShutdown());
+        Assertions.assertFalse(target.scheduledThreadPool.isShutdown());
+
+        // The rebuilt scheduler must accept new work; submit a no-op task and verify it does
+        // not raise RejectedExecutionException.
+        Assertions.assertTrue(target.submit(new TestLeaderTask(99L)));
+
+        target.close(5000L);
+    }
+
+    @Test
+    public void testStartRefusesToRestartBeforePoolTerminates() {
+        // Mirror of BatchWriteMgr / AlterHandler restart guard. If close() returns but the
+        // underlying executor has not yet terminated (in-flight task ignoring interrupt),
+        // start() must throw IllegalStateException instead of spinning up a parallel pool.
+        LeaderTaskExecutor target = new LeaderTaskExecutor("leader_task_executor_refuse_test", 1, 10, false);
+        target.start();
+        ThreadPoolExecutor blockedPool = new java.util.concurrent.ThreadPoolExecutor(
+                1, 1, 0L, TimeUnit.MILLISECONDS, new java.util.concurrent.ArrayBlockingQueue<>(1));
+        blockedPool.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedPool.shutdown();
+        target.executor = blockedPool;
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, target::start);
+        } finally {
+            blockedPool.shutdownNow();
+        }
     }
 
     private class TestLeaderTask extends LeaderTask {

--- a/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
@@ -170,6 +170,32 @@ public class PriorityLeaderTaskExecutorTest {
     }
 
     @Test
+    public void testCloseWithTimeoutLogsWhenExecutorRefusesToTerminate() {
+        // close(awaitMillis) returning false from awaitTermination triggers a LOG.warn for
+        // each pool that did not drain. Exercise both branches by submitting an
+        // uninterruptible task and using a very short timeout budget.
+        PriorityLeaderTaskExecutor target =
+                new PriorityLeaderTaskExecutor("priority_task_executor_timeout_test", 1, 100, false);
+        target.start();
+        target.executor.execute(() -> {
+            long deadline = System.currentTimeMillis() + 1500L;
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                    // simulate uninterruptible work
+                }
+            }
+        });
+
+        target.close(50L);
+
+        Assertions.assertTrue(target.executor.isShutdown());
+        // worker is still running but close() returned; cleanup at the end
+        target.executor.shutdownNow();
+    }
+
+    @Test
     public void testCloseWithTimeoutAwaitsTermination() throws Exception {
         // close(awaitMillis) must block until BOTH pools have actually terminated, so a
         // re-elected leader does not race a still-alive worker from the previous session.

--- a/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
@@ -16,7 +16,7 @@
 package com.starrocks.task;
 
 import com.starrocks.common.PriorityThreadPoolExecutor;
-import com.starrocks.common.jmockit.Deencapsulation;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class PriorityLeaderTaskExecutorTest {
     private static final Logger LOG = LoggerFactory.getLogger(PriorityLeaderTaskExecutorTest.class);
@@ -39,6 +40,7 @@ public class PriorityLeaderTaskExecutorTest {
 
     @BeforeEach
     public void setUp() {
+        SEQ.clear();
         executor = new PriorityLeaderTaskExecutor("priority_task_executor_test", THREAD_NUM, 100, false);
         executor.start();
     }
@@ -94,7 +96,7 @@ public class PriorityLeaderTaskExecutorTest {
 
     @Test
     public void testUpdatePoolSize() {
-        PriorityThreadPoolExecutor priorityExecutor = Deencapsulation.getField(executor, "executor");
+        PriorityThreadPoolExecutor priorityExecutor = executor.executor;
         Assertions.assertEquals(THREAD_NUM, executor.getCorePoolSize());
         Assertions.assertEquals(THREAD_NUM, priorityExecutor.getMaximumPoolSize());
 
@@ -111,14 +113,71 @@ public class PriorityLeaderTaskExecutorTest {
     }
 
     @Test
+    public void testStartAfterCloseRebuildsPoolsForReuse() {
+        // close() shuts down both pools so a singleton instance can be used by the demotion
+        // drain. A subsequent start() on the SAME instance must rebuild both pools so the next
+        // leader session does not get RejectedExecutionException when scheduling tasks.
+        PriorityLeaderTaskExecutor target =
+                new PriorityLeaderTaskExecutor("priority_task_executor_reuse_test", 1, 100, false);
+        target.start();
+        PriorityThreadPoolExecutor originalExecutor = target.executor;
+        ScheduledThreadPoolExecutor originalSched = target.scheduledThreadPool;
+
+        target.close(5000L);
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).until(originalExecutor::isTerminated);
+
+        target.start();
+
+        Assertions.assertNotSame(originalExecutor, target.executor, "executor must be rebuilt on restart");
+        Assertions.assertNotSame(originalSched, target.scheduledThreadPool,
+                "scheduledThreadPool must be rebuilt on restart");
+        Assertions.assertFalse(target.executor.isShutdown());
+        Assertions.assertFalse(target.scheduledThreadPool.isShutdown());
+
+        // The rebuilt executor must accept new work; submit a no-op task and verify it does
+        // not raise RejectedExecutionException.
+        Assertions.assertTrue(target.submit(new TestLeaderTask(99L)));
+
+        target.close(5000L);
+    }
+
+    @Test
+    public void testStartRefusesToRestartBeforePoolTerminates() {
+        // Mirror of BatchWriteMgr / AlterHandler restart guard. If close() returns but the
+        // underlying executor has not yet terminated, start() must throw IllegalStateException
+        // instead of spinning up a parallel pool against the same runningTasks map.
+        PriorityLeaderTaskExecutor target =
+                new PriorityLeaderTaskExecutor("priority_task_executor_refuse_test", 1, 100, false);
+        target.start();
+        PriorityThreadPoolExecutor blockedPool = com.starrocks.common.ThreadPoolManager
+                .newDaemonFixedPriorityThreadPool(
+                        1, 100, "priority_task_executor_refuse_test_blocked_pool", false);
+        blockedPool.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedPool.shutdown();
+        target.executor = blockedPool;
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, target::start);
+        } finally {
+            blockedPool.shutdownNow();
+        }
+    }
+
+    @Test
     public void testCloseWithTimeoutAwaitsTermination() throws Exception {
         // close(awaitMillis) must block until BOTH pools have actually terminated, so a
         // re-elected leader does not race a still-alive worker from the previous session.
         PriorityLeaderTaskExecutor target =
                 new PriorityLeaderTaskExecutor("priority_task_executor_close_test", 1, 100, false);
         target.start();
-        PriorityThreadPoolExecutor inner = Deencapsulation.getField(target, "executor");
-        ScheduledThreadPoolExecutor sched = Deencapsulation.getField(target, "scheduledThreadPool");
+        PriorityThreadPoolExecutor inner = target.executor;
+        ScheduledThreadPoolExecutor sched = target.scheduledThreadPool;
 
         target.close(5000L);
 

--- a/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 public class PriorityLeaderTaskExecutorTest {
     private static final Logger LOG = LoggerFactory.getLogger(PriorityLeaderTaskExecutorTest.class);
@@ -107,6 +108,25 @@ public class PriorityLeaderTaskExecutorTest {
         executor.setPoolSize(THREAD_NUM);
         Assertions.assertEquals(THREAD_NUM, executor.getCorePoolSize());
         Assertions.assertEquals(THREAD_NUM, priorityExecutor.getMaximumPoolSize());
+    }
+
+    @Test
+    public void testCloseWithTimeoutAwaitsTermination() throws Exception {
+        // close(awaitMillis) must block until BOTH pools have actually terminated, so a
+        // re-elected leader does not race a still-alive worker from the previous session.
+        PriorityLeaderTaskExecutor target =
+                new PriorityLeaderTaskExecutor("priority_task_executor_close_test", 1, 100, false);
+        target.start();
+        PriorityThreadPoolExecutor inner = Deencapsulation.getField(target, "executor");
+        ScheduledThreadPoolExecutor sched = Deencapsulation.getField(target, "scheduledThreadPool");
+
+        target.close(5000L);
+
+        Assertions.assertTrue(inner.isShutdown(), "executor must be shutdown");
+        Assertions.assertTrue(inner.isTerminated(), "executor must be terminated after close(awaitMillis)");
+        Assertions.assertTrue(sched.isShutdown(), "scheduledThreadPool must be shutdown");
+        Assertions.assertTrue(sched.isTerminated(),
+                "scheduledThreadPool must be terminated after close(awaitMillis)");
     }
 
     private class TestLeaderTask extends PriorityLeaderTask {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -582,42 +582,74 @@ public class PublishVersionDaemonTest {
     }
 
     @Test
-    public void testOnStoppedReleasesExecutorsAndDedupSets() throws Exception {
+    public void testOnStoppedReleasesExecutorsAndDedupSets() {
         PublishVersionDaemon daemon = new PublishVersionDaemon();
-        // Force lazy init of both executors through their getters; getDeleteTxnLogExecutor is private.
+        // Force lazy init of both executors through their getters.
         ThreadPoolExecutor taskExec = daemon.getTaskExecutor();
-        ThreadPoolExecutor deleteExec =
-                (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getDeleteTxnLogExecutor");
+        ThreadPoolExecutor deleteExec = daemon.getDeleteTxnLogExecutor();
         Assertions.assertNotNull(taskExec);
         Assertions.assertNotNull(deleteExec);
 
         // Populate both dedup sets so we can verify onStopped() clears them.
         Set<Long> publishing = Sets.newConcurrentHashSet();
         publishing.add(42L);
-        FieldUtils.writeField(daemon, "publishingTransactionIds", publishing, true);
+        daemon.publishingTransactionIds = publishing;
         Set<Long> batchTable = Sets.newConcurrentHashSet();
         batchTable.add(7L);
-        FieldUtils.writeField(daemon, "publishingLakeTransactionsBatchTableId", batchTable, true);
+        daemon.publishingLakeTransactionsBatchTableId = batchTable;
 
         daemon.onStopped();
 
         Assertions.assertTrue(taskExec.isShutdown(), "taskExecutor must be shut down");
         Assertions.assertTrue(deleteExec.isShutdown(), "deleteTxnLogExecutor must be shut down");
-        Assertions.assertNull(FieldUtils.readField(daemon, "taskExecutor", true));
-        Assertions.assertNull(FieldUtils.readField(daemon, "deleteTxnLogExecutor", true));
+        Assertions.assertTrue(taskExec.isTerminated(),
+                "taskExecutor must be terminated after onStopped() awaits drain");
+        Assertions.assertTrue(deleteExec.isTerminated(),
+                "deleteTxnLogExecutor must be terminated after onStopped() awaits drain");
+        Assertions.assertNull(daemon.taskExecutor,
+                "taskExecutor reference must be nulled after successful drain so getter rebuilds fresh");
+        Assertions.assertNull(daemon.deleteTxnLogExecutor,
+                "deleteTxnLogExecutor reference must be nulled after successful drain");
         Assertions.assertTrue(publishing.isEmpty(), "publishingTransactionIds must be cleared");
         Assertions.assertTrue(batchTable.isEmpty(), "publishingLakeTransactionsBatchTableId must be cleared");
     }
 
     @Test
-    public void testOnStoppedTolerantOfNullExecutorsAndNullSets() throws Exception {
+    public void testOnStoppedTolerantOfNullExecutorsAndNullSets() {
         // Fresh instance: executors and dedup sets may both be null. onStopped must be no-op-safe.
         PublishVersionDaemon daemon = new PublishVersionDaemon();
-        FieldUtils.writeField(daemon, "taskExecutor", null, true);
-        FieldUtils.writeField(daemon, "deleteTxnLogExecutor", null, true);
-        FieldUtils.writeField(daemon, "publishingTransactionIds", null, true);
-        FieldUtils.writeField(daemon, "publishingLakeTransactionsBatchTableId", null, true);
+        daemon.taskExecutor = null;
+        daemon.deleteTxnLogExecutor = null;
+        daemon.publishingTransactionIds = null;
+        daemon.publishingLakeTransactionsBatchTableId = null;
         Assertions.assertDoesNotThrow(daemon::onStopped);
+    }
+
+    @Test
+    public void testStartRefusesToRestartBeforeTaskExecutorTerminates() {
+        // Mirror of BatchWriteMgr / AlterHandler restart guard. If a previous taskExecutor is
+        // shutdown but has not yet terminated (publish RPC ignoring interrupt), start() must
+        // throw IllegalStateException rather than spinning up a fresh pool against the same
+        // publishingTransactionIds dedup set.
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        ThreadPoolExecutor blockedPool = new ThreadPoolExecutor(
+                1, 1, 0L, java.util.concurrent.TimeUnit.MILLISECONDS,
+                new java.util.concurrent.ArrayBlockingQueue<>(1));
+        blockedPool.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedPool.shutdown();
+        daemon.taskExecutor = blockedPool;
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, daemon::start);
+        } finally {
+            blockedPool.shutdownNow();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -653,6 +653,66 @@ public class PublishVersionDaemonTest {
     }
 
     @Test
+    public void testStartRefusesToRestartBeforeDeleteTxnLogExecutorTerminates() {
+        // Mirror for the deleteTxnLogExecutor branch of the restart guard.
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        ThreadPoolExecutor blockedPool = new ThreadPoolExecutor(
+                1, 1, 0L, java.util.concurrent.TimeUnit.MILLISECONDS,
+                new java.util.concurrent.ArrayBlockingQueue<>(1));
+        blockedPool.execute(() -> {
+            try {
+                Thread.sleep(30_000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockedPool.shutdown();
+        daemon.deleteTxnLogExecutor = blockedPool;
+
+        try {
+            Assertions.assertThrows(IllegalStateException.class, daemon::start);
+        } finally {
+            blockedPool.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testOnStoppedLogsWhenExecutorRefusesToTerminate() {
+        // awaitExecutorTermination returns false when the underlying pool ignores the
+        // interrupt long enough to outlast the drain budget; onStopped must log a warning
+        // and proceed instead of nulling the reference, so the next start() restart guard
+        // can fire. Covers the LOG.warn branches in awaitExecutorTermination plus the
+        // "keep reference" outcome.
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        ThreadPoolExecutor stuck = new ThreadPoolExecutor(
+                1, 1, 0L, java.util.concurrent.TimeUnit.MILLISECONDS,
+                new java.util.concurrent.ArrayBlockingQueue<>(1));
+        stuck.execute(() -> {
+            long deadline = System.currentTimeMillis() + 2000L;
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                    // simulate uninterruptible publish RPC
+                }
+            }
+        });
+        daemon.taskExecutor = stuck;
+        int oldTimeout = Config.leader_demotion_drain_timeout_sec;
+        Config.leader_demotion_drain_timeout_sec = 1;
+        try {
+            daemon.onStopped();
+            // Reference is retained because the await timed out; subsequent start() guard
+            // would fire.
+            Assertions.assertNotNull(daemon.taskExecutor,
+                    "taskExecutor reference must be retained when drain timed out");
+        } finally {
+            Config.leader_demotion_drain_timeout_sec = oldTimeout;
+            stuck.shutdownNow();
+        }
+    }
+
+    @Test
     public void testConfigRefreshListenersDoNotAccumulateAcrossStopCycles() throws Exception {
         ConfigRefreshDaemon configDaemon = GlobalStateMgr.getCurrentState().getConfigRefreshDaemon();
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Why I'm doing:

Part of safe leader demotion (#63357). PR #72340 migrated the first batch of leader-only daemons to `LeaderDaemon` and PR #73043 (in review) covers tier 2 (Load/Statistics + DDL/Backup/Balance). The remaining daemons started by `GlobalStateMgr.startLeaderOnlyDaemonThreads()` — Pipe / Scheduler specials and the lake / shared-data set — still extend `FrontendDaemon`, so they cannot be drained through the new demotion path. After a leader demotion they keep leader-session state and BE-side worker threads alive, which forces process restart instead of clean failover.

This PR migrates the tier-3 scope so demotion can stop these daemons cleanly and release transient leader-session state without relying on process exit.

## What I'm doing:

### Migrate tier-3 leader-only daemons to `LeaderDaemon`

Pipe / Scheduler:

- `PipeListener`
- `PipeScheduler` — `onStopped()` resets `recovered` and clears `beSlotMap` so the next leader re-runs `Pipe.recovery()`.
- `TaskRunStateSynchronizer` — `onStopped()` clears `runningTaskRunProgressMap`.
- `TaskManager` (does **not** extend `FrontendDaemon` — special form) — `periodScheduler` / `dispatchScheduler` are now `volatile`, rebuilt by `start()`; new `stop()` cancels every `periodFutureMap` entry, shuts both pools with `shutdownNow()`, and resets `isStart` so re-election is idempotent.
- `taskCleaner` (inline daemon in `GlobalStateMgr.createTaskCleaner`)

Lake / shared-data:

- `StarMgrMetaSyncer`
- `AutovacuumDaemon` and `FullVacuumDaemon` — owned `BlockingThreadPoolExecutorService` is now `volatile`, rebuilt by `start()`; `onStopped()` calls `shutdownNow()` and clears `vacuumingPartitions`.
- `VectorIndexBuildScheduler` — `onStopped()` clears `pendingTablets`, `runningTasks`, `preferredNodes`, `cooldownUntil` and resets `recoveryScanDone` so the next leader re-runs the recovery scan.
- `TabletReshardJobMgr` — base-class swap only; both `tabletReshardJobs` and `reshardingTabletInfos` are persisted via image (gson `writer.writeJson(this)`), so `onStopped()` is deliberately a no-op.
- `TabletWriteLogHistorySyncer`
- `ClusterSnapshotJobScheduler` (the inner daemon owned by `ClusterSnapshotMgr`).

Export:

- `ExportChecker` — extends `LeaderDaemon`; new static `stopAll(timeoutMs)` drains both PENDING/EXPORTING checkers and closes all three owned `LeaderTaskExecutor` instances. The next `ExportChecker.init()` from `startLeaderOnlyDaemonThreads` replaces the static maps with fresh instances.
- `LeaderTaskExecutor.close()` — switched from `shutdown()` to `shutdownNow()` so worker threads exit promptly (once the follow-up interruptible-lock PR lands the threads will also escape blocking lock acquisitions).

### Add `ClusterSnapshotMgr` stop aggregator

`ClusterSnapshotMgr` now exposes `stopGracefully(timeoutMs)` that fans out to the inner `ClusterSnapshotJobScheduler`, matching the `AlterJobMgr` pattern from tier-2. The persistent `automatedSnapshotJobs` map is intentionally preserved.

### LeaderDaemon framework

Added a `protected ComputeResource computeResource` field and `acquireBackgroundComputeResource()` helper mirroring `FrontendDaemon`. Lake daemons that already relied on this contract (`StarMgrMetaSyncer`, `AutovacuumDaemon`) keep compiling unchanged after the base-class swap. Existing `LeaderDaemon` subclasses that do not need a background compute resource are unaffected.

### Wire demotion stop order

`GlobalStateMgr.stopLeaderOnlyDaemonThreads()` now stops the new daemons in reverse of `startLeaderOnlyDaemonThreads()`, with guards mirroring the start side:

- `tabletReshardJobMgr`, `clusterSnapshotMgr`, `vectorIndexBuildScheduler` / `fullVacuumDaemon` / `autovacuumDaemon` / `starMgrMetaSyncer`, and `tabletWriteLogHistorySyncer` are guarded by `if (RunMode.isSharedDataMode())`.
- `taskRunStateSynchronizer` and `taskCleaner` are guarded by `!= null` (lazy-initialized).
- `taskManager.stop()` is called directly because `TaskManager` does not extend `LeaderDaemon`.
- `ExportChecker.stopAll(timeoutMs)` is the single static entry for export checkers + their executors.

### Relationship with PR #73043 (tier-2)

This PR is based on `upstream/main` and is independent of PR #73043. The two PRs touch disjoint sets of daemons and aggregator types; they only mechanically conflict on the stop list body inside `stopLeaderOnlyDaemonThreads()`. Whichever lands second only needs to re-merge that method in reverse-of-start order — there is no functional dependency.

### Verification

- `mvn -pl fe-core -am test-compile -DskipTests`: BUILD SUCCESS
- `mvn -pl fe-core -am test -Dtest='GlobalStateMgrTest,LeaderDaemonTest,StarMgrMetaSyncerTest,VacuumTest,VectorIndexBuildSchedulerTest,TabletReshardJobMgrTest,ClusterSnapshotTest,TaskManagerTest,ExportCheckerTest'`: **Tests run: 178, Failures: 0, Errors: 0, Skipped: 1**
- `mvn -pl fe-core checkstyle:check`: 0 violations

Related to #63357

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Leader demotion now drains the migrated leader-only daemons through `LeaderDaemon.stopGracefully()` (or the per-aggregator `stopGracefully` / `stopAll` / `stop` entries) instead of leaving them on the old `FrontendDaemon` stop path.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4