### PR TITLE
[Enhancement] Support avro.schema.literal and avro.schema.url for Hive Avro tables in native scanner

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -812,6 +812,9 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.min_max_conjunct_ctxs = _min_max_conjunct_ctxs;
     scanner_params.min_max_tuple_desc = _min_max_tuple_desc;
     scanner_params.hive_column_names = &_hive_column_names;
+    if (const auto* hdfs_desc = dynamic_cast<const HdfsTableDescriptor*>(_hive_table)) {
+        scanner_params.avro_schema_json = hdfs_desc->get_avro_schema_json();
+    }
     scanner_params.case_sensitive = _case_sensitive;
     scanner_params.profile = &_profile;
     scanner_params.lazy_column_coalesce_counter = get_lazy_column_coalesce_counter();

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -259,6 +259,7 @@ struct HdfsScannerParams {
     const TupleDescriptor* min_max_tuple_desc = nullptr;
 
     std::vector<std::string>* hive_column_names = nullptr;
+    std::string avro_schema_json;
 
     bool case_sensitive = false;
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
@@ -73,7 +73,7 @@ Status HdfsAvroScanner::do_open(RuntimeState* state) {
     return _avro_reader->init(std::move(input_stream), _scanner_params.path, state, &_scanner_counter,
                               &_materialize_slot_descs, &_column_readers,
                               /*col_not_found_as_null=*/true, _file.get(), config::avro_reader_buffer_size_bytes,
-                              split_offset, split_length);
+                              split_offset, split_length, _scanner_params.avro_schema_json);
 }
 
 Status HdfsAvroScanner::do_get_next(RuntimeState* state, ChunkPtr* chunk) {

--- a/be/src/formats/avro/cpp/avro_reader.cpp
+++ b/be/src/formats/avro/cpp/avro_reader.cpp
@@ -300,7 +300,8 @@ AvroReader::~AvroReader() {
 Status AvroReader::init(std::unique_ptr<avro::InputStream> input_stream, const std::string& filename,
                         RuntimeState* state, ScannerCounter* counter, const std::vector<SlotDescriptor*>* slot_descs,
                         const std::vector<avrocpp::ColumnReaderUniquePtr>* column_readers, bool col_not_found_as_null,
-                        RandomAccessFile* raw_file, size_t buffer_size, int64_t split_offset, int64_t split_length) {
+                        RandomAccessFile* raw_file, size_t buffer_size, int64_t split_offset, int64_t split_length,
+                        const std::string& reader_schema_json) {
     if (_is_inited) {
         return Status::OK();
     }
@@ -320,6 +321,8 @@ Status AvroReader::init(std::unique_ptr<avro::InputStream> input_stream, const s
         // and apply column projection before setting up the decoder.
         auto base = std::make_unique<avro::DataFileReaderBase>(std::move(input_stream));
         const auto& writer_schema = base->dataSchema();
+        avro::ValidSchema reader_schema =
+                reader_schema_json.empty() ? writer_schema : avro::compileJsonSchemaFromString(reader_schema_json);
 
         // Collect the column names that actually need to be decoded.
         std::set<std::string> needed_cols;
@@ -334,17 +337,20 @@ Status AvroReader::init(std::unique_ptr<avro::InputStream> input_stream, const s
         // Build a projected reader schema that contains only the needed columns.
         // The ResolvingDecoder will then skip unwanted fields at the binary level,
         // saving CPU deserialization work — the Trino-equivalent of maskColumnsFromTableSchema.
-        avro::ValidSchema projected = build_projected_schema(writer_schema, needed_cols);
-        bool using_projection = !needed_cols.empty() && projected.root()->leaves() < writer_schema.root()->leaves();
+        avro::ValidSchema projected = build_projected_schema(reader_schema, needed_cols);
+        bool using_projection = !needed_cols.empty() && projected.root()->leaves() < reader_schema.root()->leaves();
 
         if (using_projection) {
             _file_reader = std::make_unique<avro::DataFileReader<avro::GenericDatum>>(std::move(base), projected);
+        } else if (!reader_schema_json.empty()) {
+            _file_reader = std::make_unique<avro::DataFileReader<avro::GenericDatum>>(std::move(base), reader_schema);
         } else {
             _file_reader = std::make_unique<avro::DataFileReader<avro::GenericDatum>>(std::move(base));
         }
 
         // The datum must match the schema the decoder will produce values for.
-        const auto& effective_schema = using_projection ? _file_reader->readerSchema() : writer_schema;
+        const auto& effective_schema =
+                (using_projection || !reader_schema_json.empty()) ? _file_reader->readerSchema() : writer_schema;
         _datum = std::make_unique<avro::GenericDatum>(effective_schema);
 
         // Split handling.

--- a/be/src/formats/avro/cpp/avro_reader.h
+++ b/be/src/formats/avro/cpp/avro_reader.h
@@ -90,7 +90,7 @@ public:
                 ScannerCounter* counter, const std::vector<SlotDescriptor*>* slot_descs,
                 const std::vector<avrocpp::ColumnReaderUniquePtr>* column_readers, bool col_not_found_as_null,
                 RandomAccessFile* raw_file = nullptr, size_t buffer_size = 0, int64_t split_offset = 0,
-                int64_t split_length = 0);
+                int64_t split_length = 0, const std::string& reader_schema_json = "");
 
     void TEST_init(const std::vector<SlotDescriptor*>* slot_descs,
                    const std::vector<avrocpp::ColumnReaderUniquePtr>* column_readers, bool col_not_found_as_null);

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -58,6 +58,9 @@ HdfsTableDescriptor::HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPo
           _hive_column_names(tdesc.hdfsTable.hive_column_names, mr),
           _hive_column_types(tdesc.hdfsTable.hive_column_types, mr),
           _serde_properties(tdesc.hdfsTable.serde_properties),
+          _avro_schema_json(tdesc.hdfsTable.__isset.avro_schema_json
+                                    ? std::pmr::string(tdesc.hdfsTable.avro_schema_json, mr)
+                                    : std::pmr::string(mr)),
           _time_zone(tdesc.hdfsTable.time_zone, mr) {
     _hdfs_base_path.assign(tdesc.hdfsTable.hdfs_base_dir);
     _columns = tdesc.hdfsTable.columns;
@@ -86,6 +89,10 @@ std::string_view HdfsTableDescriptor::get_serde_lib() const {
 
 const std::map<std::string, std::string> HdfsTableDescriptor::get_serde_properties() const {
     return _serde_properties;
+}
+
+std::string_view HdfsTableDescriptor::get_avro_schema_json() const {
+    return _avro_schema_json;
 }
 
 std::string_view HdfsTableDescriptor::get_time_zone() const {

--- a/be/src/runtime/descriptors_ext.h
+++ b/be/src/runtime/descriptors_ext.h
@@ -90,6 +90,7 @@ public:
     std::string_view get_input_format() const;
     std::string_view get_serde_lib() const;
     const std::map<std::string, std::string> get_serde_properties() const;
+    std::string_view get_avro_schema_json() const;
     std::string_view get_time_zone() const;
 
 private:
@@ -98,6 +99,7 @@ private:
     std::pmr::string _hive_column_names;
     std::pmr::string _hive_column_types;
     std::map<std::string, std::string> _serde_properties;
+    std::pmr::string _avro_schema_json;
     std::pmr::string _time_zone;
 };
 

--- a/be/test/formats/avro/cpp/avro_reader_test.cpp
+++ b/be/test/formats/avro/cpp/avro_reader_test.cpp
@@ -469,6 +469,37 @@ TEST_F(AvroReaderTest, test_column_projection) {
     ASSERT_TRUE(avro_reader->read_chunk(chunk, 2).is_end_of_file());
 }
 
+TEST_F(AvroReaderTest, test_external_reader_schema_default_field) {
+    std::string filename = "primitive.avro";
+    std::string reader_schema = R"({
+        "type": "record",
+        "name": "PrimitiveTypesRecord",
+        "fields": [
+            {"name": "added_field", "type": "int", "default": 7}
+        ]
+    })";
+
+    std::vector<SlotDescriptor> descs;
+    descs.emplace_back(100, "added_field", TypeDescriptor::from_logical_type(TYPE_INT));
+    std::vector<SlotDescriptor*> slot_descs = {&descs[0]};
+    create_column_readers(slot_descs, _timezone, false);
+
+    auto file_or = FileSystem::Default()->new_random_access_file(_test_exec_dir + filename);
+    ASSERT_OK(file_or.status());
+    auto avro_reader = std::make_unique<AvroReader>();
+    ASSERT_OK(avro_reader->init(std::make_unique<AvroBufferInputStream>(
+                                        std::move(file_or.value()), config::avro_reader_buffer_size_bytes, _counter),
+                                filename, _state.get(), _counter, &slot_descs, &_column_readers,
+                                /*col_not_found_as_null=*/false, nullptr, 0, 0, 0, reader_schema));
+
+    auto chunk = create_src_chunk(slot_descs);
+    ASSERT_OK(avro_reader->read_chunk(chunk, 2));
+    materialize_src_chunk_adaptive_nullable_column(chunk);
+
+    ASSERT_EQ(1, chunk->num_rows());
+    ASSERT_EQ("[7]", chunk->debug_row(0));
+}
+
 TEST_F(AvroReaderTest, test_read_logical_types) {
     std::string filename = "logical.avro";
     std::vector<SlotDescriptor*> slot_descs;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -134,6 +134,7 @@ public class HiveTable extends Table {
     private Map<String, String> hiveProperties = Maps.newHashMap();
     @SerializedName(value = "sp")
     private Map<String, String> serdeProperties = Maps.newHashMap();
+    @SerializedName(value = "asj") private String avroSchemaJson;
 
     private HiveTableType hiveTableType = HiveTableType.MANAGED_TABLE;
 
@@ -256,6 +257,10 @@ public class HiveTable extends Table {
     public Map<String, String> getSerdeProperties() {
         return serdeProperties;
     }
+
+    public String getAvroSchemaJson() { return avroSchemaJson; }
+
+    public void setAvroSchemaJson(String avroSchemaJson) { this.avroSchemaJson = avroSchemaJson; }
 
     public boolean hasBooleanTypePartitionColumn() {
         return getPartitionColumns().stream().anyMatch(column -> column.getType().isBoolean());
@@ -389,6 +394,9 @@ public class HiveTable extends Table {
         tHdfsTable.setHive_column_names(hiveProperties.get(HIVE_TABLE_COLUMN_NAMES));
         tHdfsTable.setHive_column_types(hiveProperties.get(HIVE_TABLE_COLUMN_TYPES));
         tHdfsTable.setSerde_properties(serdeProperties);
+        if (avroSchemaJson != null) {
+            tHdfsTable.setAvro_schema_json(avroSchemaJson);
+        }
         tHdfsTable.setTime_zone(TimeUtils.getSessionTimeZone());
 
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.HDFS_TABLE, fullSchema.size(),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -258,9 +258,13 @@ public class HiveTable extends Table {
         return serdeProperties;
     }
 
-    public String getAvroSchemaJson() { return avroSchemaJson; }
+    public String getAvroSchemaJson() {
+        return avroSchemaJson;
+    }
 
-    public void setAvroSchemaJson(String avroSchemaJson) { this.avroSchemaJson = avroSchemaJson; }
+    public void setAvroSchemaJson(String avroSchemaJson) {
+        this.avroSchemaJson = avroSchemaJson;
+    }
 
     public boolean hasBooleanTypePartitionColumn() {
         return getPartitionColumns().stream().anyMatch(column -> column.getType().isBoolean());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/AvroSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/AvroSchemaResolver.java
@@ -17,16 +17,17 @@ package com.starrocks.connector.hive;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
 import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 
 public class AvroSchemaResolver {
     public static final String AVRO_SCHEMA_LITERAL = "avro.schema.literal";
@@ -34,7 +35,9 @@ public class AvroSchemaResolver {
 
     private final Configuration hadoopConf;
 
-    public AvroSchemaResolver(Configuration hadoopConf) { this.hadoopConf = hadoopConf; }
+    public AvroSchemaResolver(Configuration hadoopConf) {
+        this.hadoopConf = hadoopConf;
+    }
 
     public Optional<String> resolve(HiveTable table) {
         if (table.getStorageFormat() != HiveStorageFormat.AVRO) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/AvroSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/AvroSchemaResolver.java
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive;
+
+import com.google.common.base.Strings;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+public class AvroSchemaResolver {
+    public static final String AVRO_SCHEMA_LITERAL = "avro.schema.literal";
+    public static final String AVRO_SCHEMA_URL = "avro.schema.url";
+
+    private final Configuration hadoopConf;
+
+    public AvroSchemaResolver(Configuration hadoopConf) { this.hadoopConf = hadoopConf; }
+
+    public Optional<String> resolve(HiveTable table) {
+        if (table.getStorageFormat() != HiveStorageFormat.AVRO) {
+            return Optional.empty();
+        }
+
+        Map<String, String> serdeProperties =
+                table.getSerdeProperties() == null ? Collections.emptyMap() : table.getSerdeProperties();
+        String literal = serdeProperties.get(AVRO_SCHEMA_LITERAL);
+        if (isConfigured(literal)) {
+            return Optional.of(parseSchema(
+                    literal, String.format("%s.%s", table.getCatalogDBName(), table.getCatalogTableName())));
+        }
+
+        String schemaUrl = serdeProperties.get(AVRO_SCHEMA_URL);
+        if (!isConfigured(schemaUrl)) {
+            return Optional.empty();
+        }
+        return Optional.of(parseSchema(readSchemaUrl(schemaUrl), schemaUrl));
+    }
+
+    private boolean isConfigured(String value) {
+        return !Strings.isNullOrEmpty(value) && !"none".equalsIgnoreCase(value);
+    }
+
+    private String readSchemaUrl(String schemaUrl) {
+        Path path = new Path(schemaUrl);
+        try {
+            FileSystem fs = path.getFileSystem(hadoopConf);
+            try (FSDataInputStream inputStream = fs.open(path)) {
+                return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        } catch (IOException e) {
+            throw new StarRocksConnectorException(
+                    "Failed to read Avro schema url %s. msg: %s", schemaUrl, e.getMessage());
+        }
+    }
+
+    private String parseSchema(String schemaJson, String source) {
+        try {
+            return new Schema.Parser().parse(schemaJson).toString();
+        } catch (RuntimeException e) {
+            throw new StarRocksConnectorException(
+                    "Failed to parse Avro schema from %s. msg: %s", source, e.getMessage());
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/AvroSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/AvroSchemaResolver.java
@@ -46,17 +46,28 @@ public class AvroSchemaResolver {
 
         Map<String, String> serdeProperties =
                 table.getSerdeProperties() == null ? Collections.emptyMap() : table.getSerdeProperties();
-        String literal = serdeProperties.get(AVRO_SCHEMA_LITERAL);
+        Map<String, String> tableProperties =
+                table.getProperties() == null ? Collections.emptyMap() : table.getProperties();
+        String literal = getConfiguredSchemaValue(serdeProperties, tableProperties, AVRO_SCHEMA_LITERAL);
         if (isConfigured(literal)) {
             return Optional.of(parseSchema(
                     literal, String.format("%s.%s", table.getCatalogDBName(), table.getCatalogTableName())));
         }
 
-        String schemaUrl = serdeProperties.get(AVRO_SCHEMA_URL);
+        String schemaUrl = getConfiguredSchemaValue(serdeProperties, tableProperties, AVRO_SCHEMA_URL);
         if (!isConfigured(schemaUrl)) {
             return Optional.empty();
         }
         return Optional.of(parseSchema(readSchemaUrl(schemaUrl), schemaUrl));
+    }
+
+    private String getConfiguredSchemaValue(
+            Map<String, String> serdeProperties, Map<String, String> tableProperties, String key) {
+        String serdeValue = serdeProperties.get(key);
+        if (isConfigured(serdeValue)) {
+            return serdeValue;
+        }
+        return tableProperties.get(key);
     }
 
     private boolean isConfigured(String value) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -187,7 +187,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         tableStatsCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadTableStatistics), executor));
 
-        avroSchemaCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize).build();
+        avroSchemaCache = newCacheBuilder(expireAfterWriteSec, NEVER_REFRESH, maxSize).build();
 
         Caffeine<Object, Object> builder = Caffeine.newBuilder().maximumSize(maxSize).executor(executor);
         if (expireAfterWriteSec > 0) {
@@ -326,7 +326,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
 
     public Table loadTable(DatabaseTableName databaseTableName) {
         Table table = metastore.getTable(databaseTableName.getDatabaseName(), databaseTableName.getTableName());
-        if (table instanceof HiveTable hiveTable && hiveTable.getAvroSchemaJson() == null) {
+        if (table instanceof HiveTable hiveTable) {
             String avroSchema = avroSchemaCache.getIfPresent(databaseTableName);
             if (avroSchema == null) {
                 Optional<String> schemaOpt = avroSchemaResolver.flatMap(resolver -> resolver.resolve(hiveTable));
@@ -707,6 +707,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         partitionCache.invalidateAll();
         tableStatsCache.invalidateAll();
         partitionStatsCache.synchronous().invalidateAll();
+        hmsExternalTableCache.invalidateAll();
         avroSchemaCache.invalidateAll();
     }
 
@@ -720,6 +721,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tableName);
         tableCache.invalidate(databaseTableName);
         tableStatsCache.invalidate(databaseTableName);
+        hmsExternalTableCache.invalidate(databaseTableName);
         avroSchemaCache.invalidate(databaseTableName);
         invalidateTablePartitionInfo(dbName, tableName, databaseTableName);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -86,6 +86,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     protected LoadingCache<DatabaseTableName, HivePartitionStats> tableStatsCache;
     protected AsyncLoadingCache<HivePartitionName, HivePartitionStats> partitionStatsCache;
     protected Cache<DatabaseTableName, String> hmsExternalTableCache;
+    protected Cache<DatabaseTableName, String> avroSchemaCache;
     private final Optional<AvroSchemaResolver> avroSchemaResolver;
 
     public static CachingHiveMetastore createQueryLevelInstance(IHiveMetastore metastore, long perQueryCacheMaxSize) {
@@ -186,6 +187,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         tableStatsCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadTableStatistics), executor));
 
+        avroSchemaCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize).build();
 
         Caffeine<Object, Object> builder = Caffeine.newBuilder().maximumSize(maxSize).executor(executor);
         if (expireAfterWriteSec > 0) {
@@ -325,7 +327,17 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     public Table loadTable(DatabaseTableName databaseTableName) {
         Table table = metastore.getTable(databaseTableName.getDatabaseName(), databaseTableName.getTableName());
         if (table instanceof HiveTable hiveTable && hiveTable.getAvroSchemaJson() == null) {
-            avroSchemaResolver.flatMap(resolver -> resolver.resolve(hiveTable)).ifPresent(hiveTable::setAvroSchemaJson);
+            String avroSchema = avroSchemaCache.getIfPresent(databaseTableName);
+            if (avroSchema == null) {
+                Optional<String> schemaOpt = avroSchemaResolver.flatMap(resolver -> resolver.resolve(hiveTable));
+                if (schemaOpt.isPresent()) {
+                    avroSchema = schemaOpt.get();
+                    avroSchemaCache.put(databaseTableName, avroSchema);
+                }
+            }
+            if (avroSchema != null) {
+                hiveTable.setAvroSchemaJson(avroSchema);
+            }
         }
         if (table.isHMSExternalTable()) {
             hmsExternalTableCache.put(databaseTableName, databaseTableName.toString());
@@ -525,6 +537,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
                                                            boolean onlyCachedPartitions) {
         Table updatedTable;
         try {
+            avroSchemaCache.invalidate(databaseTableName);
             updatedTable = loadTable(databaseTableName);
         } catch (StarRocksConnectorException e) {
             Throwable cause = e.getCause();
@@ -694,6 +707,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         partitionCache.invalidateAll();
         tableStatsCache.invalidateAll();
         partitionStatsCache.synchronous().invalidateAll();
+        avroSchemaCache.invalidateAll();
     }
 
     public synchronized void invalidateDatabase(String dbName) {
@@ -706,6 +720,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tableName);
         tableCache.invalidate(databaseTableName);
         tableStatsCache.invalidate(databaseTableName);
+        avroSchemaCache.invalidate(databaseTableName);
         invalidateTablePartitionInfo(dbName, tableName, databaseTableName);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -86,24 +86,31 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     protected LoadingCache<DatabaseTableName, HivePartitionStats> tableStatsCache;
     protected AsyncLoadingCache<HivePartitionName, HivePartitionStats> partitionStatsCache;
     protected Cache<DatabaseTableName, String> hmsExternalTableCache;
+    private final Optional<AvroSchemaResolver> avroSchemaResolver;
 
     public static CachingHiveMetastore createQueryLevelInstance(IHiveMetastore metastore, long perQueryCacheMaxSize) {
-        return new CachingHiveMetastore(
-                metastore,
-                newDirectExecutorService(),
-                newDirectExecutorService(),
-                NEVER_EVICT,
-                NEVER_REFRESH,
-                perQueryCacheMaxSize,
-                true);
+        return createQueryLevelInstance(metastore, perQueryCacheMaxSize, Optional.empty());
+    }
+
+    public static CachingHiveMetastore createQueryLevelInstance(
+            IHiveMetastore metastore, long perQueryCacheMaxSize, Optional<AvroSchemaResolver> avroSchemaResolver) {
+        return new CachingHiveMetastore(metastore, newDirectExecutorService(), newDirectExecutorService(), NEVER_EVICT,
+                NEVER_REFRESH, perQueryCacheMaxSize, true, avroSchemaResolver);
     }
 
     public static CachingHiveMetastore createCatalogLevelInstance(IHiveMetastore metastore, Executor executor,
                                                                   Executor partitionExecutor, long expireAfterWrite,
                                                                   long refreshInterval, long maxSize,
                                                                   boolean enableListNamesCache) {
-        return new CachingHiveMetastore(metastore, executor, partitionExecutor,
-          expireAfterWrite, refreshInterval, maxSize, enableListNamesCache);
+        return createCatalogLevelInstance(metastore, executor, partitionExecutor, expireAfterWrite, refreshInterval,
+                maxSize, enableListNamesCache, Optional.empty());
+    }
+
+    public static CachingHiveMetastore createCatalogLevelInstance(IHiveMetastore metastore, Executor executor,
+            Executor partitionExecutor, long expireAfterWrite, long refreshInterval, long maxSize,
+            boolean enableListNamesCache, Optional<AvroSchemaResolver> avroSchemaResolver) {
+        return new CachingHiveMetastore(metastore, executor, partitionExecutor, expireAfterWrite, refreshInterval,
+                maxSize, enableListNamesCache, avroSchemaResolver);
     }
 
     public static class PartitionStatisticsLoader implements AsyncCacheLoader<HivePartitionName, HivePartitionStats> {
@@ -129,10 +136,18 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     protected CachingHiveMetastore(IHiveMetastore metastore, Executor executor, Executor partitionExecutor,
                                    long expireAfterWriteSec, long refreshIntervalSec, long maxSize,
                                    boolean enableListNamesCache) {
+        this(metastore, executor, partitionExecutor, expireAfterWriteSec, refreshIntervalSec, maxSize,
+                enableListNamesCache, Optional.empty());
+    }
+
+    protected CachingHiveMetastore(IHiveMetastore metastore, Executor executor, Executor partitionExecutor,
+            long expireAfterWriteSec, long refreshIntervalSec, long maxSize, boolean enableListNamesCache,
+            Optional<AvroSchemaResolver> avroSchemaResolver) {
         super(executor, expireAfterWriteSec, refreshIntervalSec, maxSize);
         this.metastore = metastore;
         this.enableListNameCache = enableListNamesCache;
         this.lastAccessTimeMap = Maps.newConcurrentMap();
+        this.avroSchemaResolver = avroSchemaResolver;
 
         // The list names interface of hive metastore latency is very low, so we default to pull the latest every time.
         if (enableListNamesCache) {
@@ -309,6 +324,9 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
 
     public Table loadTable(DatabaseTableName databaseTableName) {
         Table table = metastore.getTable(databaseTableName.getDatabaseName(), databaseTableName.getTableName());
+        if (table instanceof HiveTable hiveTable && hiveTable.getAvroSchemaJson() == null) {
+            avroSchemaResolver.flatMap(resolver -> resolver.resolve(hiveTable)).ifPresent(hiveTable::setAvroSchemaJson);
+        }
         if (table.isHMSExternalTable()) {
             hmsExternalTableCache.put(databaseTableName, databaseTableName.toString());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -14,10 +14,6 @@
 
 package com.starrocks.connector.hive;
 
-import static com.starrocks.connector.CachingRemoteFileIO.NEVER_REFRESH;
-import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
-import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -30,12 +26,17 @@ import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.ReentrantExecutor;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.sql.analyzer.SemanticException;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import static com.starrocks.connector.CachingRemoteFileIO.NEVER_REFRESH;
+import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
+import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
 
 public class HiveConnectorInternalMgr {
     public static final List<String> SUPPORTED_METASTORE_TYPE = Lists.newArrayList("hive", "glue", "dlf");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -14,6 +14,10 @@
 
 package com.starrocks.connector.hive;
 
+import static com.starrocks.connector.CachingRemoteFileIO.NEVER_REFRESH;
+import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
+import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -26,16 +30,12 @@ import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.ReentrantExecutor;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.sql.analyzer.SemanticException;
-
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import static com.starrocks.connector.CachingRemoteFileIO.NEVER_REFRESH;
-import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
-import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
 
 public class HiveConnectorInternalMgr {
     public static final List<String> SUPPORTED_METASTORE_TYPE = Lists.newArrayList("hive", "glue", "dlf");
@@ -124,14 +124,13 @@ public class HiveConnectorInternalMgr {
                     new ThreadFactoryBuilder().setNameFormat("hive-metastore-refresh-%d").build());
             refreshHiveExternalTableExecutor = Executors.newCachedThreadPool(
                     new ThreadFactoryBuilder().setNameFormat("hive-external-table-refresh-%d").build());
-            baseHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
-                    hiveMetastore,
+            baseHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(hiveMetastore,
                     new ReentrantExecutor(refreshHiveMetastoreExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
                     new ReentrantExecutor(refreshHiveExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
                     hmsConf.getCacheTtlSec(),
                     enableHmsEventsIncrementalSync ? NEVER_REFRESH : hmsConf.getCacheRefreshIntervalSec(),
-                    hmsConf.getCacheMaxNum(),
-                    hmsConf.enableListNamesCache());
+                    hmsConf.getCacheMaxNum(), hmsConf.enableListNamesCache(),
+                    Optional.of(new AvroSchemaResolver(hdfsEnvironment.getConfiguration())));
         }
 
         return baseHiveMetastore;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
@@ -78,9 +78,10 @@ public class HiveMetadataFactory {
 
     public HiveMetadata create() {
         HiveMetastoreOperations hiveMetastoreOperations = new HiveMetastoreOperations(
-                createQueryLevelInstance(metastore, perQueryMetastoreMaxNum),
-                metastore instanceof CachingHiveMetastore,
-                hdfsEnvironment.getConfiguration(), metastoreType, catalogName);
+                createQueryLevelInstance(metastore, perQueryMetastoreMaxNum,
+                        Optional.of(new AvroSchemaResolver(hdfsEnvironment.getConfiguration()))),
+                metastore instanceof CachingHiveMetastore, hdfsEnvironment.getConfiguration(), metastoreType,
+                catalogName);
         RemoteFileOperations remoteFileOperations = new RemoteFileOperations(
                 CachingRemoteFileIO.createQueryLevelInstance(remoteFileIO, perQueryCacheRemotePathMaxMemoryRatio),
                 pullRemoteFileExecutor,

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
@@ -298,6 +298,9 @@ public class HiveTableTest {
 
             Assertions.assertTrue(table instanceof HiveTable);
             HiveTable hiveTable = (HiveTable) table;
+            if (targetFormat.equals("AVRO")) {
+                hiveTable.setAvroSchemaJson("{\"type\":\"record\",\"name\":\"T\",\"fields\":[]}");
+            }
             List<DescriptorTable.ReferencedPartitionInfo> partitions = new ArrayList<>();
             TTableDescriptor tTableDescriptor = hiveTable.toThrift(partitions);
 
@@ -305,6 +308,12 @@ public class HiveTableTest {
             Assertions.assertEquals(tTableDescriptor.getHdfsTable().getSerde_lib(), serde);
             Assertions.assertEquals(tTableDescriptor.getHdfsTable().getHive_column_names(), "col2");
             Assertions.assertEquals(tTableDescriptor.getHdfsTable().getHive_column_types(), "INT");
+            if (targetFormat.equals("AVRO")) {
+                Assertions.assertEquals("{\"type\":\"record\",\"name\":\"T\",\"fields\":[]}",
+                        tTableDescriptor.getHdfsTable().getAvro_schema_json());
+            } else {
+                Assertions.assertFalse(tTableDescriptor.getHdfsTable().isSetAvro_schema_json());
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -74,11 +74,16 @@ public class CachingHiveMetastoreTest {
     }
 
     private HiveTable createAvroTable(Map<String, String> serdeProperties) {
+        return createAvroTable(serdeProperties, Map.of());
+    }
+
+    private HiveTable createAvroTable(Map<String, String> serdeProperties, Map<String, String> tableProperties) {
         Map<String, String> properties = new HashMap<>();
         properties.put(HiveTable.HIVE_TABLE_SERDE_LIB, HiveClassNames.AVRO_SERDE_CLASS);
         properties.put(HiveTable.HIVE_TABLE_INPUT_FORMAT, HiveClassNames.AVRO_INPUT_FORMAT_CLASS);
         properties.put(HiveTable.HIVE_TABLE_COLUMN_NAMES, "id");
         properties.put(HiveTable.HIVE_TABLE_COLUMN_TYPES, "int");
+        properties.putAll(tableProperties);
         return new HiveTable.Builder()
                 .setId(1)
                 .setTableName("avro_tbl")
@@ -167,10 +172,52 @@ public class CachingHiveMetastoreTest {
     }
 
     @Test
+    public void testLoadTableResolveAvroSchemaLiteralFromTableProperties() {
+        HiveTable table = createAvroTable(Map.of(), Map.of(AvroSchemaResolver.AVRO_SCHEMA_LITERAL, AVRO_SCHEMA_LITERAL));
+        new Expectations(metastore) {
+            {
+                metastore.getTable("db1", "avro_tbl");
+                result = table;
+            }
+        };
+
+        CachingHiveMetastore cachingHiveMetastore =
+                new CachingHiveMetastore(metastore, executor, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000,
+                        false, Optional.of(new AvroSchemaResolver(new Configuration())));
+
+        HiveTable loadedTable = (HiveTable) cachingHiveMetastore.loadTable(DatabaseTableName.of("db1", "avro_tbl"));
+        Assertions.assertEquals(new org.apache.avro.Schema.Parser().parse(AVRO_SCHEMA_LITERAL).toString(),
+                loadedTable.getAvroSchemaJson());
+    }
+
+    @Test
     public void testLoadTableResolveAvroSchemaUrl() throws Exception {
         java.nio.file.Path schemaPath = Files.createTempFile("sr-avro-schema", ".avsc");
         Files.writeString(schemaPath, AVRO_SCHEMA_LITERAL);
         HiveTable table = createAvroTable(Map.of(AvroSchemaResolver.AVRO_SCHEMA_URL, schemaPath.toUri().toString()));
+        new Expectations(metastore) {
+            {
+                metastore.getTable("db1", "avro_tbl");
+                result = table;
+                minTimes = 0;
+            }
+        };
+
+        CachingHiveMetastore cachingHiveMetastore =
+                new CachingHiveMetastore(metastore, executor, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000,
+                        false, Optional.of(new AvroSchemaResolver(new Configuration())));
+
+        HiveTable loadedTable = (HiveTable) cachingHiveMetastore.loadTable(DatabaseTableName.of("db1", "avro_tbl"));
+        Assertions.assertEquals(new org.apache.avro.Schema.Parser().parse(AVRO_SCHEMA_LITERAL).toString(),
+                loadedTable.getAvroSchemaJson());
+    }
+
+    @Test
+    public void testLoadTableResolveAvroSchemaUrlFromTableProperties() throws Exception {
+        java.nio.file.Path schemaPath = Files.createTempFile("sr-avro-schema-table-properties", ".avsc");
+        Files.writeString(schemaPath, AVRO_SCHEMA_LITERAL);
+        HiveTable table =
+                createAvroTable(Map.of(), Map.of(AvroSchemaResolver.AVRO_SCHEMA_URL, schemaPath.toUri().toString()));
         new Expectations(metastore) {
             {
                 metastore.getTable("db1", "avro_tbl");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -14,10 +14,6 @@
 
 package com.starrocks.connector.hive;
 
-import static com.starrocks.connector.hive.RemoteFileInputFormat.ORC;
-import static org.apache.hadoop.hive.common.StatsSetupConst.TASK;
-import static org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE;
-
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -32,6 +28,14 @@ import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.type.BitmapType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.PrimitiveType;
+import mockit.Expectations;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.util.HashMap;
@@ -40,13 +44,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import mockit.Expectations;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import static com.starrocks.connector.hive.RemoteFileInputFormat.ORC;
+import static org.apache.hadoop.hive.common.StatsSetupConst.TASK;
+import static org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE;
 
 public class CachingHiveMetastoreTest {
     private HiveMetaClient client;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -14,6 +14,10 @@
 
 package com.starrocks.connector.hive;
 
+import static com.starrocks.connector.hive.RemoteFileInputFormat.ORC;
+import static org.apache.hadoop.hive.common.StatsSetupConst.TASK;
+import static org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE;
+
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -28,23 +32,21 @@ import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.type.BitmapType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.PrimitiveType;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import mockit.Expectations;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import static com.starrocks.connector.hive.RemoteFileInputFormat.ORC;
-import static org.apache.hadoop.hive.common.StatsSetupConst.TASK;
-import static org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE;
 
 public class CachingHiveMetastoreTest {
     private HiveMetaClient client;
@@ -52,6 +54,11 @@ public class CachingHiveMetastoreTest {
     private ExecutorService executor;
     private long expireAfterWriteSec = 30;
     private long refreshAfterWriteSec = -1;
+    private static final String AVRO_SCHEMA_LITERAL = "{\"type\":\"record\",\"name\":\"AvroSchemaTest\","
+            + "\"fields\":[{\"name\":\"id\",\"type\":\"int\"}]}";
+    private static final String AVRO_SCHEMA_LITERAL_UPDATED = "{\"type\":\"record\",\"name\":\"AvroSchemaTest\","
+            + "\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"name\",\"type\":\"string\","
+            + "\"default\":\"unknown\"}]}";
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -63,6 +70,28 @@ public class CachingHiveMetastoreTest {
     @AfterEach
     public void tearDown() {
         executor.shutdown();
+    }
+
+    private HiveTable createAvroTable(Map<String, String> serdeProperties) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(HiveTable.HIVE_TABLE_SERDE_LIB, HiveClassNames.AVRO_SERDE_CLASS);
+        properties.put(HiveTable.HIVE_TABLE_INPUT_FORMAT, HiveClassNames.AVRO_INPUT_FORMAT_CLASS);
+        properties.put(HiveTable.HIVE_TABLE_COLUMN_NAMES, "id");
+        properties.put(HiveTable.HIVE_TABLE_COLUMN_TYPES, "int");
+        return new HiveTable.Builder()
+                .setId(1)
+                .setTableName("avro_tbl")
+                .setCatalogName("hive_catalog")
+                .setHiveDbName("db1")
+                .setHiveTableName("avro_tbl")
+                .setTableLocation("file:///tmp/avro_tbl")
+                .setFullSchema(Lists.newArrayList(new Column("id", IntegerType.INT)))
+                .setDataColumnNames(Lists.newArrayList("id"))
+                .setPartitionColumnNames(Lists.newArrayList())
+                .setProperties(properties)
+                .setSerdeProperties(serdeProperties)
+                .setStorageFormat(HiveStorageFormat.AVRO)
+                .build();
     }
 
     @Test
@@ -115,6 +144,77 @@ public class CachingHiveMetastoreTest {
         Assertions.assertEquals(IntegerType.INT, hiveTable.getPartitionColumns().get(0).getType());
         Assertions.assertEquals(IntegerType.INT, hiveTable.getBaseSchema().get(0).getType());
         Assertions.assertEquals("hive_catalog", hiveTable.getCatalogName());
+    }
+
+    @Test
+    public void testLoadTableResolveAvroSchemaLiteral() {
+        HiveTable table = createAvroTable(Map.of(AvroSchemaResolver.AVRO_SCHEMA_LITERAL, AVRO_SCHEMA_LITERAL));
+        new Expectations(metastore) {
+            {
+                metastore.getTable("db1", "avro_tbl");
+                result = table;
+            }
+        };
+
+        CachingHiveMetastore cachingHiveMetastore =
+                new CachingHiveMetastore(metastore, executor, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000,
+                        false, Optional.of(new AvroSchemaResolver(new Configuration())));
+
+        HiveTable loadedTable = (HiveTable) cachingHiveMetastore.loadTable(DatabaseTableName.of("db1", "avro_tbl"));
+        Assertions.assertEquals(new org.apache.avro.Schema.Parser().parse(AVRO_SCHEMA_LITERAL).toString(),
+                loadedTable.getAvroSchemaJson());
+    }
+
+    @Test
+    public void testLoadTableResolveAvroSchemaUrl() throws Exception {
+        java.nio.file.Path schemaPath = Files.createTempFile("sr-avro-schema", ".avsc");
+        Files.writeString(schemaPath, AVRO_SCHEMA_LITERAL);
+        HiveTable table = createAvroTable(Map.of(AvroSchemaResolver.AVRO_SCHEMA_URL, schemaPath.toUri().toString()));
+        new Expectations(metastore) {
+            {
+                metastore.getTable("db1", "avro_tbl");
+                result = table;
+                minTimes = 0;
+            }
+        };
+
+        CachingHiveMetastore cachingHiveMetastore =
+                new CachingHiveMetastore(metastore, executor, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000,
+                        false, Optional.of(new AvroSchemaResolver(new Configuration())));
+
+        HiveTable loadedTable = (HiveTable) cachingHiveMetastore.loadTable(DatabaseTableName.of("db1", "avro_tbl"));
+        Assertions.assertEquals(new org.apache.avro.Schema.Parser().parse(AVRO_SCHEMA_LITERAL).toString(),
+                loadedTable.getAvroSchemaJson());
+    }
+
+    @Test
+    public void testLoadTableResolveAvroSchemaUrlAfterInvalidate() throws Exception {
+        java.nio.file.Path schemaPath = Files.createTempFile("sr-avro-schema-refresh", ".avsc");
+        Files.writeString(schemaPath, AVRO_SCHEMA_LITERAL);
+        HiveTable firstTable =
+                createAvroTable(Map.of(AvroSchemaResolver.AVRO_SCHEMA_URL, schemaPath.toUri().toString()));
+        HiveTable refreshedTable =
+                createAvroTable(Map.of(AvroSchemaResolver.AVRO_SCHEMA_URL, schemaPath.toUri().toString()));
+        new Expectations(metastore) {
+            {
+                metastore.getTable("db1", "avro_tbl");
+                returns(firstTable, refreshedTable);
+            }
+        };
+
+        CachingHiveMetastore cachingHiveMetastore =
+                new CachingHiveMetastore(metastore, executor, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000,
+                        false, Optional.of(new AvroSchemaResolver(new Configuration())));
+
+        HiveTable loadedTable = (HiveTable) cachingHiveMetastore.getTable("db1", "avro_tbl");
+        Assertions.assertEquals(new org.apache.avro.Schema.Parser().parse(AVRO_SCHEMA_LITERAL).toString(),
+                loadedTable.getAvroSchemaJson());
+
+        Files.writeString(schemaPath, AVRO_SCHEMA_LITERAL_UPDATED);
+        cachingHiveMetastore.invalidateTable("db1", "avro_tbl");
+        HiveTable reloadedTable = (HiveTable) cachingHiveMetastore.getTable("db1", "avro_tbl");
+        Assertions.assertEquals(new org.apache.avro.Schema.Parser().parse(AVRO_SCHEMA_LITERAL_UPDATED).toString(),
+                reloadedTable.getAvroSchemaJson());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -219,6 +219,46 @@ public class CachingHiveMetastoreTest {
     }
 
     @Test
+    public void testLoadTableResolveAvroSchemaUrlWithCache() throws Exception {
+        java.nio.file.Path schemaPath = Files.createTempFile("sr-avro-schema-cache", ".avsc");
+        Files.writeString(schemaPath, AVRO_SCHEMA_LITERAL);
+        HiveTable table = createAvroTable(Map.of(AvroSchemaResolver.AVRO_SCHEMA_URL, schemaPath.toUri().toString()));
+        new Expectations(metastore) {
+            {
+                metastore.getTable("db1", "avro_tbl");
+                result = table;
+                minTimes = 0;
+            }
+        };
+
+        AvroSchemaResolver resolver = new AvroSchemaResolver(new Configuration());
+        CachingHiveMetastore cachingHiveMetastore =
+                new CachingHiveMetastore(metastore, executor, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000,
+                        false, Optional.of(resolver));
+
+        // First load: resolve from URL
+        HiveTable loadedTable1 = (HiveTable) cachingHiveMetastore.loadTable(DatabaseTableName.of("db1", "avro_tbl"));
+        String schema1 = loadedTable1.getAvroSchemaJson();
+        Assertions.assertNotNull(schema1);
+
+        // Update the file content
+        Files.writeString(schemaPath, AVRO_SCHEMA_LITERAL_UPDATED);
+
+        // Second load (direct call to loadTable, bypass tableCache):
+        // avroSchemaCache should return cached schema, avoiding URL re-read
+        HiveTable loadedTable2 = (HiveTable) cachingHiveMetastore.loadTable(DatabaseTableName.of("db1", "avro_tbl"));
+        String schema2 = loadedTable2.getAvroSchemaJson();
+        Assertions.assertEquals(schema1, schema2); // Should be cached old value
+
+        // After invalidateTable: avroSchemaCache cleared, should get new schema
+        cachingHiveMetastore.invalidateTable("db1", "avro_tbl");
+        HiveTable loadedTable3 = (HiveTable) cachingHiveMetastore.loadTable(DatabaseTableName.of("db1", "avro_tbl"));
+        String schema3 = loadedTable3.getAvroSchemaJson();
+        Assertions.assertEquals(new org.apache.avro.Schema.Parser().parse(AVRO_SCHEMA_LITERAL_UPDATED).toString(),
+                schema3);
+    }
+
+    @Test
     public void testGetTransactionalTable() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
                 metastore, executor, executor,

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -494,6 +494,9 @@ struct THdfsTable {
 
     // timezone
     11: optional string time_zone
+
+    // resolved Avro reader schema json from avro.schema.literal/url
+    12: optional string avro_schema_json
 }
 
 struct TFileTable {


### PR DESCRIPTION
## Why I'm doing:
PR #73237 replaced the JNI Avro scanner with a native C++ implementation to enable DataCache-aware IO and avoid JNI overhead. However, Hive Avro tables frequently define their schema externally via `avro.schema.literal` or `avro.schema.url` in serde properties, rather than embedding it in the data file itself. The native scanner previously only read the embedded writer schema, which caused:
- Schema mismatch errors when the table schema evolved (e.g., new columns with default values)
- Missing columns when the query referenced fields defined only in the external schema

## What I'm doing:

### 1. FE: resolve and cache external Avro schema
Added `AvroSchemaResolver` to parse `avro.schema.literal` (inline JSON) and `avro.schema.url` (HDFS/FS URL) from Hive table serde properties during `CachingHiveMetastore.loadTable()`. The resolved schema is stored in `HiveTable.avroSchemaJson` and properly invalidated on cache refresh.

### 2. FE → BE: propagate reader schema
Extended `THdfsTable` Thrift definition and `HiveTable` serialization to pass the external Avro schema JSON to the backend. BE's `HdfsTableDescriptor` exposes it to `HdfsAvroScanner`.

### 3. BE: AvroReader uses external schema for resolution
`AvroReader::init()` now accepts an optional `reader_schema_json`. When provided, it is used as the reader schema for Avro's `ResolvingDecoder`, enabling correct schema evolution against the file's embedded writer schema.

```
Before:
  AVRO file (writer schema) ──→ AvroReader ──→ decoded with writer schema only
                                    │
                                    ▼
                            fails on evolved/external schema queries

After:
  AVRO file (writer schema) ──→ AvroReader ──→ ResolvingDecoder ──→ decoded with reader schema
                                    ▲                                      │
                                    │                                      ▼
  Hive serde props ──→ AvroSchemaResolver ──→ reader schema         correct evolution
  (literal / url)
```

### 4. Tests
- `AvroSchemaResolver`: literal/url parsing and cache-invalidation refresh
- `AvroReader`: reading a file with an external reader schema that adds a default-value field
- `HiveTable`: Thrift serialization round-trip for `avro_schema_json`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
