### PR TITLE
[Enhancement] Add load_segments_for_iter_with_delvec_us publish-trace counter

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -486,7 +486,10 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         const std::vector<SparseRangePtr>* rowid_range_per_segment) {
     TRACE_COUNTER_SCOPE_LATENCY_US("get_each_segment_iterator_with_delvec_us");
     std::vector<SegmentPtr> segments;
-    RETURN_IF_ERROR(load_segments(&segments, false));
+    {
+        TRACE_COUNTER_SCOPE_LATENCY_US("load_segments_for_iter_with_delvec_us");
+        RETURN_IF_ERROR(load_segments(&segments, false));
+    }
     auto root_loc = _tablet_mgr->tablet_root_location(tablet_id());
     std::vector<ChunkIteratorPtr> seg_iterators;
     seg_iterators.reserve(segments.size());


### PR DESCRIPTION
## Why I'm doing:

`get_each_segment_iterator_with_delvec_us` shows up on the cold `pindex_load_from_lake_tablet` rebuild path of primary-key lake tables. In production publish traces today the counter is a single number — we can't tell whether the time is in the footer-load step (`load_segments`, already parallelized via `enable_load_segment_parallel`) or in the per-segment `new_iterator(...)` loop after it.

A typical real trace today:

\`\`\`
pindex_load_from_lake_tablet_us              1,533,556
├─ get_each_segment_iterator_with_delvec_us    157,593   ← opaque
└─ rebuild_index_segment_cost_us             1,375,879
\`\`\`

## What I'm doing:

Wrap the `load_segments(...)` call inside `Rowset::get_each_segment_iterator_with_delvec` in `TRACE_COUNTER_SCOPE_LATENCY_US(\"load_segments_for_iter_with_delvec_us\")`.

After this change the same trace becomes:

\`\`\`
pindex_load_from_lake_tablet_us              1,533,556
├─ get_each_segment_iterator_with_delvec_us    157,593
│  ├─ load_segments_for_iter_with_delvec_us    117,863   ← new sub-counter
│  └─ (remainder = per-segment new_iterator loop)
└─ rebuild_index_segment_cost_us             1,375,879
\`\`\`

so we can quantify the per-segment iterator-construction cost (and decide whether further optimization there is worth pursuing in a given workload) directly from a publish trace, without rebuilding or running a debug build.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The new scope counter only emits into the publish trace when a trace context is active (e.g. when the publish task crosses `lake_publish_version_slow_log_ms` and the trace gets dumped). No runtime behavior changes.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Test plan

- BE module boundary harness passes
- Existing `test_get_each_segment_iterator_with_delvec_*` UTs cover the function; this PR only adds a tracing scope and does not change return values.
- Behavior-validated by running a cold-cache PK lake `pindex_load_from_lake_tablet` on a TSP shared-data cluster (\`enable_load_segment_parallel=true\`, \`lake_publish_version_slow_log_ms=1\`) and confirming \`load_segments_for_iter_with_delvec_us\` is present in the dumped publish trace alongside the existing \`get_each_segment_iterator_with_delvec_us\`.