### PR TITLE
[BugFix] Reuse HttpClient instances to fix FE FD leak

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
@@ -43,10 +43,21 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class OAuth2Action extends RestBaseAction {
+    // Reuse a single HttpClient instance across all OAuth2 token exchanges.
+    // java.net.http.HttpClient is thread-safe and designed to be used as a singleton.
+    // Creating a new instance per request leaks FDs (selector epoll/eventfd/pipe + idle
+    // sockets) because the JDK 17 HttpClient has no close() method and relies on GC,
+    // which fails to keep up under sustained load. See: https://bugs.openjdk.org/browse/JDK-8277459
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .version(HttpClient.Version.HTTP_1_1)
+            .build();
+
     public OAuth2Action(ActionController controller) {
         super(controller);
     }
@@ -137,14 +148,13 @@ public class OAuth2Action extends RestBaseAction {
                             URLEncoder.encode(entry.getValue().toString(), StandardCharsets.UTF_8))
                     .collect(Collectors.joining("&"));
 
-            HttpClient client = HttpClient.newHttpClient();
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(oAuth2Context.tokenServerUrl()))
                     .header("Content-Type", "application/x-www-form-urlencoded")
                     .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 
-            response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() == 200) {
                 return response.body();
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
@@ -48,13 +48,16 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class OAuth2Action extends RestBaseAction {
+    private static final int CONNECT_TIMEOUT_SECOND = 5;
+    private static final int REQUEST_TIMEOUT_SECOND = 30;
+
     // Reuse a single HttpClient instance across all OAuth2 token exchanges.
     // java.net.http.HttpClient is thread-safe and designed to be used as a singleton.
     // Creating a new instance per request leaks FDs (selector epoll/eventfd/pipe + idle
     // sockets) because the JDK 17 HttpClient has no close() method and relies on GC,
-    // which fails to keep up under sustained load. See: https://bugs.openjdk.org/browse/JDK-8277459
+    // which fails to keep up under sustained load.
     private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(5))
+            .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECOND))
             .version(HttpClient.Version.HTTP_1_1)
             .build();
 
@@ -150,6 +153,7 @@ public class OAuth2Action extends RestBaseAction {
 
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(oAuth2Context.tokenServerUrl()))
+                    .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECOND))
                     .header("Content-Type", "application/x-www-form-urlencoded")
                     .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/OAuth2Action.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 
 public class OAuth2Action extends RestBaseAction {
     private static final int CONNECT_TIMEOUT_SECOND = 5;
-    private static final int REQUEST_TIMEOUT_SECOND = 30;
+    private static final int REQUEST_TIMEOUT_SECOND = 10;
 
     // Reuse a single HttpClient instance across all OAuth2 token exchanges.
     // java.net.http.HttpClient is thread-safe and designed to be used as a singleton.

--- a/fe/fe-core/src/main/java/com/starrocks/summary/StreamLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/StreamLoader.java
@@ -31,6 +31,7 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -41,6 +42,17 @@ import java.util.Optional;
 
 class StreamLoader {
     private static final String LOAD_URL_PATTERN = "/api/%s/%s/_stream_load";
+
+    // Reuse a single HttpClient instance across all stream load batches.
+    // java.net.http.HttpClient is thread-safe and designed to be used as a singleton.
+    // Creating a new instance per batch leaks FDs (selector epoll/eventfd/pipe + idle
+    // sockets) because the JDK 17 HttpClient has no close() method and relies on GC,
+    // which fails to keep up under sustained periodic load.
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .version(HttpClient.Version.HTTP_1_1)
+            .build();
+
     private final String loadUrlStr;
 
     private final List<String> columns;
@@ -77,8 +89,7 @@ class StreamLoader {
                 .PUT(HttpRequest.BodyPublishers.ofString(sb))
                 .build();
 
-        HttpClient client = HttpClient.newHttpClient();
-        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
 
         if (response.statusCode() == HttpStatus.SC_OK) {
             JsonElement obj = JsonParser.parseString(response.body());

--- a/fe/fe-core/src/main/java/com/starrocks/summary/StreamLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/StreamLoader.java
@@ -44,7 +44,6 @@ class StreamLoader {
     private static final String LOAD_URL_PATTERN = "/api/%s/%s/_stream_load";
 
     private static final int CONNECT_TIMEOUT_SECOND = 5;
-    private static final int REQUEST_TIMEOUT_SECOND = 60;
 
     // Reuse a single HttpClient instance across all stream load batches.
     // java.net.http.HttpClient is thread-safe and designed to be used as a singleton.
@@ -83,7 +82,6 @@ class StreamLoader {
         }
         URI uri = new URI("http", null, be.get().getHost(), be.get().getHttpPort(), loadUrlStr, null, null);
         HttpRequest request = HttpRequest.newBuilder(uri)
-                .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECOND))
                 .header("Authorization", "Basic " + authEncoding)
                 .header("Content-Type", "text/plain; charset=UTF-8")
                 .header("format", "json")

--- a/fe/fe-core/src/main/java/com/starrocks/summary/StreamLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/StreamLoader.java
@@ -43,13 +43,16 @@ import java.util.Optional;
 class StreamLoader {
     private static final String LOAD_URL_PATTERN = "/api/%s/%s/_stream_load";
 
+    private static final int CONNECT_TIMEOUT_SECOND = 5;
+    private static final int REQUEST_TIMEOUT_SECOND = 60;
+
     // Reuse a single HttpClient instance across all stream load batches.
     // java.net.http.HttpClient is thread-safe and designed to be used as a singleton.
     // Creating a new instance per batch leaks FDs (selector epoll/eventfd/pipe + idle
     // sockets) because the JDK 17 HttpClient has no close() method and relies on GC,
     // which fails to keep up under sustained periodic load.
     private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(5))
+            .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECOND))
             .version(HttpClient.Version.HTTP_1_1)
             .build();
 
@@ -80,6 +83,7 @@ class StreamLoader {
         }
         URI uri = new URI("http", null, be.get().getHost(), be.get().getHttpPort(), loadUrlStr, null, null);
         HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECOND))
                 .header("Authorization", "Basic " + authEncoding)
                 .header("Content-Type", "text/plain; charset=UTF-8")
                 .header("format", "json")


### PR DESCRIPTION
## Why I'm doing:

A production FE has been running out of file descriptors and getting restarted regularly. Investigation found `java.net.http.HttpClient.newHttpClient()` is invoked per-request in two sites and the instances are never released:

- **`OAuth2Action.getToken()`** — one HttpClient per OAuth2 token exchange.
- **`StreamLoader.loadBatch()`** — one HttpClient per query-history flush (default every 15 min when `enable_query_history` is on).

In JDK 17, `java.net.http.HttpClient` has no `close()` method (only added in JDK 21). The only release path is GC — but the SelectorManager daemon thread keeps the implementation reachable, and under sustained periodic load GC simply cannot keep up. Each leaked instance holds:

- a SelectorManager thread
- an `anon_inode:[eventpoll]` FD
- an `anon_inode:[eventfd]` FD
- a pipe pair
- any still-open keep-alive sockets (left in `CLOSE_WAIT`)

Evidence from one affected FE (uptime ~65 h):

| Signal | Count |
|---|---|
| Live `HttpClient-*-SelectorManager` threads | 370 |
| `anon_inode:[eventpoll]` FDs | 370 |
| `anon_inode:[eventfd]` FDs | 370 |
| TCP sockets in `CLOSE_WAIT` | 781 |
| HttpClient instances created across JVM lifetime (peak observed) | 19,119+ |
| Total FDs at the time | ~2,700 (≈ 3× normal baseline) |

The FE ultimately exhausts its FD limit and stops accepting connections.

The same anti-pattern is used in three places on `main`; one (`QueryStatisticsInfo`) has already been refactored away to not need HTTP at all, leaving the two sites this PR fixes. Other FE code uses HTTP correctly: `EsRestClient` keeps a `private static final OkHttpClient` singleton, `CostPredictor` keeps an instance-level `CloseableHttpClient`. This PR aligns the two regressing sites with that existing pattern.

## What I'm doing:

Convert both call sites to a `private static final HttpClient HTTP_CLIENT` singleton, configured with:

- `connectTimeout(Duration.ofSeconds(5))` — avoid hanging indefinitely on an unreachable endpoint.
- `version(HttpClient.Version.HTTP_1_1)` — match the existing implicit behavior and avoid HTTP/2-specific stream FD usage.

`java.net.http.HttpClient` is documented as thread-safe and intended to be reused; sharing a single instance is the recommended pattern.

No behavioral change for callers — same request, same response handling — only the underlying client is now shared instead of recreated.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4