### PR TITLE
[BugFix] Fix COW race in join probe copy path (MOST_MATCH_ONE)

### DIFF
--- a/be/src/common/cow.h
+++ b/be/src/common/cow.h
@@ -232,8 +232,8 @@ protected:
         const T& operator*() const { return *value; }
         T& operator*() { return *get(); }
 
-        operator const ImmutPtr<T>&() const { return value; }
-        operator ImmutPtr<T>&() & { return value; }
+        operator const ImmutPtr<T> &() const { return value; }
+        operator ImmutPtr<T> &() & { return value; }
 
         operator bool() const { return value.get() != nullptr; }
         bool operator!() const { return value.get() == nullptr; }

--- a/be/src/common/cow.h
+++ b/be/src/common/cow.h
@@ -247,8 +247,10 @@ public:
     using Ptr = ImmutPtr<Derived>;
     using WrappedPtr = ChameleonPtr<Derived>;
 
-protected:
-    // trigger clone-on-write, deep clone if the data is shared with others, otherwise shadow clone.
+    // COW-safe mutation: returns a mutable pointer to this object.
+    // If this is the sole owner (use_count == 1) the existing object is returned in-place;
+    // otherwise a deep clone is made so that the shared copy is not mutated.
+    // Prefer this over as_mutable_ptr() / as_mutable_raw_ptr() whenever COW semantics matter.
     MutablePtr try_mutate() const {
         uint32_t ref_count = this->use_count();
         if (config::cow_optimization_diagnose_level > 0 && ref_count > config::cow_optimization_diagnose_level) {
@@ -262,7 +264,6 @@ protected:
         }
     }
 
-public:
     uint32_t use_count() const { return _use_count.load(); }
 
     template <typename... Args>

--- a/be/src/exec/join/join_hash_map.hpp
+++ b/be/src/exec/join/join_hash_map.hpp
@@ -291,13 +291,18 @@ void JoinHashMap<LT, CT, MT>::_copy_probe_column(ColumnPtr& src_column, ChunkPtr
             (*chunk)->append_column(src_column, slot->id());
         }
     } else if (_probe_state->match_flag == JoinMatchFlag::MOST_MATCH_ONE) {
+        // MOST_MATCH_ONE and has_remain=true are mutually exclusive: RETURN_IF_CHUNK_FULL fires
+        // before CHECK_MATCH runs, so a full chunk never reaches this branch with has_remain set.
+        DCHECK(!_probe_state->has_remain);
+        MutableColumnPtr mutable_col = src_column->try_mutate();
+        mutable_col->mutate_each_subcolumn();
+        mutable_col->filter(_probe_state->probe_match_filter, _probe_state->probe_row_count);
         if (to_nullable) {
-            src_column->as_mutable_raw_ptr()->filter(_probe_state->probe_match_filter, _probe_state->probe_row_count);
-            auto dest_column = NullableColumn::create(src_column, NullColumn::create(src_column->size()));
+            const size_t filtered_size = mutable_col->size();
+            auto dest_column = NullableColumn::create(std::move(mutable_col), NullColumn::create(filtered_size));
             (*chunk)->append_column(std::move(dest_column), slot->id());
         } else {
-            src_column->as_mutable_raw_ptr()->filter(_probe_state->probe_match_filter, _probe_state->probe_row_count);
-            (*chunk)->append_column(src_column, slot->id());
+            (*chunk)->append_column(std::move(mutable_col), slot->id());
         }
     } else {
         MutableColumnPtr dest_column = ColumnHelper::create_column(slot->type(), to_nullable);
@@ -312,8 +317,13 @@ void JoinHashMap<LT, CT, MT>::_copy_probe_nullable_column(ColumnPtr& src_column,
     if (_probe_state->match_flag == JoinMatchFlag::ALL_MATCH_ONE) {
         (*chunk)->append_column(src_column, slot->id());
     } else if (_probe_state->match_flag == JoinMatchFlag::MOST_MATCH_ONE) {
-        src_column->as_mutable_raw_ptr()->filter(_probe_state->probe_match_filter, _probe_state->probe_row_count);
-        (*chunk)->append_column(src_column, slot->id());
+        // MOST_MATCH_ONE and has_remain=true are mutually exclusive: RETURN_IF_CHUNK_FULL fires
+        // before CHECK_MATCH runs, so a full chunk never reaches this branch with has_remain set.
+        DCHECK(!_probe_state->has_remain);
+        MutableColumnPtr mutable_col = src_column->try_mutate();
+        mutable_col->mutate_each_subcolumn();
+        mutable_col->filter(_probe_state->probe_match_filter, _probe_state->probe_row_count);
+        (*chunk)->append_column(std::move(mutable_col), slot->id());
     } else {
         MutableColumnPtr dest_column = ColumnHelper::create_column(slot->type(), true);
         dest_column->append_selective(*src_column, _probe_state->probe_index.data(), 0, _probe_state->count);

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -3392,4 +3392,305 @@ TEST_F(JoinHashMapTest, TestProbeKeyConstructorForSerializedNullable) {
     }
 }
 
+// NOLINTNEXTLINE
+TEST_F(JoinHashMapTest, CopyProbeColumnMostMatchOneRespectsCOW) {
+    JoinHashTableItems table_items;
+    HashTableProbeState probe_state;
+
+    const uint32_t row_count = 8;
+
+    TDescriptorTableBuilder row_desc_builder;
+    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 1);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    const SlotDescriptor* slot = probe_row_desc->tuple_descriptors()[0]->slots()[0];
+
+    probe_state.match_flag = JoinMatchFlag::MOST_MATCH_ONE;
+    probe_state.probe_row_count = row_count;
+    probe_state.probe_match_filter.resize(config::vector_chunk_size, 0);
+    for (uint32_t i = 0; i < row_count; i++) {
+        probe_state.probe_match_filter[i] = (i % 2 == 0) ? 1 : 0;
+    }
+
+    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
+
+    {
+        ColumnPtr src_col = create_int32_column(row_count, 0);
+        ColumnPtr alias = src_col;
+        ASSERT_EQ(src_col->use_count(), 2);
+
+        auto chunk = std::make_shared<Chunk>();
+        join_hash_map->_copy_probe_column(src_col, &chunk, slot, false);
+
+        ASSERT_EQ(src_col->size(), row_count) << "src_col mutated in-place, breaking COW";
+
+        ASSERT_EQ(chunk->num_columns(), 1);
+        const ColumnPtr& out = chunk->get_column_by_slot_id(slot->id());
+        ASSERT_FALSE(out->is_nullable());
+        ASSERT_EQ(out->size(), 4u);
+        const auto& data = ColumnHelper::as_raw_column<Int32Column>(out)->get_data();
+        ASSERT_EQ(data[0], 0);
+        ASSERT_EQ(data[1], 2);
+        ASSERT_EQ(data[2], 4);
+        ASSERT_EQ(data[3], 6);
+    }
+
+    {
+        ColumnPtr src_col = create_int32_column(row_count, 0);
+        ColumnPtr alias = src_col;
+        ASSERT_EQ(src_col->use_count(), 2);
+
+        auto chunk = std::make_shared<Chunk>();
+        join_hash_map->_copy_probe_column(src_col, &chunk, slot, true);
+
+        ASSERT_EQ(src_col->size(), row_count) << "src_col mutated in-place, breaking COW";
+
+        ASSERT_EQ(chunk->num_columns(), 1);
+        const ColumnPtr& out = chunk->get_column_by_slot_id(slot->id());
+        ASSERT_TRUE(out->is_nullable());
+        ASSERT_EQ(out->size(), 4u);
+        const auto* nullable_out = ColumnHelper::as_raw_column<NullableColumn>(out);
+        const auto& data = ColumnHelper::as_raw_column<Int32Column>(nullable_out->data_column())->get_data();
+        ASSERT_EQ(data[0], 0);
+        ASSERT_EQ(data[1], 2);
+        ASSERT_EQ(data[2], 4);
+        ASSERT_EQ(data[3], 6);
+        for (size_t i = 0; i < 4; i++) {
+            ASSERT_EQ(nullable_out->null_column()->get_data()[i], 0);
+        }
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(JoinHashMapTest, CopyProbeNullableColumnMostMatchOneRespectsCOW) {
+    JoinHashTableItems table_items;
+    HashTableProbeState probe_state;
+
+    const uint32_t row_count = 8;
+
+    TDescriptorTableBuilder row_desc_builder;
+    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, true, 1);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    const SlotDescriptor* slot = probe_row_desc->tuple_descriptors()[0]->slots()[0];
+
+    probe_state.match_flag = JoinMatchFlag::MOST_MATCH_ONE;
+    probe_state.probe_row_count = row_count;
+    probe_state.probe_match_filter.resize(config::vector_chunk_size, 0);
+    for (uint32_t i = 0; i < row_count; i++) {
+        probe_state.probe_match_filter[i] = (i % 2 == 0) ? 1 : 0;
+    }
+
+    // Even-indexed rows are non-null (values 0,2,4,6); filter keeps even indices — all non-null.
+    ColumnPtr src_col = create_int32_nullable_column(row_count, 0);
+    ColumnPtr alias = src_col;
+    ASSERT_EQ(src_col->use_count(), 2);
+
+    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
+    auto chunk = std::make_shared<Chunk>();
+    join_hash_map->_copy_probe_nullable_column(src_col, &chunk, slot);
+
+    ASSERT_EQ(src_col->size(), row_count) << "src_col mutated in-place, breaking COW";
+
+    ASSERT_EQ(chunk->num_columns(), 1);
+    const ColumnPtr& out = chunk->get_column_by_slot_id(slot->id());
+    ASSERT_TRUE(out->is_nullable());
+    ASSERT_EQ(out->size(), 4u);
+    const auto* nullable_out = ColumnHelper::as_raw_column<NullableColumn>(out);
+    const auto& data = ColumnHelper::as_raw_column<Int32Column>(nullable_out->data_column())->get_data();
+    ASSERT_EQ(data[0], 0);
+    ASSERT_EQ(data[1], 2);
+    ASSERT_EQ(data[2], 4);
+    ASSERT_EQ(data[3], 6);
+    for (size_t i = 0; i < 4; i++) {
+        ASSERT_EQ(nullable_out->null_column()->get_data()[i], 0);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(JoinHashMapTest, CopyProbeColumnMostMatchOneSoleOwnerCorrectness) {
+    JoinHashTableItems table_items;
+    HashTableProbeState probe_state;
+
+    const uint32_t row_count = 8;
+
+    TDescriptorTableBuilder row_desc_builder;
+    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 1);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    const SlotDescriptor* slot = probe_row_desc->tuple_descriptors()[0]->slots()[0];
+
+    probe_state.match_flag = JoinMatchFlag::MOST_MATCH_ONE;
+    probe_state.probe_row_count = row_count;
+    probe_state.probe_match_filter.resize(config::vector_chunk_size, 0);
+    for (uint32_t i = 0; i < row_count; i++) {
+        probe_state.probe_match_filter[i] = (i % 2 == 0) ? 1 : 0;
+    }
+
+    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
+
+    // Sole owner (use_count=1): try_mutate() returns the same object in-place.
+    // src_col IS the output column after the call (same object, filtered).
+    {
+        ColumnPtr src_col = create_int32_column(row_count, 0);
+        ASSERT_EQ(src_col->use_count(), 1);
+
+        auto chunk = std::make_shared<Chunk>();
+        join_hash_map->_copy_probe_column(src_col, &chunk, slot, false);
+
+        ASSERT_EQ(chunk->num_columns(), 1);
+        const ColumnPtr& out = chunk->get_column_by_slot_id(slot->id());
+        ASSERT_FALSE(out->is_nullable());
+        ASSERT_EQ(out->size(), 4u);
+        const auto& data = ColumnHelper::as_raw_column<Int32Column>(out)->get_data();
+        ASSERT_EQ(data[0], 0);
+        ASSERT_EQ(data[1], 2);
+        ASSERT_EQ(data[2], 4);
+        ASSERT_EQ(data[3], 6);
+        // try_mutate() with use_count=1 mutates in-place: src_col reflects the filter.
+        ASSERT_EQ(src_col->size(), 4u);
+    }
+
+    // Sole owner, to_nullable=true: filtered data column is wrapped in a new NullableColumn.
+    {
+        ColumnPtr src_col = create_int32_column(row_count, 0);
+        ASSERT_EQ(src_col->use_count(), 1);
+
+        auto chunk = std::make_shared<Chunk>();
+        join_hash_map->_copy_probe_column(src_col, &chunk, slot, true);
+
+        ASSERT_EQ(chunk->num_columns(), 1);
+        const ColumnPtr& out = chunk->get_column_by_slot_id(slot->id());
+        ASSERT_TRUE(out->is_nullable());
+        ASSERT_EQ(out->size(), 4u);
+        const auto* nullable_out = ColumnHelper::as_raw_column<NullableColumn>(out);
+        const auto& data = ColumnHelper::as_raw_column<Int32Column>(nullable_out->data_column())->get_data();
+        ASSERT_EQ(data[0], 0);
+        ASSERT_EQ(data[1], 2);
+        ASSERT_EQ(data[2], 4);
+        ASSERT_EQ(data[3], 6);
+        for (size_t i = 0; i < 4; i++) {
+            ASSERT_EQ(nullable_out->null_column()->get_data()[i], 0);
+        }
+        ASSERT_EQ(src_col->size(), 4u);
+    }
+
+    // _copy_probe_nullable_column sole-owner path.
+    {
+        ColumnPtr src_col = create_int32_nullable_column(row_count, 0);
+        ASSERT_EQ(src_col->use_count(), 1);
+
+        auto chunk = std::make_shared<Chunk>();
+        join_hash_map->_copy_probe_nullable_column(src_col, &chunk, slot);
+
+        ASSERT_EQ(chunk->num_columns(), 1);
+        const ColumnPtr& out = chunk->get_column_by_slot_id(slot->id());
+        ASSERT_TRUE(out->is_nullable());
+        ASSERT_EQ(out->size(), 4u);
+        const auto* nullable_out = ColumnHelper::as_raw_column<NullableColumn>(out);
+        const auto& data = ColumnHelper::as_raw_column<Int32Column>(nullable_out->data_column())->get_data();
+        ASSERT_EQ(data[0], 0);
+        ASSERT_EQ(data[1], 2);
+        ASSERT_EQ(data[2], 4);
+        ASSERT_EQ(data[3], 6);
+        ASSERT_EQ(src_col->size(), 4u);
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(JoinHashMapTest, CopyProbeNullableColumnMostMatchOnePreservesNulls) {
+    // Verifies that null rows passing through the filter are preserved in the output.
+    // create_int32_nullable_column(4, 0): row0=non-null(0), row1=null, row2=non-null(2), row3=null.
+    // Filter keeps all four rows → output must contain both null and non-null entries.
+    JoinHashTableItems table_items;
+    HashTableProbeState probe_state;
+
+    const uint32_t row_count = 4;
+
+    TDescriptorTableBuilder row_desc_builder;
+    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, true, 1);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    const SlotDescriptor* slot = probe_row_desc->tuple_descriptors()[0]->slots()[0];
+
+    probe_state.match_flag = JoinMatchFlag::MOST_MATCH_ONE;
+    probe_state.probe_row_count = row_count;
+    probe_state.probe_match_filter.resize(config::vector_chunk_size, 0);
+    for (uint32_t i = 0; i < row_count; i++) {
+        probe_state.probe_match_filter[i] = 1; // keep all rows
+    }
+
+    ColumnPtr src_col = create_int32_nullable_column(row_count, 0);
+    ColumnPtr alias = src_col; // use_count=2 to exercise COW clone path
+    ASSERT_EQ(src_col->use_count(), 2);
+
+    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
+    auto chunk = std::make_shared<Chunk>();
+    join_hash_map->_copy_probe_nullable_column(src_col, &chunk, slot);
+
+    // COW invariant: shared source must not be mutated in-place.
+    ASSERT_EQ(src_col->size(), row_count) << "src_col mutated in-place, breaking COW";
+
+    ASSERT_EQ(chunk->num_columns(), 1);
+    const ColumnPtr& out = chunk->get_column_by_slot_id(slot->id());
+    ASSERT_TRUE(out->is_nullable());
+    ASSERT_EQ(out->size(), row_count);
+
+    const auto* nullable_out = ColumnHelper::as_raw_column<NullableColumn>(out);
+    const auto& null_data = nullable_out->null_column()->get_data();
+    // row0 non-null, row1 null, row2 non-null, row3 null
+    ASSERT_EQ(null_data[0], 0);
+    ASSERT_EQ(null_data[1], 1);
+    ASSERT_EQ(null_data[2], 0);
+    ASSERT_EQ(null_data[3], 1);
+
+    const auto& data = ColumnHelper::as_raw_column<Int32Column>(nullable_out->data_column())->get_data();
+    ASSERT_EQ(data[0], 0);
+    ASSERT_EQ(data[2], 2);
+}
+
+// NOLINTNEXTLINE
+TEST_F(JoinHashMapTest, CopyProbeNullableColumnMostMatchOneSubcolumnCOW) {
+    // The outer NullableColumn is sole-owned (use_count=1) but its internal data_column is
+    // shared (use_count=2). mutate_each_subcolumn() must clone the data_column before filter()
+    // reaches it via ChameleonPtr, which otherwise hands out a mutable raw pointer even to a
+    // shared sub-column (bypassing COW at the sub-column level).
+    JoinHashTableItems table_items;
+    HashTableProbeState probe_state;
+
+    const uint32_t row_count = 8;
+
+    TDescriptorTableBuilder row_desc_builder;
+    add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, true, 1);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    const SlotDescriptor* slot = probe_row_desc->tuple_descriptors()[0]->slots()[0];
+
+    probe_state.match_flag = JoinMatchFlag::MOST_MATCH_ONE;
+    probe_state.probe_row_count = row_count;
+    probe_state.probe_match_filter.resize(config::vector_chunk_size, 0);
+    for (uint32_t i = 0; i < row_count; i++) {
+        probe_state.probe_match_filter[i] = (i % 2 == 0) ? 1 : 0;
+    }
+
+    ColumnPtr src_col = create_int32_nullable_column(row_count, 0);
+    ASSERT_EQ(src_col->use_count(), 1);
+    // Pin a second shared_ptr to the internal data_column so it becomes shared (use_count=2).
+    ColumnPtr data_alias = ColumnHelper::as_raw_column<NullableColumn>(src_col)->data_column();
+    ASSERT_EQ(data_alias->use_count(), 2);
+
+    auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
+    auto chunk = std::make_shared<Chunk>();
+    join_hash_map->_copy_probe_nullable_column(src_col, &chunk, slot);
+
+    // Sub-column COW: the shared data_column must not be filtered in-place.
+    ASSERT_EQ(data_alias->size(), row_count) << "data_column mutated in-place, violating sub-column COW";
+
+    ASSERT_EQ(chunk->num_columns(), 1);
+    const ColumnPtr& out = chunk->get_column_by_slot_id(slot->id());
+    ASSERT_TRUE(out->is_nullable());
+    ASSERT_EQ(out->size(), 4u);
+    const auto* nullable_out = ColumnHelper::as_raw_column<NullableColumn>(out);
+    const auto& out_data = ColumnHelper::as_raw_column<Int32Column>(nullable_out->data_column())->get_data();
+    ASSERT_EQ(out_data[0], 0);
+    ASSERT_EQ(out_data[1], 2);
+    ASSERT_EQ(out_data[2], 4);
+    ASSERT_EQ(out_data[3], 6);
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I am doing:

In `JoinHashMap::_copy_probe_column` and `_copy_probe_nullable_column`,
the `MOST_MATCH_ONE` branch called `as_mutable_raw_ptr()->filter()` to
trim the probe column before appending it to the output chunk.
`as_mutable_raw_ptr()` is documented as unsafe in `cow.h:299-317` — it
returns a raw mutable pointer to the underlying column storage
**without checking the reference count**, so a column shared with
another holder is mutated in place, breaking the COW contract.

A production SIGSEGV reproduced this fault (StarRocks 4.1.0,
`enable_spill=true`, high concurrency):

```
SIGSEGV @0x7f1ef0400000  (page-aligned; precise origin not determined from coredump alone)
  __memcpy_evex_unaligned_erms
  BinaryColumnBase<uint32_t>::filter_range
  NullableColumn::filter_range
  MapColumn::filter_range
  NullableColumn::filter_range
  JoinHashMap<LARGEINT,SERIALIZED_FIXED_SIZE,LINEAR_CHAINED>::_copy_probe_nullable_column
  SpillableHashJoinProbeOperator::pull_chunk
```

## Root cause: COW contract violation at the mutation point

`use_count > 1` propagation at this site is normal and pervasive in
this codebase by design. The same function's `ALL_MATCH_ONE` branch
itself appends `src_column` directly (`join_hash_map.h:117, 128`):

```cpp
(*chunk)->append_column(src_column, slot->id());
```

So the function as a whole already operates under mixed-ownership
input. Additional legitimate share sources in the codebase include:

- Parquet `GroupReader::_create_read_chunk` view chunks (chunk-model
  comment at `group_reader.cpp:540-566`)
- `BinaryColumn::_resource` zero-copy page cache (#62331)
- `MultiCastLocalExchange::pull_chunk` (CTE / multi-consumer)
- `_prepare_key_columns` SlotRef sharing — confirmed harmless in
  review (prepare column not used after `copy_probe_chunk`)

These are by design; the `MOST_MATCH_ONE` branch is the one site
where the consumer mutates without honoring the COW contract.

The codebase's COW contract is: **producers share freely; mutators
call `try_mutate()` to obtain exclusivity.** PR #66037
(`9eb0840f8a`, COW Tighten) systematically applied this contract at
30+ mutation sites. The `MOST_MATCH_ONE` branch is the one site that
migration missed — it remained on the unsafe API.

## What I am doing:

**`be/src/common/cow.h` — make `try_mutate()` public**

`try_mutate()` was `protected`, inaccessible to code outside the `Column`
class hierarchy. The only public alternatives were `as_mutable_raw_ptr()`
and `as_mutable_ptr()`, both of which bypass COW entirely (no `use_count`
check). Hiding the safe variant while exposing the two unsafe escape
hatches is inconsistent; this commit promotes `try_mutate()` to `public`
and updates its doc-comment to mark it as the preferred API for callers
that need COW-safe mutation.

**`be/src/exec/join/join_hash_map.hpp` — fix the COW violation**

Replace `as_mutable_raw_ptr()->filter()` in both `_copy_probe_column`
and `_copy_probe_nullable_column` with:

```cpp
MutableColumnPtr mutable_col = src_column->try_mutate();
mutable_col->mutate_each_subcolumn();
mutable_col->filter(_probe_state->probe_match_filter, _probe_state->probe_row_count);
```

This is exactly the cascade that `Column::mutate() const&&`
(`column.h:471-479`) uses internally, and which is the canonical pattern
at 30+ composite-column mutation sites across the codebase (grep
`\.mutate\(\)` under `be/src/column` and `be/src/exec`). The COW Tighten
commit (`9eb0840f8a`, #66037) migrated all other composite-column
mutation sites to this cascade but left this one site on
`as_mutable_raw_ptr()->filter()`; this PR closes that remaining gap.

`mutate_each_subcolumn()` is required in addition to `try_mutate()`:
`NullableColumn` stores `_data_column` as a `WrappedPtr` (ChameleonPtr)
that hands out a mutable raw pointer via `const_cast` when the parent is
non-const. Without `mutate_each_subcolumn()`, a sole-owner outer column
whose inner `_data_column` is shared would still be filtered in-place,
violating COW at the sub-column level. The cascade clones each
sub-column with `use_count > 1`.

`try_mutate()` is a no-op when `use_count == 1` (returns the existing
mutable pointer with zero allocation overhead), so for sole-owner inputs
the fast path is preserved bit-for-bit. Only the shared-input case
incurs the clone, which is necessary for correctness.

Add `DCHECK(!_probe_state->has_remain)` in both MOST_MATCH_ONE branches
to document that MOST_MATCH_ONE and `has_remain=true` are mutually
exclusive: `PROBE_OVER()` always clears `has_remain` before `CHECK_MATCH`
can set MOST_MATCH_ONE. The DCHECK catches future regressions in debug
builds.

## Empirical verification

Reproduced the production SIGSEGV on vanilla 4.1.0 + `BUILD_TYPE=ASAN`,
deployed to a test cluster (workload: 10 concurrent queries × 3 rounds):

- **Plan (`EXPLAIN COSTS`, 2122 lines)**: `enable_spill=true`,
  5 Hive Parquet scans, 5 BROADCAST hash joins, multiple
  `MAP<VARCHAR, BIGINT>` columns from both Parquet-native reads and
  14+ `map_from_arrays[array_append[...], array_append[...]]` BE
  expressions. Crash stack `JoinHashMap<7,1,5>`
  (LogicalType=7=VARCHAR) and inner column `BinaryColumnBase<uint32_t>`
  match the plan's `MAP<VARCHAR, *>` key type.

- **Vanilla 4.1.0 ASAN build**: 8/8 BEs crashed with SIGSEGV at the
  stack shown above. ASAN did NOT emit `heap-buffer-overflow` or
  `use-after-free` before the SIGSEGV — consistent with a data race
  (ASAN detects spatial/temporal violations, not unsynchronized
  concurrent writes).

- **With this PR applied**: 0 crashes on the identical workload. The
  PR's only functional change is at the `_copy_probe_*` `MOST_MATCH_ONE`
  branch — the other commits are a `cow.h::try_mutate()` visibility
  exposure and a clang-format auto-fix — so the A/B controlled
  experiment isolates this site as the necessary fix location.

Direct first-share capture for the crash path via
`cow_optimization_diagnose_level=1` instrumentation was infeasible —
the diagnostic's atomic counter and stack-trace path introduce enough
memory-barrier/scheduling skew to close the race window (heisenbug
pattern). The exact inter-thread interleaving is therefore not
directly traced. The crash's necessary condition is the
`as_mutable_raw_ptr()->filter()` contract violation on a shared
column — independent of whether the share is single- or
multi-threaded — and the A/B reproduction (along with the static
`cow.h:299-317` documentation) demonstrates that closing this
contract gap at the mutation point is what eliminates the crash.

## Tests added

- `CopyProbeColumnMostMatchOneRespectsCOW` — shared column
  (`use_count=2`), asserts `src_col` is unchanged after the call for
  both `to_nullable=false` and `to_nullable=true`.
- `CopyProbeNullableColumnMostMatchOneRespectsCOW` — same COW
  invariant for `_copy_probe_nullable_column`.
- `CopyProbeColumnMostMatchOneSoleOwnerCorrectness` — sole-owner
  (`use_count=1`) paths; asserts correctly filtered output and that
  `src_col` reflects in-place mutation.
- `CopyProbeNullableColumnMostMatchOnePreservesNulls` — null flags
  preserved after filtering.
- `CopyProbeNullableColumnMostMatchOneSubcolumnCOW` — sole-owner outer
  `NullableColumn` with a shared `_data_column`; verifies
  `mutate_each_subcolumn()` clones the sub-column before `filter()`
  reaches it via `WrappedPtr`.

## What type of PR is this:

- [x] BugFix

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
    - [x] 4.1