### PR TITLE
[BugFix] Fix task history management for failed tasks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -119,6 +119,9 @@ public class TaskRunManager implements MemoryTrackable {
             if (force) {
                 // remove it from running TaskRun map
                 taskRunScheduler.removeRunningTask(taskRun.getTaskId());
+                TaskRunStatus status = taskRun.getStatus();
+                status.setFinishTime(System.currentTimeMillis());
+                taskRunHistory.addHistory(status);
             }
         }
     }
@@ -132,7 +135,11 @@ public class TaskRunManager implements MemoryTrackable {
         Set<TaskRun> pendingTaskRuns = taskRunScheduler.getPendingTaskRunsByTaskId(taskId);
         if (CollectionUtils.isNotEmpty(pendingTaskRuns)) {
             for (TaskRun pendingTaskRun : pendingTaskRuns) {
+                TaskRunStatus status = pendingTaskRun.getStatus();
+                status.setState(Constants.TaskRunState.FAILED);
+                status.setFinishTime(System.currentTimeMillis());
                 taskRunScheduler.removePendingTaskRun(pendingTaskRun, Constants.TaskRunState.FAILED);
+                taskRunHistory.addHistory(status);
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerTest.java
@@ -92,7 +92,7 @@ public class TaskRunManagerTest {
         boolean[] forces = {false, true};
         for (boolean force : forces) {
             for (int i = 0; i < N; i++) {
-                TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(true, false, 1));
+                TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(true, false, 1), System.currentTimeMillis());
                 taskRuns.add(taskRun);
                 scheduler.addPendingTaskRun(taskRun);
             }
@@ -797,6 +797,101 @@ public class TaskRunManagerTest {
         // All finish states should be in history
         List<TaskRunStatus> history = taskManager.getTaskRunHistory().getInMemoryHistory();
         Assertions.assertEquals(5, history.size()); // RUNNING, FAILED, SUCCESS, MERGED, SKIPPED
+    }
+
+    @Test
+    public void testKillPendingTaskRunsAddsToHistory() {
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        long taskId = 200L;
+
+        TaskRunScheduler scheduler = new TaskRunScheduler();
+        TaskRunManager taskRunManager = new TaskRunManager(scheduler);
+
+        int numPending = 3;
+        for (int i = 0; i < numPending; i++) {
+            TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(true, false, 1));
+            taskRun.initStatus("pending-query-" + i, System.currentTimeMillis());
+            scheduler.addPendingTaskRun(taskRun);
+        }
+        Assertions.assertEquals(numPending, scheduler.getPendingQueueCount());
+
+        taskRunManager.killPendingTaskRuns(taskId);
+
+        Assertions.assertTrue(CollectionUtils.isEmpty(scheduler.getPendingTaskRunsByTaskId(taskId)));
+
+        List<TaskRunStatus> history = taskRunManager.getTaskRunHistory().getInMemoryHistory();
+        Assertions.assertEquals(numPending, history.size());
+        for (TaskRunStatus status : history) {
+            Assertions.assertEquals(Constants.TaskRunState.FAILED, status.getState());
+            Assertions.assertTrue(status.getFinishTime() > 0);
+        }
+    }
+
+    @Test
+    public void testKillRunningTaskRunForceAddsToHistory() {
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        long taskId = 201L;
+
+        TaskRunScheduler scheduler = new TaskRunScheduler();
+        TaskRunManager taskRunManager = new TaskRunManager(scheduler);
+
+        TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(true, false, 1));
+        taskRun.initStatus("running-query-1", System.currentTimeMillis());
+        scheduler.addPendingTaskRun(taskRun);
+
+        scheduler.scheduledPendingTaskRun(tr -> {});
+
+        TaskRun runningTaskRun = scheduler.getRunningTaskRun(taskId);
+        Assertions.assertNotNull(runningTaskRun);
+
+        taskRunManager.killRunningTaskRun(runningTaskRun, true);
+
+        Assertions.assertNull(scheduler.getRunningTaskRun(taskId));
+
+        List<TaskRunStatus> history = taskRunManager.getTaskRunHistory().getInMemoryHistory();
+        Assertions.assertEquals(1, history.size());
+        Assertions.assertTrue(history.get(0).getFinishTime() > 0);
+    }
+
+    @Test
+    public void testKillTaskRunForceAddsAllToHistory() {
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        long taskId = 202L;
+        int numTotalRuns = 4;
+
+        TaskRunScheduler scheduler = new TaskRunScheduler();
+        TaskRunManager taskRunManager = new TaskRunManager(scheduler);
+
+        for (int i = 0; i < numTotalRuns; i++) {
+            TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(true, false, 1));
+            taskRun.initStatus("combined-query-" + i, System.currentTimeMillis());
+            scheduler.addPendingTaskRun(taskRun);
+        }
+
+        scheduler.scheduledPendingTaskRun(tr -> {});
+
+        Assertions.assertNotNull(scheduler.getRunningTaskRun(taskId));
+        Assertions.assertEquals(numTotalRuns - 1, scheduler.getPendingTaskRunsByTaskId(taskId).size());
+
+        taskRunManager.killTaskRun(taskId, true);
+
+        Assertions.assertNull(scheduler.getRunningTaskRun(taskId));
+        Assertions.assertTrue(CollectionUtils.isEmpty(scheduler.getPendingTaskRunsByTaskId(taskId)));
+
+        List<TaskRunStatus> history = taskRunManager.getTaskRunHistory().getInMemoryHistory();
+        Assertions.assertEquals(numTotalRuns, history.size());
+
+        long failedCount = history.stream()
+                                  .filter(s -> s.getState() == Constants.TaskRunState.FAILED)
+                                  .count();
+        Assertions.assertEquals(numTotalRuns - 1, failedCount);
+
+        for (TaskRunStatus status : history) {
+            Assertions.assertTrue(status.getFinishTime() > 0);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
When task runs were killed (either running or pending), they were removed from the scheduler queues but never added to the task run history. This caused killed/failed tasks to disappear entirely — they would not show up in SHOW TASK RUNS history or any observability surface, making it hard to audit or debug task failures.

## What I'm doing:
- In killRunningTaskRun, after force-removing the task from the running map, set a finish time on the status and add it to taskRunHistory.
  - In killPendingTaskRuns, before removing each pending task run, set its state to FAILED, set a finish time, and add it to taskRunHistory.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
