### PR TITLE
[BugFix] Reject empty ALTER TABLE clause and improve OPTIMIZE replay

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -701,7 +701,7 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
         }
         sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
 
-        if (allPartitionOptimized) {
+        if (allPartitionOptimized && replayedJob.distributionInfo != null) {
             this.distributionInfo = replayedJob.distributionInfo;
             LOG.debug("set distribution info to table: {}", distributionInfo);
             targetTable.setDefaultDistributionInfo(distributionInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -775,7 +775,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         }
         sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
 
-        if (allPartitionOptimized) {
+        if (allPartitionOptimized && replayedJob.distributionInfo != null) {
             this.distributionInfo = replayedJob.distributionInfo;
             LOG.debug("set distribution info to table: {}", distributionInfo);
             targetTable.setDefaultDistributionInfo(distributionInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5207,6 +5207,10 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     @Override
     public ParseNode visitOptimizeClause(com.starrocks.sql.parser.StarRocksParser.OptimizeClauseContext context) {
+        if (context.keyDesc() == null && context.partitionDesc() == null && context.distributionDesc() == null
+                && context.orderByDesc() == null && context.partitionNames() == null && context.optimizeRange() == null) {
+            throw new ParsingException("ALTER TABLE requires at least one alter clause", createPos(context));
+        }
         return new OptimizeClause(
                 context.keyDesc() == null ? null : getKeysDesc(context.keyDesc()),
                 context.partitionDesc() == null ? null : getPartitionDesc(context.partitionDesc(), null),

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
@@ -279,6 +279,32 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
         Assertions.assertEquals(JobState.FINISHED, replayOptimizeJob.getJobState());
     }
 
+    @Test
+    public void testReplayFinishedWithNullDistributionInfo() throws Exception {
+        // Regression: a job persisted with allPartitionOptimized=true but no distribution change
+        // (e.g. from a previously-accepted empty alter clause) must not clobber the table's
+        // defaultDistributionInfo during replay.
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
+        Assertions.assertNotNull(olapTable.getDefaultDistributionInfo());
+
+        OnlineOptimizeJobV2 badPersistedJob = new OnlineOptimizeJobV2(
+                9999L, db.getId(), olapTable.getId(), olapTable.getName(), 1000);
+        badPersistedJob.setJobState(JobState.FINISHED);
+        java.lang.reflect.Field allOptField = OnlineOptimizeJobV2.class.getDeclaredField("allPartitionOptimized");
+        allOptField.setAccessible(true);
+        allOptField.set(badPersistedJob, true);
+        // distributionInfo stays null - this is the corruption shape
+
+        OnlineOptimizeJobV2 replayJob = new OnlineOptimizeJobV2(
+                9999L, db.getId(), olapTable.getId(), olapTable.getName(), 1000);
+        replayJob.replay(badPersistedJob);
+
+        Assertions.assertNotNull(olapTable.getDefaultDistributionInfo(),
+                "replay must not null out defaultDistributionInfo when persisted job has null distributionInfo");
+    }
+
     private OnlineOptimizeJobV2 spyPreviousTxnFinished(OnlineOptimizeJobV2 job) throws AnalysisException {
         // Detach the job from schema change handler to prevent background scheduler from changing state
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
@@ -697,6 +697,32 @@ public class OptimizeJobV2Test extends DDLTestBase {
         }
     }
 
+    @Test
+    public void testReplayFinishedWithNullDistributionInfo() throws Exception {
+        // Regression: a job persisted with allPartitionOptimized=true but no distribution change
+        // (e.g. from a previously-accepted empty alter clause) must not clobber the table's
+        // defaultDistributionInfo during replay.
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable7);
+        Assertions.assertNotNull(olapTable.getDefaultDistributionInfo());
+
+        OptimizeJobV2 badPersistedJob = new OptimizeJobV2(
+                9999L, db.getId(), olapTable.getId(), olapTable.getName(), 1000);
+        badPersistedJob.setJobState(JobState.FINISHED);
+        java.lang.reflect.Field allOptField = OptimizeJobV2.class.getDeclaredField("allPartitionOptimized");
+        allOptField.setAccessible(true);
+        allOptField.set(badPersistedJob, true);
+        // distributionInfo stays null - this is the corruption shape
+
+        OptimizeJobV2 replayJob = new OptimizeJobV2(
+                9999L, db.getId(), olapTable.getId(), olapTable.getName(), 1000);
+        replayJob.replay(badPersistedJob);
+
+        Assertions.assertNotNull(olapTable.getDefaultDistributionInfo(),
+                "replay must not null out defaultDistributionInfo when persisted job has null distributionInfo");
+    }
+
     private OptimizeJobV2 spyPreviousTxnFinished(OptimizeJobV2 job) {
         // Detach the job from schema change handler to prevent the background scheduler
         // from mutating its state in parallel with the UT driven state machine, which

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -158,6 +158,18 @@ class ParserTest {
     }
 
     @Test
+    void testAlterTableWithoutAlterClause() {
+        String sql = "alter table tbl";
+        SessionVariable sessionVariable = new SessionVariable();
+        try {
+            SqlParser.parse(sql, sessionVariable);
+            fail("sql should fail to parse.");
+        } catch (Exception e) {
+            assertContains(e.getMessage(), "ALTER TABLE requires at least one alter clause");
+        }
+    }
+
+    @Test
     void testNonReservedWords_1() {
         String sql = "select anti, authentication, auto_increment, cancel, distributed, enclose, escape, export," +
                 "host, incremental, minus, nodes, optimizer, privileges, qualify, skip_header, semi, trace, trim_space "


### PR DESCRIPTION
## Why I'm doing:

  `optimizeClause` in the grammar has every child optional with no leading
  keyword, so `ALTER TABLE tbl` parsed as an alter with an empty optimize
  clause. The analyzer interpreted the missing `partitionNames` as
  "optimize the whole table" and set `allPartitionOptimized=true`, while
  `distributionInfo` stayed null because no `distributionDesc` was given.
  On FE replay, `OptimizeJobV2`/`OnlineOptimizeJobV2` only checked
  `allPartitionOptimized` before calling `setDefaultDistributionInfo`, so
  such a persisted job nulled out the table's default distribution.

## What I'm doing:

  - Reject fully-empty `OptimizeClause` in `AstBuilder.visitOptimizeClause`
    so `ALTER TABLE tbl` fails with a clear parse error.
  - Add `replayedJob.distributionInfo != null` to the replay guard in both
    `OptimizeJobV2` and `OnlineOptimizeJobV2`, matching the live-execution
    invariant in `onFinished` (`allPartitionOptimized && distributionDesc
    != null`). 
    Protects already-persisted bad jobs from corrupting the table
    on FE restart / follower replay.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
