### PR TITLE
[Tool] Surface clang-format/checkstyle CI errors in job logs

### DIFF
--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -174,6 +174,9 @@ jobs:
             git reset HEAD~1
             echo "::error::Auto-push failed. Files that need formatting:"
             git diff --name-only
+            echo "::group::Full clang-format diff (apply locally with 'git apply' to fix)"
+            git --no-pager diff
+            echo "::endgroup::"
             if [ "${HEAD_REPO}" != "${{ github.repository }}" ]; then
               echo "::error::This is a fork PR. Please enable 'Allow edits from maintainers' on your PR."
             else

--- a/.github/workflows/ci-pipeline-branch.yml
+++ b/.github/workflows/ci-pipeline-branch.yml
@@ -464,6 +464,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_error: true
           level: error
+          reviewdog_flags: "-tee"
 
   fe-ut:
     runs-on: [self-hosted, normal]

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -765,6 +765,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_error: true
           level: error
+          reviewdog_flags: "-tee"
 
   fe-ut:
     runs-on: [self-hosted, normal]


### PR DESCRIPTION
## Why I'm doing:

Two related papercuts in the FE/BE lint CI that make failures hard to triage without clicking through to the PR Files-changed tab:

1. **`ci-clang-format.yml` (auto-fix push) — silent on fork PRs.** The workflow tries to clang-format the diff and push the fixup back into the head branch. On fork PRs (the common case for external contributors) the push fails because the workflow's bot account has no write access to the fork. The fail-path then runs `git reset HEAD~1` and emits only `git diff --name-only` — so contributors see *which* files need formatting but not *what* needs to change. They have to either guess or set up `clang-format-10` locally to reproduce — and `clang-format-10` is fairly hard to come by on modern dev machines (Homebrew on macOS, for instance, only ships clang-format from version 11 upwards), which makes "just run it locally" a non-trivial ask.

2. **`ci-pipeline*.yml` checkstyle step — no errors in job log.** The step uses `dbelyaev/action-checkstyle` with `reporter: "github-pr-check"`. Reviewdog sends findings only to the GitHub Check Runs API, so annotations appear in the PR's Files-changed tab but the job log itself prints only a pass/fail summary. (Errors used to show up directly in the log at some point; today the log is effectively empty on failure, which means triage requires opening the PR UI.)

## What I'm doing:

1. In the clang-format fail path, print the full unified diff inside a `::group::` block so it's collapsible in the Actions log and copy-paste applicable via `git apply` locally:
   ```yaml
   echo "::group::Full clang-format diff (apply locally with 'git apply' to fix)"
   git --no-pager diff
   echo "::endgroup::"
   ```
   No-op on the success path (only fires when the auto-push fails).

2. Pass `reviewdog_flags: "-tee"` to the checkstyle action. `-tee` keeps the existing PR annotations behaviour intact and additionally writes each finding to stdout, so the job log contains the actionable detail. Applied symmetrically to both pipelines.

Fixes #73300

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

CI logging only; no product behaviour changes.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
