### PR TITLE
[Enhancement] Reserve proto/thrift fields for external cluster snapshot feature

### DIFF
--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -313,7 +313,7 @@ message RestoreSnapshotsResponse {
     optional int32 pad = 1;
 }
 
-// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+// Placeholder for external cluster snapshot feature.
 message TabletDataSnapshotPB {
     optional int64 tablet_id = 1;
     repeated string new_data_files = 2;
@@ -321,7 +321,7 @@ message TabletDataSnapshotPB {
     repeated string new_schema_files = 4;
 }
 
-// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+// Placeholder for external cluster snapshot feature.
 message UploadSnapshotFilesRequestPB {
     optional int64 job_id = 1;
     optional int64 db_id = 2;
@@ -332,7 +332,7 @@ message UploadSnapshotFilesRequestPB {
     repeated TabletDataSnapshotPB tablet_snapshots = 7;
 }
 
-// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+// Placeholder for external cluster snapshot feature.
 message UploadSnapshotFilesResponsePB {
     optional StatusPB status = 1;
     repeated int64 failed_tablets = 2;
@@ -539,7 +539,7 @@ service LakeService {
     rpc drop_tablet_cache(DropTabletCacheRequest) returns (DropTabletCacheResponse);
     rpc get_tablet_metadatas(GetTabletMetadatasRequest) returns (GetTabletMetadatasResponse);
     rpc repair_tablet_metadata(RepairTabletMetadataRequest) returns (RepairTabletMetadataResponse);
-    // Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+    // Placeholder for external cluster snapshot feature.
     rpc upload_snapshot_files(UploadSnapshotFilesRequestPB) returns (UploadSnapshotFilesResponsePB);
     rpc build_vector_index(BuildVectorIndexRequest) returns (BuildVectorIndexResponse);
 }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -313,6 +313,31 @@ message RestoreSnapshotsResponse {
     optional int32 pad = 1;
 }
 
+// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+message TabletDataSnapshotPB {
+    optional int64 tablet_id = 1;
+    repeated string new_data_files = 2;
+    repeated string new_metadata_files = 3;
+    repeated string new_schema_files = 4;
+}
+
+// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+message UploadSnapshotFilesRequestPB {
+    optional int64 job_id = 1;
+    optional int64 db_id = 2;
+    optional int64 table_id = 3;
+    optional int64 partition_id = 4;
+    optional int64 physical_partition_id = 5;
+    optional int64 dest_tablet_id = 6;
+    repeated TabletDataSnapshotPB tablet_snapshots = 7;
+}
+
+// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+message UploadSnapshotFilesResponsePB {
+    optional StatusPB status = 1;
+    repeated int64 failed_tablets = 2;
+}
+
 message AbortCompactionRequest {
     optional int64 txn_id = 1;
 }
@@ -514,5 +539,7 @@ service LakeService {
     rpc drop_tablet_cache(DropTabletCacheRequest) returns (DropTabletCacheResponse);
     rpc get_tablet_metadatas(GetTabletMetadatasRequest) returns (GetTabletMetadatasResponse);
     rpc repair_tablet_metadata(RepairTabletMetadataRequest) returns (RepairTabletMetadataResponse);
+    // Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+    rpc upload_snapshot_files(UploadSnapshotFilesRequestPB) returns (UploadSnapshotFilesResponsePB);
     rpc build_vector_index(BuildVectorIndexRequest) returns (BuildVectorIndexResponse);
 }

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -412,7 +412,7 @@ message TxnInfoPB {
     optional bool rebuild_pindex = 6;
     optional int64 gtid = 7 [default=0];
     repeated PUniqueId load_ids = 8;
-    // Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+    // Placeholder for external cluster snapshot feature.
     optional bool restore_force_publish = 9; // Txn from snapshot restore, publish directly succeed
     optional int64 restore_gtid = 10;
     // Number of leading sort-key columns that participate in the table's range
@@ -448,7 +448,7 @@ message ReshardingTabletInfoPB {
     optional IdenticalTabletInfoPB identical_tablet_info = 3;
 }
 
-// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+// Placeholder for external cluster snapshot feature.
 message ExternalClusterSnapshotLogPB {
     optional int64 job_id = 1;
     optional int64 db_id = 2;

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -412,6 +412,9 @@ message TxnInfoPB {
     optional bool rebuild_pindex = 6;
     optional int64 gtid = 7 [default=0];
     repeated PUniqueId load_ids = 8;
+    // Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+    optional bool restore_force_publish = 9; // Txn from snapshot restore, publish directly succeed
+    optional int64 restore_gtid = 10;
     // Number of leading sort-key columns that participate in the table's range
     // colocate group. Only used by tablet split (TXN_TABLET_RESHARD with split
     // direction). 0 (default) = legacy / non-colocate-aware split. BE uses this
@@ -443,4 +446,16 @@ message ReshardingTabletInfoPB {
     optional SplittingTabletInfoPB splitting_tablet_info = 1;
     optional MergingTabletInfoPB merging_tablet_info = 2;
     optional IdenticalTabletInfoPB identical_tablet_info = 3;
+}
+
+// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+message ExternalClusterSnapshotLogPB {
+    optional int64 job_id = 1;
+    optional int64 db_id = 2;
+    optional int64 table_id = 3;
+    optional int64 partition_id = 4;
+    optional int64 physical_partition_id = 5;
+    repeated string delete_data_files = 6;
+    repeated string delete_meta_files = 7;
+    repeated string delete_schema_files = 8;
 }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -459,18 +459,48 @@ struct TReplicateSnapshotRequest {
     20: optional string src_partition_full_path
 }
 
+// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+struct TComputeNodeTablets {
+    1: optional Types.TBackend compute_node
+    2: optional list<Types.TTabletId> tablets
+}
+
+// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+// NOTE: this struct overwrites a prior OSS placeholder (which had fields 9/10 as
+// src_tablets/compute_nodes); the prior version was never wired into any OSS code
+// path. Aligning ordinals 9..11 with enterprise to keep the wire format 1:1.
 struct TExternalClusterSnapshotRequest {
-    1: optional i64 job_id // ExternalClusterSnapshot job id
+    1: optional i64 job_id
     2: optional i64 db_id
     3: optional Types.TTableId table_id
     4: optional Types.TPartitionId partition_id
     5: optional Types.TPartitionId physical_partition_id
     6: optional Types.TVersion pre_version
     7: optional Types.TVersion new_version
-    8: optional Types.TTabletId dest_tablet_id // tablet id of the target storage volume
-    9: optional list<Types.TTabletId> src_tablets // tablets need to file synchronization
-    10: optional list<Types.TBackend> compute_nodes  // candidate cn to do file sync
- }
+    8: optional Types.TTabletId dest_tablet_id
+    9: optional bool is_filebundling
+    10: required bool is_drop_partition
+    11: optional list<TComputeNodeTablets> compute_node_tablets
+}
+
+// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+struct TRestoreTabletInfo {
+    1: optional Types.TTabletId source_tablet_id
+    2: optional Types.TTabletId target_tablet_id
+    3: optional i64 target_schema_id
+}
+
+// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+struct TRestoreTabletRequest {
+    1: optional list<TRestoreTabletInfo> tablet_infos
+    2: optional i64 source_visible_version
+}
+
+// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+struct TRestoreTabletResult {
+     1: optional bool success
+     2: optional string error_msg
+}
 
 enum TTabletMetaType {
     PARTITIONID,
@@ -558,6 +588,8 @@ struct TAgentTaskRequest {
     31: optional TUpdateSchemaReq update_schema_req
     32: optional TCompactionControlReq compaction_control_req
     33: optional TExternalClusterSnapshotRequest external_cluster_snapshot_req
+    // Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+    34: optional TRestoreTabletRequest restore_tablet_req
 }
 
 struct TAgentResult {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -459,16 +459,15 @@ struct TReplicateSnapshotRequest {
     20: optional string src_partition_full_path
 }
 
-// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+// Placeholder for external cluster snapshot feature.
 struct TComputeNodeTablets {
     1: optional Types.TBackend compute_node
     2: optional list<Types.TTabletId> tablets
 }
 
-// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
-// NOTE: this struct overwrites a prior OSS placeholder (which had fields 9/10 as
-// src_tablets/compute_nodes); the prior version was never wired into any OSS code
-// path. Aligning ordinals 9..11 with enterprise to keep the wire format 1:1.
+// Placeholder for external cluster snapshot feature.
+// NOTE: fields 9-11 replace a prior placeholder definition (src_tablets/compute_nodes
+// at 9/10) that was never wired into any code path.
 struct TExternalClusterSnapshotRequest {
     1: optional i64 job_id
     2: optional i64 db_id
@@ -483,20 +482,20 @@ struct TExternalClusterSnapshotRequest {
     11: optional list<TComputeNodeTablets> compute_node_tablets
 }
 
-// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+// Placeholder for external cluster snapshot feature.
 struct TRestoreTabletInfo {
     1: optional Types.TTabletId source_tablet_id
     2: optional Types.TTabletId target_tablet_id
     3: optional i64 target_schema_id
 }
 
-// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+// Placeholder for external cluster snapshot feature.
 struct TRestoreTabletRequest {
     1: optional list<TRestoreTabletInfo> tablet_infos
     2: optional i64 source_visible_version
 }
 
-// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+// Placeholder for external cluster snapshot feature.
 struct TRestoreTabletResult {
      1: optional bool success
      2: optional string error_msg
@@ -588,7 +587,7 @@ struct TAgentTaskRequest {
     31: optional TUpdateSchemaReq update_schema_req
     32: optional TCompactionControlReq compaction_control_req
     33: optional TExternalClusterSnapshotRequest external_cluster_snapshot_req
-    // Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+    // Placeholder for external cluster snapshot feature.
     34: optional TRestoreTabletRequest restore_tablet_req
 }
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -479,7 +479,7 @@ struct TExternalClusterSnapshotRequest {
     7: optional Types.TVersion new_version
     8: optional Types.TTabletId dest_tablet_id
     9: optional bool is_filebundling
-    10: required bool is_drop_partition
+    10: optional bool is_drop_partition
     11: optional list<TComputeNodeTablets> compute_node_tablets
 }
 

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -94,7 +94,7 @@ struct TFinishTaskRequest {
     17: optional list<TTabletVersionPair> tablet_versions;
     18: optional list<TTabletVersionPair> tablet_publish_versions;
     19: optional Types.TSnapshotInfo snapshot_info
-    // Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+    // Placeholder for external cluster snapshot feature.
     20: optional Types.TClusterSnapshotPartitionSpec cluster_snapshot_partition_spec
     21: optional AgentService.TRestoreTabletResult restore_tablet_result
 }

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -94,6 +94,9 @@ struct TFinishTaskRequest {
     17: optional list<TTabletVersionPair> tablet_versions;
     18: optional list<TTabletVersionPair> tablet_publish_versions;
     19: optional Types.TSnapshotInfo snapshot_info
+    // Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+    20: optional Types.TClusterSnapshotPartitionSpec cluster_snapshot_partition_spec
+    21: optional AgentService.TRestoreTabletResult restore_tablet_result
 }
 
 struct TTablet {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -220,7 +220,7 @@ enum TTaskType {
     UPDATE_SCHEMA,
     COMPACTION_CONTROL,
     EXTERNAL_CLUSTER_SNAPSHOT,
-    // Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+    // Placeholder for external cluster snapshot feature.
     TABLET_RESTORE,
     NUM_TASK_TYPE
 }
@@ -632,7 +632,7 @@ struct TSnapshotInfo {
     3: optional bool incremental_snapshot
 }
 
-// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+// Placeholder for external cluster snapshot feature.
 struct TClusterSnapshotPartitionSpec {
     1: optional i64 db_id
     2: optional i64 table_id

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -220,6 +220,8 @@ enum TTaskType {
     UPDATE_SCHEMA,
     COMPACTION_CONTROL,
     EXTERNAL_CLUSTER_SNAPSHOT,
+    // Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+    TABLET_RESTORE,
     NUM_TASK_TYPE
 }
 
@@ -628,6 +630,14 @@ struct TSnapshotInfo {
     1: optional TBackend backend
     2: optional string snapshot_path
     3: optional bool incremental_snapshot
+}
+
+// Reserved for enterprise external cluster snapshot feature; OSS implementation TBD.
+struct TClusterSnapshotPartitionSpec {
+    1: optional i64 db_id
+    2: optional i64 table_id
+    3: optional i64 partition_id
+    4: optional i64 physical_partition_id
 }
 
 enum TTxnType {


### PR DESCRIPTION
## Why I'm doing:
Reserve proto/thrift fields for external cluster snapshot feature


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
