### PR TITLE
[BugFix] carry load times as UTC epoch ms across BE/FE thrift

### DIFF
--- a/be/src/exec/schema_scanner/schema_column_filler.h
+++ b/be/src/exec/schema_scanner/schema_column_filler.h
@@ -36,6 +36,10 @@ void fill_data_column_with_slot(Column* data_column, void* slot) {
         result->append(date_value);
     } else if constexpr (IsTimestamp<ValueType>) {
         auto* date_time_value = (DateTimeValue*)slot;
+        // Microseconds are dropped here. TimestampValue::create has a default
+        // microsecond=0 7th parameter; pass date_time_value->microsecond() to
+        // preserve it. Today's callers all populate DateTimeValue at second
+        // precision, so this is a no-op for them.
         TimestampValue timestamp_value =
                 TimestampValue::create(date_time_value->year(), date_time_value->month(), date_time_value->day(),
                                        date_time_value->hour(), date_time_value->minute(), date_time_value->second());

--- a/be/src/exec/schema_scanner/schema_loads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_loads_scanner.cpp
@@ -14,8 +14,11 @@
 
 #include "exec/schema_scanner/schema_loads_scanner.h"
 
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
 
+#include "cctz/civil_time.h"
+#include "cctz/time_zone.h"
 #include "exec/schema_scanner/schema_helper.h"
 #include "exprs/column_ref.h"
 #include "exprs/expr_context.h"
@@ -26,7 +29,17 @@
 namespace starrocks {
 
 namespace {
-bool _extract_literal_datetime_value(Expr* expr, std::string& result) {
+// Bound for a datetime range predicate extracted from BE conjuncts. Carries
+// both the legacy wall-clock string (for old FEs that still parse strings) and
+// the unambiguous UTC epoch ms (for new FEs that compare epochs directly).
+struct DateTimeRangeBound {
+    std::string str_value;
+    int64_t epoch_ms = 0;
+    bool has_value = false;
+};
+
+bool _extract_literal_datetime_value(Expr* expr, const cctz::time_zone& session_tz, bool is_lower_bound,
+                                     DateTimeRangeBound& result) {
     auto* literal = dynamic_cast<VectorizedLiteral*>(expr);
     if (literal == nullptr) {
         return false;
@@ -43,13 +56,22 @@ bool _extract_literal_datetime_value(Expr* expr, std::string& result) {
     }
 
     const auto datum = literal_col->get(0);
-    result = datum.get_timestamp().to_string(true);
+    const auto ts = datum.get_timestamp();
+    result.str_value = ts.to_string(true);
+    int year, month, day, hour, minute, second, usec;
+    ts.to_timestamp(&year, &month, &day, &hour, &minute, &second, &usec);
+    // Second precision; see literal_to_epoch_ms for the contract and DST
+    // handling. To enable ms support, also propagate `usec` into the result.
+    (void)usec;
+    result.epoch_ms = SchemaLoadsScanner::literal_to_epoch_ms(
+            session_tz, cctz::civil_second(year, month, day, hour, minute, second), is_lower_bound);
 
     return true;
 }
 
 bool _try_parse_datetime_range_predicate(const SchemaScannerParam* param, Expr* conjunct, const std::string& col_name,
-                                         std::string& literal_value, bool& is_lower_bound) {
+                                         const cctz::time_zone& session_tz, DateTimeRangeBound& bound,
+                                         bool& is_lower_bound) {
     const TExprNodeType::type& node_type = conjunct->node_type();
     const TExprOpcode::type& op_type = conjunct->op();
     if (node_type != TExprNodeType::BINARY_PRED || (op_type != TExprOpcode::GE && op_type != TExprOpcode::GT &&
@@ -77,21 +99,24 @@ bool _try_parse_datetime_range_predicate(const SchemaScannerParam* param, Expr* 
         return false;
     }
 
-    if (!_extract_literal_datetime_value(value_child, literal_value)) {
+    if (!_extract_literal_datetime_value(value_child, session_tz, is_lower_bound, bound)) {
         return false;
     }
+    bound.has_value = true;
 
     return true;
 }
 
-void _update_range_bound(std::string& bound, bool& has_bound, const std::string& candidate, bool is_lower_bound) {
-    if (!has_bound) {
+void _update_range_bound(DateTimeRangeBound& bound, const DateTimeRangeBound& candidate, bool is_lower_bound) {
+    if (!bound.has_value) {
         bound = candidate;
-        has_bound = true;
         return;
     }
 
-    if ((is_lower_bound && candidate > bound) || (!is_lower_bound && candidate < bound)) {
+    // Lower bound: keep the largest candidate (tightest >= literal).
+    // Upper bound: keep the smallest candidate (tightest <= literal).
+    if ((is_lower_bound && candidate.epoch_ms > bound.epoch_ms) ||
+        (!is_lower_bound && candidate.epoch_ms < bound.epoch_ms)) {
         bound = candidate;
     }
 }
@@ -102,25 +127,28 @@ void _update_range_bound(std::string& bound, bool& has_bound, const std::string&
 // 2. This function scans conjuncts and picks predicates with operators in {>, >=, <, <=}.
 // 3. It normalizes them into [lower_bound, upper_bound] (both inclusive for FE-side filtering).
 // Purpose: convert BE-side scan predicates into FE RPC parameters to reduce rows returned by getLoads().
+//
+// session_tz is used to compute the epoch-ms representation of each literal; the
+// wall-clock string is preserved for FEs that still parse the string field.
 void _parse_datetime_range_predicates(const SchemaScannerParam* param, const std::string& col_name,
-                                      std::string& lower_bound, bool& has_lower_bound, std::string& upper_bound,
-                                      bool& has_upper_bound) {
+                                      const cctz::time_zone& session_tz, DateTimeRangeBound& lower,
+                                      DateTimeRangeBound& upper) {
     if (param->expr_contexts == nullptr) {
         return;
     }
 
     for (auto* expr_context : *(param->expr_contexts)) {
-        std::string literal_value;
+        DateTimeRangeBound candidate;
         bool is_lower_bound = false;
-        if (!_try_parse_datetime_range_predicate(param, expr_context->root(), col_name, literal_value,
+        if (!_try_parse_datetime_range_predicate(param, expr_context->root(), col_name, session_tz, candidate,
                                                  is_lower_bound)) {
             continue;
         }
 
         if (is_lower_bound) {
-            _update_range_bound(lower_bound, has_lower_bound, literal_value, true);
+            _update_range_bound(lower, candidate, true);
         } else {
-            _update_range_bound(upper_bound, has_upper_bound, literal_value, false);
+            _update_range_bound(upper, candidate, false);
         }
     }
 }
@@ -160,6 +188,47 @@ SchemaLoadsScanner::SchemaLoadsScanner()
 
 SchemaLoadsScanner::~SchemaLoadsScanner() = default;
 
+int64_t SchemaLoadsScanner::literal_to_epoch_ms(const cctz::time_zone& session_tz, cctz::civil_second cs,
+                                                bool is_lower_bound) {
+    // DST makes the civil-to-absolute mapping non-unique. cctz returns two
+    // candidates named by which transition offset was applied, NOT by temporal
+    // order:
+    //   - REPEATED (fall-back, e.g. America/New_York 2026-11-01 01:30):
+    //       lookup.pre is the earlier instant, lookup.post the later.
+    //   - SKIPPED  (spring-forward gap, e.g. America/New_York 2026-03-08 02:30):
+    //       senses SWAPPED - lookup.pre applies the pre-transition offset and
+    //       is the LATER instant, lookup.post the EARLIER. For UNIQUE civil
+    //       times pre == post.
+    // BE re-evaluates the predicate after materializing the column in
+    // session_tz, so this prefilter must be no-false-negative against the
+    // post-filter. Picking min/max(pre, post) widens for both DST cases.
+    //
+    // Returns second-aligned ms. To enable ms support, also propagate `usec`
+    // from _extract_literal_datetime_value.
+    const auto lookup = session_tz.lookup(cs);
+    const auto tp = is_lower_bound ? std::min(lookup.pre, lookup.post) : std::max(lookup.pre, lookup.post);
+    return tp.time_since_epoch().count() * 1000;
+}
+
+bool SchemaLoadsScanner::_fill_datetime_column_from_ms(Column* column, bool is_set, int64_t epoch_ms) const {
+    if (!is_set) {
+        return false;
+    }
+    if (epoch_ms <= 0) {
+        // Defensive: FE writers leave the field unset for unknown timestamps,
+        // so an explicit sentinel here only happens on malformed input.
+        down_cast<NullableColumn*>(column)->append_nulls(1);
+        return true;
+    }
+    DateTimeValue t;
+    // Second precision: the column filler at schema_column_filler.h strips
+    // microseconds regardless. To enable ms support, use the (s, us, tz)
+    // overload here AND pass microsecond() through in the column filler.
+    t.from_unixtime(epoch_ms / 1000, _runtime_state->timezone_obj());
+    fill_column_with_slot<TYPE_DATETIME>(column, (void*)&t);
+    return true;
+}
+
 Status SchemaLoadsScanner::start(RuntimeState* state) {
     RETURN_IF_ERROR(SchemaScanner::start(state));
     TGetLoadsParams load_params;
@@ -179,43 +248,47 @@ Status SchemaLoadsScanner::start(RuntimeState* state) {
         load_params.__set_state(state_str);
     }
 
-    std::string load_start_time_from;
-    std::string load_start_time_to;
-    bool has_load_start_time_from = false;
-    bool has_load_start_time_to = false;
-    _parse_datetime_range_predicates(_param, "LOAD_START_TIME", load_start_time_from, has_load_start_time_from,
-                                     load_start_time_to, has_load_start_time_to);
-    if (has_load_start_time_from) {
-        load_params.__set_load_start_time_from(load_start_time_from);
+    // BE evaluates the SQL literal in the session timezone (a wall-clock value
+    // with no zone marker). The new *_ms fields carry the unambiguous UTC epoch
+    // ms derived from that wall-clock via the session zone. The legacy *_from /
+    // *_to string fields are still populated for old FEs.
+    const auto& session_tz = state->timezone_obj();
+
+    DateTimeRangeBound load_start_time_from;
+    DateTimeRangeBound load_start_time_to;
+    _parse_datetime_range_predicates(_param, "LOAD_START_TIME", session_tz, load_start_time_from, load_start_time_to);
+    if (load_start_time_from.has_value) {
+        load_params.__set_load_start_time_from(load_start_time_from.str_value);
+        load_params.__set_load_start_time_from_ms(load_start_time_from.epoch_ms);
     }
-    if (has_load_start_time_to) {
-        load_params.__set_load_start_time_to(load_start_time_to);
+    if (load_start_time_to.has_value) {
+        load_params.__set_load_start_time_to(load_start_time_to.str_value);
+        load_params.__set_load_start_time_to_ms(load_start_time_to.epoch_ms);
     }
 
-    std::string load_finish_time_from;
-    std::string load_finish_time_to;
-    bool has_load_finish_time_from = false;
-    bool has_load_finish_time_to = false;
-    _parse_datetime_range_predicates(_param, "LOAD_FINISH_TIME", load_finish_time_from, has_load_finish_time_from,
-                                     load_finish_time_to, has_load_finish_time_to);
-    if (has_load_finish_time_from) {
-        load_params.__set_load_finish_time_from(load_finish_time_from);
+    DateTimeRangeBound load_finish_time_from;
+    DateTimeRangeBound load_finish_time_to;
+    _parse_datetime_range_predicates(_param, "LOAD_FINISH_TIME", session_tz, load_finish_time_from,
+                                     load_finish_time_to);
+    if (load_finish_time_from.has_value) {
+        load_params.__set_load_finish_time_from(load_finish_time_from.str_value);
+        load_params.__set_load_finish_time_from_ms(load_finish_time_from.epoch_ms);
     }
-    if (has_load_finish_time_to) {
-        load_params.__set_load_finish_time_to(load_finish_time_to);
+    if (load_finish_time_to.has_value) {
+        load_params.__set_load_finish_time_to(load_finish_time_to.str_value);
+        load_params.__set_load_finish_time_to_ms(load_finish_time_to.epoch_ms);
     }
 
-    std::string create_time_from;
-    std::string create_time_to;
-    bool has_create_time_from = false;
-    bool has_create_time_to = false;
-    _parse_datetime_range_predicates(_param, "CREATE_TIME", create_time_from, has_create_time_from, create_time_to,
-                                     has_create_time_to);
-    if (has_create_time_from) {
-        load_params.__set_create_time_from(create_time_from);
+    DateTimeRangeBound create_time_from;
+    DateTimeRangeBound create_time_to;
+    _parse_datetime_range_predicates(_param, "CREATE_TIME", session_tz, create_time_from, create_time_to);
+    if (create_time_from.has_value) {
+        load_params.__set_create_time_from(create_time_from.str_value);
+        load_params.__set_create_time_from_ms(create_time_from.epoch_ms);
     }
-    if (has_create_time_to) {
-        load_params.__set_create_time_to(create_time_to);
+    if (create_time_to.has_value) {
+        load_params.__set_create_time_to(create_time_to.str_value);
+        load_params.__set_create_time_to_ms(create_time_to.epoch_ms);
     }
 
     if (nullptr != _param->label) {
@@ -357,6 +430,9 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             case 18: {
                 // create time
+                if (_fill_datetime_column_from_ms(column, info.__isset.create_time_ms, info.create_time_ms)) {
+                    break;
+                }
                 DateTimeValue t;
                 if (info.__isset.create_time) {
                     if (t.from_date_str(info.create_time.data(), info.create_time.size())) {
@@ -369,6 +445,9 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             case 19: {
                 // load start time
+                if (_fill_datetime_column_from_ms(column, info.__isset.load_start_time_ms, info.load_start_time_ms)) {
+                    break;
+                }
                 DateTimeValue t;
                 if (info.__isset.load_start_time) {
                     if (t.from_date_str(info.load_start_time.data(), info.load_start_time.size())) {
@@ -381,6 +460,9 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             case 20: {
                 // load commit time
+                if (_fill_datetime_column_from_ms(column, info.__isset.load_commit_time_ms, info.load_commit_time_ms)) {
+                    break;
+                }
                 DateTimeValue t;
                 if (info.__isset.load_commit_time) {
                     if (t.from_date_str(info.load_commit_time.data(), info.load_commit_time.size())) {
@@ -393,6 +475,9 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             case 21: {
                 // load finish time
+                if (_fill_datetime_column_from_ms(column, info.__isset.load_finish_time_ms, info.load_finish_time_ms)) {
+                    break;
+                }
                 DateTimeValue t;
                 if (info.__isset.load_finish_time) {
                     if (t.from_date_str(info.load_finish_time.data(), info.load_finish_time.size())) {

--- a/be/src/exec/schema_scanner/schema_loads_scanner.h
+++ b/be/src/exec/schema_scanner/schema_loads_scanner.h
@@ -14,10 +14,17 @@
 
 #pragma once
 
+#include <cctz/civil_time.h>
+#include <cctz/time_zone.h>
+
+#include <cstdint>
+
 #include "exec/schema_scanner.h"
 #include "gen_cpp/FrontendService_types.h"
 
 namespace starrocks {
+
+class Column;
 
 class SchemaLoadsScanner : public SchemaScanner {
 public:
@@ -27,8 +34,24 @@ public:
     Status start(RuntimeState* state) override;
     Status get_next(ChunkPtr* chunk, bool* eos) override;
 
+    // Convert a session-zone DATETIME literal (extracted from a predicate) to
+    // the UTC epoch ms FE compares against. Returns a second-aligned value
+    // (information_schema.loads is second-precision today); for DST-ambiguous
+    // civil times the result widens the bound via min/max of
+    // cctz::civil_lookup.pre/post so the FE prefilter never drops a row that
+    // BE's post-filter would have kept. Public so the anonymous-namespace
+    // predicate-extraction helper and the unit test can call it.
+    static int64_t literal_to_epoch_ms(const cctz::time_zone& session_tz, cctz::civil_second cs, bool is_lower_bound);
+
 private:
     Status fill_chunk(ChunkPtr* chunk);
+
+    // Fill a DATETIME column from a UTC-epoch-ms thrift field, converting to the
+    // session zone via from_unixtime() so the materialized wall-clock matches what
+    // the user expects in their session. Returns true when the ms field was set
+    // (and the column was populated, either with a value or a NULL); the caller
+    // should then skip its legacy string-parsing fallback.
+    bool _fill_datetime_column_from_ms(Column* column, bool is_set, int64_t epoch_ms) const;
 
     int _cur_idx = 0;
     TGetLoadsResult _result;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -90,6 +90,7 @@ set(EXEC_FILES
         ./exec/query_cache/transform_operator.cpp
         ./exec/schema_columns_scanner_test.cpp
         ./exec/schema_fe_tablet_schedules_scanner_test.cpp
+        ./exec/schema_loads_scanner_test.cpp
         ./exec/schema_materialized_views_scanner_test.cpp
         ./exec/schema_task_runs_scanner_test.cpp
         ./exec/schema_scanner/schema_be_tablet_write_log_scanner_test.cpp

--- a/be/test/exec/schema_loads_scanner_test.cpp
+++ b/be/test/exec/schema_loads_scanner_test.cpp
@@ -1,0 +1,286 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_loads_scanner.h"
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "runtime/runtime_state.h"
+#include "types/timestamp_value.h"
+
+namespace starrocks {
+
+// BE-side coverage for the FE->BE epoch-ms contract introduced for
+// information_schema.loads. The scanner's start() goes through a thrift RPC to
+// FE; the test bypasses that by populating _result directly and exercises the
+// fill_chunk path (and specifically _fill_datetime_column_from_ms). Access to
+// private fields/methods is allowed because BE unit tests are compiled with
+// -fno-access-control (see be/CMakeLists.txt).
+class SchemaLoadsScannerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _params.ip = &_ip;
+        _params.port = 9020;
+        _state = std::make_unique<RuntimeState>(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr);
+    }
+
+    // Configure the scanner for a specific session timezone, mirroring the
+    // production path where _runtime_state->timezone_obj() drives the
+    // wall-clock rendering of every DATETIME column.
+    void init_scanner(SchemaLoadsScanner& scanner, const std::string& session_tz) {
+        EXPECT_TRUE(_state->set_timezone(session_tz));
+        EXPECT_OK(scanner.init(&_params, &_pool));
+        scanner._runtime_state = _state.get();
+    }
+
+    ChunkPtr create_chunk(const std::vector<SlotDescriptor*>& slot_descs) {
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        for (const auto* slot_desc : slot_descs) {
+            MutableColumnPtr column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
+            chunk->append_column(std::move(column), slot_desc->id());
+        }
+        return chunk;
+    }
+
+    // Construct a minimal TLoadInfo with required string fields populated; the
+    // caller layers DATETIME fields on top per scenario.
+    TLoadInfo make_min_load_info(int64_t job_id) {
+        TLoadInfo info;
+        info.__set_job_id(job_id);
+        info.__set_label("test_label_" + std::to_string(job_id));
+        info.__set_db("test_db");
+        info.__set_table("test_tbl");
+        info.__set_user("test_user");
+        info.__set_state("FINISHED");
+        info.__set_progress("100%");
+        info.__set_type("BROKER");
+        info.__set_priority("NORMAL");
+        info.__set_num_scan_rows(0);
+        info.__set_num_scan_bytes(0);
+        info.__set_num_filtered_rows(0);
+        info.__set_num_unselected_rows(0);
+        info.__set_num_sink_rows(0);
+        info.__set_properties("{}");
+        return info;
+    }
+
+    // Extract the TimestampValue from the nullable DATETIME column at the
+    // given 1-indexed slot id, expecting exactly one materialized row.
+    TimestampValue read_datetime(const ChunkPtr& chunk, int slot_id) {
+        auto* column = chunk->get_column_raw_ptr_by_slot_id(slot_id);
+        auto* nullable = down_cast<NullableColumn*>(column);
+        EXPECT_FALSE(nullable->is_null(0));
+        auto* data = down_cast<TimestampColumn*>(nullable->data_column_raw_ptr());
+        return data->get_data()[0];
+    }
+
+    bool is_null_at(const ChunkPtr& chunk, int slot_id) {
+        auto* column = chunk->get_column_raw_ptr_by_slot_id(slot_id);
+        return down_cast<NullableColumn*>(column)->is_null(0);
+    }
+
+    SchemaScannerParam _params;
+    std::string _ip = "127.0.0.1";
+    ObjectPool _pool;
+    std::unique_ptr<RuntimeState> _state;
+
+    // Slot ids for the four DATETIME columns under test (matches the case
+    // labels in SchemaLoadsScanner::fill_chunk).
+    static constexpr int CREATE_TIME = 18;
+    static constexpr int LOAD_START_TIME = 19;
+    static constexpr int LOAD_COMMIT_TIME = 20;
+    static constexpr int LOAD_FINISH_TIME = 21;
+};
+
+// Pin the wall-clock that an epoch-ms job timestamp renders to in two
+// different session zones. This is the symptom the PR fixes: the same UTC
+// instant must show up as the local wall-clock of whoever is querying, with
+// no UTC+8 contamination from the legacy string path.
+TEST_F(SchemaLoadsScannerTest, ms_field_materializes_in_session_zone) {
+    // 2026-05-15 06:45:08.123 UTC.
+    const int64_t epoch_ms = 1778827508123L;
+
+    struct Case {
+        std::string session_tz;
+        std::string expected_wallclock;
+    };
+    const std::vector<Case> cases = {
+            // UTC+8 baseline (the legacy zone, which used to be hard-coded).
+            {"Asia/Shanghai", "2026-05-15 14:45:08"},
+            // EDT in May (DST-active; this is the case to_unixtime(zone) used
+            // to silently mis-handle by resolving the offset at the epoch).
+            {"America/New_York", "2026-05-15 02:45:08"},
+            {"UTC", "2026-05-15 06:45:08"},
+    };
+
+    for (const auto& c : cases) {
+        SchemaLoadsScanner scanner;
+        init_scanner(scanner, c.session_tz);
+
+        TLoadInfo info = make_min_load_info(1);
+        info.__set_create_time_ms(epoch_ms);
+        info.__set_load_start_time_ms(epoch_ms);
+        info.__set_load_commit_time_ms(epoch_ms);
+        info.__set_load_finish_time_ms(epoch_ms);
+        scanner._result.loads = {info};
+        scanner._cur_idx = 0;
+
+        auto chunk = create_chunk(scanner.get_slot_descs());
+        bool eos = false;
+        EXPECT_OK(scanner.get_next(&chunk, &eos));
+        EXPECT_EQ(1, chunk->num_rows()) << c.session_tz;
+
+        // Drop the sub-second part for the wall-clock comparison; sub-second
+        // precision is covered by a dedicated test below.
+        for (int slot : {CREATE_TIME, LOAD_START_TIME, LOAD_COMMIT_TIME, LOAD_FINISH_TIME}) {
+            auto ts = read_datetime(chunk, slot);
+            EXPECT_EQ(c.expected_wallclock, ts.to_string(/*ignore_microsecond=*/true))
+                    << "tz=" << c.session_tz << " slot=" << slot;
+        }
+    }
+}
+
+// information_schema.loads is a second-precision view (the legacy "YYYY-MM-DD
+// HH:MM:SS" wire format never carried fractional seconds, and the column
+// filler at schema_column_filler.h drops microseconds when building a
+// TimestampValue). Pin that the materialized column truncates to whole
+// seconds regardless of any ms remainder in the wire payload.
+TEST_F(SchemaLoadsScannerTest, ms_field_is_truncated_to_second_precision) {
+    SchemaLoadsScanner scanner;
+    init_scanner(scanner, "UTC");
+
+    const int64_t epoch_ms = 1778827508789L; // 2026-05-15 06:45:08.789 UTC.
+
+    TLoadInfo info = make_min_load_info(1);
+    info.__set_create_time_ms(epoch_ms);
+    scanner._result.loads = {info};
+    scanner._cur_idx = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+
+    auto ts = read_datetime(chunk, CREATE_TIME);
+    // Wall-clock rendered at second precision; microsecond field is zero.
+    EXPECT_EQ("2026-05-15 06:45:08", ts.to_string(/*ignore_microsecond=*/true));
+    EXPECT_EQ(std::string::npos, ts.to_string(/*ignore_microsecond=*/false).find("789"))
+            << "rendered: " << ts.to_string(false);
+}
+
+// Old BE never sets the ms field. New BE must keep parsing the legacy
+// wall-clock string for compatibility, preserving the pre-fix semantics.
+TEST_F(SchemaLoadsScannerTest, legacy_string_fallback_when_ms_unset) {
+    SchemaLoadsScanner scanner;
+    init_scanner(scanner, "Asia/Shanghai");
+
+    TLoadInfo info = make_min_load_info(1);
+    // Intentionally leave *_ms unset; only the legacy string field is provided.
+    info.__set_create_time("2026-05-15 14:45:08");
+    scanner._result.loads = {info};
+    scanner._cur_idx = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+
+    auto ts = read_datetime(chunk, CREATE_TIME);
+    EXPECT_EQ("2026-05-15 14:45:08", ts.to_string(true));
+    // The other three datetime columns are neither ms nor legacy-string set;
+    // they must render NULL rather than silently appearing as epoch.
+    EXPECT_TRUE(is_null_at(chunk, LOAD_START_TIME));
+    EXPECT_TRUE(is_null_at(chunk, LOAD_COMMIT_TIME));
+    EXPECT_TRUE(is_null_at(chunk, LOAD_FINISH_TIME));
+}
+
+// Predicate-literal conversion: a well-defined (UNIQUE) civil time maps to
+// the same second-aligned epoch ms for both lower and upper bounds. Pre-fix
+// the FE-side string parse produced the same second-aligned value, so this
+// matches historical behavior.
+TEST_F(SchemaLoadsScannerTest, literal_to_epoch_ms_unique_civil_time) {
+    cctz::time_zone utc;
+    ASSERT_TRUE(cctz::load_time_zone("UTC", &utc));
+
+    // 2026-05-15 06:45:08 UTC is unix second 1778827508.
+    const cctz::civil_second cs(2026, 5, 15, 6, 45, 8);
+    const int64_t second_aligned = 1778827508L * 1000;
+
+    EXPECT_EQ(second_aligned, SchemaLoadsScanner::literal_to_epoch_ms(utc, cs, /*is_lower_bound=*/true));
+    EXPECT_EQ(second_aligned, SchemaLoadsScanner::literal_to_epoch_ms(utc, cs, /*is_lower_bound=*/false));
+}
+
+// DST fall-back (REPEATED civil time): the same wall-clock occurs at two
+// distinct UTC instants. Lower bound picks the earlier; upper bound the
+// later. America/New_York 2026-11-01 01:30 sits inside the fall-back hour:
+// 01:30 EDT (= 05:30 UTC) and 01:30 EST (= 06:30 UTC) are both valid
+// interpretations.
+TEST_F(SchemaLoadsScannerTest, literal_to_epoch_ms_handles_dst_repeated) {
+    cctz::time_zone ny;
+    ASSERT_TRUE(cctz::load_time_zone("America/New_York", &ny));
+
+    const cctz::civil_second cs(2026, 11, 1, 1, 30, 0);
+    const int64_t edt_ms = 1793511000L * 1000; // 2026-11-01 05:30:00 UTC
+    const int64_t est_ms = 1793514600L * 1000; // 2026-11-01 06:30:00 UTC
+
+    EXPECT_EQ(edt_ms, SchemaLoadsScanner::literal_to_epoch_ms(ny, cs, /*is_lower_bound=*/true));
+    EXPECT_EQ(est_ms, SchemaLoadsScanner::literal_to_epoch_ms(ny, cs, /*is_lower_bound=*/false));
+}
+
+// DST spring-forward (SKIPPED civil time): the wall-clock doesn't exist; cctz
+// returns two candidates with the pre/post offsets, and they are swapped
+// relative to the temporal order (lookup.pre uses the pre-transition offset
+// and is the LATER instant; lookup.post the EARLIER). min/max(pre,post) must
+// disambiguate by absolute time, not by struct name. America/New_York
+// 2026-03-08 02:30 sits inside the spring-forward gap.
+TEST_F(SchemaLoadsScannerTest, literal_to_epoch_ms_handles_dst_skipped) {
+    cctz::time_zone ny;
+    ASSERT_TRUE(cctz::load_time_zone("America/New_York", &ny));
+
+    const cctz::civil_second cs(2026, 3, 8, 2, 30, 0);
+    // Interpreted with EDT (post-transition, -4): 02:30 -> 06:30 UTC = 1772951400.
+    // Interpreted with EST (pre-transition, -5):  02:30 -> 07:30 UTC = 1772955000.
+    const int64_t earlier_ms = 1772951400L * 1000;
+    const int64_t later_ms = 1772955000L * 1000;
+
+    EXPECT_EQ(earlier_ms, SchemaLoadsScanner::literal_to_epoch_ms(ny, cs, /*is_lower_bound=*/true));
+    EXPECT_EQ(later_ms, SchemaLoadsScanner::literal_to_epoch_ms(ny, cs, /*is_lower_bound=*/false));
+}
+
+// Defensive branch: when the ms field is technically set but carries 0/-1, BE
+// renders NULL rather than 1970. FE writers (LoadJob, StreamLoadTask,
+// MergeCommitTask) never actually send those sentinels - they leave the field
+// unset - so this exercises pure defense in depth.
+TEST_F(SchemaLoadsScannerTest, sentinel_ms_renders_null) {
+    SchemaLoadsScanner scanner;
+    init_scanner(scanner, "UTC");
+
+    TLoadInfo info = make_min_load_info(1);
+    info.__set_create_time_ms(0);
+    info.__set_load_start_time_ms(-1);
+    scanner._result.loads = {info};
+    scanner._cur_idx = 0;
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+
+    EXPECT_TRUE(is_null_at(chunk, CREATE_TIME));
+    EXPECT_TRUE(is_null_at(chunk, LOAD_START_TIME));
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.starrocks.catalog.system.information;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
@@ -204,24 +205,32 @@ public class LoadsSystemTable {
         if (value == null || value < 0) {
             return true;
         }
-        if (lowerBound != null && value < lowerBound) {
+        // Truncate the full-ms job timestamp to second so this prefilter
+        // matches BE's second-precision materialized column. Otherwise a job
+        // at e.g. ...:08.789 with a `<= ...:08` upper bound is dropped here
+        // but kept by BE's post-filter on the rendered column. To enable ms
+        // support, drop the truncation (the wire carries full ms).
+        long secondAlignedValue = (value / 1000) * 1000;
+        if (lowerBound != null && secondAlignedValue < lowerBound) {
             return false;
         }
-        return upperBound == null || value <= upperBound;
+        return upperBound == null || secondAlignedValue <= upperBound;
     }
 
-    private static class LoadRequestFilter {
-        private Long dbId;
-        private String tableName;
-        private String user;
-        private String state;
-        private Long loadStartTimeFrom;
-        private Long loadStartTimeTo;
-        private Long loadFinishTimeFrom;
-        private Long loadFinishTimeTo;
-        private Long createTimeFrom;
-        private Long createTimeTo;
+    @VisibleForTesting
+    static class LoadRequestFilter {
+        Long dbId;
+        String tableName;
+        String user;
+        String state;
+        Long loadStartTimeFrom;
+        Long loadStartTimeTo;
+        Long loadFinishTimeFrom;
+        Long loadFinishTimeTo;
+        Long createTimeFrom;
+        Long createTimeTo;
 
+        @VisibleForTesting
         static LoadRequestFilter from(TGetLoadsParams request) {
             LoadRequestFilter filter = new LoadRequestFilter();
 
@@ -240,21 +249,43 @@ public class LoadsSystemTable {
             if (request.isSetState()) {
                 filter.state = request.getState();
             }
-            filter.loadStartTimeFrom = parseTime(request.isSetLoad_start_time_from() ? request.getLoad_start_time_from() : null);
-            filter.loadStartTimeTo = parseTime(request.isSetLoad_start_time_to() ? request.getLoad_start_time_to() : null);
-            filter.loadFinishTimeFrom =
-                    parseTime(request.isSetLoad_finish_time_from() ? request.getLoad_finish_time_from() : null);
-            filter.loadFinishTimeTo = parseTime(request.isSetLoad_finish_time_to() ? request.getLoad_finish_time_to() : null);
-            filter.createTimeFrom = parseTime(request.isSetCreate_time_from() ? request.getCreate_time_from() : null);
-            filter.createTimeTo = parseTime(request.isSetCreate_time_to() ? request.getCreate_time_to() : null);
+
+            // Prefer the new UTC epoch-ms fields when the BE sets them - those are
+            // already comparable to LoadJob.finishTimestamp (System.currentTimeMillis).
+            // Fall back to parsing the legacy wall-clock string fields only when an
+            // older BE hasn't been upgraded yet; that path keeps the historical
+            // (buggy on non-Asia/Shanghai sessions) semantics rather than introducing
+            // a third interpretation.
+            filter.loadStartTimeFrom = pickTime(
+                    request.isSetLoad_start_time_from_ms() ? request.getLoad_start_time_from_ms() : null,
+                    request.isSetLoad_start_time_from() ? request.getLoad_start_time_from() : null);
+            filter.loadStartTimeTo = pickTime(
+                    request.isSetLoad_start_time_to_ms() ? request.getLoad_start_time_to_ms() : null,
+                    request.isSetLoad_start_time_to() ? request.getLoad_start_time_to() : null);
+            filter.loadFinishTimeFrom = pickTime(
+                    request.isSetLoad_finish_time_from_ms() ? request.getLoad_finish_time_from_ms() : null,
+                    request.isSetLoad_finish_time_from() ? request.getLoad_finish_time_from() : null);
+            filter.loadFinishTimeTo = pickTime(
+                    request.isSetLoad_finish_time_to_ms() ? request.getLoad_finish_time_to_ms() : null,
+                    request.isSetLoad_finish_time_to() ? request.getLoad_finish_time_to() : null);
+            filter.createTimeFrom = pickTime(
+                    request.isSetCreate_time_from_ms() ? request.getCreate_time_from_ms() : null,
+                    request.isSetCreate_time_from() ? request.getCreate_time_from() : null);
+            filter.createTimeTo = pickTime(
+                    request.isSetCreate_time_to_ms() ? request.getCreate_time_to_ms() : null,
+                    request.isSetCreate_time_to() ? request.getCreate_time_to() : null);
             return filter;
         }
 
-        private static Long parseTime(String value) {
-            if (value == null) {
+        @VisibleForTesting
+        static Long pickTime(Long msField, String legacyStringField) {
+            if (msField != null) {
+                return msField;
+            }
+            if (legacyStringField == null) {
                 return null;
             }
-            long ts = TimeUtils.timeStringToLong(value);
+            long ts = TimeUtils.timeStringToLong(legacyStringField);
             return ts >= 0 ? ts : null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
@@ -925,6 +925,24 @@ public class MergeCommitTask extends AbstractStreamLoadTask implements Runnable 
             info.setLoad_start_time(TimeUtils.longToTimeString(loadTimeTrace.startTimeMs.get()));
             info.setLoad_commit_time(TimeUtils.longToTimeString(loadTimeTrace.commitTimeMs.get()));
             info.setLoad_finish_time(TimeUtils.longToTimeString(endTimeMs()));
+            // New BE prefers these UTC epoch-ms fields (rendered in the session zone),
+            // so the displayed column value and any predicate literal evaluated in the
+            // same session agree on the wall-clock representation.
+            long startMs = loadTimeTrace.startTimeMs.get();
+            long commitMs = loadTimeTrace.commitTimeMs.get();
+            long finishMs = endTimeMs();
+            if (loadTimeTrace.createTimeMs > 0) {
+                info.setCreate_time_ms(loadTimeTrace.createTimeMs);
+            }
+            if (startMs > 0) {
+                info.setLoad_start_time_ms(startMs);
+            }
+            if (commitMs > 0) {
+                info.setLoad_commit_time_ms(commitMs);
+            }
+            if (finishMs > 0) {
+                info.setLoad_finish_time_ms(finishMs);
+            }
 
             info.setWarehouse(warehouseName);
             info.setRuntime_details(getRuntimeDetails());

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -1083,9 +1083,13 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback
                 info.setError_msg("type:" + failMsg.getCancelType() + "; msg:" + failMsg.getMsg());
             }
 
-            // create time
+            // create time. Set both the legacy wall-clock string and the new
+            // UTC epoch ms. New BE materializes the DATETIME column from the
+            // ms field (via from_unixtime() in the session zone), bypassing
+            // the from_date_str() round-trip that loses timezone information.
             if (createTimestamp != -1) {
                 info.setCreate_time(TimeUtils.longToTimeString(createTimestamp));
+                info.setCreate_time_ms(createTimestamp);
             }
             // etl start time
             if (getEtlStartTimestamp() != -1) {
@@ -1096,13 +1100,16 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback
                 info.setEtl_finish_time(TimeUtils.longToTimeString(loadStartTimestamp));
                 // load start time
                 info.setLoad_start_time(TimeUtils.longToTimeString(loadStartTimestamp));
+                info.setLoad_start_time_ms(loadStartTimestamp);
             }
             if (loadCommittedTimestamp != -1) {
                 info.setLoad_commit_time(TimeUtils.longToTimeString(loadCommittedTimestamp));
+                info.setLoad_commit_time_ms(loadCommittedTimestamp);
             }
             // load end time
             if (finishTimestamp != -1) {
                 info.setLoad_finish_time(TimeUtils.longToTimeString(finishTimestamp));
+                info.setLoad_finish_time_ms(finishTimestamp);
             }
             // tracking url
             if (!loadingStatus.getTrackingUrl().equals(EtlStatus.DEFAULT_TRACKING_URL)) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1728,6 +1728,21 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
             info.setLoad_start_time(TimeUtils.longToTimeString(startLoadingTimeMs));
             info.setLoad_commit_time(TimeUtils.longToTimeString(commitTimeMs));
             info.setLoad_finish_time(TimeUtils.longToTimeString(endTimeMs));
+            // New BE prefers these UTC epoch-ms fields and converts to the session
+            // zone on materialization, so the rendered column value matches whatever
+            // zone the querying session is in.
+            if (createTimeMs > 0) {
+                info.setCreate_time_ms(createTimeMs);
+            }
+            if (startLoadingTimeMs > 0) {
+                info.setLoad_start_time_ms(startLoadingTimeMs);
+            }
+            if (commitTimeMs > 0) {
+                info.setLoad_commit_time_ms(commitTimeMs);
+            }
+            if (endTimeMs > 0) {
+                info.setLoad_finish_time_ms(endTimeMs);
+            }
 
             info.setType(getStringByType());
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/LoadsSystemTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/LoadsSystemTableTest.java
@@ -1,0 +1,487 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.system.information;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.load.loadv2.LoadJob;
+import com.starrocks.load.loadv2.LoadMgr;
+import com.starrocks.load.streamload.AbstractStreamLoadTask;
+import com.starrocks.load.streamload.StreamLoadMgr;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TGetLoadsParams;
+import com.starrocks.thrift.TGetLoadsResult;
+import com.starrocks.thrift.TLoadInfo;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the predicate-pushdown filter parsing in
+ * {@link LoadsSystemTable.LoadRequestFilter}.
+ *
+ * <p>Historical bug: BE pushed a session-zone wall-clock string (e.g.
+ * "2026-05-15 02:45:08") into TGetLoadsParams; FE parsed it via the
+ * hardcoded UTC+8 zone in TimeUtils, silently shifting the filter bound on
+ * any non-Asia/Shanghai session.
+ *
+ * <p>Current contract: BE attaches the UTC epoch ms alongside the legacy
+ * string field. FE reads the ms field first; only falls back to the string
+ * when the ms field is absent (old BE during a rolling upgrade). The legacy
+ * string path preserves the pre-fix behavior so we don't introduce a third
+ * incompatible interpretation mid-flight.
+ */
+public class LoadsSystemTableTest {
+
+    private static long epochMillis(String wallClock, ZoneId zone) {
+        return LocalDateTime.parse(wallClock.replace(' ', 'T'))
+                .atZone(zone)
+                .toInstant()
+                .toEpochMilli();
+    }
+
+    // ---------------------------------------------------------------------
+    // pickTime: ms-field-preferred / legacy-string fallback
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testPickTime() {
+        long edtMs = epochMillis("2026-05-15 02:45:08", ZoneId.of("America/New_York"));
+
+        // ms field set: wins over string. The string field's UTC+8 interpretation
+        // is precisely the bug we're avoiding.
+        Long picked = LoadsSystemTable.LoadRequestFilter.pickTime(edtMs, "2026-05-15 02:45:08");
+        assertNotNull(picked);
+        assertEquals(edtMs, picked.longValue());
+
+        // No ms: fall back to legacy UTC+8 parse. Pin that behavior so a future
+        // TimeUtils refactor doesn't silently change the rolling-upgrade fallback.
+        picked = LoadsSystemTable.LoadRequestFilter.pickTime(null, "2026-05-15 02:45:08");
+        assertNotNull(picked);
+        assertEquals(TimeUtils.timeStringToLong("2026-05-15 02:45:08"), picked.longValue());
+
+        // Neither set: null (no bound).
+        assertNull(LoadsSystemTable.LoadRequestFilter.pickTime(null, null));
+
+        // Unparseable legacy string must yield "no bound" rather than -1 leaking
+        // into matchTimeRange and being mis-treated as an upper bound.
+        assertNull(LoadsSystemTable.LoadRequestFilter.pickTime(null, "not-a-datetime"));
+    }
+
+    // ---------------------------------------------------------------------
+    // LoadRequestFilter.from(TGetLoadsParams): primary epoch-ms path
+    // ---------------------------------------------------------------------
+
+    /**
+     * All six bounds flow through the same pickTime path - pin them all so a
+     * future refactor can't quietly drop one and reintroduce the bug for that
+     * specific field.
+     */
+    @Test
+    public void testFrom_allSixBoundsFromMs() {
+        TGetLoadsParams req = new TGetLoadsParams();
+        req.setLoad_start_time_from_ms(1_000L);
+        req.setLoad_start_time_to_ms(2_000L);
+        req.setLoad_finish_time_from_ms(3_000L);
+        req.setLoad_finish_time_to_ms(4_000L);
+        req.setCreate_time_from_ms(5_000L);
+        req.setCreate_time_to_ms(6_000L);
+
+        LoadsSystemTable.LoadRequestFilter filter = LoadsSystemTable.LoadRequestFilter.from(req);
+
+        assertEquals(1_000L, filter.loadStartTimeFrom.longValue());
+        assertEquals(2_000L, filter.loadStartTimeTo.longValue());
+        assertEquals(3_000L, filter.loadFinishTimeFrom.longValue());
+        assertEquals(4_000L, filter.loadFinishTimeTo.longValue());
+        assertEquals(5_000L, filter.createTimeFrom.longValue());
+        assertEquals(6_000L, filter.createTimeTo.longValue());
+    }
+
+    /**
+     * Old BE (no ms field set, only legacy string). FE must fall back to the
+     * legacy UTC+8 parse - matching the historical behavior exactly, so a
+     * mixed-version cluster doesn't see a third interpretation of the same
+     * wall-clock literal.
+     */
+    @Test
+    public void testFrom_legacyStringFallback() {
+        TGetLoadsParams req = new TGetLoadsParams();
+        req.setLoad_finish_time_to("2026-05-15 02:45:08");
+        // intentionally no setLoad_finish_time_to_ms(...)
+
+        LoadsSystemTable.LoadRequestFilter filter = LoadsSystemTable.LoadRequestFilter.from(req);
+
+        long expectedLegacy = TimeUtils.timeStringToLong("2026-05-15 02:45:08");
+        long sameStringAsEdt = epochMillis("2026-05-15 02:45:08", ZoneId.of("America/New_York"));
+
+        assertNotNull(filter.loadFinishTimeTo);
+        assertEquals(expectedLegacy, filter.loadFinishTimeTo.longValue());
+        // And it differs from the (correct) EDT interpretation by exactly 12 h -
+        // proof that the legacy path remains UTC+8 and is precisely what an old
+        // BE would have meant. New BEs that care about correctness must send ms.
+        assertEquals(12L * 3600 * 1000, sameStringAsEdt - filter.loadFinishTimeTo);
+    }
+
+    /**
+     * Mixed signals: ms field present takes priority even if the legacy string
+     * would have produced a different number. Otherwise a partially-upgraded
+     * BE could pin a stale, wrong value through the string field.
+     */
+    @Test
+    public void testFrom_msTakesPrecedenceOverString() {
+        long edtMs = epochMillis("2026-05-15 02:45:08", ZoneId.of("America/New_York"));
+
+        TGetLoadsParams req = new TGetLoadsParams();
+        req.setLoad_finish_time_to_ms(edtMs);
+        req.setLoad_finish_time_to("1999-01-01 00:00:00"); // deliberately stale
+
+        LoadsSystemTable.LoadRequestFilter filter = LoadsSystemTable.LoadRequestFilter.from(req);
+
+        assertEquals(edtMs, filter.loadFinishTimeTo.longValue());
+    }
+
+    @Test
+    public void testFrom_emptyRequestLeavesAllBoundsNull() {
+        LoadsSystemTable.LoadRequestFilter filter = LoadsSystemTable.LoadRequestFilter.from(new TGetLoadsParams());
+        assertNull(filter.loadStartTimeFrom);
+        assertNull(filter.loadStartTimeTo);
+        assertNull(filter.loadFinishTimeFrom);
+        assertNull(filter.loadFinishTimeTo);
+        assertNull(filter.createTimeFrom);
+        assertNull(filter.createTimeTo);
+    }
+
+    // =====================================================================
+    // Black-box tests on LoadsSystemTable.query(...).
+    // ---------------------------------------------------------------------
+    // Mock LoadMgr / StreamLoadMgr so that we can pin job finish times
+    // deterministically, then check that the request's _ms field decides
+    // which jobs survive the filter and that toThrift() output flows through
+    // to the result.
+    // =====================================================================
+
+    private static TLoadInfo loadInfoWithLabel(String label) {
+        TLoadInfo info = new TLoadInfo();
+        info.setLabel(label);
+        return info;
+    }
+
+    private static List<String> labels(TGetLoadsResult result) {
+        return result.getLoads().stream().map(TLoadInfo::getLabel).collect(Collectors.toList());
+    }
+
+    /**
+     * Three load jobs + two stream load tasks. Finish-times are anchored to
+     * an arbitrary {@code anchorMs} so the tests below can pick a bound
+     * relative to it and produce a deterministic answer:
+     *   loadJobBefore:      anchorMs - 15 min
+     *   loadJobAfter:       anchorMs +  5 min
+     *   loadJobUnfinished:  -1     (matchTimeRange short-circuits true)
+     *   streamTaskBefore:   anchorMs - 30 min
+     *   streamTaskAfter:    anchorMs + 10 min
+     */
+    private static long wireMocks(GlobalStateMgr globalStateMgr,
+                                  LoadMgr loadMgr,
+                                  StreamLoadMgr streamLoadMgr,
+                                  LoadJob loadJobBefore,
+                                  LoadJob loadJobAfter,
+                                  LoadJob loadJobUnfinished,
+                                  AbstractStreamLoadTask streamTaskBefore,
+                                  AbstractStreamLoadTask streamTaskAfter) {
+        // Anchor is "now-ish" so finish times are real ms values that exercise
+        // matchTimeRange's positive-value branch (not the value<0 shortcut).
+        long anchorMs = epochMillis("2026-05-15 02:45:08", ZoneId.of("America/New_York"));
+        long jobBeforeMs = anchorMs - 15L * 60 * 1000;
+        long jobAfterMs = anchorMs + 5L * 60 * 1000;
+        long streamBeforeMs = anchorMs - 30L * 60 * 1000;
+        long streamAfterMs = anchorMs + 10L * 60 * 1000;
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getLoadMgr();
+                minTimes = 0;
+                result = loadMgr;
+
+                globalStateMgr.getStreamLoadMgr();
+                minTimes = 0;
+                result = streamLoadMgr;
+
+                loadMgr.getLoadJobs(null);
+                minTimes = 0;
+                result = Lists.newArrayList(loadJobBefore, loadJobAfter, loadJobUnfinished);
+
+                streamLoadMgr.getTaskByName(null);
+                minTimes = 0;
+                result = Lists.newArrayList(streamTaskBefore, streamTaskAfter);
+
+                loadJobBefore.getDbId();
+                minTimes = 0;
+                result = -1L;
+                loadJobBefore.getLoadFinishTimeMs();
+                minTimes = 0;
+                result = jobBeforeMs;
+                loadJobBefore.getLoadStartTimeMs();
+                minTimes = 0;
+                result = null;
+                loadJobBefore.getCreateTimeMs();
+                minTimes = 0;
+                result = null;
+                loadJobBefore.toThrift();
+                minTimes = 0;
+                result = loadInfoWithLabel("loadJobBefore");
+
+                loadJobAfter.getDbId();
+                minTimes = 0;
+                result = -1L;
+                loadJobAfter.getLoadFinishTimeMs();
+                minTimes = 0;
+                result = jobAfterMs;
+                loadJobAfter.getLoadStartTimeMs();
+                minTimes = 0;
+                result = null;
+                loadJobAfter.getCreateTimeMs();
+                minTimes = 0;
+                result = null;
+                loadJobAfter.toThrift();
+                minTimes = 0;
+                result = loadInfoWithLabel("loadJobAfter");
+
+                loadJobUnfinished.getDbId();
+                minTimes = 0;
+                result = -1L;
+                loadJobUnfinished.getLoadFinishTimeMs();
+                minTimes = 0;
+                result = -1L;
+                loadJobUnfinished.getLoadStartTimeMs();
+                minTimes = 0;
+                result = null;
+                loadJobUnfinished.getCreateTimeMs();
+                minTimes = 0;
+                result = null;
+                loadJobUnfinished.toThrift();
+                minTimes = 0;
+                result = loadInfoWithLabel("loadJobUnfinished");
+
+                streamTaskBefore.getDbId();
+                minTimes = 0;
+                result = -1L;
+                streamTaskBefore.getLoadFinishTimeMs();
+                minTimes = 0;
+                result = streamBeforeMs;
+                streamTaskBefore.getLoadStartTimeMs();
+                minTimes = 0;
+                result = null;
+                streamTaskBefore.getCreateTimeMs();
+                minTimes = 0;
+                result = null;
+                streamTaskBefore.toThrift();
+                minTimes = 0;
+                result = Lists.newArrayList(loadInfoWithLabel("streamTaskBefore"));
+
+                streamTaskAfter.getDbId();
+                minTimes = 0;
+                result = -1L;
+                streamTaskAfter.getLoadFinishTimeMs();
+                minTimes = 0;
+                result = streamAfterMs;
+                streamTaskAfter.getLoadStartTimeMs();
+                minTimes = 0;
+                result = null;
+                streamTaskAfter.getCreateTimeMs();
+                minTimes = 0;
+                result = null;
+                streamTaskAfter.toThrift();
+                minTimes = 0;
+                result = Lists.newArrayList(loadInfoWithLabel("streamTaskAfter"));
+            }
+        };
+        return anchorMs;
+    }
+
+    /** With no time predicate, every mocked job/task flows through. */
+    @Test
+    public void testQuery_noFilterReturnsEverything(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked LoadMgr loadMgr,
+            @Mocked StreamLoadMgr streamLoadMgr,
+            @Mocked LoadJob loadJobBefore,
+            @Mocked LoadJob loadJobAfter,
+            @Mocked LoadJob loadJobUnfinished,
+            @Mocked AbstractStreamLoadTask streamTaskBefore,
+            @Mocked AbstractStreamLoadTask streamTaskAfter) {
+        wireMocks(globalStateMgr, loadMgr, streamLoadMgr,
+                loadJobBefore, loadJobAfter, loadJobUnfinished,
+                streamTaskBefore, streamTaskAfter);
+
+        TGetLoadsResult result = LoadsSystemTable.query(new TGetLoadsParams());
+
+        assertEquals(5, result.getLoads().size());
+        List<String> got = labels(result);
+        assertTrue(got.contains("loadJobBefore"));
+        assertTrue(got.contains("loadJobAfter"));
+        assertTrue(got.contains("loadJobUnfinished"));
+        assertTrue(got.contains("streamTaskBefore"));
+        assertTrue(got.contains("streamTaskAfter"));
+    }
+
+    /**
+     * Request carries the bound as UTC epoch ms (the new contract).
+     * Only Before-jobs and the unfinished load job survive.
+     */
+    @Test
+    public void testQuery_filtersByFinishTimeToMs(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked LoadMgr loadMgr,
+            @Mocked StreamLoadMgr streamLoadMgr,
+            @Mocked LoadJob loadJobBefore,
+            @Mocked LoadJob loadJobAfter,
+            @Mocked LoadJob loadJobUnfinished,
+            @Mocked AbstractStreamLoadTask streamTaskBefore,
+            @Mocked AbstractStreamLoadTask streamTaskAfter) {
+        long anchorMs = wireMocks(globalStateMgr, loadMgr, streamLoadMgr,
+                loadJobBefore, loadJobAfter, loadJobUnfinished,
+                streamTaskBefore, streamTaskAfter);
+
+        TGetLoadsParams req = new TGetLoadsParams();
+        req.setLoad_finish_time_to_ms(anchorMs);
+
+        TGetLoadsResult result = LoadsSystemTable.query(req);
+
+        List<String> got = labels(result);
+        assertEquals(3, got.size(),
+                "Before-jobs and the unfinished load job must clear an at-anchor bound");
+        assertTrue(got.contains("loadJobBefore"));
+        assertTrue(got.contains("loadJobUnfinished"));
+        assertTrue(got.contains("streamTaskBefore"));
+        assertTrue(!got.contains("loadJobAfter"));
+        assertTrue(!got.contains("streamTaskAfter"));
+    }
+
+    /**
+     * Pre-fix scenario, expressed end-to-end: an old BE (no _ms field) sends
+     * the wall-clock literal "2026-05-15 02:45:08" with the session in EDT.
+     * FE falls back to UTC+8 parse for the bound (~12 h earlier in absolute
+     * time than EDT) and as a result drops every finished job - only the
+     * unfinished load job survives. The new BE path (testQuery_filtersByFinishTimeToMs)
+     * does not have this property; this test pins the legacy fallback as the
+     * deterministic-but-buggy behavior we deliberately preserve during
+     * rolling upgrade.
+     */
+    @Test
+    public void testQuery_legacyStringPathPreservesOldSemantics(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked LoadMgr loadMgr,
+            @Mocked StreamLoadMgr streamLoadMgr,
+            @Mocked LoadJob loadJobBefore,
+            @Mocked LoadJob loadJobAfter,
+            @Mocked LoadJob loadJobUnfinished,
+            @Mocked AbstractStreamLoadTask streamTaskBefore,
+            @Mocked AbstractStreamLoadTask streamTaskAfter) {
+        wireMocks(globalStateMgr, loadMgr, streamLoadMgr,
+                loadJobBefore, loadJobAfter, loadJobUnfinished,
+                streamTaskBefore, streamTaskAfter);
+
+        TGetLoadsParams req = new TGetLoadsParams();
+        // Only legacy string set; the EDT-session user typed this wall-clock.
+        req.setLoad_finish_time_to("2026-05-15 02:45:08");
+
+        TGetLoadsResult result = LoadsSystemTable.query(req);
+
+        List<String> got = labels(result);
+        // FE parses the literal as UTC+8 = absolute time ~12 h before the EDT
+        // jobs finished -> every finished job is excluded; only the unfinished
+        // load job has a value<0 finish ms and short-circuits to "match".
+        assertEquals(1, got.size());
+        assertTrue(got.contains("loadJobUnfinished"));
+    }
+
+    /**
+     * Phase-5 second-precision contract: the BE pushdown literal is second-
+     * aligned (see SchemaLoadsScanner::literal_to_epoch_ms) and BE materializes
+     * the column at second precision, so FE must compare its full-ms job
+     * timestamp at second precision too. A job finishing at the literal second
+     * with a non-zero ms remainder must pass an at-anchor `<=` upper bound,
+     * matching what BE's post-filter on the materialized column would do.
+     */
+    @Test
+    public void testQuery_secondPrecisionContractFiltersJobMsRemainder(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked LoadMgr loadMgr,
+            @Mocked StreamLoadMgr streamLoadMgr,
+            @Mocked LoadJob jobAtBoundary) {
+        long anchorMs = epochMillis("2026-05-15 02:45:08", ZoneId.of("America/New_York"));
+        long jobMsWithRemainder = anchorMs + 789; // same rendered second as the bound
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+                globalStateMgr.getLoadMgr();
+                minTimes = 0;
+                result = loadMgr;
+                globalStateMgr.getStreamLoadMgr();
+                minTimes = 0;
+                result = streamLoadMgr;
+                loadMgr.getLoadJobs(null);
+                minTimes = 0;
+                result = Lists.newArrayList(jobAtBoundary);
+                streamLoadMgr.getTaskByName(null);
+                minTimes = 0;
+                result = Lists.newArrayList();
+                jobAtBoundary.getDbId();
+                minTimes = 0;
+                result = -1L;
+                jobAtBoundary.getLoadFinishTimeMs();
+                minTimes = 0;
+                result = jobMsWithRemainder;
+                jobAtBoundary.getLoadStartTimeMs();
+                minTimes = 0;
+                result = null;
+                jobAtBoundary.getCreateTimeMs();
+                minTimes = 0;
+                result = null;
+                jobAtBoundary.toThrift();
+                minTimes = 0;
+                result = loadInfoWithLabel("jobAtBoundary");
+            }
+        };
+
+        TGetLoadsParams req = new TGetLoadsParams();
+        req.setLoad_finish_time_to_ms(anchorMs); // second-aligned bound
+
+        TGetLoadsResult result = LoadsSystemTable.query(req);
+
+        // Without phase-5 truncation, the raw-ms compare `anchorMs+789 <= anchorMs`
+        // is false and the row is dropped - even though BE's post-filter on the
+        // second-precision materialized column would have kept it.
+        assertEquals(1, labels(result).size());
+        assertTrue(labels(result).contains("jobAtBoundary"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
@@ -898,6 +898,14 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
             assertNull(info.getTracking_sql());
             assertNull(info.getRejected_record_path());
             assertNotNull(info.getCreate_time());
+            // PENDING has the createTimeMs set at construction but no later
+            // timestamps yet. New BE uses these ms fields for materialization
+            // so any drop in setters would silently regress non-Asia/Shanghai
+            // sessions to the legacy UTC+8 string.
+            assertTrue(info.getCreate_time_ms() > 0);
+            assertFalse(info.isSetLoad_start_time_ms());
+            assertFalse(info.isSetLoad_commit_time_ms());
+            assertFalse(info.isSetLoad_finish_time_ms());
         } else if (taskState == MergeCommitTask.TaskState.FINISHED) {
             assertTrue(info.getTxn_id() > 0);
             assertTrue(task.endTimeMs() > 0);
@@ -907,6 +915,10 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
             assertFalse(info.getLoad_commit_time().isEmpty());
             assertNotNull(info.getLoad_finish_time());
             assertFalse(info.getLoad_finish_time().isEmpty());
+            assertTrue(info.getCreate_time_ms() > 0);
+            assertTrue(info.getLoad_start_time_ms() > 0);
+            assertTrue(info.getLoad_commit_time_ms() > 0);
+            assertTrue(info.getLoad_finish_time_ms() > 0);
             assertTrue(info.getNum_scan_rows() > 0);
             assertTrue(info.getNum_scan_bytes() > 0);
             assertTrue(info.getNum_sink_rows() > 0);
@@ -922,6 +934,8 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
             assertTrue(info.getTxn_id() > 0);
             assertTrue(task.endTimeMs() > 0);
             assertNotNull(info.getLoad_finish_time());
+            assertTrue(info.getCreate_time_ms() > 0);
+            assertTrue(info.getLoad_finish_time_ms() > 0);
             assertNotNull(info.getError_msg());
             assertFalse(info.getError_msg().isEmpty());
             
@@ -942,6 +956,8 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
             assertEquals(-1, info.getTxn_id());
             assertTrue(task.endTimeMs() > 0);
             assertNotNull(info.getLoad_finish_time());
+            assertTrue(info.getCreate_time_ms() > 0);
+            assertTrue(info.getLoad_finish_time_ms() > 0);
             assertNotNull(info.getError_msg());
             assertEquals("test cancellation", info.getError_msg());
             assertEquals(0, info.getNum_scan_rows());

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
@@ -492,6 +492,61 @@ public class LoadJobTest {
     }
 
     @Test
+    public void testToThrift_timestampMsFields() {
+        // Regression coverage: BE materializes information_schema.loads DATETIME
+        // columns from the *_ms fields. If a future change ever drops a setter,
+        // the column silently falls back to the legacy UTC+8 string and loads in
+        // non-Asia/Shanghai sessions go missing again.
+        long createMs = 1_700_000_000_000L;
+        long startMs = createMs + 1_000;
+        long commitMs = createMs + 2_000;
+        long finishMs = createMs + 3_000;
+
+        LoadJob loadJob = new BrokerLoadJob();
+        Deencapsulation.setField(loadJob, "createTimestamp", createMs);
+        Deencapsulation.setField(loadJob, "loadStartTimestamp", startMs);
+        Deencapsulation.setField(loadJob, "loadCommittedTimestamp", commitMs);
+        Deencapsulation.setField(loadJob, "finishTimestamp", finishMs);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getWarehouseMgr();
+                minTimes = 0;
+                result = warehouseManager;
+
+                warehouseManager.getWarehouseAllowNull(anyLong);
+                minTimes = 0;
+                result = null;
+            }
+        };
+
+        TLoadInfo info = loadJob.toThrift();
+        Assertions.assertEquals(createMs, info.getCreate_time_ms());
+        Assertions.assertEquals(startMs, info.getLoad_start_time_ms());
+        Assertions.assertEquals(commitMs, info.getLoad_commit_time_ms());
+        Assertions.assertEquals(finishMs, info.getLoad_finish_time_ms());
+        // Legacy strings must still be set so old BEs in a rolling upgrade keep working.
+        Assertions.assertEquals(TimeUtils.longToTimeString(createMs), info.getCreate_time());
+        Assertions.assertEquals(TimeUtils.longToTimeString(startMs), info.getLoad_start_time());
+        Assertions.assertEquals(TimeUtils.longToTimeString(commitMs), info.getLoad_commit_time());
+        Assertions.assertEquals(TimeUtils.longToTimeString(finishMs), info.getLoad_finish_time());
+
+        // Sentinel path: unset timestamps must leave both the string and the ms
+        // field unset so BE can fall back to NULL via its !__isset branch
+        // instead of materializing the epoch.
+        LoadJob unset = new BrokerLoadJob();
+        TLoadInfo unsetInfo = unset.toThrift();
+        Assertions.assertFalse(unsetInfo.isSetCreate_time_ms());
+        Assertions.assertFalse(unsetInfo.isSetLoad_start_time_ms());
+        Assertions.assertFalse(unsetInfo.isSetLoad_commit_time_ms());
+        Assertions.assertFalse(unsetInfo.isSetLoad_finish_time_ms());
+    }
+
+    @Test
     public void testJsonOptionsEnvelope() throws DdlException {
         Map<String, String> properties = Maps.newHashMap();
         properties.put(LoadStmt.ENVELOPE, LoadStmt.ENVELOPE_DEBEZIUM);

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadTaskTest.java
@@ -196,6 +196,42 @@ public class StreamLoadTaskTest {
     }
 
     @Test
+    public void testToThrift_timestampMsFields() {
+        // Regression coverage for the BE materialization path: if a future
+        // change drops one of the *_ms setters, BE silently falls back to the
+        // legacy UTC+8 string and stream-load rows go missing in
+        // non-Asia/Shanghai sessions.
+        long createMs = 1_700_000_000_000L;
+        long startMs = createMs + 1_000;
+        long commitMs = createMs + 2_000;
+        long endMs = createMs + 3_000;
+
+        Deencapsulation.setField(streamLoadTask, "createTimeMs", createMs);
+        Deencapsulation.setField(streamLoadTask, "startLoadingTimeMs", startMs);
+        Deencapsulation.setField(streamLoadTask, "commitTimeMs", commitMs);
+        Deencapsulation.setField(streamLoadTask, "endTimeMs", endMs);
+
+        TLoadInfo info = streamLoadTask.toThrift().get(0);
+        Assertions.assertEquals(createMs, info.getCreate_time_ms());
+        Assertions.assertEquals(startMs, info.getLoad_start_time_ms());
+        Assertions.assertEquals(commitMs, info.getLoad_commit_time_ms());
+        Assertions.assertEquals(endMs, info.getLoad_finish_time_ms());
+
+        // Sentinel path: zero/unset timestamps must leave the ms field unset so
+        // BE's !__isset branch can fall back to NULL instead of materializing
+        // epoch values.
+        Deencapsulation.setField(streamLoadTask, "createTimeMs", 0L);
+        Deencapsulation.setField(streamLoadTask, "startLoadingTimeMs", 0L);
+        Deencapsulation.setField(streamLoadTask, "commitTimeMs", 0L);
+        Deencapsulation.setField(streamLoadTask, "endTimeMs", 0L);
+        TLoadInfo unsetInfo = streamLoadTask.toThrift().get(0);
+        Assertions.assertFalse(unsetInfo.isSetCreate_time_ms());
+        Assertions.assertFalse(unsetInfo.isSetLoad_start_time_ms());
+        Assertions.assertFalse(unsetInfo.isSetLoad_commit_time_ms());
+        Assertions.assertFalse(unsetInfo.isSetLoad_finish_time_ms());
+    }
+
+    @Test
     public void testBuildProfile() throws StarRocksException {
         streamLoadTask.setCoordinator(coord);
         streamLoadTask.setIsSyncStreamLoad(true);

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -552,12 +552,25 @@ struct TGetLoadsParams {
     6: optional string table_name
     7: optional string user
     8: optional string state
-    9: optional string load_start_time_from
+    // Legacy wall-clock-string bounds. BE writes them in whatever zone its session
+    // is in (no zone marker on the wire) and FE parses them in TimeUtils.TIME_ZONE
+    // (Asia/Shanghai). They are kept for cross-version compatibility only; new
+    // code should rely on the *_ms fields below, which are unambiguous UTC epoch ms.
+    9:  optional string load_start_time_from
     10: optional string load_start_time_to
     11: optional string load_finish_time_from
     12: optional string load_finish_time_to
     13: optional string create_time_from
     14: optional string create_time_to
+    // UTC epoch milliseconds. Preferred by new FE; set by new BE alongside the
+    // legacy string fields. Lets FE filter without round-tripping through a
+    // wall-clock string in some implicit zone.
+    15: optional i64 load_start_time_from_ms
+    16: optional i64 load_start_time_to_ms
+    17: optional i64 load_finish_time_from_ms
+    18: optional i64 load_finish_time_to_ms
+    19: optional i64 create_time_from_ms
+    20: optional i64 create_time_to_ms
 }
 
 struct TTrackingLoadInfo {
@@ -606,6 +619,14 @@ struct TLoadInfo {
     31: optional string runtime_details
     32: optional string properties
     33: optional i64 num_scan_bytes
+    // UTC epoch milliseconds. Preferred by new BE for materializing the DATETIME
+    // columns of information_schema.loads. When set, BE converts to a DateTimeValue
+    // in the session zone via from_unixtime(); the legacy string fields above are
+    // kept only for old BEs whose code path still relies on from_date_str().
+    34: optional i64 create_time_ms
+    35: optional i64 load_start_time_ms
+    36: optional i64 load_commit_time_ms
+    37: optional i64 load_finish_time_ms
 }
 
 struct TGetLoadsResult {


### PR DESCRIPTION
information_schema.loads silently dropped rows on any cluster whose
session timezone differs from Asia/Shanghai, because the FE-BE thrift
boundary exchanged datetimes as naive wall-clock strings:

- BE pushed pushdown literals (NOW() - INTERVAL 1 MINUTE etc.) as a
  session-zone wall-clock with no zone marker. FE parsed it via
  TimeUtils.timeStringToLong, which is locked to UTC+8, shifting the
  filter bound by (+08:00 - session_offset) hours.
- FE serialized job timestamps via TimeUtils.longToTimeString (also
  UTC+8 on main after the java.time refactor). BE re-evaluated the
  same pushdown predicate after materializing the row, comparing a
  UTC+8 wall-clock column against a session-zone literal, and dropped
  the rows the FE-side filter let through.

Fix: add unambiguous UTC epoch-ms siblings to the existing thrift
string fields and prefer them on both sides.

- TGetLoadsParams: +6 i64 *_ms fields (15-20). BE populates them by
  converting the literal's civil_second through the session time_zone
  via cctz::time_zone::lookup + std::min/std::max(pre, post) so DST
  fall-back / spring-forward ambiguities widen the FE prefilter
  rather than narrow it. The TimestampValue::to_unixtime(zone)
  overload is unusable here on two counts: it returns ms (not
  seconds), and TimezoneUtils::to_utc_offset resolves the offset at
  the Unix epoch, so DST-active zones (e.g. America/New_York in May)
  silently get the standard-time offset.
- TLoadInfo: +4 i64 *_ms fields (34-37). FE populates them with
  System.currentTimeMillis() values directly.
- schema_loads_scanner.cpp: fill_chunk materializes DATETIME columns
  via from_unixtime(ms/1000, session_tz) when *_ms is set, so the
  rendered column is in the session zone and matches the literal.
  information_schema.loads remains a second-precision view (same as
  pre-fix); sub-second is not supported on either FE filtering or BE
  materialization.
- LoadsSystemTable.LoadRequestFilter.from: prefers *_ms; falls back
  to the legacy UTC+8 string parse for old BEs during rolling
  upgrades (semantics-preserving, not introducing a third
  interpretation).

The legacy string fields are kept for cross-version compatibility:
old code on either side keeps working unchanged; the full fix only
activates when both sides know the new fields.

Note on precision: the new *_ms wire fields carry the full
System.currentTimeMillis() value, but all current consumers (BE
materialization, FE matchTimeRange) truncate to second precision so
the user-visible behavior of information_schema.loads matches the
pre-fix view. A follow-up PR will flip the truncation sites to
enable ms precision; that change is a ~5-line consumer-side flip
with no wire-format or data migration, will be backported to 4.1
only (not 4.0), and is documented inline at each flip site for
discoverability. LoadsHistorySyncer is unaffected by either today's
behavior or the future ms flip: its loads_history.load_finish_time
is plain DATETIME (second-precision at INSERT) so its watermark
caps at second regardless of upstream precision.

## Why I'm doing:

Introduced in #69472

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4


