### PR TITLE
[auto-perf-opt] Bulk-load PK index memtable on lake cold-load rebuild

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1359,6 +1359,15 @@ CONF_mInt32(cloud_native_pk_index_rebuild_files_threshold, "50");
 // If rows which need to be rebuilt exceed this threshold, we will flush memtable immediately
 // to reduce index rebuild cost. 0 means disabled.
 CONF_mInt64(cloud_native_pk_index_rebuild_rows_threshold, "10000000");
+// If true, the lake PK-index cold-load rebuild path accumulates all
+// (key, IndexValueWithVer) pairs into a scratch vector, sorts them once at the
+// end of the rebuild loop, and bulk-inserts them into the memtable using
+// end-hint inserts (O(1) amortized per element for strictly-sorted input).
+// This replaces the per-chunk `_memtable->insert()` call site, which was the
+// single-threaded `phmap::btree_map::emplace()` chain that dominated cold-load
+// wall-clock (~85% on the `1_100gb_sortkey` workload at iter-008 measurement).
+// Set to false to fall back to the per-chunk insert path bit-for-bit.
+CONF_mBool(lake_pk_index_rebuild_bulk_load_sort, "true");
 // if set to true, CACHE SELECT will only read file, save CPU time
 // if set to false, CACHE SELECT will behave like SELECT
 CONF_mBool(lake_cache_select_in_physical_way, "true");

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1139,6 +1139,19 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     int64_t get_next_cost_us = 0;
     int64_t pk_encode_cost_us = 0;
     int64_t build_values_cost_us = 0;
+    // Scratch buffer for the bulk-load path. The per-chunk `insert()` chain
+    // dominates cold-load wall-clock (~85% on the 1_100gb_sortkey workload)
+    // because every emplace into an initially-empty `phmap::btree_map` is
+    // O(log N) with random-PK keys. We accumulate the keys here, sort once at
+    // the end, and call `_memtable->bulk_load_sorted_unique()`, which uses
+    // end-hint inserts that are O(1) amortized for sorted input.
+    const bool bulk_load_mode = config::lake_pk_index_rebuild_bulk_load_sort;
+    std::vector<std::pair<std::string, IndexValueWithVer>> scratch;
+    if (bulk_load_mode && _need_rebuild_row_cnt > 0) {
+        scratch.reserve(_need_rebuild_row_cnt);
+    }
+    // Defer del-file processing in bulk-load mode (see the call site below).
+    std::vector<std::pair<RowsetPtr, int64_t>> deferred_dels;
     // Rowset whose version is between max_sstable_version and base_version should be recovered.
     for (auto& rowset : rowsets) {
         TRACE_COUNTER_INCREMENT("total_segment_cnt", rowset->num_segments());
@@ -1231,7 +1244,28 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                         continue;
                     }
                     TRACE_COUNTER_INCREMENT("rebuild_index_num_rows", pkc->size());
-                    if (pkc->is_binary()) {
+                    if (bulk_load_mode) {
+                        // Deep-copy key bytes into owning std::strings since
+                        // `chunk->reset()` on the next loop iteration would
+                        // invalidate any Slice/pkc-backed pointers we kept.
+                        const Slice* slices = nullptr;
+                        std::vector<Slice> slice_holder;
+                        if (pkc->is_binary()) {
+                            slices = reinterpret_cast<const Slice*>(pkc->raw_data());
+                        } else {
+                            slice_holder.reserve(pkc->size());
+                            const auto* fkeys = pkc->continuous_data();
+                            for (size_t k = 0; k < pkc->size(); ++k) {
+                                slice_holder.emplace_back(fkeys, _key_size);
+                                fkeys += _key_size;
+                            }
+                            slices = slice_holder.data();
+                        }
+                        for (uint32_t k = 0; k < pkc->size(); ++k) {
+                            scratch.emplace_back(std::string(slices[k].data, slices[k].size),
+                                                 std::make_pair(rowset_version, values[k]));
+                        }
+                    } else if (pkc->is_binary()) {
                         RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()),
                                                values.data(), rowset_version));
                     } else {
@@ -1248,10 +1282,46 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                 }
             }
         }
-        // Rebuild from del files
+        // Rebuild from del files. In bulk-load mode this is deferred until
+        // after the bulk-load (see below): load_dels writes NullIndexValue
+        // markers to the memtable, and those markers would either (a) block
+        // the bulk-load's end-hint fast path or (b) collide with bulk-load
+        // keys (since end-hint insert is a no-op on duplicate keys). Final
+        // index state is identical either way because load_dels' own filter
+        // (`found_rssid > del_rebuild_rssid` → skip) already encodes the
+        // "this delete is too old for this key" rule against whatever index
+        // state get() returns.
         if (rowset->metadata().del_files_size() > 0) {
-            RETURN_IF_ERROR(load_dels(rowset, pkey_schema, rowset_version));
+            if (bulk_load_mode) {
+                deferred_dels.emplace_back(rowset, rowset_version);
+            } else {
+                RETURN_IF_ERROR(load_dels(rowset, pkey_schema, rowset_version));
+            }
         }
+    }
+    if (bulk_load_mode && !scratch.empty()) {
+        TRACE_COUNTER_INCREMENT("rebuild_bulk_load_pair_count", scratch.size());
+        // Sort by key. Strictly-sorted unique input is required by the bulk-load
+        // method; rebuild within one pass produces each PK at most once, so a
+        // plain ascending sort is sufficient.
+        int64_t t_sort_start = GetCurrentTimeMicros();
+        std::sort(scratch.begin(), scratch.end(),
+                  [](const auto& a, const auto& b) { return a.first < b.first; });
+        TRACE_COUNTER_INCREMENT("rebuild_bulk_load_sort_us", GetCurrentTimeMicros() - t_sort_start);
+        // Hand the sorted vector to the memtable; it walks the input once and
+        // appends with end-hint inserts (O(1) amortized each).
+        RETURN_IF_ERROR(_memtable->bulk_load_sorted_unique(std::move(scratch)));
+    }
+    if (bulk_load_mode) {
+        // Apply deferred del files now that the memtable carries the final
+        // insert state. Order across rowsets is preserved (rowsets-list order).
+        for (auto& [rs, rs_ver] : deferred_dels) {
+            RETURN_IF_ERROR(load_dels(rs, pkey_schema, rs_ver));
+        }
+        // The per-chunk `insert()` path used to call `flush_memtable()` after
+        // every chunk. Now that we populate the memtable in one shot, flush
+        // once at the end to honor the same size-based flush trigger.
+        RETURN_IF_ERROR(flush_memtable());
     }
     TRACE_COUNTER_INCREMENT("rebuild_get_next_cost_us", get_next_cost_us);
     TRACE_COUNTER_INCREMENT("rebuild_pk_encode_cost_us", pk_encode_cost_us);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1305,8 +1305,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         // method; rebuild within one pass produces each PK at most once, so a
         // plain ascending sort is sufficient.
         int64_t t_sort_start = GetCurrentTimeMicros();
-        std::sort(scratch.begin(), scratch.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
+        std::sort(scratch.begin(), scratch.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
         TRACE_COUNTER_INCREMENT("rebuild_bulk_load_sort_us", GetCurrentTimeMicros() - t_sort_start);
         // Hand the sorted vector to the memtable; it walks the input once and
         // appends with end-hint inserts (O(1) amortized each).

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -86,6 +86,36 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
     return Status::OK();
 }
 
+Status PersistentIndexMemtable::bulk_load_sorted_unique(
+        std::vector<std::pair<std::string, IndexValueWithVer>>&& sorted_unique_pairs) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("pindex_memtable_bulk_load_insert_us");
+    if (sorted_unique_pairs.empty()) {
+        return Status::OK();
+    }
+    // Strict-sortedness sanity check. The lake cold-load rebuild path guarantees
+    // unique PKs per pass, so duplicates here would mirror the AlreadyExist case
+    // that `insert()` raises — fail loudly rather than silently overwrite.
+    auto bad = std::adjacent_find(sorted_unique_pairs.begin(), sorted_unique_pairs.end(),
+                                  [](const auto& a, const auto& b) { return !(a.first < b.first); });
+    if (bad != sorted_unique_pairs.end()) {
+        return Status::InternalError(
+                strings::Substitute("bulk_load_sorted_unique: input not strictly sorted at index $0",
+                                    static_cast<int64_t>(bad - sorted_unique_pairs.begin())));
+    }
+    // End-hint insert is O(1) amortized when key > all existing keys, which
+    // holds because (a) the input is strictly sorted and (b) we don't mix this
+    // call with concurrent inserts on the same memtable.
+    uint64_t max_v = _max_rss_rowid;
+    for (auto& kv : sorted_unique_pairs) {
+        const uint64_t v = kv.second.second.get_value();
+        max_v = std::max(max_v, v);
+        auto it = _map.insert(_map.end(), std::move(kv));
+        _keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
+    }
+    _max_rss_rowid = max_v;
+    return Status::OK();
+}
+
 Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* old_values, KeyIndexSet* not_founds,
                                       size_t* num_found, int64_t version, uint32_t rowset_id) {
     TRACE_COUNTER_SCOPE_LATENCY_US("pindex_memtable_erase_us");

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -46,6 +46,15 @@ public:
     // |version|: version of index values
     Status insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version);
 
+    // Bulk-load a vector of (key, IndexValueWithVer) pairs that is already
+    // strictly sorted by key (no duplicate keys). Used by the lake PK-index
+    // cold-load rebuild path to amortize the cost of populating an initially-
+    // empty `phmap::btree_map`: with sorted input and an end-hint, each
+    // `insert(end(), ...)` is O(1) amortized, giving O(N) total — vs O(N log N)
+    // for a per-key `emplace`. Takes ownership of the vector so callers don't
+    // pay a second copy of the key strings.
+    Status bulk_load_sorted_unique(std::vector<std::pair<std::string, IndexValueWithVer>>&& sorted_unique_pairs);
+
     // |version|: version of index values
     // |rowset_id|: The rowset that keys belong to. Used for setup rebuild point
     Status erase(size_t n, const Slice* keys, IndexValue* old_values, KeyIndexSet* not_founds, size_t* num_found,


### PR DESCRIPTION
## Summary

Replace the per-chunk `_memtable->insert()` chain in
`LakePersistentIndex::load_from_lake_tablet` with a single
*accumulate → sort → bulk-load* pass. For the cold-load case the
memtable starts empty, the input is in random PK order (sort key ≠ PK),
and every emplace into the `phmap::btree_map` is an O(log N)
cache-miss-y tree walk. With sorted input and `_map.insert(end(), …)`,
phmap's hint path collapses to an O(1)-amortized internal_emplace —
total O(N) instead of O(N log N).

## Bottleneck this addresses

Iter-008 measurement on the `1_100gb_sortkey` workload (StarRocks
shared-data, 6 CN, PK ≠ sort key, ~1.84 M rebuild rows / cold-load
tablet):

| metric | value | share |
|---|---:|---:|
| `pindex_load_from_lake_tablet_us` | 1 960 ms | 100 % |
| `pindex_memtable_insert_us` | 1 672 ms | **85 %** |
| wrapper tax (`lake_persistent_index_insert_us − pindex_memtable_insert_us`) | 146 ms | 7 % |
| OSS read + PK encode | ~150 ms | 7 % |

CPU and disk were idle during this — the bottleneck is single-threaded
btree fan-out, not host resources. Per-iteration history is in
`docs/showcase-*.md` of the auto-perf-opt run; iter-008's PR #73256
already amortized the wrapper tax 7.4× (1 070 → 146 ms), exposing the
btree emplace chain as the next dominant cost.

## How it works

1. **Accumulation.** During the rebuild loop, deep-copy each PK into a
   `std::string` and push `(key, IndexValueWithVer)` onto a stack-local
   `std::vector`. Deep copy is needed because the source chunk is
   reused across iterations.
2. **Sort once.** After the loop, `std::sort` the scratch by key.
   Contiguous-vector access pattern beats btree-walk cache misses
   even though both are O(N log N) in comparisons.
3. **Bulk-load.** Call new `PersistentIndexMemtable::bulk_load_sorted_unique()`:
   walks the sorted input and emits `_map.insert(end(), pair)` for each.
   Phmap's `insert_hint_unique(end(), key, ...)` short-circuits to
   `internal_emplace` when the new key > the rightmost — O(1) amortized
   per element.
4. **Defer load_dels.** Per-rowset `load_dels` calls used to interleave
   with inserts. In bulk-load mode they're deferred to after the
   bulk-load. Final index state is identical because `load_dels`'s own
   filter (`found_rssid > del_rebuild_rssid → skip`) already encodes
   the "delete is too old for this key" rule against whatever index
   state `get()` returns.

## Kill switch

`CONF_mBool(lake_pk_index_rebuild_bulk_load_sort, "true")`. Setting it
to `false` restores the per-chunk insert path bit-for-bit, including
in-loop `load_dels` ordering.

## New trace counters

- `rebuild_bulk_load_pair_count` — total `(key, value)` pairs handed
  to the bulk-load.
- `rebuild_bulk_load_sort_us` — `std::sort` wall-clock.
- `pindex_memtable_bulk_load_insert_us` — `bulk_load_sorted_unique`
  wall-clock (sort excluded).

## Expected impact

Reduces per-tablet cold-load wall-clock from ~1 960 ms toward
~700-900 ms (~50 % reduction). This shortens the deploy-time "freshness
hump" measurable as `freshness P99` on the realtime-benchmark
`1_100gb_sortkey` template. Steady-state writes are unaffected — this
code path runs only at tablet metadata load.

## Test plan

- [ ] Build BE on `branch-4.1` with the patch applied. (TSP build for
      the auto-perf-opt run handles this in the next iteration.)
- [ ] Deploy to a 6-CN cluster with the `1_100gb_sortkey` template.
- [ ] Run `realtime_benchmark --template 1_100gb_sortkey
      --skip-setup --duration-minutes 20`.
- [ ] Confirm new trace counters are emitted on cold-load events
      (`grep pindex_memtable_bulk_load_insert_us` in publish-trace logs).
- [ ] Confirm `pindex_load_from_lake_tablet_us` P99 in the first 60 s
      drops from ~1 960 ms to ≤ 1 100 ms.
- [ ] Confirm steady-state real-upsert P99 unchanged (≤ 100 ms
      server-side).
- [ ] Confirm freshness P99 over 20 min drops by ≥ 5 s vs the
      iter-008 baseline.
- [ ] Verify the kill switch: at least one trace with
      `lake_pk_index_rebuild_bulk_load_sort=false` should reproduce the
      pre-patch per-chunk insert pattern (optional — leave for code
      review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
