### PR TITLE
[BugFix] Fix race on response->tablet_metas in lake publish_version

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -388,7 +388,11 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                     if (res.ok()) {
                         auto metadata = std::move(res).value();
                         auto score = compaction_score(_tablet_mgr, metadata);
-                        TabletMetadataPB* prealloc_metadata = nullptr;
+                        // Copy metadata out of the lock(response_mtx), to let it execute in parallel.
+                        TabletMetadataPB local_metadata;
+                        if (skip_write_tablet_metadata) {
+                            local_metadata.CopyFrom(*metadata);
+                        }
                         {
                             std::lock_guard l(response_mtx);
                             response->mutable_compaction_scores()->insert({metadata->id(), score});
@@ -400,13 +404,8 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                                 response->mutable_tablet_row_nums()->insert({metadata->id(), row_nums});
                             }
                             if (skip_write_tablet_metadata) {
-                                auto& map = *response->mutable_tablet_metas();
-                                prealloc_metadata = &map[metadata->id()];
+                                (*response->mutable_tablet_metas())[metadata->id()].Swap(&local_metadata);
                             }
-                        }
-                        // Move copy metadata out of the lock(response_mtx), to let it execute in parallel.
-                        if (prealloc_metadata != nullptr) {
-                            prealloc_metadata->CopyFrom(*metadata);
                         }
                         // Report tablet for async VI build only on async-mode tables
                         // whose new rowset(s) have vector_index_ids. Sync-mode tables

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -934,6 +934,12 @@ public class DatabaseTransactionMgr {
         }
     }
 
+    // Per-partition state carried across TransactionStates while building a
+    // TransactionStateBatch: previous version (must stay consecutive) and the
+    // materialized-index id snapshot (must stay identical across the batch).
+    private record PartitionCommitState(long version, List<Long> loadedIndexIds) {
+    }
+
     public List<TransactionStateBatch> getReadyToPublishTxnListBatch() {
         List<TransactionStateBatch> result = new ArrayList<>();
         readLock();
@@ -960,9 +966,11 @@ public class DatabaseTransactionMgr {
 
                 long tableId = states.get(0).getTableIdList().get(0);
 
-                // check whether version is consequent
-                // for schema change will occupy a version
-                Map<Long, PartitionCommitInfo> versions = new HashMap<>();
+                // Cut the batch whenever a per-partition invariant breaks: version must stay
+                // consecutive (schema change can occupy a version) and the loaded materialized-index
+                // id snapshot must stay identical (so a SplitTabletJob window does not let one batch
+                // mix old + new tablet ids and produce overlapping PublishTabletInfo tasks on BE).
+                Map<Long, PartitionCommitState> partitionCommitStates = new HashMap<>();
 
                 outerLoop:
                 for (int i = 0; i < states.size(); i++) {
@@ -985,15 +993,19 @@ public class DatabaseTransactionMgr {
                     Map<Long, PartitionCommitInfo> partitionInfoMap = tableInfo.getIdToPartitionCommitInfo();
                     for (Map.Entry<Long, PartitionCommitInfo> item : partitionInfoMap.entrySet()) {
                         PartitionCommitInfo currTxnInfo = item.getValue();
-                        PartitionCommitInfo prevTxnInfo = versions.get(item.getKey());
-                        if (prevTxnInfo != null && prevTxnInfo.getVersion() + 1 != currTxnInfo.getVersion()) {
+                        PartitionCommitState previousCommitState = partitionCommitStates.get(item.getKey());
+                        List<Long> currentLoadedIndexIds =
+                                state.getPartitionLoadedIndexIdsWithoutLock(tableId, item.getKey());
+                        if (previousCommitState != null
+                                && (previousCommitState.version() + 1 != currTxnInfo.getVersion()
+                                        || !Objects.equals(previousCommitState.loadedIndexIds(),
+                                                currentLoadedIndexIds))) {
                             assert i > 0;
-                            // version is not consecutive
-                            // may schema change occupy a version
                             states = states.subList(0, i);
                             break outerLoop;
                         }
-                        versions.put(item.getKey(), currTxnInfo);
+                        partitionCommitStates.put(item.getKey(),
+                                new PartitionCommitState(currTxnInfo.getVersion(), currentLoadedIndexIds));
                     }
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -1028,6 +1028,16 @@ public class TransactionState implements Writable, GsonPreProcessable {
         }
     }
 
+    // Raw materialized-index id snapshot recorded at OlapTableSink planning time
+    // for (tableId, physicalPartitionId); null if not recorded.
+    public List<Long> getPartitionLoadedIndexIdsWithoutLock(long tableId, long physicalPartitionId) {
+        Map<Long, List<Long>> loadedPartitionIndexes = loadedTblPartitionIndexes.get(tableId);
+        if (loadedPartitionIndexes == null) {
+            return null;
+        }
+        return loadedPartitionIndexes.get(physicalPartitionId);
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("TransactionState. ");

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -655,6 +655,21 @@ public class LakePublishBatchTest {
 
     @Test
     public void testBatchPublishShadowIndex() throws Exception {
+        // Strict cut on diverging loaded-index snapshots (see
+        // DatabaseTransactionMgr.getReadyToPublishTxnListBatch) breaks this scenario into
+        // single-txn batches per snapshot, but TransactionGraph.getTxnsWithTxnDependencyBatch
+        // refuses to return chains smaller than min_version_num. Production default is 1; the
+        // class-level setUp raises it to 2 to stress batching. Lower it back for this one
+        // test so the post-cut single-txn batches actually publish.
+        Config.lake_batch_publish_min_version_num = 1;
+        try {
+            doTestBatchPublishShadowIndex();
+        } finally {
+            Config.lake_batch_publish_min_version_num = 2;
+        }
+    }
+
+    private void doTestBatchPublishShadowIndex() throws Exception {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getTable(db.getFullName(), TABLE_SCHEMA_CHANGE);
@@ -730,12 +745,23 @@ public class LakePublishBatchTest {
         LakeService lakeService = BrpcProxy.getLakeService(shadowTabletNode.getHost(), shadowTabletNode.getBrpcPort());
         assertInstanceOf(MockedBackend.MockLakeService.class, lakeService);
         MockedBackend.MockLakeService mockLakeService = (MockedBackend.MockLakeService) lakeService;
-        PublishLogVersionBatchRequest request = mockLakeService.pollPublishLogVersionBatchRequests();
-        assertNotNull(request);
-        assertEquals(List.of(shadowTablet.getId()), request.getTabletIds());
-        assertEquals(2, request.getTxnInfos().size());
-        assertEquals(txn2, request.getTxnInfos().get(0).getTxnId());
-        assertEquals(txn3, request.getTxnInfos().get(1).getTxnId());
+        // Strict cut in DatabaseTransactionMgr.getReadyToPublishTxnListBatch splits txn1
+        // away from txn2/txn3 (their loadedIndexIds snapshots differ across the schema
+        // change boundary), and the resulting single-txn batches publish via
+        // PublishVersionDaemon.publishLakeTransactionAsync. That path calls
+        // Utils.publishLogVersion per txn, producing one PublishLogVersionBatchRequest
+        // per shadow-loaded txn (txn2 then txn3) instead of one combined request.
+        PublishLogVersionBatchRequest firstShadowRequest = mockLakeService.pollPublishLogVersionBatchRequests();
+        assertNotNull(firstShadowRequest);
+        assertEquals(List.of(shadowTablet.getId()), firstShadowRequest.getTabletIds());
+        assertEquals(1, firstShadowRequest.getTxnInfos().size());
+        assertEquals(txn2, firstShadowRequest.getTxnInfos().get(0).getTxnId());
+
+        PublishLogVersionBatchRequest secondShadowRequest = mockLakeService.pollPublishLogVersionBatchRequests();
+        assertNotNull(secondShadowRequest);
+        assertEquals(List.of(shadowTablet.getId()), secondShadowRequest.getTabletIds());
+        assertEquals(1, secondShadowRequest.getTxnInfos().size());
+        assertEquals(txn3, secondShadowRequest.getTxnInfos().get(0).getTxnId());
     }
 
     private List<TabletCommitInfo> getPartitionTabletCommitInfos(Partition partition) {


### PR DESCRIPTION
## Why I'm doing:

`LakeServiceImpl::publish_version` crashes the CN under file-bundling
publish (`enable_aggregate_publish=true` → `skip_write_tablet_metadata`)
when two concurrent `PublishTabletInfo` tasks resolve to the same
`metadata->id()`. Crash signature on a production branch-4.1 core
(build a1daea6):

```
RowsetMetadataPB::IsInitialized() this=0x276d1ad1   ← torn pointer
TabletMetadataPB::IsInitialized()
PublishVersionResponse::IsInitialized()
brpc::policy::SendRpcResponse(...)
LakeServiceImpl::publish_version(...)
```

The `this=0x276d1ad1` is a torn 64-bit pointer (high 32 bits zeroed)
inside `tablet_metas[child].rowsets_.rep_->elements[i]`. The same core
shows `rowsets_.current_size_ = 146` vs `total_size_ = 73` for both
children — exactly 2× the original allocation, the unmistakable
signature of two threads concurrently `Add()`-ing into the same
`RepeatedPtrField`.

### Two-layer root cause

#### BE — `lake_service.cpp`

`lake_service.cpp:222-267` expands `publish_tablet_infos` from
`request->tablet_ids` and from each `resharding_tablet_info` without
dedup. A SPLITTING op whose `new_tablet_ids` overlap with `tablet_ids`
produces two `PublishTabletInfo` per child (`PUBLISH_NORMAL` plus
`SPLITTING_TABLET` cross-publish):

| # | type | tablet_id_in_metadata |
|---|---|---|
| 1 | PUBLISH_NORMAL | child_A |
| 2 | PUBLISH_NORMAL | child_B |
| 3 | SPLITTING_TABLET(old → child_A) | child_A |
| 4 | SPLITTING_TABLET(old → child_B) | child_B |

The per-tablet defense `tablet_txns` in `transactions.cpp` only covers
the body of `lake::publish_version` — its `DeferOp` releases on return
BEFORE the caller's `prealloc_metadata->CopyFrom(*metadata)` runs
outside `response_mtx`:

```
Task A: lake::publish_version(T) acquires tablet_txns[T]
Task A: produces metadata, DeferOp releases tablet_txns[T]   ←
Task A: under response_mtx: P = &map[T]; releases response_mtx
Task A: P->CopyFrom(*metadata)              [outside both locks]
                                                       Task B: lake::publish_version(T) re-acquires tablet_txns[T]
                                                       Task B: under response_mtx: same P = &map[T]
                                                       Task B: P->CopyFrom(*metadata)  ← CONCURRENT WITH TASK A
```

`CopyFrom = Clear + MergeFrom`. `Clear` walks `rowsets_.elements[]`
while the other thread's `MergeFrom` reallocates that array → torn
pointer → SIGSEGV in `RowsetMetadataPB::IsInitialized` at serialization
time. Introduced by #61410 (`75854adf72`, "optimize tablet meta copy
when enable file bundling"); the resharding branch in the same file
already implements the correct swap-under-lock pattern.

#### FE — `PublishVersionDaemon.publishPartitionBatch`

The crash core's request body:

```
tablet_ids                 = [child_A, child_B]
resharding_tablet_infos[0] = SPLITTING(old=77599, new_tablet_ids=[child_A, child_B])
txn_infos                  = 5 transactions, commit_time span ≈ 102 seconds
base_version=70, new_version=75, enable_aggregate_publish=true
```

`publishPartitionBatch` unions per-txn loaded materialized indexes
across **every** `TransactionState` in the batch. Each txn's
`loadedIndexIds` was snapshotted at OlapTableSink planning time. If
`SplitTabletJob.addNewMaterializedIndexes()` runs in the middle of a
batch's planning window, early txns capture `[oldIndexId]` and late
txns capture `[newIndexId]`. The union then contains:

- `77599` (early txns' OLD tablet, still resolvable until
  `removeOldMaterializedIndexes` in CLEANING)
- children (late txns', from the new index)

`Utils.processTablets` then emits both lists in the same RPC,
producing the dup-id input that triggers the BE race.

## What I'm doing

Two-layer defense; both layers necessary. BE stops the crash regardless
of caller. FE removes the production trigger so the underlying
data-correctness gap (two tasks producing different partial metadata
for the same child) does not occur in the first place.

### BE: swap-under-lock (`be/src/service/service_be/lake_service.cpp`)

Build a thread-local `TabletMetadataPB` outside `response_mtx`, then
`Swap` it into `response->tablet_metas[id]` under the lock. The heavy
`CopyFrom` still runs in parallel; the in-lock `Swap` is fast and
atomic w.r.t. other tasks. Two tasks targeting the same id will Swap
serially under the lock — last writer wins, no torn array. Mirrors the
safe pattern in the resharding branch.

### FE: strict per-partition snapshot invariant (`fe/fe-core/.../transaction/DatabaseTransactionMgr.java`)

In `getReadyToPublishTxnListBatch`, fold the existing
version-must-be-consecutive check and a new
loaded-materialized-index-id-snapshot-must-be-equal check into a single
per-partition `PartitionCommitState` record. Break the batch on either
invariant violation. Any divergence (including schema-change shadow
addition/removal) is a cut point — keeps the invariant simple and
conservative, doesn't depend on knowing whether the diverging txns
came from a split or schema change.

A new accessor
`TransactionState.getPartitionLoadedIndexIdsWithoutLock(tableId,
physicalPartitionId)` exposes the raw recorded id list. Sequential
sub-batches are correct because the BE's
`metacache().lookup_tablet_metadata` makes already-published
`(tablet_id, version)` pairs idempotent.

### Test

`LakePublishBatchTest.testBatchPublishShadowIndex` previously relied on
three out-of-order commits (txn2, txn1, txn3) batching into one publish
whose shadow `PublishLogVersionBatchRequest` contained both txn2 and
txn3. The strict cut now separates txn1 (snapshot lacks the shadow id)
from txn2/txn3, producing one single-txn batch per shadow-loaded txn.
With the class-level `Config.lake_batch_publish_min_version_num = 2`
(test-only stress; production default is 1), `TransactionGraph` refuses
chains of size 1 and `awaitPublish` times out. The test scopes
`min_version_num = 1` to this method and expects two separate
`PublishLogVersionBatchRequest` entries (one per shadow-loaded txn).

### Empirical repro

A standalone test modeling `acquire → produce → release → CopyFrom
outside lock` with 16 threads × 500 ops × 32 IDs (heavy dup-id
pressure): **5/5 SIGSEGV** with the buggy BE pattern, **0/5** with the
swap-under-lock fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4