### PR TITLE
[auto-perf-opt] PK index size-tiered compaction: pick multiple levels per cycle

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -495,6 +495,12 @@ CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 CONF_mInt64(pk_index_size_tiered_min_level_size, "131072");
 CONF_mInt64(pk_index_size_tiered_level_multiplier, "10");
 CONF_mInt64(pk_index_size_tiered_max_level, "5");
+// When true, pick_compaction_candidates may issue filesets from multiple
+// priority levels in a single cycle (up to lake_pk_index_sst_max_compaction_versions
+// total filesets). This lets the parallel compact thread pool overlap level
+// compactions that would otherwise drain sequentially. Set false to restore
+// the previous one-level-per-cycle behaviour.
+CONF_mBool(pk_index_size_tiered_pick_multi_levels, "true");
 // Used to control the sampling interval size for SSTable files.
 CONF_mInt64(pk_index_sstable_sample_interval_bytes, "16777216");
 // Controls merge condition evaluation behavior within the same transaction for primary key tables.

--- a/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
+++ b/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
@@ -169,37 +169,67 @@ StatusOr<CompactionCandidateResult> LakePersistentIndexSizeTieredCompactionStrat
         order_levels.emplace_back(std::move(level));
     }
 
-    // Pick the best level for compaction
+    // Pick the best level for compaction. When pk_index_size_tiered_pick_multi_levels
+    // is enabled, also continue with subsequent priority levels so the parallel
+    // compact pool can overlap level compactions that would otherwise drain in
+    // sequential rounds (the pool is typically idle in steady state).
     if (priority_levels.empty()) {
         return result;
     }
 
-    SizeTieredLevel* selected_level = *priority_levels.begin();
-    if (selected_level->fileset_indexes.size() < min_compaction_filesets) {
-        return result;
-    }
-
-    // Build result: for each selected fileset, add all its sstables
     uint64_t max_max_rss_rowid = 0;
     bool merge_base_level = false;
-    for (size_t fileset_idx : selected_level->fileset_indexes) {
-        const FilesetInfo& fileset = filesets[fileset_idx];
-        std::vector<PersistentIndexSstablePB> fileset_sstables;
+    bool picked_any = false;
+    const int32_t max_versions = config::lake_pk_index_sst_max_compaction_versions;
+    const bool pick_multi_levels = config::pk_index_size_tiered_pick_multi_levels;
 
-        for (int sstable_idx : fileset.sstable_indices) {
-            fileset_sstables.push_back(sstable_meta.sstables(sstable_idx));
-            max_max_rss_rowid = std::max(max_max_rss_rowid, sstable_meta.sstables(sstable_idx).max_rss_rowid());
-        }
-        if (fileset.fileset_id == base_level_fileset_id) {
-            merge_base_level = true;
+    for (SizeTieredLevel* level : priority_levels) {
+        if (level->fileset_indexes.size() < min_compaction_filesets) {
+            // priority_levels is sorted by score (best first). A level that
+            // does not meet the minimum is not actionable here, but a later
+            // level might still have higher score+lower fileset count? No --
+            // min_compaction_filesets is an absolute lower bound; skip and
+            // continue checking remaining levels.
+            continue;
         }
 
-        result.candidate_filesets.push_back(std::move(fileset_sstables));
-        if (result.candidate_filesets.size() >= config::lake_pk_index_sst_max_compaction_versions) {
-            // Already reach max compaction versions, stop picking more filesets.
+        if (!picked_any) {
+            // Preserve original behaviour: the first level picked must also
+            // satisfy min_compaction_filesets (already checked above).
+            picked_any = true;
+        }
+
+        // Build result: for each selected fileset, add all its sstables.
+        for (size_t fileset_idx : level->fileset_indexes) {
+            const FilesetInfo& fileset = filesets[fileset_idx];
+            std::vector<PersistentIndexSstablePB> fileset_sstables;
+
+            for (int sstable_idx : fileset.sstable_indices) {
+                fileset_sstables.push_back(sstable_meta.sstables(sstable_idx));
+                max_max_rss_rowid =
+                        std::max(max_max_rss_rowid, sstable_meta.sstables(sstable_idx).max_rss_rowid());
+            }
+            if (fileset.fileset_id == base_level_fileset_id) {
+                merge_base_level = true;
+            }
+
+            result.candidate_filesets.push_back(std::move(fileset_sstables));
+            if (result.candidate_filesets.size() >= max_versions) {
+                // Already reach max compaction versions, stop picking more filesets.
+                break;
+            }
+        }
+
+        if (result.candidate_filesets.size() >= max_versions || !pick_multi_levels) {
+            // Either hit the cap or only one level is allowed per cycle.
             break;
         }
     }
+
+    if (!picked_any) {
+        return result;
+    }
+
     result.merge_base_level = merge_base_level;
     result.max_max_rss_rowid = max_max_rss_rowid;
 

--- a/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
+++ b/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
@@ -206,8 +206,7 @@ StatusOr<CompactionCandidateResult> LakePersistentIndexSizeTieredCompactionStrat
 
             for (int sstable_idx : fileset.sstable_indices) {
                 fileset_sstables.push_back(sstable_meta.sstables(sstable_idx));
-                max_max_rss_rowid =
-                        std::max(max_max_rss_rowid, sstable_meta.sstables(sstable_idx).max_rss_rowid());
+                max_max_rss_rowid = std::max(max_max_rss_rowid, sstable_meta.sstables(sstable_idx).max_rss_rowid());
             }
             if (fileset.fileset_id == base_level_fileset_id) {
                 merge_base_level = true;


### PR DESCRIPTION
## What this changes

`LakePersistentIndexSizeTieredCompactionStrategy::pick_compaction_candidates` now appends filesets from multiple priority-sorted levels into a single `result.candidate_filesets`, up to the existing `lake_pk_index_sst_max_compaction_versions` cap (default 100). Previously it returned only the single best level.

Gated by `pk_index_size_tiered_pick_multi_levels` (default `true`; flip to `false` for the prior behaviour).

## Why

In the auto-perf-opt run `pk-sortkey-opt` (1×100 GB sortkey, 6 CN shared-data), iter-004 measured the post-#73245/#73250 residual upsert tail:

- ~40 traces of 140 k in a 20-min window with `cost ≥ 300 ms`, dominated by `parallel_upsert_wait_us = 90–412 ms` bounded by `pindex_sstables_queried_cnt = 400–410` and `parallel_upsert_cnt = 10`.
- `cloud_native_pk_index_compact` thread pool: **max queue 0, max util 0.26 %** across the test window (PromQL `max_over_time` over 20 min).

The compact pool has tons of headroom; the bottleneck is purely scheduling. `compact_mgr->async_compact` already parallelises across the filesets handed to it. By feeding it more filesets per cycle, level compactions overlap instead of draining round-by-round.

## Risk / blast radius

- Memory: each fileset's sstable list is held in `result.candidate_filesets` until compaction completes. Already capped by `lake_pk_index_sst_max_compaction_versions = 100`. The cap is unchanged.
- Correctness: each fileset still becomes an independent compaction task (mergers run per-fileset). Mixing filesets across levels does not cross-pollinate per-fileset merges — it just submits more independent tasks to the pool.
- `merge_base_level`: becomes true if ANY picked level contains the base-level fileset_id. Same condition as before, just evaluated across the broader set of picked levels.
- Failure mode for memory-tight clusters: set `pk_index_size_tiered_pick_multi_levels=false` to restore the previous behaviour.

## Acceptance criteria (to be validated by the next auto-perf-opt iteration)

- `pindex_sstables_queried_cnt` P99 for upsert publishes on rt_bench tablets drops from ~410 (iter-004) to ≤ 250.
- `parallel_upsert_wait_us` P99 for slow upserts drops from ~300 ms to ≤ 150 ms.
- No regression on:
  - Upsert P99 (≤ 6 100 ms — iter-004 was 5 909 ms).
  - Throughput (≥ 40 K rows/s).
  - Compaction publish max (≤ 250 ms — iter-004 was 241 ms).
  - Query Q1 P99 within 10 % of iter-004 (5 242 ms).
- `cloud_native_pk_index_compact` util peak rises (indicating the pool is now being used), but max queue stays ≤ 1 (no backlog).

If any of these fails or there is no measurable reduction in `pindex_sstables_queried_cnt`, the next iteration closes this PR and records the result. If reduction is real but no client-side P99 improvement, leaves draft and investigates upstream blocker.

Auto-perf-opt program: `pk-sortkey-opt` iteration 004.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>