### PR TITLE
[Enhancement] Upgrade tenann to v0.5.1-beta.2

### DIFF
--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -40,15 +40,15 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux-el7-aarch64"
 JINDOSDK_MD5SUM="27a4e2cd9a403c6e21079a866287d88b"
 
 # tenann
-TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-BETA/tenann-v0.5.1-BETA-arm64-nosve.tar.gz"
-TENANN_NAME="tenann-v0.5.1-BETA-arm64-nosve.tar.gz"
-TENANN_SOURCE="tenann-v0.5.1-BETA"
-TENANN_MD5SUM="fa35efc6066a5172a6ab73873b4ef31f"
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.2/tenann-v0.5.1-beta.2-nosve-arm64.tar.gz"
+TENANN_NAME="tenann-v0.5.1-beta.2-nosve-arm64.tar.gz"
+TENANN_SOURCE="tenann-v0.5.1-beta.2-nosve"
+TENANN_MD5SUM="70c12d229bec5e40bbe5f704f1a43d1f"
 # uncomment this for SVE version for better performance on ARM servers with SVE support
-#TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-BETA/tenann-v0.5.1-BETA-arm64.tar.gz"
-#TENANN_NAME="tenann-v0.5.1-BETA-arm64.tar.gz"
-#TENANN_SOURCE="tenann-v0.5.1-BETA"
-#TENANN_MD5SUM="03f5d4cf3512029d7acfb2cddeb49a69"
+#TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.2/tenann-v0.5.1-beta.2-arm64.tar.gz"
+#TENANN_NAME="tenann-v0.5.1-beta.2-arm64.tar.gz"
+#TENANN_SOURCE="tenann-v0.5.1-beta.2"
+#TENANN_MD5SUM="6df6bf495013407c75d7a8b4b388cd00"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.1-rc3/starcache-centos7_arm64.tar.gz"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -40,10 +40,10 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux"
 JINDOSDK_MD5SUM="5436e4fe39c4dfdc942e41821f1dd8a9"
 
 # tenann
-TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-BETA/tenann-v0.5.1-BETA-x86_64.tar.gz"
-TENANN_NAME="tenann-v0.5.1-BETA-x86_64.tar.gz"
-TENANN_SOURCE="tenann-v0.5.1-BETA"
-TENANN_MD5SUM="5b4ccc87389948c11ebb666a8700f7c4"
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.2/tenann-v0.5.1-beta.2-x86_64.tar.gz"
+TENANN_NAME="tenann-v0.5.1-beta.2-x86_64.tar.gz"
+TENANN_SOURCE="tenann-v0.5.1-beta.2"
+TENANN_MD5SUM="fae1c6b6b733f178a29455af66713b94"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.1-rc3/starcache-centos7_amd64.tar.gz"


### PR DESCRIPTION
## Why I'm doing:

Bump the tenann thirdparty pin to the newly published `v0.5.1-beta.2` release.

Release: https://github.com/StarRocks/tenann/releases/tag/v0.5.1-beta.2

## What I'm doing:

Update `TENANN_DOWNLOAD` / `TENANN_NAME` / `TENANN_SOURCE` / `TENANN_MD5SUM` in:

- `thirdparty/vars-x86_64.sh`
- `thirdparty/vars-aarch64.sh`

On `aarch64` the no-SVE variant remains the default; the SVE variant is kept below as an opt-in alternative for ARM servers with SVE support.

All three asset checksums were verified against the GitHub Release `sha256` digests before computing the MD5s included in this change:

| Arch | File | MD5 |
| --- | --- | --- |
| x86_64 | `tenann-v0.5.1-beta.2-x86_64.tar.gz` | `fae1c6b6b733f178a29455af66713b94` |
| aarch64 (no-SVE, default) | `tenann-v0.5.1-beta.2-nosve-arm64.tar.gz` | `70c12d229bec5e40bbe5f704f1a43d1f` |
| aarch64 (SVE, alt) | `tenann-v0.5.1-beta.2-arm64.tar.gz` | `6df6bf495013407c75d7a8b4b388cd00` |

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4