### PR TITLE
[BugFix] Fix Hive partition descriptor UAF across fragment teardown

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -394,11 +394,9 @@ static std::unordered_set<int32_t> collect_broadcast_join_right_offsprings(
     return offsprings;
 }
 
-// there will be partition values used by this batch of scan ranges and maybe following scan ranges
-// so before process this batch of scan ranges, we have to put partition values into the table associated with.
-static Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
-                                               const std::vector<TScanRangeParams>& scan_ranges) {
-    auto* obj_pool = runtime_state->obj_pool();
+Status FragmentExecutor::add_scan_ranges_partition_values(RuntimeState* runtime_state,
+                                                          const std::vector<TScanRangeParams>& scan_ranges) {
+    auto* obj_pool = RuntimeStateHelper::global_obj_pool(runtime_state);
     const DescriptorTbl& desc_tbl = runtime_state->desc_tbl();
     TTableId cache_table_id = -1;
     TableDescriptor* table = nullptr;
@@ -427,7 +425,7 @@ static Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
 static Status add_per_driver_scan_ranges_partition_values(RuntimeState* runtime_state,
                                                           const PerDriverScanRangesMap& map) {
     for (const auto& [_, scan_ranges] : map) {
-        RETURN_IF_ERROR(add_scan_ranges_partition_values(runtime_state, scan_ranges));
+        RETURN_IF_ERROR(FragmentExecutor::add_scan_ranges_partition_values(runtime_state, scan_ranges));
     }
     return Status::OK();
 }
@@ -577,7 +575,7 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
             enable_shared_scan = false;
         }
 
-        RETURN_IF_ERROR(add_scan_ranges_partition_values(runtime_state, scan_ranges));
+        RETURN_IF_ERROR(FragmentExecutor::add_scan_ranges_partition_values(runtime_state, scan_ranges));
         RETURN_IF_ERROR(add_per_driver_scan_ranges_partition_values(runtime_state, scan_ranges_per_driver_seq));
         bool has_more_morsel = ScanMorsel::has_more_scan_ranges(scan_ranges) ||
                                has_more_per_driver_seq_scan_ranges(scan_ranges_per_driver_seq);
@@ -1071,7 +1069,7 @@ Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const
                                 print_id(query_id), print_id(instance_id)));
         }
 
-        RETURN_IF_ERROR(add_scan_ranges_partition_values(runtime_state, scan_ranges));
+        RETURN_IF_ERROR(FragmentExecutor::add_scan_ranges_partition_values(runtime_state, scan_ranges));
         pipeline::Morsels morsels;
         bool has_more_morsel = false;
         pipeline::ScanMorsel::build_scan_morsels(node_id, scan_ranges, true, &morsels, &has_more_morsel);
@@ -1102,7 +1100,7 @@ Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const
             bool has_more_morsel = has_more_per_driver_seq_scan_ranges(per_driver_scan_ranges);
             for (const auto& [driver_seq, scan_ranges] : per_driver_scan_ranges) {
                 if (scan_ranges.size() == 0) continue;
-                RETURN_IF_ERROR(add_scan_ranges_partition_values(runtime_state, scan_ranges));
+                RETURN_IF_ERROR(FragmentExecutor::add_scan_ranges_partition_values(runtime_state, scan_ranges));
                 pipeline::Morsels morsels;
                 [[maybe_unused]] bool local_has_more;
                 pipeline::ScanMorsel::build_scan_morsels(node_id, scan_ranges, true, &morsels, &local_has_more);

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -108,6 +108,17 @@ public:
     static Status append_incremental_scan_ranges(ExecEnv* exec_env, const TExecPlanFragmentParams& request,
                                                  TExecPlanFragmentResult* response);
 
+    // Register the partition_value of each scan range into its HiveTableDescriptor's
+    // _partition_id_to_desc_map. The HdfsPartitionDescriptor is allocated from the
+    // query-level ObjectPool (RuntimeStateHelper::global_obj_pool) so that the map's
+    // entries outlive any single fragment instance — see the function body for the
+    // UAF this prevents.
+    //
+    // Exposed here so unit tests can pin the contract; production callers go through
+    // _prepare_exec_plan / append_incremental_scan_ranges, not this entry point.
+    static Status add_scan_ranges_partition_values(RuntimeState* runtime_state,
+                                                   const std::vector<TScanRangeParams>& scan_ranges);
+
     Status prepare_global_state(ExecEnv* exec_env, const TExecPlanFragmentParams& common_request);
     void _fail_cleanup(bool fragment_has_registed);
 

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -62,17 +62,7 @@ RuntimeState::RuntimeState() : _obj_pool(new ObjectPool()) {}
 RuntimeState::RuntimeState(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,
                            const TQueryGlobals& query_globals, const QueryExecutionServices* query_execution_services,
                            ExecEnv* exec_env)
-        : _exec_env(exec_env),
-          _obj_pool(new ObjectPool()),
-          _is_cancelled(false),
-          _per_fragment_instance_idx(0),
-          _num_rows_load_total_from_source(0),
-          _num_bytes_load_from_source(0),
-          _num_rows_load_sink(0),
-          _num_bytes_load_sink(0),
-          _num_rows_load_filtered(0),
-          _num_rows_load_unselected(0),
-          _num_print_error_rows(0) {
+        : _exec_env(exec_env), _obj_pool(new ObjectPool()) {
     _profile = std::make_shared<RuntimeProfile>("Fragment " + print_id(fragment_instance_id));
     _load_channel_profile = std::make_shared<RuntimeProfile>("LoadChannel");
     _init(fragment_instance_id, query_options, query_globals, query_execution_services);
@@ -87,17 +77,7 @@ RuntimeState::RuntimeState(const TUniqueId& fragment_instance_id, const TQueryOp
 RuntimeState::RuntimeState(const TUniqueId& query_id, const TUniqueId& fragment_instance_id,
                            const TQueryOptions& query_options, const TQueryGlobals& query_globals,
                            const QueryExecutionServices* query_execution_services, ExecEnv* exec_env)
-        : _query_id(query_id),
-          _exec_env(exec_env),
-          _obj_pool(new ObjectPool()),
-          _per_fragment_instance_idx(0),
-          _num_rows_load_total_from_source(0),
-          _num_bytes_load_from_source(0),
-          _num_rows_load_sink(0),
-          _num_bytes_load_sink(0),
-          _num_rows_load_filtered(0),
-          _num_rows_load_unselected(0),
-          _num_print_error_rows(0) {
+        : _query_id(query_id), _exec_env(exec_env), _obj_pool(new ObjectPool()) {
     _profile = std::make_shared<RuntimeProfile>("Fragment " + print_id(fragment_instance_id));
     _load_channel_profile = std::make_shared<RuntimeProfile>("LoadChannel");
     _init(fragment_instance_id, query_options, query_globals, query_execution_services);
@@ -108,8 +88,7 @@ RuntimeState::RuntimeState(const TUniqueId& query_id, const TUniqueId& fragment_
         : RuntimeState(query_id, fragment_instance_id, query_options, query_globals,
                        static_cast<const QueryExecutionServices*>(nullptr), exec_env) {}
 
-RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
-        : _obj_pool(new ObjectPool()), _is_cancelled(false), _per_fragment_instance_idx(0) {
+RuntimeState::RuntimeState(const TQueryGlobals& query_globals) : _obj_pool(new ObjectPool()) {
     _profile = std::make_shared<RuntimeProfile>("<unnamed>");
     _load_channel_profile = std::make_shared<RuntimeProfile>("<unnamed>");
     _query_options.batch_size = DEFAULT_CHUNK_SIZE;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -664,7 +664,7 @@ private:
     // if true, execution should stop with a CANCELLED status
     std::atomic<bool> _is_cancelled{false};
 
-    int _per_fragment_instance_idx;
+    int _per_fragment_instance_idx = 0;
     int _num_per_fragment_instances = 0;
 
     // used as send id

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -81,6 +81,7 @@ set(EXEC_FILES
         ./exec/pipeline/local_exchange_memory_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/pipeline/exec_group_test.cpp
+        ./exec/pipeline/fragment_executor_test.cpp
         ./exec/pipeline/glm_manager_tablet_adaptor_test.cpp
         ./exec/pipeline/scan/physical_split_morsel_queue_test.cpp
         ./exec/query_cache/query_cache_test.cpp

--- a/be/test/exec/pipeline/fragment_executor_test.cpp
+++ b/be/test/exec/pipeline/fragment_executor_test.cpp
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "exec/pipeline/fragment_executor.h"
+
 #include <gtest/gtest.h>
 
 #include "base/testutil/assert.h"
 #include "common/config.h"
-#include "exec/pipeline/fragment_executor.h"
 #include "exec/pipeline/query_context.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/InternalService_types.h"

--- a/be/test/exec/pipeline/fragment_executor_test.cpp
+++ b/be/test/exec/pipeline/fragment_executor_test.cpp
@@ -1,0 +1,144 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "common/config.h"
+#include "exec/pipeline/fragment_executor.h"
+#include "exec/pipeline/query_context.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "gen_cpp/InternalService_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gutil/casts.h"
+#include "runtime/descriptors.h"
+#include "runtime/descriptors_ext.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "runtime/runtime_state_helper.h"
+
+namespace starrocks::pipeline {
+
+class FragmentExecutorPartitionTest : public ::testing::Test {
+public:
+    void SetUp() override { _exec_env = ExecEnv::GetInstance(); }
+
+    std::shared_ptr<RuntimeState> _make_runtime_state(QueryContext* query_ctx, DescriptorTbl* desc_tbl) {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        auto rs = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, _exec_env);
+        TUniqueId query_id;
+        rs->init_mem_trackers(query_id);
+        rs->set_query_ctx(query_ctx);
+        rs->set_desc_tbl(desc_tbl);
+        return rs;
+    }
+
+    static TScanRangeParams _make_scan_range(TTableId table_id, int64_t partition_id) {
+        TScanRangeParams params;
+        TScanRange& sr = params.scan_range;
+        sr.__isset.hdfs_scan_range = true;
+        sr.hdfs_scan_range.__set_table_id(table_id);
+        sr.hdfs_scan_range.__set_partition_id(partition_id);
+        THdfsPartition pv;
+        pv.__set_file_format(THdfsFileFormat::TEXT);
+        THdfsPartitionLocation loc;
+        loc.__set_suffix("");
+        pv.__set_location(loc);
+        sr.hdfs_scan_range.__set_partition_value(pv);
+        return params;
+    }
+
+protected:
+    ExecEnv* _exec_env = nullptr;
+};
+
+// Regression test for a heap-use-after-free in add_scan_ranges_partition_values.
+//
+// HiveTableDescriptor::_partition_id_to_desc_map is shared across all fragment
+// instances of the same query (the descriptor itself lives in the query-level
+// ObjectPool via DescriptorTbl). The partition descriptors stored in that map
+// must therefore outlive any single fragment instance.
+//
+// Before the fix, add_scan_ranges_partition_values allocated partition descriptors
+// from `runtime_state->obj_pool()` (per-fragment). When one fragment finished and
+// tore down its pool, the descriptors it inserted into the shared map were freed,
+// leaving dangling pointers. A sibling fragment then hit UAF on the duplicate-check
+// path `partition->thrift_partition_key_exprs() != old_partition->...`.
+//
+// The fix switches the allocation to `RuntimeStateHelper::global_obj_pool(rs)`
+// (query-level). Together with the earlier refactor that made HdfsPartitionDescriptor
+// thrift-only (no fragment-bound ExprContexts on the descriptor), this lets the
+// descriptor live for the whole query without smuggling fragment-scoped state.
+//
+// This test asserts: after a fragment-level RuntimeState (and its per-fragment
+// pool) is destroyed, the partition descriptor it inserted via this helper remains
+// alive in the query-level pool and its thrift fields are still readable. Under
+// ASAN, reading those fields after the fragment's pool dies would otherwise be
+// reported as heap-use-after-free.
+TEST_F(FragmentExecutorPartitionTest, PartitionDescriptorOutlivesFragmentPool) {
+    constexpr TTableId kTableId = 100;
+    constexpr int64_t kPartitionId = 42;
+
+    TDescriptorTable thrift_tbl;
+    {
+        TTableDescriptor tt;
+        tt.id = kTableId;
+        tt.tableType = TTableType::HDFS_TABLE;
+        thrift_tbl.tableDescriptors.push_back(tt);
+    }
+
+    // The QueryContext owns the per-query ObjectPool; the partition descriptor must
+    // ultimately end up here so it survives fragment teardown.
+    auto query_ctx = std::make_shared<QueryContext>();
+
+    DescriptorTbl* desc_tbl = nullptr;
+    {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        RuntimeState bootstrap_rs(fragment_id, query_options, query_globals, _exec_env);
+        ASSERT_OK(DescriptorTbl::create(&bootstrap_rs, query_ctx->object_pool(), thrift_tbl, &desc_tbl,
+                                        config::vector_chunk_size));
+    }
+
+    auto* table_desc = desc_tbl->get_table_descriptor(kTableId);
+    ASSERT_NE(nullptr, table_desc);
+    auto* hive_table = down_cast<HiveTableDescriptor*>(table_desc);
+
+    std::vector<TScanRangeParams> scan_ranges = {_make_scan_range(kTableId, kPartitionId)};
+
+    // Run add_scan_ranges_partition_values inside a fragment-level scope. The
+    // RuntimeState (and its per-fragment obj_pool) is destroyed when the scope
+    // exits, simulating one fragment finishing while a sibling continues.
+    {
+        auto rs = _make_runtime_state(query_ctx.get(), desc_tbl);
+        // Sanity: the contract being asserted only holds when the two pools really
+        // differ. If a future refactor unified them, the assertion below would not
+        // tell us anything useful, so guard it.
+        ASSERT_NE(rs->obj_pool(), RuntimeStateHelper::global_obj_pool(rs.get()));
+
+        ASSERT_OK(FragmentExecutor::add_scan_ranges_partition_values(rs.get(), scan_ranges));
+    }
+
+    // After the fragment is gone, the partition descriptor must still be reachable
+    // through the shared map and its heap-owned fields must not have been freed.
+    HdfsPartitionDescriptor* partition = hive_table->get_partition(kPartitionId);
+    ASSERT_NE(nullptr, partition);
+    // Reading the vector trips ASAN if the descriptor's backing memory was freed.
+    (void)partition->thrift_partition_key_exprs().size();
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/fragment_executor_test.cpp
+++ b/be/test/exec/pipeline/fragment_executor_test.cpp
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "base/testutil/assert.h"
-#include "common/config.h"
+#include "common/config_exec_fwd.h"
 #include "exec/pipeline/query_context.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/InternalService_types.h"


### PR DESCRIPTION
## Why I'm doing:

The 3st pr for https://github.com/StarRocks/starrocks/issues/73136

Why I'm doing:

<img width="1137" height="659" alt="image" src="https://github.com/user-attachments/assets/c14623be-d0a1-450b-935d-446a6872a107" />

HiveTableDescriptor::_partition_id_to_desc_map is shared across all fragment instances of a query — the owning HiveTableDescriptor lives in the query-level ObjectPool via DescriptorTbl, and any fragment of the query reaches into the same map through desc_tbl().get_table_descriptor(...).

However, FragmentExecutor::add_scan_ranges_partition_values allocated the HdfsPartitionDescriptor it inserted into this map from runtime_state->obj_pool():

```
auto* obj_pool = runtime_state->obj_pool();   // ← per fragment instance
...
hive_table->add_partition_value(obj_pool, hdfs_scan_range.partition_id, hdfs_scan_range.partition_value);
```

runtime_state->obj_pool() is owned by the fragment instance's RuntimeState. When the fragment finishes and its RuntimeState is destroyed (QueryContext::~QueryContext → _fragment_mgr.reset()), the obj_pool destructs and every HdfsPartitionDescriptor it owns is freed — but the pointer to that descriptor stays in _partition_id_to_desc_map.

A sibling fragment of the same query (e.g. a Hive/Iceberg table referenced multiple times via CTE, or parallel pipeline-driver fragments sharing the table) then hits the dangling pointer on the dedup-check path:

```
// HiveTableDescriptor::add_partition_value, fast path
auto* old_partition = it->second;                                    // dangling
if (thrift_partition.partition_key_exprs !=
    old_partition->thrift_partition_key_exprs()) {                   // UAF here
    ...
}
```

This is reproducible under ASAN and has surfaced in production as sporadic crashes / dirty reads in Hive/Iceberg scans with many concurrent fragments. The previous mitigations on the FE side (watchSlowClose, async clearExternalResources) only contained downstream symptoms; the BE-side dangling pointer was the root cause.

This PR depends on the earlier refactor [Refactor] Build Hive partition ExprContexts in data source open phase (#) — without that, simply moving the descriptor to the query pool would introduce a second UAF: the descriptor used to store opened ExprContexts whose _runtime_state field captures a fragment-level RuntimeState, so closing them at query-pool teardown (after the capturing fragment is gone) would dereference freed memory. With that refactor in place, HdfsPartitionDescriptor is thrift-only and carries no fragment-bound state, so promoting it to query scope is safe.

## What I'm doing:

Fix Hive partition descriptor UAF across fragment teardown

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
