### PR TITLE
[Feature] Add automatic warehouse routing for write operations

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3374,6 +3374,17 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static String lake_background_warehouse = "default_warehouse";
 
+    @ConfField(mutable = true, comment = "Enable automatic warehouse routing for write operations. " +
+            "When enabled, write statements (INSERT, CTAS, MV create/refresh, LOAD, ANALYZE) are " +
+            "automatically routed to the warehouse specified by warehouse_route_write. " +
+            "Read queries and other statements use the session's current warehouse. " +
+            "Per-query hints /*+ SET_VAR(warehouse='x') */ always take priority over auto-routing.")
+    public static boolean enable_warehouse_auto_routing = false;
+
+    @ConfField(mutable = true, comment = "Target warehouse for write operations when enable_warehouse_auto_routing is true. " +
+            "Applies to INSERT INTO, CREATE TABLE AS SELECT, CREATE/REFRESH MATERIALIZED VIEW, LOAD, and ANALYZE statements.")
+    public static String warehouse_route_write = "default_warehouse";
+
     @ConfField(mutable = true)
     public static String lake_vector_index_build_warehouse = "default_warehouse";
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -176,6 +176,7 @@ import com.starrocks.sql.ast.AnalyzeProfileStmt;
 import com.starrocks.sql.ast.AnalyzeStmt;
 import com.starrocks.sql.ast.AnalyzeTypeDesc;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.CreateTemporaryTableAsSelectStmt;
 import com.starrocks.sql.ast.CreateTemporaryTableStmt;
@@ -713,6 +714,21 @@ public class StmtExecutor {
         return parsedStmt instanceof DmlStmt || parsedStmt instanceof CreateTableAsSelectStmt;
     }
 
+    /**
+     * Returns true if the statement is a write operation that should be auto-routed
+     * to the write warehouse when warehouse auto-routing is enabled.
+     * Covers: INSERT, UPDATE, DELETE, CTAS, MV create/refresh, LOAD, ANALYZE.
+     */
+    static boolean isWriteStmt(StatementBase stmt) {
+        return stmt instanceof DmlStmt
+                || stmt instanceof CreateTableAsSelectStmt
+                || stmt instanceof CreateMaterializedViewStatement
+                || stmt instanceof RefreshMaterializedViewStatement
+                || stmt instanceof LoadStmt
+                || stmt instanceof CreateRoutineLoadStmt
+                || stmt instanceof AnalyzeStmt;
+    }
+
     public Pair<String, Integer> getTableQueryTimeoutInfo() {
         if (tableQueryTimeoutTableName != null && tableQueryTimeoutValue > 0) {
             return Pair.create(tableQueryTimeoutTableName, tableQueryTimeoutValue);
@@ -953,6 +969,24 @@ public class StmtExecutor {
             context.getState().setIsQuery(context.isQueryStmt(parsedStmt));
             if (parsedStmt.isExistQueryScopeHint()) {
                 processQueryScopeHint();
+            }
+
+            // Auto-route write operations to a dedicated warehouse when enabled.
+            // Per-query hints take priority (already applied above).
+            // Clone session variable before modifying so the backup restore in finally
+            // reverts to the original warehouse.
+            if (Config.enable_warehouse_auto_routing && !parsedStmt.isExistQueryScopeHint() && isWriteStmt(parsedStmt)) {
+                String targetWarehouse = Config.warehouse_route_write;
+                if (!Strings.isNullOrEmpty(targetWarehouse) &&
+                        GlobalStateMgr.getCurrentState().getWarehouseMgr().warehouseExists(targetWarehouse)) {
+                    SessionVariable cloned = (SessionVariable) context.getSessionVariable().clone();
+                    context.setSessionVariable(cloned);
+                    context.setCurrentWarehouse(targetWarehouse);
+                    LOG.info("auto-routed write stmt queryId={} to warehouse {}",
+                            DebugUtil.printId(context.getQueryId()), targetWarehouse);
+                } else if (!Strings.isNullOrEmpty(targetWarehouse)) {
+                    LOG.warn("warehouse_route_write '{}' does not exist, skipping auto-routing", targetWarehouse);
+                }
             }
 
             // set warehouse for auditLog

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -32,6 +32,7 @@ import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
@@ -264,10 +265,29 @@ public class TaskRun implements Comparable<TaskRun> {
 
             Warehouse w = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(
                     materializedView.getWarehouseId());
-            newProperties.put(PROPERTIES_WAREHOUSE, w.getName());
+            String warehouseName = w.getName();
+
+            // Auto-route MV refresh to the configured write warehouse when enabled.
+            if (Config.enable_warehouse_auto_routing && !Strings.isNullOrEmpty(Config.warehouse_route_write)) {
+                if (GlobalStateMgr.getCurrentState().getWarehouseMgr().warehouseExists(Config.warehouse_route_write)) {
+                    warehouseName = Config.warehouse_route_write;
+                    LOG.info("auto-routed MV refresh (mvId={}) to warehouse {}", mvId, warehouseName);
+                } else {
+                    LOG.warn("warehouse_route_write '{}' does not exist, using MV's assigned warehouse '{}'",
+                            Config.warehouse_route_write, warehouseName);
+                }
+            }
+
+            newProperties.put(PROPERTIES_WAREHOUSE, warehouseName);
 
             // set current warehouse
-            ctx.setCurrentWarehouse(w.getName());
+            ctx.setCurrentWarehouse(warehouseName);
+        } catch (ErrorReportException e) {
+            // Warehouse no longer exists — propagate so the refresh fails with a clear error
+            // rather than silently running in the wrong warehouse.
+            LOG.warn("Warehouse assigned to materialized view (id={}) no longer exists, " +
+                    "aborting refresh: {}", task.getProperties().get(MV_ID), e.getMessage());
+            throw e;
         } catch (Exception e) {
             LOG.warn("refresh task properties failed:", e);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/WarehouseAutoRoutingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/WarehouseAutoRoutingTest.java
@@ -1,0 +1,124 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.utframe.StarRocksTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WarehouseAutoRoutingTest extends StarRocksTestBase {
+    private ConnectContext ctx;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setQueryId(UUIDUtil.genUUID());
+        ConnectContext.threadLocalInfo.set(ctx);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ConnectContext.threadLocalInfo.remove();
+        Config.enable_warehouse_auto_routing = false;
+        Config.warehouse_route_write = "default_warehouse";
+    }
+
+    private StatementBase parse(String sql) throws Exception {
+        return SqlParser.parseSingleStatement(sql, ctx.getSessionVariable().getSqlMode());
+    }
+
+    // ---- isWriteStmt classification tests ----
+
+    @Test
+    public void testInsertIsWriteStmt() throws Exception {
+        StatementBase stmt = parse("INSERT INTO t1 SELECT * FROM t0");
+        assertTrue(StmtExecutor.isWriteStmt(stmt));
+    }
+
+    @Test
+    public void testSelectIsNotWriteStmt() throws Exception {
+        StatementBase stmt = parse("SELECT * FROM t0");
+        assertFalse(StmtExecutor.isWriteStmt(stmt));
+    }
+
+    @Test
+    public void testSelectWithCTEIsNotWriteStmt() throws Exception {
+        StatementBase stmt = parse("WITH cte AS (SELECT 1) SELECT * FROM cte");
+        assertFalse(StmtExecutor.isWriteStmt(stmt));
+    }
+
+    @Test
+    public void testCreateTableAsSelectIsWriteStmt() throws Exception {
+        StatementBase stmt = parse("CREATE TABLE t_new AS SELECT * FROM t0");
+        assertTrue(StmtExecutor.isWriteStmt(stmt));
+    }
+
+    @Test
+    public void testAnalyzeIsWriteStmt() throws Exception {
+        StatementBase stmt = parse("ANALYZE TABLE t0");
+        assertTrue(StmtExecutor.isWriteStmt(stmt));
+    }
+
+    @Test
+    public void testShowTablesIsNotWriteStmt() throws Exception {
+        StatementBase stmt = parse("SHOW TABLES");
+        assertFalse(StmtExecutor.isWriteStmt(stmt));
+    }
+
+    @Test
+    public void testDeleteIsWriteStmt() throws Exception {
+        StatementBase stmt = parse("DELETE FROM t0 WHERE v1 = 1");
+        assertTrue(StmtExecutor.isWriteStmt(stmt));
+    }
+
+    @Test
+    public void testUpdateIsWriteStmt() throws Exception {
+        StatementBase stmt = parse("UPDATE t0 SET v2 = 1 WHERE v1 = 1");
+        assertTrue(StmtExecutor.isWriteStmt(stmt));
+    }
+
+    @Test
+    public void testExplainIsNotWriteStmt() throws Exception {
+        StatementBase stmt = parse("EXPLAIN SELECT * FROM t0");
+        assertFalse(StmtExecutor.isWriteStmt(stmt));
+    }
+
+    @Test
+    public void testDescribeIsNotWriteStmt() throws Exception {
+        StatementBase stmt = parse("DESCRIBE t0");
+        assertFalse(StmtExecutor.isWriteStmt(stmt));
+    }
+
+    // ---- Config default tests ----
+
+    @Test
+    public void testAutoRoutingDisabledByDefault() {
+        assertFalse(Config.enable_warehouse_auto_routing);
+    }
+
+    @Test
+    public void testDefaultWriteWarehouse() {
+        assertTrue(Config.warehouse_route_write.equals("default_warehouse"));
+    }
+}


### PR DESCRIPTION
Add auto-routing support that automatically routes write operations (INSERT, CTAS, MV create/refresh, LOAD, ANALYZE) to a dedicated warehouse, providing workload isolation between ETL and query workloads.

New FE configs:
- enable_warehouse_auto_routing: enable/disable auto-routing (default: false)
- warehouse_route_write: target warehouse for write operations (default: default_warehouse)

Behavior:
- When enabled, write statements are routed to warehouse_route_write
- Read queries use the session's current warehouse (unchanged)
- Per-query hints SET_VAR(warehouse='x') always take priority
- Session warehouse is correctly restored after write completes (clone session variable before modifying to prevent reference mutation)
- Both configs are mutable at runtime via ADMIN SET FRONTEND CONFIG

## Setup

1. Create a dedicated warehouse for write/ETL workloads:

   CREATE WAREHOUSE etl_warehouse WITH ( "compute_replica" = "1" );

2. Enable auto-routing and set the target warehouse:

   ADMIN SET FRONTEND CONFIG ("enable_warehouse_auto_routing" = "true"); ADMIN SET FRONTEND CONFIG ("warehouse_route_write" = "etl_warehouse");

3. Verify configuration:

   ADMIN SHOW FRONTEND CONFIG LIKE "warehouse%"; ADMIN SHOW FRONTEND CONFIG LIKE "enable_warehouse_auto%";

4. All write operations (INSERT, CTAS, MV refresh, LOAD, ANALYZE) will now automatically route to `etl_warehouse`. Read queries (SELECT) continue using the session's current warehouse.

5. To override routing for a specific query, use hints:

   INSERT /*+ SET_VAR(warehouse='default_warehouse') */ INTO t VALUES (1);

Includes unit tests for statement classification and config defaults.

## Why I'm doing:
When running ETL workloads alongside interactive queries on a multi-warehouse cluster, a long-running or resource-intensive ETL job (INSERT, MV refresh, LOAD) can impact query performance by competing for compute resources on  
  the same warehouse.
                                                                                                                                                                                                                                     
  Today, users must explicitly set the warehouse for every write operation (via SET warehouse or query hints), which is error-prone and impractical at scale — especially for scheduled jobs, MV refreshes, and third-party tools    
  that don't support warehouse hints.
                                                                                                                                                                                                                                     
  This PR adds automatic warehouse routing that transparently routes write operations to a dedicated warehouse while keeping reads on the session's default warehouse, providing workload isolation without requiring user-side      
  changes.

## What I'm doing:
Adding a feature that automatically isolates ETL/write workloads from query workloads at the warehouse level. When enabled, all write operations (INSERT, CTAS, MV refresh, LOAD, ANALYZE) are transparently routed to a dedicated 
  "ETL warehouse" without requiring any changes from end users, schedulers, or third-party tools. Read queries continue using the session's default warehouse, ensuring query performance is not impacted by heavy write jobs. It reverts to default wh (or the one that is set) on other queries. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
