### PR TITLE
[Feature] Implement Iceberg UPDATE commit path and routing decoupling

### DIFF
--- a/be/src/connector/iceberg_row_delta_sink.cpp
+++ b/be/src/connector/iceberg_row_delta_sink.cpp
@@ -90,6 +90,12 @@ Status IcebergRowDeltaSink::add(const ChunkPtr& chunk) {
         return Status::OK();
     }
 
+    if (_op_code_index < 0) {
+        RETURN_IF_ERROR(_delete_sink->add(chunk));
+        RETURN_IF_ERROR(_data_sink->add(chunk));
+        return Status::OK();
+    }
+
     auto op_code_column = chunk->get_column_by_index(_op_code_index);
     const auto* op_codes = ColumnHelper::get_data_column(op_code_column.get());
     const auto* op_code_data = down_cast<const FixedLengthColumn<int8_t>*>(op_codes)->get_data().data();
@@ -117,8 +123,8 @@ Status IcebergRowDeltaSink::add(const ChunkPtr& chunk) {
         }
     }
 
-    // Fast path: when all rows have the same op_code (common for pure UPDATE where
-    // every row is OP_UPDATE), pass the original chunk directly without copying.
+    // Fast path: when all mixed-mode rows have the same op_code, pass the
+    // original chunk directly without copying.
     bool all_to_delete = (_delete_rows.size() == num_rows);
     bool all_to_data = (_data_rows.size() == num_rows);
 

--- a/be/src/connector/iceberg_row_delta_sink.h
+++ b/be/src/connector/iceberg_row_delta_sink.h
@@ -33,7 +33,9 @@ struct IcebergRowDeltaSinkContext : public ConnectorChunkSinkContext {
     std::shared_ptr<IcebergDeleteSinkContext> delete_sink_ctx;
     std::shared_ptr<IcebergChunkSinkContext> data_sink_ctx;
 
-    // Index of the op_code column in the input chunk (last column)
+    // Index of the op_code column in the input chunk.
+    // The default -1 means no extra op_code column (such as UPDATE operation),
+    // every row goes to both delete and data sub-sinks.
     int32_t op_code_index = -1;
 
     // Query-level memory manager for creating child managers for sub-sinks.
@@ -43,7 +45,7 @@ struct IcebergRowDeltaSinkContext : public ConnectorChunkSinkContext {
     void set_sink_mem_mgr(SinkMemoryManager* mgr) override { sink_mem_mgr = mgr; }
 };
 
-// IcebergRowDeltaSinkProvider creates IcebergRowDeltaSink for Iceberg UPDATE operations.
+// IcebergRowDeltaSinkProvider creates IcebergRowDeltaSink for Iceberg row-delta operations.
 // It composes an IcebergDeleteSinkProvider and an IcebergChunkSinkProvider.
 class IcebergRowDeltaSinkProvider final : public ConnectorChunkSinkProvider {
 public:
@@ -53,9 +55,9 @@ public:
                                                                     int32_t driver_id) override;
 };
 
-// IcebergRowDeltaSink routes rows from an input chunk to a delete sink and a data sink
-// based on the op_code column. Used for Iceberg UPDATE which atomically deletes old rows
-// and inserts new rows (row-level delta / Merge-On-Read).
+// IcebergRowDeltaSink routes rows from an input chunk to a delete sink and a data sink.
+// Pure UPDATE has no op_code column and forwards every row to both sub-sinks.
+// Mixed row-level operations use an op_code column for per-row routing.
 //
 // Op codes:
 //   0 = no-op (skip)

--- a/be/src/exec/data_sinks/iceberg_table_sink.cpp
+++ b/be/src/exec/data_sinks/iceberg_table_sink.cpp
@@ -30,6 +30,7 @@
 #include "runtime/descriptors_ext.h"
 #include "runtime/runtime_state.h"
 #include "runtime/service_contexts.h"
+#include "types/logical_type.h"
 
 namespace starrocks {
 
@@ -397,17 +398,36 @@ Status IcebergTableSink::create_row_delta_sink_context(
     }
 
     // Determine column layout indices:
-    //   [_file, _pos, data_col1, ..., data_colN, op_code]
+    //   ROW_DELTA_UPDATE: [_file, _pos, data_col1, ..., data_colN]
+    //   ROW_DELTA_MIXED:  [_file, _pos, data_col1, ..., data_colN, op_code]
     // No partition prefix — partition columns are part of data_cols (full table schema).
     const size_t total_slots = slots.size();
     const int32_t data_column_start = 2; // after _file and _pos
-    const int32_t op_code_index = static_cast<int32_t>(total_slots - 1);
-    const int32_t data_column_count = op_code_index - data_column_start;
-
-    if (data_column_count < 0 || data_column_start > op_code_index) {
+    if (!t_iceberg_sink.__isset.write_mode) {
+        return Status::InternalError("Iceberg row delta sink requires write_mode");
+    }
+    const auto write_mode = t_iceberg_sink.write_mode;
+    if (write_mode != TIcebergWriteMode::ROW_DELTA_UPDATE && write_mode != TIcebergWriteMode::ROW_DELTA_MIXED) {
         return Status::InternalError(
-                fmt::format("Invalid row delta column layout: total_slots={}, data_column_start={}", total_slots,
-                            data_column_start));
+                fmt::format("Invalid Iceberg row delta write_mode: {}", static_cast<int>(write_mode)));
+    }
+    const bool has_routing_column = write_mode == TIcebergWriteMode::ROW_DELTA_MIXED;
+    const int32_t op_code_index = has_routing_column ? static_cast<int32_t>(total_slots) - 1 : -1;
+    const int32_t data_column_end =
+            has_routing_column ? static_cast<int32_t>(total_slots) - 1 : static_cast<int32_t>(total_slots);
+
+    if (data_column_end <= data_column_start) {
+        return Status::InternalError(
+                fmt::format("Iceberg row delta layout has no data columns: total_slots={}, data_column_start={}, "
+                            "write_mode={}",
+                            total_slots, data_column_start, static_cast<int>(write_mode)));
+    }
+
+    if (has_routing_column) {
+        if (slots[op_code_index]->type().type != TYPE_TINYINT) {
+            return Status::InternalError(fmt::format("Iceberg row delta op column must be TINYINT, actual={}",
+                                                     type_to_string(slots[op_code_index]->type().type)));
+        }
     }
 
     // --- Create delete sub-context ---
@@ -441,12 +461,15 @@ Status IcebergTableSink::create_row_delta_sink_context(
     // Configure partition columns for delete context
     delete_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
 
-    // Build column name → slot reference map from all columns (except op_code).
+    // Build column name → slot reference map from all columns (except mixed-mode op_code).
     // IcebergDeleteSink::add() uses this to locate _file/_pos by slot_id,
     // and update_partition_expr_slot_refs_by_map() uses it to bind partition exprs.
     // Since we pass the full original chunk to sub-sinks (not sub-chunks),
     // all slot_ids are available at runtime.
-    for (int32_t i = 0; i < op_code_index; ++i) {
+    for (int32_t i = 0; i < static_cast<int32_t>(total_slots); ++i) {
+        if (i == op_code_index) {
+            continue;
+        }
         const auto* slot = slots[i];
         const auto& expr = output_exprs[i];
         for (const auto& node : expr.nodes) {
@@ -472,9 +495,10 @@ Status IcebergTableSink::create_row_delta_sink_context(
         data_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
     }
 
-    // Data output_exprs: columns from data_column_start to op_code_index-1
+    // Data output_exprs: data columns only; mixed-mode op_code is private to the
+    // composite row-delta sink and must not be written into data files.
     std::vector<TExpr> data_output_exprs(output_exprs.begin() + data_column_start,
-                                         output_exprs.begin() + op_code_index);
+                                         output_exprs.begin() + data_column_end);
     data_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(data_output_exprs, runtime_state);
 
     size_t num_data_evaluators = data_sink_ctx->column_evaluators.size();
@@ -499,9 +523,10 @@ Status IcebergTableSink::create_row_delta_sink_context(
     data_sink_ctx->fragment_context = fragment_ctx;
 
     // Create a data-only tuple descriptor for the data sub-sink.
-    // The full row-delta tuple includes _file, _pos, data_cols, op_code, but the data
-    // writer only has evaluators for data_cols. SpillPartitionChunkWriter sizes merged
-    // chunks from tuple_desc->slots().size(), so the full tuple causes out-of-bounds.
+    // The full row-delta tuple includes _file, _pos, data_cols and optionally op_code,
+    // but the data writer only has evaluators for data_cols. SpillPartitionChunkWriter
+    // sizes merged chunks from tuple_desc->slots().size(), so the full tuple causes
+    // out-of-bounds.
     {
         TSlotDescriptorBuilder slot_builder;
         TTupleDescriptorBuilder tuple_builder;

--- a/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
@@ -153,6 +153,31 @@ protected:
         return chunk;
     }
 
+    ChunkPtr build_update_chunk(const std::vector<std::string>& files, const std::vector<int64_t>& positions,
+                                const std::vector<std::string>& data_values) {
+        auto chunk = std::make_shared<Chunk>();
+
+        auto file_col = BinaryColumn::create();
+        for (const auto& f : files) {
+            file_col->append(f);
+        }
+        chunk->append_column(file_col, 0);
+
+        auto pos_col = FixedLengthColumn<int64_t>::create();
+        for (auto p : positions) {
+            pos_col->append(p);
+        }
+        chunk->append_column(pos_col, 1);
+
+        auto data_col = BinaryColumn::create();
+        for (const auto& v : data_values) {
+            data_col->append(v);
+        }
+        chunk->append_column(data_col, 2);
+
+        return chunk;
+    }
+
     // Create the IcebergRowDeltaSink with mock sub-sinks.
     // Returns the sink and raw pointers to the mock sinks for verification.
     struct SinkWithMocks {
@@ -243,6 +268,21 @@ TEST_F(IcebergRowDeltaSinkTest, op_code_routing) {
     auto* dat_col = down_cast<const BinaryColumn*>(dat_chunk->get_column_by_index(2).get());
     EXPECT_EQ(dat_col->get_slice(0).to_string(), "val2");
     EXPECT_EQ(dat_col->get_slice(1).to_string(), "val3");
+}
+
+TEST_F(IcebergRowDeltaSinkTest, update_without_routing_column_forwards_to_both_sub_sinks) {
+    auto [sink, delete_mock, data_mock] = create_row_delta_sink_with_mocks(/*op_code_index=*/-1);
+
+    auto chunk = build_update_chunk({"file1.parquet", "file2.parquet"}, {0, 7}, {"val0", "val1"});
+
+    ASSERT_OK(sink->add(chunk));
+
+    EXPECT_EQ(delete_mock->total_rows, 2);
+    EXPECT_EQ(data_mock->total_rows, 2);
+    ASSERT_EQ(delete_mock->received_chunks.size(), 1u);
+    ASSERT_EQ(data_mock->received_chunks.size(), 1u);
+    EXPECT_EQ(delete_mock->received_chunks[0].get(), chunk.get());
+    EXPECT_EQ(data_mock->received_chunks[0].get(), chunk.get());
 }
 
 // Test 3: Verify add() with an empty chunk returns OK without invoking sub-sinks

--- a/be/test/connector_sink/iceberg_table_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_table_sink_test.cpp
@@ -616,7 +616,85 @@ TExpr make_slot_ref_expr(int slot_id) {
 }
 } // namespace
 
-// Drives create_row_delta_sink_context() end-to-end via decompose_to_pipeline,
+TEST_F(IcebergTableSinkTest, decompose_to_pipeline_row_delta_update) {
+    // Tuple layout for a pure UPDATE row-delta write: [_file, _pos, c1].
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto file_slot = slot_desc_builder.type(LogicalType::TYPE_VARCHAR)
+                             .column_name("_file")
+                             .column_pos(0)
+                             .nullable(false)
+                             .build();
+    auto pos_slot =
+            slot_desc_builder.type(LogicalType::TYPE_BIGINT).column_name("_pos").column_pos(1).nullable(false).build();
+    auto c1_slot = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(2).nullable(true).build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(file_slot);
+    tuple_desc_builder.add_slot(pos_slot);
+    tuple_desc_builder.add_slot(c1_slot);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    TIcebergTable t_iceberg_table;
+    TColumn t_column;
+    t_column.__set_column_name("c1");
+    t_iceberg_table.__set_columns({t_column});
+
+    TIcebergSchemaField c1_field;
+    c1_field.__set_field_id(1);
+    c1_field.__set_name("c1");
+    TIcebergSchema iceberg_schema;
+    iceberg_schema.__set_fields({c1_field});
+    t_iceberg_table.__set_iceberg_schema(iceberg_schema);
+
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1);
+
+    TDataSink data_sink;
+    data_sink.__set_type(TDataSinkType::ICEBERG_ROW_DELTA_SINK);
+    TIcebergTableSink iceberg_table_sink;
+    iceberg_table_sink.__set_location("/path/to/table");
+    iceberg_table_sink.__set_data_location("/path/to/table/data");
+    iceberg_table_sink.__set_tuple_id(0);
+    iceberg_table_sink.__set_write_mode(TIcebergWriteMode::ROW_DELTA_UPDATE);
+    data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+    std::vector<TExpr> exprs = {make_slot_ref_expr(0), make_slot_ref_expr(1), make_slot_ref_expr(2)};
+
+    IcebergTableSink sink(&_pool, exprs);
+    pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(10, 10)};
+
+    EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
+
+    pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
+    pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
+    auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
+    ASSERT_NE(connector_sink_factory, nullptr);
+
+    auto* row_delta_ctx =
+            dynamic_cast<connector::IcebergRowDeltaSinkContext*>(connector_sink_factory->_sink_context.get());
+    ASSERT_NE(row_delta_ctx, nullptr);
+    EXPECT_EQ(row_delta_ctx->op_code_index, -1);
+
+    EXPECT_EQ(row_delta_ctx->delete_sink_ctx->output_exprs.size(), 3);
+    EXPECT_EQ(row_delta_ctx->delete_sink_ctx->column_slot_map.size(), 3);
+    EXPECT_EQ(row_delta_ctx->data_sink_ctx->column_evaluators.size(), 1);
+    ASSERT_NE(row_delta_ctx->data_sink_ctx->override_tuple_desc, nullptr);
+    EXPECT_EQ(row_delta_ctx->data_sink_ctx->override_tuple_desc->slots().size(), 1);
+    ASSERT_EQ(row_delta_ctx->data_sink_ctx->column_names.size(), 1);
+    EXPECT_EQ(row_delta_ctx->data_sink_ctx->column_names[0], "c1");
+    EXPECT_EQ(row_delta_ctx->data_sink_ctx->parquet_field_ids[0].field_id, 1);
+}
+
+// Drives mixed row-delta create_row_delta_sink_context() end-to-end via decompose_to_pipeline,
 // then exercises IcebergRowDeltaSinkProvider::create_chunk_sink() on the
 // resulting context. Covers:
 //   - the row-delta dispatch branch in decompose_to_pipeline
@@ -627,7 +705,7 @@ TExpr make_slot_ref_expr(int slot_id) {
 //   - IcebergRowDeltaSinkProvider::create_chunk_sink() success path, which in
 //     turn drives IcebergDeleteSinkProvider and IcebergChunkSinkProvider
 TEST_F(IcebergTableSinkTest, decompose_to_pipeline_row_delta) {
-    // Tuple layout for a row-delta write: [_file, _pos, c1, op_code]
+    // Tuple layout for a MERGE-style row-delta write: [_file, _pos, c1, op_code]
     TDescriptorTableBuilder table_desc_builder;
     TSlotDescriptorBuilder slot_desc_builder;
     auto file_slot = slot_desc_builder.type(LogicalType::TYPE_VARCHAR)
@@ -682,6 +760,7 @@ TEST_F(IcebergTableSinkTest, decompose_to_pipeline_row_delta) {
     iceberg_table_sink.__set_location("/path/to/table");
     iceberg_table_sink.__set_data_location("/path/to/table/data");
     iceberg_table_sink.__set_tuple_id(0);
+    iceberg_table_sink.__set_write_mode(TIcebergWriteMode::ROW_DELTA_MIXED);
     iceberg_table_sink.__set_target_max_file_size(128LL * 1024 * 1024);
     data_sink.__set_iceberg_table_sink(iceberg_table_sink);
 
@@ -771,6 +850,7 @@ TEST_F(IcebergTableSinkTest, row_delta_invalid_column_layout) {
     TIcebergTableSink iceberg_table_sink;
     iceberg_table_sink.__set_location("/path/to/table");
     iceberg_table_sink.__set_tuple_id(0);
+    iceberg_table_sink.__set_write_mode(TIcebergWriteMode::ROW_DELTA_UPDATE);
     data_sink.__set_iceberg_table_sink(iceberg_table_sink);
 
     std::vector<TExpr> exprs = {make_slot_ref_expr(0), make_slot_ref_expr(1)};
@@ -780,7 +860,111 @@ TEST_F(IcebergTableSinkTest, row_delta_invalid_column_layout) {
 
     auto status = sink.decompose_to_pipeline(prev_operators, data_sink, context.get());
     EXPECT_FALSE(status.ok());
-    EXPECT_THAT(std::string(status.message()), testing::HasSubstr("Invalid row delta column layout"));
+    EXPECT_THAT(std::string(status.message()), testing::HasSubstr("row delta layout has no data columns"));
+}
+
+TEST_F(IcebergTableSinkTest, row_delta_mixed_requires_data_column_before_op_column) {
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto file_slot = slot_desc_builder.type(LogicalType::TYPE_VARCHAR)
+                             .column_name("_file")
+                             .column_pos(0)
+                             .nullable(false)
+                             .build();
+    auto pos_slot =
+            slot_desc_builder.type(LogicalType::TYPE_BIGINT).column_name("_pos").column_pos(1).nullable(false).build();
+    auto c1_slot = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(2).nullable(true).build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(file_slot);
+    tuple_desc_builder.add_slot(pos_slot);
+    tuple_desc_builder.add_slot(c1_slot);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    TIcebergTable t_iceberg_table;
+    TIcebergSchema iceberg_schema;
+    t_iceberg_table.__set_iceberg_schema(iceberg_schema);
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1);
+
+    TDataSink data_sink;
+    data_sink.__set_type(TDataSinkType::ICEBERG_ROW_DELTA_SINK);
+    TIcebergTableSink iceberg_table_sink;
+    iceberg_table_sink.__set_location("/path/to/table");
+    iceberg_table_sink.__set_tuple_id(0);
+    iceberg_table_sink.__set_write_mode(TIcebergWriteMode::ROW_DELTA_MIXED);
+    data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+    std::vector<TExpr> exprs = {make_slot_ref_expr(0), make_slot_ref_expr(1), make_slot_ref_expr(2)};
+
+    IcebergTableSink sink(&_pool, exprs);
+    pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(13, 13)};
+
+    auto status = sink.decompose_to_pipeline(prev_operators, data_sink, context.get());
+    EXPECT_FALSE(status.ok());
+    EXPECT_THAT(std::string(status.message()), testing::HasSubstr("row delta layout has no data columns"));
+}
+
+TEST_F(IcebergTableSinkTest, row_delta_routing_column_must_be_tinyint) {
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto file_slot = slot_desc_builder.type(LogicalType::TYPE_VARCHAR)
+                             .column_name("_file")
+                             .column_pos(0)
+                             .nullable(false)
+                             .build();
+    auto pos_slot =
+            slot_desc_builder.type(LogicalType::TYPE_BIGINT).column_name("_pos").column_pos(1).nullable(false).build();
+    auto c1_slot = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(2).nullable(true).build();
+    auto op_slot =
+            slot_desc_builder.type(LogicalType::TYPE_INT).column_name("op_code").column_pos(3).nullable(false).build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(file_slot);
+    tuple_desc_builder.add_slot(pos_slot);
+    tuple_desc_builder.add_slot(c1_slot);
+    tuple_desc_builder.add_slot(op_slot);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    TIcebergTable t_iceberg_table;
+    TIcebergSchema iceberg_schema;
+    t_iceberg_table.__set_iceberg_schema(iceberg_schema);
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1);
+
+    TDataSink data_sink;
+    data_sink.__set_type(TDataSinkType::ICEBERG_ROW_DELTA_SINK);
+    TIcebergTableSink iceberg_table_sink;
+    iceberg_table_sink.__set_location("/path/to/table");
+    iceberg_table_sink.__set_tuple_id(0);
+    iceberg_table_sink.__set_write_mode(TIcebergWriteMode::ROW_DELTA_MIXED);
+    data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+    std::vector<TExpr> exprs = {make_slot_ref_expr(0), make_slot_ref_expr(1), make_slot_ref_expr(2),
+                                make_slot_ref_expr(3)};
+
+    IcebergTableSink sink(&_pool, exprs);
+    pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(14, 14)};
+
+    auto status = sink.decompose_to_pipeline(prev_operators, data_sink, context.get());
+    EXPECT_FALSE(status.ok());
+    EXPECT_THAT(std::string(status.message()), testing::HasSubstr("row delta op column must be TINYINT"));
 }
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1762,7 +1762,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                            ConnectContext context) {
         // Skip the commit entirely when there is nothing to write — a zero-row INSERT/UPDATE/DELETE
         // would otherwise produce an empty `append` snapshot that pollutes snapshot history and
-        // confuses downstream CDC consumers. Aligns with Trino's fix in trinodb/trino#12412.
+        // confuses downstream CDC consumers.
         if (commitInfos.isEmpty()) {
             LOG.info("Skipping empty Iceberg commit for {}.{} (no data or delete files produced)", dbName, tableName);
             return;
@@ -2102,8 +2102,16 @@ public class IcebergMetadata implements ConnectorMetadata {
                 getOrDefault(UPDATE_ISOLATION_LEVEL, UPDATE_ISOLATION_LEVEL_DEFAULT));
         if (isolationLevel == IsolationLevel.SERIALIZABLE) {
             rowDelta.validateNoConflictingDataFiles();
-            rowDelta.validateNoConflictingDeleteFiles();
         }
+        // Per Iceberg's RowDelta contract, validateNoConflictingDeleteFiles must be
+        // called for UPDATE/MERGE "independently of the isolation level" — a concurrent
+        // writer adding position-delete files that overlap rows being updated would
+        // otherwise commit silently and resurrect rows that were concurrently deleted.
+        // Not required for pure DELETE (deleting an already-deleted record is
+        // idempotent), which is why the sibling DELETE-commit path above does not call
+        // this method.
+        // Reference: https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/RowDelta.java#L149-L163
+        rowDelta.validateNoConflictingDeleteFiles();
 
         if (context != null) {
             updateCommitInfo(rowDelta, context);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -201,6 +201,8 @@ import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE_DEFA
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL_DEFAULT;
 import static org.apache.iceberg.TableProperties.ENCRYPTION_TABLE_KEY;
+import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
+import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL_DEFAULT;
 
 public class IcebergMetadata implements ConnectorMetadata {
 
@@ -1758,6 +1760,14 @@ public class IcebergMetadata implements ConnectorMetadata {
     @Override
     public void finishSink(String dbName, String tableName, List<TSinkCommitInfo> commitInfos, String branch, Object extra,
                            ConnectContext context) {
+        // Skip the commit entirely when there is nothing to write — a zero-row INSERT/UPDATE/DELETE
+        // would otherwise produce an empty `append` snapshot that pollutes snapshot history and
+        // confuses downstream CDC consumers. Aligns with Trino's fix in trinodb/trino#12412.
+        if (commitInfos.isEmpty()) {
+            LOG.info("Skipping empty Iceberg commit for {}.{} (no data or delete files produced)", dbName, tableName);
+            return;
+        }
+
         // Normalize db name and table name to lower case for commit queue key
         // because some catalogs are case-insensitive (e.g., Hive, Glue)
         //
@@ -1797,15 +1807,32 @@ public class IcebergMetadata implements ConnectorMetadata {
             org.apache.iceberg.Table nativeTbl = table.getNativeTable();
             Transaction transaction = nativeTbl.newTransaction();
 
-            // Check if this is a delete operation (any file is marked as POSITION_DELETES)
-            boolean isDeleteOperation = dataFiles.stream().anyMatch(dataFile ->
-                    dataFile.isSetFile_content() &&
-                            (dataFile.getFile_content() == TIcebergFileContent.POSITION_DELETES));
-            if (isDeleteOperation) {
-                commitDeleteOperation(transaction, nativeTbl, dataFiles, branch, dbName, tableName, extra, context);
+            boolean hasPositionDeletes = false;
+            boolean hasDataFiles = false;
+            for (TIcebergDataFile dataFile : dataFiles) {
+                if (dataFile.isSetFile_content() &&
+                        dataFile.getFile_content() == TIcebergFileContent.POSITION_DELETES) {
+                    hasPositionDeletes = true;
+                } else {
+                    hasDataFiles = true;
+                }
+                if (hasPositionDeletes && hasDataFiles) {
+                    break;
+                }
+            }
+
+            if (hasPositionDeletes && hasDataFiles) {
+                // UPDATE / MERGE: RowDelta with both delete and data files
+                commitRowDeltaOperation(transaction, nativeTbl, dataFiles, branch,
+                        dbName, tableName, extra, context);
+            } else if (hasPositionDeletes) {
+                // Pure DELETE (unchanged)
+                commitDeleteOperation(transaction, nativeTbl, dataFiles, branch,
+                        dbName, tableName, extra, context);
             } else {
-                commitDataOperation(transaction, nativeTbl, dataFiles, branch, isOverwrite, isRewrite, extra,
-                        dbName, tableName, context);
+                // Pure INSERT/OVERWRITE (unchanged)
+                commitDataOperation(transaction, nativeTbl, dataFiles, branch, isOverwrite,
+                        isRewrite, extra, dbName, tableName, context);
             }
         };
 
@@ -1866,6 +1893,55 @@ public class IcebergMetadata implements ConnectorMetadata {
         icebergCatalog.invalidatePartitionCache(dbName, tableName);
     }
 
+    private org.apache.iceberg.DeleteFile buildPositionDeleteFile(
+            TIcebergDataFile dataFile, PartitionSpec partitionSpec, org.apache.iceberg.Table nativeTbl) {
+        FileMetadata.Builder builder = FileMetadata.deleteFileBuilder(partitionSpec)
+                .ofPositionDeletes()
+                .withPath(dataFile.path)
+                .withFormat(FileFormat.PARQUET)
+                .withFileSizeInBytes(dataFile.file_size_in_bytes)
+                .withRecordCount(dataFile.record_count)
+                .withPartition(partitionSpec.isPartitioned() ?
+                        IcebergPartitionData.partitionDataFromPath(
+                                getIcebergRelativePartitionPath(
+                                        IcebergUtil.tableDataLocation(nativeTbl),
+                                        dataFile.partition_path),
+                                dataFile.isSetPartition_null_fingerprint() ?
+                                        dataFile.getPartition_null_fingerprint() :
+                                        "0".repeat(partitionSpec.fields().size()),
+                                partitionSpec) : null)
+                .withMetrics(dataFile.isSetColumn_stats() ?
+                        IcebergApiConverter.buildDataFileMetrics(dataFile, nativeTbl) : null);
+
+        if (dataFile.isSetReferenced_data_file()) {
+            builder.withReferencedDataFile(dataFile.getReferenced_data_file());
+        }
+        return builder.build();
+    }
+
+    private org.apache.iceberg.DataFile buildDataFile(
+            TIcebergDataFile dataFile, PartitionSpec partitionSpec, org.apache.iceberg.Table nativeTbl) {
+        Metrics metrics = IcebergApiConverter.buildDataFileMetrics(dataFile, nativeTbl);
+        DataFiles.Builder builder = DataFiles.builder(partitionSpec)
+                .withMetrics(metrics)
+                .withPath(dataFile.path)
+                .withFormat(dataFile.format)
+                .withRecordCount(dataFile.record_count)
+                .withFileSizeInBytes(dataFile.file_size_in_bytes)
+                .withSplitOffsets(dataFile.split_offsets);
+
+        if (partitionSpec.isPartitioned()) {
+            String nullFingerprint = dataFile.isSetPartition_null_fingerprint() ?
+                    dataFile.getPartition_null_fingerprint() :
+                    "0".repeat(partitionSpec.fields().size());
+            String relativePartitionLocation = getIcebergRelativePartitionPath(
+                    IcebergUtil.tableDataLocation(nativeTbl), dataFile.partition_path);
+            builder.withPartition(IcebergPartitionData.partitionDataFromPath(
+                    relativePartitionLocation, nullFingerprint, partitionSpec));
+        }
+        return builder.build();
+    }
+
     private void commitDeleteOperation(Transaction transaction, org.apache.iceberg.Table nativeTbl,
                                        List<TIcebergDataFile> dataFiles, String branch,
                                        String dbName, String tableName, Object extra,
@@ -1882,34 +1958,11 @@ public class IcebergMetadata implements ConnectorMetadata {
         PartitionSpec partitionSpec = nativeTbl.spec();
         ImmutableSet.Builder<String> referencedDataFiles = ImmutableSet.builder();
         for (TIcebergDataFile dataFile : dataFiles) {
-            // All files should be delete files in a delete operation
-            FileMetadata.Builder builder = FileMetadata.deleteFileBuilder(partitionSpec)
-                    .ofPositionDeletes()
-                    .withPath(dataFile.path)
-                    .withFormat(FileFormat.PARQUET)
-                    .withFileSizeInBytes(dataFile.file_size_in_bytes)
-                    .withRecordCount(dataFile.record_count)
-                    .withPartition(partitionSpec.isPartitioned() ?
-                            IcebergPartitionData.partitionDataFromPath(
-                                    getIcebergRelativePartitionPath(
-                                            IcebergUtil.tableDataLocation(nativeTbl),
-                                            dataFile.partition_path),
-                                    dataFile.isSetPartition_null_fingerprint() ?
-                                            dataFile.getPartition_null_fingerprint() :
-                                            "0".repeat(partitionSpec.fields().size()),
-                                    partitionSpec) : null)
-                    .withMetrics(dataFile.isSetColumn_stats() ?
-                            IcebergApiConverter.buildDataFileMetrics(dataFile, nativeTbl) : null);
-
-            // Set referenced data file if available
-            if (dataFile.isSetReferenced_data_file()) {
-                String referencedFile = dataFile.getReferenced_data_file();
-                builder.withReferencedDataFile(referencedFile);
-                referencedDataFiles.add(referencedFile);
-            }
-
-            org.apache.iceberg.DeleteFile deleteFile = builder.build();
+            org.apache.iceberg.DeleteFile deleteFile = buildPositionDeleteFile(dataFile, partitionSpec, nativeTbl);
             rowDelta.addDeletes(deleteFile);
+            if (dataFile.isSetReferenced_data_file()) {
+                referencedDataFiles.add(dataFile.getReferenced_data_file());
+            }
         }
 
         // Use the base snapshot id frozen at plan time so conflict detection covers
@@ -1983,6 +2036,110 @@ public class IcebergMetadata implements ConnectorMetadata {
         asyncRefreshOthersFeMetadataCache(dbName, tableName);
     }
 
+    private void commitRowDeltaOperation(Transaction transaction, org.apache.iceberg.Table nativeTbl,
+                                          List<TIcebergDataFile> dataFiles, String branch,
+                                          String dbName, String tableName, Object extra,
+                                          ConnectContext context) {
+        long startMs = System.currentTimeMillis();
+
+        // UPDATE operations - use RowDelta with both delete and data files
+        RowDelta rowDelta = transaction.newRowDelta();
+        if (branch != null) {
+            rowDelta.toBranch(branch);
+        }
+
+        PartitionSpec partitionSpec = nativeTbl.spec();
+        ImmutableSet.Builder<String> referencedDataFiles = ImmutableSet.builder();
+        long deleteFileCount = 0;
+        long dataFileCount = 0;
+        long deleteBytes = 0;
+        long dataBytes = 0;
+        for (TIcebergDataFile dataFile : dataFiles) {
+            if (dataFile.isSetFile_content() &&
+                    dataFile.getFile_content() == TIcebergFileContent.POSITION_DELETES) {
+                rowDelta.addDeletes(buildPositionDeleteFile(dataFile, partitionSpec, nativeTbl));
+                if (dataFile.isSetReferenced_data_file()) {
+                    referencedDataFiles.add(dataFile.getReferenced_data_file());
+                }
+                deleteFileCount++;
+                deleteBytes += dataFile.file_size_in_bytes;
+            } else {
+                rowDelta.addRows(buildDataFile(dataFile, partitionSpec, nativeTbl));
+                dataFileCount++;
+                dataBytes += dataFile.file_size_in_bytes;
+            }
+        }
+
+        // Use the base snapshot id frozen at plan time so conflict detection covers
+        // every commit landed between scan and commit. Falling back to currentSnapshot
+        // here would silently skip that window and defeat SERIALIZABLE isolation.
+        Long baseSnapshotId = extra instanceof IcebergSinkExtra
+                ? ((IcebergSinkExtra) extra).getBaseSnapshotId() : null;
+        if (baseSnapshotId == null) {
+            Snapshot currentSnapshot = nativeTbl.currentSnapshot();
+            if (currentSnapshot != null) {
+                baseSnapshotId = currentSnapshot.snapshotId();
+            }
+        }
+        if (baseSnapshotId != null) {
+            rowDelta.validateFromSnapshot(baseSnapshotId);
+        }
+
+        // Validate that referenced data files exist and haven't been deleted
+        rowDelta.validateDataFilesExist(referencedDataFiles.build());
+        rowDelta.validateDeletedFiles();
+
+        // Set conflict detection filter if available
+        // This filter defines which data files should be checked for conflicts during validation
+        if (extra instanceof IcebergSinkExtra) {
+            Expression conflictDetectionFilterObj = ((IcebergSinkExtra) extra).getConflictDetectionFilter();
+            if (conflictDetectionFilterObj != null) {
+                rowDelta.conflictDetectionFilter(conflictDetectionFilterObj);
+            }
+        }
+
+        IsolationLevel isolationLevel = IsolationLevel.fromName(nativeTbl.properties().
+                getOrDefault(UPDATE_ISOLATION_LEVEL, UPDATE_ISOLATION_LEVEL_DEFAULT));
+        if (isolationLevel == IsolationLevel.SERIALIZABLE) {
+            rowDelta.validateNoConflictingDataFiles();
+            rowDelta.validateNoConflictingDeleteFiles();
+        }
+
+        if (context != null) {
+            updateCommitInfo(rowDelta, context);
+        }
+
+        try {
+            commitWithCleanup(() -> {
+                rowDelta.commit();
+                transaction.commitTransaction();
+            }, () -> invalidateCacheAfterCommit(dbName, tableName), dataFiles, dbName, tableName);
+
+            ConnectorMetricsMgr.increaseUpdateTotalSuccess(ConnectorMetricsMgr.CONNECTOR_ICEBERG);
+
+            Snapshot newSnapshot = nativeTbl.currentSnapshot();
+            if (newSnapshot != null && newSnapshot.summary() != null) {
+                long affectedRows = Long.parseLong(newSnapshot.summary()
+                        .getOrDefault(SnapshotSummary.ADDED_POS_DELETES_PROP, "0"));
+                ConnectorMetricsMgr.increaseUpdateRows(ConnectorMetricsMgr.CONNECTOR_ICEBERG, affectedRows);
+            }
+
+            ConnectorMetricsMgr.increaseUpdateBytes(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                    deleteBytes, ConnectorMetricsMgr.FILE_TYPE_POSITION_DELETE);
+            ConnectorMetricsMgr.increaseUpdateBytes(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                    dataBytes, ConnectorMetricsMgr.FILE_TYPE_DATA);
+            ConnectorMetricsMgr.increaseUpdateFiles(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                    deleteFileCount, ConnectorMetricsMgr.FILE_TYPE_POSITION_DELETE);
+            ConnectorMetricsMgr.increaseUpdateFiles(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                    dataFileCount, ConnectorMetricsMgr.FILE_TYPE_DATA);
+        } finally {
+            ConnectorMetricsMgr.increaseUpdateDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                    System.currentTimeMillis() - startMs);
+        }
+
+        asyncRefreshOthersFeMetadataCache(dbName, tableName);
+    }
+
     private void commitDataOperation(Transaction transaction, org.apache.iceberg.Table nativeTbl,
                                      List<TIcebergDataFile> dataFiles, String branch,
                                      boolean isOverwrite, boolean isRewrite, Object extra,
@@ -2007,29 +2164,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         PartitionSpec partitionSpec = nativeTbl.spec();
         for (TIcebergDataFile dataFile : dataFiles) {
-            Metrics metrics = IcebergApiConverter.buildDataFileMetrics(dataFile, nativeTbl);
-            DataFiles.Builder builder =
-                    DataFiles.builder(partitionSpec)
-                            .withMetrics(metrics)
-                            .withPath(dataFile.path)
-                            .withFormat(dataFile.format)
-                            .withRecordCount(dataFile.record_count)
-                            .withFileSizeInBytes(dataFile.file_size_in_bytes)
-                            .withSplitOffsets(dataFile.split_offsets);
-            String nullFingerprint = "";
-            if (!dataFile.isSetPartition_null_fingerprint()) {
-                nullFingerprint = "0".repeat(partitionSpec.fields().size());
-            } else {
-                nullFingerprint = dataFile.getPartition_null_fingerprint();
-            }
-            if (partitionSpec.isPartitioned()) {
-                String relativePartitionLocation = getIcebergRelativePartitionPath(
-                        IcebergUtil.tableDataLocation(nativeTbl), dataFile.partition_path);
-                IcebergPartitionData partitionData = IcebergPartitionData.partitionDataFromPath(
-                        relativePartitionLocation, nullFingerprint, partitionSpec);
-                builder.withPartition(partitionData);
-            }
-            batchWrite.addFile(builder.build());
+            batchWrite.addFile(buildDataFile(dataFile, partitionSpec, nativeTbl));
         }
 
         if (isRewrite && extra != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.planner;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergUtil;
@@ -139,6 +140,8 @@ public class IcebergDeleteSink extends DataSink {
         // DeleteSink only emits position-delete files; the codec belongs in the
         // delete-file slot. `compression_type` is reserved for data files now.
         TCompressionType compression = PARQUET_COMPRESSION_TYPE_MAP.get(compressionType);
+        Preconditions.checkState(compression != null,
+                "delete file compression type not supported: " + compressionType);
         tIcebergTableSink.setDelete_compression_type(compression);
         tIcebergTableSink.setTarget_max_file_size(targetMaxFileSize);
         com.starrocks.thrift.TCloudConfiguration tCloudConfiguration = new com.starrocks.thrift.TCloudConfiguration();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergRowDeltaSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergRowDeltaSink.java
@@ -35,22 +35,26 @@ import static org.apache.iceberg.TableProperties.DELETE_PARQUET_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 
 /**
- * IcebergRowDeltaSink is used to support UPDATE operations on Iceberg tables
+ * IcebergRowDeltaSink is used to support row-delta operations on Iceberg tables
  * using the RowDelta model. It writes both position delete files and new data
  * files in a single atomic operation.
  * <p>
  * Required columns:
  * - _file (STRING): Path of the data file
  * - _pos (BIGINT): Row position within the file
- * - Plus data columns for the updated rows
+ * - Plus data columns for the new rows
+ * - Optional trailing op_code column for mixed row-level routing
  */
 public class IcebergRowDeltaSink extends DataSink {
-    public static final String WRITE_MODE_ROW_DELTA = "ROW_DELTA";
 
     /**
      * Operation codes for row-level delta operations.
-     * Each row in the RowDelta output carries an op_code that tells the BE sink
-     * how to route it. Values must stay in sync with BE IcebergRowDeltaSink::OP_*.
+     * MERGE row-delta output carries an op_code that tells the BE sink how to
+     * route each row. Values must stay in sync with BE IcebergRowDeltaSink::OP_*.
+     * These values are the RowDelta sink's internal routing protocol; never expose
+     * them as SQL-visible analyzer output columns. UPDATE uses ROW_DELTA_UPDATE
+     * mode with no per-row routing; MERGE uses ROW_DELTA_MIXED with a
+     * planner-injected routing projection.
      */
     public enum OpCode {
         NO_OP(0),           // discard (MERGE row matches no WHEN clause)
@@ -79,6 +83,7 @@ public class IcebergRowDeltaSink extends DataSink {
     private final String deleteCompressionType;
     private final long targetMaxFileSize;
     private final String tableIdentifier;
+    private final TIcebergWriteMode writeMode;
     private CloudConfiguration cloudConfiguration;
     private com.starrocks.connector.iceberg.IcebergMetadata.IcebergSinkExtra sinkExtraInfo;
 
@@ -88,9 +93,10 @@ public class IcebergRowDeltaSink extends DataSink {
      * @param icebergTable    The target Iceberg table
      * @param desc            Tuple descriptor containing operation columns
      * @param sessionVariable Session variables for configuration
+     * @param writeMode       RowDelta physical layout mode
      */
     public IcebergRowDeltaSink(IcebergTable icebergTable, TupleDescriptor desc,
-                               SessionVariable sessionVariable) {
+                               SessionVariable sessionVariable, TIcebergWriteMode writeMode) {
         this.icebergTable = icebergTable;
         Table nativeTable = icebergTable.getNativeTable();
         this.desc = desc;
@@ -109,6 +115,10 @@ public class IcebergRowDeltaSink extends DataSink {
         this.dataCompressionType = dataCodec;
         this.deleteCompressionType = nativeTable.properties().getOrDefault(DELETE_PARQUET_COMPRESSION, dataCodec);
         this.targetMaxFileSize = IcebergUtil.resolveTargetMaxFileSize(nativeTable, sessionVariable);
+        Preconditions.checkArgument(writeMode == TIcebergWriteMode.ROW_DELTA_UPDATE ||
+                        writeMode == TIcebergWriteMode.ROW_DELTA_MIXED,
+                "IcebergRowDeltaSink write mode must be ROW_DELTA_UPDATE or ROW_DELTA_MIXED");
+        this.writeMode = writeMode;
     }
 
     public void init() {
@@ -162,7 +172,7 @@ public class IcebergRowDeltaSink extends DataSink {
         strBuilder.append("\n");
         strBuilder.append(prefix).append("  TABLE: ").append(tableIdentifier).append("\n");
         strBuilder.append(prefix).append("  LOCATION: ").append(tableLocation).append("\n");
-        strBuilder.append(prefix).append("  WRITE MODE: ").append(WRITE_MODE_ROW_DELTA).append("\n");
+        strBuilder.append(prefix).append("  WRITE MODE: ").append(writeMode.name()).append("\n");
         strBuilder.append(prefix).append("  TUPLE ID: ").append(desc.getId()).append("\n");
         return strBuilder.toString();
     }
@@ -177,7 +187,7 @@ public class IcebergRowDeltaSink extends DataSink {
         tIcebergTableSink.setData_location(dataLocation);
         tIcebergTableSink.setFile_format(fileFormat);
         tIcebergTableSink.setIs_static_partition_sink(false);
-        tIcebergTableSink.setWrite_mode(TIcebergWriteMode.ROW_DELTA);
+        tIcebergTableSink.setWrite_mode(writeMode);
         TCompressionType dataCompression = PARQUET_COMPRESSION_TYPE_MAP.get(dataCompressionType);
         Preconditions.checkState(dataCompression != null,
                 "data file compression type not supported: " + dataCompressionType);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergRowDeltaSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergRowDeltaSink.java
@@ -14,11 +14,13 @@
 
 package com.starrocks.planner;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TDataSinkType;
 import com.starrocks.thrift.TExplainLevel;
@@ -176,8 +178,14 @@ public class IcebergRowDeltaSink extends DataSink {
         tIcebergTableSink.setFile_format(fileFormat);
         tIcebergTableSink.setIs_static_partition_sink(false);
         tIcebergTableSink.setWrite_mode(TIcebergWriteMode.ROW_DELTA);
-        tIcebergTableSink.setCompression_type(PARQUET_COMPRESSION_TYPE_MAP.get(dataCompressionType));
-        tIcebergTableSink.setDelete_compression_type(PARQUET_COMPRESSION_TYPE_MAP.get(deleteCompressionType));
+        TCompressionType dataCompression = PARQUET_COMPRESSION_TYPE_MAP.get(dataCompressionType);
+        Preconditions.checkState(dataCompression != null,
+                "data file compression type not supported: " + dataCompressionType);
+        TCompressionType deleteCompression = PARQUET_COMPRESSION_TYPE_MAP.get(deleteCompressionType);
+        Preconditions.checkState(deleteCompression != null,
+                "delete file compression type not supported: " + deleteCompressionType);
+        tIcebergTableSink.setCompression_type(dataCompression);
+        tIcebergTableSink.setDelete_compression_type(deleteCompression);
         tIcebergTableSink.setTarget_max_file_size(targetMaxFileSize);
         com.starrocks.thrift.TCloudConfiguration tCloudConfiguration = new com.starrocks.thrift.TCloudConfiguration();
         cloudConfiguration.toThrift(tCloudConfiguration);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -65,6 +65,7 @@ import com.starrocks.sql.optimizer.transformer.OptExprBuilder;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
+import com.starrocks.thrift.TIcebergWriteMode;
 import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TResultSinkType;
 
@@ -237,7 +238,7 @@ public class UpdatePlanner {
 
         descriptorTable.addReferencedTable(icebergTable);
         IcebergRowDeltaSink dataSink = new IcebergRowDeltaSink(
-                icebergTable, rowDeltaTuple, session.getSessionVariable());
+                icebergTable, rowDeltaTuple, session.getSessionVariable(), TIcebergWriteMode.ROW_DELTA_UPDATE);
         dataSink.init();
 
         IcebergMetadata.IcebergSinkExtra icebergSinkExtra = new IcebergMetadata.IcebergSinkExtra();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -24,7 +24,6 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
-import com.starrocks.planner.IcebergRowDeltaSink;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SelectAnalyzer.RewriteAliasVisitor;
@@ -41,13 +40,11 @@ import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.expression.DefaultValueExpr;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.TypeManager;
-import com.starrocks.type.IntegerType;
 import com.starrocks.type.NullType;
 
 import java.util.HashMap;
@@ -81,7 +78,7 @@ public class UpdateAnalyzer {
      *   UPDATE table SET col1=expr1, col2=expr2 WHERE condition
      * to:
      *   INSERT INTO iceberg_row_delta_sink
-     *   SELECT _file, _pos, partition_col1, ..., new_col1, new_col2, ..., 2 AS op_code
+     *   SELECT _file, _pos, partition_col1, ..., new_col1, new_col2, ...
      *   FROM table WHERE condition
      */
     private static void analyzeIcebergTable(UpdateStmt updateStmt, IcebergTable icebergTable,
@@ -130,7 +127,7 @@ public class UpdateAnalyzer {
             }
         }
 
-        // Build SELECT list: _file, _pos, partition_cols, full schema (with SET exprs), op_code
+        // Build SELECT list: _file, _pos, partition_cols, full schema (with SET exprs)
         SelectList selectList = new SelectList();
 
         // Add _file column
@@ -144,7 +141,7 @@ public class UpdateAnalyzer {
         // No separate partition prefix — partition columns are already part of the full
         // table schema in the data section below. Adding them here would create duplicate
         // SlotRefs that the optimizer merges, changing the column count and breaking
-        // the BE layout assumptions (data_column_start, op_code_index).
+        // the BE layout assumptions.
         // Partition shuffle uses the partition columns from the data section.
 
         // Add full target-table schema: for assigned columns use the SET expression,
@@ -169,14 +166,6 @@ public class UpdateAnalyzer {
             }
         }
 
-        // Add op_code = OP_UPDATE as the last column
-        try {
-            selectList.addItem(new SelectListItem(
-                    new IntLiteral(IcebergRowDeltaSink.OpCode.UPDATE.value(), IntegerType.TINYINT), "op_code"));
-        } catch (Exception e) {
-            throw new SemanticException("analyze update failed", e);
-        }
-
         // Create table relation with WHERE predicate
         TableRelation tableRelation = new TableRelation(tableName);
         SelectRelation selectRelation = new SelectRelation(
@@ -195,8 +184,8 @@ public class UpdateAnalyzer {
         new QueryAnalyzer(session).analyze(queryStatement);
 
         // Cast data columns to target schema types.
-        // Layout: [_file, _pos, data_cols..., op_code]
-        // Only data_cols need casting — _file/_pos are fixed types, op_code is a literal.
+        // Layout: [_file, _pos, data_cols...]
+        // Only data_cols need casting — _file/_pos are fixed types.
         List<Expr> outputExprs = queryStatement.getQueryRelation().getOutputExpression();
         int dataColumnStart = 2;
         List<Expr> castOutputExprs = Lists.newArrayList(outputExprs);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -123,7 +123,7 @@ public class UpdateAnalyzer {
         for (String colName : assignmentByColName.keySet()) {
             Column col = icebergTable.getColumn(colName);
             if (col == null) {
-                throw new SemanticException("table '%s' do not existing column '%s'", tableName.getTbl(), colName);
+                throw new SemanticException("table '%s' does not have column '%s'", tableName.getTbl(), colName);
             }
             if (col.isHidden()) {
                 throw new SemanticException("Updating metadata column '%s' is not allowed", colName);
@@ -256,7 +256,7 @@ public class UpdateAnalyzer {
         }
         for (String colName : assignmentByColName.keySet()) {
             if (table.getColumn(colName) == null) {
-                throw new SemanticException("table '%s' do not existing column '%s'", tableName.getTbl(), colName);
+                throw new SemanticException("table '%s' does not have column '%s'", tableName.getTbl(), colName);
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1226,6 +1226,59 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testFinishSinkSkipsEmptyCommit() {
+        // Zero-row INSERT / UPDATE / DELETE should NOT produce a new snapshot.
+        // Aligns with Trino's fix in trinodb/trino#12412 — empty DML pollutes
+        // snapshot history and confuses downstream CDC consumers.
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        // Case 1: empty commitInfos against a fresh table — no snapshot should appear.
+        mockedNativeTableA.refresh();
+        Assertions.assertNull(mockedNativeTableA.currentSnapshot(),
+                "Precondition: fresh table has no snapshot");
+
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(), null);
+
+        mockedNativeTableA.refresh();
+        Assertions.assertNull(mockedNativeTableA.currentSnapshot(),
+                "Empty commitInfos must not create a snapshot");
+
+        // Case 2: after a real commit, a subsequent empty commit must not advance the snapshot.
+        TSinkCommitInfo tSinkCommitInfo = new TSinkCommitInfo();
+        TIcebergDataFile tIcebergDataFile = new TIcebergDataFile();
+        tIcebergDataFile.setPath(mockedNativeTableA.location() + "/data/data_bucket=0/c.parquet");
+        tIcebergDataFile.setFormat("parquet");
+        tIcebergDataFile.setRecord_count(10);
+        tIcebergDataFile.setSplit_offsets(Lists.newArrayList(4L));
+        tIcebergDataFile.setPartition_path(mockedNativeTableA.location() + "/data/data_bucket=0/");
+        tIcebergDataFile.setFile_size_in_bytes(2000);
+        tIcebergDataFile.setPartition_null_fingerprint("0");
+        tSinkCommitInfo.setIs_overwrite(false);
+        tSinkCommitInfo.setIceberg_data_file(tIcebergDataFile);
+
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null);
+        mockedNativeTableA.refresh();
+        long snapshotIdAfterRealCommit = mockedNativeTableA.currentSnapshot().snapshotId();
+
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(), null);
+        mockedNativeTableA.refresh();
+        Assertions.assertEquals(snapshotIdAfterRealCommit, mockedNativeTableA.currentSnapshot().snapshotId(),
+                "Empty commitInfos after a real commit must not advance the snapshot");
+    }
+
+    @Test
     public void testFinishSinkWithCommitFailed(@Mocked IcebergMetadata.Append append) throws IOException {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
 
@@ -3178,8 +3231,12 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
+        // Provide a non-empty commit list so finishSink does not short-circuit on the
+        // empty-commit path (see testFinishSinkSkipsEmptyCommit) and actually reaches getTable().
+        TSinkCommitInfo dummyCommit = new TSinkCommitInfo();
+        dummyCommit.setIceberg_data_file(new TIcebergDataFile());
         RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
-                () -> metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(), null));
+                () -> metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(dummyCommit), null));
         Assertions.assertTrue(exception.getMessage().contains("checked failure"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1228,8 +1228,8 @@ public class IcebergMetadataTest extends TableTestBase {
     @Test
     public void testFinishSinkSkipsEmptyCommit() {
         // Zero-row INSERT / UPDATE / DELETE should NOT produce a new snapshot.
-        // Aligns with Trino's fix in trinodb/trino#12412 — empty DML pollutes
-        // snapshot history and confuses downstream CDC consumers.
+        // Empty DML would otherwise pollute snapshot history and confuse
+        // downstream CDC consumers.
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
@@ -3006,6 +3006,169 @@ public class IcebergMetadataTest extends TableTestBase {
         mockedNativeTableA.refresh();
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableA.newScan().planFiles());
         Assertions.assertFalse(fileScanTasks.isEmpty());
+    }
+
+    // Helpers for row-delta commit tests. A row-delta commit (UPDATE / MERGE) goes
+    // through commitRowDeltaOperation when commitInfos contains BOTH a position-delete
+    // file and a new data file, exercising RowDelta-specific validations.
+    //
+    // column_stats must be set on both files: buildPositionDeleteFile passes
+    // null metrics to Iceberg's FileMetadata.Builder when column_stats is unset,
+    // and Iceberg then NPEs on metrics.recordCount() during build.
+    private TIcebergColumnStats emptyColumnStats() {
+        TIcebergColumnStats stats = new TIcebergColumnStats();
+        stats.setColumn_sizes(Map.of());
+        stats.setValue_counts(Map.of());
+        stats.setNull_value_counts(Map.of());
+        stats.setLower_bounds(Map.of());
+        stats.setUpper_bounds(Map.of());
+        return stats;
+    }
+
+    private TIcebergDataFile buildRowDeltaPositionDeleteFile() {
+        TIcebergDataFile deleteFile = new TIcebergDataFile();
+        deleteFile.setPath(mockedNativeTableA.location() + "/data/delete_for_update.parquet");
+        deleteFile.setFormat("parquet");
+        deleteFile.setRecord_count(3);
+        deleteFile.setFile_size_in_bytes(256);
+        deleteFile.setPartition_path(mockedNativeTableA.location() + "/data/data_bucket=1/");
+        deleteFile.setPartition_null_fingerprint("0");
+        deleteFile.setFile_content(TIcebergFileContent.POSITION_DELETES);
+        deleteFile.setReferenced_data_file(FILE_A.path().toString());
+        deleteFile.setColumn_stats(emptyColumnStats());
+        return deleteFile;
+    }
+
+    private TIcebergDataFile buildRowDeltaDataFile() {
+        TIcebergDataFile dataFile = new TIcebergDataFile();
+        dataFile.setPath(mockedNativeTableA.location() + "/data/data_bucket=0/new_after_update.parquet");
+        dataFile.setFormat("parquet");
+        dataFile.setRecord_count(3);
+        dataFile.setSplit_offsets(Lists.newArrayList(4L));
+        dataFile.setPartition_path(mockedNativeTableA.location() + "/data/data_bucket=0/");
+        dataFile.setFile_size_in_bytes(512);
+        dataFile.setPartition_null_fingerprint("0");
+        dataFile.setColumn_stats(emptyColumnStats());
+        return dataFile;
+    }
+
+    @Test
+    public void testCommitRowDeltaOperationWithBaseSnapshotAndConflictFilter() throws Exception {
+        // Establish a baseline snapshot so RowDelta has something to validate against.
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        long baseSnapshotId = mockedNativeTableA.currentSnapshot().snapshotId();
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        TSinkCommitInfo deleteCommit = new TSinkCommitInfo();
+        deleteCommit.setIceberg_data_file(buildRowDeltaPositionDeleteFile());
+        TSinkCommitInfo dataCommit = new TSinkCommitInfo();
+        dataCommit.setIceberg_data_file(buildRowDeltaDataFile());
+
+        // Explicit baseSnapshotId frozen at plan time + conflict detection filter:
+        // exercises the IcebergSinkExtra.baseSnapshotId branch and the
+        // conflictDetectionFilter set-up in commitRowDeltaOperation.
+        IcebergMetadata.IcebergSinkExtra extra = new IcebergMetadata.IcebergSinkExtra();
+        extra.setBaseSnapshotId(baseSnapshotId);
+        extra.setConflictDetectionFilter(org.apache.iceberg.expressions.Expressions.greaterThan("id", 100));
+
+        metadata.finishSink("iceberg_db", "iceberg_table",
+                Lists.newArrayList(deleteCommit, dataCommit), null, extra);
+
+        mockedNativeTableA.refresh();
+        Snapshot newSnapshot = mockedNativeTableA.currentSnapshot();
+        Assertions.assertNotNull(newSnapshot, "row-delta commit must produce a snapshot");
+        Assertions.assertNotEquals(baseSnapshotId, newSnapshot.snapshotId(),
+                "row-delta commit must advance the snapshot id past the plan-time base");
+    }
+
+    @Test
+    public void testCommitRowDeltaOperationSerializableIsolation() throws Exception {
+        // SERIALIZABLE turns on validateNoConflictingDataFiles in addition to the
+        // unconditional validateNoConflictingDeleteFiles. Cover both checks here.
+        mockedNativeTableA.updateProperties()
+                .set(org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL, "serializable")
+                .commit();
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        TSinkCommitInfo deleteCommit = new TSinkCommitInfo();
+        deleteCommit.setIceberg_data_file(buildRowDeltaPositionDeleteFile());
+        TSinkCommitInfo dataCommit = new TSinkCommitInfo();
+        dataCommit.setIceberg_data_file(buildRowDeltaDataFile());
+
+        IcebergMetadata.IcebergSinkExtra extra = new IcebergMetadata.IcebergSinkExtra();
+        extra.setBaseSnapshotId(mockedNativeTableA.currentSnapshot().snapshotId());
+
+        metadata.finishSink("iceberg_db", "iceberg_table",
+                Lists.newArrayList(deleteCommit, dataCommit), null, extra);
+
+        mockedNativeTableA.refresh();
+        Assertions.assertNotNull(mockedNativeTableA.currentSnapshot(),
+                "serializable-isolation row-delta commit must still produce a snapshot");
+    }
+
+    @Test
+    public void testCommitRowDeltaOperationFallsBackToCurrentSnapshotWhenExtraMissing() throws Exception {
+        // When IcebergSinkExtra (or its baseSnapshotId) is not provided, the commit
+        // path falls back to nativeTbl.currentSnapshot() to scope validateFromSnapshot.
+        // This branch covers the null-extra / null-baseSnapshotId fallback.
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        long baseSnapshotId = mockedNativeTableA.currentSnapshot().snapshotId();
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        TSinkCommitInfo deleteCommit = new TSinkCommitInfo();
+        deleteCommit.setIceberg_data_file(buildRowDeltaPositionDeleteFile());
+        TSinkCommitInfo dataCommit = new TSinkCommitInfo();
+        dataCommit.setIceberg_data_file(buildRowDeltaDataFile());
+
+        // No extra → commitRowDeltaOperation must derive baseSnapshotId from currentSnapshot().
+        metadata.finishSink("iceberg_db", "iceberg_table",
+                Lists.newArrayList(deleteCommit, dataCommit), null, null);
+
+        mockedNativeTableA.refresh();
+        Snapshot newSnapshot = mockedNativeTableA.currentSnapshot();
+        Assertions.assertNotNull(newSnapshot, "row-delta commit must produce a snapshot");
+        Assertions.assertNotEquals(baseSnapshotId, newSnapshot.snapshotId(),
+                "row-delta commit must advance past the implicit base snapshot");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/UpdateAnalyzerIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/UpdateAnalyzerIcebergTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.sql.analyzer;
 
 import com.starrocks.catalog.IcebergTable;
-import com.starrocks.planner.IcebergRowDeltaSink;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
@@ -24,7 +23,6 @@ import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.utframe.StarRocksAssert;
@@ -144,7 +142,7 @@ public class UpdateAnalyzerIcebergTest {
     }
 
     @Test
-    public void testIcebergUpdateConvertsToSelectWithOpCode() {
+    public void testIcebergUpdateConvertsToSelectWithoutOpCode() {
         String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'new' WHERE id = 1";
         UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
                 sql, connectContext.getSessionVariable().getSqlMode()).get(0);
@@ -160,7 +158,7 @@ public class UpdateAnalyzerIcebergTest {
         SelectRelation selectRelation = (SelectRelation) queryRelation;
         assertNotNull(selectRelation.getSelectList());
 
-        // Check that select list contains _file, _pos, and op_code columns
+        // Check that select list contains _file and _pos columns, but no routing op_code.
         boolean hasFileColumn = false;
         boolean hasPosColumn = false;
         boolean hasOpCode = false;
@@ -180,7 +178,7 @@ public class UpdateAnalyzerIcebergTest {
 
         assertTrue(hasFileColumn, "Select list should contain _file column");
         assertTrue(hasPosColumn, "Select list should contain _pos column");
-        assertTrue(hasOpCode, "Select list should contain op_code column");
+        assertFalse(hasOpCode, "UPDATE select list should not expose op_code column");
     }
 
     @Test
@@ -234,14 +232,13 @@ public class UpdateAnalyzerIcebergTest {
         // Verify column output names include all expected columns
         List<String> colNames = updateStmt.getQueryStatement().getQueryRelation().getColumnOutputNames();
         assertNotNull(colNames);
-        // _file, _pos, id, data, date, op_code
-        assertEquals(6, colNames.size());
+        // _file, _pos, id, data, date
+        assertEquals(5, colNames.size());
         assertEquals(IcebergTable.FILE_PATH, colNames.get(0));
         assertEquals(IcebergTable.ROW_POSITION, colNames.get(1));
         assertEquals("id", colNames.get(2));
         assertEquals("data", colNames.get(3));
         assertEquals("date", colNames.get(4));
-        assertEquals("op_code", colNames.get(5));
     }
 
     @Test
@@ -254,11 +251,11 @@ public class UpdateAnalyzerIcebergTest {
 
         List<String> colNames = updateStmt.getQueryStatement().getQueryRelation().getColumnOutputNames();
         assertNotNull(colNames);
-        // _file, _pos, id, data, date, op_code
-        assertEquals(6, colNames.size());
+        // _file, _pos, id, data, date
+        assertEquals(5, colNames.size());
         assertEquals(IcebergTable.FILE_PATH, colNames.get(0));
         assertEquals(IcebergTable.ROW_POSITION, colNames.get(1));
-        assertEquals("op_code", colNames.get(colNames.size() - 1));
+        assertFalse(colNames.contains("op_code"));
     }
 
     @Test
@@ -274,13 +271,13 @@ public class UpdateAnalyzerIcebergTest {
         SelectList selectList = selectRelation.getSelectList();
         List<SelectListItem> items = selectList.getItems();
 
-        // Expected: _file, _pos, id, data, date, op_code = 6 items
-        assertEquals(6, items.size());
+        // Expected: _file, _pos, id, data, date = 5 items
+        assertEquals(5, items.size());
 
         // Verify output expressions are present and cast correctly
         List<Expr> outputExprs = selectRelation.getOutputExpression();
         assertNotNull(outputExprs);
-        assertEquals(6, outputExprs.size());
+        assertEquals(5, outputExprs.size());
     }
 
     @Test
@@ -327,8 +324,8 @@ public class UpdateAnalyzerIcebergTest {
         // Verify output expressions have been set (cast step completed)
         List<Expr> outputExprs = selectRelation.getOutputExpression();
         assertNotNull(outputExprs);
-        // All 6 columns should have output expressions
-        assertEquals(6, outputExprs.size());
+        // All 5 columns should have output expressions
+        assertEquals(5, outputExprs.size());
         // None should be null
         for (Expr expr : outputExprs) {
             assertNotNull(expr);
@@ -389,15 +386,15 @@ public class UpdateAnalyzerIcebergTest {
         assertNotNull(updateStmt.getQueryStatement());
         SelectRelation selectRelation =
                 (SelectRelation) updateStmt.getQueryStatement().getQueryRelation();
-        // Expect _file, _pos, id, data, date, op_code
-        assertEquals(6, selectRelation.getSelectList().getItems().size());
-        assertEquals(6, selectRelation.getOutputExpression().size());
+        // Expect _file, _pos, id, data, date
+        assertEquals(5, selectRelation.getSelectList().getItems().size());
+        assertEquals(5, selectRelation.getOutputExpression().size());
     }
 
     @Test
     public void testIcebergUpdateWithNullAssignment() {
         // SET col = NULL is a valid assignment; analyzer must cast the null literal
-        // to the target column type and produce 6 output exprs.
+        // to the target column type and produce 5 output exprs.
         String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = NULL WHERE id = 1";
         UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
                 sql, connectContext.getSessionVariable().getSqlMode()).get(0);
@@ -406,13 +403,13 @@ public class UpdateAnalyzerIcebergTest {
 
         SelectRelation selectRelation =
                 (SelectRelation) updateStmt.getQueryStatement().getQueryRelation();
-        assertEquals(6, selectRelation.getOutputExpression().size());
+        assertEquals(5, selectRelation.getOutputExpression().size());
     }
 
     @Test
-    public void testIcebergUpdateLastItemIsOpCodeLiteral() {
-        // The last SELECT item must be an IntLiteral tagged with the UPDATE op code
-        // (exercises the op_code literal creation in analyzeIcebergTable).
+    public void testIcebergUpdateDoesNotAppendOpCodeLiteral() {
+        // UPDATE uses a fixed row-delta routing mode; op_code is not part of the
+        // analyzer's public SELECT output.
         String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
         UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
                 sql, connectContext.getSessionVariable().getSqlMode()).get(0);
@@ -423,10 +420,8 @@ public class UpdateAnalyzerIcebergTest {
                 (SelectRelation) updateStmt.getQueryStatement().getQueryRelation();
         SelectList selectList = selectRelation.getSelectList();
         SelectListItem last = selectList.getItems().get(selectList.getItems().size() - 1);
-        assertEquals("op_code", last.getAlias());
-        assertInstanceOf(IntLiteral.class, last.getExpr());
-        assertEquals(IcebergRowDeltaSink.OpCode.UPDATE.value(),
-                ((IntLiteral) last.getExpr()).getValue());
+        assertEquals("date", last.getAlias());
+        assertFalse(selectList.getItems().stream().anyMatch(item -> "op_code".equals(item.getAlias())));
     }
 
     @Test
@@ -458,7 +453,7 @@ public class UpdateAnalyzerIcebergTest {
     @Test
     public void testIcebergUpdatePartitionedTableColumnOutputNames() {
         // For a partitioned V2 table, the column output list must still follow the
-        // same contract: [_file, _pos, id, data, date, op_code].
+        // same contract: [_file, _pos, id, data, date].
         String sql = "UPDATE iceberg0.partitioned_db.t1_v2 SET data = 'new' WHERE id = 1";
         UpdateStmt updateStmt = (UpdateStmt) SqlParser.parse(
                 sql, connectContext.getSessionVariable().getSqlMode()).get(0);
@@ -467,10 +462,10 @@ public class UpdateAnalyzerIcebergTest {
 
         List<String> colNames = updateStmt.getQueryStatement().getQueryRelation().getColumnOutputNames();
         assertNotNull(colNames);
-        assertEquals(6, colNames.size());
+        assertEquals(5, colNames.size());
         assertEquals(IcebergTable.FILE_PATH, colNames.get(0));
         assertEquals(IcebergTable.ROW_POSITION, colNames.get(1));
-        assertEquals("op_code", colNames.get(colNames.size() - 1));
+        assertFalse(colNames.contains("op_code"));
     }
 
     @Test
@@ -515,10 +510,9 @@ public class UpdateAnalyzerIcebergTest {
         SelectRelation selectRelation =
                 (SelectRelation) updateStmt.getQueryStatement().getQueryRelation();
         List<Expr> outputExprs = selectRelation.getOutputExpression();
-        // _file + _pos + 3 data cols + op_code = 6
-        assertEquals(6, outputExprs.size());
-        // Last expression is the op_code literal
-        assertInstanceOf(IntLiteral.class, outputExprs.get(outputExprs.size() - 1));
+        // _file + _pos + 3 data cols = 5
+        assertEquals(5, outputExprs.size());
+        assertFalse(selectRelation.getColumnOutputNames().contains("op_code"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/UpdateAnalyzerIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/UpdateAnalyzerIcebergTest.java
@@ -105,7 +105,7 @@ public class UpdateAnalyzerIcebergTest {
 
         SemanticException exception = assertThrows(SemanticException.class,
                 () -> UpdateAnalyzer.analyze(updateStmt, connectContext));
-        assertTrue(exception.getMessage().contains("do not existing column"));
+        assertTrue(exception.getMessage().contains("does not have column"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -342,12 +342,12 @@ public class UpdatePlanTest extends PlanTestBase {
     @Test
     public void testIcebergUpdateOutputExprsMatchSchema() throws Exception {
         // The sink tuple slots are built from execPlan.getOutputExprs() — verify
-        // the planner produces the expected 6 output exprs for a V2 unpartitioned
-        // update: [_file, _pos, id, data, date, op_code].
+        // the planner produces the expected 5 output exprs for a V2 unpartitioned
+        // update: [_file, _pos, id, data, date].
         String sql = "UPDATE iceberg0.unpartitioned_db.t0_v2 SET data = 'x' WHERE id = 1";
         ExecPlan execPlan = getIcebergUpdateExecPlan(sql);
         assertNotNull(execPlan.getOutputExprs());
-        Assertions.assertEquals(6, execPlan.getOutputExprs().size());
+        Assertions.assertEquals(5, execPlan.getOutputExprs().size());
     }
 
     @Test
@@ -366,7 +366,7 @@ public class UpdatePlanTest extends PlanTestBase {
         assertSame(TDataSinkType.ICEBERG_ROW_DELTA_SINK, tDataSink.getType());
         TIcebergTableSink tIcebergTableSink = tDataSink.getIceberg_table_sink();
         assertNotNull(tIcebergTableSink);
-        assertSame(TIcebergWriteMode.ROW_DELTA, tIcebergTableSink.getWrite_mode());
+        assertSame(TIcebergWriteMode.ROW_DELTA_UPDATE, tIcebergTableSink.getWrite_mode());
         assertFalse(tIcebergTableSink.is_static_partition_sink);
         assertNotNull(tIcebergTableSink.getCloud_configuration());
         assertTrue(tIcebergTableSink.getTarget_max_file_size() > 0);
@@ -379,6 +379,36 @@ public class UpdatePlanTest extends PlanTestBase {
                 "delete-file compression codec must be set");
         // Tuple id from sink must match what the planner attached to the fragment.
         assertTrue(sink.getExplainString("", TExplainLevel.NORMAL).contains("TUPLE ID:"));
+    }
+
+    @Test
+    public void testIcebergRowDeltaSinkToThriftSetsMixedWriteModeWhenConfigured() throws Exception {
+        ScalarType varchar = TypeFactory.createVarcharType(1024);
+        TupleDescriptor tuple = buildTupleDescriptor(
+                new String[] {IcebergTable.FILE_PATH, IcebergTable.ROW_POSITION, "data", "op_code"},
+                new com.starrocks.type.Type[] {varchar, IntegerType.BIGINT, varchar, IntegerType.TINYINT});
+        IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable(), TIcebergWriteMode.ROW_DELTA_MIXED);
+        sink.init();
+
+        java.lang.reflect.Method toThrift = IcebergRowDeltaSink.class.getDeclaredMethod("toThrift");
+        toThrift.setAccessible(true);
+        TDataSink tDataSink = (TDataSink) toThrift.invoke(sink);
+        TIcebergTableSink tIcebergTableSink = tDataSink.getIceberg_table_sink();
+        assertSame(TIcebergWriteMode.ROW_DELTA_MIXED, tIcebergTableSink.getWrite_mode());
+    }
+
+    @Test
+    public void testIcebergRowDeltaSinkRejectsInvalidWriteMode() throws Exception {
+        ScalarType varchar = TypeFactory.createVarcharType(1024);
+        TupleDescriptor tuple = buildTupleDescriptor(
+                new String[] {IcebergTable.FILE_PATH, IcebergTable.ROW_POSITION, "data"},
+                new com.starrocks.type.Type[] {varchar, IntegerType.BIGINT, varchar});
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> new IcebergRowDeltaSink(
+                        lookupV2IcebergTable(), tuple, connectContext.getSessionVariable(), TIcebergWriteMode.APPEND));
+        assertTrue(ex.getMessage().contains("must be ROW_DELTA_UPDATE or ROW_DELTA_MIXED"));
     }
 
     @Test
@@ -442,7 +472,7 @@ public class UpdatePlanTest extends PlanTestBase {
                 new String[] {IcebergTable.ROW_POSITION, "data"},
                 new com.starrocks.type.Type[] {IntegerType.BIGINT, varchar});
         IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
-                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable());
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable(), TIcebergWriteMode.ROW_DELTA_UPDATE);
         StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class, sink::init);
         assertTrue(ex.getMessage().contains("requires _file and _pos"));
     }
@@ -455,7 +485,7 @@ public class UpdatePlanTest extends PlanTestBase {
                 new String[] {IcebergTable.FILE_PATH, "data"},
                 new com.starrocks.type.Type[] {varchar, varchar});
         IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
-                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable());
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable(), TIcebergWriteMode.ROW_DELTA_UPDATE);
         StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class, sink::init);
         assertTrue(ex.getMessage().contains("requires _file and _pos"));
     }
@@ -467,7 +497,7 @@ public class UpdatePlanTest extends PlanTestBase {
                 new String[] {IcebergTable.FILE_PATH, IcebergTable.ROW_POSITION},
                 new com.starrocks.type.Type[] {IntegerType.INT, IntegerType.BIGINT});
         IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
-                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable());
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable(), TIcebergWriteMode.ROW_DELTA_UPDATE);
         StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class, sink::init);
         assertTrue(ex.getMessage().contains("_file column must be type of VARCHAR"));
     }
@@ -480,7 +510,7 @@ public class UpdatePlanTest extends PlanTestBase {
                 new String[] {IcebergTable.FILE_PATH, IcebergTable.ROW_POSITION},
                 new com.starrocks.type.Type[] {varchar, IntegerType.INT});
         IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
-                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable());
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable(), TIcebergWriteMode.ROW_DELTA_UPDATE);
         StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class, sink::init);
         assertTrue(ex.getMessage().contains("_pos column must be type of BIGINT"));
     }
@@ -593,7 +623,7 @@ public class UpdatePlanTest extends PlanTestBase {
                 new String[] {IcebergTable.FILE_PATH, IcebergTable.ROW_POSITION, null},
                 new com.starrocks.type.Type[] {varchar, IntegerType.BIGINT, IntegerType.INT});
         IcebergRowDeltaSink sink = new IcebergRowDeltaSink(
-                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable());
+                lookupV2IcebergTable(), tuple, connectContext.getSessionVariable(), TIcebergWriteMode.ROW_DELTA_UPDATE);
         sink.init(); // must not throw
     }
 

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -257,7 +257,12 @@ struct TSchemaTableSink {
 
 enum TIcebergWriteMode {
     APPEND,
-    ROW_DELTA
+    // Iceberg row-delta UPDATE layout:
+    //   [_file, _pos, data_col1, ..., data_colN]
+    ROW_DELTA_UPDATE,
+    // Iceberg row-delta mixed-operation layout:
+    //   [_file, _pos, data_col1, ..., data_colN, op_code]
+    ROW_DELTA_MIXED
 }
 
 struct TIcebergTableSink {
@@ -271,7 +276,8 @@ struct TIcebergTableSink {
     7: optional i64 target_max_file_size
     8: optional i32 tuple_id
     9: optional string data_location
-    // write mode: ROW_DELTA for UPDATE / MERGE (mixed delete + data files)
+    // write mode: ROW_DELTA_UPDATE for pure UPDATE, ROW_DELTA_MIXED for MERGE-style
+    // mixed routing (delete / update / insert / no-op)
     10: optional TIcebergWriteMode write_mode
     // Codec for position-delete files. `compression_type` is the codec for data
     // files. Each sink populates only the field(s) it actually writes:

--- a/test/sql/test_iceberg/R/test_iceberg_update_partitioned
+++ b/test/sql/test_iceberg/R/test_iceberg_update_partitioned
@@ -1,0 +1,148 @@
+-- name: test_iceberg_update_partitioned
+create external catalog iceberg_upd_part_${uuid0}
+PROPERTIES ( "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}",
+    "enable_iceberg_metadata_cache"="false");
+-- result:
+-- !result
+create database iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_update_partitioned/${uuid0}/iceberg_update_db_${uuid0}"
+);
+-- result:
+-- !result
+create table iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders (
+    id INT,
+    product STRING,
+    amount DECIMAL(10,2),
+    status STRING,
+    order_date DATE
+) PARTITION BY (order_date) PROPERTIES ("format-version" = "2");
+-- result:
+-- !result
+INSERT INTO iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders VALUES
+    (1, 'Widget', 100.00, 'PENDING', '2024-01-01'),
+    (2, 'Gadget', 200.00, 'PENDING', '2024-01-01'),
+    (3, 'Widget', 150.00, 'SHIPPED', '2024-01-02'),
+    (4, 'Gadget', 300.00, 'PENDING', '2024-01-02'),
+    (5, 'Widget', 250.00, 'PENDING', '2024-01-03');
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders ORDER BY id;
+-- result:
+1	Widget	100.00	PENDING	2024-01-01
+2	Gadget	200.00	PENDING	2024-01-01
+3	Widget	150.00	SHIPPED	2024-01-02
+4	Gadget	300.00	PENDING	2024-01-02
+5	Widget	250.00	PENDING	2024-01-03
+-- !result
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders SET status = 'CANCELLED' WHERE order_date = '2024-01-01' AND status = 'PENDING';
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders ORDER BY id;
+-- result:
+1	Widget	100.00	CANCELLED	2024-01-01
+2	Gadget	200.00	CANCELLED	2024-01-01
+3	Widget	150.00	SHIPPED	2024-01-02
+4	Gadget	300.00	PENDING	2024-01-02
+5	Widget	250.00	PENDING	2024-01-03
+-- !result
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders SET status = 'DELIVERED' WHERE product = 'Widget';
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders ORDER BY id;
+-- result:
+1	Widget	100.00	DELIVERED	2024-01-01
+2	Gadget	200.00	CANCELLED	2024-01-01
+3	Widget	150.00	DELIVERED	2024-01-02
+4	Gadget	300.00	PENDING	2024-01-02
+5	Widget	250.00	DELIVERED	2024-01-03
+-- !result
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders SET amount = amount * 1.1 WHERE order_date = '2024-01-02';
+-- result:
+-- !result
+SELECT id, amount FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders WHERE order_date = '2024-01-02' ORDER BY id;
+-- result:
+3	165.00
+4	330.00
+-- !result
+SELECT id, amount FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders WHERE order_date = '2024-01-01' ORDER BY id;
+-- result:
+1	100.00
+2	200.00
+-- !result
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders SET order_date = '2099-01-01' WHERE id = 1;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Update for Iceberg table do not support updating partition column: order_date.')
+-- !result
+create table iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events (
+    id INT,
+    message STRING,
+    level STRING,
+    region STRING
+) PARTITION BY (region) PROPERTIES ("format-version" = "2");
+-- result:
+-- !result
+INSERT INTO iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events VALUES
+    (1, 'Login failed', 'ERROR', 'US'),
+    (2, 'Disk full', 'WARN', 'US'),
+    (3, 'Login OK', 'INFO', 'EU'),
+    (4, 'Timeout', 'ERROR', 'EU'),
+    (5, 'OOM', 'ERROR', 'APAC');
+-- result:
+-- !result
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events SET level = 'RESOLVED' WHERE region = 'US' AND level = 'ERROR';
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events ORDER BY id;
+-- result:
+1	Login failed	RESOLVED	US
+2	Disk full	WARN	US
+3	Login OK	INFO	EU
+4	Timeout	ERROR	EU
+5	OOM	ERROR	APAC
+-- !result
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events SET message = concat(message, ' [acked]') WHERE level = 'ERROR';
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events WHERE level = 'ERROR' ORDER BY id;
+-- result:
+4	Timeout [acked]	ERROR	EU
+5	OOM [acked]	ERROR	APAC
+-- !result
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders SET status = 'ARCHIVED' WHERE order_date = '2024-01-01';
+-- result:
+-- !result
+INSERT INTO iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders VALUES
+    (6, 'Gizmo', 500.00, 'PENDING', '2024-01-01');
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders WHERE order_date = '2024-01-01' ORDER BY id;
+-- result:
+1	Widget	100.00	ARCHIVED	2024-01-01
+2	Gadget	200.00	ARCHIVED	2024-01-01
+6	Gizmo	500.00	PENDING	2024-01-01
+-- !result
+drop table iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events force;
+-- result:
+-- !result
+drop table iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders force;
+-- result:
+-- !result
+drop database iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_upd_part_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_update_partitioned/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_update_unpartitioned
+++ b/test/sql/test_iceberg/R/test_iceberg_update_unpartitioned
@@ -1,0 +1,210 @@
+-- name: test_iceberg_update_unpartitioned
+create external catalog iceberg_upd_unp_${uuid0}
+PROPERTIES ( "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}",
+    "enable_iceberg_metadata_cache"="false");
+-- result:
+-- !result
+create database iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_update_unpartitioned/${uuid0}/iceberg_update_db_${uuid0}"
+);
+-- result:
+-- !result
+create table iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update (
+    id INT,
+    name STRING,
+    age INT,
+    salary BIGINT
+) PROPERTIES ("format-version" = "2");
+-- result:
+-- !result
+INSERT INTO iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update VALUES
+    (1, 'Alice', 25, 50000),
+    (2, 'Bob', 30, 60000),
+    (3, 'Charlie', 35, 70000),
+    (4, 'David', 28, 55000),
+    (5, 'Eve', 32, 65000);
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob	30	60000
+3	Charlie	35	70000
+4	David	28	55000
+5	Eve	32	65000
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'UPDATED' WHERE id = 3;
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob	30	60000
+3	UPDATED	35	70000
+4	David	28	55000
+5	Eve	32	65000
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET salary = salary + 10000 WHERE age > 30;
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob	30	60000
+3	UPDATED	35	80000
+4	David	28	55000
+5	Eve	32	75000
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'Bob_v2', age = 31 WHERE id = 2;
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob_v2	31	60000
+3	UPDATED	35	80000
+4	David	28	55000
+5	Eve	32	75000
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET salary = 99999 WHERE age >= 30 AND salary < 70000;
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob_v2	31	99999
+3	UPDATED	35	80000
+4	David	28	55000
+5	Eve	32	75000
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'BATCH_UPDATED' WHERE id IN (1, 4);
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+-- result:
+1	BATCH_UPDATED	25	50000
+2	Bob_v2	31	99999
+3	UPDATED	35	80000
+4	BATCH_UPDATED	28	55000
+5	Eve	32	75000
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'GHOST' WHERE id = 999;
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+-- result:
+1	BATCH_UPDATED	25	50000
+2	Bob_v2	31	99999
+3	UPDATED	35	80000
+4	BATCH_UPDATED	28	55000
+5	Eve	32	75000
+-- !result
+INSERT INTO iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update VALUES
+    (6, NULL, 40, 80000),
+    (7, 'Grace', NULL, 58000);
+-- result:
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'WAS_NULL' WHERE name IS NULL;
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE id IN (6, 7) ORDER BY id;
+-- result:
+6	WAS_NULL	40	80000
+7	Grace	None	58000
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET age = 0 WHERE age IS NULL;
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE id IN (6, 7) ORDER BY id;
+-- result:
+6	WAS_NULL	40	80000
+7	Grace	0	58000
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET salary = 100000 WHERE id = 1;
+-- result:
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET salary = 200000 WHERE id = 1;
+-- result:
+-- !result
+SELECT salary FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE id = 1;
+-- result:
+200000
+-- !result
+SELECT count(*) > 1 FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update$snapshots;
+-- result:
+1
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'ALL';
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Update must specify where clause to prevent full table update.')
+-- !result
+create table iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_v1 (
+    id INT, name STRING
+) PROPERTIES ("format-version" = "1");
+-- result:
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_v1 SET name = 'X' WHERE id = 1;
+-- result:
+[REGEX]E: \(1064.*UPDATE is only supported for Iceberg V2 tables.*
+-- !result
+drop table iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_v1 force;
+-- result:
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET nonexistent_col = 1 WHERE id = 1;
+-- result:
+[REGEX]E: \(1064.*do not existing column.*
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET _file = 'fake.parquet' WHERE id = 1;
+-- result:
+[REGEX]E: \(1064.*Updating metadata column.*
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = DEFAULT WHERE id = 3;
+-- result:
+[REGEX]E: \(1064.*DEFAULT value is not supported for Iceberg V2.*
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET salary = 12345 WHERE id = 1;
+-- result:
+-- !result
+SELECT id, salary FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE id = 1;
+-- result:
+1	12345
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'SUBQUERY_HIT'
+WHERE id IN (SELECT id FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE age > 35);
+-- result:
+-- !result
+SELECT id, name FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE name = 'SUBQUERY_HIT' ORDER BY id;
+-- result:
+6	SUBQUERY_HIT
+-- !result
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'TO_DELETE' WHERE id = 2;
+-- result:
+-- !result
+DELETE FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE name = 'TO_DELETE';
+-- result:
+-- !result
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE id = 2;
+-- result:
+-- !result
+drop table iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update force;
+-- result:
+-- !result
+drop database iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_upd_unp_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_update_unpartitioned/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_update_unpartitioned
+++ b/test/sql/test_iceberg/R/test_iceberg_update_unpartitioned
@@ -157,7 +157,7 @@ drop table iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_v1 force;
 -- !result
 UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET nonexistent_col = 1 WHERE id = 1;
 -- result:
-[REGEX]E: \(1064.*do not existing column.*
+[REGEX]E: \(1064.*does not have column.*
 -- !result
 UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET _file = 'fake.parquet' WHERE id = 1;
 -- result:

--- a/test/sql/test_iceberg/T/test_iceberg_update_partitioned
+++ b/test/sql/test_iceberg/T/test_iceberg_update_partitioned
@@ -1,0 +1,108 @@
+-- name: test_iceberg_update_partitioned
+
+create external catalog iceberg_upd_part_${uuid0}
+PROPERTIES ( "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}",
+    "enable_iceberg_metadata_cache"="false");
+
+create database iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_update_partitioned/${uuid0}/iceberg_update_db_${uuid0}"
+);
+
+-- ================================================
+-- SECTION 1: DATE-PARTITIONED TABLE
+-- ================================================
+
+create table iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders (
+    id INT,
+    product STRING,
+    amount DECIMAL(10,2),
+    status STRING,
+    order_date DATE
+) PARTITION BY (order_date) PROPERTIES ("format-version" = "2");
+
+INSERT INTO iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders VALUES
+    (1, 'Widget', 100.00, 'PENDING', '2024-01-01'),
+    (2, 'Gadget', 200.00, 'PENDING', '2024-01-01'),
+    (3, 'Widget', 150.00, 'SHIPPED', '2024-01-02'),
+    (4, 'Gadget', 300.00, 'PENDING', '2024-01-02'),
+    (5, 'Widget', 250.00, 'PENDING', '2024-01-03');
+
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders ORDER BY id;
+
+-- Test 1.1: UPDATE within a single partition
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders SET status = 'CANCELLED' WHERE order_date = '2024-01-01' AND status = 'PENDING';
+
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders ORDER BY id;
+
+-- Test 1.2: UPDATE across multiple partitions
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders SET status = 'DELIVERED' WHERE product = 'Widget';
+
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders ORDER BY id;
+
+-- Test 1.3: UPDATE with partition filter (should benefit from partition pruning)
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders SET amount = amount * 1.1 WHERE order_date = '2024-01-02';
+
+SELECT id, amount FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders WHERE order_date = '2024-01-02' ORDER BY id;
+
+-- Test 1.4: Verify data in unaffected partitions is unchanged
+SELECT id, amount FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders WHERE order_date = '2024-01-01' ORDER BY id;
+
+-- ================================================
+-- SECTION 2: ERROR CASES
+-- ================================================
+
+-- Test 2.1: UPDATE on partition column should fail
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders SET order_date = '2099-01-01' WHERE id = 1;
+
+-- ================================================
+-- SECTION 3: STRING-PARTITIONED TABLE
+-- ================================================
+
+create table iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events (
+    id INT,
+    message STRING,
+    level STRING,
+    region STRING
+) PARTITION BY (region) PROPERTIES ("format-version" = "2");
+
+INSERT INTO iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events VALUES
+    (1, 'Login failed', 'ERROR', 'US'),
+    (2, 'Disk full', 'WARN', 'US'),
+    (3, 'Login OK', 'INFO', 'EU'),
+    (4, 'Timeout', 'ERROR', 'EU'),
+    (5, 'OOM', 'ERROR', 'APAC');
+
+-- Test 3.1: UPDATE within one partition
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events SET level = 'RESOLVED' WHERE region = 'US' AND level = 'ERROR';
+
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events ORDER BY id;
+
+-- Test 3.2: UPDATE across all partitions
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events SET message = concat(message, ' [acked]') WHERE level = 'ERROR';
+
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events WHERE level = 'ERROR' ORDER BY id;
+
+-- ================================================
+-- SECTION 4: UPDATE + INSERT + SELECT interleaved
+-- ================================================
+
+UPDATE iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders SET status = 'ARCHIVED' WHERE order_date = '2024-01-01';
+
+INSERT INTO iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders VALUES
+    (6, 'Gizmo', 500.00, 'PENDING', '2024-01-01');
+
+SELECT * FROM iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders WHERE order_date = '2024-01-01' ORDER BY id;
+
+-- Cleanup
+drop table iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.events force;
+drop table iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0}.orders force;
+drop database iceberg_upd_part_${uuid0}.iceberg_update_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_upd_part_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_update_partitioned/${uuid0} >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_iceberg/T/test_iceberg_update_unpartitioned
+++ b/test/sql/test_iceberg/T/test_iceberg_update_unpartitioned
@@ -1,0 +1,159 @@
+-- name: test_iceberg_update_unpartitioned
+
+create external catalog iceberg_upd_unp_${uuid0}
+PROPERTIES ( "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}",
+    "enable_iceberg_metadata_cache"="false");
+
+create database iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_update_unpartitioned/${uuid0}/iceberg_update_db_${uuid0}"
+);
+
+-- Create non-partitioned V2 table
+create table iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update (
+    id INT,
+    name STRING,
+    age INT,
+    salary BIGINT
+) PROPERTIES ("format-version" = "2");
+
+-- Insert initial data
+INSERT INTO iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update VALUES
+    (1, 'Alice', 25, 50000),
+    (2, 'Bob', 30, 60000),
+    (3, 'Charlie', 35, 70000),
+    (4, 'David', 28, 55000),
+    (5, 'Eve', 32, 65000);
+
+-- Verify initial data
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+
+-- ================================================
+-- Test 1: Basic single-column UPDATE
+-- ================================================
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'UPDATED' WHERE id = 3;
+
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+
+-- ================================================
+-- Test 2: UPDATE with expression in SET
+-- ================================================
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET salary = salary + 10000 WHERE age > 30;
+
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+
+-- ================================================
+-- Test 3: Multi-column UPDATE
+-- ================================================
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'Bob_v2', age = 31 WHERE id = 2;
+
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+
+-- ================================================
+-- Test 4: UPDATE with complex WHERE conditions
+-- ================================================
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET salary = 99999 WHERE age >= 30 AND salary < 70000;
+
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+
+-- ================================================
+-- Test 5: UPDATE with IN clause
+-- ================================================
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'BATCH_UPDATED' WHERE id IN (1, 4);
+
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+
+-- ================================================
+-- Test 6: UPDATE that matches no rows (should succeed with 0 affected)
+-- ================================================
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'GHOST' WHERE id = 999;
+
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update ORDER BY id;
+
+-- ================================================
+-- Test 7: UPDATE with NULL values
+-- ================================================
+INSERT INTO iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update VALUES
+    (6, NULL, 40, 80000),
+    (7, 'Grace', NULL, 58000);
+
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'WAS_NULL' WHERE name IS NULL;
+
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE id IN (6, 7) ORDER BY id;
+
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET age = 0 WHERE age IS NULL;
+
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE id IN (6, 7) ORDER BY id;
+
+-- ================================================
+-- Test 8: UPDATE followed by another UPDATE on same rows
+-- ================================================
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET salary = 100000 WHERE id = 1;
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET salary = 200000 WHERE id = 1;
+
+SELECT salary FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE id = 1;
+
+-- ================================================
+-- Test 9: Verify snapshot is created after UPDATE
+-- ================================================
+SELECT count(*) > 1 FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update$snapshots;
+
+-- ================================================
+-- Error tests
+-- ================================================
+
+-- Test E1: UPDATE without WHERE should fail
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'ALL';
+
+-- Test E2: UPDATE on V1 table should fail
+create table iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_v1 (
+    id INT, name STRING
+) PROPERTIES ("format-version" = "1");
+
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_v1 SET name = 'X' WHERE id = 1;
+
+drop table iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_v1 force;
+
+-- Test E3: UPDATE non-existent column should fail
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET nonexistent_col = 1 WHERE id = 1;
+
+-- Test E4: UPDATE hidden metadata column should fail
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET _file = 'fake.parquet' WHERE id = 1;
+
+-- Test E5: SET col = DEFAULT not supported on Iceberg V2
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = DEFAULT WHERE id = 3;
+
+-- ================================================
+-- Test 12: Type cast — SET string literal to match column type
+-- ================================================
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET salary = 12345 WHERE id = 1;
+
+SELECT id, salary FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE id = 1;
+
+-- ================================================
+-- Test 13: UPDATE with subquery in WHERE
+-- ================================================
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'SUBQUERY_HIT'
+WHERE id IN (SELECT id FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE age > 35);
+
+SELECT id, name FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE name = 'SUBQUERY_HIT' ORDER BY id;
+
+-- ================================================
+-- Test 14: UPDATE followed by DELETE on same table
+-- ================================================
+UPDATE iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update SET name = 'TO_DELETE' WHERE id = 2;
+DELETE FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE name = 'TO_DELETE';
+
+SELECT * FROM iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update WHERE id = 2;
+
+-- Cleanup
+drop table iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0}.t_update force;
+drop database iceberg_upd_unp_${uuid0}.iceberg_update_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_upd_unp_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_update_unpartitioned/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:

This is step 3 of the Iceberg UPDATE rollout. It brings the feature to a usable state by implementing the commit path with end-to-end coverage, fixing two issues found during integration, and responding to review feedback by decoupling the row-delta routing protocol from the analyzer's SELECT output.

## What I'm doing:

We covered the following aspects in this PR:

-  Implements the RowDelta atomic snapshot (position-delete files + new data files in a single commit), wires up partition / exchange handling for partitioned tables, and adds SQL integration coverage.

- Use the actually-validated snapshot id rather than the latest at commit time, preventing false serialization-isolation failures under concurrent writers.

- Reject unsupported codecs up front rather than during write; clean up an error message produced by the UPDATE analyzer.

- Decouple Iceberg row-delta routing from analyzer SELECT output. We split `TIcebergWriteMode` into `ROW_DELTA_UPDATE` / `ROW_DELTA_MIXED`. UPDATE no longer carries the `op_code` literal in its SELECT output; the BE row-delta sink defaults to "all rows are UPDATE" when no routing column is configured. MERGE-style per-row routing is preserved for the next step (mixed mode requires a trailing TINYINT `op_code` column). See the appendix below for the rationale and compatibility analysis.

Notes：
1. We decouple Iceberg row-delta routing from analyzer SELECT output

The earlier iteration appended `2 AS op_code` to the analyzer's SELECT output so the BE row-delta sink could read each row's operation from the trailing column. Review feedback raised that this **mixes a sink-internal routing protocol into the query output layout**:

- It contradicts the precedent set by `IcebergDeleteSink`, which derives the operation from the sink type itself and needs no per-row marker.
- The column carries no data the user asked for; it is a side channel for routing that happens to ride on the SELECT output.
- If not careful, it might be pruned out by some new optimization rules later on.

The new design moves the routing declaration into the sink's write-mode:

- **Pure UPDATE** (every row is delete-old + write-new): the analyzer emits a clean `[_file, _pos, data_cols...]` tuple and the planner sets `write_mode = ROW_DELTA_UPDATE`. BE forwards every chunk to both sub-sinks without scanning any routing column.
- **Mixed routing** (reserved for MERGE): the planner injects an `op_code` column as a **sink-private physical projection** and sets `write_mode = ROW_DELTA_MIXED`. Because the planner registers the column as part of the sink's input tuple (so column pruning cannot remove it) and Thrift write_mode = ROW_DELTA_MIXED declares the layout convention that BE then validates (trailing TINYINT slot required, otherwise Status::InternalError).

2. The Thrift change is safe for compatibility

(1). **The Iceberg UPDATE feature has not been released**, so there are no historical query plans, no persisted state, and no production deployments speaking the old wire enum.
(2). **Even if a stale plan reached a new BE**, no silent miswriting is possible. `create_row_delta_sink_context` explicitly validates the tuple layout against `write_mode`: `ROW_DELTA_UPDATE` requires no `op_code` column, `ROW_DELTA_MIXED` requires a trailing TINYINT `op_code` column, and any mismatch returns `Status::InternalError` before any rows are written.

Fixes: https://github.com/StarRocks/starrocks/issues/72046
StarrocksTest: https://github.com/StarRocks/StarRocksTest/pull/11258

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
