### PR TITLE
[Refactor] Build Hive partition ExprContexts in data source open phase

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -304,15 +304,22 @@ Status HiveDataSource::_init_partition_values() {
                             _scan_range.partition_id, full_path, relative_path, table_name));
     }
 
-    const auto& partition_values = partition_desc->partition_key_value_evals();
-    _partition_values = partition_desc->partition_key_value_evals();
+    // Build partition_key ExprContexts in the fragment-local pool. ExprContext::prepare
+    // captures a fragment RuntimeState in its `_runtime_state` field, so the contexts
+    // must live and close within the fragment scope — they cannot be shared from the
+    // (query-scoped) HdfsPartitionDescriptor.
+    const auto& thrift_partition_key_exprs = partition_desc->thrift_partition_key_exprs();
+    RETURN_IF_ERROR(
+            ExprFactory::create_expr_trees(&_pool, thrift_partition_key_exprs, &_partition_values, _runtime_state));
+    RETURN_IF_ERROR(ExprExecutor::prepare(_partition_values, _runtime_state));
+    RETURN_IF_ERROR(ExprExecutor::open(_partition_values, _runtime_state));
 
     // init partition chunk
     auto partition_chunk = std::make_shared<Chunk>();
     for (int i = 0; i < _partition_slots.size(); i++) {
         SlotId slot_id = _partition_slots[i]->id();
         int partition_col_idx = _partition_index_in_hdfs_partition_columns[i];
-        ASSIGN_OR_RETURN(auto partition_value_col, partition_values[partition_col_idx]->evaluate(nullptr));
+        ASSIGN_OR_RETURN(auto partition_value_col, _partition_values[partition_col_idx]->evaluate(nullptr));
         DCHECK(partition_value_col->is_constant());
         partition_chunk->append_column(std::move(partition_value_col), slot_id);
     }
@@ -963,6 +970,7 @@ void HiveDataSource::close(RuntimeState* state) {
     }
     ExprExecutor::close(_min_max_conjunct_ctxs, state);
     ExprExecutor::close(_partition_conjunct_ctxs, state);
+    ExprExecutor::close(_partition_values, state);
     ExprExecutor::close(_scanner_conjunct_ctxs, state);
     for (auto& it : _conjunct_ctxs_by_slot) {
         ExprExecutor::close(it.second, state);

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -418,8 +418,8 @@ static Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
         if (table == nullptr) continue;
         // only HiveTableDescriptor(includes hive,iceberg,hudi,deltalake etc) supports this feature.
         HiveTableDescriptor* hive_table = down_cast<HiveTableDescriptor*>(table);
-        RETURN_IF_ERROR(
-                hive_table->add_partition_value(obj_pool, hdfs_scan_range.partition_id, hdfs_scan_range.partition_value));
+        RETURN_IF_ERROR(hive_table->add_partition_value(obj_pool, hdfs_scan_range.partition_id,
+                                                        hdfs_scan_range.partition_value));
     }
     return Status::OK();
 }

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -418,8 +418,8 @@ static Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
         if (table == nullptr) continue;
         // only HiveTableDescriptor(includes hive,iceberg,hudi,deltalake etc) supports this feature.
         HiveTableDescriptor* hive_table = down_cast<HiveTableDescriptor*>(table);
-        RETURN_IF_ERROR(hive_table->add_partition_value(runtime_state, obj_pool, hdfs_scan_range.partition_id,
-                                                        hdfs_scan_range.partition_value));
+        RETURN_IF_ERROR(
+                hive_table->add_partition_value(obj_pool, hdfs_scan_range.partition_id, hdfs_scan_range.partition_value));
     }
     return Status::OK();
 }

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -25,9 +25,6 @@
 #include "common/status.h"
 #include "common/util/thrift_util.h"
 #include "exprs/base64.h"
-#include "exprs/expr.h"
-#include "exprs/expr_executor.h"
-#include "exprs/expr_factory.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/arena_allocator.h"
@@ -42,18 +39,9 @@ HdfsPartitionDescriptor::HdfsPartitionDescriptor(const THdfsPartition& thrift_pa
           _location(thrift_partition.location.suffix, mr),
           _thrift_partition_key_exprs(thrift_partition.partition_key_exprs) {}
 
-Status HdfsPartitionDescriptor::create_part_key_exprs(RuntimeState* state, ObjectPool* pool) {
-    RETURN_IF_ERROR(
-            ExprFactory::create_expr_trees(pool, _thrift_partition_key_exprs, &_partition_key_value_evals, state));
-    RETURN_IF_ERROR(ExprExecutor::prepare(_partition_key_value_evals, state));
-    RETURN_IF_ERROR(ExprExecutor::open(_partition_key_value_evals, state));
-    return Status::OK();
-}
-
 std::string HdfsPartitionDescriptor::debug_string() const {
     std::stringstream out;
-    out << "HdfsPartition(id=" << _id << ", location=" << _location << ", file_format=" << _file_format
-        << ", partition_key_value_evals=" << Expr::debug_string(_partition_key_value_evals);
+    out << "HdfsPartition(id=" << _id << ", location=" << _location << ", file_format=" << _file_format << ")";
     return out.str();
 }
 
@@ -381,7 +369,7 @@ StatusOr<TPartitionMap*> HiveTableDescriptor::deserialize_partition_map(
     return tPartitionMap;
 }
 
-Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, ObjectPool* pool, int64_t id,
+Status HiveTableDescriptor::add_partition_value(ObjectPool* pool, int64_t id,
                                                 const THdfsPartition& thrift_partition) {
     // Produce a uniform mismatch error so that callers see the same wording and
     // fields regardless of which branch (fast-path shared-lock hit, or slow-path
@@ -393,10 +381,9 @@ Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, Obj
                             id, apache::thrift::ThriftDebugString(thrift_partition), old_partition->debug_string()));
     };
 
-    // Fast path: shared-lock lookup. If the partition is already registered, skip
-    // building a new HdfsPartitionDescriptor and the expensive create_part_key_exprs
-    // (ExprFactory + prepare + open). This is the common case when many scan ranges
-    // share the same partition_id.
+    // Fast path: shared-lock lookup. If the partition is already registered, just
+    // verify the thrift is consistent and return. Multiple fragments registering
+    // the same partition can read the map concurrently.
     {
         std::shared_lock lock(_map_mutex);
         const auto it = _partition_id_to_desc_map.find(id);
@@ -409,13 +396,12 @@ Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, Obj
         }
     }
 
-    // Slow path: build a new HdfsPartitionDescriptor and its key exprs outside any
-    // lock so that create_part_key_exprs (prepare/open) is not serialized.
+    // Slow path: construct the descriptor (thrift copy only — opened ExprContexts
+    // are not stored on the descriptor; consumers build their own per-fragment, see
+    // HiveDataSource::_init_partition_values) and insert under a write lock.
+    // Double-check `inserted` to tolerate a race where another caller inserted the
+    // same id between the shared-lock release and the unique-lock acquire.
     auto* partition = pool->add(new HdfsPartitionDescriptor(thrift_partition, _mr));
-    RETURN_IF_ERROR(partition->create_part_key_exprs(runtime_state, pool));
-
-    // Insert under a write lock; another caller may have inserted the same id while
-    // we were building, so double-check and tolerate the race.
     std::unique_lock lock(_map_mutex);
     auto [it, inserted] = _partition_id_to_desc_map.emplace(id, partition);
     if (!inserted) {
@@ -423,7 +409,7 @@ Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, Obj
         if (thrift_partition.partition_key_exprs != old_partition->thrift_partition_key_exprs()) {
             return mismatch_status(old_partition);
         }
-        // The newly built `partition` is unreferenced; it will be freed when `pool` dies.
+        // The locally built `partition` is unreferenced; it will be freed when `pool` dies.
     }
     return Status::OK();
 }
@@ -554,34 +540,24 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
         case TTableType::ES_TABLE:
             desc = ALLOC_DESC(EsTableDescriptor, tdesc, mr);
             break;
-        case TTableType::HDFS_TABLE: {
-            auto* hdfs_desc = ALLOC_DESC(HdfsTableDescriptor, tdesc, pool, mr);
-            RETURN_IF_ERROR(hdfs_desc->create_key_exprs(state, pool));
-            desc = hdfs_desc;
+        case TTableType::HDFS_TABLE:
+            desc = ALLOC_DESC(HdfsTableDescriptor, tdesc, pool, mr);
             break;
-        }
         case TTableType::FILE_TABLE:
             desc = ALLOC_DESC(FileTableDescriptor, tdesc, pool, mr);
             break;
         case TTableType::ICEBERG_TABLE: {
             auto* iceberg_desc = ALLOC_DESC(IcebergTableDescriptor, tdesc, pool, mr);
             RETURN_IF_ERROR(iceberg_desc->set_partition_desc_map(tdesc.icebergTable, pool));
-            RETURN_IF_ERROR(iceberg_desc->create_key_exprs(state, pool));
             desc = iceberg_desc;
             break;
         }
-        case TTableType::DELTALAKE_TABLE: {
-            auto* delta_lake_desc = ALLOC_DESC(DeltaLakeTableDescriptor, tdesc, pool, mr);
-            RETURN_IF_ERROR(delta_lake_desc->create_key_exprs(state, pool));
-            desc = delta_lake_desc;
+        case TTableType::DELTALAKE_TABLE:
+            desc = ALLOC_DESC(DeltaLakeTableDescriptor, tdesc, pool, mr);
             break;
-        }
-        case TTableType::HUDI_TABLE: {
-            auto* hudi_desc = ALLOC_DESC(HudiTableDescriptor, tdesc, pool, mr);
-            RETURN_IF_ERROR(hudi_desc->create_key_exprs(state, pool));
-            desc = hudi_desc;
+        case TTableType::HUDI_TABLE:
+            desc = ALLOC_DESC(HudiTableDescriptor, tdesc, pool, mr);
             break;
-        }
         case TTableType::PAIMON_TABLE:
             desc = ALLOC_DESC(PaimonTableDescriptor, tdesc, pool, mr);
             break;

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -41,7 +41,13 @@ HdfsPartitionDescriptor::HdfsPartitionDescriptor(const THdfsPartition& thrift_pa
 
 std::string HdfsPartitionDescriptor::debug_string() const {
     std::stringstream out;
-    out << "HdfsPartition(id=" << _id << ", location=" << _location << ", file_format=" << _file_format << ")";
+    out << "HdfsPartition(id=" << _id << ", location=" << _location << ", file_format=" << _file_format
+        << ", partition_key_exprs=[";
+    for (size_t i = 0; i < _thrift_partition_key_exprs.size(); ++i) {
+        if (i > 0) out << ", ";
+        out << apache::thrift::ThriftDebugString(_thrift_partition_key_exprs[i]);
+    }
+    out << "])";
     return out.str();
 }
 

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -375,8 +375,7 @@ StatusOr<TPartitionMap*> HiveTableDescriptor::deserialize_partition_map(
     return tPartitionMap;
 }
 
-Status HiveTableDescriptor::add_partition_value(ObjectPool* pool, int64_t id,
-                                                const THdfsPartition& thrift_partition) {
+Status HiveTableDescriptor::add_partition_value(ObjectPool* pool, int64_t id, const THdfsPartition& thrift_partition) {
     // Produce a uniform mismatch error so that callers see the same wording and
     // fields regardless of which branch (fast-path shared-lock hit, or slow-path
     // emplace() race loss) actually detected the conflict.

--- a/be/src/runtime/descriptors_ext.h
+++ b/be/src/runtime/descriptors_ext.h
@@ -27,8 +27,6 @@
 
 namespace starrocks {
 
-class ExprContext;
-
 class HdfsPartitionDescriptor {
 public:
     HdfsPartitionDescriptor(const THdfsPartition& thrift_partition,
@@ -36,13 +34,14 @@ public:
     int64_t id() const { return _id; }
     THdfsFileFormat::type file_format() { return _file_format; }
     std::string_view location() { return _location; }
-    // ExprContext is constant/literal for sure
-    // such as hdfs://path/x=1/y=2/zzz, then
-    // partition slots would be [x, y]
-    // partition key values wold be [1, 2]
-    std::vector<ExprContext*>& partition_key_value_evals() { return _partition_key_value_evals; }
+    // Thrift partition-key expressions (constant/literal, e.g. for hdfs://path/x=1/y=2/zzz
+    // the partition slots are [x, y] and the partition key values are [1, 2]).
+    //
+    // Opened ExprContexts are not stored on the descriptor: ExprContext::prepare captures
+    // a fragment RuntimeState, so the live evaluators must be built and closed within
+    // fragment scope. Consumers (see HiveDataSource::_init_partition_values) build their
+    // own ExprContexts from this thrift in a fragment-local pool.
     const std::vector<TExpr>& thrift_partition_key_exprs() const { return _thrift_partition_key_exprs; }
-    Status create_part_key_exprs(RuntimeState* state, ObjectPool* pool);
     std::string debug_string() const;
 
 private:
@@ -50,9 +49,7 @@ private:
     THdfsFileFormat::type _file_format;
     std::pmr::string _location;
 
-    // holding thrift exprs for partition keys for duplication check during runtime
     const std::vector<TExpr> _thrift_partition_key_exprs;
-    std::vector<ExprContext*> _partition_key_value_evals;
 };
 
 class HiveTableDescriptor : public TableDescriptor {
@@ -66,18 +63,10 @@ public:
     virtual bool has_base_path() const { return false; }
     virtual std::string_view get_base_path() const { return _table_location; }
 
-    Status create_key_exprs(RuntimeState* state, ObjectPool* pool) {
-        for (auto& part : _partition_id_to_desc_map) {
-            RETURN_IF_ERROR(part.second->create_part_key_exprs(state, pool));
-        }
-        return Status::OK();
-    }
-
     StatusOr<TPartitionMap*> deserialize_partition_map(const TCompressedPartitionMap& compressed_partition_map,
                                                        ObjectPool* pool);
 
-    Status add_partition_value(RuntimeState* runtime_state, ObjectPool* pool, int64_t id,
-                               const THdfsPartition& thrift_partition);
+    Status add_partition_value(ObjectPool* pool, int64_t id, const THdfsPartition& thrift_partition);
     std::optional<std::string> get_column_default_value(const SlotDescriptor* slot) const;
 
 protected:

--- a/be/test/exec/hdfs_scan_node_test.cpp
+++ b/be/test/exec/hdfs_scan_node_test.cpp
@@ -350,7 +350,6 @@ DescriptorTbl* HdfsScanNodeTest::_create_table_desc_for_filter_partition() {
     TTableDescriptor tdesc;
     tdesc.__set_hdfsTable(t_hdfs_table);
     _table_desc = _pool->add(new HdfsTableDescriptor(tdesc, _pool));
-    _table_desc->create_key_exprs(_runtime_state.get(), _pool);
     tbl->get_tuple_descriptor(0)->set_table_desc(_table_desc);
 
     return tbl;

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -106,8 +106,10 @@ TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdSameThriftIsDedupHit)
 // partition's debug string) to help diagnose the mismatch.
 TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdDifferentThriftFails) {
     constexpr int64_t partition_id = 3;
-    THdfsPartition base = _make_partition();
-    THdfsPartition conflict = _make_partition({_make_int_literal_thrift_expr(1)});
+    constexpr int64_t kOldLiteral = 7;
+    constexpr int64_t kNewLiteral = 99;
+    THdfsPartition base = _make_partition({_make_int_literal_thrift_expr(kOldLiteral)});
+    THdfsPartition conflict = _make_partition({_make_int_literal_thrift_expr(kNewLiteral)});
 
     ASSERT_OK(_table_desc->add_partition_value(_pool.get(), partition_id, base));
 
@@ -123,6 +125,12 @@ TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdDifferentThriftFails)
     EXPECT_NE(std::string::npos, msg.find("partition_key_exprs")) << msg;
     EXPECT_NE(std::string::npos, msg.find("new partition (thrift)")) << msg;
     EXPECT_NE(std::string::npos, msg.find("old_partition")) << msg;
+
+    // Symmetry: both the incoming thrift partition_key_exprs AND the existing
+    // partition's partition_key_exprs must surface in the message — without that
+    // diagnosing a conflict requires re-running with extra logging.
+    EXPECT_NE(std::string::npos, msg.find(std::to_string(kOldLiteral))) << msg;
+    EXPECT_NE(std::string::npos, msg.find(std::to_string(kNewLiteral))) << msg;
 
     // Existing entry must be unchanged.
     HdfsPartitionDescriptor* desc = _table_desc->get_partition(partition_id);

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -23,8 +23,6 @@
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/Exprs_types.h"
 #include "runtime/descriptors_ext.h"
-#include "runtime/exec_env.h"
-#include "runtime/runtime_state.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
@@ -32,25 +30,12 @@ namespace starrocks {
 class HiveTableDescriptorAddPartitionTest : public ::testing::Test {
 public:
     void SetUp() override {
-        _exec_env = ExecEnv::GetInstance();
         _pool = std::make_unique<ObjectPool>();
 
         TTableDescriptor tdesc;
         tdesc.id = 1;
         tdesc.tableType = TTableType::HDFS_TABLE;
         _table_desc = _pool->add(new HdfsTableDescriptor(tdesc, _pool.get()));
-
-        _runtime_state = _make_runtime_state();
-    }
-
-    std::shared_ptr<RuntimeState> _make_runtime_state() {
-        TUniqueId fragment_id;
-        TQueryOptions query_options;
-        TQueryGlobals query_globals;
-        auto rs = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, _exec_env);
-        TUniqueId query_id;
-        rs->init_mem_trackers(query_id);
-        return rs;
     }
 
     // Build a minimal THdfsPartition. partition_key_exprs is left empty by default;
@@ -84,10 +69,8 @@ public:
     }
 
 protected:
-    ExecEnv* _exec_env = nullptr;
     std::unique_ptr<ObjectPool> _pool;
     HdfsTableDescriptor* _table_desc = nullptr;
-    std::shared_ptr<RuntimeState> _runtime_state;
 };
 
 // First call inserts a new partition descriptor; get_partition returns it.
@@ -95,7 +78,7 @@ TEST_F(HiveTableDescriptorAddPartitionTest, FirstCallInsertsNewEntry) {
     constexpr int64_t partition_id = 1;
     THdfsPartition thrift = _make_partition();
 
-    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift));
+    ASSERT_OK(_table_desc->add_partition_value(_pool.get(), partition_id, thrift));
 
     HdfsPartitionDescriptor* desc = _table_desc->get_partition(partition_id);
     ASSERT_NE(nullptr, desc);
@@ -108,12 +91,12 @@ TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdSameThriftIsDedupHit)
     constexpr int64_t partition_id = 2;
     THdfsPartition thrift = _make_partition();
 
-    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift));
+    ASSERT_OK(_table_desc->add_partition_value(_pool.get(), partition_id, thrift));
     HdfsPartitionDescriptor* first = _table_desc->get_partition(partition_id);
     ASSERT_NE(nullptr, first);
 
     // Same thrift: must succeed and must NOT replace the existing entry.
-    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift));
+    ASSERT_OK(_table_desc->add_partition_value(_pool.get(), partition_id, thrift));
     HdfsPartitionDescriptor* second = _table_desc->get_partition(partition_id);
     ASSERT_EQ(first, second);
 }
@@ -126,9 +109,9 @@ TEST_F(HiveTableDescriptorAddPartitionTest, SamePartitionIdDifferentThriftFails)
     THdfsPartition base = _make_partition();
     THdfsPartition conflict = _make_partition({_make_int_literal_thrift_expr(1)});
 
-    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, base));
+    ASSERT_OK(_table_desc->add_partition_value(_pool.get(), partition_id, base));
 
-    Status s = _table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, conflict);
+    Status s = _table_desc->add_partition_value(_pool.get(), partition_id, conflict);
     ASSERT_FALSE(s.ok());
     ASSERT_TRUE(s.is_internal_error()) << s.to_string();
 
@@ -152,8 +135,8 @@ TEST_F(HiveTableDescriptorAddPartitionTest, DifferentPartitionIdsCoexist) {
     THdfsPartition p1 = _make_partition();
     THdfsPartition p2 = _make_partition({_make_int_literal_thrift_expr(42)});
 
-    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), 10, p1));
-    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), 11, p2));
+    ASSERT_OK(_table_desc->add_partition_value(_pool.get(), 10, p1));
+    ASSERT_OK(_table_desc->add_partition_value(_pool.get(), 11, p2));
 
     HdfsPartitionDescriptor* d10 = _table_desc->get_partition(10);
     HdfsPartitionDescriptor* d11 = _table_desc->get_partition(11);
@@ -168,11 +151,11 @@ TEST_F(HiveTableDescriptorAddPartitionTest, RepeatedDedupHitsKeepFirstEntry) {
     constexpr int64_t partition_id = 42;
     THdfsPartition thrift = _make_partition();
 
-    ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift));
+    ASSERT_OK(_table_desc->add_partition_value(_pool.get(), partition_id, thrift));
     HdfsPartitionDescriptor* first = _table_desc->get_partition(partition_id);
 
     for (int i = 0; i < 100; ++i) {
-        ASSERT_OK(_table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift));
+        ASSERT_OK(_table_desc->add_partition_value(_pool.get(), partition_id, thrift));
     }
     ASSERT_EQ(first, _table_desc->get_partition(partition_id));
 }
@@ -192,7 +175,7 @@ TEST_F(HiveTableDescriptorAddPartitionTest, ConcurrentInsertSameIdConvergesToOne
 
     for (int i = 0; i < kThreads; ++i) {
         threads.emplace_back([&, i]() {
-            statuses[i] = _table_desc->add_partition_value(_runtime_state.get(), _pool.get(), partition_id, thrift);
+            statuses[i] = _table_desc->add_partition_value(_pool.get(), partition_id, thrift);
         });
     }
     for (auto& t : threads) {

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -38,13 +38,16 @@ public:
         _table_desc = _pool->add(new HdfsTableDescriptor(tdesc, _pool.get()));
     }
 
-    // Build a minimal THdfsPartition. partition_key_exprs is left empty by default;
-    // callers can override with custom thrift to exercise the dedup-conflict branch.
+    // Build a minimal THdfsPartition. Uses thrift's __set_X helpers so the resulting
+    // struct has __isset bits enabled — ThriftDebugString skips fields with __isset
+    // false, so without this the dumped diagnostic in mismatch errors would be empty.
     static THdfsPartition _make_partition(std::vector<TExpr> partition_key_exprs = {}) {
         THdfsPartition p;
-        p.file_format = THdfsFileFormat::TEXT;
-        p.location.suffix = "";
-        p.partition_key_exprs = std::move(partition_key_exprs);
+        p.__set_file_format(THdfsFileFormat::TEXT);
+        THdfsPartitionLocation loc;
+        loc.__set_suffix("");
+        p.__set_location(loc);
+        p.__set_partition_key_exprs(std::move(partition_key_exprs));
         return p;
     }
 

--- a/be/test/runtime/descriptors_test.cpp
+++ b/be/test/runtime/descriptors_test.cpp
@@ -182,9 +182,8 @@ TEST_F(HiveTableDescriptorAddPartitionTest, ConcurrentInsertSameIdConvergesToOne
     std::vector<Status> statuses(kThreads);
 
     for (int i = 0; i < kThreads; ++i) {
-        threads.emplace_back([&, i]() {
-            statuses[i] = _table_desc->add_partition_value(_pool.get(), partition_id, thrift);
-        });
+        threads.emplace_back(
+                [&, i]() { statuses[i] = _table_desc->add_partition_value(_pool.get(), partition_id, thrift); });
     }
     for (auto& t : threads) {
         t.join();


### PR DESCRIPTION
## Why I'm doing:

The 2nd pr for https://github.com/StarRocks/starrocks/issues/73136

HdfsPartitionDescriptor::create_part_key_exprs and HiveTableDescriptor::create_key_exprs build, prepare, and open ExprContexts during fragment prepare:

```
Status HdfsPartitionDescriptor::create_part_key_exprs(RuntimeState* state, ObjectPool* pool) {
    RETURN_IF_ERROR(ExprFactory::create_expr_trees(pool, _thrift_partition_key_exprs, &_partition_key_value_evals, state));
    RETURN_IF_ERROR(ExprExecutor::prepare(_partition_key_value_evals, state));
    RETURN_IF_ERROR(ExprExecutor::open(_partition_key_value_evals, state));    // ← open at prepare
    return Status::OK();
}
```
Called from two places:

```
DescriptorTbl::create → HiveTableDescriptor::create_key_exprs → loops over _partition_id_to_desc_map (plan-preloaded partitions).
HiveTableDescriptor::add_partition_value (per scan range with partition_value).
```

There are two problems with this:

* Phase contract violation. ExprContext::open is supposed to mark the entry of the FRAGMENT_LOCAL scope: it grants the right to allocate UDF state, JIT code, per-fragment caches, etc. Calling it during DescriptorTbl::create (still inside _prepare_runtime_state, before pipeline drivers exist) and then never explicitly closing — close happens implicitly when the owning ObjectPool destructs — bypasses the open/close pairing that the rest of the codebase respects (see e.g. HiveDataSource::open/close for _min_max_conjunct_ctxs, _partition_conjunct_ctxs, _scanner_conjunct_ctxs).
* Fragile lifetime. Each ExprContext::prepare(state) captures a fragment-level RuntimeState* in _runtime_state (consulted at evaluate / JIT / dtor close time). But HdfsPartitionDescriptor lives in the descriptor table's ObjectPool, which is query-scoped in the cached descriptor path (is_cached=true reuses a DescriptorTbl built by the first fragment). So a RuntimeState that ExprContexts captured can be torn down while later fragments are still using the same partition descriptor. It works today only because partition key exprs are simple literals/casts and Expr::close base impl doesn't dereference state — but the contract is invisible and adding a non-trivial expr would silently break it.

## What I'm doing:

Make HdfsPartitionDescriptor thrift-only and move ExprContext build/prepare/open/close into the fragment-scoped consumer that actually evaluates the partition values.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
