### PR TITLE
[BugFix] Fix the issue that Iceberg DELETE conflict-detection uses incorrect snapshot id and filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1912,10 +1912,19 @@ public class IcebergMetadata implements ConnectorMetadata {
             rowDelta.addDeletes(deleteFile);
         }
 
-        // Validate from snapshot if table has current snapshot
-        Snapshot currentSnapshot = nativeTbl.currentSnapshot();
-        if (currentSnapshot != null) {
-            rowDelta.validateFromSnapshot(currentSnapshot.snapshotId());
+        // Use the base snapshot id frozen at plan time so conflict detection covers
+        // every commit landed between scan and commit. Falling back to currentSnapshot
+        // here would silently skip that window and defeat SERIALIZABLE isolation.
+        Long baseSnapshotId = extra instanceof IcebergSinkExtra
+                ? ((IcebergSinkExtra) extra).getBaseSnapshotId() : null;
+        if (baseSnapshotId == null) {
+            Snapshot currentSnapshot = nativeTbl.currentSnapshot();
+            if (currentSnapshot != null) {
+                baseSnapshotId = currentSnapshot.snapshotId();
+            }
+        }
+        if (baseSnapshotId != null) {
+            rowDelta.validateFromSnapshot(baseSnapshotId);
         }
 
         // Validate that referenced data files exist and haven't been deleted
@@ -2201,6 +2210,10 @@ public class IcebergMetadata implements ConnectorMetadata {
         private final Set<DataFile> scannedDataFiles;
         private final Set<DeleteFile> appliedDeleteFiles;
         private Expression conflictDetectionFilter;
+        // Base snapshot id frozen at plan time. Used by RowDelta.validateFromSnapshot
+        // so conflict detection covers the window between scan and commit, not a fresher
+        // snapshot re-read at commit time.
+        private Long baseSnapshotId;
 
         public IcebergSinkExtra() {
             this.scannedDataFiles = new HashSet<>();
@@ -2229,6 +2242,14 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         public Expression getConflictDetectionFilter() {
             return conflictDetectionFilter;
+        }
+
+        public void setBaseSnapshotId(Long baseSnapshotId) {
+            this.baseSnapshotId = baseSnapshotId;
+        }
+
+        public Long getBaseSnapshotId() {
+            return baseSnapshotId;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -459,4 +459,11 @@ public class IcebergScanNode extends ScanNode {
     public Set<DeleteFile> getEqualAppliedDeleteFiles() {
         return scanRangeSource.getEqualAppliedDeleteFiles();
     }
+
+    public Optional<Long> getBaseSnapshotId() {
+        if (tvrVersionRange == null) {
+            return Optional.empty();
+        }
+        return tvrVersionRange.end();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -313,11 +313,15 @@ public class DeletePlanner {
         dataSink.init();
         // Create IcebergSinkExtra for DELETE operations
         IcebergMetadata.IcebergSinkExtra icebergSinkExtra = new IcebergMetadata.IcebergSinkExtra();
-        // Build Iceberg filter expression from scan node for conflict detection
-        org.apache.iceberg.expressions.Expression filterExpr = IcebergPlannerUtils.buildIcebergFilterExpr(execPlan);
+        // Build Iceberg filter expression from scan node for conflict detection.
+        // Both helpers filter by the target table so subqueries over other Iceberg tables
+        // don't leak their scan's predicate / snapshot id into the target's commit.
+        org.apache.iceberg.expressions.Expression filterExpr =
+                IcebergPlannerUtils.buildIcebergFilterExpr(execPlan, icebergTable);
         if (filterExpr != null) {
             icebergSinkExtra.setConflictDetectionFilter(filterExpr);
         }
+        icebergSinkExtra.setBaseSnapshotId(IcebergPlannerUtils.extractBaseSnapshotId(execPlan, icebergTable));
         // Set the sink extra info to be used during commit
         dataSink.setSinkExtraInfo(icebergSinkExtra);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/IcebergPlannerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/IcebergPlannerUtils.java
@@ -66,8 +66,39 @@ public class IcebergPlannerUtils {
         return new PhysicalPropertySet(distributionProperty);
     }
 
-    public static org.apache.iceberg.expressions.Expression buildIcebergFilterExpr(ExecPlan execPlan) {
-        if (execPlan == null || execPlan.getScanNodes() == null) {
+    /**
+     * Extracts the base snapshot id frozen at plan time from the IcebergScanNode that
+     * scans {@code targetTable}. The plan may contain scans for other Iceberg tables
+     * (e.g. {@code DELETE FROM t WHERE id IN (SELECT id FROM other_iceberg)}); using a
+     * source table's snapshot id with RowDelta.validateFromSnapshot is either rejected by
+     * Iceberg (snapshot not in the target's history) or silently validates against the
+     * wrong window.
+     * <p>
+     * Returns null when no scan over {@code targetTable} exists or the table had no
+     * snapshot when planned.
+     */
+    public static Long extractBaseSnapshotId(ExecPlan execPlan, IcebergTable targetTable) {
+        if (execPlan == null || execPlan.getScanNodes() == null || targetTable == null) {
+            return null;
+        }
+        for (PlanNode node : execPlan.getScanNodes()) {
+            if (node instanceof IcebergScanNode scanNode
+                    && scanNode.getIcebergTable().getId() == targetTable.getId()) {
+                return scanNode.getBaseSnapshotId().orElse(null);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Builds the Iceberg conflict-detection filter from the scan node that targets
+     * {@code targetTable}. Selecting any other Iceberg scan in the plan would produce a
+     * filter whose column references and schema do not match the target's, leading to
+     * spurious conflicts or invalid expressions on the Iceberg side.
+     */
+    public static org.apache.iceberg.expressions.Expression buildIcebergFilterExpr(ExecPlan execPlan,
+                                                                                     IcebergTable targetTable) {
+        if (execPlan == null || execPlan.getScanNodes() == null || targetTable == null) {
             return null;
         }
 
@@ -75,7 +106,8 @@ public class IcebergPlannerUtils {
         org.apache.iceberg.Schema nativeSchema = null;
 
         for (PlanNode node : execPlan.getScanNodes()) {
-            if (node instanceof IcebergScanNode scanNode) {
+            if (node instanceof IcebergScanNode scanNode
+                    && scanNode.getIcebergTable().getId() == targetTable.getId()) {
                 predicate = scanNode.getIcebergJobPlanningPredicate();
                 nativeSchema = scanNode.getIcebergTable().getNativeTable().schema();
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -241,10 +241,12 @@ public class UpdatePlanner {
         dataSink.init();
 
         IcebergMetadata.IcebergSinkExtra icebergSinkExtra = new IcebergMetadata.IcebergSinkExtra();
-        org.apache.iceberg.expressions.Expression filterExpr = IcebergPlannerUtils.buildIcebergFilterExpr(execPlan);
+        org.apache.iceberg.expressions.Expression filterExpr =
+                IcebergPlannerUtils.buildIcebergFilterExpr(execPlan, icebergTable);
         if (filterExpr != null) {
             icebergSinkExtra.setConflictDetectionFilter(filterExpr);
         }
+        icebergSinkExtra.setBaseSnapshotId(IcebergPlannerUtils.extractBaseSnapshotId(execPlan, icebergTable));
         dataSink.setSinkExtraInfo(icebergSinkExtra);
 
         execPlan.getFragments().get(0).setSink(dataSink);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -548,6 +548,10 @@ public class IcebergScanNodeTest {
 
         Assertions.assertTrue(sinkExtra.getScannedDataFiles().contains(df));
         Assertions.assertTrue(sinkExtra.getAppliedDeleteFiles().contains(del));
+
+        Assertions.assertNull(sinkExtra.getBaseSnapshotId());
+        sinkExtra.setBaseSnapshotId(42L);
+        Assertions.assertEquals(42L, sinkExtra.getBaseSnapshotId());
     }
 
     @Test
@@ -598,6 +602,114 @@ public class IcebergScanNodeTest {
         // 8. Assert
         Assertions.assertTrue(info1.isIs_rewrite());
         Assertions.assertTrue(info2.isIs_rewrite());
+    }
+
+    @Test
+    public void testExtractBaseSnapshotIdFromExecPlan() {
+        IcebergTable target = Mockito.mock(IcebergTable.class);
+        Mockito.when(target.getId()).thenReturn(42L);
+
+        IcebergScanNode scanNode = Mockito.mock(IcebergScanNode.class);
+        Mockito.when(scanNode.getIcebergTable()).thenReturn(target);
+        Mockito.when(scanNode.getBaseSnapshotId()).thenReturn(Optional.of(777L));
+
+        ExecPlan execPlan = Mockito.mock(ExecPlan.class);
+        Mockito.when(execPlan.getScanNodes()).thenReturn(new ArrayList<>(List.of(scanNode)));
+
+        Assertions.assertEquals(777L,
+                com.starrocks.sql.IcebergPlannerUtils.extractBaseSnapshotId(execPlan, target));
+
+        // Empty plan -> null.
+        ExecPlan empty = Mockito.mock(ExecPlan.class);
+        Mockito.when(empty.getScanNodes()).thenReturn(new ArrayList<>());
+        Assertions.assertNull(
+                com.starrocks.sql.IcebergPlannerUtils.extractBaseSnapshotId(empty, target));
+
+        // Scan over the target but with no plan-time snapshot -> null.
+        IcebergScanNode noSnap = Mockito.mock(IcebergScanNode.class);
+        Mockito.when(noSnap.getIcebergTable()).thenReturn(target);
+        Mockito.when(noSnap.getBaseSnapshotId()).thenReturn(Optional.empty());
+        ExecPlan planNoSnap = Mockito.mock(ExecPlan.class);
+        Mockito.when(planNoSnap.getScanNodes()).thenReturn(new ArrayList<>(List.of(noSnap)));
+        Assertions.assertNull(
+                com.starrocks.sql.IcebergPlannerUtils.extractBaseSnapshotId(planNoSnap, target));
+    }
+
+    @Test
+    public void testBuildIcebergFilterExprSkipsNonTargetIcebergScans() {
+        // Symmetric to testExtractBaseSnapshotIdSkipsNonTargetIcebergScans: same fix
+        // applies to buildIcebergFilterExpr, which previously picked the first
+        // IcebergScanNode regardless of which table it scanned. With a non-target
+        // source scan listed first, the helper must still consult only the target's
+        // scan. Verified two ways:
+        //   (1) the result is null because the target's predicate is null
+        //       (legacy code would have produced a non-null filter from the source's
+        //       predicate);
+        //   (2) Mockito.verify confirms the source's predicate getter is never called.
+        IcebergTable target = Mockito.mock(IcebergTable.class);
+        Mockito.when(target.getId()).thenReturn(100L);
+        Table nativeTable = Mockito.mock(Table.class);
+        Schema nativeSchema = Mockito.mock(Schema.class);
+        Mockito.when(target.getNativeTable()).thenReturn(nativeTable);
+        Mockito.when(nativeTable.schema()).thenReturn(nativeSchema);
+
+        IcebergTable source = Mockito.mock(IcebergTable.class);
+        Mockito.when(source.getId()).thenReturn(200L);
+
+        IcebergScanNode sourceScan = Mockito.mock(IcebergScanNode.class);
+        Mockito.when(sourceScan.getIcebergTable()).thenReturn(source);
+
+        IcebergScanNode targetScan = Mockito.mock(IcebergScanNode.class);
+        Mockito.when(targetScan.getIcebergTable()).thenReturn(target);
+        Mockito.when(targetScan.getIcebergJobPlanningPredicate()).thenReturn(null);
+
+        ExecPlan execPlan = Mockito.mock(ExecPlan.class);
+        Mockito.when(execPlan.getScanNodes())
+                .thenReturn(new ArrayList<>(List.of(sourceScan, targetScan)));
+
+        Assertions.assertNull(
+                com.starrocks.sql.IcebergPlannerUtils.buildIcebergFilterExpr(execPlan, target));
+        Mockito.verify(targetScan).getIcebergJobPlanningPredicate();
+        Mockito.verify(sourceScan, Mockito.never()).getIcebergJobPlanningPredicate();
+    }
+
+    @Test
+    public void testExtractBaseSnapshotIdSkipsNonTargetIcebergScans() {
+        // Simulates `UPDATE target SET ... WHERE id IN (SELECT id FROM source_iceberg)`:
+        // the plan contains two IcebergScanNodes (target + source). The helper must
+        // return the TARGET's plan-time snapshot id, not the source's — passing the
+        // source snapshot id into RowDelta.validateFromSnapshot would either be rejected
+        // by Iceberg (snapshot missing from target's history) or validate against an
+        // unrelated window.
+        IcebergTable target = Mockito.mock(IcebergTable.class);
+        Mockito.when(target.getId()).thenReturn(100L);
+        IcebergTable source = Mockito.mock(IcebergTable.class);
+        Mockito.when(source.getId()).thenReturn(200L);
+
+        // Source scan appears FIRST in the plan — the legacy "first IcebergScan wins"
+        // logic would have returned 999L, the wrong snapshot id.
+        IcebergScanNode sourceScan = Mockito.mock(IcebergScanNode.class);
+        Mockito.when(sourceScan.getIcebergTable()).thenReturn(source);
+        Mockito.when(sourceScan.getBaseSnapshotId()).thenReturn(Optional.of(999L));
+
+        IcebergScanNode targetScan = Mockito.mock(IcebergScanNode.class);
+        Mockito.when(targetScan.getIcebergTable()).thenReturn(target);
+        Mockito.when(targetScan.getBaseSnapshotId()).thenReturn(Optional.of(123L));
+
+        ExecPlan execPlan = Mockito.mock(ExecPlan.class);
+        Mockito.when(execPlan.getScanNodes())
+                .thenReturn(new ArrayList<>(List.of(sourceScan, targetScan)));
+
+        Assertions.assertEquals(123L,
+                com.starrocks.sql.IcebergPlannerUtils.extractBaseSnapshotId(execPlan, target));
+
+        // No scan matches the target (e.g. target is referenced only by the sink, not by
+        // any scan) -> null.
+        ExecPlan onlySource = Mockito.mock(ExecPlan.class);
+        Mockito.when(onlySource.getScanNodes())
+                .thenReturn(new ArrayList<>(List.of(sourceScan)));
+        Assertions.assertNull(
+                com.starrocks.sql.IcebergPlannerUtils.extractBaseSnapshotId(onlySource, target));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -515,14 +515,16 @@ public class UpdatePlanTest extends PlanTestBase {
 
     @Test
     public void testIcebergPlannerUtilsBuildIcebergFilterExprNullPlan() {
-        // Null exec plan returns null without NPE.
-        assertNull(IcebergPlannerUtils.buildIcebergFilterExpr(null));
+        // Null exec plan returns null without NPE. Target table is irrelevant — the
+        // null-plan guard short-circuits before the target filter ever runs.
+        assertNull(IcebergPlannerUtils.buildIcebergFilterExpr(null, null));
     }
 
     @Test
     public void testIcebergPlannerUtilsBuildIcebergFilterExprNoIcebergScan() throws Exception {
-        // OLAP update plan has no IcebergScanNode, so the helper finds no predicate
-        // and short-circuits to null.
+        // OLAP update plan has no IcebergScanNode, so the helper finds no scan over the
+        // target and short-circuits to null. Passing null target also hits the null-target
+        // guard — either way the result is null for a non-Iceberg plan.
         String sql = "update tprimary set v2 = v2 + 1 where v1 = 'aaa'";
         connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
@@ -531,7 +533,7 @@ public class UpdatePlanTest extends PlanTestBase {
                 sql, connectContext.getSessionVariable().getSqlMode()).get(0);
         connectContext.getDumpInfo().setOriginStmt(sql);
         ExecPlan execPlan = new StatementPlanner().plan(stmt, connectContext);
-        assertNull(IcebergPlannerUtils.buildIcebergFilterExpr(execPlan));
+        assertNull(IcebergPlannerUtils.buildIcebergFilterExpr(execPlan, null));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`RowDelta.validateFromSnapshot` defines the conflict-detection window that catches commits which landed between the plan-time read and the commit. Two related issues weakened this guarantee for the Iceberg DELETE commit path (and, on the in-flight UPDATE/MERGE work, for those paths too):

1. **Commit-time `currentSnapshot()` widened the validation window.** `commitDeleteOperation` passed `nativeTbl.currentSnapshot()` into `validateFromSnapshot`, re-read at commit time. Commits that landed between scan and commit slipped through SERIALIZABLE isolation silently.
2. **`buildIcebergFilterExpr` selected the wrong Iceberg scan.** The helper matched the **first** `IcebergScanNode` in the plan. Statements with a subquery over another Iceberg table — e.g. `DELETE FROM t WHERE id IN (SELECT id FROM other_iceberg)` — could feed the source table's predicate into the target's commit, producing either spurious conflicts or invalid expressions on the Iceberg side.

Carved out as a standalone PR so it is cleanly backportable to `branch-4.1`, where the Iceberg DELETE operation is already released.

## What I'm doing:

- Introduce `IcebergPlannerUtils.extractBaseSnapshotId(ExecPlan, IcebergTable)` that reads the plan-time `baseSnapshotId` off the **target table's** `IcebergScanNode`. `DeletePlanner` and `UpdatePlanner` invoke it when populating `IcebergSinkExtra`, and `commitDeleteOperation` uses that id for `validateFromSnapshot` (falling back to `currentSnapshot()` only when extra information is absent, preserving compatibility for callers that don't thread it through).
- `IcebergPlannerUtils.buildIcebergFilterExpr` now takes the target `IcebergTable` and filters scans by `getId()`. Subquery scans over other Iceberg tables are skipped.
- Update the two callers (`DeletePlanner`, `UpdatePlanner`) to pass the target table.
- Tests cover the multi-`IcebergScanNode` plan layout for both helpers (`testExtractBaseSnapshotIdSkipsNonTargetIcebergScans`, `testBuildIcebergFilterExprSkipsNonTargetIcebergScans`) so the target's scan is the one consulted.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4