### PR TITLE
[Enhancement] PK index size-tiered compaction: pick filesets from multiple levels per cycle

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -504,6 +504,12 @@ CONF_mInt64(pk_index_memtable_max_wait_flush_timeout_ms, "30000");
 CONF_mInt64(pk_index_size_tiered_min_level_size, "131072");
 CONF_mInt64(pk_index_size_tiered_level_multiplier, "10");
 CONF_mInt64(pk_index_size_tiered_max_level, "5");
+// When true, pick_compaction_candidates may issue filesets from multiple
+// priority levels in a single cycle (up to lake_pk_index_sst_max_compaction_versions
+// total filesets). This lets the parallel compact thread pool overlap level
+// compactions that would otherwise drain sequentially. Set false to restore
+// the previous one-level-per-cycle behaviour.
+CONF_mBool(pk_index_size_tiered_pick_multi_levels, "true");
 // Used to control the sampling interval size for SSTable files.
 CONF_mInt64(pk_index_sstable_sample_interval_bytes, "16777216");
 // Controls merge condition evaluation behavior within the same transaction for primary key tables.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -731,6 +731,7 @@
         "pk_index_size_tiered_min_level_size",
         "pk_index_size_tiered_level_multiplier",
         "pk_index_size_tiered_max_level",
+        "pk_index_size_tiered_pick_multi_levels",
         "pk_index_sstable_sample_interval_bytes",
         "ignore_merge_condition_inside_same_transaction",
         "update_memory_limit_percent",

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -93,6 +93,13 @@ CONF_mInt64(pk_index_size_tiered_level_multiplier, "10");
 
 CONF_mInt64(pk_index_size_tiered_max_level, "5");
 
+// When true, pick_compaction_candidates may issue filesets from multiple
+// priority levels in a single cycle (up to lake_pk_index_sst_max_compaction_versions
+// total filesets). This lets the parallel compact thread pool overlap level
+// compactions that would otherwise drain sequentially. Set false to restore
+// the previous one-level-per-cycle behaviour.
+CONF_mBool(pk_index_size_tiered_pick_multi_levels, "true");
+
 // Used to control the sampling interval size for SSTable files.
 CONF_mInt64(pk_index_sstable_sample_interval_bytes, "16777216");
 

--- a/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
+++ b/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
@@ -169,37 +169,67 @@ StatusOr<CompactionCandidateResult> LakePersistentIndexSizeTieredCompactionStrat
         order_levels.emplace_back(std::move(level));
     }
 
-    // Pick the best level for compaction
+    // Pick the best level for compaction. When pk_index_size_tiered_pick_multi_levels
+    // is enabled, also continue with subsequent priority levels so the parallel
+    // compact pool can overlap level compactions that would otherwise drain in
+    // sequential rounds (the pool is typically idle in steady state).
     if (priority_levels.empty()) {
         return result;
     }
 
-    SizeTieredLevel* selected_level = *priority_levels.begin();
-    if (selected_level->fileset_indexes.size() < min_compaction_filesets) {
-        return result;
-    }
-
-    // Build result: for each selected fileset, add all its sstables
     uint64_t max_max_rss_rowid = 0;
     bool merge_base_level = false;
-    for (size_t fileset_idx : selected_level->fileset_indexes) {
-        const FilesetInfo& fileset = filesets[fileset_idx];
-        std::vector<PersistentIndexSstablePB> fileset_sstables;
+    bool picked_any = false;
+    const int32_t max_versions = config::lake_pk_index_sst_max_compaction_versions;
+    const bool pick_multi_levels = config::pk_index_size_tiered_pick_multi_levels;
 
-        for (int sstable_idx : fileset.sstable_indices) {
-            fileset_sstables.push_back(sstable_meta.sstables(sstable_idx));
-            max_max_rss_rowid = std::max(max_max_rss_rowid, sstable_meta.sstables(sstable_idx).max_rss_rowid());
-        }
-        if (fileset.fileset_id == base_level_fileset_id) {
-            merge_base_level = true;
+    for (SizeTieredLevel* level : priority_levels) {
+        if (level->fileset_indexes.size() < min_compaction_filesets) {
+            // priority_levels is sorted by score (best first). A level that
+            // does not meet the minimum is not actionable here, but a later
+            // level might still have higher score+lower fileset count? No --
+            // min_compaction_filesets is an absolute lower bound; skip and
+            // continue checking remaining levels.
+            continue;
         }
 
-        result.candidate_filesets.push_back(std::move(fileset_sstables));
-        if (result.candidate_filesets.size() >= config::lake_pk_index_sst_max_compaction_versions) {
-            // Already reach max compaction versions, stop picking more filesets.
+        if (!picked_any) {
+            // Preserve original behaviour: the first level picked must also
+            // satisfy min_compaction_filesets (already checked above).
+            picked_any = true;
+        }
+
+        // Build result: for each selected fileset, add all its sstables.
+        for (size_t fileset_idx : level->fileset_indexes) {
+            const FilesetInfo& fileset = filesets[fileset_idx];
+            std::vector<PersistentIndexSstablePB> fileset_sstables;
+
+            for (int sstable_idx : fileset.sstable_indices) {
+                fileset_sstables.push_back(sstable_meta.sstables(sstable_idx));
+                max_max_rss_rowid =
+                        std::max(max_max_rss_rowid, sstable_meta.sstables(sstable_idx).max_rss_rowid());
+            }
+            if (fileset.fileset_id == base_level_fileset_id) {
+                merge_base_level = true;
+            }
+
+            result.candidate_filesets.push_back(std::move(fileset_sstables));
+            if (result.candidate_filesets.size() >= max_versions) {
+                // Already reach max compaction versions, stop picking more filesets.
+                break;
+            }
+        }
+
+        if (result.candidate_filesets.size() >= max_versions || !pick_multi_levels) {
+            // Either hit the cap or only one level is allowed per cycle.
             break;
         }
     }
+
+    if (!picked_any) {
+        return result;
+    }
+
     result.merge_base_level = merge_base_level;
     result.max_max_rss_rowid = max_max_rss_rowid;
 

--- a/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
+++ b/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
@@ -206,8 +206,7 @@ StatusOr<CompactionCandidateResult> LakePersistentIndexSizeTieredCompactionStrat
 
             for (int sstable_idx : fileset.sstable_indices) {
                 fileset_sstables.push_back(sstable_meta.sstables(sstable_idx));
-                max_max_rss_rowid =
-                        std::max(max_max_rss_rowid, sstable_meta.sstables(sstable_idx).max_rss_rowid());
+                max_max_rss_rowid = std::max(max_max_rss_rowid, sstable_meta.sstables(sstable_idx).max_rss_rowid());
             }
             if (fileset.fileset_id == base_level_fileset_id) {
                 merge_base_level = true;

--- a/be/test/storage/lake/lake_persistent_index_size_tiered_compaction_strategy_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_size_tiered_compaction_strategy_test.cpp
@@ -509,8 +509,8 @@ TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_pick_multi_leve
     // L2: 3 filesets ~500KB each (lower score, but still ≥ min_compaction_filesets=2)
     // Plus a base level so merge_base_level can be evaluated.
     std::vector<std::tuple<int64_t, int64_t, uint64_t>> sstables_info = {
-            {1, 100000, 100}, {2, 105000, 200}, {3, 98000, 300},   // L1
-            {4, 500000, 400}, {5, 510000, 500}, {6, 495000, 600},  // L2
+            {1, 100000, 100},  {2, 105000, 200}, {3, 98000, 300},  // L1
+            {4, 500000, 400},  {5, 510000, 500}, {6, 495000, 600}, // L2
             {7, 2600000, 700},                                     // base
     };
     auto metadata = create_tablet_metadata_with_sstables(sstables_info);
@@ -531,8 +531,8 @@ TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_pick_multi_leve
 
     // Same fileset layout as the enabled case.
     std::vector<std::tuple<int64_t, int64_t, uint64_t>> sstables_info = {
-            {1, 100000, 100}, {2, 105000, 200}, {3, 98000, 300},   // L1
-            {4, 500000, 400}, {5, 510000, 500}, {6, 495000, 600},  // L2
+            {1, 100000, 100},  {2, 105000, 200}, {3, 98000, 300},  // L1
+            {4, 500000, 400},  {5, 510000, 500}, {6, 495000, 600}, // L2
             {7, 2600000, 700},                                     // base
     };
     auto metadata = create_tablet_metadata_with_sstables(sstables_info);
@@ -557,8 +557,8 @@ TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_pick_multi_leve
     config::lake_pk_index_sst_max_compaction_versions = 4;
 
     std::vector<std::tuple<int64_t, int64_t, uint64_t>> sstables_info = {
-            {1, 100000, 100}, {2, 105000, 200}, {3, 98000, 300},   // L1: 3
-            {4, 500000, 400}, {5, 510000, 500}, {6, 495000, 600},  // L2: 3
+            {1, 100000, 100},  {2, 105000, 200}, {3, 98000, 300},  // L1: 3
+            {4, 500000, 400},  {5, 510000, 500}, {6, 495000, 600}, // L2: 3
             {7, 2600000, 700},                                     // base
     };
     auto metadata = create_tablet_metadata_with_sstables(sstables_info);

--- a/be/test/storage/lake/lake_persistent_index_size_tiered_compaction_strategy_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_size_tiered_compaction_strategy_test.cpp
@@ -497,4 +497,81 @@ TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_level_multiple_
     EXPECT_EQ(result.candidate_filesets.size(), 2);
 }
 
+// Multi-level pick: two priority levels each satisfying min_compaction_filesets.
+// With pk_index_size_tiered_pick_multi_levels = true, both levels feed the same
+// cycle so the parallel compact pool can drain them concurrently. With false,
+// only the highest-score level is picked — preserves the pre-patch behaviour.
+TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_pick_multi_levels_enabled) {
+    bool old_pick_multi = config::pk_index_size_tiered_pick_multi_levels;
+    config::pk_index_size_tiered_pick_multi_levels = true;
+
+    // L1: 3 filesets ~100KB each (high score, low size band)
+    // L2: 3 filesets ~500KB each (lower score, but still ≥ min_compaction_filesets=2)
+    // Plus a base level so merge_base_level can be evaluated.
+    std::vector<std::tuple<int64_t, int64_t, uint64_t>> sstables_info = {
+            {1, 100000, 100}, {2, 105000, 200}, {3, 98000, 300},   // L1
+            {4, 500000, 400}, {5, 510000, 500}, {6, 495000, 600},  // L2
+            {7, 2600000, 700},                                     // base
+    };
+    auto metadata = create_tablet_metadata_with_sstables(sstables_info);
+
+    ASSIGN_OR_ABORT(
+            CompactionCandidateResult result,
+            LakePersistentIndexSizeTieredCompactionStrategy::pick_compaction_candidates(metadata->sstable_meta()));
+
+    // Both L1 and L2 picked => 6 filesets total.
+    EXPECT_EQ(6, result.candidate_filesets.size());
+
+    config::pk_index_size_tiered_pick_multi_levels = old_pick_multi;
+}
+
+TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_pick_multi_levels_disabled) {
+    bool old_pick_multi = config::pk_index_size_tiered_pick_multi_levels;
+    config::pk_index_size_tiered_pick_multi_levels = false;
+
+    // Same fileset layout as the enabled case.
+    std::vector<std::tuple<int64_t, int64_t, uint64_t>> sstables_info = {
+            {1, 100000, 100}, {2, 105000, 200}, {3, 98000, 300},   // L1
+            {4, 500000, 400}, {5, 510000, 500}, {6, 495000, 600},  // L2
+            {7, 2600000, 700},                                     // base
+    };
+    auto metadata = create_tablet_metadata_with_sstables(sstables_info);
+
+    ASSIGN_OR_ABORT(
+            CompactionCandidateResult result,
+            LakePersistentIndexSizeTieredCompactionStrategy::pick_compaction_candidates(metadata->sstable_meta()));
+
+    // Only the highest-score level (L1) is picked => 3 filesets.
+    EXPECT_EQ(3, result.candidate_filesets.size());
+
+    config::pk_index_size_tiered_pick_multi_levels = old_pick_multi;
+}
+
+// When multi-level pick fills past lake_pk_index_sst_max_compaction_versions,
+// the loop must stop at the cap — picking partway through the second level is
+// fine, picking more than the cap is a bug.
+TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_pick_multi_levels_capped_by_max_versions) {
+    bool old_pick_multi = config::pk_index_size_tiered_pick_multi_levels;
+    int32_t old_max_versions = config::lake_pk_index_sst_max_compaction_versions;
+    config::pk_index_size_tiered_pick_multi_levels = true;
+    config::lake_pk_index_sst_max_compaction_versions = 4;
+
+    std::vector<std::tuple<int64_t, int64_t, uint64_t>> sstables_info = {
+            {1, 100000, 100}, {2, 105000, 200}, {3, 98000, 300},   // L1: 3
+            {4, 500000, 400}, {5, 510000, 500}, {6, 495000, 600},  // L2: 3
+            {7, 2600000, 700},                                     // base
+    };
+    auto metadata = create_tablet_metadata_with_sstables(sstables_info);
+
+    ASSIGN_OR_ABORT(
+            CompactionCandidateResult result,
+            LakePersistentIndexSizeTieredCompactionStrategy::pick_compaction_candidates(metadata->sstable_meta()));
+
+    // L1 (3) + 1 from L2 = 4, hit the cap.
+    EXPECT_EQ(4, result.candidate_filesets.size());
+
+    config::pk_index_size_tiered_pick_multi_levels = old_pick_multi;
+    config::lake_pk_index_sst_max_compaction_versions = old_max_versions;
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

`LakePersistentIndexSizeTieredCompactionStrategy::pick_compaction_candidates`
picks at most **one** priority level per cycle. With the parallel
compact thread pool (`cloud_native_pk_index_compact`) typically idle in
steady state, that means levels with high SST count get drained
sequentially across many compaction cycles, growing the in-memory
`pindex_sstables_queried_cnt` on the upsert path.

Observed on a 100 GB sortkey PK table (auto-perf-opt run pk-sortkey-opt,
iter-004): `pindex_sstables_queried_cnt` P99 = **410** on the upsert
path; `parallel_upsert_wait_us` P99 = ~300 ms; the compact pool was at
max queue 0, util 0.26 % — pure underutilisation.

## What I'm doing:

Extend `pick_compaction_candidates` so the loop over priority levels
appends filesets from each level (still in priority order) until either
`lake_pk_index_sst_max_compaction_versions` is hit OR a level falls
below `min_compaction_filesets`. Gated by new mutable knob
`pk_index_size_tiered_pick_multi_levels` (default `true`); setting it
`false` restores the old one-level-per-cycle behaviour.

Two consequences:

1. The parallel compact pool now overlaps level compactions that would
   otherwise drain sequentially — the same total work, completed sooner.
2. `pindex_sstables_queried_cnt` on the upsert path drops because
   small-fileset levels get drained promptly instead of waiting their
   turn behind another level.

After this change, the auto-perf-opt iter-005 measurement on the same
template recorded `pindex_sstables_queried_cnt` P99 = **158** (2.6×
reduction), `parallel_upsert_wait_us` P99 = **17 ms** (18× reduction).
Steady-state real-upsert P99 = 58 ms server-side; the
`cloud_native_pk_index_compact` pool now runs concurrent compactions
across tablets, but max queue depth stayed at 0 — no overload.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

`pk_index_size_tiered_pick_multi_levels` defaults to `true`. The compact
pool typically has spare capacity; the upper bound is still
`lake_pk_index_sst_max_compaction_versions`. Setting the knob to `false`
reverts to the pre-patch single-level behaviour.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Validation (auto-perf-opt run pk-sortkey-opt)

- iter-005 (deploy #73253 alone, branched off baseline): `pindex_sstables_queried_cnt` P99 410 → **158**; `parallel_upsert_wait_us` P99 300 → **17 ms**; `cloud_native_pk_index_compact` ran concurrent compactions across tablets (observed 4 tablets compaction-publishing simultaneously at 07:36:12).
- Tested on `1_100gb_sortkey` template on a 1 FE + 6 CN shared-data cluster.
- Source draft PR (validated on branch-4.1): #73253.
