### PR TITLE
[Enhancement] Add acquireTvrSnapshot SPI for storage-pinned snapshots

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
@@ -166,6 +167,16 @@ public class CatalogConnectorMetadata implements ConnectorMetadata, DelegatingCo
         }
 
         return metadata.getCurrentTvrSnapshot(dbName, table);
+    }
+
+    @Override
+    public TvrTableSnapshot acquireTvrSnapshot(String dbName, Table table, MvId mvId) {
+        ConnectorMetadata metadata = metadataOfTable(table);
+        if (metadata == null) {
+            metadata = metadataOfDb(dbName);
+        }
+
+        return metadata.acquireTvrSnapshot(dbName, table, mvId);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
@@ -154,6 +155,15 @@ public interface ConnectorMetadata {
      */
     default TvrTableSnapshot getCurrentTvrSnapshot(String dbName, Table table) {
         return TvrTableSnapshot.empty();
+    }
+
+    /**
+     * Like {@link #getCurrentTvrSnapshot} but lets storages that pin snapshots
+     * per caller attach a reference for {@code mvId} as a side effect. Default
+     * is a pure read.
+     */
+    default TvrTableSnapshot acquireTvrSnapshot(String dbName, Table table, MvId mvId) {
+        return getCurrentTvrSnapshot(dbName, table);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.unified;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
@@ -139,6 +140,12 @@ public class UnifiedMetadata implements ConnectorMetadata, DelegatingConnectorMe
     public TvrTableSnapshot getCurrentTvrSnapshot(String dbName, Table table) {
         ConnectorMetadata metadata = metadataOfTable(table);
         return metadata.getCurrentTvrSnapshot(dbName, table);
+    }
+
+    @Override
+    public TvrTableSnapshot acquireTvrSnapshot(String dbName, Table table, MvId mvId) {
+        ConnectorMetadata metadata = metadataOfTable(table);
+        return metadata.acquireTvrSnapshot(dbName, table, mvId);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -313,7 +313,7 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         // For now, we always refresh the latest snapshot from the last refresh.
         // current tvr snapshot
         TvrVersionRange currentTvrSnapshot = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getCurrentTvrSnapshot(baseTableInfo.getDbName(), snapshotTable);
+                .acquireTvrSnapshot(baseTableInfo.getDbName(), snapshotTable, mv.getMvId());
         if (currentTvrSnapshot == null || !(currentTvrSnapshot instanceof TvrTableSnapshot)) {
             logger.warn("Current tvr snapshot is null for base table: {}, db: {}",
                     baseTableInfo.getTableName(), baseTableInfo.getDbName());

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -32,6 +32,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExternalCatalogTableBasicInfo;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
@@ -546,6 +547,12 @@ public class MetadataMgr {
     public TvrTableSnapshot getCurrentTvrSnapshot(String dbName, Table table) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(table.getCatalogName());
         return connectorMetadata.map(metadata -> metadata.getCurrentTvrSnapshot(dbName, table))
+                .orElse(TvrTableSnapshot.empty());
+    }
+
+    public TvrTableSnapshot acquireTvrSnapshot(String dbName, Table table, MvId mvId) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(table.getCatalogName());
+        return connectorMetadata.map(metadata -> metadata.acquireTvrSnapshot(dbName, table, mvId))
                 .orElse(TvrTableSnapshot.empty());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -16,6 +16,7 @@ package com.starrocks.connector;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.common.StarRocksException;
@@ -265,5 +266,27 @@ public class CatalogConnectorMetadataTest {
 
         Map<String, String> actualProperties = catalogConnectorMetadata.getCatalogProperties();
         assertEquals(expectedProperties, actualProperties);
+    }
+
+    @Test
+    void testAcquireTvrSnapshotDelegatesToChild(@Mocked ConnectorMetadata connectorMetadata, @Mocked Table table) {
+        MvId mvId = new MvId(1L, 2L);
+        TvrTableSnapshot expected = TvrTableSnapshot.of(123L);
+        new Expectations() {
+            {
+                connectorMetadata.acquireTvrSnapshot("test_db", table, mvId);
+                result = expected;
+                times = 1;
+            }
+        };
+
+        CatalogConnectorMetadata catalogConnectorMetadata = new CatalogConnectorMetadata(
+                connectorMetadata,
+                informationSchemaMetadata,
+                metaMetadata
+        );
+
+        TvrTableSnapshot actual = catalogConnectorMetadata.acquireTvrSnapshot("test_db", table, mvId);
+        assertEquals(expected, actual);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.HudiTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.KuduTable;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.DdlException;
@@ -556,5 +557,26 @@ public class UnifiedMetadataTest {
         };
         boolean exists = unifiedMetadata.tableExists(new ConnectContext(), "test_db", "test_tbl");
         Assert.assertTrue(exists);
+    }
+
+    @Test
+    public void testAcquireTvrSnapshotRoutesByTableType(@Mocked IcebergTable icebergTable) {
+        MvId mvId = new MvId(1L, 2L);
+        TvrTableSnapshot expected = TvrTableSnapshot.of(42L);
+        new Expectations() {
+            {
+                icebergTable.getType();
+                result = ICEBERG;
+                minTimes = 1;
+            }
+            {
+                icebergMetadata.acquireTvrSnapshot("test_db", icebergTable, mvId);
+                result = expected;
+                times = 1;
+            }
+        };
+
+        TvrTableSnapshot actual = unifiedMetadata.acquireTvrSnapshot("test_db", icebergTable, mvId);
+        assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

IVM refresh today calls `ConnectorMetadata.getCurrentTvrSnapshot(dbName, table)` to anchor a base table at refresh start. The method's contract is a pure read — fine for storages with intrinsic snapshot retention like Iceberg — but it has no way to identify the caller, so a storage that needs to pin its snapshot per caller has nowhere to attach the per-caller reference.

This PR opens that extension point with a strictly additive default method, without changing behaviour for any existing storage.

## What I'm doing:

- `ConnectorMetadata.acquireTvrSnapshot(dbName, table, mvId)` — new default method. For storages with intrinsic retention (Iceberg, Paimon, etc.) `mvId` is ignored and the call is a pure read; the default delegates to `getCurrentTvrSnapshot(dbName, table)` so existing connectors inherit the right behaviour with no override.
- `MetadataMgr.acquireTvrSnapshot` wrapper — standard connector dispatch via `getOptionalMetadata`, same shape as the existing `getCurrentTvrSnapshot` wrapper.
- `MVIVMRefreshProcessor.getBaseTableMaxChangedDelta` — switches the IVM caller to the new method, passing `mv.getMvId()` so future storage overrides can identify which MV is asking. The default returns the same value `getCurrentTvrSnapshot` did, so behaviour for every existing IVM path is unchanged.

`MvId` is the natural caller identity here — IVM refresh is currently the only caller; the parameter is nullable for callers that don't need pinning.

Verified locally: `IVMBasedMvRefreshProcessorIcebergTest` passes 50/50 unchanged.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Default behaviour is exercised by the existing Iceberg IVM test suite (passes unchanged). Connectors that override with side effects should add tests in the override PR.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4