### PR TITLE
[auto-perf-opt] Wait for oldest PK-index flush on publish path instead of sync OSS write

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -335,9 +335,24 @@ Status LakePersistentIndex::flush_memtable(bool force) {
         if (finish_point >= 0) {
             _inactive_memtables.erase(_inactive_memtables.begin(), _inactive_memtables.begin() + finish_point + 1);
         }
-        // 3. flush current memtable
+        // 3. If we're at the inflight cap, wait for the oldest async flush to
+        //    complete rather than synchronously flushing the current memtable on
+        //    the publish thread. The wall-clock back-pressure is the same, but
+        //    the I/O runs on the dedicated pk_index_memtable_flush thread pool
+        //    (preserving its concurrency across tablets), and the publish thread
+        //    can resume replace work on a new memtable as soon as one slot frees.
+        while (!_inactive_memtables.empty() &&
+               _inactive_memtables.size() + 1 >= config::pk_index_memtable_max_count) {
+            TRACE_COUNTER_SCOPE_LATENCY_US("wait_oldest_pk_flush_us");
+            _inactive_memtables.front()->wait_flush_done();
+            RETURN_IF_ERROR(_inactive_memtables.front()->flush_status());
+            auto sstable = _inactive_memtables.front()->release_sstable();
+            RETURN_IF_ERROR(merge_sstable_into_fileset(sstable));
+            _inactive_memtables.erase(_inactive_memtables.begin());
+        }
+        // 4. flush current memtable
         bool flush_async = false;
-        if (_inactive_memtables.size() + 1 < config::pk_index_memtable_max_count) {
+        if (_inactive_memtables.size() + 1 <= config::pk_index_memtable_max_count) {
             if (ExecEnv::GetInstance()->pk_index_memtable_flush_thread_pool()->submit(_memtable).ok()) {
                 flush_async = true;
             }
@@ -345,7 +360,7 @@ Status LakePersistentIndex::flush_memtable(bool force) {
         if (flush_async) {
             _inactive_memtables.push_back(_memtable);
         } else {
-            // If too many memtables or submit flush job fail, switch to sync flush.
+            // Thread pool submit failed (e.g. shutting down). Fall back to sync flush.
             RETURN_IF_ERROR(_memtable->flush());
             if (_inactive_memtables.empty()) {
                 auto sstable = _memtable->release_sstable();

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -341,8 +341,7 @@ Status LakePersistentIndex::flush_memtable(bool force) {
         //    the I/O runs on the dedicated pk_index_memtable_flush thread pool
         //    (preserving its concurrency across tablets), and the publish thread
         //    can resume replace work on a new memtable as soon as one slot frees.
-        while (!_inactive_memtables.empty() &&
-               _inactive_memtables.size() + 1 >= config::pk_index_memtable_max_count) {
+        while (!_inactive_memtables.empty() && _inactive_memtables.size() + 1 >= config::pk_index_memtable_max_count) {
             TRACE_COUNTER_SCOPE_LATENCY_US("wait_oldest_pk_flush_us");
             _inactive_memtables.front()->wait_flush_done();
             RETURN_IF_ERROR(_inactive_memtables.front()->flush_status());

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -245,16 +245,24 @@ void PersistentIndexMemtable::clear() {
 
 void PersistentIndexMemtable::run() {
     auto st = flush();
-    if (!st.ok()) {
-        LOG(ERROR) << "PersistentIndexMemtable flush failed for tablet " << _tablet_id << ": " << st;
+    {
         std::lock_guard<std::mutex> lg(_flush_mutex);
-        _flush_status = st;
+        if (!st.ok()) {
+            LOG(ERROR) << "PersistentIndexMemtable flush failed for tablet " << _tablet_id << ": " << st;
+            _flush_status = st;
+        }
+        _flush_done = true;
     }
+    _flush_done_cv.notify_all();
 }
 
 void PersistentIndexMemtable::cancel() {
-    std::lock_guard<std::mutex> lg(_flush_mutex);
-    _flush_status = Status::Cancelled("PersistentIndexMemtable flush cancelled");
+    {
+        std::lock_guard<std::mutex> lg(_flush_mutex);
+        _flush_status = Status::Cancelled("PersistentIndexMemtable flush cancelled");
+        _flush_done = true;
+    }
+    _flush_done_cv.notify_all();
 }
 
 std::unique_ptr<PersistentIndexSstable> PersistentIndexMemtable::release_sstable() {
@@ -265,6 +273,11 @@ std::unique_ptr<PersistentIndexSstable> PersistentIndexMemtable::release_sstable
 Status PersistentIndexMemtable::flush_status() const {
     std::lock_guard<std::mutex> lg(_flush_mutex);
     return _flush_status;
+}
+
+void PersistentIndexMemtable::wait_flush_done() const {
+    std::unique_lock<std::mutex> lk(_flush_mutex);
+    _flush_done_cv.wait(lk, [this] { return _flush_done; });
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <condition_variable>
+
 #include "storage/lake/types_fwd.h"
 #include "storage/persistent_index.h"
 #include "util/phmap/btree.h"
@@ -94,6 +96,11 @@ public:
 
     Status flush_status() const;
 
+    // Block the caller until run() or cancel() has set the terminal flush state.
+    // Only valid for memtables already submitted to the flush thread pool;
+    // memtables that were never submitted will block forever.
+    void wait_flush_done() const;
+
 private:
     Status flush(WritableFile* wf, uint64_t* filesize, PersistentIndexSstableRangePB* range_pb);
     static void update_index_value(IndexValueWithVer* index_value_info, int64_t version, const IndexValue& value);
@@ -111,6 +118,10 @@ private:
     Status _flush_status = Status::OK();
     // flush state mutex
     mutable std::mutex _flush_mutex;
+    // Signaled when run()/cancel() has completed, so a waiter can block on
+    // a specific memtable's flush without polling the thread pool.
+    mutable std::condition_variable _flush_done_cv;
+    bool _flush_done{false};
 };
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Background

Auto-perf-opt iter-002 on the `1_100gb_sortkey` shared-data workload. Previous iter-001 PR #73234 raised `pk_index_memtable_max_count` 2 → 6 as a config-only stop-gap and produced a measurable but incomplete win (publish max 41.5 s → 1.4 s, client upsert P99 −10 %, throughput +8 %). This PR is the structural code-level fix for the same bottleneck and is independent of the `max_count` value.

## Problem

`LakePersistentIndex::flush_memtable` (`be/src/storage/lake/lake_persistent_index.cpp`) falls back to a synchronous `_memtable->flush()` on the publish thread whenever the per-tablet inflight memtable cap is reached:

```cpp
if (_inactive_memtables.size() + 1 < config::pk_index_memtable_max_count) {
    // async submit to pk_index_memtable_flush pool
} else {
    // SYNC: blocks the publish thread on an OSS write
    RETURN_IF_ERROR(_memtable->flush());
    ...
}
```

The dedicated `pk_index_memtable_flush` thread pool is sized to 1024 threads/CN and sits 99 %+ idle during compaction publishes (iter-001 measured peak active = 2 of 6 144 cluster-wide), yet the publish thread does the OSS write inline on the critical path because the cap is hit. A `flush_times = 20` compaction publish observed in iter-001 spent 21 s in `pindex_memtable_replace_us` and 2.2 s in `flush_memtable_us` for a total publish cost of 41.5 s; ~18 of those flushes were the sync-fallback.

The previous sync-fallback also temporarily lets `_inactive_memtables.size()` exceed `max_count` (the just-synced memtable is pushed back onto the deque while older flushes are still in flight), making the cap a soft limit rather than a true ceiling.

## Fix

When the cap is hit, instead of doing the OSS write inline:

1. **Wait for the oldest inflight async flush to complete**, signaled by a new `wait_flush_done()` on `PersistentIndexMemtable` backed by a `std::condition_variable`. `run()` and `cancel()` notify under the existing `_flush_mutex` so any waiter is woken regardless of which terminal state the runnable reached.
2. **Merge that oldest sstable into the fileset** and pop it.
3. **Always submit the current memtable async** to the dedicated pool. The sync flush remains only as a fallback if `submit()` itself fails (e.g. the pool is being shut down).

Net effect:

- Flush I/O stays on the dedicated `pk_index_memtable_flush` pool's reserved concurrency, where it can overlap with other tablets' flushes — instead of doing serial OSS writes inline on each publish thread.
- The publish thread is freed to resume `_memtable->replace()` work on a fresh memtable as soon as one slot opens, rather than blocking until its own OSS write returns.
- `_inactive_memtables.size()` now stays ≤ `max_count` at all times, restoring the cap as a true ceiling.

This is complementary to PR #73234 — that PR raises the cap (giving more I/O pipeline depth); this PR ensures all flush I/O always goes through the dedicated pool regardless of cap size.

## Diff

- `be/src/storage/lake/persistent_index_memtable.h` — declare `wait_flush_done()`, add `_flush_done_cv` + `_flush_done` flag.
- `be/src/storage/lake/persistent_index_memtable.cpp` — implement `wait_flush_done()`; signal `_flush_done` from `run()` and `cancel()`.
- `be/src/storage/lake/lake_persistent_index.cpp` — replace the sync-fallback branch in `flush_memtable()` with a wait-on-oldest loop, then unconditionally try async submit.

Total: 47 insertions, 8 deletions across 3 files.

## Why not just keep PR #73234

PR #73234 is a default-value bump that helps this specific workload's memory and CPU profile. The wait-on-oldest pattern is the correct structural shape independent of `max_count` — it prevents publish-thread serialization on OSS even if a future workload (smaller hosts, tighter memory) needs `max_count` reduced. Default config tuning addresses symptoms; this addresses the structural cause.

## Acceptance criteria (to be verified by the next iteration's benchmark)

iter-002 baseline (PR #73234 alone): upsert P99 = 6 079 ms, freshness P99 = 15 847 ms, throughput 41 764 rows/s, publish max = 1 443 ms.

This PR builds from the pinned run baseline (8813309 — max_count = 2, NO PR #73234 changes). Expected acceptance vs that ORIGINAL baseline:

- Upsert P99 measurably below 6 753 ms (the iter-001 baseline with max_count = 2 + sync fallback).
- Publish-trace max well below 41.5 s (any 5×+ reduction is a win).
- No throughput regression (≥ 38 618 rows/s).
- Query Q1 P99 within 10 % of baseline.

A PR that meets these is a clear win. If it doesn't move P99 in isolation against max_count = 2, it still has structural value and should be combined with PR #73234.

## Safety

- The `wait_flush_done()` waiter only ever blocks on memtables already in `_inactive_memtables`, which by construction means `submit()` succeeded; the runnable will either `run()` or `cancel()`, both of which now signal the condvar.
- No new allocations or heap state — only a `bool` + `std::condition_variable` per memtable, on existing mutex.
- The error-propagation path is preserved (`RETURN_IF_ERROR(flush_status())` after the wait).
- No public API changes. No config knob changes.

## Out of scope

- Client-side urllib3 connection-pool exhaustion in the benchmark adapter (contributes ~4-5 s to client P99; cannot be fixed in StarRocks code).
- Q5 wide-scan latency on this workload — query-side, orthogonal to upsert publish path.
- PK-index sstable count growth (303 sstables queried in a single publish observed in iter-002) — separate investigation.

🤖 Generated with auto-perf-opt + [Claude Code](https://claude.com/claude-code)
