### PR TITLE
[Enhancement] Cost-penalize local streaming agg when group bys do not match actual distribution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -353,8 +353,10 @@ public class CostModel {
             }
 
             // With mismatched distribution, each node sees all distinct groups.
-            final int numBackends = Math.max(1, ConnectContext.get().getAliveBackendNumber());
-            final double outputRows = Math.min(estimatedOutputRows * numBackends, inputRows);
+            // Include compute nodes for shared-data deployments, consistent with HashJoinCostModel.
+            final int numWorkers = Math.max(1, ConnectContext.get().getAliveBackendNumber()
+                    + GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAliveComputeNodeNumber());
+            final double outputRows = Math.min(estimatedOutputRows * numWorkers, inputRows);
             final double toShuffleRows = Math.max(0, outputRows - estimatedOutputRows);
 
             return toShuffleRows * statistics.getAvgRowSize();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.optimizer.GroupExpression;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.DistributionCol;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
@@ -284,8 +285,79 @@ public class CostModel {
                 factor = 0.1;
             }
 
-            return CostEstimate.of(inputStatistics.getComputeSize() * factor, statistics.getComputeSize() * factor,
-                    0);
+            double networkCost = computeLocalAggDistributionMismatchPenalty(node, statistics, inputStatistics);
+            return CostEstimate.of(inputStatistics.getComputeSize() * factor,
+                    statistics.getComputeSize() * factor, networkCost);
+        }
+
+        /**
+         * For a local agg, if the child's distribution does not cover the
+         * group-by columns, the aggregation cannot effectively reduce rows and each node essentially sees all distinct
+         * groups. This method models the respective network cost.
+         * We have to add the network cost to the agg since statistics are derived once
+         * before child distribution properties are known.
+         * The downstream exchange reads those pre-computed stats. During Phase-2 re-costing the agg is the first
+         * operator that sees the actual child distribution, so it is the only place that can correct for
+         * the mismatch. The network cost term here acts as a proxy for the exchange cost that would
+         * exist if the exchange could see the true, un-reduced row count.
+         */
+        private double computeLocalAggDistributionMismatchPenalty(PhysicalHashAggregateOperator node, Statistics statistics,
+                                                                  Statistics inputStatistics) {
+            // Only applies to LOCAL split aggs with group-by columns
+            if (!node.isSplit() || !node.getType().isLocal() || node.getGroupBys().isEmpty()) {
+                return 0;
+            }
+
+            // Need physical distribution to assess this penalty.
+            if (CollectionUtils.isEmpty(inputProperties)) {
+                return 0;
+            }
+
+            double inputRows = inputStatistics.getOutputRowCount();
+            double estimatedOutputRows = statistics.getOutputRowCount();
+
+            // Only penalize if the agg estimates significant reduction that won't actually happen
+            // due to the induced network costs.
+            if (estimatedOutputRows >= inputRows * 0.5) {
+                return 0;
+            }
+
+            final var childDistribution = inputProperties.get(0).getDistributionProperty();
+
+            if (childDistribution.isGather()) {
+                // For gather, there is no penalty since there is no exchange.
+                return 0;
+            }
+
+            // If the child is hash-distributed on columns that cover the group-by columns there is no network penalty.
+            // For any other distribution (shuffle on wrong columns, random, round-robin, gather, etc.),
+            // each node may see all distinct groups, so the local agg can not reduce rows effectively.
+            // We use EquivalentDescriptor.isConnected() rather than raw column ID comparison to account for
+            // equivalences established by joins (e.g., after A.a = B.b, distribution on A.a covers GROUP BY B.b).
+            if (childDistribution.isShuffle()) {
+                final var childHashSpec = (HashDistributionSpec) childDistribution.getSpec();
+                final var distributionColumns = childHashSpec.getHashDistributionDesc().getDistributionCols();
+                final var equivDesc = childHashSpec.getEquivDesc();
+
+                final var groupByDistCols = node.getGroupBys().stream() //
+                        .map(col -> new DistributionCol(col.getId(), false)) //
+                        .toList();
+
+                final boolean distributionCoversGroupBy = distributionColumns.stream() //
+                        .allMatch(dc -> groupByDistCols.stream()
+                                .anyMatch(groupByCol -> equivDesc.isConnected(groupByCol, dc)));
+
+                if (distributionCoversGroupBy) {
+                    return 0;
+                }
+            }
+
+            // With mismatched distribution, each node sees all distinct groups.
+            final int numBackends = Math.max(1, ConnectContext.get().getAliveBackendNumber());
+            final double outputRows = Math.min(estimatedOutputRows * numBackends, inputRows);
+            final double toShuffleRows = Math.max(0, outputRows - estimatedOutputRows);
+
+            return toShuffleRows * statistics.getAvgRowSize();
         }
 
         private List<ColumnRefOperator> getGroupBysWithoutDistinctColumn(List<ColumnRefOperator> groupByList,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1721,4 +1721,24 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         Assertions.assertEquals(19930101, keyRange.get(0).end_key);
         Assertions.assertEquals(1, scanNodes.getPartitionConjuncts().size());
     }
+
+    @Test
+    public void testLocalAggDistributionMismatchPenalty() throws Exception {
+        // Force two-phase aggregation so the penalty on LOCAL split aggs is actually exercised.
+        connectContext.getSessionVariable().setNewPlanerAggStage(2);
+
+        // GIVEN
+        final var sql = "select l_partkey, count(*) from lineitem " +
+                "join supplier on l_suppkey = s_suppkey group by l_partkey";
+
+        // WHEN
+        final var plan = getFragmentPlan(sql);
+
+        // THEN
+        // The penalty should steer the optimizer towards a BROADCAST join (preserving lineitem's
+        // distribution) instead of a SHUFFLE join on l_suppkey which would misalign with GROUP BY l_partkey.
+        assertContains(plan, "join op: INNER JOIN (BROADCAST)");
+        // Verify a two-phase (local streaming + global) aggregation is actually used.
+        assertContains(plan, "STREAMING");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
We had a particular case where the optimizer chose a shuffle-join instead of a broadcast join. The shuffle-join destroyed the co-location of group by keys with partitions downstream, leading to a significantly worse query execution performance. Upon debugging, I found that the issue was that the optimizer assumed the local streaming aggregation can reduce the amount of rows (and requires only a small shuffle) since it assumed `global_ndv / # BEs` of output rows per backend. 
When the distribution is misaligned to the group by keys, this is not the case and the aggregation potentially sees all group keys and can barely reduce the amount of rows. As a result, you need to shuffle a lot of data (up to `global_ndv` per BE) afterwards.
This cost is hidden to the optimizer when it chooses the shuffle-join. A broadcast join leads a significantly better plan in this case. (~80s vs ~1s)

## What I'm doing:
I am introducing a network cost penalty for local split aggs when the distribution of data does not match the group by distribution. It adds an approximation of to be shuffled rows as cost. Ideally, the exchange operator downstream would price this correctly (since the agg itself does not really have a network cost), but since we only know the distribution in phase 2 of the optimization and statistics are derived once per group before physical properties (distribution) and are shared across all equivalent expressions in the group, we cannot adjust them per physical alternative. Instead, we model this through the network cost of the agg.

The penalty only fires when the agg estimates significant reduction (output < 50% of input) that won't actually materialize, avoiding false positives for aggs that already expect low reduction.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
