### PR TITLE
[BugFix] Compute iceberg partitions metadata last_updated_* per entry

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergPartitionsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergPartitionsTable.java
@@ -80,6 +80,7 @@ public class IcebergPartitionsTable extends MetadataTable {
                         .column("equality_delete_record_count", BIGINT)
                         .column("equality_delete_file_count", BIGINT)
                         .column("last_updated_at", DATETIME)
+                        .column("last_updated_snapshot_id", BIGINT)
                         .build(),
                 originDb,
                 originTable,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/IcebergPartitionsTableRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/IcebergPartitionsTableRewriteRule.java
@@ -28,9 +28,11 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergMetadataScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
@@ -64,9 +66,41 @@ public class IcebergPartitionsTableRewriteRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalIcebergMetadataScanOperator operator = input.getOp().cast();
+        Map<ColumnRefOperator, Column> originalColRefMap = operator.getColRefToColumnMetaMap();
+        Map<Column, ColumnRefOperator> originalColumnMetaToColRefMap = operator.getColumnMetaToColRefMap();
+
+        Map<String, ColumnRefOperator> refsByName = new HashMap<>();
+        for (ColumnRefOperator ref : originalColRefMap.keySet()) {
+            refsByName.put(ref.getName(), ref);
+        }
+
+        // Iceberg snapshot ids are not monotonic with commit time, so aggregating
+        // last_updated_snapshot_id independently from last_updated_at (e.g. max() on each) can
+        // pick the snapshot id and the timestamp from different scan rows. To return a coherent
+        // pair we use max_by(last_updated_snapshot_id, last_updated_at), which requires the
+        // last_updated_at column to be present in the scan output. If the user did not request
+        // it, force-include it here and hide it again via a project on top of the aggregation.
+        ColumnRefOperator syntheticLastUpdatedAt = null;
+        Map<ColumnRefOperator, Column> scanColRefMap = originalColRefMap;
+        Map<Column, ColumnRefOperator> scanColumnMetaToColRefMap = originalColumnMetaToColRefMap;
+        if (refsByName.containsKey("last_updated_snapshot_id") && !refsByName.containsKey("last_updated_at")) {
+            Column lastUpdatedAtCol = operator.getTable().getColumn("last_updated_at");
+            if (lastUpdatedAtCol == null) {
+                throw new StarRocksConnectorException(
+                        "Missing last_updated_at column in iceberg_partitions_table metadata schema");
+            }
+            syntheticLastUpdatedAt = context.getColumnRefFactory().create(
+                    "last_updated_at", lastUpdatedAtCol.getType(), lastUpdatedAtCol.isAllowNull());
+            scanColRefMap = new HashMap<>(originalColRefMap);
+            scanColRefMap.put(syntheticLastUpdatedAt, lastUpdatedAtCol);
+            scanColumnMetaToColRefMap = new HashMap<>(originalColumnMetaToColRefMap);
+            scanColumnMetaToColRefMap.put(lastUpdatedAtCol, syntheticLastUpdatedAt);
+            refsByName.put("last_updated_at", syntheticLastUpdatedAt);
+        }
+
         List<ColumnRefOperator> groupingKeys = new ArrayList<>();
         Map<ColumnRefOperator, CallOperator> aggregations = new HashMap<>();
-        for (Map.Entry<ColumnRefOperator, Column> entries : operator.getColRefToColumnMetaMap().entrySet()) {
+        for (Map.Entry<ColumnRefOperator, Column> entries : originalColRefMap.entrySet()) {
             ColumnRefOperator columnRefOperator = entries.getKey();
             Column column = entries.getValue();
             CallOperator agg = null;
@@ -95,6 +129,14 @@ public class IcebergPartitionsTableRewriteRule extends TransformationRule {
                     fun = ExprUtils.getBuiltinFunction("max", argTypes, Function.CompareMode.IS_IDENTICAL);
                     agg = new CallOperator("max", DateType.DATETIME, Lists.newArrayList(columnRefOperator), fun);
                     break;
+                case "last_updated_snapshot_id": {
+                    ColumnRefOperator lastUpdatedAtRef = refsByName.get("last_updated_at");
+                    Type[] maxByArgs = new Type[] {column.getType(), lastUpdatedAtRef.getType()};
+                    fun = ExprUtils.getBuiltinFunction("max_by", maxByArgs, Function.CompareMode.IS_IDENTICAL);
+                    agg = new CallOperator("max_by", IntegerType.BIGINT,
+                            Lists.newArrayList(columnRefOperator, lastUpdatedAtRef), fun);
+                    break;
+                }
                 default:
                     throw new StarRocksConnectorException("Unknown column name %s when rewriting " +
                             "iceberg partitions table", columnName);
@@ -105,14 +147,24 @@ public class IcebergPartitionsTableRewriteRule extends TransformationRule {
             }
         }
 
-        LogicalAggregationOperator agg = new LogicalAggregationOperator(AggType.GLOBAL, groupingKeys, aggregations);
+        LogicalAggregationOperator aggOp = new LogicalAggregationOperator(AggType.GLOBAL, groupingKeys, aggregations);
         LogicalIcebergMetadataScanOperator newScanOp = new LogicalIcebergMetadataScanOperator(
                 operator.getTable(),
-                operator.getColRefToColumnMetaMap(),
-                operator.getColumnMetaToColRefMap(),
+                scanColRefMap,
+                scanColumnMetaToColRefMap,
                 operator.getLimit(),
                 operator.getPredicate());
         newScanOp.setTransformed(true);
-        return Collections.singletonList(OptExpression.create(agg, OptExpression.create(newScanOp)));
+        OptExpression aggExpr = OptExpression.create(aggOp, OptExpression.create(newScanOp));
+
+        if (syntheticLastUpdatedAt == null) {
+            return Collections.singletonList(aggExpr);
+        }
+
+        Map<ColumnRefOperator, ScalarOperator> projectMap = new HashMap<>();
+        for (ColumnRefOperator ref : originalColRefMap.keySet()) {
+            projectMap.put(ref, ref);
+        }
+        return Collections.singletonList(OptExpression.create(new LogicalProjectOperator(projectMap), aggExpr));
     }
 }

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionsTableScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionsTableScanner.java
@@ -19,13 +19,14 @@ import com.starrocks.connector.share.iceberg.IcebergPartitionUtils;
 import com.starrocks.jni.connector.ColumnValue;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.FileContent;
-import org.apache.iceberg.ManifestContent;
+import org.apache.iceberg.ManifestEntryScanHelper;
+import org.apache.iceberg.ManifestEntryScanHelper.LiveEntry;
 import org.apache.iceberg.ManifestFile;
-import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.types.Type;
@@ -45,9 +46,8 @@ public class IcebergPartitionsTableScanner extends AbstractIcebergMetadataScanne
 
     private final String manifestBean;
     private ManifestFile manifestFile;
-    private CloseableIterator<? extends ContentFile<?>> reader;
+    private CloseableIterator<LiveEntry> entryReader;
     private List<PartitionField> partitionFields;
-    private Long lastUpdateTime;
     private Integer spedId;
     private Schema schema;
     private GenericRecord reusedRecord;
@@ -62,8 +62,6 @@ public class IcebergPartitionsTableScanner extends AbstractIcebergMetadataScanne
         this.manifestFile = deserializeFromBase64(manifestBean);
         this.schema = table.schema();
         this.spedId = manifestFile.partitionSpecId();
-        this.lastUpdateTime = table.snapshot(manifestFile.snapshotId()) != null ?
-                table.snapshot(manifestFile.snapshotId()).timestampMillis() : null;
         this.partitionFields = IcebergPartitionUtils.getAllPartitionFields(table);
         this.reusedRecord = GenericRecord.create(getResultType());
     }
@@ -72,12 +70,16 @@ public class IcebergPartitionsTableScanner extends AbstractIcebergMetadataScanne
     public int doGetNext() {
         int numRows = 0;
         for (; numRows < getTableSize(); numRows++) {
-            if (!reader.hasNext()) {
+            if (!entryReader.hasNext()) {
                 break;
             }
-            ContentFile<?> file = reader.next();
+            LiveEntry entry = entryReader.next();
+            ContentFile<?> file = entry.file();
+            Snapshot snapshot = table.snapshot(entry.snapshotId());
+            Long lastUpdatedAt = snapshot != null ? snapshot.timestampMillis() : null;
+            Long lastUpdatedSnapshotId = snapshot != null ? snapshot.snapshotId() : null;
             for (int i = 0; i < requiredFields.length; i++) {
-                Object fieldData = get(requiredFields[i], file);
+                Object fieldData = get(requiredFields[i], file, lastUpdatedAt, lastUpdatedSnapshotId);
                 if (fieldData == null) {
                     appendData(i, null);
                 } else {
@@ -91,8 +93,8 @@ public class IcebergPartitionsTableScanner extends AbstractIcebergMetadataScanne
 
     @Override
     public void doClose() throws IOException {
-        if (reader != null) {
-            reader.close();
+        if (entryReader != null) {
+            entryReader.close();
         }
         reusedRecord = null;
 
@@ -101,17 +103,7 @@ public class IcebergPartitionsTableScanner extends AbstractIcebergMetadataScanne
     @Override
     protected void initReader() {
         Map<Integer, PartitionSpec> specs = table.specs();
-        if (manifestFile.content() == ManifestContent.DATA) {
-            reader = ManifestFiles.read(manifestFile, fileIO, specs)
-                    .select(SCAN_COLUMNS)
-                    .caseSensitive(false)
-                    .iterator();
-        } else {
-            reader = ManifestFiles.readDeleteManifest(manifestFile, fileIO, specs)
-                    .select(SCAN_COLUMNS)
-                    .caseSensitive(false)
-                    .iterator();
-        }
+        entryReader = ManifestEntryScanHelper.liveEntries(manifestFile, fileIO, specs, SCAN_COLUMNS).iterator();
     }
 
     private Types.StructType getResultType() {
@@ -126,7 +118,7 @@ public class IcebergPartitionsTableScanner extends AbstractIcebergMetadataScanne
         return Types.StructType.of(fields);
     }
 
-    private Object get(String columnName, ContentFile<?> file) {
+    private Object get(String columnName, ContentFile<?> file, Long lastUpdatedAt, Long lastUpdatedSnapshotId) {
         FileContent content = file.content();
         switch (columnName) {
             case "partition_value":
@@ -148,7 +140,9 @@ public class IcebergPartitionsTableScanner extends AbstractIcebergMetadataScanne
             case "equality_delete_file_count":
                 return content == FileContent.EQUALITY_DELETES ? 1L : 0L;
             case "last_updated_at":
-                return lastUpdateTime;
+                return lastUpdatedAt;
+            case "last_updated_snapshot_id":
+                return lastUpdatedSnapshotId;
             default:
                 throw new IllegalArgumentException("Unrecognized column name " + columnName);
         }

--- a/java-extensions/iceberg-metadata-reader/src/main/java/org/apache/iceberg/ManifestEntryScanHelper.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/org/apache/iceberg/ManifestEntryScanHelper.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+
+import java.util.List;
+import java.util.Map;
+
+// Lives in org.apache.iceberg to access ManifestReader.liveEntries(), which is package-private
+// in iceberg 1.10. Iceberg's own PartitionsTable uses the same API to compute last_updated_at /
+// last_updated_snapshot_id per partition by iterating ManifestEntry rather than ContentFile,
+// so we mirror that here to preserve per-entry snapshot id after manifest rewrites.
+//
+// Because ManifestEntry itself is package-private, callers outside this package cannot even
+// reference it in their type signatures. We expose a narrow LiveEntry view that surfaces only
+// the two bits the scanner needs: the file and the snapshot id that introduced it.
+public final class ManifestEntryScanHelper {
+    private ManifestEntryScanHelper() {
+    }
+
+    public static final class LiveEntry {
+        private final ContentFile<?> file;
+        private final long snapshotId;
+
+        private LiveEntry(ContentFile<?> file, long snapshotId) {
+            this.file = file;
+            this.snapshotId = snapshotId;
+        }
+
+        public ContentFile<?> file() {
+            return file;
+        }
+
+        public long snapshotId() {
+            return snapshotId;
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static CloseableIterable<LiveEntry> liveEntries(
+            ManifestFile manifest,
+            FileIO io,
+            Map<Integer, PartitionSpec> specs,
+            List<String> select) {
+        ManifestReader<?> reader = manifest.content() == ManifestContent.DATA
+                ? ManifestFiles.read(manifest, io, specs).select(select).caseSensitive(false)
+                : ManifestFiles.readDeleteManifest(manifest, io, specs).select(select).caseSensitive(false);
+        CloseableIterable<? extends ManifestEntry<?>> entries =
+                (CloseableIterable<? extends ManifestEntry<?>>) reader.liveEntries();
+        return CloseableIterable.transform(entries, e -> new LiveEntry(e.file(), e.snapshotId()));
+    }
+}

--- a/test/sql/test_iceberg/R/test_metadata_table
+++ b/test/sql/test_iceberg/R/test_metadata_table
@@ -118,6 +118,7 @@ position_delete_file_count	BIGINT	Yes	false	None
 equality_delete_record_count	BIGINT	Yes	false	None		
 equality_delete_file_count	BIGINT	Yes	false	None		
 last_updated_at	DATETIME	Yes	false	None		
+last_updated_snapshot_id	BIGINT	Yes	false	None		
 -- !result
 desc iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$partitions;
 -- result:
@@ -129,6 +130,7 @@ position_delete_file_count	BIGINT	Yes	false	None
 equality_delete_record_count	BIGINT	Yes	false	None		
 equality_delete_file_count	BIGINT	Yes	false	None		
 last_updated_at	DATETIME	Yes	false	None		
+last_updated_snapshot_id	BIGINT	Yes	false	None		
 -- !result
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}_${uuid0} force;
 -- result:


### PR DESCRIPTION
## Why I'm doing:

`iceberg_partitions_table` derives `last_updated_at` from `ManifestFile.snapshotId()` (manifest-level). Per Iceberg's `PARTITIONS` schema, this column (and the missing `last_updated_snapshot_id`) should be "commit time / id of snapshot that last updated this partition" — i.e. the snapshot in which a data or delete file was added/removed for that partition. Iceberg's own `PartitionsTable.update()` computes this per `ManifestEntry`.

After housekeeping (`rewrite_manifests`, `compactManifests`), the manifest-level resolution makes every partition that lived in a rewritten manifest report the maintenance snapshot's id/timestamp, hiding the real "when did this partition's data last change" answer. The same query against Spark/Flink on the same Iceberg table returns the historical snapshot.

The column `last_updated_snapshot_id` has existed in Apache Iceberg's `PARTITIONS` metadata since [iceberg 1.4.0 (apache/iceberg#7581)](https://github.com/apache/iceberg/pull/7581); StarRocks already runs iceberg 1.10.0, so the underlying data is available — it was just not exposed in `iceberg_partitions_table`.

## What I'm doing:

- `IcebergPartitionsTableScanner` now iterates `ManifestEntry` instead of `ContentFile`, via `ManifestReader.liveEntries()`. That API is package-private; exposed through a small `ManifestEntryScanHelper` in `package org.apache.iceberg` (same pattern `fe-core` already uses for its `ManifestReader` override). `last_updated_at` and `last_updated_snapshot_id` are resolved from `table.snapshot(entry.snapshotId())` per entry, matching `org.apache.iceberg.PartitionsTable.update()` semantics.
- Add `last_updated_snapshot_id BIGINT` column to `IcebergPartitionsTable` schema.
- Add `case "last_updated_snapshot_id"` (max-aggregation) in `IcebergPartitionsTableRewriteRule` so the column aggregates correctly across split-level scans.

Fixes #73308

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
