### PR TITLE
[UT] Fix the compile issues of VectorIndexSearchTest (backport #72074)

### DIFF
--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -24,6 +24,8 @@
 #include "storage/index/index_descriptor.h"
 #include "storage/index/vector/tenann/del_id_filter.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
+#include "storage/index/vector/vector_index_reader.h"
+#include "storage/index/vector/vector_index_reader_factory.h"
 #include "storage/index/vector/vector_index_writer.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "storage/rowset/bitmap_index_writer.h"
@@ -120,14 +122,14 @@ TEST_F(VectorIndexSearchTest, test_search_vector_index) {
         auto status = get_vector_meta(tablet_index, empty_meta);
 
         CHECK_OK(status);
-        const auto& meta = status.value();
+        auto index_meta = std::make_shared<tenann::IndexMeta>(status.value());
 
         std::shared_ptr<VectorIndexReader> ann_reader;
-        VectorIndexReaderFactory::create_from_file(index_path, meta, &ann_reader);
+        VectorIndexReaderFactory::create_from_file(index_path, index_meta, &ann_reader);
 
-        auto status = ann_reader->init_searcher(meta, index_path);
+        auto init_status = ann_reader->init_searcher(*index_meta, index_path);
 
-        ASSERT_TRUE(!status.is_not_supported());
+        ASSERT_TRUE(!init_status.is_not_supported());
 
         Status st;
         std::vector<int64_t> result_ids;
@@ -168,14 +170,14 @@ TEST_F(VectorIndexSearchTest, test_select_empty_mark) {
         auto status = get_vector_meta(tablet_index, empty_meta);
 
         CHECK_OK(status);
-        const auto& meta = status.value();
+        auto index_meta = std::make_shared<tenann::IndexMeta>(status.value());
 
         std::shared_ptr<VectorIndexReader> ann_reader;
-        VectorIndexReaderFactory::create_from_file(index_path, meta, &ann_reader);
+        VectorIndexReaderFactory::create_from_file(index_path, index_meta, &ann_reader);
 
-        auto status = ann_reader->init_searcher(meta, index_path);
+        auto init_status = ann_reader->init_searcher(*index_meta, index_path);
 
-        ASSERT_TRUE(status.is_not_supported());
+        ASSERT_TRUE(init_status.is_not_supported());
     } catch (tenann::Error& e) {
         LOG(WARNING) << e.what();
     }


### PR DESCRIPTION
## Why I'm doing:

```
❯ /root/starrocks/be/test/storage/index/vector_search_test.cpp: In member function ‘virtual void starrocks::VectorIndexSearchTest_test_search_vector_index_Test::TestBody()’:                                                           
  /root/starrocks/be/test/storage/index/vector_search_test.cpp:125:25: error: ‘VectorIndexReader’ was not declared in this scope; did you mean ‘VectorIndexWriter’?                                                                     
    125 |         std::shared_ptr<VectorIndexReader> ann_reader;                                                                                                                                                                        
        |                         ^~~~~~~~~~~~~~~~~                                                                                                                                                                                     
        |                         VectorIndexWriter                                                                                                                                                                                     
  /root/starrocks/be/test/storage/index/vector_search_test.cpp:125:42: error: template argument 1 is invalid                                                                                                                            
    125 |         std::shared_ptr<VectorIndexReader> ann_reader;                                                                                                                                                                        
        |                                          ^                                                                                                                                                                                    
  /root/starrocks/be/test/storage/index/vector_search_test.cpp:126:9: error: ‘VectorIndexReaderFactory’ has not been declared                                                                                                           
    126 |         VectorIndexReaderFactory::create_from_file(index_path, meta, &ann_reader);                                                                                                                                            
        |         ^~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                              
  /root/starrocks/be/test/storage/index/vector_search_test.cpp:128:14: error: conflicting declaration ‘auto status’                                                                                                                     
    128 |         auto status = ann_reader->init_searcher(meta, index_path);                                                                                                                                                            
        |              ^~~~~~                                                                                                                                                                                                           
  /root/starrocks/be/test/storage/index/vector_search_test.cpp:120:14: note: previous declaration as ‘starrocks::StatusOr<tenann::IndexMeta> status’                                                                                    
    120 |         auto status = get_vector_meta(tablet_index, empty_meta);  
```

## What I'm doing:

Fix the compile issues of VectorIndexSearchTest

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

