### PR TITLE
[auto-perf-opt] Raise pk_index_memtable_max_count default from 2 to 6

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -488,7 +488,15 @@ CONF_mInt32(lake_partial_update_thread_pool_max_threads, "0");
 // Queue size for the lake partial update threadpool.
 CONF_mInt32(lake_partial_update_thread_pool_queue_size, "2048");
 // The maximum number of memtables for pk index in shared-data mode.
-CONF_mInt32(pk_index_memtable_max_count, "2");
+// Each compaction publish builds a fresh PK-index memtable by chunk-replacing
+// up to ~tens-of-millions of rows; when it reaches l0_max_mem_usage (default
+// 100 MB) it must flush. With max_count=2 only one flush can run async — the
+// next one falls back to a synchronous OSS write that blocks the compaction
+// publish (observed on 1_100gb_sortkey: flush_times=20, single publish cost
+// up to 41 s, driving freshness P99 to ~20 s). Allowing more inflight async
+// flushes lets the flush thread pool absorb bursty per-tablet flushes during
+// large compactions without serializing them on the publish path.
+CONF_mInt32(pk_index_memtable_max_count, "6");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 // The parameters for pk index size-tiered compaction strategy.


### PR DESCRIPTION
## Why / what this changes

Bumps the BE default for `pk_index_memtable_max_count` from **2** to **6** (`be/src/common/config.h`).

This config caps how many PK-index `PersistentIndexMemtable` flushes can be in flight per tablet at the same time. In `LakePersistentIndex::flush_memtable` (`be/src/storage/lake/lake_persistent_index.cpp:317-358`) a flush is submitted async only while

```cpp
_inactive_memtables.size() + 1 < config::pk_index_memtable_max_count
```

…otherwise the publish path falls back to a **synchronous** OSS write that blocks the compaction-publish thread itself.

## Evidence (auto-perf-opt iter-001 baseline)

Workload: realtime-benchmark `1_100gb_sortkey` template — 1 PK table, 500 M rows, 12 buckets, `ORDER BY (region, country, event_time)` ≠ PK `(tenant_id, event_time, event_id)`, 32 writers, 20 min test phase, 6×CN @ 32c/49 GB-mem shared-data cluster.

Baseline metrics (branch-4.1 HEAD `8813309`):

| Metric | Value |
|---|---|
| Upsert P50 / P99 | **4 362 / 6 753 ms** |
| Ingest throughput | 38 618 rows/s (target 100 K) |
| Freshness P50 / P99 | 3 092 / **19 900 ms** |
| CN CPU peak / avg | 40–44 % / 27–29 % (idle) |
| CN disk %util peak | 15–21 % (idle) |
| pk-index flush pool active / size | 2 / 1 024 per CN |

Cluster is **not** CPU- or disk-bound and **no** thread pool is queued. Per-CN publish-cost distribution on one CN (77 607 publishes):

```
min: 80 µs  ·  P50: 142 µs  ·  P90: 6.97 ms  ·  P99: 45 ms  ·  max: 41.5 s
```

The tail (P99 + max) comes entirely from compaction publishes. Two representative slow traces:

```
cost = 41 528 917 us, tablet 109668085
  compaction_replace_index_latency_us = 39 367 674
  pindex_memtable_replace_us          = 21 327 749
  flush_memtable_us                   =  2 181 132
  flush_times                         = 20
  input_rowsets_size                  = 13
  primary_index_load_latency_us       = 1    ← index is cached, NOT a cold-load issue
  compaction_delvec_loader_latency_us = 5    ← NOT the delvec pattern
```

```
cost = 7 144 911 us, tablet 109668085
  compaction_replace_index_latency_us = 5 981 583
  flush_memtable_us                   =   478 077
  flush_times                         = 4
  input_rowsets_size                  = 83
```

Every slow publish carries the same signature: `flush_times` × `flush_memtable_us` dominates `compaction_replace_index_latency_us`. With `max_count=2`, all but one flush per publish is synchronous.

## Why this is safe

- **Memory**: peak per-tablet PK-index memtable footprint rises from `2 × l0_max_mem_usage` (200 MB) to `6 × l0_max_mem_usage` (600 MB). With 2-3 tablets/CN under compaction simultaneously this is ≤ 1.8 GB on a 49 GB-mem CN.
- **Correctness**: only changes how many flushes can be inflight in parallel. Flush ordering, SST merge into filesets (`merge_sstable_into_fileset`) and `sync_flush_all_memtables` semantics are unchanged.
- **Thread pool capacity**: the flush threadpool (`pk_index_memtable_flush_threadpool_max_threads`) already has 1 024 threads/CN; observed peak active = 2, so it can absorb the extra concurrency.
- **Per-pool cap remains tight**: `max_count=6` is still a per-tablet cap. Bursts across many tablets still throttle on the thread pool, not unbounded growth.

## Expected impact

- Compaction publishes with `flush_times` between 3 and 6 become fully async (today: 2 sync, with the fix: 0 sync). For larger compactions (e.g. `flush_times=20`), the sync-flush count drops by ~4 fewer synchronous OSS writes, each ~110 ms.
- Lower **Upsert P99** and **Freshness P99**. Per-batch P50 should be roughly unchanged because the bulk of writes don't hit a compaction publish.
- Throughput uplift expected but modest (the 38 % gap to 100 K target appears mostly client-side; see follow-up notes in iteration diagnosis).

## Validation plan

This PR is **draft** because it has not been measured yet. auto-perf-opt iter-002 will redeploy via `--pr <N>` against the same `benchmark_luoyixin_1tb_6cn_2disk2` cluster + same `1_100gb_sortkey` reused dataset, re-run the 20-min workload, and compare to the iter-001 numbers above. Acceptance criteria for promoting to ready-for-review:

- Upsert P99 ≤ **5 500 ms** (≥ 18 % improvement over 6 753 ms baseline), AND
- Freshness P99 ≤ **15 000 ms** (≥ 25 % improvement over 19 900 ms), AND
- No regression on Upsert P50 beyond noise, AND
- No new ingest/query error rate, AND
- Query P99 within 10 % of baseline (constraints guardrail).

If acceptance fails or a regression is observed, the PR will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
