### PR TITLE
[BugFix] Fix slot lookup for output slots with empty col_name in spark connector external scan

### DIFF
--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -277,17 +277,6 @@ SlotDescriptor* DescriptorTbl::get_slot_descriptor(SlotId id) const {
     }
 }
 
-SlotDescriptor* DescriptorTbl::get_slot_descriptor_with_column(SlotId id) const {
-    // TODO: is there some boost function to do exactly this?
-    auto i = _slot_with_column_name_map.find(id);
-
-    if (i == _slot_with_column_name_map.end()) {
-        return nullptr;
-    } else {
-        return i->second;
-    }
-}
-
 // return all registered tuple descriptors
 void DescriptorTbl::get_tuple_descs(std::vector<TupleDescriptor*>* descs) const {
     descs->clear();

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -176,7 +176,6 @@ public:
     TableDescriptor* get_table_descriptor(TableId id) const;
     TupleDescriptor* get_tuple_descriptor(TupleId id) const;
     SlotDescriptor* get_slot_descriptor(SlotId id) const;
-    SlotDescriptor* get_slot_descriptor_with_column(SlotId id) const;
 
     // return all registered tuple descriptors
     void get_tuple_descs(std::vector<TupleDescriptor*>* descs) const;
@@ -193,17 +192,12 @@ private:
     TableDescriptorMap _tbl_desc_map;
     TupleDescriptorMap _tuple_desc_map;
     SlotDescriptorMap _slot_desc_map;
-    SlotDescriptorMap _slot_with_column_name_map;
 
     DescriptorTbl()
-            : _mr(std::pmr::get_default_resource()),
-              _tbl_desc_map(_mr),
-              _tuple_desc_map(_mr),
-              _slot_desc_map(_mr),
-              _slot_with_column_name_map(_mr) {}
+            : _mr(std::pmr::get_default_resource()), _tbl_desc_map(_mr), _tuple_desc_map(_mr), _slot_desc_map(_mr) {}
 
     explicit DescriptorTbl(std::pmr::memory_resource* mr)
-            : _mr(mr), _tbl_desc_map(_mr), _tuple_desc_map(_mr), _slot_desc_map(_mr), _slot_with_column_name_map(_mr) {}
+            : _mr(mr), _tbl_desc_map(_mr), _tuple_desc_map(_mr), _slot_desc_map(_mr) {}
 
     friend class ObjectPool;
 };

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -601,9 +601,6 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
     for (const auto& tdesc : thrift_tbl.slotDescriptors) {
         SlotDescriptor* slot_d = ALLOC_DESC(SlotDescriptor, tdesc, mr);
         (*tbl)->_slot_desc_map[tdesc.id] = slot_d;
-        if (!slot_d->col_name().empty()) {
-            (*tbl)->_slot_with_column_name_map[tdesc.id] = slot_d;
-        }
         // link to parent
         auto entry = (*tbl)->_tuple_desc_map.find(tdesc.parent);
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -832,6 +832,9 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
         return Status::InvalidArgument(msg.str());
     }
 
+    VLOG_ROW << "BackendService execute open() TQueryPlanInfo: "
+             << apache::thrift::ThriftDebugString(t_query_plan_info);
+
     *query_id = t_query_plan_info.query_id;
 
     // set up desc tbl
@@ -861,7 +864,7 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
             LOG(WARNING) << "tuple descriptor is null. id: " << slot_ref.tuple_id;
             return Status::InvalidArgument("tuple descriptor is null");
         }
-        auto* slot_desc = desc_tbl->get_slot_descriptor_with_column(slot_ref.slot_id);
+        auto* slot_desc = desc_tbl->get_slot_descriptor(slot_ref.slot_id);
         if (slot_desc == nullptr) {
             LOG(WARNING) << "slot descriptor is null. id: " << slot_ref.slot_id;
             return Status::InvalidArgument("slot descriptor is null");
@@ -878,8 +881,6 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
         i++;
     }
 
-    LOG(INFO) << "BackendService execute open()  TQueryPlanInfo: "
-              << apache::thrift::ThriftDebugString(t_query_plan_info);
     // assign the param used to execute PlanFragment
     TExecPlanFragmentParams exec_fragment_params;
     exec_fragment_params.protocol_version = (InternalServiceVersion::type)0;

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -892,9 +892,6 @@ DescriptorTbl* JoinHashMapTest::create_descriptor_tbl(TDescriptorTableBuilder* t
     for (const auto& sdesc : thrift_tbl.slotDescriptors) {
         auto* slot_desc = _object_pool->add(new SlotDescriptor(sdesc));
         tbl->_slot_desc_map[sdesc.id] = slot_desc;
-        if (!slot_desc->col_name().empty()) {
-            tbl->_slot_with_column_name_map[sdesc.id] = slot_desc;
-        }
 
         auto tuple = tbl->_tuple_desc_map.find(sdesc.parent);
         CHECK(tuple != tbl->_tuple_desc_map.end());

--- a/be/test/runtime/fragment_mgr_test.cpp
+++ b/be/test/runtime/fragment_mgr_test.cpp
@@ -41,9 +41,18 @@
 
 #include "base/testutil/assert.h"
 #include "base/time/monotime.h"
+#include "base/url_coding.h"
 #include "common/config_runtime_fwd.h"
+#include "common/util/thrift_util.h"
 #include "exec/data_sink.h"
 #include "exec/pipeline/query_context.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "gen_cpp/Exprs_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/Planner_types.h"
+#include "gen_cpp/QueryPlanExtra_types.h"
+#include "gen_cpp/StarrocksExternalService_types.h"
+#include "gen_cpp/Types_types.h"
 #include "runtime/exec_env.h"
 #include "runtime/plan_fragment_executor.h"
 #include "runtime/profile_report_worker.h"
@@ -85,6 +94,52 @@ protected:
         config::fragment_pool_queue_size = 1024;
     }
     void TearDown() override {}
+
+    static TExprNode make_slot_ref_node(TSlotId slot_id, TTupleId tuple_id, TPrimitiveType::type primitive_type,
+                                        int32_t varchar_len = -1) {
+        TExprNode node;
+        node.node_type = TExprNodeType::SLOT_REF;
+        node.num_children = 0;
+        node.output_scale = -1;
+        node.__set_is_nullable(true);
+
+        TScalarType scalar_type;
+        scalar_type.type = primitive_type;
+        if (primitive_type == TPrimitiveType::VARCHAR || primitive_type == TPrimitiveType::CHAR) {
+            scalar_type.__set_len(varchar_len);
+        }
+        TTypeNode type_node;
+        type_node.type = TTypeNodeType::SCALAR;
+        type_node.__set_scalar_type(scalar_type);
+        node.type.types.push_back(type_node);
+
+        TSlotRef slot_ref;
+        slot_ref.slot_id = slot_id;
+        slot_ref.tuple_id = tuple_id;
+        node.__set_slot_ref(slot_ref);
+        return node;
+    }
+
+    static TSlotDescriptor make_slot(TSlotId id, TTupleId parent, TPrimitiveType::type primitive_type,
+                                     const std::string& col_name, int32_t varchar_len = -1) {
+        TSlotDescriptor slot;
+        slot.__set_id(id);
+        slot.__set_parent(parent);
+        TScalarType scalar_type;
+        scalar_type.type = primitive_type;
+        if (primitive_type == TPrimitiveType::VARCHAR || primitive_type == TPrimitiveType::CHAR) {
+            scalar_type.__set_len(varchar_len);
+        }
+        TTypeNode type_node;
+        type_node.type = TTypeNodeType::SCALAR;
+        type_node.__set_scalar_type(scalar_type);
+        TTypeDesc type_desc;
+        type_desc.types.push_back(type_node);
+        slot.__set_slotType(type_desc);
+        slot.__set_colName(col_name);
+        slot.__set_isNullable(true);
+        return slot;
+    }
 };
 
 TEST_F(FragmentMgrTest, Normal) {
@@ -184,6 +239,85 @@ TEST_F(FragmentMgrTest, ProfileReportWorkerUsesInjectedServices) {
     worker.unregister_pipeline_load(query_id, fragment_instance_id);
     worker.unregister_non_pipeline_load(fragment_instance_id);
     worker.close();
+}
+
+// Reproduces the scenario where an output slot has an empty col_name (e.g. the
+// VARCHAR slot generated for the DECODE_NODE output tuple). Before switching to
+// get_slot_descriptor(), the lookup went through _slot_with_column_name_map,
+// which dropped slots with empty col_name and produced "slot descriptor is null".
+TEST_F(FragmentMgrTest, ExecExternalPlanFragmentLooksUpSlotWithEmptyColName) {
+    TQueryPlanInfo query_plan_info;
+
+    // tuple 0: scan tuple (k1 INT, k2 INT for dict-encoded k2)
+    // tuple 1: decode output tuple (k1 INT, "" VARCHAR - empty colName)
+    TTupleDescriptor tuple0;
+    tuple0.__set_id(0);
+    TTupleDescriptor tuple1;
+    tuple1.__set_id(1);
+    query_plan_info.desc_tbl.tupleDescriptors = {tuple0, tuple1};
+
+    query_plan_info.desc_tbl.__set_slotDescriptors({
+            make_slot(/*id=*/1, /*parent=*/0, TPrimitiveType::INT, "k1"),
+            make_slot(/*id=*/10, /*parent=*/0, TPrimitiveType::INT, "k2"),
+            make_slot(/*id=*/1, /*parent=*/1, TPrimitiveType::INT, "k1"),
+            // The slot under test: tuple 1, slot id 2, VARCHAR, empty col_name.
+            make_slot(/*id=*/2, /*parent=*/1, TPrimitiveType::VARCHAR, "", /*varchar_len=*/65533),
+    });
+
+    TExpr expr_k1;
+    expr_k1.nodes.push_back(make_slot_ref_node(/*slot_id=*/1, /*tuple_id=*/1, TPrimitiveType::INT));
+    TExpr expr_k2;
+    expr_k2.nodes.push_back(
+            make_slot_ref_node(/*slot_id=*/2, /*tuple_id=*/1, TPrimitiveType::VARCHAR, /*varchar_len=*/65533));
+
+    query_plan_info.plan_fragment.__set_output_exprs({expr_k1, expr_k2});
+    TDataPartition partition;
+    partition.type = TPartitionType::RANDOM;
+    query_plan_info.plan_fragment.partition = partition;
+
+    query_plan_info.query_id.__set_hi(1);
+    query_plan_info.query_id.__set_lo(2);
+    query_plan_info.tablet_info = {};
+    query_plan_info.__set_output_names({"k1", "k2"});
+
+    // Serialize via binary protocol (matches deserialize_thrift_msg in
+    // exec_external_plan_fragment) and base64-encode.
+    ThriftSerializer serializer(/*compact=*/false, /*initial_buffer_size=*/1024);
+    std::string serialized;
+    ASSERT_OK(serializer.serialize(&query_plan_info, &serialized));
+    std::string opaqued;
+    base64_encode(serialized, &opaqued);
+
+    TScanOpenParams open_params;
+    open_params.cluster = "default_cluster";
+    open_params.database = "test_db";
+    open_params.table = "t1";
+    // Unknown tablet id forces the function to return NotFound *after* the slot
+    // descriptor lookup loop completes, so selected_columns is populated but the
+    // heavy FragmentExecutor::prepare path is skipped.
+    open_params.tablet_ids = {99999};
+    open_params.opaqued_query_plan = opaqued;
+    open_params.__set_batch_size(1024);
+
+    TUniqueId fragment_instance_id;
+    fragment_instance_id.__set_hi(3);
+    fragment_instance_id.__set_lo(4);
+
+    FragmentMgr mgr(ExecEnv::GetInstance());
+    std::vector<TScanColumnDesc> selected_columns;
+    TUniqueId out_query_id;
+    Status st = mgr.exec_external_plan_fragment(open_params, fragment_instance_id, &selected_columns, &out_query_id);
+
+    // Slot lookup succeeded for the empty-colName slot (otherwise we would get
+    // InvalidArgument "slot descriptor is null" with empty selected_columns).
+    ASSERT_EQ(2u, selected_columns.size());
+    EXPECT_EQ("k1", selected_columns[0].name);
+    EXPECT_EQ(TPrimitiveType::INT, selected_columns[0].type);
+    EXPECT_EQ("k2", selected_columns[1].name);
+    EXPECT_EQ(TPrimitiveType::VARCHAR, selected_columns[1].type);
+
+    EXPECT_EQ(query_plan_info.query_id, out_query_id);
+    EXPECT_TRUE(st.is_not_found()) << "expected NotFound from unknown tablet, got: " << st;
 }
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -327,6 +327,8 @@ public class TableQueryPlanAction extends RestBaseAction {
         });
         tQueryPlanInfo.tablet_info = tabletInfo;
 
+        LOG.debug("query plan: {}", tQueryPlanInfo);
+
         // serialize TQueryPlanInfo and encode plan with Base64 to string in order to translate by json format
         String opaquedQueryPlan;
         try {


### PR DESCRIPTION
## Why I'm doing:

  When the Spark connector opens an external scan via `exec_external_plan_fragment`
  and an output slot has an empty col_name (e.g. the `VARCHAR` slot generated for
  a `DECODE_NODE` output tuple), the call failed with "slot descriptor is null"
  because the lookup went through `_slot_with_column_name_map`, which skipped
  slots whose `col_name` was empty.

## What I'm doing:

  - Switch the output-expr slot lookup to `DescriptorTbl::get_slot_descriptor`,
    which is keyed solely by slot id.
  - Drop the now-unused `_slot_with_column_name_map` and
    `get_slot_descriptor_with_column` from `DescriptorTbl` (no remaining callers).

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
