### PR TITLE
[BugFix] Fix AsyncTaskQueue infinite loop on InterruptedException

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/AsyncTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/AsyncTaskQueue.java
@@ -173,6 +173,7 @@ public class AsyncTaskQueue<T> {
                 outputQueueSize.addAndGet(-size);
             }
         } catch (InterruptedException e) {
+            hasMoreOutput = false;
             Thread.currentThread().interrupt();
             LOG.warn("Thread interrupted while waiting for outputs in AsyncTaskQueue", e);
         } finally {


### PR DESCRIPTION
## Why I'm doing:

After InterruptedException in tryGetOutputs(), the interrupt flag is  restored but hasMoreOutput remains true, causing getOutputs() to loop indefinitely
    
Come From #66791 which changed
```
      throw new RuntimeException(e)
    to
      Thread.currentThread().interrupt()
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
