### PR TITLE
[BugFix] Respect ALLOW_THROW_EXCEPTION in get_json_string

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -359,6 +359,9 @@ StatusOr<ColumnPtr> _string_json(FunctionContext* context, const Columns& column
             JsonValue json_value;
             auto st = JsonValue::parse(raw, &json_value);
             if (!st.ok()) {
+                if (context != nullptr && context->allow_throw_exception()) {
+                    return st;
+                }
                 result.append_null();
             } else {
                 result.append(std::move(json_value));

--- a/be/test/exprs/json_functions_test.cpp
+++ b/be/test/exprs/json_functions_test.cpp
@@ -38,6 +38,7 @@
 #include "gtest/gtest-param-test.h"
 #include "gutil/casts.h"
 #include "gutil/strings/strip.h"
+#include "runtime/runtime_state.h"
 #include "types/json_value.h"
 #include "types/logical_type.h"
 #include "util/json_flattener.h"
@@ -237,6 +238,36 @@ TEST_F(JsonFunctionsTest, get_json_string_array) {
     ASSERT_TRUE(JsonFunctions::native_json_path_close(
                         ctx.get(), FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
+}
+
+TEST_F(JsonFunctionsTest, get_json_string_invalid_json_respects_allow_throw_exception) {
+    Columns columns;
+    auto strings = BinaryColumn::create();
+    auto paths = BinaryColumn::create();
+    strings->append(std::string(kJSONLengthLimit + 1, '{'));
+    paths->append("$.a");
+    columns.emplace_back(strings);
+    columns.emplace_back(paths);
+
+    {
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+        auto result = JsonFunctions::get_json_string(ctx.get(), columns);
+        ASSERT_TRUE(result.ok()) << result.status();
+        ASSERT_EQ(1, ColumnHelper::count_nulls(result.value()));
+    }
+
+    {
+        TQueryOptions query_options;
+        query_options.__set_allow_throw_exception(true);
+        TQueryGlobals query_globals;
+        RuntimeState state(TUniqueId(), query_options, query_globals, nullptr);
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+        ctx->set_runtime_state(&state);
+
+        auto result = JsonFunctions::get_json_string(ctx.get(), columns);
+        ASSERT_FALSE(result.ok());
+        ASSERT_EQ("JSON string exceed maximum length 16MB", result.status().message());
+    }
 }
 
 TEST_F(JsonFunctionsTest, get_json_emptyTest) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

  Return the JSON parse error from `get_json_string/get_json_*` when implicit
  `VARCHAR-to-JSON` parsing fails under `ALLOW_THROW_EXCEPTION`. Keep the default
  behavior of returning NULL when the mode is disabled.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
