### PR TITLE
[Enhancement] Only detect skew in joins if all join keys are skewed (backport #72753)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
@@ -56,8 +56,6 @@ import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.skew.DataSkew;
 import com.starrocks.sql.optimizer.statistics.Statistics;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +87,6 @@ import java.util.stream.Collectors;
  */
 
 public class SkewJoinOptimizeRule extends TransformationRule {
-    private static final Logger LOG = LogManager.getLogger(SkewJoinOptimizeRule.class);
 
     private static final String RAND_COL = "rand_col";
 
@@ -102,6 +99,32 @@ public class SkewJoinOptimizeRule extends TransformationRule {
     public List<Rule> successorRules() {
         // skew join generate new join and on predicate, need to push down join on expression to child project again
         return Lists.newArrayList(new PushDownJoinOnExpressionToChildProject());
+    }
+
+    /**
+     * For a given equality predicate (e.g., a.x = b.x), resolves the left-side column
+     * (the one belonging to leftOutputColumns).
+     */
+    private static Optional<ColumnRefOperator> getLeftSideColumn(BinaryPredicateOperator equalConj,
+            ColumnRefSet leftOutputColumns) {
+        if (!equalConj.getChild(0).isColumnRef() || !equalConj.getChild(1).isColumnRef()) {
+            return Optional.empty();
+        }
+        final var leftCol = (ColumnRefOperator) equalConj.getChild(0);
+        return Optional.of(leftOutputColumns.contains(leftCol.getId())
+                ? leftCol : (ColumnRefOperator) equalConj.getChild(1));
+    }
+
+    /**
+     * For a given equality predicate (e.g., a.x = b.x), resolves the left-side column and
+     * computes its skew info.
+     */
+    private static Optional<DataSkew.SkewInfo> getSkewInfoForPredicate(BinaryPredicateOperator equalConj,
+            ColumnRefSet leftOutputColumns, Statistics leftChildStats, DataSkew.Thresholds skewThresholds) {
+        return getLeftSideColumn(equalConj, leftOutputColumns)
+                .filter(col -> leftChildStats.getColumnStatistics().containsKey(col))
+                .map(leftChildStats::getColumnStatistic)
+                .map(colStats -> DataSkew.getColumnSkewInfo(leftChildStats, colStats, skewThresholds));
     }
 
     @Override
@@ -134,64 +157,60 @@ public class SkewJoinOptimizeRule extends TransformationRule {
         if (leftChildStats == null) {
             return false;
         }
+        final var mcvLimit = context.getSessionVariable().getSkewJoinOptimizeUseMCVCount();
+        final var rowPercentageThreshold = context.getSessionVariable().getSkewJoinDataSkewThreshold();
+        final var skewThresholds = new DataSkew.Thresholds(mcvLimit, rowPercentageThreshold);
+
+        // If any predicate is not skewed, the composite hash key already distributes data well,
+        // and we do not need to add salting.
+        // Idea: the most frequent composite tuple (k_1, k_2, ..., k_n) is bounded by the most
+        // frequent value of each individual key. If any key k_i is not skewed (no value exceeds
+        // the threshold), then no composite tuple can exceed it either, so no partition is skewed.
+        record PredicateSkewInfo(ColumnRefOperator column, DataSkew.SkewInfo skewInfo) {}
+
+        List<PredicateSkewInfo> skewedPredicates = new ArrayList<>();
         for (BinaryPredicateOperator equalConj : equalConjs) {
-            if (!equalConj.getChild(0).isColumnRef() || !equalConj.getChild(1).isColumnRef()) {
-                // only support column equal column
+            var columnOpt = getLeftSideColumn(equalConj, leftOutputColumns);
+            var skewInfoOpt = getSkewInfoForPredicate(equalConj, leftOutputColumns, leftChildStats, skewThresholds);
+            if (columnOpt.isEmpty() || skewInfoOpt.isEmpty()) {
                 continue;
             }
-            ColumnRefOperator leftColumn = (ColumnRefOperator) equalConj.getChild(0);
-            ColumnRefOperator rightColumn = (ColumnRefOperator) equalConj.getChild(1);
-            ColumnRefOperator skewJoinColumn;
-            // choose the skew join column, it could be left or right column of the predicate
-            if (leftOutputColumns.contains(leftColumn.getId())) {
-                skewJoinColumn = leftColumn;
-            } else {
-                skewJoinColumn = rightColumn;
+            if (!skewInfoOpt.get().isSkewed()) {
+                return false;
             }
-            if (!leftChildStats.getColumnStatistics().containsKey(skewJoinColumn)) {
-                continue;
-            }
-            final var skewColumnStats = leftChildStats.getColumnStatistic(skewJoinColumn);
+            skewedPredicates.add(new PredicateSkewInfo(columnOpt.get(), skewInfoOpt.get()));
+        }
 
-            if (skewColumnStats == null) {
-                // Only support column with some stats
-                continue;
-            }
+        for (final var skewPredicate : skewedPredicates) {
+            final var skewJoinColumn = skewPredicate.column();
+            final var skewInfo = skewPredicate.skewInfo();
 
-            final var mcvLimit = context.getSessionVariable().getSkewJoinOptimizeUseMCVCount();
-            final var rowPercentageThreshold = context.getSessionVariable().getSkewJoinDataSkewThreshold();
-            final var skewInfo = DataSkew.getColumnSkewInfo(leftChildStats, skewColumnStats,
-                    new DataSkew.Thresholds(mcvLimit, rowPercentageThreshold));
+            // Handle NULL-only skew case: when MCV is empty but NULL fraction indicates skew
+            List<ScalarOperator> skewValues;
+            if (skewInfo.type() == DataSkew.SkewType.SKEWED_NULL) {
+                // Create a special NULL skew value for NULL-only skew cases
+                skewValues = Lists.newArrayList(ConstantOperator.createNull(skewJoinColumn.getType()));
+            } else if (skewInfo.type() == DataSkew.SkewType.SKEWED_MCV) {
+                // Use MCV-based skew values
+                skewValues = skewInfo.maybeMcvs().get()
+                        .stream() //
+                        .map(mcv -> ConstantOperator.createVarchar(mcv.first) //
+                                .castTo(skewJoinColumn.getType())) //
+                        .filter(Optional::isPresent) //
+                        .map(Optional::get) //
+                        .collect(Collectors.toList());
 
-            if (skewInfo.isSkewed()) {
-                joinOperator.setSkewColumn(skewJoinColumn);
-
-                // Handle NULL-only skew case: when MCV is empty but NULL fraction indicates skew
-                List<ScalarOperator> skewValues;
-                if (skewInfo.type() == DataSkew.SkewType.SKEWED_NULL) {
-                    // Create a special NULL skew value for NULL-only skew cases
-                    skewValues = Lists.newArrayList(ConstantOperator.createNull(skewJoinColumn.getType()));
-                } else if (skewInfo.type() == DataSkew.SkewType.SKEWED_MCV) {
-                    // Use MCV-based skew values
-                    skewValues = skewInfo.maybeMcvs().get()
-                            .stream() //
-                            .map(mcv -> ConstantOperator.createVarchar(mcv.first) //
-                                    .castTo(skewJoinColumn.getType())) //
-                            .filter(Optional::isPresent) //
-                            .map(Optional::get) //
-                            .collect(Collectors.toList());
-
-                    if (skewValues.isEmpty()) {
-                        // If all explicit casts failed.
-                        continue;
-                    }
-                } else {
-                    throw new StarRocksPlannerException("Did not handle skew type in SkewOptimizeRule", ErrorType.INTERNAL_ERROR);
+                if (skewValues.isEmpty()) {
+                    // If all explicit casts failed.
+                    continue;
                 }
-
-                joinOperator.setSkewValues(skewValues);
-                return true;
+            } else {
+                throw new StarRocksPlannerException("Did not handle skew type in SkewOptimizeRule", ErrorType.INTERNAL_ERROR);
             }
+
+            joinOperator.setSkewColumn(skewJoinColumn);
+            joinOperator.setSkewValues(skewValues);
+            return true;
         }
         return false;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -429,6 +429,48 @@ public class SkewJoinTest extends PlanTestBase {
         }
     }
 
+    @Test
+    void testSkewJoinNotAppliedWhenAtLeastOnePredicateIsUnskewed() throws Exception {
+        final var oldStatisticsStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        final double oldThreshold = connectContext.getSessionVariable().getSkewJoinDataSkewThreshold();
+        try {
+            // GIVEN
+            // v1 is skewed (high NULL fraction), but v2 is not skewed
+            final var statisticsStorage = new EmptyStatisticStorage() {
+                @Override
+                public ColumnStatistic getColumnStatistic(Table table, String column) {
+                    if (table.getName().equalsIgnoreCase("t0") && column.equalsIgnoreCase("v1")) {
+                        return ColumnStatistic.builder()
+                                .setNullsFraction(0.8) // skewed
+                                .build();
+                    }
+                    if (table.getName().equalsIgnoreCase("t0") && column.equalsIgnoreCase("v2")) {
+                        return ColumnStatistic.builder()
+                                .setNullsFraction(0.01) // NOT skewed
+                                .build();
+                    }
+                    return ColumnStatistic.builder()
+                            .setNullsFraction(0.01)
+                            .build();
+                }
+            };
+            setTableStatistics(getOlapTable("t0"), 1337);
+            connectContext.getGlobalStateMgr().setStatisticStorage(statisticsStorage);
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(0.1);
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(true);
+
+            // WHEN
+            String sql = "select * from t0 left join t1 on t0.v1 = t1.v4 and t0.v2 = t1.v5";
+            String plan = getFragmentPlan(sql);
+
+            // THEN
+            assertNotContains(plan, "rand_col");
+        } finally {
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(oldThreshold);
+            connectContext.getGlobalStateMgr().setStatisticStorage(oldStatisticsStorage);
+        }
+    }
+
     private static File newFolder(File root, String... subDirs) throws IOException {
         String subFolder = String.join("/", subDirs);
         File result = new File(root, subFolder);


### PR DESCRIPTION
Backport of #72753 to `branch-3.5-cc`.

Original commit: f5b1b44e925cb6ad7344649618b19af86475ba53
Original PR: https://github.com/StarRocks/starrocks/pull/72753

---

<!-- Original PR description below -->

## Why I'm doing:

The `SkewJoinOptimizeRule`(v1) may add a salting to a join if there is one skewed column but other join keys acctually distribute well. This can blow up the join size by 1000x (due to adding the `rand_col` salting column), which is inefficient and can cause memory pressure although it brings no benefit in this case.

## What I'm doing:
Changing the skew detection so that only if all join keys are skewed, we apply the rule and salt the join. 
This can be proven to be correct since if at least one of our join keys is not skewed, the hash already distributed well enough for multiple partitions and the join is actually not causing partition skew. 

More mathematically speaking, the most frequent (k₁, k₂, ..., kₙ) tuple is bounded by the most frequent value of each individual key. If any join key kᵢ is not skewed, no composite tuple can dominate. (where k is a join key)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
