### PR TITLE
[UT] Fix the test failure when running with USER_STAROS=false.

### DIFF
--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -688,6 +688,7 @@ TEST_F(PersistentIndexSstableTest, test_metric_sst_open_read_error) {
     ASSERT_EQ(before + 1, StorageMetrics::instance()->pk_index_sst_read_error_total.value());
 }
 
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
 TEST_F(PersistentIndexSstableTest, test_sst_open_retry_after_clear_corrupted_cache) {
     auto location_provider = std::make_shared<FixedLocationProvider>(kTestDir);
     auto metadata = std::make_shared<TabletMetadata>();
@@ -728,6 +729,7 @@ TEST_F(PersistentIndexSstableTest, test_sst_open_retry_after_clear_corrupted_cac
 
     ASSERT_OK(st);
 }
+#endif // USE_STAROS && !BUILD_FORMAT_LIB
 
 TEST_F(PersistentIndexSstableTest, test_metric_sst_multiget_read_error) {
     const std::string path = lake::join_path(kTestDir, "metric_multiget_error.sst");
@@ -762,6 +764,7 @@ TEST_F(PersistentIndexSstableTest, test_metric_sst_multiget_read_error) {
     ASSERT_EQ(before + 1, StorageMetrics::instance()->pk_index_sst_read_error_total.value());
 }
 
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
 TEST_F(PersistentIndexSstableTest, test_multiget_retry_after_clear_corrupted_cache) {
     const std::string path = lake::join_path(kTestDir, "multiget_retry_corrupted_cache.sst");
     uint64_t filesize = 0;
@@ -801,6 +804,7 @@ TEST_F(PersistentIndexSstableTest, test_multiget_retry_after_clear_corrupted_cac
     ASSERT_TRUE(found.contains(0));
     ASSERT_EQ(IndexValue(0), values[0]);
 }
+#endif // USE_STAROS && !BUILD_FORMAT_LIB
 
 // Tombstones are stored as (rssid=UINT32_MAX, rowid=UINT32_MAX) so that the
 // 64-bit packed value equals NullIndexValue on the way out. When the owning


### PR DESCRIPTION
## Why I'm doing:

- `test_sst_open_retry_after_clear_corrupted_cache` and `test_multiget_retry_after_clear_corrupted_cache` were unconditionally compiled, but they exercise `drop_corrupted_sstable_cache()` whose body is gated by `#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)` in `be/src/storage/lake/persistent_index_sstable.cpp`.
- In non-STAROS / format-lib builds, that function short-circuits to `Status::NotSupported` before firing the `PersistentIndexSstable::drop_corrupted_cache` sync point the tests install. The retry block never runs and the injected `Corruption("inject_open_corruption")` propagates out, failing `ASSERT_OK(st)`.
- Wrap both tests with the same `#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)` guard so they only run where the code path they cover is actually compiled in.

```
[ RUN      ] PersistentIndexSstableTest.test_sst_open_retry_after_clear_corrupted_cache
W20260515 06:57:24.643820 +0000 139725993254912 persistent_index_sstable.cpp:102]  Failed to open PersistentIndex SST file: open_retry_corrupted_cache.sst, error: Corruption: inject_open_corruption
/root/starrocks/be/test/storage/lake/persistent_index_sstable_test.cpp:729: Failure
Value of: st__.ok()
  Actual: false
Expected: true
Corruption: inject_open_corruption
[  FAILED  ] PersistentIndexSstableTest.test_sst_open_retry_after_clear_corrupted_cache (2 ms)
```

## What I'm doing:

Fix the test failure when running with USER_STAROS=false.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
