### PR TITLE
[Tool] weekly review: disable auto-PR step pending PAT setup

### DIFF
--- a/.github/workflows/weekly-unstable-case-review.yml
+++ b/.github/workflows/weekly-unstable-case-review.yml
@@ -283,6 +283,13 @@ jobs:
           echo "REPORT_URL=${REPORT_OSS}report.html" >> $GITHUB_OUTPUT
 
       - name: Open PR with updated unstable_case.json
+        # Temporarily disabled: secrets.SYNC_PAT is not configured on
+        # this repo (the `SYNC_PAT` name lives in celerdata-enterprise),
+        # so `gh pr create` runs with an empty GH_TOKEN and fails. Also
+        # /var/lib/ci-tool is a shared dirty working tree on the runner.
+        # Re-enable after a working PAT is wired in and a clean-checkout
+        # safeguard is added to the step.
+        if: false
         id: open_pr
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT }}


### PR DESCRIPTION
## Why I'm doing:

The auto-PR step added in #73277 failed in its first real scheduled run ([run 25856927925](https://github.com/StarRocks/starrocks/actions/runs/25856927925)):

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
Error: Process completed with exit code 4.
```

Two root causes:

1. **`secrets.SYNC_PAT` doesn't exist on this repo.** That secret lives in `celerdata-enterprise` (used by repo-sync.yml, sync-scan-pending.yml, etc.). I confirmed by grepping every secret reference in `.github/workflows/`: only this newly-merged step references it. `gh pr create` then runs with an empty `GH_TOKEN` and bails.
2. **`/var/lib/ci-tool` on the runner is a shared dirty working tree.** Same run shows dozens of `M scripts/…  M tests/…` lines before our changes — so even if step 1 were fixed, the would-be cleanup PR is committed onto a polluted base.

Until both are addressed, the step will keep failing on every scheduled run.

## What I'm doing:

Set `if: false` on `Open PR with updated unstable_case.json`. The `Notify int-cd-rd-ci Slack channel` step already gates on `steps.open_pr.outputs.pr_url != ''`, so it falls through silently — no further changes needed.

The original disabled `Commit updated unstable_case.json` step (which #73277 replaced) is gone, so disabling means we go back to "no-op after report generation", same as before #73277.

### Re-enable checklist (future PR)

- [ ] Configure a PAT secret on `StarRocks/starrocks` with `pull-requests:write` + `contents:write` on `StarRocks/ci-tool`. Options: add a new `SYNC_PAT`, or check whether the existing `PAT2` already has the scope.
- [ ] Add `git fetch origin main && git reset --hard origin/main && git clean -fd` at the top of the Open PR step so the cleanup PR's base is clean.
- [ ] Re-test by `workflow_dispatch` once before letting the Monday cron run.

Fixes #(none — partially reverts behavior of merged #73277)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4