### PR TITLE
[Refactor] Move LambdaArgument transformed ref cache to ColumnRefFactory

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -45,14 +45,12 @@ import com.starrocks.sql.analyzer.AlterTableClauseAnalyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddPartitionClause;
-import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.LambdaArgument;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.MetaUtils;
@@ -371,15 +369,10 @@ public class InsertOverwriteJobRunner {
 
     private void executeInsert() throws Exception {
         long insertStartTimestamp = System.currentTimeMillis();
-        // should replan here because prepareInsert has changed the targetPartitionNames of insertStmt
-        // Before re-plan, clear cached LambdaArgument.transformedOp from the first plan.
-        // The first plan() creates ColumnRefOperators via ColumnRefFactory and caches them in
-        // LambdaArgument.transformedOp. The re-plan creates a NEW ColumnRefFactory, but the AST
-        // nodes (including LambdaArgument) are reused. If transformedOp is not cleared, the stale
-        // ColumnRefOperator (from the old ColumnRefFactory) will be returned by
-        // SqlToScalarOperatorTranslator.visitLambdaArguments(), causing ID collisions and
-        // "expr_type does not match slot_type" errors, especially with UNION ALL + lambda expressions.
-        clearLambdaArgumentTransformedOps(insertStmt);
+        // should replan here because prepareInsert has changed the targetPartitionNames of insertStmt.
+        // The re-plan creates a fresh ColumnRefFactory; lambda-argument -> ColumnRefOperator caches
+        // live on the factory (see ColumnRefFactory.computeLambdaArgRefIfAbsent), so stale ids from
+        // the first plan cannot leak into the second.
         try (var guard = context.bindScope()) {
             // For dynamic overwrite, set the txnId to insertStmt so that StatementPlanner.beginTransaction()
             // will skip creating a new transaction and reuse the one we created in prepare().
@@ -403,29 +396,6 @@ public class InsertOverwriteJobRunner {
             LOG.warn("insert overwrite failed. error message:{}", context.getState().getErrorMessage());
             throw new DmlException(context.getState().getErrorMessage());
         }
-    }
-
-    /**
-     * Clear all cached LambdaArgument.transformedOp in the AST tree of the InsertStmt.
-     * This is necessary before re-planning because:
-     * 1. The first plan() caches ColumnRefOperator in LambdaArgument.transformedOp
-     * 2. Re-plan creates a new ColumnRefFactory with fresh ID allocation
-     * 3. Stale cached ColumnRefOperators reference IDs from the old ColumnRefFactory
-     * 4. This causes type mismatches when the new ColumnRefFactory assigns the same ID
-     *    to a different column with a different type
-     *
-     * Uses AstTraverser to ensure complete coverage of all AST paths, including
-     * CTE relations, ORDER BY, aggregate, ViewRelation, JoinRelation.onPredicate,
-     * and Expr-level Subquery nodes.
-     */
-    public void clearLambdaArgumentTransformedOps(InsertStmt stmt) {
-        new AstTraverser<Void, Void>() {
-            @Override
-            public Void visitLambdaArguments(LambdaArgument node, Void context) {
-                node.setTransformed(null);
-                return null;
-            }
-        }.visit(stmt);
     }
 
     private void createTempPartitions() throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LambdaArgument.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LambdaArgument.java
@@ -17,21 +17,10 @@ package com.starrocks.sql.ast.expression;
 
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
-import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 public class LambdaArgument extends Expr {
     private String name;
     private boolean nullable;
-
-    ColumnRefOperator transformedOp = null;
-
-    public ColumnRefOperator getTransformed() {
-        return transformedOp;
-    }
-
-    public void setTransformed(ColumnRefOperator op) {
-        transformedOp = op;
-    }
 
     public LambdaArgument(String name) {
         this.name = name;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.ast.expression.CaseExpr;
 import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.LambdaArgument;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
@@ -32,9 +33,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.Type;
 
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 public class ColumnRefFactory {
     private int nextId = 1;
@@ -45,6 +48,13 @@ public class ColumnRefFactory {
     private final Map<Integer, Integer> columnToRelationIds = Maps.newHashMap();
     private final Map<ColumnRefOperator, Column> columnRefToColumns = Maps.newHashMap();
     private final Map<ColumnRefOperator, Table> columnRefToTable = Maps.newHashMap();
+
+    // Cache of ColumnRefOperators resolved for LambdaArgument AST nodes during this planning session.
+    // Keyed by AST identity so that the same lambda argument referenced multiple times within a plan
+    // resolves to the same ColumnRefOperator id. Lifetime matches this factory: a re-plan creates a
+    // fresh factory and thus a fresh cache, which prevents stale ids from leaking across plans
+    // (see issue #72831 / PR #72832).
+    private final Map<LambdaArgument, ColumnRefOperator> lambdaArgRefs = new IdentityHashMap<>();
 
     // introduced to used to get unique id for query,
     // now used to identify nondeterministic function.
@@ -158,5 +168,10 @@ public class ColumnRefFactory {
 
     public int getNextUniqueId() {
         return id++;
+    }
+
+    public ColumnRefOperator computeLambdaArgRefIfAbsent(LambdaArgument arg,
+                                                         Function<LambdaArgument, ColumnRefOperator> creator) {
+        return lambdaArgRefs.computeIfAbsent(arg, creator);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -290,7 +290,10 @@ public final class SqlToScalarOperatorTranslator {
 
     private static class Visitor implements AstVisitorExtendInterface<ScalarOperator, Context> {
         private ExpressionMapping expressionMapping;
-        private final ColumnRefFactory columnRefFactory;
+        // protected so that nested subclasses (LoadExprVisitor) can reach the factory-scoped
+        // lambda-arg cache. javac rejects inherited private access here even though both classes
+        // are nestmates of the enclosing top-level class.
+        protected final ColumnRefFactory columnRefFactory;
         private final List<ColumnRefOperator> correlation;
         private final ConnectContext session;
         private final CTETransformerContext cteContext;
@@ -456,11 +459,10 @@ public final class SqlToScalarOperatorTranslator {
 
         @Override
         public ScalarOperator visitLambdaArguments(LambdaArgument node, Context context) {
-            // To avoid the ids of lambda arguments are different after each visit()
-            if (node.getTransformed() == null) {
-                node.setTransformed(columnRefFactory.create(node.getName(), node.getType(), node.isNullable(), true));
-            }
-            return node.getTransformed();
+            // Cache by AST identity on the factory so repeated visits within one plan share the same id,
+            // while a re-plan (new factory) starts fresh.
+            return columnRefFactory.computeLambdaArgRefIfAbsent(node,
+                    n -> columnRefFactory.create(n.getName(), n.getType(), n.isNullable(), true));
         }
 
         @Override
@@ -1003,15 +1005,13 @@ public final class SqlToScalarOperatorTranslator {
 
         @Override
         public ScalarOperator visitLambdaArguments(LambdaArgument node, Context context) {
-            // To avoid the ids of lambda arguments are different after each visit()
-            if (node.getTransformed() == null) {
+            return columnRefFactory.computeLambdaArgRefIfAbsent(node, n -> {
                 SlotRef slotRef = new SlotRef(
-                        new TableName(TableName.LAMBDA_FUNC_TABLE, TableName.LAMBDA_FUNC_TABLE), node.getName());
-                slotRef.setType(node.getType());
-                slotRef.setNullable(node.isNullable());
-                node.setTransformed(slotResolver.apply(slotRef));
-            }
-            return node.getTransformed();
+                        new TableName(TableName.LAMBDA_FUNC_TABLE, TableName.LAMBDA_FUNC_TABLE), n.getName());
+                slotRef.setType(n.getType());
+                slotRef.setNullable(n.isNullable());
+                return slotResolver.apply(slotRef);
+            });
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -28,13 +28,9 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
-import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.InsertStmt;
-import com.starrocks.sql.ast.expression.LambdaArgument;
 import com.starrocks.sql.common.DmlException;
-import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.statistic.StatisticsMetaManager;
-import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -43,8 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 
 public class InsertOverwriteJobRunnerTest {
 
@@ -333,68 +327,16 @@ public class InsertOverwriteJobRunnerTest {
     }
 
     @Test
-    public void testClearLambdaArgumentTransformedOps() throws Exception {
-        // Test that clearLambdaArgumentTransformedOps correctly clears all LambdaArgument.transformedOp
-        // in the AST tree. This is critical for INSERT OVERWRITE re-plan correctness.
-        String sql = "insert overwrite t_lambda_target " +
-                "select k1, array_map(x -> x + 1, k2) from t_lambda_src1 " +
-                "union all " +
-                "select k1, array_map(x -> x + 2, k2) from t_lambda_src2";
-        InsertStmt insertStmt = (InsertStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-
-        // Collect all LambdaArgument nodes from the AST
-        List<LambdaArgument> lambdaArgs = new ArrayList<>();
-        new AstTraverser<Void, Void>() {
-            @Override
-            public Void visitLambdaArguments(LambdaArgument node, Void context) {
-                lambdaArgs.add(node);
-                return null;
-            }
-        }.visit(insertStmt);
-
-        // Verify that lambda arguments exist in the AST
-        Assertions.assertFalse(lambdaArgs.isEmpty(),
-                "InsertStmt with array_map should contain LambdaArgument nodes");
-        // UNION ALL with two array_map calls should have at least 2 lambda arguments
-        Assertions.assertTrue(lambdaArgs.size() >= 2,
-                "Expected at least 2 LambdaArgument nodes for UNION ALL with two array_map calls, got: " + lambdaArgs.size());
-
-        // Simulate the first plan() caching ColumnRefOperators in LambdaArgument.transformedOp
-        for (LambdaArgument arg : lambdaArgs) {
-            ColumnRefOperator mockOp = new ColumnRefOperator(999, IntegerType.INT, "mock_col", true);
-            arg.setTransformed(mockOp);
-            Assertions.assertNotNull(arg.getTransformed(), "transformedOp should be set");
-        }
-
-        // Call clearLambdaArgumentTransformedOps directly
-        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("insert_overwrite_test");
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "t_lambda_target");
-        OlapTable olapTable = (OlapTable) table;
-        InsertOverwriteJob job = new InsertOverwriteJob(300L, insertStmt, database.getId(), olapTable.getId(),
-                WarehouseManager.DEFAULT_WAREHOUSE_ID, false);
-        StmtExecutor executor = new StmtExecutor(connectContext, insertStmt);
-        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job, connectContext, executor);
-
-        runner.clearLambdaArgumentTransformedOps(insertStmt);
-
-        // Verify all LambdaArgument.transformedOp are cleared
-        for (LambdaArgument arg : lambdaArgs) {
-            Assertions.assertNull(arg.getTransformed(),
-                    "LambdaArgument.transformedOp should be null after clearLambdaArgumentTransformedOps");
-        }
-    }
-
-    @Test
     public void testInsertOverwriteWithUnionAllAndLambda() throws Exception {
-        // Integration test: INSERT OVERWRITE + UNION ALL + Lambda expressions
-        // This is the exact scenario that triggers the "expr_type does not match slot_type" bug
-        // if clearLambdaArgumentTransformedOps is not called before re-plan.
+        // Integration regression for issue #72831: INSERT OVERWRITE + UNION ALL + lambda used to
+        // surface "expr_type does not match slot_type" because the second plan was reading
+        // ColumnRefOperators allocated by the first plan's ColumnRefFactory. The lambda-arg cache
+        // now lives on ColumnRefFactory, so re-plan automatically starts with a fresh cache.
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000000);
         String sql = "insert overwrite t_lambda_target " +
                 "select k1, array_map(x -> x + 1, k2) from t_lambda_src1 " +
                 "union all " +
                 "select k1, array_map(x -> x + 2, k2) from t_lambda_src2";
-        // This should not throw any exception (especially not "expr_type does not match slot_type")
         cluster.runSql("insert_overwrite_test", sql);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslatorTest.java
@@ -20,18 +20,23 @@ import com.starrocks.sql.ast.expression.BinaryPredicate;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.DateLiteral;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.LambdaArgument;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class SqlToScalarOperatorTranslatorTest {
 
@@ -59,5 +64,28 @@ public class SqlToScalarOperatorTranslatorTest {
         CallOperator so = (CallOperator) SqlToScalarOperatorTranslator.translate(complexFunc,
                 new ExpressionMapping(null, Collections.emptyList()), new ColumnRefFactory());
         assertEquals("if", so.getFnName());
+    }
+
+    // Regression for issue #72831 / PR #72832. The LambdaArgument -> ColumnRefOperator cache must live
+    // on the ColumnRefFactory (not on the AST node), so that re-planning with a fresh factory yields
+    // a fresh ColumnRefOperator rather than a stale id from a previous factory. Within one factory,
+    // repeated lookups for the same AST node must return the identical ref.
+    @Test
+    public void testLambdaArgRefCacheScopedToFactory() {
+        LambdaArgument arg = new LambdaArgument("x");
+        arg.setType(IntegerType.INT);
+        arg.setOriginType(IntegerType.INT);
+
+        ColumnRefFactory firstFactory = new ColumnRefFactory();
+        ColumnRefOperator first = firstFactory.computeLambdaArgRefIfAbsent(arg,
+                n -> firstFactory.create(n.getName(), n.getType(), n.isNullable(), true));
+        ColumnRefOperator firstAgain = firstFactory.computeLambdaArgRefIfAbsent(arg,
+                n -> firstFactory.create(n.getName(), n.getType(), n.isNullable(), true));
+        assertSame(first, firstAgain, "same factory must reuse the cached ref");
+
+        ColumnRefFactory secondFactory = new ColumnRefFactory();
+        ColumnRefOperator second = secondFactory.computeLambdaArgRefIfAbsent(arg,
+                n -> secondFactory.create(n.getName(), n.getType(), n.isNullable(), true));
+        assertNotSame(first, second, "re-plan with a new factory must allocate a new ref");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -1148,4 +1148,34 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                 "args: INVALID_TYPE; result: ARRAY<INT>; args nullable: true; result nullable: true], ]\n" +
                 "  |  partition by: [1: v1, BIGINT, true]"));
     }
+
+    // Regression for the LambdaArgument transformed-ref cache refactor (issue #72831 / PR #72832).
+    // Two array_map calls reuse the same lambda argument name `x` on different array<varchar>
+    // columns of the low-cardinality-eligible table s3. The two LambdaArgument AST nodes are
+    // distinct instances; the factory-scoped IdentityHashMap cache must give each its own
+    // ColumnRefOperator. A name-keyed cache (or any cache that conflates AST identity) would
+    // collapse the two `x`s into one slot id, mixing the two lambda bodies' argument bindings.
+    @Test
+    public void testLambdaOverLowCardinalityArray() throws Exception {
+        String sql = "select array_map(x -> upper(x), a1), array_map(x -> lower(x), a3) "
+                + "from s3 where v1 > 0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "upper");
+        assertContains(plan, "lower");
+        // Exactly two array_map operators survived translation + optimization.
+        Assertions.assertEquals(2, plan.split("array_map\\[", -1).length - 1,
+                "expected two array_map operators, plan was:\n" + plan);
+        // Core invariant: the two lambdas' argument slot ids must differ. The plan format is
+        // `array_map[([<slot-id>, VARCHAR... -> ...`. If a future change collapses the cache
+        // by name instead of identity, both would render with the same slot id and this fails.
+        java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile("array_map\\[\\(\\[(\\d+),\\s*VARCHAR")
+                .matcher(plan);
+        Assertions.assertTrue(m.find(), "first array_map arg slot not found, plan was:\n" + plan);
+        String firstSlot = m.group(1);
+        Assertions.assertTrue(m.find(), "second array_map arg slot not found, plan was:\n" + plan);
+        String secondSlot = m.group(1);
+        Assertions.assertNotEquals(firstSlot, secondSlot,
+                "two array_map calls reusing arg name `x` must get distinct slot ids, plan was:\n" + plan);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

The ColumnRefOperator cache for lambda arguments lived as a mutable field on the LambdaArgument AST node. Because ColumnRefOperator ids belong to a ColumnRefFactory whose lifetime is one planning session, INSERT OVERWRITE's two-phase plan/re-plan cycle could observe stale ids: the second plan creates a fresh factory but the AST still hands back operators allocated from the first one, producing the "expr_type does not match slot_type" error fixed in PR #72832 (issue #72831).

Move the cache onto ColumnRefFactory keyed by AST identity. Its lifetime now matches the cache's correct lifetime: a re-plan instantiates a new factory and therefore a fresh cache automatically, structurally preventing this bug class without any explicit traversal-and-clear step. Also restores the "AST nodes must be immutable" invariant called out in fe/CLAUDE.md.

Tests:
- SqlToScalarOperatorTranslatorTest.testLambdaArgRefCacheScopedToFactory: asserts same-factory reuse and cross-factory isolation directly.
- LowCardinalityArrayTest.testLambdaOverLowCardinalityArray: regression covering AST-translation + global dict rewrite end-to-end with two array_map lambdas reusing the argument name `x` on different array<varchar> low-cardinality columns. A name-keyed cache would collapse the two `x`s; identity keying keeps them distinct.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

https://claude.ai/code/session_011PKLRuMDohp19fD6bjwzRt