### PR TITLE
[Enhancement] Use BasicTable in FrontendService.getTableNames to avoid network IO

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -49,6 +49,7 @@ import com.starrocks.authentication.UserAuthenticationInfo;
 import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.PrivilegeType;
+import com.starrocks.catalog.BasicTable;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -558,13 +559,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (db != null) {
             for (String tableName : metadataMgr.listTableNames(context, catalogName, params.db)) {
                 LOG.debug("get table: {}, wait to check", tableName);
-                Table tbl = null;
+                BasicTable tbl = null;
                 if (!PatternMatcher.matchPattern(params.getPattern(), tableName, matcher, caseSensitive)) {
                     continue;
                 }
 
                 try {
-                    tbl = metadataMgr.getTable(context, catalogName, params.db, tableName);
+                    tbl = metadataMgr.getBasicTable(context, catalogName, params.db, tableName,
+                            Config.enable_external_catalog_information_schema_tables_access_full_metadata);
                 } catch (Exception e) {
                     LOG.warn(e.getMessage(), e);
                 }


### PR DESCRIPTION
## Why I'm doing:

`FrontendServiceImpl.getTableNames` (the `getTableMeta` Thrift RPC, backing `SHOW TABLES` and the `TABLE_NAME` column of `information_schema.tables`) iterates over `listTableNames` and calls `metadataMgr.getTable()` for every table to perform a privilege check. For external catalogs (Iceberg, Hive, Hudi, etc.), `getTable()` triggers a full metadata fetch — one network round trip per table name. On large external catalogs this turns a single `SHOW TABLES` into O(N) network round trips.

This is the same N+1 problem that #70197 fixed in `InformationSchemaDataSource.generateTablesInfoResponse` for `information_schema.tables_config` content, but for a different RPC path that the previous PR did not touch.

## What I'm doing:

Switch the loop to `metadataMgr.getBasicTable(...)`, which is the lightweight variant designed to avoid network interaction with external services (see `BasicTable` javadoc). The downstream call `Authorizer.checkAnyActionOnTableLikeObject` already accepts `BasicTable` directly — no cast needed, no behavior change for default settings.

Honour the existing config flag `enable_external_catalog_information_schema_tables_access_full_metadata` introduced in #70197 so that when an operator opts in to full external metadata for `information_schema.tables_config`, the same applies here.

Fixes #73246
Related: #70197

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
