### PR TITLE
[BugFix] Filter resource groups by warehouse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
@@ -127,8 +127,12 @@ public class ResourceGroupClassifier {
         return planMemCostRange;
     }
 
-    public boolean isSatisfied(String user, List<String> activeRoles, QueryType queryType, String sourceIp,
-                               Set<Long> dbIds, double planCpuCost, double planMemCost) {
+    public boolean isSatisfied(Set<Long> candidateResourceGroupIds, String user, List<String> activeRoles,
+                               QueryType queryType, String sourceIp, Set<Long> dbIds, double planCpuCost,
+                               double planMemCost) {
+        if (candidateResourceGroupIds != null && !candidateResourceGroupIds.contains(resourceGroupId)) {
+            return false;
+        }
         if (!isVisible(user, activeRoles, sourceIp)) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -762,6 +762,9 @@ public class ResourceGroupMgr implements Writable {
      * @return the TWorkGroupOp that may be marked as inactive
      */
     private TWorkGroupOp setInactiveOp(TWorkGroupOp op, String warehouseName) {
+        if (ResourceGroup.BUILTIN_WG_NAMES.contains(op.getWorkgroup().getName())) {
+            return op;
+        }
         List<String> warehouses = op.getWorkgroup().getWarehouses();
         if (warehouseName == null || warehouses == null || warehouses.isEmpty() || warehouses.contains(warehouseName)) {
             return op;
@@ -833,11 +836,22 @@ public class ResourceGroupMgr implements Writable {
         }
     }
 
-    public TWorkGroup chooseResourceGroupByName(String wgName) {
+    private boolean isResourceGroupMatchWarehouse(ResourceGroup rg, String warehouseName) {
+        if (ResourceGroup.BUILTIN_WG_NAMES.contains(rg.getName())) {
+            return true;
+        }
+        List<String> warehouses = rg.getWarehouses();
+        return warehouses == null || warehouses.isEmpty() || warehouses.contains(warehouseName);
+    }
+
+    public TWorkGroup chooseResourceGroupByName(ConnectContext ctx, String wgName) {
         readLock();
         try {
             ResourceGroup rg = resourceGroupMap.get(wgName);
             if (rg == null) {
+                return null;
+            }
+            if (ctx != null && !isResourceGroupMatchWarehouse(rg, ctx.getCurrentWarehouseName())) {
                 return null;
             }
             return rg.toThrift();
@@ -846,11 +860,14 @@ public class ResourceGroupMgr implements Writable {
         }
     }
 
-    public TWorkGroup chooseResourceGroupByID(long wgID) {
+    public TWorkGroup chooseResourceGroupByID(ConnectContext ctx, long wgID) {
         readLock();
         try {
             ResourceGroup rg = id2ResourceGroupMap.get(wgID);
             if (rg == null) {
+                return null;
+            }
+            if (ctx != null && !isResourceGroupMatchWarehouse(rg, ctx.getCurrentWarehouseName())) {
                 return null;
             }
             return rg.toThrift();
@@ -866,15 +883,21 @@ public class ResourceGroupMgr implements Writable {
         try {
             String user = getUnqualifiedUser(ctx);
             String remoteIp = ctx.getRemoteIP();
+            String warehouseName = ctx.getCurrentWarehouseName();
             final double planCpuCost = ctx.getAuditEventBuilder().build().planCpuCosts;
             final double planMemCost = CostPredictor.getServiceBasedCostPredictor().isAvailable() ?
                     ctx.getAuditEventBuilder().build().predictMemBytes :
                     ctx.getAuditEventBuilder().build().planMemCosts;
+            Set<Long> candidateGroupIds = resourceGroupMap.values().stream()
+                    .filter(rg -> isResourceGroupMatchWarehouse(rg, warehouseName))
+                    .map(ResourceGroup::getId)
+                    .collect(Collectors.toSet());
 
             // check short query first
             if (shortQueryResourceGroup != null) {
                 List<ResourceGroupClassifier> shortQueryClassifierList = shortQueryResourceGroup.classifiers.stream()
-                        .filter(f -> f.isSatisfied(user, activeRoles, queryType, remoteIp, databases, planCpuCost, planMemCost))
+                        .filter(f -> f.isSatisfied(candidateGroupIds, user, activeRoles, queryType, remoteIp,
+                                databases, planCpuCost, planMemCost))
                         .sorted(Comparator.comparingDouble(ResourceGroupClassifier::weight))
                         .collect(Collectors.toList());
                 if (!shortQueryClassifierList.isEmpty()) {
@@ -884,8 +907,8 @@ public class ResourceGroupMgr implements Writable {
 
             List<ResourceGroupClassifier> classifierList =
                     classifierMap.values().stream()
-                            .filter(f -> f.isSatisfied(user, activeRoles, queryType, remoteIp, databases, planCpuCost,
-                                    planMemCost))
+                            .filter(f -> f.isSatisfied(candidateGroupIds, user, activeRoles, queryType,
+                                    remoteIp, databases, planCpuCost, planMemCost))
                             .sorted(Comparator.comparingDouble(ResourceGroupClassifier::weight))
                             .collect(Collectors.toList());
             if (classifierList.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -150,7 +150,7 @@ public class CoordinatorPreprocessor {
     private WorkerProvider.Factory newWorkerProviderFactory() {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
         boolean skipBlackList = sessionVariable.isSkipBlackList();
-        
+
         if (RunMode.isSharedDataMode()) {
             BlacklistBackupRoutingPolicy blacklistBackupRoutingPolicy =
                     sessionVariable.getBlacklistBackupRoutingPolicy();
@@ -350,13 +350,13 @@ public class CoordinatorPreprocessor {
         // 1. try to use the resource group specified by the variable
         if (StringUtils.isNotEmpty(sessionVariable.getResourceGroup())) {
             String rgName = sessionVariable.getResourceGroup();
-            resourceGroup = resourceGroupMgr.chooseResourceGroupByName(rgName);
+            resourceGroup = resourceGroupMgr.chooseResourceGroupByName(connect, rgName);
         }
 
         // 2. try to use the resource group specified by workgroup_id
         long workgroupId = connect.getSessionVariable().getResourceGroupId();
         if (resourceGroup == null && workgroupId > 0) {
-            resourceGroup = resourceGroupMgr.chooseResourceGroupByID(workgroupId);
+            resourceGroup = resourceGroupMgr.chooseResourceGroupByID(connect, workgroupId);
         }
 
         // 3. if the specified resource group not exist try to use the default one
@@ -366,7 +366,7 @@ public class CoordinatorPreprocessor {
         }
 
         if (resourceGroup == null) {
-            resourceGroup = resourceGroupMgr.chooseResourceGroupByName(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME);
+            resourceGroup = resourceGroupMgr.chooseResourceGroupByName(connect, ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME);
         }
 
         if (resourceGroup != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
@@ -405,6 +405,12 @@ public class ResourceGroupAnalyzer {
                         "'big_query_mem_limit', 'big_query_scan_rows_limit','big_query_cpu_second_limit'," +
                         "'spill_mem_limit_threshold','warehouses') should be specified");
             }
+
+            List<String> warehouses = tempResourceGroup.getWarehouses();
+            if (ResourceGroup.BUILTIN_WG_NAMES.contains(name) && warehouses != null && !warehouses.isEmpty()) {
+                throw new SemanticException(
+                        String.format("cannot set non-empty warehouses for builtin resource group [%s]", name));
+            }
         }
 
         // Validate builtin resource group constraints

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -199,7 +199,7 @@ public class SetStmtAnalyzer {
             String rgName = resolvedExpression.getStringValue();
             if (!StringUtils.isEmpty(rgName)) {
                 TWorkGroup wg =
-                        GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByName(rgName);
+                        GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByName(null, rgName);
                 if (wg == null) {
                     throw new SemanticException("resource group not exists: " + rgName);
                 }
@@ -209,7 +209,7 @@ public class SetStmtAnalyzer {
             long rgID = resolvedExpression.getLongValue();
             if (rgID > 0) {
                 TWorkGroup wg =
-                        GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByID(rgID);
+                        GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByID(null, rgID);
                 if (wg == null) {
                     throw new SemanticException("resource group not exists: " + rgID);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -5,11 +5,13 @@ import com.google.common.collect.ImmutableSet;
 import com.staros.util.LockCloseable;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.ResourceGroupClassifier;
+import com.starrocks.catalog.ResourceGroupMgr;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.persist.DropWarehouseLog;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.CoordinatorPreprocessor;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
@@ -17,6 +19,7 @@ import com.starrocks.sql.analyzer.ResourceGroupAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TWorkGroup;
+import com.starrocks.thrift.TWorkGroupOp;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.DefaultWarehouse;
@@ -28,6 +31,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -565,6 +569,131 @@ public class ResourceGroupStmtTest {
                 null);
         Assertions.assertEquals("rg1", wg.getName());
         dropResourceGroups();
+    }
+
+    @Test
+    public void testChooseResourceGroupFiltersByCurrentWarehouse() throws Exception {
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        warehouseManager.addWarehouse(new DefaultWarehouse(2, "wh2"));
+        BackendResourceStat.getInstance().setNumCoresOfBe(2, 2, 32);
+
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String qualifiedUser = "rg1_user1";
+        ctx.setQualifiedUser(qualifiedUser);
+        ctx.setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));
+        ctx.setCurrentRoleIds(
+                ctx.getGlobalStateMgr().getAuthorizationMgr().getRoleIdsByUser(new UserIdentity(qualifiedUser, "%"))
+        );
+        ctx.setRemoteIP("192.168.88.9");
+
+        try {
+            // Case 1: no resource group has warehouses property, so normal classifier matching still works.
+            starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rg_auto_global\n" +
+                    "TO (user='rg1_user1')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'cpu_weight' = '10'" +
+                    ");");
+
+            ctx.setCurrentWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+                    ctx, ResourceGroupClassifier.QueryType.SELECT, null);
+            Assertions.assertEquals("rg_auto_global", wg.getName());
+
+            // Case 2: current warehouse is wh2, so a resource group whose warehouses contains wh2 is eligible.
+            starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rg_auto_wh2\n" +
+                    "TO (user='rg1_user1', source_ip='192.168.88.1/24')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'warehouses' = 'wh2'," +
+                    "   'cpu_weight_percent' = '20'" +
+                    ");");
+
+            ctx.setCurrentWarehouse("wh2");
+            wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+                    ctx, ResourceGroupClassifier.QueryType.SELECT, null);
+            Assertions.assertEquals("rg_auto_wh2", wg.getName());
+
+            // Case 3: current warehouse is default_warehouse, so the wh2-only resource group is filtered out.
+            ctx.setCurrentWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+                    ctx, ResourceGroupClassifier.QueryType.SELECT, null);
+            Assertions.assertEquals("rg_auto_global", wg.getName());
+
+            // Case 4: current warehouse is explicitly listed in warehouses, so that resource group is eligible.
+            starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rg_auto_default_warehouse\n" +
+                    "TO (user='rg1_user1', source_ip='192.168.88.1/24')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'warehouses' = 'default_warehouse'," +
+                    "   'cpu_weight_percent' = '20'" +
+                    ");");
+
+            wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+                    ctx, ResourceGroupClassifier.QueryType.SELECT, null);
+            Assertions.assertEquals("rg_auto_default_warehouse", wg.getName());
+
+            // Case 5: empty warehouses is treated as global and still participates in classifier ranking.
+            starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rg_auto_empty_warehouses\n" +
+                    "TO (user='rg1_user1', source_ip='192.168.88.1/24', query_type in ('select'))\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'warehouses' = ''," +
+                    "   'exclusive_cpu_percent' = '10'" +
+                    ");");
+
+            wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+                    ctx, ResourceGroupClassifier.QueryType.SELECT, null);
+            Assertions.assertEquals("rg_auto_empty_warehouses", wg.getName());
+        } finally {
+            starRocksAssert.getCtx().setCurrentWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP IF EXISTS rg_auto_empty_warehouses");
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP IF EXISTS rg_auto_default_warehouse");
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP IF EXISTS rg_auto_wh2");
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP IF EXISTS rg_auto_global");
+            warehouseManager.replayDropWarehouse(new DropWarehouseLog("wh2"));
+        }
+    }
+
+    @Test
+    public void testChooseResourceGroupByNameAndIdFiltersByCurrentWarehouse() throws Exception {
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        warehouseManager.addWarehouse(new DefaultWarehouse(2, "wh2"));
+        BackendResourceStat.getInstance().setNumCoresOfBe(2, 2, 32);
+
+        try {
+            ConnectContext ctx = starRocksAssert.getCtx();
+            ResourceGroupMgr resourceGroupMgr = GlobalStateMgr.getCurrentState().getResourceGroupMgr();
+            starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rg_by_name_id_wh2\n" +
+                    "TO (user='rg1_user1')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'warehouses' = 'wh2'," +
+                    "   'cpu_weight_percent' = '20'" +
+                    ");");
+
+            long rgId = resourceGroupMgr.getResourceGroup("rg_by_name_id_wh2").getId();
+
+            // Case 1: null ConnectContext ignores warehouses, matching SET resource_group analysis behavior.
+            Assertions.assertNotNull(resourceGroupMgr.chooseResourceGroupByName(null, "rg_by_name_id_wh2"));
+            Assertions.assertNotNull(resourceGroupMgr.chooseResourceGroupByID(null, rgId));
+
+            // Case 2: current warehouse is default_warehouse, so the wh2-only resource group is filtered out.
+            ctx.setCurrentWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            Assertions.assertNull(resourceGroupMgr.chooseResourceGroupByName(ctx, "rg_by_name_id_wh2"));
+            Assertions.assertNull(resourceGroupMgr.chooseResourceGroupByID(ctx, rgId));
+
+            // Case 3: current warehouse is wh2, so the wh2-only resource group is eligible by name and id.
+            ctx.setCurrentWarehouse("wh2");
+            Assertions.assertEquals("rg_by_name_id_wh2",
+                    resourceGroupMgr.chooseResourceGroupByName(ctx, "rg_by_name_id_wh2").getName());
+            Assertions.assertEquals("rg_by_name_id_wh2",
+                    resourceGroupMgr.chooseResourceGroupByID(ctx, rgId).getName());
+        } finally {
+            starRocksAssert.getCtx().setCurrentWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP IF EXISTS rg_by_name_id_wh2");
+            warehouseManager.replayDropWarehouse(new DropWarehouseLog("wh2"));
+        }
     }
 
     @Test
@@ -2111,6 +2240,82 @@ public class ResourceGroupStmtTest {
             assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|null|80.0%|0|0|0|null|80%|(weight=0.0)|\n" +
                     "default_wg|100|null|100.0%|0|0|0|null|100%|(weight=0.0)|");
         }
+    }
+
+    @Test
+    public void testAlterBuiltinGroupRejectsNonEmptyWarehouses() throws Exception {
+        assertThatThrownBy(() -> starRocksAssert.executeResourceGroupDdlSql(
+                "ALTER RESOURCE GROUP default_wg WITH ('warehouses' = 'default_warehouse')"))
+                .isInstanceOf(SemanticException.class)
+                .hasMessageContaining("cannot set non-empty warehouses for builtin resource group [default_wg]");
+
+        assertThatThrownBy(() -> starRocksAssert.executeResourceGroupDdlSql(
+                "ALTER RESOURCE GROUP default_mv_wg WITH ('warehouses' = 'default_warehouse')"))
+                .isInstanceOf(SemanticException.class)
+                .hasMessageContaining("cannot set non-empty warehouses for builtin resource group [default_mv_wg]");
+
+        starRocksAssert.executeResourceGroupDdlSql("ALTER RESOURCE GROUP default_wg WITH ('warehouses' = '')");
+        starRocksAssert.executeResourceGroupDdlSql("ALTER RESOURCE GROUP default_mv_wg WITH ('warehouses' = '')");
+    }
+
+    @Test
+    public void testLegacyBuiltinGroupWarehousesDoNotBlockDefaultFallback() {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        ResourceGroupMgr resourceGroupMgr = GlobalStateMgr.getCurrentState().getResourceGroupMgr();
+        ResourceGroup defaultWg = resourceGroupMgr
+                .getResourceGroup(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME);
+        ResourceGroup defaultMvWg = resourceGroupMgr
+                .getResourceGroup(ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME);
+        List<String> originalWarehouses = defaultWg.getWarehouses();
+        List<String> originalMvWarehouses = defaultMvWg.getWarehouses();
+        try {
+            ctx.setCurrentWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+            defaultWg.setWarehouses(Collections.singletonList("legacy_wh"));
+            defaultMvWg.setWarehouses(Collections.singletonList("legacy_wh"));
+
+            TWorkGroup wg = CoordinatorPreprocessor.prepareResourceGroup(
+                    ctx, ResourceGroupClassifier.QueryType.SELECT);
+            Assertions.assertNotNull(wg);
+            Assertions.assertEquals(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME, wg.getName());
+            Assertions.assertNotNull(resourceGroupMgr.chooseResourceGroupByName(
+                    ctx, ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME));
+        } finally {
+            defaultWg.setWarehouses(originalWarehouses);
+            defaultMvWg.setWarehouses(originalMvWarehouses);
+        }
+    }
+
+    @Test
+    public void testLegacyBuiltinGroupWarehousesDoNotMarkInactiveOnDelivery() throws Exception {
+        ResourceGroupMgr resourceGroupMgr = GlobalStateMgr.getCurrentState().getResourceGroupMgr();
+        Method setInactiveOpMethod = ResourceGroupMgr.class.getDeclaredMethod(
+                "setInactiveOp", TWorkGroupOp.class, String.class);
+        setInactiveOpMethod.setAccessible(true);
+
+        TWorkGroupOp defaultOp = new TWorkGroupOp();
+        TWorkGroup defaultWg = resourceGroupMgr.getResourceGroup(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME).toThrift();
+        defaultWg.setWarehouses(Collections.singletonList("legacy_wh"));
+        defaultOp.setWorkgroup(defaultWg);
+        TWorkGroupOp filteredDefaultOp = (TWorkGroupOp) setInactiveOpMethod.invoke(
+                resourceGroupMgr, defaultOp, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+        Assertions.assertFalse(filteredDefaultOp.getWorkgroup().isInactive());
+
+        TWorkGroupOp defaultMvOp = new TWorkGroupOp();
+        TWorkGroup defaultMvWg = resourceGroupMgr.getResourceGroup(ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME).toThrift();
+        defaultMvWg.setWarehouses(Collections.singletonList("legacy_wh"));
+        defaultMvOp.setWorkgroup(defaultMvWg);
+        TWorkGroupOp filteredDefaultMvOp = (TWorkGroupOp) setInactiveOpMethod.invoke(
+                resourceGroupMgr, defaultMvOp, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+        Assertions.assertFalse(filteredDefaultMvOp.getWorkgroup().isInactive());
+
+        TWorkGroupOp normalOp = new TWorkGroupOp();
+        TWorkGroup normalWg = new TWorkGroup();
+        normalWg.setName("normal_rg");
+        normalWg.setWarehouses(Collections.singletonList("legacy_wh"));
+        normalOp.setWorkgroup(normalWg);
+        TWorkGroupOp filteredNormalOp = (TWorkGroupOp) setInactiveOpMethod.invoke(
+                resourceGroupMgr, normalOp, WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+        Assertions.assertTrue(filteredNormalOp.getWorkgroup().isInactive());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -19,13 +19,17 @@ import com.starrocks.catalog.UserIdentity;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SetExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.Subquery;
+import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.DefaultWarehouse;
 import com.uber.m3.util.ImmutableMap;
 import mockit.Mock;
 import mockit.MockUp;
@@ -237,8 +241,34 @@ public class AnalyzeSetVariableTest {
         analyzeSuccess(sql);
     }
 
+    @Test
+    public void testSetResourceGroupNameIgnoresWarehouse() throws Exception {
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        warehouseManager.addWarehouse(new DefaultWarehouse(2, "wh2"));
+        BackendResourceStat.getInstance().setNumCoresOfBe(2, 2, 32);
+
+        String createRgSql = "create resource group rg_set_wh2\n" +
+                "to (user='rg1_user1')\n" +
+                "   with (" +
+                "   'mem_limit' = '20%'," +
+                "   'warehouses' = 'wh2'," +
+                "   'cpu_weight_percent' = '20'" +
+                "   );";
+        starRocksAssert.executeResourceGroupDdlSql(createRgSql);
+
+        try {
+            analyzeSuccess("SET resource_group = rg_set_wh2");
+            long rgId = GlobalStateMgr.getCurrentState().getResourceGroupMgr().getResourceGroup("rg_set_wh2").getId();
+            analyzeSuccess("SET resource_group_id = " + rgId);
+        } finally {
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP IF EXISTS rg_set_wh2");
+            warehouseManager.replayDropWarehouse(new com.starrocks.persist.DropWarehouseLog("wh2"));
+            BackendResourceStat.getInstance().reset();
+        }
+    }
+
     /**
-     * Mock up {@link ResourceGroupMgr#chooseResourceGroupByID(long)}.
+     * Mock up {@link ResourceGroupMgr#chooseResourceGroupByID(ConnectContext, long)}.
      */
     @Test
     public void testSetResourceGroupID() {
@@ -248,7 +278,8 @@ public class AnalyzeSetVariableTest {
 
         new MockUp<ResourceGroupMgr>() {
             @Mock
-            public TWorkGroup chooseResourceGroupByID(long wgID) {
+            public TWorkGroup chooseResourceGroupByID(ConnectContext ctx, long wgID) {
+                Assertions.assertNull(ctx);
                 if (wgID == rg1ID) {
                     return rg1;
                 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

- FE matching rules:
  - When a query matches a resource group, it can only match resource groups whose `warehouses` is empty, or whose `warehouses.contains(query.currentWarehouse)` is true.
  - When using the `resource_group` or `resource_group_id` session variable, the resource group's `warehouses` is considered in the same way.
    - However, when executing `set resource_group` or `set resource_group_id`, the current warehouse is not required to match the target resource group's `warehouses`, because the current session may switch warehouses later.
- The default resource groups cannot be configured with non-empty `warehouses`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4


