### PR TITLE
[auto-perf-opt] Batch per-chunk replace() in PK compaction conflict resolver

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1355,6 +1355,12 @@ CONF_mBool(lake_clear_corrupted_cache_data, "true");
 // The maximum number of files which need to rebuilt in cloud native pk index.
 // If files which need to rebuilt larger than this, we will flush memtable immediately.
 CONF_mInt32(cloud_native_pk_index_rebuild_files_threshold, "50");
+// Batch row count for PrimaryKeyCompactionConflictResolver::execute() — multiple per-chunk
+// `params.index->replace()` calls are accumulated into one call across this many rows. Each
+// replace() in LakePersistentIndex runs a memtable flush check + lock round-trip; batching N
+// chunks amortises that work by ~N×. Setting this <= vector_chunk_size (4096) effectively
+// disables batching. 32 K rows ≈ 8 chunks ≈ ~1.6 MB of accumulated PK bytes.
+CONF_mInt32(primary_key_compaction_replace_batch_rows, "32768");
 // The maximum number of rows which need to be rebuilt in cloud native pk index.
 // If rows which need to be rebuilt exceed this threshold, we will flush memtable immediately
 // to reduce index rebuild cost. 0 means disabled.

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -42,6 +42,14 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
             [&](const CompactConflictResolveParams& params, const std::vector<ChunkIteratorPtr>& segment_iters,
                 const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>& handle_delvec_result_func) {
                 std::map<uint32_t, DelVectorPtr> rssid_to_delvec;
+                // Accumulate multiple chunks' PKs into a single replace() call to reduce per-chunk
+                // overhead: each `params.index->replace()` ends with a memtable flush check + lock
+                // round-trip in LakePersistentIndex::replace(). For a 1 M-row segment with the default
+                // 4 K chunk, that is ~250 such calls per segment. Batching N chunks amortises the
+                // per-call setup, vector allocations, and memtable bookkeeping by ~N×. 0 disables
+                // batching (one replace per chunk).
+                const size_t batch_rows_threshold = std::max<size_t>(
+                        1, static_cast<size_t>(config::primary_key_compaction_replace_batch_rows));
                 for (size_t segment_id = 0; segment_id < segment_iters.size(); segment_id++) {
                     RETURN_IF_ERROR(breakpoint_check());
                     // only hold pkey, so can use larger chunk size
@@ -49,15 +57,34 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                     TRY_CATCH_BAD_ALLOC(chunk_shared_ptr =
                                                 ChunkHelper::new_chunk(pkey_schema, config::vector_chunk_size));
                     auto chunk = chunk_shared_ptr.get();
-                    auto col = pk_column->clone();
+                    auto batch_col = pk_column->clone();
                     vector<uint32_t> tmp_deletes;
+                    std::vector<uint32_t> batch_replace_indexes;
                     uint32_t current_rowid = 0;
+                    uint32_t batch_start_rowid = 0; // segment offset of the first row in batch_col
+                    uint32_t batch_acc_rows = 0;    // rows already accumulated in batch_col
+
+                    auto flush_replace_batch = [&]() -> Status {
+                        if (batch_acc_rows == 0) {
+                            return Status::OK();
+                        }
+                        if (!batch_replace_indexes.empty()) {
+                            TRACE_COUNTER_SCOPE_LATENCY_US("compaction_replace_index_latency_us");
+                            RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id,
+                                                                  batch_start_rowid, batch_replace_indexes,
+                                                                  *batch_col));
+                        }
+                        batch_start_rowid += batch_acc_rows;
+                        batch_acc_rows = 0;
+                        batch_col->reset_column();
+                        batch_replace_indexes.clear();
+                        return Status::OK();
+                    };
 
                     auto itr = segment_iters[segment_id].get();
                     if (itr != nullptr) {
                         while (true) {
                             chunk->reset();
-                            col->reset_column();
                             auto st = Status::OK();
                             // 4. get chunk
                             {
@@ -72,7 +99,6 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                             } else {
                                 // 5. get input rssid & rowids, so we can generate delvec
                                 std::vector<uint64_t> rssid_rowids;
-                                std::vector<uint32_t> replace_indexes;
                                 RETURN_IF_ERROR(mapper_iter.next_values(chunk->num_rows(), &rssid_rowids));
                                 DCHECK(chunk->num_rows() == rssid_rowids.size());
                                 for (int i = 0; i < rssid_rowids.size(); i++) {
@@ -93,19 +119,25 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                                         // Input row had been deleted, so we need to delete it from output rowset
                                         tmp_deletes.push_back(current_rowid + i);
                                     } else {
-                                        // replace pk index
-                                        replace_indexes.push_back(i);
+                                        // Index into batch_col after this chunk's encode has appended.
+                                        // batch_acc_rows currently holds the count BEFORE appending this
+                                        // chunk, so this is the absolute position in batch_col.
+                                        batch_replace_indexes.push_back(batch_acc_rows + i);
                                     }
                                 }
-                                // 6. replace pk index
-                                TRACE_COUNTER_SCOPE_LATENCY_US("compaction_replace_index_latency_us");
+                                // 6. accumulate encoded PKs into batch_col (encode appends).
                                 TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(),
-                                                                              col.get(), encoding_type));
-                                RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id, current_rowid,
-                                                                      replace_indexes, *col));
+                                                                              batch_col.get(), encoding_type));
                                 current_rowid += chunk->num_rows();
+                                batch_acc_rows += chunk->num_rows();
+
+                                if (batch_acc_rows >= batch_rows_threshold) {
+                                    RETURN_IF_ERROR(flush_replace_batch());
+                                }
                             }
                         }
+                        // Flush any trailing rows that did not reach the threshold.
+                        RETURN_IF_ERROR(flush_replace_batch());
                         itr->close();
                         // 7. generate final delvec
                         DelVectorPtr dv = std::make_shared<DelVector>();

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -48,8 +48,8 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                 // 4 K chunk, that is ~250 such calls per segment. Batching N chunks amortises the
                 // per-call setup, vector allocations, and memtable bookkeeping by ~N×. 0 disables
                 // batching (one replace per chunk).
-                const size_t batch_rows_threshold = std::max<size_t>(
-                        1, static_cast<size_t>(config::primary_key_compaction_replace_batch_rows));
+                const size_t batch_rows_threshold =
+                        std::max<size_t>(1, static_cast<size_t>(config::primary_key_compaction_replace_batch_rows));
                 for (size_t segment_id = 0; segment_id < segment_iters.size(); segment_id++) {
                     RETURN_IF_ERROR(breakpoint_check());
                     // only hold pkey, so can use larger chunk size
@@ -70,9 +70,8 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                         }
                         if (!batch_replace_indexes.empty()) {
                             TRACE_COUNTER_SCOPE_LATENCY_US("compaction_replace_index_latency_us");
-                            RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id,
-                                                                  batch_start_rowid, batch_replace_indexes,
-                                                                  *batch_col));
+                            RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id, batch_start_rowid,
+                                                                  batch_replace_indexes, *batch_col));
                         }
                         batch_start_rowid += batch_acc_rows;
                         batch_acc_rows = 0;


### PR DESCRIPTION
## Background

Auto-perf-opt iter-003 (run `pk-sortkey-opt`, template `1_100gb_sortkey`, shared-data). iter-001 PR #73234 raised `pk_index_memtable_max_count` (config), and iter-002 PR #73245 replaced the sync-flush fallback with `wait_flush_done()` on the oldest async flush (structural). Both PRs were validated in this iteration's measurement (publish max 41.5 s → 574 ms vs the original baseline) and have been promoted to ready-for-review.

This PR addresses the next residual on the publish path that the human operator specifically pointed at:

> Batch the per-chunk `params.index->replace(...)` calls in `primary_key_compaction_conflict_resolver.cpp` so memtable rollover happens less often per compaction.

## Problem

`PrimaryKeyCompactionConflictResolver::execute()` walks the output rowset of a PK compaction in chunks of `config::vector_chunk_size` (default 4 096) rows and calls `params.index->replace(...)` once per chunk. For a 1 M-row segment that is ~250 calls.

For shared-data tables, the call lands in `LakePersistentIndex::replace()`:

```cpp
Status LakePersistentIndex::replace(size_t n, ...) {
    std::vector<size_t> tmp_replace_idxes(replace_indexes.begin(), replace_indexes.end());
    RETURN_IF_ERROR(_memtable->replace(keys, values, tmp_replace_idxes, _version.major_number()));
    RETURN_IF_ERROR(flush_memtable());   // memtable cap check + lock round-trip every call
    return Status::OK();
}
```

Each call performs:
- A memtable flush check + (after PR #73245) a `wait_flush_done` decision under the LakePersistentIndex internal lock.
- A `std::vector<size_t>` copy of `replace_indexes`.
- `build_persistent_keys` / `_build_persistent_values` setup in `PrimaryIndex::_replace_persistent_index_by_indexes`.

None of that is per-row work; it is per-call work that runs 250 times per segment.

## Fix

Accumulate multiple chunks' encoded PK rows into one `batch_col` and one `batch_replace_indexes`, then issue a single `params.index->replace()` per `~primary_key_compaction_replace_batch_rows` accumulated rows (default 32 K ≈ 8 chunks ≈ ~1.6 MB).

Mechanically:

1. `PrimaryKeyEncoder::encode(...)` already appends to its destination column, so chunks can be encoded directly into a growing `batch_col` rather than into a fresh-each-chunk column.
2. For each row in the current chunk, the position in the batched column is `batch_acc_rows + i` (where `batch_acc_rows` is the count of rows in `batch_col` BEFORE this chunk's encode). That offset is recorded in `batch_replace_indexes` so the eventual `replace()` call uses the same offset semantics as before.
3. `batch_start_rowid` tracks the segment offset of the first row in `batch_col`. The `replace(rssid + segment_id, batch_start_rowid, batch_replace_indexes, *batch_col)` call therefore has the same effect on the PK index as the per-chunk calls.
4. After every chunk, if `batch_acc_rows >= batch_rows_threshold`, the batch is flushed. A final flush after the segment loop drains the remainder.

Setting `primary_key_compaction_replace_batch_rows <= vector_chunk_size` effectively disables batching for environments that want the prior behaviour (one replace per chunk).

## Diff

- `be/src/storage/primary_key_compaction_conflict_resolver.cpp` — refactor the inner loop of `execute()` to accumulate chunks into a single `batch_col` + `batch_replace_indexes` and call `params.index->replace()` per batch instead of per chunk.
- `be/src/common/config.h` — add `primary_key_compaction_replace_batch_rows` (default 32 768).

`execute_without_update_index()` is unchanged — it does not call `replace()`.

Total: 48 insertions, 10 deletions across 2 files.

## Why not just remove the per-call `flush_memtable()` inside `LakePersistentIndex::replace()`

Two reasons. (1) `upsert()` also calls `flush_memtable()` per call by design, so the symmetry is intentional and removing it from `replace()` would diverge the path. (2) The `flush_memtable()` call is the place where memtable cap is enforced; removing it would let the active memtable grow without bound between segment boundaries. Batching upstream is the safer change.

## Acceptance criteria (to be verified by the next iteration's benchmark)

iter-003 baseline against PR #73245 (commit `34f43c6`, branch-4.1 + PR #73245): publish-trace max 574 ms; top-20 slow publishes dominated by upsert publishes with `parallel_upsert_wait_us` ≈ 190 ms over `pindex_sstables_queried_cnt` ≈ 300+.

This PR specifically targets **compaction publishes** (the iter-002 pattern with `input_rowsets_size > 50` and `flush_times > 0` that no longer appears in the iter-003 top-20). The next iteration's publish trace should show:

- Compaction publishes with non-empty `compaction_replace_index_latency_us` carrying fewer accumulated occurrences per publish (one entry per 8 chunks instead of one per chunk).
- No regression in upsert-publish-dominated metrics: publish-trace max ≤ 600 ms, upsert P99 ≤ 6 500 ms, throughput ≥ 40 K rows/s.
- No regression in query P99.

A clear win on compaction publishes shows up as reduced wall-clock cost on traces with `input_rowsets_size > 50`. Inconclusive evidence (compaction publishes not present in the next test window) → keep this PR as draft for one more iteration; if still inconclusive, close.

## Safety

- The behaviour is identical to the prior path when `primary_key_compaction_replace_batch_rows <= vector_chunk_size`. The same `replace(rssid, rowid_start, replace_indexes, col)` semantics are used; only the chunking granularity changes.
- `PrimaryKeyEncoder::encode(...)` is documented to append (existing call sites in the same file rely on the same behaviour); no new allocation path.
- Memory is bounded by `batch_rows_threshold` times the PK encoding width — ~1.6 MB at the default for the 1_100gb_sortkey schema, well within the existing per-tablet compaction memory budget.
- Final-flush idempotent: `flush_replace_batch()` returns early if `batch_acc_rows == 0`.
- `breakpoint_check()` is still called once per segment, matching prior cadence.

## Out of scope

- Upsert-publish PK-index fan-out (`pindex_sstables_queried_cnt` 280–348 per publish) — a separate compaction-strategy issue.
- Cold-init segment loading (564 ms on first publish per tablet) — `enable_load_segment_parallel` is `false` by default; orthogonal change.
- Client-side urllib3 floor.

🤖 Generated with auto-perf-opt + [Claude Code](https://claude.com/claude-code)
