### PR TITLE
[Tool] weekly review: make auto-PR branch unique across reruns

### DIFF
--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -298,7 +298,10 @@ jobs:
             exit 0
           fi
 
-          BR="auto/weekly-review-cleanup-$(date +%Y-%m-%d)-${COMMIT_SHA:0:8}"
+          # Include GITHUB_RUN_ID so reruns of the same workflow (same date,
+          # same commit) get a fresh head branch instead of colliding with a
+          # previous attempt's branch / PR.
+          BR="auto/weekly-review-cleanup-$(date +%Y-%m-%d)-${COMMIT_SHA:0:8}-r${GITHUB_RUN_ID}"
           git checkout -b "$BR"
           git add files/unstable_case.json
           git commit -m "[Tool] weekly review cleanup ${BRANCH} ${COMMIT_SHA:0:8} (auto)"


### PR DESCRIPTION
## Why I'm doing:

Codex review on #73277 flagged: the auto-PR head branch is derived only from `date + COMMIT_SHA`. Reruns of the same workflow (same day, same commit) would reuse the existing branch, and `git push` would fail with non-fast-forward, or `gh pr create` would fail because a PR already exists — blocking recovery from transient failures in later steps (e.g. Slack notification).

> The branch name is derived only from date and COMMIT_SHA, so rerunning the same workflow run (or rerunning later the same day for the same commit) reuses the same head branch. In this report job, that makes `git push origin "$BR"` fail with a non-fast-forward rejection (or gh pr create fail because a PR already exists), which blocks recovery from transient failures in later steps like Slack notification. Include a run-attempt discriminator (for example GITHUB_RUN_ATTEMPT or GITHUB_RUN_ID) in BR so retries are idempotent.

## What I'm doing:

Append `-r${GITHUB_RUN_ID}` to the head branch name. `GITHUB_RUN_ID` is unique across every workflow invocation (including manual reruns of the same `workflow_dispatch`/cron trigger), covering both scenarios codex called out — same-day rerun of the same run, and same-day rerun for the same commit.

Resulting branches look like:
```
auto/weekly-review-cleanup-2026-05-14-98f654c8-r25846105389
auto/weekly-review-cleanup-2026-05-14-98f654c8-r25851244542
```

Local verification: replayed two different `GITHUB_RUN_ID` values against the new template — branch names differ on the suffix as expected. `yaml.safe_load` passes.

Fixes #(none — review feedback on the merged PR #73277)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4