### PR TITLE
[Enhancement] Batch per-chunk replace() calls in PK compaction conflict resolver

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1367,6 +1367,12 @@ CONF_mBool(lake_clear_corrupted_cache_data, "false");
 // The maximum number of files which need to rebuilt in cloud native pk index.
 // If files which need to rebuilt larger than this, we will flush memtable immediately.
 CONF_mInt32(cloud_native_pk_index_rebuild_files_threshold, "50");
+// Batch row count for PrimaryKeyCompactionConflictResolver::execute() — multiple per-chunk
+// `params.index->replace()` calls are accumulated into one call across this many rows. Each
+// replace() in LakePersistentIndex runs a memtable flush check + lock round-trip; batching N
+// chunks amortises that work by ~N×. Setting this <= vector_chunk_size (4096) effectively
+// disables batching. 32 K rows ≈ 8 chunks ≈ ~1.6 MB of accumulated PK bytes.
+CONF_mInt32(primary_key_compaction_replace_batch_rows, "32768");
 // The maximum number of rows which need to be rebuilt in cloud native pk index.
 // If rows which need to be rebuilt exceed this threshold, we will flush memtable immediately
 // to reduce index rebuild cost. 0 means disabled.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -747,6 +747,7 @@
         "lake_pk_index_cumulative_base_compaction_ratio",
         "lake_pk_index_block_cache_limit_percent",
         "cloud_native_pk_index_rebuild_files_threshold",
+        "primary_key_compaction_replace_batch_rows",
         "cloud_native_pk_index_rebuild_rows_threshold",
         "l0_l1_merge_ratio",
         "l0_max_file_size",

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -145,6 +145,13 @@ CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
 // If files which need to rebuilt larger than this, we will flush memtable immediately.
 CONF_mInt32(cloud_native_pk_index_rebuild_files_threshold, "50");
 
+// Batch row count for PrimaryKeyCompactionConflictResolver::execute() — multiple per-chunk
+// `params.index->replace()` calls are accumulated into one call across this many rows. Each
+// replace() in LakePersistentIndex runs a memtable flush check + lock round-trip; batching N
+// chunks amortises that work by ~N×. Setting this <= vector_chunk_size (4096) effectively
+// disables batching. 32 K rows ≈ 8 chunks ≈ ~1.6 MB of accumulated PK bytes.
+CONF_mInt32(primary_key_compaction_replace_batch_rows, "32768");
+
 // The maximum number of rows which need to be rebuilt in cloud native pk index.
 // If rows which need to be rebuilt exceed this threshold, we will flush memtable immediately
 // to reduce index rebuild cost. 0 means disabled.

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -51,8 +51,8 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                 // per-call setup, vector allocations, and memtable bookkeeping by ~N×. Values <= 1
                 // (including negatives, which would otherwise wrap when cast to size_t) collapse to
                 // a per-chunk threshold of 1, reverting to pre-patch behaviour.
-                const size_t batch_rows_threshold = static_cast<size_t>(
-                        std::max<int32_t>(1, config::primary_key_compaction_replace_batch_rows));
+                const size_t batch_rows_threshold =
+                        static_cast<size_t>(std::max<int32_t>(1, config::primary_key_compaction_replace_batch_rows));
                 for (size_t segment_id = 0; segment_id < segment_iters.size(); segment_id++) {
                     RETURN_IF_ERROR(breakpoint_check());
                     // only hold pkey, so can use larger chunk size

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -16,6 +16,7 @@
 
 #include "base/debug/trace.h"
 #include "common/config_exec_fwd.h"
+#include "common/config_primary_key_fwd.h"
 #include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"
 #include "storage/del_vector.h"

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -43,6 +43,14 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
             [&](const CompactConflictResolveParams& params, const std::vector<ChunkIteratorPtr>& segment_iters,
                 const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>& handle_delvec_result_func) {
                 std::map<uint32_t, DelVectorPtr> rssid_to_delvec;
+                // Accumulate multiple chunks' PKs into a single replace() call to reduce per-chunk
+                // overhead: each `params.index->replace()` ends with a memtable flush check + lock
+                // round-trip in LakePersistentIndex::replace(). For a 1 M-row segment with the default
+                // 4 K chunk, that is ~250 such calls per segment. Batching N chunks amortises the
+                // per-call setup, vector allocations, and memtable bookkeeping by ~N×. 0 disables
+                // batching (one replace per chunk).
+                const size_t batch_rows_threshold = std::max<size_t>(
+                        1, static_cast<size_t>(config::primary_key_compaction_replace_batch_rows));
                 for (size_t segment_id = 0; segment_id < segment_iters.size(); segment_id++) {
                     RETURN_IF_ERROR(breakpoint_check());
                     // only hold pkey, so can use larger chunk size
@@ -50,15 +58,34 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                     TRY_CATCH_BAD_ALLOC(chunk_shared_ptr =
                                                 ChunkHelper::new_chunk(pkey_schema, config::vector_chunk_size));
                     auto chunk = chunk_shared_ptr.get();
-                    auto col = pk_column->clone();
+                    auto batch_col = pk_column->clone();
                     vector<uint32_t> tmp_deletes;
+                    std::vector<uint32_t> batch_replace_indexes;
                     uint32_t current_rowid = 0;
+                    uint32_t batch_start_rowid = 0; // segment offset of the first row in batch_col
+                    uint32_t batch_acc_rows = 0;    // rows already accumulated in batch_col
+
+                    auto flush_replace_batch = [&]() -> Status {
+                        if (batch_acc_rows == 0) {
+                            return Status::OK();
+                        }
+                        if (!batch_replace_indexes.empty()) {
+                            TRACE_COUNTER_SCOPE_LATENCY_US("compaction_replace_index_latency_us");
+                            RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id,
+                                                                  batch_start_rowid, batch_replace_indexes,
+                                                                  *batch_col));
+                        }
+                        batch_start_rowid += batch_acc_rows;
+                        batch_acc_rows = 0;
+                        batch_col->reset_column();
+                        batch_replace_indexes.clear();
+                        return Status::OK();
+                    };
 
                     auto itr = segment_iters[segment_id].get();
                     if (itr != nullptr) {
                         while (true) {
                             chunk->reset();
-                            col->reset_column();
                             auto st = Status::OK();
                             // 4. get chunk
                             {
@@ -73,7 +100,6 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                             } else {
                                 // 5. get input rssid & rowids, so we can generate delvec
                                 std::vector<uint64_t> rssid_rowids;
-                                std::vector<uint32_t> replace_indexes;
                                 RETURN_IF_ERROR(mapper_iter.next_values(chunk->num_rows(), &rssid_rowids));
                                 DCHECK(chunk->num_rows() == rssid_rowids.size());
                                 for (int i = 0; i < rssid_rowids.size(); i++) {
@@ -94,19 +120,25 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                                         // Input row had been deleted, so we need to delete it from output rowset
                                         tmp_deletes.push_back(current_rowid + i);
                                     } else {
-                                        // replace pk index
-                                        replace_indexes.push_back(i);
+                                        // Index into batch_col after this chunk's encode has appended.
+                                        // batch_acc_rows currently holds the count BEFORE appending this
+                                        // chunk, so this is the absolute position in batch_col.
+                                        batch_replace_indexes.push_back(batch_acc_rows + i);
                                     }
                                 }
-                                // 6. replace pk index
-                                TRACE_COUNTER_SCOPE_LATENCY_US("compaction_replace_index_latency_us");
+                                // 6. accumulate encoded PKs into batch_col (encode appends).
                                 TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(),
-                                                                              col.get(), encoding_type));
-                                RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id, current_rowid,
-                                                                      replace_indexes, *col));
+                                                                              batch_col.get(), encoding_type));
                                 current_rowid += chunk->num_rows();
+                                batch_acc_rows += chunk->num_rows();
+
+                                if (batch_acc_rows >= batch_rows_threshold) {
+                                    RETURN_IF_ERROR(flush_replace_batch());
+                                }
                             }
                         }
+                        // Flush any trailing rows that did not reach the threshold.
+                        RETURN_IF_ERROR(flush_replace_batch());
                         itr->close();
                         // 7. generate final delvec
                         DelVectorPtr dv = std::make_shared<DelVector>();

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -49,8 +49,8 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                 // 4 K chunk, that is ~250 such calls per segment. Batching N chunks amortises the
                 // per-call setup, vector allocations, and memtable bookkeeping by ~N×. 0 disables
                 // batching (one replace per chunk).
-                const size_t batch_rows_threshold = std::max<size_t>(
-                        1, static_cast<size_t>(config::primary_key_compaction_replace_batch_rows));
+                const size_t batch_rows_threshold =
+                        std::max<size_t>(1, static_cast<size_t>(config::primary_key_compaction_replace_batch_rows));
                 for (size_t segment_id = 0; segment_id < segment_iters.size(); segment_id++) {
                     RETURN_IF_ERROR(breakpoint_check());
                     // only hold pkey, so can use larger chunk size
@@ -71,9 +71,8 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                         }
                         if (!batch_replace_indexes.empty()) {
                             TRACE_COUNTER_SCOPE_LATENCY_US("compaction_replace_index_latency_us");
-                            RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id,
-                                                                  batch_start_rowid, batch_replace_indexes,
-                                                                  *batch_col));
+                            RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id, batch_start_rowid,
+                                                                  batch_replace_indexes, *batch_col));
                         }
                         batch_start_rowid += batch_acc_rows;
                         batch_acc_rows = 0;

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -48,10 +48,11 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                 // overhead: each `params.index->replace()` ends with a memtable flush check + lock
                 // round-trip in LakePersistentIndex::replace(). For a 1 M-row segment with the default
                 // 4 K chunk, that is ~250 such calls per segment. Batching N chunks amortises the
-                // per-call setup, vector allocations, and memtable bookkeeping by ~N×. 0 disables
-                // batching (one replace per chunk).
-                const size_t batch_rows_threshold =
-                        std::max<size_t>(1, static_cast<size_t>(config::primary_key_compaction_replace_batch_rows));
+                // per-call setup, vector allocations, and memtable bookkeeping by ~N×. Values <= 1
+                // (including negatives, which would otherwise wrap when cast to size_t) collapse to
+                // a per-chunk threshold of 1, reverting to pre-patch behaviour.
+                const size_t batch_rows_threshold = static_cast<size_t>(
+                        std::max<int32_t>(1, config::primary_key_compaction_replace_batch_rows));
                 for (size_t segment_id = 0; segment_id < segment_iters.size(); segment_id++) {
                     RETURN_IF_ERROR(breakpoint_check());
                     // only hold pkey, so can use larger chunk size

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -1831,6 +1831,106 @@ TEST_P(LakePrimaryKeyCompactionTest, test_preload_compaction_state_slow_log) {
     ASSERT_EQ(kChunkSize, read(version));
 }
 
+// Exercise PrimaryKeyCompactionConflictResolver::execute() under a sweep of
+// `primary_key_compaction_replace_batch_rows` settings, including a negative
+// value that would wrap into a huge size_t if the clamp were applied after the
+// cast. All settings must produce identical post-compaction state.
+TEST_P(LakePrimaryKeyCompactionTest, test_replace_batch_rows_correctness) {
+    // The resolver's batched replace() path only runs when persistent index is enabled.
+    if (!GetParam().enable_persistent_index) {
+        return;
+    }
+    const int32_t saved_batch_rows = config::primary_key_compaction_replace_batch_rows;
+    const int32_t saved_chunk_size = config::vector_chunk_size;
+    DeferOp restore_config([&]() {
+        config::primary_key_compaction_replace_batch_rows = saved_batch_rows;
+        config::vector_chunk_size = saved_chunk_size;
+    });
+    // Force the resolver to read multiple chunks per segment so we exercise both
+    // the mid-loop flush and the trailing flush paths. kChunkSize (12) / 4 = 3 chunks.
+    config::vector_chunk_size = 4;
+
+    auto chunk0 = generate_data(kChunkSize, 0);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    // Cover the interesting threshold values:
+    //  -1 : must clamp; without the fix this wraps to ~0ULL and disables flushing.
+    //   0 : also clamps to 1.
+    //   1 : per-chunk fallback (flush after every chunk).
+    //   5 : crosses chunk boundary (chunk_size 4, threshold 5 → mid-loop flush at row 8).
+    //  1024: never reached for a kChunkSize=12 segment → only trailing flush runs.
+    for (int32_t batch_rows : {-1, 0, 1, 5, 1024}) {
+        SCOPED_TRACE("batch_rows=" + std::to_string(batch_rows));
+        config::primary_key_compaction_replace_batch_rows = batch_rows;
+
+        // Fresh tablet per iteration so state from previous compactions doesn't leak.
+        auto tablet_metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+        tablet_metadata->set_enable_persistent_index(GetParam().enable_persistent_index);
+        tablet_metadata->set_persistent_index_type(GetParam().persistent_index_type);
+        auto tablet_schema = TabletSchema::create(tablet_metadata->schema());
+        auto tablet_schema_shared = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+        ASSERT_OK(_tablet_mgr->put_tablet_metadata(*tablet_metadata));
+        const auto tablet_id = tablet_metadata->id();
+
+        // Three rowsets writing the same keys → compaction must dedupe two segments worth of rows.
+        int64_t version = 1;
+        for (int i = 0; i < 3; i++) {
+            auto txn_id = next_id();
+            ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                       .set_tablet_manager(_tablet_mgr.get())
+                                                       .set_tablet_id(tablet_id)
+                                                       .set_txn_id(txn_id)
+                                                       .set_partition_id(_partition_id)
+                                                       .set_mem_tracker(_mem_tracker.get())
+                                                       .set_schema_id(tablet_schema->id())
+                                                       .set_profile(&_dummy_runtime_profile)
+                                                       .build());
+            ASSERT_OK(delta_writer->open());
+            ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+            ASSERT_OK(delta_writer->finish_with_txnlog());
+            delta_writer->close();
+            ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+            version++;
+        }
+
+        // Read row count on this tablet (inline; the fixture's read() targets _tablet_metadata).
+        auto read_rows = [&](int64_t v) {
+            ASSIGN_OR_ABORT(auto md, _tablet_mgr->get_tablet_metadata(tablet_id, v));
+            auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), md, *tablet_schema_shared);
+            CHECK_OK(reader->prepare());
+            CHECK_OK(reader->open(TabletReaderParams()));
+            auto chunk = ChunkHelper::new_chunk(*tablet_schema_shared, 128);
+            int64_t total = 0;
+            while (true) {
+                auto st = reader->get_next(chunk.get());
+                if (st.is_end_of_file()) break;
+                CHECK_OK(st);
+                total += chunk->num_rows();
+                chunk->reset();
+            }
+            return total;
+        };
+        ASSERT_EQ(kChunkSize, read_rows(version));
+
+        auto compact_txn_id = next_id();
+        auto task_context =
+                std::make_unique<CompactionTaskContext>(compact_txn_id, tablet_id, version, false, false, nullptr);
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
+        ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, compact_txn_id).status());
+        version++;
+
+        ASSERT_EQ(kChunkSize, read_rows(version));
+        ASSIGN_OR_ABORT(auto post_md, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        EXPECT_EQ(1, post_md->rowsets_size());
+        EXPECT_EQ(3, post_md->compaction_inputs_size());
+        EXPECT_EQ(0, post_md->rowsets(0).num_dels());
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(
         LakePrimaryKeyCompactionTest, LakePrimaryKeyCompactionTest,
         ::testing::Values(CompactionParam{HORIZONTAL_COMPACTION, 5, false},


### PR DESCRIPTION
## Why I'm doing:

`PrimaryKeyCompactionConflictResolver::execute()` iterates segment
chunks one at a time and issues `params.index->replace(chunk_size)` per
chunk. Each `replace()` ends with a `LakePersistentIndex::replace()`
that runs a memtable-flush-cap check, vector allocations, and a
memtable lock round-trip. Across ~250 per-segment chunks on a 1 M-row
segment, that per-call overhead dominates compaction publish time.

Observed on a 100 GB sortkey PK table (auto-perf-opt run pk-sortkey-opt,
iter-003): slow compaction publishes carried `flush_times >= 4` and
`compaction_replace_index_latency_us` accumulated per-chunk overhead in
the hundreds of milliseconds even when each individual `replace()` was
sub-millisecond.

## What I'm doing:

Introduce row-count-driven batching inside the resolver loop:

- Accumulate encoded PK bytes from successive chunks into a single
  `batch_col` (column clone of the PK schema). Replace indexes are
  tracked relative to the batch base, not the per-chunk offset.
- When `batch_acc_rows >= primary_key_compaction_replace_batch_rows`
  (new mutable knob, default 32 768 ≈ 8 chunks), issue ONE
  `params.index->replace(rowset_id+segment_id, batch_start, indexes,
  batch_col)`.
- Always flush the trailing batch at segment end.
- Setting the knob to 0 reverts to per-chunk behaviour (config-toggleable
  rollback if any regression is observed in the wild).

Same `compaction_replace_index_latency_us` trace point as before. After
this change, the auto-perf-opt iter-004 measurement on the same template
recorded compaction publish max **241 ms** (vs iter-001 baseline 41.5
s), Upsert P99 5,909 ms (best of run), throughput +8.7%.
`compaction_replace_index_latency_us` per-batch P99 = 66.5 ms (max 78.8
ms), one entry per ~8-chunk batch as designed.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Adds `primary_key_compaction_replace_batch_rows` (mInt32, default
32768). Setting to 0 restores pre-patch per-chunk behaviour.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Validation (auto-perf-opt run pk-sortkey-opt)

- iter-004 (deploy #73250 alone, branched off baseline): compaction publish max → **241 ms**, Upsert P99 **5,909 ms** (best of run), throughput +8.7%.
- `rebuild_batch_insert_cnt` ≈ ceil(rows / 32 768) — matches design.
- Tested on `1_100gb_sortkey` template on a 1 FE + 6 CN shared-data cluster.
- Source draft PR (validated on branch-4.1): #73250.
