### PR TITLE
[BugFix] Fix query cache conflicts local shuffle agg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleDistributionNodeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleDistributionNodeRule.java
@@ -46,6 +46,9 @@ public class PruneShuffleDistributionNodeRule implements TreeRewriteRule {
                 !GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().isSingleBackendAndComputeNode()) {
             return root;
         }
+        if (sv.isEnableQueryCache()) {
+            return root;
+        }
 
         return root.getOp().accept(VISITOR, root, null);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -419,7 +419,7 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
                 return false;
             }
 
-            if (sv.isEnableLocalShuffleAgg() &&
+            if (sv.isEnableLocalShuffleAgg() && !sv.isEnableQueryCache() &&
                     GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().isSingleBackendAndComputeNode()) {
                 return true;
             }

--- a/test/sql/test_query_cache/R/test_query_cache_with_localshuffle_agg
+++ b/test/sql/test_query_cache/R/test_query_cache_with_localshuffle_agg
@@ -1,0 +1,35 @@
+-- name: test_query_cache_with_localshuffle_agg
+CREATE TABLE t1 (
+  id        int(11)        NOT NULL,
+  category  varchar(192)   NULL
+) ENGINE=OLAP
+PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 10
+PROPERTIES (
+  "compression"             = "LZ4",
+  "enable_persistent_index" = "true",
+  "fast_schema_evolution"   = "true",
+  "replicated_storage"      = "true",
+  "replication_num"         = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1 (id, category)
+SELECT generate_series,
+       CONCAT('cat-', CAST(generate_series % 10 AS STRING))
+FROM TABLE(generate_series(1, 1000));
+-- result:
+-- !result
+SELECT category, COUNT(*) FROM t1 GROUP BY category ORDER BY category limit 10;
+-- result:
+cat-0	100
+cat-1	100
+cat-2	100
+cat-3	100
+cat-4	100
+cat-5	100
+cat-6	100
+cat-7	100
+cat-8	100
+cat-9	100
+-- !result

--- a/test/sql/test_query_cache/T/test_query_cache_with_localshuffle_agg
+++ b/test/sql/test_query_cache/T/test_query_cache_with_localshuffle_agg
@@ -1,0 +1,22 @@
+-- name: test_query_cache_with_localshuffle_agg
+
+CREATE TABLE t1 (
+  id        int(11)        NOT NULL,
+  category  varchar(192)   NULL
+) ENGINE=OLAP
+PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 10
+PROPERTIES (
+  "compression"             = "LZ4",
+  "enable_persistent_index" = "true",
+  "fast_schema_evolution"   = "true",
+  "replicated_storage"      = "true",
+  "replication_num"         = "1"
+);
+
+INSERT INTO t1 (id, category)
+SELECT generate_series,
+       CONCAT('cat-', CAST(generate_series % 10 AS STRING))
+FROM TABLE(generate_series(1, 1000));
+
+SELECT category, COUNT(*) FROM t1 GROUP BY category ORDER BY category limit 10;


### PR DESCRIPTION


## Why I'm doing:

Query cache require assign tablet to per drivers. But local shuffle agg will blocking cannot work without could_local_shufle=false.

In this patch we disable the local shuffle agg when enable the query cache.
## What I'm doing:

Fixes #73183

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
