### PR TITLE
[Enhancement] Support ADMIN EXECUTE on multiple BE/CN targets

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteScriptExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteScriptExecutor.java
@@ -24,6 +24,7 @@ import com.starrocks.rpc.BackendServiceClient;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ExecuteScriptStmt;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.type.StringType;
 import groovy.lang.Binding;
@@ -32,9 +33,12 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class ExecuteScriptExecutor {
     private static final Logger LOG = LogManager.getLogger(ExecuteScriptExecutor.class);
@@ -48,6 +52,15 @@ public class ExecuteScriptExecutor {
             rowset.add(Lists.newArrayList(line));
         }
         return new ShowResultSet(meta, rowset);
+    }
+
+    static ShowResultSet makeMultiNodeResultSet(List<List<String>> rows) {
+        ShowResultSetMetaData meta = ShowResultSetMetaData.builder()
+                .addColumn(new Column("node_id", StringType.STRING))
+                .addColumn(new Column("status", StringType.STRING))
+                .addColumn(new Column("result", StringType.STRING))
+                .build();
+        return new ShowResultSet(meta, rows);
     }
 
     public static ShowResultSet execute(ExecuteScriptStmt stmt, ConnectContext ctx) throws StarRocksException {
@@ -79,11 +92,48 @@ public class ExecuteScriptExecutor {
         }
     }
 
+    private static List<Long> resolveTargetNodes(ExecuteScriptStmt stmt) throws StarRocksException {
+        SystemInfoService cluster = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        List<Long> ids;
+        switch (stmt.getTargetType()) {
+            case ALL_BACKENDS:
+                ids = cluster.getBackendIds(false);
+                break;
+            case ALL_COMPUTE_NODES:
+                ids = cluster.getComputeNodeIds(false);
+                break;
+            case NODES:
+            default:
+                ids = stmt.getNodeIds();
+                break;
+        }
+        if (ids == null || ids.isEmpty()) {
+            throw new StarRocksException("no target nodes resolved for ADMIN EXECUTE");
+        }
+        // Stable order helps deterministic output.
+        List<Long> sorted = new ArrayList<>(ids);
+        Collections.sort(sorted);
+        return sorted;
+    }
+
     private static ShowResultSet executeBackendScript(ExecuteScriptStmt stmt, ConnectContext ctx) throws
             StarRocksException {
-        ComputeNode be = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(stmt.getBeId());
+        List<Long> nodeIds = resolveTargetNodes(stmt);
+
+        // Single-target: preserve the legacy single-column "result" output and fail-fast behavior.
+        if (nodeIds.size() == 1) {
+            return executeOnSingleNode(stmt, ctx, nodeIds.get(0));
+        }
+
+        return executeOnMultipleNodes(stmt, ctx, nodeIds);
+    }
+
+    private static ShowResultSet executeOnSingleNode(ExecuteScriptStmt stmt, ConnectContext ctx, long nodeId)
+            throws StarRocksException {
+        SystemInfoService cluster = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        ComputeNode be = cluster.getBackendOrComputeNode(nodeId);
         if (be == null) {
-            throw new StarRocksException("node not found: " + stmt.getBeId());
+            throw new StarRocksException("node not found: " + nodeId);
         }
         TNetworkAddress address = new TNetworkAddress(be.getHost(), be.getBrpcPort());
         ExecuteCommandRequestPB request = new ExecuteCommandRequestPB();
@@ -93,12 +143,12 @@ public class ExecuteScriptExecutor {
             Future<ExecuteCommandResultPB> future = BackendServiceClient.getInstance().executeCommand(address, request);
             ExecuteCommandResultPB result = future.get(stmt.getTimeoutSec(), TimeUnit.SECONDS);
             if (result.status.statusCode != 0) {
-                LOG.warn("execute script error BE: {} script:{} result: {}", stmt.getBeId(),
+                LOG.warn("execute script error BE: {} script:{} result: {}", nodeId,
                         StringUtils.abbreviate(stmt.getScript(), 1000),
                         result.status.errorMsgs);
                 throw new StarRocksException(result.status.toString());
             } else {
-                LOG.info("execute script ok BE: {} script:{} result: {}", stmt.getBeId(),
+                LOG.info("execute script ok BE: {} script:{} result: {}", nodeId,
                         StringUtils.abbreviate(stmt.getScript(), 1000), StringUtils.abbreviate(result.result, 1000));
                 ctx.getState().setOk();
                 return makeResultSet(result.result);
@@ -110,5 +160,89 @@ public class ExecuteScriptExecutor {
         } catch (Exception e) {
             throw new StarRocksException("executeCommand RPC failed BE:" + address + " err " + e.getMessage());
         }
+    }
+
+    // Fan out to all target nodes in parallel; aggregate one row per node with status + result.
+    // A failure on one node is reported as an error row, not a hard abort, so operators can see
+    // which nodes succeeded.
+    private static ShowResultSet executeOnMultipleNodes(ExecuteScriptStmt stmt, ConnectContext ctx, List<Long> nodeIds) {
+        SystemInfoService cluster = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        int n = nodeIds.size();
+        List<Future<ExecuteCommandResultPB>> futures = new ArrayList<>(n);
+        List<TNetworkAddress> addresses = new ArrayList<>(n);
+
+        // Fire all RPCs first. brpc returns a Future per call so this is naturally concurrent
+        // without an extra thread pool.
+        for (long id : nodeIds) {
+            ComputeNode node = cluster.getBackendOrComputeNode(id);
+            if (node == null) {
+                futures.add(null);
+                addresses.add(null);
+                continue;
+            }
+            TNetworkAddress address = new TNetworkAddress(node.getHost(), node.getBrpcPort());
+            ExecuteCommandRequestPB request = new ExecuteCommandRequestPB();
+            request.command = "execute_script";
+            request.params = stmt.getScript();
+            try {
+                futures.add(BackendServiceClient.getInstance().executeCommand(address, request));
+                addresses.add(address);
+            } catch (Exception e) {
+                LOG.warn("submit execute_command to {} failed: {}", address, e.getMessage());
+                futures.add(null);
+                addresses.add(address);
+            }
+        }
+
+        long deadlineMs = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(stmt.getTimeoutSec());
+        List<List<String>> rows = new ArrayList<>(n);
+        int okCount = 0;
+        int failCount = 0;
+        for (int i = 0; i < n; i++) {
+            long nodeId = nodeIds.get(i);
+            String idStr = Long.toString(nodeId);
+            Future<ExecuteCommandResultPB> future = futures.get(i);
+            TNetworkAddress address = addresses.get(i);
+
+            if (future == null) {
+                rows.add(Lists.newArrayList(idStr, "ERROR",
+                        address == null ? "node not found" : "submit failed for " + address));
+                failCount++;
+                continue;
+            }
+
+            long waitMs = Math.max(0, deadlineMs - System.currentTimeMillis());
+            try {
+                ExecuteCommandResultPB result = future.get(waitMs, TimeUnit.MILLISECONDS);
+                if (result.status.statusCode != 0) {
+                    LOG.warn("execute script error node:{} script:{} result:{}", nodeId,
+                            StringUtils.abbreviate(stmt.getScript(), 1000), result.status.errorMsgs);
+                    rows.add(Lists.newArrayList(idStr, "ERROR", String.valueOf(result.status)));
+                    failCount++;
+                } else {
+                    LOG.info("execute script ok node:{} script:{} result:{}", nodeId,
+                            StringUtils.abbreviate(stmt.getScript(), 1000),
+                            StringUtils.abbreviate(result.result, 1000));
+                    rows.add(Lists.newArrayList(idStr, "OK", result.result == null ? "" : result.result));
+                    okCount++;
+                }
+            } catch (TimeoutException te) {
+                rows.add(Lists.newArrayList(idStr, "ERROR", "timeout after " + stmt.getTimeoutSec() + "s"));
+                failCount++;
+                future.cancel(true);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                rows.add(Lists.newArrayList(idStr, "ERROR", "interrupted"));
+                failCount++;
+            } catch (Exception e) {
+                rows.add(Lists.newArrayList(idStr, "ERROR",
+                        "rpc failed " + (address == null ? "" : address.toString()) + ": " + e.getMessage()));
+                failCount++;
+            }
+        }
+
+        LOG.info("ADMIN EXECUTE fan-out done: ok={} fail={} total={}", okCount, failCount, n);
+        ctx.getState().setOk();
+        return makeMultiNodeResultSet(rows);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteScriptExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteScriptExecutor.java
@@ -34,8 +34,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.TreeSet;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -110,10 +110,10 @@ public class ExecuteScriptExecutor {
         if (ids == null || ids.isEmpty()) {
             throw new StarRocksException("no target nodes resolved for ADMIN EXECUTE");
         }
-        // Stable order helps deterministic output.
-        List<Long> sorted = new ArrayList<>(ids);
-        Collections.sort(sorted);
-        return sorted;
+        // Deduplicate so a repeated id (e.g. "ADMIN EXECUTE ON 10001,10001 ...") doesn't
+        // apply a side-effectful script twice on the same node. TreeSet also yields
+        // a stable ascending order for deterministic output.
+        return new ArrayList<>(new TreeSet<>(ids));
     }
 
     private static ShowResultSet executeBackendScript(ExecuteScriptStmt stmt, ConnectContext ctx) throws

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4722,13 +4722,26 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     @Override
     public ParseNode visitExecuteScriptStatement(com.starrocks.sql.parser.StarRocksParser.ExecuteScriptStatementContext context) {
-        long beId = -1;
-        if (context.INTEGER_VALUE() != null) {
-            beId = Long.parseLong(context.INTEGER_VALUE().getText());
-        }
         StringLiteral stringLiteral = (StringLiteral) visit(context.string());
         String script = stringLiteral.getStringValue();
-        return new ExecuteScriptStmt(beId, script, createPos(context));
+        com.starrocks.sql.parser.StarRocksParser.ExecuteScriptTargetContext target = context.executeScriptTarget();
+
+        ExecuteScriptStmt.TargetType targetType;
+        java.util.List<Long> nodeIds = java.util.Collections.emptyList();
+        if (target.FRONTEND() != null) {
+            targetType = ExecuteScriptStmt.TargetType.FRONTEND;
+        } else if (target.ALL() != null && target.BACKENDS() != null) {
+            targetType = ExecuteScriptStmt.TargetType.ALL_BACKENDS;
+        } else if (target.ALL() != null && target.COMPUTE() != null) {
+            targetType = ExecuteScriptStmt.TargetType.ALL_COMPUTE_NODES;
+        } else {
+            targetType = ExecuteScriptStmt.TargetType.NODES;
+            nodeIds = new java.util.ArrayList<>(target.INTEGER_VALUE().size());
+            for (org.antlr.v4.runtime.tree.TerminalNode node : target.INTEGER_VALUE()) {
+                nodeIds.add(Long.parseLong(node.getText()));
+            }
+        }
+        return new ExecuteScriptStmt(targetType, nodeIds, script, createPos(context));
     }
 
     // ---------------------------------------- Storage Volume Statement ----------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ExecuteScriptStmtParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ExecuteScriptStmtParserTest.java
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.parser;
+
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.ast.ExecuteScriptStmt;
+import com.starrocks.sql.ast.StatementBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExecuteScriptStmtParserTest {
+
+    private static ExecuteScriptStmt parse(String sql) {
+        List<StatementBase> stmts = SqlParser.parse(sql, new SessionVariable());
+        return (ExecuteScriptStmt) stmts.get(0);
+    }
+
+    @Test
+    void testFrontendTarget() {
+        ExecuteScriptStmt stmt = parse("ADMIN EXECUTE ON FRONTEND 'print 1'");
+        assertEquals(ExecuteScriptStmt.TargetType.FRONTEND, stmt.getTargetType());
+        assertTrue(stmt.isFrontendScript());
+        assertTrue(stmt.getNodeIds().isEmpty());
+        assertEquals("print 1", stmt.getScript());
+    }
+
+    @Test
+    void testSingleBackendTarget() {
+        ExecuteScriptStmt stmt = parse("ADMIN EXECUTE ON 10001 'do_thing'");
+        assertEquals(ExecuteScriptStmt.TargetType.NODES, stmt.getTargetType());
+        assertEquals(List.of(10001L), stmt.getNodeIds());
+        assertEquals(10001L, stmt.getBeId());
+    }
+
+    @Test
+    void testMultipleBackendTargets() {
+        ExecuteScriptStmt stmt = parse("ADMIN EXECUTE ON 10001, 10002, 10003 'do_thing'");
+        assertEquals(ExecuteScriptStmt.TargetType.NODES, stmt.getTargetType());
+        assertEquals(List.of(10001L, 10002L, 10003L), stmt.getNodeIds());
+    }
+
+    @Test
+    void testAllBackendsTarget() {
+        ExecuteScriptStmt stmt = parse("ADMIN EXECUTE ON ALL BACKENDS 'do_thing'");
+        assertEquals(ExecuteScriptStmt.TargetType.ALL_BACKENDS, stmt.getTargetType());
+        assertTrue(stmt.getNodeIds().isEmpty());
+    }
+
+    @Test
+    void testAllComputeNodesTarget() {
+        ExecuteScriptStmt stmt = parse("ADMIN EXECUTE ON ALL COMPUTE NODES 'do_thing'");
+        assertEquals(ExecuteScriptStmt.TargetType.ALL_COMPUTE_NODES, stmt.getTargetType());
+        assertTrue(stmt.getNodeIds().isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ExecuteScriptStmtParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ExecuteScriptStmtParserTest.java
@@ -19,9 +19,11 @@ import com.starrocks.sql.ast.ExecuteScriptStmt;
 import com.starrocks.sql.ast.StatementBase;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExecuteScriptStmtParserTest {
@@ -67,5 +69,18 @@ class ExecuteScriptStmtParserTest {
         ExecuteScriptStmt stmt = parse("ADMIN EXECUTE ON ALL COMPUTE NODES 'do_thing'");
         assertEquals(ExecuteScriptStmt.TargetType.ALL_COMPUTE_NODES, stmt.getTargetType());
         assertTrue(stmt.getNodeIds().isEmpty());
+    }
+
+    @Test
+    void testNodeIdsAreDefensivelyCopied() {
+        List<Long> mutable = new ArrayList<>();
+        mutable.add(10001L);
+        mutable.add(10002L);
+        ExecuteScriptStmt stmt = new ExecuteScriptStmt(
+                ExecuteScriptStmt.TargetType.NODES, mutable, "s", NodePosition.ZERO);
+        mutable.add(99999L);
+        mutable.set(0, 77777L);
+        assertEquals(List.of(10001L, 10002L), stmt.getNodeIds());
+        assertThrows(UnsupportedOperationException.class, () -> stmt.getNodeIds().add(1L));
     }
 }

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2254,7 +2254,14 @@ roleList
     ;
 
 executeScriptStatement
-    : ADMIN EXECUTE ON (FRONTEND | INTEGER_VALUE) string
+    : ADMIN EXECUTE ON executeScriptTarget string
+    ;
+
+executeScriptTarget
+    : FRONTEND
+    | INTEGER_VALUE (',' INTEGER_VALUE)*
+    | ALL BACKENDS
+    | ALL COMPUTE NODES
     ;
 
 unsupportedStatement

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ExecuteScriptStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ExecuteScriptStmt.java
@@ -60,7 +60,7 @@ public class ExecuteScriptStmt extends StatementBase {
     public ExecuteScriptStmt(TargetType targetType, List<Long> nodeIds, String script, NodePosition pos) {
         super(pos);
         this.targetType = targetType;
-        this.nodeIds = (nodeIds == null) ? Collections.emptyList() : Collections.unmodifiableList(nodeIds);
+        this.nodeIds = (nodeIds == null) ? Collections.emptyList() : List.copyOf(nodeIds);
         this.script = script;
     }
 

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ExecuteScriptStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ExecuteScriptStmt.java
@@ -16,14 +16,30 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
-// EXECUTE ON <BE_ID> <SCRIPT>
+import java.util.Collections;
+import java.util.List;
+
+// ADMIN EXECUTE ON <target> <SCRIPT>
+//   <target> := FRONTEND
+//             | <node_id> (, <node_id>)*
+//             | ALL BACKENDS
+//             | ALL COMPUTE NODES
 public class ExecuteScriptStmt extends StatementBase {
     static long TIMEOUT_SEC_DEFAULT = 600;
 
-    long beId;
-    String script;
+    public enum TargetType {
+        FRONTEND,
+        NODES,
+        ALL_BACKENDS,
+        ALL_COMPUTE_NODES,
+    }
 
-    long timeoutSec = TIMEOUT_SEC_DEFAULT;
+    private final TargetType targetType;
+    // Explicit node ids when targetType == NODES; empty otherwise (resolved at execution time).
+    private final List<Long> nodeIds;
+    private final String script;
+
+    private long timeoutSec = TIMEOUT_SEC_DEFAULT;
 
     public ExecuteScriptStmt(long beId, String script) {
         this(beId, script, NodePosition.ZERO);
@@ -31,12 +47,38 @@ public class ExecuteScriptStmt extends StatementBase {
 
     public ExecuteScriptStmt(long beId, String script, NodePosition pos) {
         super(pos);
-        this.beId = beId;
+        if (beId == -1) {
+            this.targetType = TargetType.FRONTEND;
+            this.nodeIds = Collections.emptyList();
+        } else {
+            this.targetType = TargetType.NODES;
+            this.nodeIds = Collections.singletonList(beId);
+        }
         this.script = script;
     }
 
+    public ExecuteScriptStmt(TargetType targetType, List<Long> nodeIds, String script, NodePosition pos) {
+        super(pos);
+        this.targetType = targetType;
+        this.nodeIds = (nodeIds == null) ? Collections.emptyList() : Collections.unmodifiableList(nodeIds);
+        this.script = script;
+    }
+
+    public TargetType getTargetType() {
+        return targetType;
+    }
+
+    public List<Long> getNodeIds() {
+        return nodeIds;
+    }
+
+    // Legacy accessor: returns -1 for frontend / unresolved fan-out targets,
+    // otherwise the first node id. Prefer getNodeIds() for new code.
     public long getBeId() {
-        return beId;
+        if (nodeIds.isEmpty()) {
+            return -1;
+        }
+        return nodeIds.get(0);
     }
 
     public String getScript() {
@@ -44,7 +86,7 @@ public class ExecuteScriptStmt extends StatementBase {
     }
 
     public boolean isFrontendScript() {
-        return beId == -1;
+        return targetType == TargetType.FRONTEND;
     }
 
     public void setTimeoutSec(long timeoutSec) {
@@ -57,8 +99,30 @@ public class ExecuteScriptStmt extends StatementBase {
 
     @Override
     public String toString() {
-        String s = String.format("EXECUTE ON %d %s", beId, script);
-        return s;
+        String targetDesc;
+        switch (targetType) {
+            case FRONTEND:
+                targetDesc = "FRONTEND";
+                break;
+            case ALL_BACKENDS:
+                targetDesc = "ALL BACKENDS";
+                break;
+            case ALL_COMPUTE_NODES:
+                targetDesc = "ALL COMPUTE NODES";
+                break;
+            case NODES:
+            default:
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < nodeIds.size(); i++) {
+                    if (i > 0) {
+                        sb.append(",");
+                    }
+                    sb.append(nodeIds.get(i));
+                }
+                targetDesc = sb.toString();
+                break;
+        }
+        return String.format("EXECUTE ON %s %s", targetDesc, script);
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:

Extend ADMIN EXECUTE ON <target> <script> so the FE can fan out a script to a comma-separated list of node ids, ALL BACKENDS, or ALL COMPUTE NODES, instead of being limited to a single backend. Single-target and FRONTEND behavior is preserved for backward compatibility; multi-target runs report one row per node with status + result so partial failures stay visible to the operator.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
