### PR TITLE
[BugFix] Use long for ConnectorTableId to avoid int overflow producing negative IDs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/KuduTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/KuduTable.java
@@ -52,7 +52,7 @@ public class KuduTable extends Table {
 
     public KuduTable(String masterAddresses, String catalogName, String dbName, String tblName, String kuduTableName,
                      List<Column> schema, List<String> partColNames) {
-        super(CONNECTOR_ID_GENERATOR.getNextId().asInt(), tblName, TableType.KUDU, schema);
+        super(CONNECTOR_ID_GENERATOR.getNextId().asLong(), tblName, TableType.KUDU, schema);
         this.masterAddresses = masterAddresses;
         this.catalogName = catalogName;
         this.databaseName = dbName;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OdpsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OdpsTable.java
@@ -50,7 +50,7 @@ public class OdpsTable extends Table {
     }
 
     public OdpsTable(String catalogName, com.aliyun.odps.Table odpsTable) {
-        super(CONNECTOR_ID_GENERATOR.getNextId().asInt(), odpsTable.getName(), TableType.ODPS,
+        super(CONNECTOR_ID_GENERATOR.getNextId().asLong(), odpsTable.getName(), TableType.ODPS,
                 EntityConvertUtils.getFullSchema(odpsTable));
         this.createTime = odpsTable.getCreatedTime().getTime();
         this.catalogName = catalogName;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
@@ -51,7 +51,7 @@ public class PaimonTable extends Table {
 
     public PaimonTable(String catalogName, String dbName, String tblName, List<Column> schema,
                        org.apache.paimon.table.Table paimonNativeTable) {
-        super(CONNECTOR_ID_GENERATOR.getNextId().asInt(), tblName, TableType.PAIMON, schema);
+        super(CONNECTOR_ID_GENERATOR.getNextId().asLong(), tblName, TableType.PAIMON, schema);
         this.catalogName = catalogName;
         this.databaseName = dbName;
         this.tableName = tblName;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableId.java
@@ -14,33 +14,43 @@
 
 package com.starrocks.connector;
 
-import com.starrocks.common.Id;
-import com.starrocks.common.IdGenerator;
+import java.util.concurrent.atomic.AtomicLong;
 
-public class ConnectorTableId extends Id<ConnectorTableId> {
+/**
+ * In-memory, per-FE-process ID for external connector tables (Hive/Iceberg/Hudi/Paimon/...).
+ * Not persisted and not synchronized across FEs — every FE assigns its own sequence and the
+ * counter resets on restart. Safe to use as a transient handle for the lifetime of an FE process;
+ * never store it on disk or send it to another FE.
+ */
+public class ConnectorTableId {
 
-    public static final IdGenerator<ConnectorTableId> CONNECTOR_ID_GENERATOR = createGenerator();
-    private static int CONNECTOR_TABLE_ID_OFFSET = 100000000;
-    public ConnectorTableId(int id) {
-        super(id + CONNECTOR_TABLE_ID_OFFSET);
+    public static final Generator CONNECTOR_ID_GENERATOR = new Generator();
+    private static final long CONNECTOR_TABLE_ID_OFFSET = 100_000_000L;
+
+    private final long id;
+
+    public ConnectorTableId(long id) {
+        this.id = id + CONNECTOR_TABLE_ID_OFFSET;
     }
 
-    public static IdGenerator<ConnectorTableId> createGenerator() {
-        return new IdGenerator<ConnectorTableId>() {
-            @Override
-            public synchronized ConnectorTableId getNextId() {
-                return new ConnectorTableId(nextId++);
-            }
-
-            @Override
-            public synchronized ConnectorTableId getMaxId() {
-                return new ConnectorTableId(nextId - 1);
-            }
-        };
+    public long asLong() {
+        return id;
     }
 
     @Override
     public String toString() {
         return String.format("F%02d", id);
+    }
+
+    public static final class Generator {
+        private final AtomicLong nextId = new AtomicLong(0);
+
+        public ConnectorTableId getNextId() {
+            return new ConnectorTableId(nextId.getAndIncrement());
+        }
+
+        public ConnectorTableId getMaxId() {
+            return new ConnectorTableId(nextId.get() - 1);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/benchmark/BenchmarkMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/benchmark/BenchmarkMetadata.java
@@ -76,7 +76,7 @@ public class BenchmarkMetadata implements ConnectorMetadata {
         if (columns == null) {
             return null;
         }
-        return new BenchmarkTable(CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName, normalizedDbName,
+        return new BenchmarkTable(CONNECTOR_ID_GENERATOR.getNextId().asLong(), catalogName, normalizedDbName,
                 normalizedTableName, columns, config);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
@@ -83,7 +83,7 @@ public class DeltaUtils {
             fullSchema.add(column);
         }
 
-        return new DeltaLakeTable(CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalog, dbName, tblName, fullSchema,
+        return new DeltaLakeTable(CONNECTOR_ID_GENERATOR.getNextId().asLong(), catalog, dbName, tblName, fullSchema,
                 loadPartitionColumnNames(snapshotImpl), snapshotImpl, deltaLakeEngine, snapshot.getMetastoreTable());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
@@ -83,7 +83,7 @@ public class ElasticsearchMetadata
         try {
             List<Column> columns = EsUtil.convertColumnSchema(esRestClient, tableName);
             properties.put(EsTable.KEY_INDEX, tableName);
-            EsTable esTable = new EsTable(CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+            EsTable esTable = new EsTable(CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                     catalogName, dbName, tableName, columns, properties, new SinglePartitionInfo());
             esTable.setComment("created by external es catalog");
             esTable.syncTableMetaData(esRestClient);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -74,7 +74,7 @@ public class HiveMetastore implements IHiveMetastore {
     @Override
     public void createDb(String dbName, Map<String, String> properties) {
         String location = properties.getOrDefault(LOCATION_PROPERTY, "");
-        long dbId = ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt();
+        long dbId = ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong();
         Database database = new Database(dbId, dbName, location);
         client.createDatabase(HiveMetastoreApiConverter.toMetastoreApiDatabase(database));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -150,7 +150,7 @@ public class HiveMetastoreApiConverter {
         if (database == null || database.getName() == null) {
             throw new StarRocksConnectorException("Hive database [%s] doesn't exist");
         }
-        return new Database(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName.toLowerCase(),
+        return new Database(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName.toLowerCase(),
                 database.getLocationUri());
     }
 
@@ -173,7 +173,7 @@ public class HiveMetastoreApiConverter {
                 properties.getOrDefault(HIVE_TABLE_SERDE_LIB, HiveStorageFormat.UNSUPPORTED.getSerde()));
 
         HiveTable.Builder tableBuilder = HiveTable.builder()
-                .setId(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt())
+                .setId(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong())
                 .setTableName(table.getTableName())
                 .setCatalogName(catalogName)
                 .setResourceName(toResourceName(catalogName, "hive"))
@@ -309,11 +309,11 @@ public class HiveMetastoreApiConverter {
             TrinoViewDefinition trinoViewDefinition = GsonUtils.GSON.fromJson(new String(bytes),
                     TrinoViewDefinition.class);
             hiveViewText = trinoViewDefinition.getOriginalSql();
-            hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName,
+            hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(), catalogName,
                     table.getDbName(), table.getTableName(), toFullSchemasForTrinoView(table, trinoViewDefinition),
                     hiveViewText, HiveView.Type.Trino);
         } else {
-            hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName,
+            hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(), catalogName,
                     table.getDbName(), table.getTableName(), toFullSchemasForHiveTable(table),
                     table.getViewExpandedText(), HiveView.Type.Hive);
         }
@@ -352,7 +352,7 @@ public class HiveMetastoreApiConverter {
         List<String> partitionColumnNames = toPartitionColumnNamesForHudiTable(table, hudiTableConfig);
 
         HudiTable.Builder tableBuilder = HudiTable.builder()
-                .setId(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt())
+                .setId(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong())
                 .setTableName(table.getTableName())
                 .setCatalogName(catalogName)
                 .setResourceName(toResourceName(catalogName, "hudi"))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -191,7 +191,7 @@ public class HiveMetastoreOperations {
             tableType = HiveTable.HiveTableType.EXTERNAL_TABLE;
         }
         HiveTable.Builder builder = HiveTable.builder()
-                .setId(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt())
+                .setId(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong())
                 .setTableName(tableName)
                 .setCatalogName(catalogName)
                 .setResourceName(toResourceName(catalogName, "hive"))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -118,7 +118,7 @@ public class IcebergApiConverter {
     public static IcebergTable toIcebergTable(Table nativeTbl, String catalogName, String remoteDbName,
                                               String remoteTableName, String nativeCatalogType) {
         IcebergTable.Builder tableBuilder = IcebergTable.builder()
-                .setId(CONNECTOR_ID_GENERATOR.getNextId().asInt())
+                .setId(CONNECTOR_ID_GENERATOR.getNextId().asLong())
                 .setSrTableName(remoteTableName)
                 .setCatalogName(catalogName)
                 .setResourceName(toResourceName(catalogName, "iceberg"))
@@ -723,7 +723,7 @@ public class IcebergApiConverter {
         String defaultDbName = currentVersion.defaultNamespace().level(0);
         String viewName = icebergView.name();
         String location = icebergView.location();
-        IcebergView view = new IcebergView(CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName, dbName, viewName,
+        IcebergView view = new IcebergView(CONNECTOR_ID_GENERATOR.getNextId().asLong(), catalogName, dbName, viewName,
                 columns, sqlView.sql(), defaultCatalogName, defaultDbName, location, icebergView.properties());
         view.setComment(comment);
         return view;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
@@ -139,7 +139,7 @@ public class IcebergGlueCatalog implements IcebergCatalog {
     @Override
     public Database getDB(ConnectContext context, String dbName) {
         Map<String, String> dbMeta = delegate.loadNamespaceMetadata(Namespace.of(dbName));
-        return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.getOrDefault(LOCATION_PROPERTY, ""));
+        return new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName, dbMeta.getOrDefault(LOCATION_PROPERTY, ""));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalog.java
@@ -155,7 +155,7 @@ public class IcebergHadoopCatalog implements IcebergCatalog {
     public Database getDB(ConnectContext context, String dbName) {
         Map<String, String> dbMeta = delegate.loadNamespaceMetadata(Namespace.of(dbName));
         Preconditions.checkNotNull(dbMeta.get(LOCATION_PROPERTY), "Database " + dbName + " doesn't exist location");
-        return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.get(LOCATION_PROPERTY));
+        return new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName, dbMeta.get(LOCATION_PROPERTY));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -177,7 +177,7 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     public Database getDB(ConnectContext context, String dbName) {
         Map<String, String> dbMeta = delegate.loadNamespaceMetadata(Namespace.of(dbName));
         Preconditions.checkNotNull(dbMeta.get(LOCATION_PROPERTY), "Database " + dbName + " doesn't exist location");
-        return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.get(LOCATION_PROPERTY));
+        return new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName, dbMeta.get(LOCATION_PROPERTY));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/jdbc/IcebergJdbcCatalog.java
@@ -169,7 +169,7 @@ public class IcebergJdbcCatalog implements IcebergCatalog {
     public Database getDB(ConnectContext context, String dbName) {
         Map<String, String> dbMeta = delegate.loadNamespaceMetadata(Namespace.of(dbName));
         Preconditions.checkNotNull(dbMeta.get(LOCATION_PROPERTY), "Database " + dbName + " doesn't exist location");
-        return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.get(LOCATION_PROPERTY));
+        return new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName, dbMeta.get(LOCATION_PROPERTY));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -257,7 +257,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public Database getDB(ConnectContext context, String dbName) {
         try {
             Map<String, String> dbMeta = delegate.loadNamespaceMetadata(buildContext(context), convertDbNameToNamespace(dbName));
-            return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.get(LOCATION_PROPERTY));
+            return new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName, dbMeta.get(LOCATION_PROPERTY));
         } catch (RESTException re) {
             LOG.error("Failed to get database using REST Catalog, for dbName {}", dbName, re);
             throw new StarRocksConnectorException("Failed to get database using REST Catalog",

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -62,7 +62,7 @@ public class JDBCMetadata implements ConnectorMetadata {
 
     private JDBCMetaCache<String, Database> dbCache;
     private JDBCMetaCache<JDBCTableName, List<String>> partitionNamesCache;
-    private JDBCMetaCache<JDBCTableName, Integer> tableIdCache;
+    private JDBCMetaCache<JDBCTableName, Long> tableIdCache;
     private JDBCMetaCache<JDBCTableName, Table> tableInstanceCache;
     private JDBCMetaCache<JDBCTableName, List<Partition>> partitionInfoCache;
 
@@ -337,8 +337,8 @@ public class JDBCMetadata implements ConnectorMetadata {
                             return null;
                         }
 
-                        Integer tableId = tableIdCache.getPersistentCache(jdbcTable,
-                                j -> ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt());
+                        Long tableId = tableIdCache.getPersistentCache(jdbcTable,
+                                j -> ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong());
                         Table table = schemaResolver.getTable(tableId, tblName, fullSchema,
                                 partitionColumns, dbName, catalogName, properties);
                         if (table != null) {
@@ -373,7 +373,7 @@ public class JDBCMetadata implements ConnectorMetadata {
                     throw new StarRocksConnectorException("pass-through query returned no columns");
                 }
 
-                int tableId = ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt();
+                long tableId = ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong();
                 JDBCTable queryTable = new JDBCTable(tableId, "_query_" + tableId, fullSchema, dbName, catalogName,
                         properties);
                 queryTable.setPassThroughQuery(normalizedQuery);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduMetadata.java
@@ -178,7 +178,7 @@ public class KuduMetadata implements ConnectorMetadata {
         if (!schemaEmulationEnabled) {
             if (DEFAULT_SCHEMA.equals(dbName)) {
                 return databases.computeIfAbsent(DEFAULT_SCHEMA,
-                        d -> new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), d));
+                        d -> new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), d));
             }
             return null;
         }
@@ -189,7 +189,7 @@ public class KuduMetadata implements ConnectorMetadata {
                 return schemaTable != null && dbName.equals(schemaTable.first);
             })) {
                 return databases.computeIfAbsent(dbName,
-                        d -> new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), d));
+                        d -> new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), d));
             }
             LOG.error("Kudu database {}.{} done not exist.", catalogName, dbName);
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergFilesTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergFilesTable.java
@@ -46,7 +46,7 @@ public class IcebergFilesTable extends MetadataTable {
 
     public static IcebergFilesTable create(String catalogName, String originDb, String originTable) {
         return new IcebergFilesTable(catalogName,
-                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergHistoryTable.java
@@ -41,7 +41,7 @@ public class IcebergHistoryTable extends MetadataTable {
 
     public static IcebergHistoryTable create(String catalogName, String originDb, String originTable) {
         return new IcebergHistoryTable(catalogName,
-                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergManifestsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergManifestsTable.java
@@ -45,7 +45,7 @@ public class IcebergManifestsTable extends MetadataTable {
 
     public static IcebergManifestsTable create(String catalogName, String originDb, String originTable) {
         return new IcebergManifestsTable(catalogName,
-                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergMetadataLogEntriesTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergMetadataLogEntriesTable.java
@@ -43,7 +43,7 @@ public class IcebergMetadataLogEntriesTable extends MetadataTable {
 
     public static IcebergMetadataLogEntriesTable create(String catalogName, String originDb, String originTable) {
         return new IcebergMetadataLogEntriesTable(catalogName,
-                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergPartitionsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergPartitionsTable.java
@@ -69,7 +69,7 @@ public class IcebergPartitionsTable extends MetadataTable {
         }
 
         return new IcebergPartitionsTable(catalogName,
-                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder.column("record_count", BIGINT)

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergPropertiesTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergPropertiesTable.java
@@ -39,7 +39,7 @@ public class IcebergPropertiesTable extends MetadataTable {
 
     public static IcebergPropertiesTable create(String catalogName, String originDb, String originTable) {
         return new IcebergPropertiesTable(catalogName,
-                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergRefsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergRefsTable.java
@@ -41,7 +41,7 @@ public class IcebergRefsTable extends MetadataTable {
 
     public static IcebergRefsTable create(String catalogName, String originDb, String originTable) {
         return new IcebergRefsTable(catalogName,
-                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergSnapshotsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergSnapshotsTable.java
@@ -42,7 +42,7 @@ public class IcebergSnapshotsTable extends MetadataTable {
 
     public static IcebergSnapshotsTable create(String catalogName, String originDb, String originTable) {
         return new IcebergSnapshotsTable(catalogName,
-                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
@@ -46,7 +46,7 @@ public class LogicalIcebergMetadataTable extends MetadataTable {
 
     public static LogicalIcebergMetadataTable create(String catalogName, String originDb, String originTable) {
         return new LogicalIcebergMetadataTable(catalogName,
-                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()

--- a/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/odps/OdpsMetadata.java
@@ -188,7 +188,7 @@ public class OdpsMetadata implements ConnectorMetadata {
     @Override
     public Database getDb(ConnectContext context, String name) {
         try {
-            return new Database(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), name);
+            return new Database(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(), name);
         } catch (StarRocksConnectorException e) {
             e.printStackTrace();
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -304,7 +304,7 @@ public class PaimonMetadata implements ConnectorMetadata {
         try {
             // get database from paimon catalog to see if the database exists
             paimonNativeCatalog.getDatabase(dbName);
-            Database db = new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName);
+            Database db = new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName);
             databases.put(dbName, db);
             return db;
         } catch (Catalog.DatabaseNotExistException e) {
@@ -369,7 +369,7 @@ public class PaimonMetadata implements ConnectorMetadata {
         } else {
             query = paimonNativeView.query();
         }
-        PaimonView view = new PaimonView(CONNECTOR_ID_GENERATOR.getNextId().asInt(),
+        PaimonView view = new PaimonView(CONNECTOR_ID_GENERATOR.getNextId().asLong(),
                 catalogName, dbName, viewName, fullSchema, query);
         view.setComment(comment);
         return view;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/TupleDescriptor.java
@@ -170,7 +170,7 @@ public class TupleDescriptor {
         ttupleDesc.setNumNullBytes(-1);
         ttupleDesc.setNumNullSlots(-1);
         if (table != null && table.getId() >= 0) {
-            ttupleDesc.setTableId((int) table.getId());
+            ttupleDesc.setTableId(table.getId());
         }
         return ttupleDesc;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -116,7 +116,7 @@ public class CatalogMgr {
                     throw new DdlException("connector create failed");
                 }
                 long id = isResourceMappingCatalog(catalogName) ?
-                        ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt() :
+                        ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong() :
                         GlobalStateMgr.getCurrentState().getNextId();
                 Catalog catalog = new ExternalCatalog(id, catalogName, comment, properties);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/IcebergEqualityDeleteRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/IcebergEqualityDeleteRewriteRule.java
@@ -165,7 +165,7 @@ public class IcebergEqualityDeleteRewriteRule extends TransformationRule {
                     .toList();
             List<Column> deleteColumns = columnNames.stream().map(icebergTable::getColumn).collect(Collectors.toList());
             IcebergTable equalityDeleteTable = new IcebergTable(
-                    ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), equalityDeleteTableName,
+                    ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(), equalityDeleteTableName,
                     icebergTable.getCatalogName(), icebergTable.getResourceName(), icebergTable.getCatalogDBName(),
                     icebergTable.getCatalogTableName(), EQUALITY_DELETE_TABLE_COMMENT, deleteColumns,
                     icebergTable.getNativeTable(), ImmutableMap.of());
@@ -299,7 +299,7 @@ public class IcebergEqualityDeleteRewriteRule extends TransformationRule {
         IcebergTable noDeleteTable = (IcebergTable) scanOperator.getTable();
         String tableName = noDeleteTable.getName() + "_" + "with_delete_file";
         IcebergTable withDeleteIcebergTable = new IcebergTable(
-                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), tableName,
+                ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong(), tableName,
                 noDeleteTable.getCatalogName(), noDeleteTable.getResourceName(), noDeleteTable.getCatalogDBName(),
                 noDeleteTable.getCatalogTableName(), "iceberg_table_with_delete", noDeleteTable.getFullSchema(),
                 noDeleteTable.getNativeTable(), ImmutableMap.of());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorTableIdTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorTableIdTest.java
@@ -1,0 +1,99 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConnectorTableIdTest {
+
+    private static final long OFFSET = 100_000_000L;
+
+    @Test
+    public void testIdsAreOffsetAndMonotonic() {
+        ConnectorTableId.Generator gen = new ConnectorTableId.Generator();
+        long first = gen.getNextId().asLong();
+        long second = gen.getNextId().asLong();
+        long third = gen.getNextId().asLong();
+
+        assertEquals(OFFSET, first);
+        assertEquals(OFFSET + 1, second);
+        assertEquals(OFFSET + 2, third);
+    }
+
+    @Test
+    public void testGetMaxIdReturnsLastAllocated() {
+        ConnectorTableId.Generator gen = new ConnectorTableId.Generator();
+        gen.getNextId();
+        gen.getNextId();
+        long last = gen.getNextId().asLong();
+
+        assertEquals(last, gen.getMaxId().asLong());
+    }
+
+    /**
+     * Regression: before the long fix, the int counter would overflow past
+     * Integer.MAX_VALUE - OFFSET allocations and produce negative IDs, which BE rejects
+     * as "Invalid table type". The ID must stay positive and monotonic well past that point.
+     */
+    @Test
+    public void testIdDoesNotOverflowPastIntegerMaxValue() {
+        long seed = (long) Integer.MAX_VALUE + 1;
+        ConnectorTableId id = new ConnectorTableId(seed);
+
+        assertTrue(id.asLong() > 0, "ID must remain positive past int range");
+        assertEquals(seed + OFFSET, id.asLong());
+    }
+
+    @Test
+    public void testConcurrentAllocationsAreUnique() throws InterruptedException {
+        ConnectorTableId.Generator gen = new ConnectorTableId.Generator();
+        int threads = 8;
+        int perThread = 1000;
+        Set<Long> ids = java.util.Collections.synchronizedSet(new HashSet<>());
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+
+        for (int t = 0; t < threads; t++) {
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < perThread; i++) {
+                        ids.add(gen.getNextId().asLong());
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        start.countDown();
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        pool.shutdownNow();
+
+        assertEquals(threads * perThread, ids.size(), "all concurrently-allocated IDs must be unique");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HiveTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HiveTableSinkTest.java
@@ -61,7 +61,7 @@ public class HiveTableSinkTest {
     @Test
     public void testHiveTableSink(@Mocked CatalogConnector hiveConnector) {
         HiveTable.Builder builder = HiveTable.builder()
-                .setId(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt())
+                .setId(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asLong())
                 .setTableName("hive_table")
                 .setCatalogName("hive_catalog")
                 .setResourceName(toResourceName("hive_catalog", "hive"))


### PR DESCRIPTION
## Why I'm doing:

On a long-running follower FE, Iceberg/Hive queries start failing with the misleading BE error:

```
Invalid table type. Only hive/iceberg/hudi/delta lake/file/paimon/kudu table are supported
```

while the same query succeeds on the leader. Restarting the cluster "fixes" it. Observed on 3.3.20; the underlying code path is the same on current `main`.

Root cause: `ConnectorTableId` allocates ids as an `int` counter plus a fixed `100_000_000` offset. After roughly `Integer.MAX_VALUE - 1e8` ≈ 2.04B allocations the int wraps to negative — fe.log shows e.g. `Table [id=-2086875593 type=ICEBERG]`. Then:

1. [`TupleDescriptor.toThrift()`](https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/planner/TupleDescriptor.java) skips negative ids (`table.getId() >= 0`) and additionally truncates the long table id with a stray `(int)` cast even though `TTableId` is `i64` in [`Types.thrift`](https://github.com/StarRocks/starrocks/blob/main/gensrc/thrift/Types.thrift).
2. BE [`HiveDataSource::open`](https://github.com/StarRocks/starrocks/blob/main/be/src/connector/hive_connector.cpp) gets no `tableId`, the `dynamic_cast<const HiveTableDescriptor*>` fails, and returns the generic "Invalid table type" error.

The counter is per-FE-process in-memory state — each FE has its own — which is why the leader and follower behave differently and a restart resets the symptom.

## What I'm doing:

- Make `ConnectorTableId` long-based, backed by `AtomicLong`. Do **not** widen the shared `Id<>` base class (its `int id` field is structural for `TupleId`/`SlotId`/`PlanNodeId` etc.). Add `asLong()`; remove `asInt()`.
- Migrate all 31 callers from `CONNECTOR_ID_GENERATOR.getNextId().asInt()` to `.asLong()`. Every consumer (`Table` / `Database` / various `Builder.setId`) already takes `long`, so the int narrowing was forced and lossy.
- Drop the `(int)` cast in `TupleDescriptor.toThrift()` since `TTableId` is `i64`.
- Add `ConnectorTableIdTest` covering: offset & monotonicity, `getMaxId`, regression for ids past `Integer.MAX_VALUE`, and concurrent uniqueness.
- Add a class-level comment on `ConnectorTableId` documenting that the id is per-FE-process, non-persistent, and not synchronized across FEs — to deter future code from assuming it can be stored on disk or shared cross-FE.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

Reviewers: please confirm which release branches need the backport (reproduced on 3.3.20, so all currently-supported branches are candidates).