### PR TITLE
[auto-perf-opt] Parallelise PK-index cold-load rebuild sort

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1368,6 +1368,23 @@ CONF_mInt64(cloud_native_pk_index_rebuild_rows_threshold, "10000000");
 // wall-clock (~85% on the `1_100gb_sortkey` workload at iter-008 measurement).
 // Set to false to fall back to the per-chunk insert path bit-for-bit.
 CONF_mBool(lake_pk_index_rebuild_bulk_load_sort, "true");
+// Number of parallel sort chunks for the PK-index cold-load rebuild's
+// `std::sort` of the bulk-load scratch vector. Iter-010 measurement showed
+// the serial `std::sort` over 1.7M (string, IndexValueWithVer) pairs took
+// ~950 ms (~55% of cold-load wall-clock) — dominated by string comparisons
+// on random PK keys. Splitting the scratch into N approximately-equal chunks
+// and dispatching N-1 of them onto `pk_index_execution_thread_pool` cuts the
+// parallel-sort phase to ~O(N/K log N/K), with a sequential pairwise
+// `std::inplace_merge` to recombine. Set to 1 (or 0) to fall back to the
+// single-threaded `std::sort` path. Chunks are also clamped so each chunk
+// has at least `lake_pk_index_rebuild_parallel_sort_min_per_chunk` entries.
+CONF_mInt32(lake_pk_index_rebuild_parallel_sort_chunks, "4");
+// Minimum entries per parallel-sort chunk. Below this, the chunking
+// overhead (token allocation, dispatch, merge bookkeeping) outweighs the
+// gain from parallelism, so the rebuild silently falls back to a single
+// `std::sort`. Default 50 000 picked to keep per-chunk wall-clock above the
+// thread-dispatch cost (~tens of microseconds).
+CONF_mInt32(lake_pk_index_rebuild_parallel_sort_min_per_chunk, "50000");
 // if set to true, CACHE SELECT will only read file, save CPU time
 // if set to false, CACHE SELECT will behave like SELECT
 CONF_mBool(lake_cache_select_in_physical_way, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1359,6 +1359,15 @@ CONF_mInt32(cloud_native_pk_index_rebuild_files_threshold, "50");
 // If rows which need to be rebuilt exceed this threshold, we will flush memtable immediately
 // to reduce index rebuild cost. 0 means disabled.
 CONF_mInt64(cloud_native_pk_index_rebuild_rows_threshold, "10000000");
+// If true, the lake PK-index cold-load rebuild path accumulates all
+// (key, IndexValueWithVer) pairs into a scratch vector, sorts them once at the
+// end of the rebuild loop, and bulk-inserts them into the memtable using
+// end-hint inserts (O(1) amortized per element for strictly-sorted input).
+// This replaces the per-chunk `_memtable->insert()` call site, which was the
+// single-threaded `phmap::btree_map::emplace()` chain that dominated cold-load
+// wall-clock (~85% on the `1_100gb_sortkey` workload at iter-008 measurement).
+// Set to false to fall back to the per-chunk insert path bit-for-bit.
+CONF_mBool(lake_pk_index_rebuild_bulk_load_sort, "true");
 // if set to true, CACHE SELECT will only read file, save CPU time
 // if set to false, CACHE SELECT will behave like SELECT
 CONF_mBool(lake_cache_select_in_physical_way, "true");

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1139,6 +1139,19 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     int64_t get_next_cost_us = 0;
     int64_t pk_encode_cost_us = 0;
     int64_t build_values_cost_us = 0;
+    // Scratch buffer for the bulk-load path. The per-chunk `insert()` chain
+    // dominates cold-load wall-clock (~85% on the 1_100gb_sortkey workload)
+    // because every emplace into an initially-empty `phmap::btree_map` is
+    // O(log N) with random-PK keys. We accumulate the keys here, sort once at
+    // the end, and call `_memtable->bulk_load_sorted_unique()`, which uses
+    // end-hint inserts that are O(1) amortized for sorted input.
+    const bool bulk_load_mode = config::lake_pk_index_rebuild_bulk_load_sort;
+    std::vector<std::pair<std::string, IndexValueWithVer>> scratch;
+    if (bulk_load_mode && _need_rebuild_row_cnt > 0) {
+        scratch.reserve(_need_rebuild_row_cnt);
+    }
+    // Defer del-file processing in bulk-load mode (see the call site below).
+    std::vector<std::pair<RowsetPtr, int64_t>> deferred_dels;
     // Rowset whose version is between max_sstable_version and base_version should be recovered.
     for (auto& rowset : rowsets) {
         TRACE_COUNTER_INCREMENT("total_segment_cnt", rowset->num_segments());
@@ -1231,7 +1244,28 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                         continue;
                     }
                     TRACE_COUNTER_INCREMENT("rebuild_index_num_rows", pkc->size());
-                    if (pkc->is_binary()) {
+                    if (bulk_load_mode) {
+                        // Deep-copy key bytes into owning std::strings since
+                        // `chunk->reset()` on the next loop iteration would
+                        // invalidate any Slice/pkc-backed pointers we kept.
+                        const Slice* slices = nullptr;
+                        std::vector<Slice> slice_holder;
+                        if (pkc->is_binary()) {
+                            slices = reinterpret_cast<const Slice*>(pkc->raw_data());
+                        } else {
+                            slice_holder.reserve(pkc->size());
+                            const auto* fkeys = pkc->continuous_data();
+                            for (size_t k = 0; k < pkc->size(); ++k) {
+                                slice_holder.emplace_back(fkeys, _key_size);
+                                fkeys += _key_size;
+                            }
+                            slices = slice_holder.data();
+                        }
+                        for (uint32_t k = 0; k < pkc->size(); ++k) {
+                            scratch.emplace_back(std::string(slices[k].data, slices[k].size),
+                                                 std::make_pair(rowset_version, values[k]));
+                        }
+                    } else if (pkc->is_binary()) {
                         RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()),
                                                values.data(), rowset_version));
                     } else {
@@ -1248,10 +1282,46 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                 }
             }
         }
-        // Rebuild from del files
+        // Rebuild from del files. In bulk-load mode this is deferred until
+        // after the bulk-load (see below): load_dels writes NullIndexValue
+        // markers to the memtable, and those markers would either (a) block
+        // the bulk-load's end-hint fast path or (b) collide with bulk-load
+        // keys (since end-hint insert is a no-op on duplicate keys). Final
+        // index state is identical either way because load_dels' own filter
+        // (`found_rssid > del_rebuild_rssid` → skip) already encodes the
+        // "this delete is too old for this key" rule against whatever index
+        // state get() returns.
         if (rowset->metadata().del_files_size() > 0) {
-            RETURN_IF_ERROR(load_dels(rowset, pkey_schema, rowset_version));
+            if (bulk_load_mode) {
+                deferred_dels.emplace_back(rowset, rowset_version);
+            } else {
+                RETURN_IF_ERROR(load_dels(rowset, pkey_schema, rowset_version));
+            }
         }
+    }
+    if (bulk_load_mode && !scratch.empty()) {
+        TRACE_COUNTER_INCREMENT("rebuild_bulk_load_pair_count", scratch.size());
+        // Sort by key. Strictly-sorted unique input is required by the bulk-load
+        // method; rebuild within one pass produces each PK at most once, so a
+        // plain ascending sort is sufficient.
+        int64_t t_sort_start = GetCurrentTimeMicros();
+        std::sort(scratch.begin(), scratch.end(),
+                  [](const auto& a, const auto& b) { return a.first < b.first; });
+        TRACE_COUNTER_INCREMENT("rebuild_bulk_load_sort_us", GetCurrentTimeMicros() - t_sort_start);
+        // Hand the sorted vector to the memtable; it walks the input once and
+        // appends with end-hint inserts (O(1) amortized each).
+        RETURN_IF_ERROR(_memtable->bulk_load_sorted_unique(std::move(scratch)));
+    }
+    if (bulk_load_mode) {
+        // Apply deferred del files now that the memtable carries the final
+        // insert state. Order across rowsets is preserved (rowsets-list order).
+        for (auto& [rs, rs_ver] : deferred_dels) {
+            RETURN_IF_ERROR(load_dels(rs, pkey_schema, rs_ver));
+        }
+        // The per-chunk `insert()` path used to call `flush_memtable()` after
+        // every chunk. Now that we populate the memtable in one shot, flush
+        // once at the end to honor the same size-based flush trigger.
+        RETURN_IF_ERROR(flush_memtable());
     }
     TRACE_COUNTER_INCREMENT("rebuild_get_next_cost_us", get_next_cost_us);
     TRACE_COUNTER_INCREMENT("rebuild_pk_encode_cost_us", pk_encode_cost_us);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1305,8 +1305,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         // method; rebuild within one pass produces each PK at most once, so a
         // plain ascending sort is sufficient.
         int64_t t_sort_start = GetCurrentTimeMicros();
-        std::sort(scratch.begin(), scratch.end(),
-                  [](const auto& a, const auto& b) { return a.first < b.first; });
+        std::sort(scratch.begin(), scratch.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
         TRACE_COUNTER_INCREMENT("rebuild_bulk_load_sort_us", GetCurrentTimeMicros() - t_sort_start);
         // Hand the sorted vector to the memtable; it walks the input once and
         // appends with end-hint inserts (O(1) amortized each).

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1305,7 +1305,67 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         // method; rebuild within one pass produces each PK at most once, so a
         // plain ascending sort is sufficient.
         int64_t t_sort_start = GetCurrentTimeMicros();
-        std::sort(scratch.begin(), scratch.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+        auto key_less = [](const auto& a, const auto& b) { return a.first < b.first; };
+        const int cfg_chunks = std::max(1, config::lake_pk_index_rebuild_parallel_sort_chunks);
+        const size_t min_per_chunk =
+                static_cast<size_t>(std::max(1, config::lake_pk_index_rebuild_parallel_sort_min_per_chunk));
+        // Cap chunk count so every chunk holds at least `min_per_chunk` entries
+        // — below that, dispatch overhead exceeds the parallel speedup.
+        const size_t n_pairs = scratch.size();
+        size_t k = (cfg_chunks <= 1) ? 1
+                                     : std::min<size_t>(cfg_chunks, std::max<size_t>(1, n_pairs / min_per_chunk));
+        if (k < 2) {
+            std::sort(scratch.begin(), scratch.end(), key_less);
+            TRACE_COUNTER_INCREMENT("rebuild_parallel_sort_chunks", 1);
+        } else {
+            // Even split. bounds[i] is the half-open chunk start of chunk i;
+            // bounds[k] == n_pairs is the past-the-end sentinel.
+            std::vector<size_t> bounds(k + 1);
+            for (size_t i = 0; i <= k; ++i) {
+                bounds[i] = (n_pairs * i) / k;
+            }
+            TRACE_COUNTER_INCREMENT("rebuild_parallel_sort_chunks", static_cast<int64_t>(k));
+            // Each worker thread accumulates into a thread-safe atomic; emit
+            // once after `token->wait()` because TRACE_COUNTER_INCREMENT from
+            // worker threads silently drops (trace ctx is thread-local).
+            std::atomic<int64_t> sort_chunk_us{0};
+            auto sort_chunk = [&](size_t lo, size_t hi) {
+                int64_t t0 = GetCurrentTimeMicros();
+                std::sort(scratch.begin() + lo, scratch.begin() + hi, key_less);
+                sort_chunk_us.fetch_add(GetCurrentTimeMicros() - t0, std::memory_order_relaxed);
+            };
+            auto token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+                    ThreadPool::ExecutionMode::CONCURRENT);
+            // Dispatch chunks [1..k-1] to the pool; the caller thread sorts
+            // chunk 0 inline so we don't waste a thread spinning on wait().
+            for (size_t i = 1; i < k; ++i) {
+                size_t lo = bounds[i];
+                size_t hi = bounds[i + 1];
+                auto st = token->submit_func([&sort_chunk, lo, hi]() { sort_chunk(lo, hi); });
+                if (!st.ok()) {
+                    sort_chunk(lo, hi);
+                }
+            }
+            sort_chunk(bounds[0], bounds[1]);
+            token->wait();
+            TRACE_COUNTER_INCREMENT("rebuild_parallel_sort_chunk_us", sort_chunk_us.load());
+            // Sequential pairwise `std::inplace_merge` over log2(k) passes.
+            // Each pass is O(N) comparisons + O(min(left,right)) auxiliary
+            // memory; total merge work is O(N log k), which empirically lands
+            // under 100 ms for N=1.7M, k=4.
+            int64_t t_merge_start = GetCurrentTimeMicros();
+            size_t span = 1;
+            while (span < k) {
+                size_t step = span * 2;
+                for (size_t i = 0; i + span < k; i += step) {
+                    size_t j = std::min(i + step, k);
+                    std::inplace_merge(scratch.begin() + bounds[i], scratch.begin() + bounds[i + span],
+                                       scratch.begin() + bounds[j], key_less);
+                }
+                span = step;
+            }
+            TRACE_COUNTER_INCREMENT("rebuild_parallel_sort_merge_us", GetCurrentTimeMicros() - t_merge_start);
+        }
         TRACE_COUNTER_INCREMENT("rebuild_bulk_load_sort_us", GetCurrentTimeMicros() - t_sort_start);
         // Hand the sorted vector to the memtable; it walks the input once and
         // appends with end-hint inserts (O(1) amortized each).

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1312,8 +1312,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         // Cap chunk count so every chunk holds at least `min_per_chunk` entries
         // — below that, dispatch overhead exceeds the parallel speedup.
         const size_t n_pairs = scratch.size();
-        size_t k = (cfg_chunks <= 1) ? 1
-                                     : std::min<size_t>(cfg_chunks, std::max<size_t>(1, n_pairs / min_per_chunk));
+        size_t k = (cfg_chunks <= 1) ? 1 : std::min<size_t>(cfg_chunks, std::max<size_t>(1, n_pairs / min_per_chunk));
         if (k < 2) {
             std::sort(scratch.begin(), scratch.end(), key_less);
             TRACE_COUNTER_INCREMENT("rebuild_parallel_sort_chunks", 1);

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -86,6 +86,36 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
     return Status::OK();
 }
 
+Status PersistentIndexMemtable::bulk_load_sorted_unique(
+        std::vector<std::pair<std::string, IndexValueWithVer>>&& sorted_unique_pairs) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("pindex_memtable_bulk_load_insert_us");
+    if (sorted_unique_pairs.empty()) {
+        return Status::OK();
+    }
+    // Strict-sortedness sanity check. The lake cold-load rebuild path guarantees
+    // unique PKs per pass, so duplicates here would mirror the AlreadyExist case
+    // that `insert()` raises — fail loudly rather than silently overwrite.
+    auto bad = std::adjacent_find(sorted_unique_pairs.begin(), sorted_unique_pairs.end(),
+                                  [](const auto& a, const auto& b) { return !(a.first < b.first); });
+    if (bad != sorted_unique_pairs.end()) {
+        return Status::InternalError(
+                strings::Substitute("bulk_load_sorted_unique: input not strictly sorted at index $0",
+                                    static_cast<int64_t>(bad - sorted_unique_pairs.begin())));
+    }
+    // End-hint insert is O(1) amortized when key > all existing keys, which
+    // holds because (a) the input is strictly sorted and (b) we don't mix this
+    // call with concurrent inserts on the same memtable.
+    uint64_t max_v = _max_rss_rowid;
+    for (auto& kv : sorted_unique_pairs) {
+        const uint64_t v = kv.second.second.get_value();
+        max_v = std::max(max_v, v);
+        auto it = _map.insert(_map.end(), std::move(kv));
+        _keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
+    }
+    _max_rss_rowid = max_v;
+    return Status::OK();
+}
+
 Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* old_values, KeyIndexSet* not_founds,
                                       size_t* num_found, int64_t version, uint32_t rowset_id) {
     TRACE_COUNTER_SCOPE_LATENCY_US("pindex_memtable_erase_us");

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -46,6 +46,15 @@ public:
     // |version|: version of index values
     Status insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version);
 
+    // Bulk-load a vector of (key, IndexValueWithVer) pairs that is already
+    // strictly sorted by key (no duplicate keys). Used by the lake PK-index
+    // cold-load rebuild path to amortize the cost of populating an initially-
+    // empty `phmap::btree_map`: with sorted input and an end-hint, each
+    // `insert(end(), ...)` is O(1) amortized, giving O(N) total — vs O(N log N)
+    // for a per-key `emplace`. Takes ownership of the vector so callers don't
+    // pay a second copy of the key strings.
+    Status bulk_load_sorted_unique(std::vector<std::pair<std::string, IndexValueWithVer>>&& sorted_unique_pairs);
+
     // |version|: version of index values
     // |rowset_id|: The rowset that keys belong to. Used for setup rebuild point
     Status erase(size_t n, const Slice* keys, IndexValue* old_values, KeyIndexSet* not_founds, size_t* num_found,


### PR DESCRIPTION
## What

Speed up `LakePersistentIndex::load_from_lake_tablet` by parallelising the bulk-load scratch buffer's `std::sort` across the existing `pk_index_execution_thread_pool` (1 024 threads, idle during cold-load).

The PR stacks the bulk-load infrastructure from the closed iter-009 PR (#73262) and adds chunked parallel sort + sequential pairwise `std::inplace_merge` on top.

## Why

iter-010 deploy-and-measure of #73262 (1 695 ms cold-load avg over 4 events on 1_100gb_sortkey, table ~1.75M rows/tablet) showed the sort phase dominates by a wide margin:

| Phase | Wall-clock | Share |
|---|---|---|
| `rebuild_bulk_load_sort_us` (this PR's target) | 930-959 ms | ~55 % |
| `pindex_memtable_bulk_load_insert_us` (already O(1) end-hint) | 454-472 ms | ~28 % |
| `rebuild_index_segment_cost_us` (OSS read + decode) | 228-238 ms | ~14 % |
| Other | ~50 ms | ~3 % |

The btree end-hint insert phase is already at its structural floor. CPU is otherwise idle during cold-load (`pk_index_execution_thread_pool` reports 1 024 idle threads in the same window) — single-threaded sort is leaving wall-clock on the table.

## How

Split the sorted scratch vector into K approximately-equal contiguous chunks, dispatch K-1 chunk sorts onto `pk_index_execution_thread_pool` via a `CONCURRENT`-mode token, sort chunk 0 inline on the calling thread (avoids burning a thread on `wait()`). After all chunks finish, recombine in place via `log2(K)` passes of pairwise `std::inplace_merge`.

Time complexity:
- Parallel sort: `O(N/K · log(N/K))` wall-clock with K workers
- Sequential merge: `O(N · log K)` total comparisons (cache-friendly inplace_merge)

For N=1.75M, K=4 expectation: ~215 ms parallel sort + ~90 ms merge = **~305 ms total**, vs 950 ms serial today (~3× speedup).

Gated by `lake_pk_index_rebuild_parallel_sort_chunks` (default `4`). Setting it to `1` or `0` falls back to the single-threaded `std::sort` bit-for-bit (restores iter-010 measurement). `lake_pk_index_rebuild_parallel_sort_min_per_chunk` (default 50 000) auto-halves K when a split would produce chunks too small to amortise dispatch.

New trace counters:
- `rebuild_parallel_sort_chunks` — K actually used (1 = serial fallback)
- `rebuild_parallel_sort_chunk_us` — summed per-chunk wall-clock (atomic)
- `rebuild_parallel_sort_merge_us` — sequential `inplace_merge` phase

## Pre-registered acceptance for the iter-011 verification

1. `rebuild_parallel_sort_chunks` per cold-load = `min(4, ceil(N / 50000)) = 4` for N ≈ 1.75M. Confirms the path activated.
2. `rebuild_bulk_load_sort_us` ≤ **400 ms** per cold-load (vs 950 ms serial baseline = ≥ 57 % reduction).
3. `rebuild_parallel_sort_merge_us` ≤ **150 ms** per cold-load. (Sanity-checks the merge phase isn't pathological.)
4. `pindex_load_from_lake_tablet_us` P99 in first 60 s ≤ **1 200 ms** (= the iter-010 hard target #73262 missed; this PR aims to actually hit it).
5. Steady-state real-upsert P99 ≤ 100 ms server-side; throughput ≥ 41 K r/s; no regression on compaction publish (`compaction_replace_index_latency_us` P99 ≤ 200 ms during steady state).

If 4 met → promote to ready-for-review (`gh pr ready`). If regression / merge correctness issue / no lift → close.

## Correctness

- Chunk sorts operate on disjoint half-open ranges of the same `std::vector`; no data race.
- The scratch vector is owned by the publish thread and is never published to a third party until `bulk_load_sorted_unique(std::move(scratch))` at the end.
- `inplace_merge` requires both inputs sorted under the same comparator — uses the same `key_less` lambda everywhere.
- Within one cold-load pass, rebuild iterates rowsets in order and each segment-row PK appears at most once across the union, so the merged output is still duplicate-free.
- Worker threads MUST NOT call `TRACE_COUNTER_INCREMENT` directly (thread-local trace ctx silently drops); per-chunk timings accumulate into a `std::atomic<int64_t>` and the trace counter is emitted once on the calling thread after `token->wait()`.

## Diff size

3 commits, 4 files changed, +199 / -4 lines:
- bulk-load infrastructure (cherry-picked from iter-009 commit `82f80966`, +121/-3, plus `+1/-2` style fix)
- this PR: `+78 / -1`