### PR TITLE
[BugFix] Re-run PRUNE_COLUMNS after view-based MV rewrite to eliminate redundant columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -812,6 +812,18 @@ public class QueryOptimizer extends Optimizer {
                 if (!isRewrittenSuccess) {
                     MvUtils.replaceLogicalViewScanOperator(tree);
                 }
+
+                /*
+                 * treeWithView is cloned from queryOptPlanWithView which was saved before
+                 * PRUNE_COLUMNS phase in MvRewritePreprocessor.processPlanWithView().
+                 * It may contain aggregation columns that have already been pruned in the
+                 * current tree. Re-run PRUNE_COLUMNS to eliminate those redundant columns.
+                 * This must come AFTER replaceLogicalViewScanOperator to avoid dangling
+                 * column references from expanded sub-plans.
+                 */
+                ColumnRefSet requiredColumns = rootTaskContext.getRequiredColumns().clone();
+                rootTaskContext.setRequiredColumns(requiredColumns);
+                scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
             }
             OptimizerTraceUtil.logMVRewriteRule("VIEW_BASED_MV_REWRITE", "original view scans size: {}, " +
                     "left view scans size: {}", origQueryViewScanOperators.size(), leftViewScanOperators.size());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
@@ -527,4 +527,40 @@ public class ViewBaseMvRewriteTest extends MaterializedViewTestBase {
         starRocksAssert.dropView("v2");
         starRocksAssert.dropTable("test_t1");
     }
+
+    @Test
+    public void testViewBasedMvRewritePruneColumns() {
+        starRocksAssert.getCtx().getSessionVariable().setOptimizerExecuteTimeout(30000000);
+        /*
+         * Verify that column pruning works correctly after view-based MV rewrite.
+         * view_q1 has 8 aggregation columns (sum_qty, sum_base_price, sum_disc_price,
+         * sum_charge, avg_qty, avg_price, avg_disc, count_order) plus 3 group-by columns.
+         * When the query only selects a subset of columns, the unused columns should be
+         * pruned from the plan even after MV rewrite replaces the tree with the
+         * pre-PRUNE_COLUMNS snapshot.
+         */
+        {
+            String mv = "select * from view_q1";
+            String query = "select l_returnflag, sum_qty from view_q1";
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            // Verify that unused aggregation columns are not present in the plan
+            checker.notContain("sum_base_price");
+            checker.notContain("sum_disc_price");
+            checker.notContain("sum_charge");
+            checker.notContain("avg_price");
+            checker.notContain("avg_disc");
+        }
+        {
+            String mv = "select * from view_q1";
+            String query = "select l_returnflag, l_linestatus, count_order from view_q1" +
+                    " where l_shipdate <= date '1998-12-01'";
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            // Verify that unused aggregation columns are pruned
+            checker.notContain("sum_qty");
+            checker.notContain("sum_base_price");
+            checker.notContain("sum_disc_price");
+            checker.notContain("avg_qty");
+            checker.notContain("avg_price");
+        }
+    }
 }


### PR DESCRIPTION

## Why I'm doing:

**PR #69063** (`[BugFix] Fix projection loss in MV rewrite due to shared mutable state`) fixed **Bug : Shared mutable state corruption** in the `viewBasedMvRuleRewrite()` method.

### Core Change

Added **clone + deriveLogicalProperty** when obtaining `treeWithView` in `viewBasedMvRuleRewrite()`:

```java
// Before fix (directly referencing the cached snapshot)
OptExpression treeWithView = queryMaterializationContext.getQueryOptPlanWithView();

// After fix (cloning a copy)
OptExpression treeWithView = MvUtils.cloneExpression(queryMaterializationContext.getQueryOptPlanWithView());
MvUtils.deriveLogicalProperty(treeWithView);
```

### Problem It Solved

`queryOptPlanWithView` is a snapshot cached in `QueryMaterializationContext`. The MV rewrite rules (`MULTI_TABLE_MV_REWRITE` / `SINGLE_TABLE_MV_REWRITE`) **mutate** the `treeWithView` nodes in-place during execution (e.g., modifying Projections, replacing subtrees).

Without cloning, the following corruption sequence occurs:

1. **Stage1 rewrite** operates directly on the cached snapshot → mutates Projection and other properties on snapshot nodes
2. Stage1 rewrite fails (or partially fails), falls through to **Stage2 retry**
3. Stage2 retrieves the snapshot via `getQueryOptPlanWithView()` → gets the **already-corrupted plan**
4. Stage2 rewrites based on the corrupted plan → **Projection loss** → incomplete column mappings → wrong query results or errors

### How This Fix Indirectly Exposed the Current Bug

Strictly speaking, the current bug (missing PRUNE_COLUMNS) has existed since PR #36359 introduced view-based MV rewrite. However, **before** PR #69063, since there was no clone, `treeWithView` directly referenced the cached snapshot, and MV rewrite rules mutated snapshot nodes in-place. This "in-place mutation" behavior, while itself a bug (snapshot corruption), **inadvertently masked** the PRUNE_COLUMNS issue in some cases — because the corrupted snapshot might happen to lose some column information, reducing the number of "resurrected" columns.

After PR #69063 added the clone:
- Every rewrite operates on a **complete, uncorrupted** copy of the original snapshot
- The original snapshot was saved **before** `PRUNE_COLUMNS`, containing all unpruned columns
- The cloned copy also contains all unpruned columns
- Replacing the pruned main tree with this complete copy → **massive number of redundant columns "resurrected"** → the problem fully surfaced
- When view-based MV rewrite succeeds and replaces the main tree with the cloned snapshot, aggregation columns that were already pruned get missed, causing query failures (e.g., missing column statistics) or performance degradation.

Fix by re-running PRUNE_COLUMNS after the tree replacement, following the same pattern used by the Union Rewrite recovery path. The re-run is placed after replaceLogicalViewScanOperator to avoid dangling column references from expanded sub-plans.

Also add a test case to verify that unused aggregation columns are correctly pruned from the plan after view-based MV rewrite.

## What I'm doing:

Fixes #73218

**Root Cause:**

In `viewBasedMvRuleRewrite()`, `queryOptPlanWithView` is saved in `MvRewritePreprocessor.processPlanWithView()` **before** the `PRUNE_COLUMNS` phase. When MV rewrite partially succeeds (`leftViewScans < origViewScans`), the early unpruned snapshot is grafted back into the main tree without a follow-up `PRUNE_COLUMNS` pass.

**Fix:**

Add `PRUNE_COLUMNS` re-run after the successful replacement in `viewBasedMvRuleRewrite()`:

### Additional context

**Trigger conditions (all must be met simultaneously):**

1. `enable_view_based_mv_rewrite = true` (this is the **default** setting)
2. Query involves a View, and the view's internal plan contains aggregation columns (e.g., `any_value`, `max`, `sum`, `bitmap_union`)
3. A materialized view exists that can be matched, causing view-based MV rewrite to succeed (at least one ViewScan is replaced)
4. The user query only SELECTs a subset of the view's columns, so `PRUNE_COLUMNS` actually prunes some aggregation columns before the MV rewrite phase
5. The MV rewrite takes the **non-Union path** (otherwise the existing `OP_MV_UNION_REWRITE` compensation logic would cover it)

**Why this is hard to reproduce in test environments:**

In test environments, all columns have default statistics (`ColumnStatistic.unknown()`), so `calculateStatistics()` will **not** fail even when redundant columns are revived. The bug is logically present — the extra columns exist in the plan — but it only manifests as an error in production environments where real column statistics have been collected 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
