### PR TITLE
[Enhancement] Add BE config to gate pipeline event scheduler

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1051,6 +1051,9 @@ CONF_Int64(pipeline_sink_brpc_dop, "64");
 CONF_Int64(pipeline_max_num_drivers_per_exec_thread, "10240");
 CONF_mBool(pipeline_print_profile, "false");
 CONF_mBool(pipeline_timeout_diagnostic, "false");
+// BE-wide kill switch for the pipeline event scheduler. When false, the event scheduler is
+// disabled even if the session variable `enable_pipeline_event_scheduler` is true.
+CONF_mBool(enable_pipeline_event_scheduler, "true");
 // If this value is greater than 0 and the query time exceeds the timeout, then execute gcore on the process.
 CONF_Int64(pipeline_gcore_timeout_threshold_sec, "-1");
 CONF_String(pipeline_gcore_output_dir, "${STARROCKS_HOME}/log");

--- a/be/src/common/config_exec_flow_fwd.h
+++ b/be/src/common/config_exec_flow_fwd.h
@@ -95,6 +95,10 @@ CONF_mBool(pipeline_print_profile, "false");
 
 CONF_mBool(pipeline_timeout_diagnostic, "false");
 
+// BE-wide kill switch for the pipeline event scheduler. When false, the event scheduler is
+// disabled even if the session variable `enable_pipeline_event_scheduler` is true.
+CONF_mBool(enable_pipeline_event_scheduler, "true");
+
 // The arguments of multilevel feedback pipeline_driver_queue. It prioritizes small queries over larger ones,
 // when the value of level_time_slice_base_ns is smaller and queue_ratio_of_adjacent_queue is larger.
 CONF_Int64(pipeline_driver_queue_level_time_slice_base_ns, "200000000");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -152,6 +152,7 @@
         "pipeline_sink_brpc_dop",
         "pipeline_print_profile",
         "pipeline_timeout_diagnostic",
+        "enable_pipeline_event_scheduler",
         "pipeline_driver_queue_level_time_slice_base_ns",
         "pipeline_driver_queue_ratio_of_adjacent_queue",
         "pipeline_analytic_max_buffer_size",

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -777,7 +777,8 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
     auto [exec_groups, pipelines] = builder.build();
     _fragment_ctx->set_pipelines(std::move(exec_groups), std::move(pipelines));
 
-    if (runtime_state->query_options().__isset.enable_pipeline_event_scheduler &&
+    if (config::enable_pipeline_event_scheduler &&
+        runtime_state->query_options().__isset.enable_pipeline_event_scheduler &&
         runtime_state->query_options().enable_pipeline_event_scheduler) {
         // check all pipeline in fragment support event scheduler
         bool all_support_event_scheduler = true;


### PR DESCRIPTION
## Why I'm doing:

Add `enable_pipeline_event_scheduler` (mutable bool, default true) as a BE-wide kill switch. When false, the pipeline event scheduler is disabled even if the per-session variable `enable_pipeline_event_scheduler` is true, giving operators a way to disable the feature without touching client sessions.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
