### PR TITLE
[auto-perf-opt] Parallelise PK-index cold-load segment iteration

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -489,6 +489,11 @@ CONF_mInt32(lake_partial_update_thread_pool_max_threads, "0");
 CONF_mInt32(lake_partial_update_thread_pool_queue_size, "2048");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
+// Parallelise the segment-iteration loop in LakePersistentIndex::load_from_lake_tablet
+// (PK-index cold-load on first publish per CN/tablet). Reads and decodes segments
+// of the same rowset concurrently on `pk_index_execution_thread_pool`; the memtable
+// insert itself remains serialised by a per-rowset mutex.
+CONF_mBool(enable_pk_index_rebuild_parallel_segment, "true");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 // The parameters for pk index size-tiered compaction strategy.

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1140,8 +1140,8 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     // segment, so segments are independent and can run concurrently; the only shared
     // state is the memtable, guarded by `insert_mutex`. OSS reads + decode + PK
     // encoding all run outside the lock, which is the cold-load wall-clock win.
-    const bool parallel_segments = config::enable_pk_index_rebuild_parallel_segment &&
-                                   config::enable_pk_index_parallel_execution;
+    const bool parallel_segments =
+            config::enable_pk_index_rebuild_parallel_segment && config::enable_pk_index_parallel_execution;
     for (auto& rowset : rowsets) {
         TRACE_COUNTER_INCREMENT("total_segment_cnt", rowset->num_segments());
         TRACE_COUNTER_INCREMENT("total_num_rows", rowset->num_rows());

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1124,22 +1124,24 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     const uint64_t rebuild_rss_rowid_point = sstables.empty() ? 0 : sstables.rbegin()->max_rss_rowid();
     const uint32_t rebuild_rss_id = rebuild_rss_rowid_point >> 32;
     OlapReaderStatistics stats;
-    MutableColumnPtr pk_column;
-    if (pk_columns.size() > 1 || pk_encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2) {
-        // more than one key column or big endian encoding
-        if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type).ok()) {
-            CHECK(false) << "create column for primary key encoder failed";
-        }
-    }
-    vector<uint32_t> rowids;
-    rowids.reserve(4096);
-    auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
-    auto chunk = chunk_shared_ptr.get();
     auto rowsets = Rowset::get_rowsets(tablet_mgr, metadata);
-    int64_t get_next_cost_us = 0;
-    int64_t pk_encode_cost_us = 0;
-    int64_t build_values_cost_us = 0;
-    // Rowset whose version is between max_sstable_version and base_version should be recovered.
+    // Accumulators that may be written from worker threads. Trace counters cannot be
+    // updated from worker threads (the trace context is thread-local and the parent
+    // increment would be silently dropped), so each worker writes to atomics here and
+    // the orchestrator emits a single TRACE_COUNTER_INCREMENT after wait().
+    std::atomic<int64_t> get_next_cost_us{0};
+    std::atomic<int64_t> pk_encode_cost_us{0};
+    std::atomic<int64_t> build_values_cost_us{0};
+    std::atomic<int64_t> rebuild_index_num_rows{0};
+    // Parallelise the segment loop within each rowset. Different rowsets MAY contain
+    // the same PK (update of a previous row), so they must be processed in order to
+    // preserve "latest version wins" semantics — the outer rowset loop stays
+    // sequential. Within one rowset (one transaction), each PK lands in at most one
+    // segment, so segments are independent and can run concurrently; the only shared
+    // state is the memtable, guarded by `insert_mutex`. OSS reads + decode + PK
+    // encoding all run outside the lock, which is the cold-load wall-clock win.
+    const bool parallel_segments = config::enable_pk_index_rebuild_parallel_segment &&
+                                   config::enable_pk_index_parallel_execution;
     for (auto& rowset : rowsets) {
         TRACE_COUNTER_INCREMENT("total_segment_cnt", rowset->num_segments());
         TRACE_COUNTER_INCREMENT("total_num_rows", rowset->num_rows());
@@ -1180,82 +1182,158 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         }
         auto& itrs = res.value();
         CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
-        for (size_t i = 0; i < itrs.size(); i++) {
-            TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_index_segment_cost_us");
-            auto itr = itrs[i].get();
+
+        std::mutex insert_mutex;
+        std::mutex status_mutex;
+        Status shared_status;
+        auto record_err = [&](const Status& s) {
+            std::lock_guard<std::mutex> lg(status_mutex);
+            shared_status.update(s);
+        };
+
+        // Process a single segment: drain its iterator, encode PKs, insert into the
+        // memtable under `insert_mutex`. Stateful local buffers (chunk, rowids,
+        // pk_column) must live on the worker stack — they cannot be hoisted out
+        // because workers run concurrently.
+        auto process_segment = [&](size_t i) {
+            ChunkIteratorPtr itr_holder = itrs[i];
+            auto* itr = itr_holder.get();
             if (itr == nullptr) {
-                continue;
+                return;
             }
             DeferOp close_iter([&] { itr->close(); });
             uint32_t rssid = rowset->id() + get_segment_idx(rowset->metadata(), static_cast<int32_t>(i));
             if (rssid < rebuild_rss_id) {
-                // lower than rebuild point, skip
-                // Notice: segment id that equal `rebuild_rss_id` can't be skip because
-                // there are maybe some rows need to rebuild.
-                continue;
+                // lower than rebuild point, skip; segment id == rebuild_rss_id
+                // can't be skipped (it may still have rows above the point).
+                return;
             }
-            TRACE_COUNTER_INCREMENT("rebuild_index_segment_cnt", 1);
+            vector<uint32_t> local_rowids;
+            local_rowids.reserve(4096);
+            auto local_chunk_sp = ChunkHelper::new_chunk(pkey_schema, 4096);
+            auto* local_chunk = local_chunk_sp.get();
+            MutableColumnPtr local_pk_column;
+            if (pk_columns.size() > 1 || pk_encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2) {
+                if (!PrimaryKeyEncoder::create_column(pkey_schema, &local_pk_column, pk_encoding_type).ok()) {
+                    record_err(Status::InternalError("create column for primary key encoder failed"));
+                    return;
+                }
+            }
+            int64_t local_get_next = 0;
+            int64_t local_encode = 0;
+            int64_t local_build = 0;
             while (true) {
-                chunk->reset();
-                rowids.clear();
+                // Cheap early-out so siblings stop draining IO after one task fails.
+                {
+                    std::lock_guard<std::mutex> lg(status_mutex);
+                    if (!shared_status.ok()) {
+                        return;
+                    }
+                }
+                local_chunk->reset();
+                local_rowids.clear();
                 int64_t t1 = GetCurrentTimeMicros();
-                auto st = itr->get_next(chunk, &rowids);
-                get_next_cost_us += GetCurrentTimeMicros() - t1;
+                auto st = itr->get_next(local_chunk, &local_rowids);
+                local_get_next += GetCurrentTimeMicros() - t1;
                 if (st.is_end_of_file()) {
                     break;
-                } else if (!st.ok()) {
-                    return st;
+                }
+                if (!st.ok()) {
+                    record_err(st);
+                    return;
+                }
+                Column* pkc = nullptr;
+                if (local_pk_column) {
+                    int64_t t2 = GetCurrentTimeMicros();
+                    local_pk_column->reset_column();
+                    PrimaryKeyEncoder::encode(pkey_schema, *local_chunk, 0, local_chunk->num_rows(),
+                                              local_pk_column.get(), pk_encoding_type);
+                    local_encode += GetCurrentTimeMicros() - t2;
+                    pkc = local_pk_column.get();
                 } else {
-                    Column* pkc = nullptr;
-                    if (pk_column) {
-                        int64_t t2 = GetCurrentTimeMicros();
-                        pk_column->reset_column();
-                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get(),
-                                                  pk_encoding_type);
-                        pk_encode_cost_us += GetCurrentTimeMicros() - t2;
-                        pkc = pk_column.get();
-                    } else {
-                        pkc = const_cast<Column*>(chunk->columns()[0].get());
+                    pkc = const_cast<Column*>(local_chunk->columns()[0].get());
+                }
+                int64_t t3 = GetCurrentTimeMicros();
+                uint64_t base = ((uint64_t)rssid) << 32;
+                std::vector<IndexValue> values;
+                values.reserve(pkc->size());
+                DCHECK(pkc->size() <= local_rowids.size());
+                for (uint32_t r = 0; r < pkc->size(); r++) {
+                    values.emplace_back(base + local_rowids[r]);
+                }
+                local_build += GetCurrentTimeMicros() - t3;
+                if (values.back().get_value() <= rebuild_rss_rowid_point) {
+                    continue;
+                }
+                rebuild_index_num_rows.fetch_add(pkc->size(), std::memory_order_relaxed);
+                Status insert_st;
+                if (pkc->is_binary()) {
+                    std::lock_guard<std::mutex> lg(insert_mutex);
+                    insert_st = insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()), values.data(),
+                                       rowset_version);
+                } else {
+                    std::vector<Slice> keys;
+                    keys.reserve(pkc->size());
+                    const auto* fkeys = pkc->continuous_data();
+                    for (size_t r = 0; r < pkc->size(); ++r) {
+                        keys.emplace_back(fkeys, _key_size);
+                        fkeys += _key_size;
                     }
-                    int64_t t3 = GetCurrentTimeMicros();
-                    uint64_t base = ((uint64_t)rssid) << 32;
-                    std::vector<IndexValue> values;
-                    values.reserve(pkc->size());
-                    DCHECK(pkc->size() <= rowids.size());
-                    for (uint32_t i = 0; i < pkc->size(); i++) {
-                        values.emplace_back(base + rowids[i]);
+                    std::lock_guard<std::mutex> lg(insert_mutex);
+                    insert_st = insert(pkc->size(), reinterpret_cast<const Slice*>(keys.data()), values.data(),
+                                       rowset_version);
+                }
+                if (!insert_st.ok()) {
+                    record_err(insert_st);
+                    return;
+                }
+            }
+            get_next_cost_us.fetch_add(local_get_next, std::memory_order_relaxed);
+            pk_encode_cost_us.fetch_add(local_encode, std::memory_order_relaxed);
+            build_values_cost_us.fetch_add(local_build, std::memory_order_relaxed);
+        };
+
+        // Count attempted segments on the orchestrator (TRACE_COUNTER is thread-local;
+        // see load_dels for the same pattern).
+        for (size_t i = 0; i < itrs.size(); i++) {
+            ChunkIterator* it = itrs[i].get();
+            if (it == nullptr) continue;
+            uint32_t rssid = rowset->id() + get_segment_idx(rowset->metadata(), static_cast<int32_t>(i));
+            if (rssid < rebuild_rss_id) continue;
+            TRACE_COUNTER_INCREMENT("rebuild_index_segment_cnt", 1);
+        }
+
+        {
+            TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_index_segment_cost_us");
+            if (parallel_segments && itrs.size() > 1) {
+                auto token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+                        ThreadPool::ExecutionMode::CONCURRENT);
+                for (size_t i = 0; i < itrs.size(); i++) {
+                    auto st = token->submit_func([&process_segment, i]() { process_segment(i); });
+                    if (!st.ok()) {
+                        // Pool full or shutting down — run inline so we don't drop the segment.
+                        process_segment(i);
                     }
-                    build_values_cost_us += GetCurrentTimeMicros() - t3;
-                    if (values.back().get_value() <= rebuild_rss_rowid_point) {
-                        // lower AND equal than rebuild point, skip
-                        continue;
-                    }
-                    TRACE_COUNTER_INCREMENT("rebuild_index_num_rows", pkc->size());
-                    if (pkc->is_binary()) {
-                        RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()),
-                                               values.data(), rowset_version));
-                    } else {
-                        std::vector<Slice> keys;
-                        keys.reserve(pkc->size());
-                        const auto* fkeys = pkc->continuous_data();
-                        for (size_t i = 0; i < pkc->size(); ++i) {
-                            keys.emplace_back(fkeys, _key_size);
-                            fkeys += _key_size;
-                        }
-                        RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(keys.data()), values.data(),
-                                               rowset_version));
-                    }
+                }
+                token->wait();
+            } else {
+                for (size_t i = 0; i < itrs.size(); i++) {
+                    process_segment(i);
                 }
             }
         }
-        // Rebuild from del files
+        RETURN_IF_ERROR(shared_status);
+
+        // Rebuild from del files (sequential — relies on the memtable populated above
+        // and the existing single-threaded erase path).
         if (rowset->metadata().del_files_size() > 0) {
             RETURN_IF_ERROR(load_dels(rowset, pkey_schema, rowset_version));
         }
     }
-    TRACE_COUNTER_INCREMENT("rebuild_get_next_cost_us", get_next_cost_us);
-    TRACE_COUNTER_INCREMENT("rebuild_pk_encode_cost_us", pk_encode_cost_us);
-    TRACE_COUNTER_INCREMENT("rebuild_build_values_cost_us", build_values_cost_us);
+    TRACE_COUNTER_INCREMENT("rebuild_get_next_cost_us", get_next_cost_us.load());
+    TRACE_COUNTER_INCREMENT("rebuild_pk_encode_cost_us", pk_encode_cost_us.load());
+    TRACE_COUNTER_INCREMENT("rebuild_build_values_cost_us", build_values_cost_us.load());
+    TRACE_COUNTER_INCREMENT("rebuild_index_num_rows", rebuild_index_num_rows.load());
     TRACE_COUNTER_INCREMENT("segment_io_local_disk_us", stats.io_ns_read_local_disk / 1000);
     TRACE_COUNTER_INCREMENT("segment_io_remote_us", stats.io_ns_remote / 1000);
     TRACE_COUNTER_INCREMENT("segment_io_count_local_disk", stats.io_count_local_disk);


### PR DESCRIPTION
## Why

`LakePersistentIndex::load_from_lake_tablet` (PK-index cold-load on the first publish per (CN, tablet) after a binary restart) is currently a single-threaded loop over (rowset, segment) pairs. Each iteration serially reads a segment from OSS, encodes its PKs, then inserts a chunk-at-a-time into the in-memory memtable. Even at idle host CPU / disk, this can dominate freshness P99 right after a deploy.

Observed on the `1_100gb_sortkey` benchmark (commit `ee2e3da`, PR #73253 build, deploy-induced cold-load):

| Trace counter (one cold-load on tablet 109668089, 2 segments, ~1 M rebuild rows) | Value |
| --- | ---: |
| `primary_index_load_latency_us` | 4 218 845 us |
| `pindex_load_from_lake_tablet_us` | 4 203 657 us |
| `rebuild_index_segment_cost_us` (sum across segments) | 4 194 404 us |
| `rebuild_get_next_cost_us` (OSS read) | 255 555 us |
| `rebuild_pk_encode_cost_us` | 63 068 us |
| `lake_persistent_index_insert_us` | 3 864 266 us |
| `pindex_memtable_insert_us` | 2 528 943 us |

So per cold-load tablet:
- ~17 % is in OSS get_next + PK encode (parallelisable, no shared state)
- ~60 % is in `_memtable->insert` (serial btree, NOT parallelisable in this patch)
- ~30 % is in the `LakePersistentIndex::insert` wrapper around the memtable (per-call vector construction, trace overhead — serial today)

The publish-version path runs each tablet's cold-load on its own worker, so within one tablet the 4.2 s is wall-clock; freshness P99 of the deploy-window publishes inherits this.

## What

Reshape the inner segment loop so segments WITHIN one rowset run on `pk_index_execution_thread_pool` concurrently. The outer rowset loop stays sequential because different rowsets may carry updates of the same PK and require monotonic-rss_rowid ordering; segments within one rowset (one transaction) cannot share a PK, so they are independent and a per-rowset mutex around the memtable insert is sufficient.

Each worker:
- Drains its assigned segment iterator (OSS read + chunk decode happen outside the lock).
- PK-encodes locally into its own `pk_column`.
- Builds the `IndexValue` vector locally.
- Takes `insert_mutex` only for the `insert(...)` call (which internally does `_memtable->insert` + `flush_memtable()`).

The orchestrator collects per-iteration stats from atomics and emits a single `TRACE_COUNTER_INCREMENT` per counter after `token->wait()` — trace context is thread-local so worker-thread increments would be silently dropped (same pattern as `load_dels`).

A new mutable config `enable_pk_index_rebuild_parallel_segment` (default `true`) gates the parallel path; it's AND'd with the existing `enable_pk_index_parallel_execution` master switch. Single-segment rowsets fall through to the original inline path.

## Correctness

- Memtable mutations are fully serialised by `insert_mutex`. The btree `_map` and `flush_memtable()`'s replacement of `_memtable` both run only inside the lock.
- The outer rowset loop remains sequential, preserving "later rss_rowid wins" semantics across rowsets.
- On `submit_func()` failure the segment runs inline, so we never drop a row from the rebuild.
- `OlapReaderStatistics` is still shared by all per-segment iterators (the iterators receive the pointer once at creation). Counter races there are observability-only (lost increments, never invalid values).
- Per-segment local buffers (`local_chunk`, `local_rowids`, `local_pk_column`) live on the worker stack — they cannot be hoisted out because workers run concurrently. Memory cost per concurrent segment ≈ a 4 K-row chunk + encoded PK column, well under 10 MB.

## Expected impact (pre-registered)

On the `1_100gb_sortkey` benchmark, restart-induced cold-load window:

| Metric | Target |
| --- | --- |
| Per-tablet `rebuild_index_segment_cost_us` (wall clock) | ≤ `sum(per_segment_cost) * 0.65` (i.e. ≥ 35 % reduction when ≥ 2 segments rebuild) |
| `pindex_load_from_lake_tablet_us` P99 in the first 60 s of test | ≤ 3 000 us (down from ~4 200 ms today) |
| Steady-state `pindex_load_from_lake_tablet_us` after cold-load | unchanged (the serial path is identical) |
| Upsert P99 / throughput | within noise vs PR #73253 |

The fix is intentionally bounded: it only collapses the ~17 % parallelisable portion of cold-load wall-clock. The dominant `_memtable->insert` cost (~60 %) is single-threaded btree work that needs a different attack (bulk-sort + sstable build) and is left for a follow-up.

## Verification

The next auto-perf-opt iteration will deploy this PR and measure all of the above on the same cluster.

This PR is opened as **draft**. It will be promoted to ready-for-review only after a subsequent iteration's benchmark confirms the pre-registered acceptance criteria; otherwise it is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
