### PR TITLE
[Enhancement] Wait for oldest PK-index memtable flush on publish path instead of falling back to sync OSS write

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -341,9 +341,24 @@ Status LakePersistentIndex::flush_memtable(bool force) {
         if (finish_point >= 0) {
             _inactive_memtables.erase(_inactive_memtables.begin(), _inactive_memtables.begin() + finish_point + 1);
         }
-        // 3. flush current memtable
+        // 3. If we're at the inflight cap, wait for the oldest async flush to
+        //    complete rather than synchronously flushing the current memtable on
+        //    the publish thread. The wall-clock back-pressure is the same, but
+        //    the I/O runs on the dedicated pk_index_memtable_flush thread pool
+        //    (preserving its concurrency across tablets), and the publish thread
+        //    can resume replace work on a new memtable as soon as one slot frees.
+        while (!_inactive_memtables.empty() &&
+               _inactive_memtables.size() + 1 >= config::pk_index_memtable_max_count) {
+            TRACE_COUNTER_SCOPE_LATENCY_US("wait_oldest_pk_flush_us");
+            _inactive_memtables.front()->wait_flush_done();
+            RETURN_IF_ERROR(_inactive_memtables.front()->flush_status());
+            auto sstable = _inactive_memtables.front()->release_sstable();
+            RETURN_IF_ERROR(merge_sstable_into_fileset(sstable));
+            _inactive_memtables.erase(_inactive_memtables.begin());
+        }
+        // 4. flush current memtable
         bool flush_async = false;
-        if (_inactive_memtables.size() + 1 < config::pk_index_memtable_max_count) {
+        if (_inactive_memtables.size() + 1 <= config::pk_index_memtable_max_count) {
             if (ExecEnv::GetInstance()->pk_index_memtable_flush_thread_pool()->submit(_memtable).ok()) {
                 flush_async = true;
             }
@@ -351,7 +366,7 @@ Status LakePersistentIndex::flush_memtable(bool force) {
         if (flush_async) {
             _inactive_memtables.push_back(_memtable);
         } else {
-            // If too many memtables or submit flush job fail, switch to sync flush.
+            // Thread pool submit failed (e.g. shutting down). Fall back to sync flush.
             RETURN_IF_ERROR(_memtable->flush());
             if (_inactive_memtables.empty()) {
                 auto sstable = _memtable->release_sstable();

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -347,8 +347,7 @@ Status LakePersistentIndex::flush_memtable(bool force) {
         //    the I/O runs on the dedicated pk_index_memtable_flush thread pool
         //    (preserving its concurrency across tablets), and the publish thread
         //    can resume replace work on a new memtable as soon as one slot frees.
-        while (!_inactive_memtables.empty() &&
-               _inactive_memtables.size() + 1 >= config::pk_index_memtable_max_count) {
+        while (!_inactive_memtables.empty() && _inactive_memtables.size() + 1 >= config::pk_index_memtable_max_count) {
             TRACE_COUNTER_SCOPE_LATENCY_US("wait_oldest_pk_flush_us");
             _inactive_memtables.front()->wait_flush_done();
             RETURN_IF_ERROR(_inactive_memtables.front()->flush_status());

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -247,16 +247,24 @@ void PersistentIndexMemtable::clear() {
 
 void PersistentIndexMemtable::run() {
     auto st = flush();
-    if (!st.ok()) {
-        LOG(ERROR) << "PersistentIndexMemtable flush failed for tablet " << _tablet_id << ": " << st;
+    {
         std::lock_guard<std::mutex> lg(_flush_mutex);
-        _flush_status = st;
+        if (!st.ok()) {
+            LOG(ERROR) << "PersistentIndexMemtable flush failed for tablet " << _tablet_id << ": " << st;
+            _flush_status = st;
+        }
+        _flush_done = true;
     }
+    _flush_done_cv.notify_all();
 }
 
 void PersistentIndexMemtable::cancel() {
-    std::lock_guard<std::mutex> lg(_flush_mutex);
-    _flush_status = Status::Cancelled("PersistentIndexMemtable flush cancelled");
+    {
+        std::lock_guard<std::mutex> lg(_flush_mutex);
+        _flush_status = Status::Cancelled("PersistentIndexMemtable flush cancelled");
+        _flush_done = true;
+    }
+    _flush_done_cv.notify_all();
 }
 
 std::unique_ptr<PersistentIndexSstable> PersistentIndexMemtable::release_sstable() {
@@ -267,6 +275,11 @@ std::unique_ptr<PersistentIndexSstable> PersistentIndexMemtable::release_sstable
 Status PersistentIndexMemtable::flush_status() const {
     std::lock_guard<std::mutex> lg(_flush_mutex);
     return _flush_status;
+}
+
+void PersistentIndexMemtable::wait_flush_done() const {
+    std::unique_lock<std::mutex> lk(_flush_mutex);
+    _flush_done_cv.wait(lk, [this] { return _flush_done; });
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <condition_variable>
+
 #include "base/phmap/btree.h"
 #include "common/thread/threadpool.h"
 #include "storage/lake/types_fwd.h"
@@ -94,6 +96,11 @@ public:
 
     Status flush_status() const;
 
+    // Block the caller until run() or cancel() has set the terminal flush state.
+    // Only valid for memtables already submitted to the flush thread pool;
+    // memtables that were never submitted will block forever.
+    void wait_flush_done() const;
+
 private:
     Status flush(WritableFile* wf, uint64_t* filesize, PersistentIndexSstableRangePB* range_pb);
     static void update_index_value(IndexValueWithVer* index_value_info, int64_t version, const IndexValue& value);
@@ -111,6 +118,10 @@ private:
     Status _flush_status = Status::OK();
     // flush state mutex
     mutable std::mutex _flush_mutex;
+    // Signaled when run()/cancel() has completed, so a waiter can block on
+    // a specific memtable's flush without polling the thread pool.
+    mutable std::condition_variable _flush_done_cv;
+    bool _flush_done{false};
 };
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/persistent_index_memtable_test.cpp
+++ b/be/test/storage/lake/persistent_index_memtable_test.cpp
@@ -16,6 +16,10 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+
 #include "base/testutil/assert.h"
 #include "storage/lake/persistent_index_sstable.h"
 
@@ -165,6 +169,44 @@ TEST(PersistentIndexMemtableTest, test_memory_usage) {
         ASSERT_OK(memtable->insert(N, key_slices.data(), values.data(), -1));
     }
     ASSERT_TRUE(memtable->memory_usage() < 100000 && memtable->memory_usage() > 0);
+}
+
+// wait_flush_done() must return immediately once cancel() has marked the
+// memtable terminal — the LakePersistentIndex publish path relies on this
+// to drain the inflight queue without polling.
+TEST(PersistentIndexMemtableTest, wait_flush_done_after_cancel) {
+    auto memtable = std::make_unique<PersistentIndexMemtable>();
+    memtable->cancel();
+
+    auto t0 = std::chrono::steady_clock::now();
+    memtable->wait_flush_done();
+    auto elapsed = std::chrono::steady_clock::now() - t0;
+
+    EXPECT_LT(elapsed, std::chrono::milliseconds(50));
+    EXPECT_FALSE(memtable->flush_status().ok());
+}
+
+// A waiter parked in wait_flush_done() before cancel() must unblock when
+// cancel() is called, not deadlock. Regression test for the new
+// _flush_done_cv / _flush_done pair.
+TEST(PersistentIndexMemtableTest, wait_flush_done_unblocks_concurrent_waiter) {
+    auto memtable = std::make_unique<PersistentIndexMemtable>();
+    std::atomic<bool> waiter_returned{false};
+
+    std::thread waiter([&] {
+        memtable->wait_flush_done();
+        waiter_returned.store(true);
+    });
+
+    // Give the waiter a chance to enter the condvar wait. The exact sleep is
+    // not load-bearing — even if cancel() races ahead, the post-condition
+    // (waiter eventually unblocks) still holds.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    EXPECT_FALSE(waiter_returned.load());
+
+    memtable->cancel();
+    waiter.join();
+    EXPECT_TRUE(waiter_returned.load());
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

On shared-data PK tables, every compaction publish has to flush the
LakePersistentIndex memtable. When the inflight async-flush count hits
`pk_index_memtable_max_count`, the existing code falls back to a
**synchronous** OSS write on the publish-version thread. That serialises
the next publish behind one OSS round-trip, blocking compaction publish
for seconds at a time on busy tablets.

Observed on a 100 GB sortkey PK table (auto-perf-opt run pk-sortkey-opt,
iter-002): single compaction publish cost up to **41.5 s** with
`flush_times=20`, `pindex_memtable_replace_us=21.3 s`,
`flush_memtable_us=2.18 s`. Hardware was idle; the flush thread pool
(`pk_index_memtable_flush`) sat at peak 2 active out of 1024. The
serialisation cap is the per-tablet inflight count, not the pool size.

## What I'm doing:

When `flush_memtable` is about to add one more inflight memtable but the
cap is hit:

1. Wait for the **oldest** inactive memtable's async flush to complete
   via a new `PersistentIndexMemtable::wait_flush_done()` condvar
   primitive (added in `persistent_index_memtable.{h,cpp}`).
2. Drain the completed memtable into the fileset via the existing
   `merge_sstable_into_fileset` path.
3. Submit the current memtable to the same async pool. The publish
   thread never falls back to sync OSS I/O on its own critical path.

The wait blocks for the same wall time as the old sync flush would
have, but the I/O still runs on `pk_index_memtable_flush_thread_pool`,
which preserves cross-tablet concurrency. Only on pool submit failure
(e.g. shutting down) does the old sync fallback fire.

After this change, the same iter-002 workload measured per-CN publish
max = **574 ms** (auto-perf-opt iter-003) — a 72× reduction vs the
baseline. The change is independent of `pk_index_memtable_max_count`
and works with the default value of 2.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The wait-flush path replaces the sync-flush fallback inside the same
`flush_memtable` API call; no observable behaviour outside performance.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Validation (auto-perf-opt run pk-sortkey-opt)

- iter-002 (deploy #73245 alone): per-CN publish max 41,500 → 1,443 ms.
- iter-003 (#73245 verified in isolation against baseline): per-CN publish max → **574 ms** (−98.6%), structurally eliminating the sync-flush stall.
- Tested on `1_100gb_sortkey` template (1 PK table, 500 M rows, 12 buckets, ORDER BY ≠ PK) on a 1 FE + 6 CN shared-data cluster.
- Source draft PR (validated on branch-4.1): #73245.
