### PR TITLE
[auto-perf-opt] Batch PK-index cold-load rebuild inserts

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -491,6 +491,13 @@ CONF_mInt32(lake_partial_update_thread_pool_queue_size, "2048");
 CONF_mInt32(pk_index_memtable_max_count, "2");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.
 CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
+// Cold-load rebuild of LakePersistentIndex used to call LakePersistentIndex::insert() once per
+// segment-iterator chunk (~2 K rows). That keeps the per-call wrapper overhead (vector
+// construction, flush_memtable cap check) on the critical path for ~hundreds of calls per
+// tablet. Accumulate up to this many rows across chunks within one rowset before invoking
+// insert(); flush at rowset boundary to preserve the rowset->version contract. 0 disables
+// the optimisation (falls back to per-chunk insert, pre-patch behaviour).
+CONF_mInt32(lake_pk_index_rebuild_batch_rows, "32768");
 // The parameters for pk index size-tiered compaction strategy.
 CONF_mInt64(pk_index_size_tiered_min_level_size, "131072");
 CONF_mInt64(pk_index_size_tiered_level_multiplier, "10");

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1286,15 +1286,13 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                                 keys.emplace_back(fkeys, _key_size);
                                 fkeys += _key_size;
                             }
-                            RETURN_IF_ERROR(insert(pkc->size(),
-                                                   reinterpret_cast<const Slice*>(keys.data()),
+                            RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(keys.data()),
                                                    values.data(), rowset_version));
                         }
                     } else {
                         // Append into the rowset-scoped batch buffer.
                         if (pkc->is_binary()) {
-                            append_batch(reinterpret_cast<const Slice*>(pkc->raw_data()), pkc->size(),
-                                         values.data());
+                            append_batch(reinterpret_cast<const Slice*>(pkc->raw_data()), pkc->size(), values.data());
                         } else {
                             // Synthesize fixed-size Slices on the stack to feed append_batch,
                             // which immediately copies the bytes into batch_key_buf.

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1139,6 +1139,48 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     int64_t get_next_cost_us = 0;
     int64_t pk_encode_cost_us = 0;
     int64_t build_values_cost_us = 0;
+    int64_t batch_insert_cnt = 0;
+    int64_t batch_total_rows = 0;
+    // Accumulator: each cold-load chunk is ~2 K rows, and the old code called insert() per
+    // chunk. The wrapper around _memtable->insert() (per-call vector construction inside the
+    // memtable, flush_memtable cap check, status plumbing) adds ~1 ms on every call, which on
+    // a 2 M-row rebuild totals ~1 s of pure wrapper time. Accumulate keys across chunks WITHIN
+    // a rowset, then flush via one insert() call. Rowset boundary is mandatory: each rowset
+    // carries a distinct version, and insert() persists that version into the memtable.
+    const int32_t batch_threshold = config::lake_pk_index_rebuild_batch_rows;
+    std::string batch_key_buf;
+    std::vector<uint32_t> batch_key_offsets;
+    std::vector<IndexValue> batch_values;
+    auto reset_batch = [&]() {
+        batch_key_buf.clear();
+        batch_key_offsets.clear();
+        batch_values.clear();
+    };
+    auto append_batch = [&](const Slice* keys, size_t n, const IndexValue* values) {
+        batch_key_offsets.reserve(batch_key_offsets.size() + n);
+        for (size_t i = 0; i < n; ++i) {
+            batch_key_offsets.push_back(static_cast<uint32_t>(batch_key_buf.size()));
+            batch_key_buf.append(keys[i].data, keys[i].size);
+        }
+        batch_values.insert(batch_values.end(), values, values + n);
+    };
+    auto flush_batch = [&](int64_t version) -> Status {
+        if (batch_values.empty()) return Status::OK();
+        std::vector<Slice> slices;
+        slices.reserve(batch_values.size());
+        const char* buf = batch_key_buf.data();
+        const size_t buf_size = batch_key_buf.size();
+        for (size_t i = 0; i < batch_values.size(); ++i) {
+            const size_t off = batch_key_offsets[i];
+            const size_t end = (i + 1 < batch_values.size()) ? batch_key_offsets[i + 1] : buf_size;
+            slices.emplace_back(buf + off, end - off);
+        }
+        batch_insert_cnt += 1;
+        batch_total_rows += batch_values.size();
+        Status st = insert(slices.size(), slices.data(), batch_values.data(), version);
+        reset_batch();
+        return st;
+    };
     // Rowset whose version is between max_sstable_version and base_version should be recovered.
     for (auto& rowset : rowsets) {
         TRACE_COUNTER_INCREMENT("total_segment_cnt", rowset->num_segments());
@@ -1231,23 +1273,49 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                         continue;
                     }
                     TRACE_COUNTER_INCREMENT("rebuild_index_num_rows", pkc->size());
-                    if (pkc->is_binary()) {
-                        RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()),
-                                               values.data(), rowset_version));
-                    } else {
-                        std::vector<Slice> keys;
-                        keys.reserve(pkc->size());
-                        const auto* fkeys = pkc->continuous_data();
-                        for (size_t i = 0; i < pkc->size(); ++i) {
-                            keys.emplace_back(fkeys, _key_size);
-                            fkeys += _key_size;
+                    if (batch_threshold <= 0) {
+                        // Disabled: per-chunk insert (pre-patch behaviour).
+                        if (pkc->is_binary()) {
+                            RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()),
+                                                   values.data(), rowset_version));
+                        } else {
+                            std::vector<Slice> keys;
+                            keys.reserve(pkc->size());
+                            const auto* fkeys = pkc->continuous_data();
+                            for (size_t i = 0; i < pkc->size(); ++i) {
+                                keys.emplace_back(fkeys, _key_size);
+                                fkeys += _key_size;
+                            }
+                            RETURN_IF_ERROR(insert(pkc->size(),
+                                                   reinterpret_cast<const Slice*>(keys.data()),
+                                                   values.data(), rowset_version));
                         }
-                        RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(keys.data()), values.data(),
-                                               rowset_version));
+                    } else {
+                        // Append into the rowset-scoped batch buffer.
+                        if (pkc->is_binary()) {
+                            append_batch(reinterpret_cast<const Slice*>(pkc->raw_data()), pkc->size(),
+                                         values.data());
+                        } else {
+                            // Synthesize fixed-size Slices on the stack to feed append_batch,
+                            // which immediately copies the bytes into batch_key_buf.
+                            std::vector<Slice> keys;
+                            keys.reserve(pkc->size());
+                            const auto* fkeys = pkc->continuous_data();
+                            for (size_t i = 0; i < pkc->size(); ++i) {
+                                keys.emplace_back(fkeys, _key_size);
+                                fkeys += _key_size;
+                            }
+                            append_batch(keys.data(), keys.size(), values.data());
+                        }
+                        if (static_cast<int64_t>(batch_values.size()) >= batch_threshold) {
+                            RETURN_IF_ERROR(flush_batch(rowset_version));
+                        }
                     }
                 }
             }
         }
+        // Drain the batch before moving to the next rowset (rowset_version changes).
+        RETURN_IF_ERROR(flush_batch(rowset_version));
         // Rebuild from del files
         if (rowset->metadata().del_files_size() > 0) {
             RETURN_IF_ERROR(load_dels(rowset, pkey_schema, rowset_version));
@@ -1256,6 +1324,8 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     TRACE_COUNTER_INCREMENT("rebuild_get_next_cost_us", get_next_cost_us);
     TRACE_COUNTER_INCREMENT("rebuild_pk_encode_cost_us", pk_encode_cost_us);
     TRACE_COUNTER_INCREMENT("rebuild_build_values_cost_us", build_values_cost_us);
+    TRACE_COUNTER_INCREMENT("rebuild_batch_insert_cnt", batch_insert_cnt);
+    TRACE_COUNTER_INCREMENT("rebuild_batch_total_rows", batch_total_rows);
     TRACE_COUNTER_INCREMENT("segment_io_local_disk_us", stats.io_ns_read_local_disk / 1000);
     TRACE_COUNTER_INCREMENT("segment_io_remote_us", stats.io_ns_remote / 1000);
     TRACE_COUNTER_INCREMENT("segment_io_count_local_disk", stats.io_count_local_disk);


### PR DESCRIPTION
## What

`LakePersistentIndex::load_from_lake_tablet` calls the public `insert(n, keys, values, version)` helper once per `ChunkIterator` chunk (~2 K rows). On a 2 M-row cold-load rebuild that is ~982 wrapper round trips. Each round trip does:

1. Slice/vector construction (the `else` branch builds a `std::vector<Slice>` from `pk_column->continuous_data()` per chunk).
2. `_memtable->insert(n, keys, values, version)` — the actual btree work, counted in `pindex_memtable_insert_us`.
3. `flush_memtable()` — cap check; on this workload the cap is not hit (`flush_times = 1` across the whole cold-load), so this is a tight no-op.

iter-007 trace numbers on rt_bench 1_100gb_sortkey (PR #73254 deployed):

| trace counter | per cold-load tablet |
|---|---:|
| `pindex_load_from_lake_tablet_us` | 3 665 – 3 945 ms |
| `lake_persistent_index_insert_us` | 3 438 – 3 613 ms |
| `pindex_memtable_insert_us` | 2 368 – 2 480 ms |
| **gap** (wrapper, ~982 calls) | **~1 070 ms** |

The ~1 070 ms gap is the wrapper tax that #73254's segment-level parallelism cannot touch because the wrapper sits inside the per-call critical path and is serialised by `insert_mutex` anyway. Get-next + PK-encode (the parallelisable portion) is < 200 ms total — small compared to the wrapper.

## How

Accumulate keys + values across chunks WITHIN one rowset into a stack-local batch buffer (`batch_key_buf` deep-copies bytes so `pk_column->reset_column()` on the next chunk can't invalidate them). When the buffer reaches `lake_pk_index_rebuild_batch_rows` rows (default **32 768**, ~16 chunks), flush with a single `insert()` call. Mandatory drain at the end of each rowset because every rowset carries its own rebuild version and `insert()` persists that version into the memtable.

- New mutable config: `lake_pk_index_rebuild_batch_rows` (default 32768). Setting it to `0` falls back to the exact per-chunk path — byte-identical to pre-patch behaviour, used as a kill switch.
- New trace counters: `rebuild_batch_insert_cnt`, `rebuild_batch_total_rows` (lets us verify the batching took effect in trace logs without grepping BE.INFO).
- Memory cost: `threshold × (avg_key_size + sizeof(IndexValue))` per rebuild, ~3-5 MB at default — bounded and lives on the publish thread's stack.

## Why not just remove the per-call `flush_memtable()` check?

`flush_memtable()` is the only cap-enforcement point (see `LakePersistentIndex::{insert,replace,upsert}()` — every public mutator funnels through it). Removing it would let the memtable grow unbounded mid-rebuild. The batch approach keeps `flush_memtable()` invariants intact while amortising the per-call overhead.

## Why batch only within a rowset?

`insert(n, keys, values, version)` writes `version` into the memtable for each key. Different rowsets carry different rebuild versions (`rowset_version = rowset->version() != 0 ? rowset->version() : base_version`), so mixing them in one batch would corrupt the version stamp. Within one rowset the version is fixed, and different segments of the same rowset cannot share a PK (one txn → one segment per PK), so it is also safe to batch across segments.

## Expected impact

Per-cold-load tablet should drop from ~3 800 ms (iter-007 with #73254) / ~4 500 ms (iter-006 baseline, no parallel rebuild) to **≤ 2 800 ms**, by collapsing ~922 wrapper calls into ~60 batched ones (~1 ms saved per dropped call).

Steady-state path: untouched. The publish-version path uses `replace()` / `upsert()` and never goes through `load_from_lake_tablet`. The compaction path uses the conflict-resolver from #73250, also untouched.

## Test plan

- [ ] `realtime_benchmark --template 1_100gb_sortkey --duration-minutes 20` on a 6-CN cluster after deploy; verify `pindex_load_from_lake_tablet_us` P99 in first 60 s ≤ 2 800 ms.
- [ ] Verify `rebuild_batch_insert_cnt` ≈ ceil(`rebuild_index_num_rows` / 32768) per cold-load trace.
- [ ] No regression on steady-state real-upsert publish (P99 ≤ 100 ms server-side).
- [ ] Throughput within ±10 % of baseline.
- [ ] `lake_pk_index_rebuild_batch_rows = 0` falls back to exact pre-patch behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
