### PR TITLE
[Enhancement] add missing MySQL 8 columns to information_schema

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -87,6 +87,7 @@ set(EXEC_SCHEMA_SCANNER_FILES
     schema_scanner/schema_be_configs_scanner.cpp
     schema_scanner/schema_be_threads_scanner.cpp
     schema_scanner/schema_charsets_scanner.cpp
+    schema_scanner/schema_collation_character_set_applicability_scanner.cpp
     schema_scanner/schema_collations_scanner.cpp
     schema_scanner/schema_dummy_scanner.cpp
     schema_scanner/schema_events_scanner.cpp

--- a/be/src/exec/schema_scanner/schema_collation_character_set_applicability_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_collation_character_set_applicability_scanner.cpp
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_collation_character_set_applicability_scanner.h"
+
+#include "exec/schema_scanner/schema_collations_scanner.h"
+#include "exec/schema_scanner/schema_column_filler.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SchemaCollationCharacterSetApplicabilityScanner::_s_cols[] = {
+        //   name,       type,          size,                     is_null
+        {"COLLATION_NAME", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
+        {"CHARACTER_SET_NAME", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
+};
+
+SchemaCollationCharacterSetApplicabilityScanner::SchemaCollationCharacterSetApplicabilityScanner()
+        : SchemaScanner(_s_cols, sizeof(_s_cols) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaCollationCharacterSetApplicabilityScanner::~SchemaCollationCharacterSetApplicabilityScanner() = default;
+
+Status SchemaCollationCharacterSetApplicabilityScanner::fill_chunk(ChunkPtr* chunk) {
+    // In MySQL this table is a view derived from COLLATIONS: one row per
+    // collation mapping it to its character set. We iterate the same static
+    // collation list that SchemaCollationsScanner exposes, so adding a
+    // collation there automatically reflects here and client joins by
+    // COLLATION_NAME stay consistent.
+    const auto* row = &SchemaCollationsScanner::collations()[_index];
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (const auto& [slot_id, index] : slot_id_to_index_map) {
+        switch (slot_id) {
+        case 1: {
+            // COLLATION_NAME
+            auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(1);
+            Slice value(row->name, strlen(row->name));
+            fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
+            break;
+        }
+        case 2: {
+            // CHARACTER_SET_NAME
+            auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(2);
+            Slice value(row->charset, strlen(row->charset));
+            fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    _index++;
+    return Status::OK();
+}
+
+Status SchemaCollationCharacterSetApplicabilityScanner::get_next(ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (SchemaCollationsScanner::collations()[_index].name == nullptr) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_collation_character_set_applicability_scanner.h
+++ b/be/src/exec/schema_scanner/schema_collation_character_set_applicability_scanner.h
@@ -14,34 +14,15 @@
 
 #pragma once
 
-#include <cstdint>
-
 #include "exec/schema_scanner.h"
 #include "gen_cpp/FrontendService_types.h"
 
 namespace starrocks {
 
-class SchemaCollationsScanner : public SchemaScanner {
+class SchemaCollationCharacterSetApplicabilityScanner : public SchemaScanner {
 public:
-    struct CollationStruct {
-        const char* name;
-        const char* charset;
-        int64_t id;
-        const char* is_default;
-        const char* is_compile;
-        int64_t sortlen;
-        const char* pad_attribute;
-    };
-
-    // The static set of collations advertised by StarRocks, terminated by a
-    // sentinel row whose `name` is nullptr. Other system-table scanners read
-    // this same array so they stay consistent with COLLATIONS (in particular
-    // COLLATION_CHARACTER_SET_APPLICABILITY, which is defined in MySQL as a
-    // view derived from COLLATIONS).
-    static const CollationStruct* collations();
-
-    SchemaCollationsScanner();
-    ~SchemaCollationsScanner() override;
+    SchemaCollationCharacterSetApplicabilityScanner();
+    ~SchemaCollationCharacterSetApplicabilityScanner() override;
 
     Status get_next(ChunkPtr* chunk, bool* eos) override;
 
@@ -49,8 +30,7 @@ private:
     Status fill_chunk(ChunkPtr* chunk);
 
     int _index{0};
-    static SchemaScanner::ColumnDesc _s_cols_columns[];
-    static CollationStruct _s_collations[];
+    static SchemaScanner::ColumnDesc _s_cols[];
 };
 
 } // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_collations_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_collations_scanner.cpp
@@ -27,11 +27,15 @@ SchemaScanner::ColumnDesc SchemaCollationsScanner::_s_cols_columns[] = {
         {"IS_DEFAULT", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"IS_COMPILED", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"SORTLEN", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"PAD_ATTRIBUTE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
 };
 
+// PAD_ATTRIBUTE follows MySQL 8 rules: UCA 9.0.0+ collations (utf8mb4_0900_*)
+// are NO PAD, all others (including utf8_general_ci) are PAD SPACE. See MySQL
+// reference manual section "Trailing Space Handling in Comparisons".
 SchemaCollationsScanner::CollationStruct SchemaCollationsScanner::_s_collations[] = {
-        {"utf8_general_ci", "utf8", 33, "Yes", "Yes", 1},
-        {nullptr, nullptr, 0, nullptr, nullptr, 0},
+        {"utf8_general_ci", "utf8", 33, "Yes", "Yes", 1, "PAD SPACE"},
+        {nullptr, nullptr, 0, nullptr, nullptr, 0, nullptr},
 };
 
 SchemaCollationsScanner::SchemaCollationsScanner()
@@ -92,6 +96,15 @@ Status SchemaCollationsScanner::fill_chunk(ChunkPtr* chunk) {
             {
                 auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(6);
                 fill_column_with_slot<TYPE_BIGINT>(column, (void*)&_s_collations[_index].sortlen);
+            }
+            break;
+        }
+        case 7: {
+            // pad_attribute
+            {
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(7);
+                Slice value(_s_collations[_index].pad_attribute, strlen(_s_collations[_index].pad_attribute));
+                fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
             }
             break;
         }

--- a/be/src/exec/schema_scanner/schema_collations_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_collations_scanner.cpp
@@ -38,6 +38,10 @@ SchemaCollationsScanner::CollationStruct SchemaCollationsScanner::_s_collations[
         {nullptr, nullptr, 0, nullptr, nullptr, 0, nullptr},
 };
 
+const SchemaCollationsScanner::CollationStruct* SchemaCollationsScanner::collations() {
+    return _s_collations;
+}
+
 SchemaCollationsScanner::SchemaCollationsScanner()
         : SchemaScanner(_s_cols_columns, sizeof(_s_cols_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
 

--- a/be/src/exec/schema_scanner/schema_collations_scanner.h
+++ b/be/src/exec/schema_scanner/schema_collations_scanner.h
@@ -36,6 +36,7 @@ private:
         const char* is_default;
         const char* is_compile;
         int64_t sortlen;
+        const char* pad_attribute;
     };
 
     Status fill_chunk(ChunkPtr* chunk);

--- a/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
@@ -26,6 +26,7 @@ SchemaScanner::ColumnDesc SchemaSchemataScanner::_s_columns[] = {
         {"DEFAULT_CHARACTER_SET_NAME", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"DEFAULT_COLLATION_NAME", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"SQL_PATH", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
+        {"DEFAULT_ENCRYPTION", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
 };
 
 SchemaSchemataScanner::SchemaSchemataScanner()
@@ -109,6 +110,16 @@ Status SchemaSchemataScanner::fill_chunk(ChunkPtr* chunk) {
             {
                 auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(5);
                 fill_data_column_with_null(column);
+            }
+            break;
+        }
+        case 6: {
+            // DEFAULT_ENCRYPTION
+            {
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(6);
+                const char* str = "NO";
+                Slice value(str, strlen(str));
+                fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
             }
             break;
         }

--- a/be/src/exec/schema_scanner/schema_statistics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_statistics_scanner.cpp
@@ -36,6 +36,7 @@ SchemaScanner::ColumnDesc SchemaStatisticsScanner::_s_cols_statistics[] = {
         {"INDEX_TYPE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"COMMENT", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
         {"INDEX_COMMENT", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
+        {"IS_VISIBLE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
         {"EXPRESSION", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
 };
 

--- a/be/src/exec/schema_scanner_factory.cpp
+++ b/be/src/exec/schema_scanner_factory.cpp
@@ -31,6 +31,7 @@
 #include "exec/schema_scanner/schema_charsets_scanner.h"
 #include "exec/schema_scanner/schema_cluster_snapshot_jobs_scanner.h"
 #include "exec/schema_scanner/schema_cluster_snapshots_scanner.h"
+#include "exec/schema_scanner/schema_collation_character_set_applicability_scanner.h"
 #include "exec/schema_scanner/schema_collations_scanner.h"
 #include "exec/schema_scanner/schema_column_stats_usage_scanner.h"
 #include "exec/schema_scanner/schema_columns_scanner.h"
@@ -82,6 +83,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaCharsetsScanner>();
     case TSchemaTableType::SCH_COLLATIONS:
         return std::make_unique<SchemaCollationsScanner>();
+    case TSchemaTableType::SCH_COLLATION_CHARACTER_SET_APPLICABILITY:
+        return std::make_unique<SchemaCollationCharacterSetApplicabilityScanner>();
     case TSchemaTableType::SCH_GLOBAL_VARIABLES:
         return std::make_unique<SchemaVariablesScanner>(TVarType::GLOBAL);
     case TSchemaTableType::SCH_SESSION_VARIABLES:

--- a/be/test/exec/schema_scanner/exec_schema_scanners_test.cpp
+++ b/be/test/exec/schema_scanner/exec_schema_scanners_test.cpp
@@ -20,6 +20,7 @@
 
 #include "column/column_helper.h"
 #include "exec/schema_scanner/schema_charsets_scanner.h"
+#include "exec/schema_scanner/schema_collation_character_set_applicability_scanner.h"
 #include "exec/schema_scanner/schema_collations_scanner.h"
 #include "exec/schema_scanner/schema_column_filler.h"
 #include "exec/schema_scanner/schema_dummy_scanner.h"
@@ -92,13 +93,14 @@ TEST(ExecSchemaScannersTest, CollationsScannerReturnsStaticCollationRow) {
     SchemaCollationsScanner scanner;
     ObjectPool pool;
     auto slots = init_scanner(&scanner, &pool);
-    ASSERT_EQ(6, slots.size());
+    ASSERT_EQ(7, slots.size());
     EXPECT_EQ("COLLATION_NAME", slots[0]->col_name());
     EXPECT_EQ("CHARACTER_SET_NAME", slots[1]->col_name());
     EXPECT_EQ("ID", slots[2]->col_name());
     EXPECT_EQ("IS_DEFAULT", slots[3]->col_name());
     EXPECT_EQ("IS_COMPILED", slots[4]->col_name());
     EXPECT_EQ("SORTLEN", slots[5]->col_name());
+    EXPECT_EQ("PAD_ATTRIBUTE", slots[6]->col_name());
 
     auto chunk = create_chunk(slots);
     bool eos = false;
@@ -106,7 +108,29 @@ TEST(ExecSchemaScannersTest, CollationsScannerReturnsStaticCollationRow) {
     ASSERT_TRUE(st.ok()) << st.to_string();
     EXPECT_FALSE(eos);
     ASSERT_EQ(1, chunk->num_rows());
-    EXPECT_EQ("['utf8_general_ci', 'utf8', 33, 'Yes', 'Yes', 1]", chunk->debug_row(0));
+    EXPECT_EQ("['utf8_general_ci', 'utf8', 33, 'Yes', 'Yes', 1, 'PAD SPACE']", chunk->debug_row(0));
+
+    chunk->reset();
+    st = scanner.get_next(&chunk, &eos);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_TRUE(eos);
+}
+
+TEST(ExecSchemaScannersTest, CollationCharacterSetApplicabilityScannerMirrorsCollations) {
+    SchemaCollationCharacterSetApplicabilityScanner scanner;
+    ObjectPool pool;
+    auto slots = init_scanner(&scanner, &pool);
+    ASSERT_EQ(2, slots.size());
+    EXPECT_EQ("COLLATION_NAME", slots[0]->col_name());
+    EXPECT_EQ("CHARACTER_SET_NAME", slots[1]->col_name());
+
+    auto chunk = create_chunk(slots);
+    bool eos = false;
+    auto st = scanner.get_next(&chunk, &eos);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_FALSE(eos);
+    ASSERT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("['utf8_general_ci', 'utf8']", chunk->debug_row(0));
 
     chunk->reset();
     st = scanner.get_next(&chunk, &eos);
@@ -125,9 +149,10 @@ TEST(ExecSchemaScannersTest, DescriptorOnlyScannersExposeStableSchemas) {
 
     SchemaStatisticsScanner statistics;
     auto statistics_slots = init_scanner(&statistics, &pool);
-    ASSERT_EQ(17, statistics_slots.size());
+    ASSERT_EQ(18, statistics_slots.size());
     EXPECT_EQ("TABLE_CATALOG", statistics_slots.front()->col_name());
     EXPECT_TRUE(statistics_slots.front()->is_nullable());
+    EXPECT_EQ("IS_VISIBLE", statistics_slots[16]->col_name());
     EXPECT_EQ("EXPRESSION", statistics_slots.back()->col_name());
 
     SchemaTriggersScanner triggers;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
@@ -114,6 +114,10 @@ public class SystemId {
 
     public static final long COLLATION_CHARACTER_SET_APPLICABILITY_ID = 48L;
 
+    public static final long ROUTINES_V5_ID = 49L;
+
+    public static final long STATISTICS_V5_ID = 50L;
+
     public static final long SYS_DB_ID = 100L;
 
     public static final long ROLE_EDGES_ID = 101L;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
@@ -112,6 +112,8 @@ public class SystemId {
 
     public static final long BE_TABLET_WRITE_LOG_ID = 47L;
 
+    public static final long COLLATION_CHARACTER_SET_APPLICABILITY_ID = 48L;
+
     public static final long SYS_DB_ID = 100L;
 
     public static final long ROLE_EDGES_ID = 101L;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CollationCharacterSetApplicabilitySystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CollationCharacterSetApplicabilitySystemTable.java
@@ -1,0 +1,38 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.catalog.system.information;
+
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.system.SystemId;
+import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.thrift.TSchemaTableType;
+import com.starrocks.type.TypeFactory;
+
+import static com.starrocks.catalog.system.SystemTable.builder;
+
+public class CollationCharacterSetApplicabilitySystemTable {
+    private static final String NAME = "collation_character_set_applicability";
+
+    public static SystemTable create(String catalogName) {
+        return new SystemTable(
+                catalogName,
+                SystemId.COLLATION_CHARACTER_SET_APPLICABILITY_ID,
+                NAME,
+                Table.TableType.SCHEMA,
+                builder()
+                        .column("COLLATION_NAME", TypeFactory.createVarcharType(64))
+                        .column("CHARACTER_SET_NAME", TypeFactory.createVarcharType(64))
+                        .build(), TSchemaTableType.SCH_COLLATION_CHARACTER_SET_APPLICABILITY);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CollationsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CollationsSystemTable.java
@@ -38,6 +38,7 @@ public class CollationsSystemTable {
                         .column("IS_DEFAULT", TypeFactory.createVarcharType(64))
                         .column("IS_COMPILED", TypeFactory.createVarcharType(64))
                         .column("SORTLEN", IntegerType.BIGINT)
+                        .column("PAD_ATTRIBUTE", TypeFactory.createVarcharType(9))
                         .build(), TSchemaTableType.SCH_COLLATIONS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/InfoSchemaDb.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/InfoSchemaDb.java
@@ -46,6 +46,7 @@ public class InfoSchemaDb extends Database {
         super.registerTableUnlocked(ColumnsSystemTable.create(catalogName));
         super.registerTableUnlocked(CharacterSetsSystemTable.create(catalogName));
         super.registerTableUnlocked(CollationsSystemTable.create(catalogName));
+        super.registerTableUnlocked(CollationCharacterSetApplicabilitySystemTable.create(catalogName));
         super.registerTableUnlocked(TableConstraintsSystemTable.create(catalogName));
         super.registerTableUnlocked(EnginesSystemTable.create(catalogName));
         super.registerTableUnlocked(UserPrivilegesSystemTable.create(catalogName));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/InfoSchemaDb.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/InfoSchemaDb.java
@@ -17,6 +17,8 @@ package com.starrocks.catalog.system.information;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
+import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.Config;
 
 import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
 import static com.starrocks.server.CatalogMgr.isInternalCatalog;
@@ -26,6 +28,12 @@ import static java.util.Objects.requireNonNull;
 public class InfoSchemaDb extends Database {
     public static final String DATABASE_NAME = "information_schema";
 
+    // Held outside nameToTable / idToTable to avoid colliding with the MySQL 8
+    // variants registered under the same name. Resolved per-query in getTable()
+    // based on the runtime-mutable Config.mysql_server_version.
+    private final SystemTable routinesV5;
+    private final SystemTable statisticsV5;
+
     public InfoSchemaDb() {
         this(DEFAULT_INTERNAL_CATALOG_NAME);
     }
@@ -34,6 +42,9 @@ public class InfoSchemaDb extends Database {
         super(SystemId.INFORMATION_SCHEMA_DB_ID, DATABASE_NAME);
         requireNonNull(catalogName, "catalogName is null");
         super.setCatalogName(catalogName);
+
+        this.routinesV5 = RoutinesSystemTable.createV5(catalogName);
+        this.statisticsV5 = StatisticsSystemTable.createV5(catalogName);
 
         super.registerTableUnlocked(TablesSystemTable.create(catalogName));
         super.registerTableUnlocked(PartitionsSystemTableSystemTable.create(catalogName));
@@ -112,7 +123,27 @@ public class InfoSchemaDb extends Database {
 
     @Override
     public Table getTable(String name) {
-        return super.getTable(name.toLowerCase());
+        String lower = name.toLowerCase();
+        if (isLegacyMysqlVersion()) {
+            if ("routines".equals(lower)) {
+                return routinesV5;
+            }
+            if ("statistics".equals(lower)) {
+                return statisticsV5;
+            }
+        }
+        return super.getTable(lower);
+    }
+
+    // True when Config.mysql_server_version advertises a MySQL 5.x release. The
+    // config is @ConfField(mutable=true), so this is read per call and changes
+    // via ADMIN SET CONFIG take effect on the next query without restart.
+    private static boolean isLegacyMysqlVersion() {
+        String v = Config.mysql_server_version;
+        if (v == null || v.isEmpty()) {
+            return false;
+        }
+        return v.startsWith("5.") || v.equals("5");
     }
 
     public static boolean isInfoSchemaDb(String dbName) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutinesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutinesSystemTable.java
@@ -67,4 +67,40 @@ public class RoutinesSystemTable {
                         .column("DATABASE_COLLATION", TypeFactory.createVarcharType(NAME_CHAR_LEN))
                         .build(), SCH_PROCEDURES);
     }
+
+    // MySQL 5.7 layout: omits the eight return-type descriptor columns
+    // (DATA_TYPE..COLLATION_NAME) that MySQL 8 inserted between ROUTINE_TYPE
+    // and DTD_IDENTIFIER. Served when Config.mysql_server_version starts with "5.".
+    public static SystemTable createV5(String catalogName) {
+        return new SystemTable(
+                catalogName,
+                SystemId.ROUTINES_V5_ID,
+                NAME,
+                Table.TableType.SCHEMA,
+                builder()
+                        .column("SPECIFIC_NAME", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("ROUTINE_CATALOG", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("ROUTINE_SCHEMA", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("ROUTINE_NAME", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("ROUTINE_TYPE", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("DTD_IDENTIFIER", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("ROUTINE_BODY", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("ROUTINE_DEFINITION", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("EXTERNAL_NAME", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("EXTERNAL_LANGUAGE", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("PARAMETER_STYLE", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("IS_DETERMINISTIC", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("SQL_DATA_ACCESS", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("SQL_PATH", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("SECURITY_TYPE", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("CREATED", DateType.DATETIME)
+                        .column("LAST_ALTERED", DateType.DATETIME)
+                        .column("SQL_MODE", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("ROUTINE_COMMENT", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("DEFINER", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("CHARACTER_SET_CLIENT", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("COLLATION_CONNECTION", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("DATABASE_COLLATION", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .build(), SCH_PROCEDURES);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutinesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutinesSystemTable.java
@@ -17,6 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
 import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
@@ -38,6 +39,14 @@ public class RoutinesSystemTable {
                         .column("ROUTINE_SCHEMA", TypeFactory.createVarcharType(NAME_CHAR_LEN))
                         .column("ROUTINE_NAME", TypeFactory.createVarcharType(NAME_CHAR_LEN))
                         .column("ROUTINE_TYPE", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("DATA_TYPE", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("CHARACTER_MAXIMUM_LENGTH", IntegerType.BIGINT)
+                        .column("CHARACTER_OCTET_LENGTH", IntegerType.BIGINT)
+                        .column("NUMERIC_PRECISION", IntegerType.BIGINT)
+                        .column("NUMERIC_SCALE", IntegerType.BIGINT)
+                        .column("DATETIME_PRECISION", IntegerType.BIGINT)
+                        .column("CHARACTER_SET_NAME", TypeFactory.createVarcharType(NAME_CHAR_LEN))
+                        .column("COLLATION_NAME", TypeFactory.createVarcharType(NAME_CHAR_LEN))
                         .column("DTD_IDENTIFIER", TypeFactory.createVarcharType(NAME_CHAR_LEN))
                         .column("ROUTINE_BODY", TypeFactory.createVarcharType(NAME_CHAR_LEN))
                         .column("ROUTINE_DEFINITION", TypeFactory.createVarcharType(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SchemataSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SchemataSystemTable.java
@@ -36,6 +36,7 @@ public class SchemataSystemTable {
                         .column("DEFAULT_CHARACTER_SET_NAME", TypeFactory.createVarcharType(32))
                         .column("DEFAULT_COLLATION_NAME", TypeFactory.createVarcharType(32))
                         .column("SQL_PATH", TypeFactory.createVarcharType(512))
+                        .column("DEFAULT_ENCRYPTION", TypeFactory.createVarcharType(3))
                         .build(), TSchemaTableType.SCH_SCHEMATA);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StatisticsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StatisticsSystemTable.java
@@ -49,6 +49,7 @@ public class StatisticsSystemTable {
                         .column("INDEX_TYPE", TypeFactory.createVarcharType(16))
                         .column("COMMENT", TypeFactory.createVarcharType(16))
                         .column("INDEX_COMMENT", TypeFactory.createVarcharType(1024))
+                        .column("IS_VISIBLE", TypeFactory.createVarcharType(3))
                         .column("EXPRESSION", TypeFactory.createVarcharType(MAX_FIELD_VARCHAR_LENGTH))
                         .build(), TSchemaTableType.SCH_STATISTICS);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StatisticsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StatisticsSystemTable.java
@@ -53,4 +53,33 @@ public class StatisticsSystemTable {
                         .column("EXPRESSION", TypeFactory.createVarcharType(MAX_FIELD_VARCHAR_LENGTH))
                         .build(), TSchemaTableType.SCH_STATISTICS);
     }
+
+    // MySQL 5.7 layout: omits both IS_VISIBLE and EXPRESSION, which were
+    // introduced together with MySQL 8 functional-index metadata. Served when
+    // Config.mysql_server_version starts with "5.".
+    public static SystemTable createV5(String catalogName) {
+        return new SystemTable(
+                catalogName,
+                SystemId.STATISTICS_V5_ID,
+                NAME,
+                Table.TableType.SCHEMA,
+                builder()
+                        .column("TABLE_CATALOG", TypeFactory.createVarcharType(512))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarcharType(64))
+                        .column("TABLE_NAME", TypeFactory.createVarcharType(64))
+                        .column("NON_UNIQUE", IntegerType.BIGINT)
+                        .column("INDEX_SCHEMA", TypeFactory.createVarcharType(64))
+                        .column("INDEX_NAME", TypeFactory.createVarcharType(64))
+                        .column("SEQ_IN_INDEX", IntegerType.BIGINT)
+                        .column("COLUMN_NAME", TypeFactory.createVarcharType(64))
+                        .column("COLLATION", TypeFactory.createVarcharType(1))
+                        .column("CARDINALITY", IntegerType.BIGINT)
+                        .column("SUB_PART", IntegerType.BIGINT)
+                        .column("PACKED", TypeFactory.createVarcharType(10))
+                        .column("NULLABLE", TypeFactory.createVarcharType(3))
+                        .column("INDEX_TYPE", TypeFactory.createVarcharType(16))
+                        .column("COMMENT", TypeFactory.createVarcharType(16))
+                        .column("INDEX_COMMENT", TypeFactory.createVarcharType(1024))
+                        .build(), TSchemaTableType.SCH_STATISTICS);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
@@ -108,6 +108,44 @@ public class InfoSchemaDbTest {
     }
 
     @Test
+    public void testRoutinesAndStatisticsSwitchOnMysqlVersion() {
+        InfoSchemaDb db = new InfoSchemaDb();
+        String original = Config.mysql_server_version;
+        try {
+            Config.mysql_server_version = "8.0.33";
+            Table routinesV8 = db.getTable("routines");
+            Table statisticsV8 = db.getTable("statistics");
+            Assertions.assertEquals(31, routinesV8.getBaseSchema().size());
+            Assertions.assertEquals(18, statisticsV8.getBaseSchema().size());
+            Assertions.assertTrue(routinesV8.getBaseSchema().stream()
+                    .anyMatch(c -> "DATA_TYPE".equalsIgnoreCase(c.getName())));
+            Assertions.assertTrue(statisticsV8.getBaseSchema().stream()
+                    .anyMatch(c -> "IS_VISIBLE".equalsIgnoreCase(c.getName())));
+
+            Config.mysql_server_version = "5.7.28";
+            Table routinesV5 = db.getTable("routines");
+            Table statisticsV5 = db.getTable("statistics");
+            Assertions.assertEquals(23, routinesV5.getBaseSchema().size());
+            Assertions.assertEquals(16, statisticsV5.getBaseSchema().size());
+            Assertions.assertFalse(routinesV5.getBaseSchema().stream()
+                    .anyMatch(c -> "DATA_TYPE".equalsIgnoreCase(c.getName())));
+            Assertions.assertFalse(statisticsV5.getBaseSchema().stream()
+                    .anyMatch(c -> "IS_VISIBLE".equalsIgnoreCase(c.getName())));
+            Assertions.assertFalse(statisticsV5.getBaseSchema().stream()
+                    .anyMatch(c -> "EXPRESSION".equalsIgnoreCase(c.getName())));
+
+            // Other MySQL-8 additions ride on tables that don't shift ordinals,
+            // so they stay registered regardless of the advertised version.
+            Table collations = db.getTable("collations");
+            Assertions.assertNotNull(collations);
+            Assertions.assertTrue(collations.getBaseSchema().stream()
+                    .anyMatch(c -> "PAD_ATTRIBUTE".equalsIgnoreCase(c.getName())));
+        } finally {
+            Config.mysql_server_version = original;
+        }
+    }
+
+    @Test
     public void testInitRole() throws Exception {
         TGetGrantsToRolesOrUserRequest request = new TGetGrantsToRolesOrUserRequest();
         request.setType(TGrantsToType.ROLE);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -85,7 +85,8 @@ public class CatalogConnectorMetadataTest {
         List<String> tblNames = catalogConnectorMetadata.listTableNames(new ConnectContext(), InfoSchemaDb.DATABASE_NAME);
         List<String> expected = ImmutableList.of("tables", "table_privileges", "referential_constraints",
                 "key_column_usage", "routines", "schemata", "columns", "character_sets", "collations",
-                "table_constraints", "engines", "user_privileges", "schema_privileges", "statistics",
+                "table_constraints", "engines", "user_privileges", "collation_character_set_applicability",
+                "schema_privileges", "statistics",
                 "triggers", "events", "views", "partitions", "column_privileges"
         );
         assertEquals(expected, tblNames);

--- a/test/sql/test_information_schema/R/test_external_catalog_information_schema
+++ b/test/sql/test_information_schema/R/test_external_catalog_information_schema
@@ -36,6 +36,12 @@ ice_hadoop_db1
 ice_hadoop_db2
 information_schema
 -- !result
+select SCHEMA_NAME, DEFAULT_ENCRYPTION from ice_hadoop${uuid0}.information_schema.schemata;
+-- result:
+ice_hadoop_db1	NO
+ice_hadoop_db2	NO
+information_schema	NO
+-- !result
 select TABLE_SCHEMA, TABLE_NAME from ice_hadoop${uuid0}.information_schema.tables;
 -- result:
 ice_hadoop_db1	test

--- a/test/sql/test_information_schema/R/test_external_catalog_information_schema
+++ b/test/sql/test_information_schema/R/test_external_catalog_information_schema
@@ -58,6 +58,7 @@ information_schema	collations
 information_schema	table_constraints
 information_schema	engines
 information_schema	user_privileges
+information_schema	collation_character_set_applicability
 information_schema	schema_privileges
 information_schema	statistics
 information_schema	triggers
@@ -127,29 +128,38 @@ information_schema	routines	ROUTINE_CATALOG	2
 information_schema	routines	ROUTINE_SCHEMA	3
 information_schema	routines	ROUTINE_NAME	4
 information_schema	routines	ROUTINE_TYPE	5
-information_schema	routines	DTD_IDENTIFIER	6
-information_schema	routines	ROUTINE_BODY	7
-information_schema	routines	ROUTINE_DEFINITION	8
-information_schema	routines	EXTERNAL_NAME	9
-information_schema	routines	EXTERNAL_LANGUAGE	10
-information_schema	routines	PARAMETER_STYLE	11
-information_schema	routines	IS_DETERMINISTIC	12
-information_schema	routines	SQL_DATA_ACCESS	13
-information_schema	routines	SQL_PATH	14
-information_schema	routines	SECURITY_TYPE	15
-information_schema	routines	CREATED	16
-information_schema	routines	LAST_ALTERED	17
-information_schema	routines	SQL_MODE	18
-information_schema	routines	ROUTINE_COMMENT	19
-information_schema	routines	DEFINER	20
-information_schema	routines	CHARACTER_SET_CLIENT	21
-information_schema	routines	COLLATION_CONNECTION	22
-information_schema	routines	DATABASE_COLLATION	23
+information_schema	routines	DATA_TYPE	6
+information_schema	routines	CHARACTER_MAXIMUM_LENGTH	7
+information_schema	routines	CHARACTER_OCTET_LENGTH	8
+information_schema	routines	NUMERIC_PRECISION	9
+information_schema	routines	NUMERIC_SCALE	10
+information_schema	routines	DATETIME_PRECISION	11
+information_schema	routines	CHARACTER_SET_NAME	12
+information_schema	routines	COLLATION_NAME	13
+information_schema	routines	DTD_IDENTIFIER	14
+information_schema	routines	ROUTINE_BODY	15
+information_schema	routines	ROUTINE_DEFINITION	16
+information_schema	routines	EXTERNAL_NAME	17
+information_schema	routines	EXTERNAL_LANGUAGE	18
+information_schema	routines	PARAMETER_STYLE	19
+information_schema	routines	IS_DETERMINISTIC	20
+information_schema	routines	SQL_DATA_ACCESS	21
+information_schema	routines	SQL_PATH	22
+information_schema	routines	SECURITY_TYPE	23
+information_schema	routines	CREATED	24
+information_schema	routines	LAST_ALTERED	25
+information_schema	routines	SQL_MODE	26
+information_schema	routines	ROUTINE_COMMENT	27
+information_schema	routines	DEFINER	28
+information_schema	routines	CHARACTER_SET_CLIENT	29
+information_schema	routines	COLLATION_CONNECTION	30
+information_schema	routines	DATABASE_COLLATION	31
 information_schema	schemata	CATALOG_NAME	1
 information_schema	schemata	SCHEMA_NAME	2
 information_schema	schemata	DEFAULT_CHARACTER_SET_NAME	3
 information_schema	schemata	DEFAULT_COLLATION_NAME	4
 information_schema	schemata	SQL_PATH	5
+information_schema	schemata	DEFAULT_ENCRYPTION	6
 information_schema	columns	TABLE_CATALOG	1
 information_schema	columns	TABLE_SCHEMA	2
 information_schema	columns	TABLE_NAME	3
@@ -184,6 +194,7 @@ information_schema	collations	ID	3
 information_schema	collations	IS_DEFAULT	4
 information_schema	collations	IS_COMPILED	5
 information_schema	collations	SORTLEN	6
+information_schema	collations	PAD_ATTRIBUTE	7
 information_schema	table_constraints	CONSTRAINT_CATALOG	1
 information_schema	table_constraints	CONSTRAINT_SCHEMA	2
 information_schema	table_constraints	CONSTRAINT_NAME	3
@@ -201,6 +212,8 @@ information_schema	user_privileges	GRANTEE	1
 information_schema	user_privileges	TABLE_CATALOG	2
 information_schema	user_privileges	PRIVILEGE_TYPE	3
 information_schema	user_privileges	IS_GRANTABLE	4
+information_schema	collation_character_set_applicability	COLLATION_NAME	1
+information_schema	collation_character_set_applicability	CHARACTER_SET_NAME	2
 information_schema	schema_privileges	GRANTEE	1
 information_schema	schema_privileges	TABLE_CATALOG	2
 information_schema	schema_privileges	TABLE_SCHEMA	3
@@ -222,7 +235,8 @@ information_schema	statistics	NULLABLE	13
 information_schema	statistics	INDEX_TYPE	14
 information_schema	statistics	COMMENT	15
 information_schema	statistics	INDEX_COMMENT	16
-information_schema	statistics	EXPRESSION	17
+information_schema	statistics	IS_VISIBLE	17
+information_schema	statistics	EXPRESSION	18
 information_schema	triggers	TRIGGER_CATALOG	1
 information_schema	triggers	TRIGGER_SCHEMA	2
 information_schema	triggers	TRIGGER_NAME	3

--- a/test/sql/test_information_schema/T/test_external_catalog_information_schema
+++ b/test/sql/test_information_schema/T/test_external_catalog_information_schema
@@ -24,6 +24,8 @@ create table ice_hadoop${uuid0}.ice_hadoop_db2.test (
 
 select SCHEMA_NAME from ice_hadoop${uuid0}.information_schema.schemata;
 
+select SCHEMA_NAME, DEFAULT_ENCRYPTION from ice_hadoop${uuid0}.information_schema.schemata;
+
 select TABLE_SCHEMA, TABLE_NAME from ice_hadoop${uuid0}.information_schema.tables;
 
 select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION from ice_hadoop${uuid0}.information_schema.columns;


### PR DESCRIPTION
## Why I'm doing:

Since the `mysql_server_version` default was raised to `8.0.33` (StarRocks 3.4+), StarRocks advertises itself as MySQL 8 to clients. An audit of `information_schema.*` against the MySQL 8 reference manual revealed several columns and one entire table that the spec requires but StarRocks does not yet expose. BI tools and JDBC drivers (Tableau, MySQL Workbench, MySQL Connector/J, DBeaver, governance/compliance tools) check for these columns during introspection and either fall back or report missing-column errors.

## Scope of this audit

Directional: **for each `information_schema` table that StarRocks already registers**, compare its column list against the MySQL 8 spec for the same-named table and patch the gaps. One trivial view (`COLLATION_CHARACTER_SET_APPLICABILITY`) was added because it derives from `COLLATIONS`.

The reverse direction — MySQL 8 tables that StarRocks does not register at all — is **not addressed in this PR**; see [#73372](https://github.com/StarRocks/starrocks/issues/73372) for the list. Each missing table needs its own design (stub vs real data, privilege model, semantics) and is left for follow-ups.

## What I'm doing:

Add the following columns/table to `information_schema` to match the MySQL 8 spec:

| Table | Addition |
|---|---|
| `STATISTICS` | `IS_VISIBLE` column |
| `COLLATIONS` | `PAD_ATTRIBUTE` column |
| `SCHEMATA` | `DEFAULT_ENCRYPTION` column |
| `ROUTINES` | 8 return-type columns: `DATA_TYPE`, `CHARACTER_MAXIMUM_LENGTH`, `CHARACTER_OCTET_LENGTH`, `NUMERIC_PRECISION`, `NUMERIC_SCALE`, `DATETIME_PRECISION`, `CHARACTER_SET_NAME`, `COLLATION_NAME` (inserted between `ROUTINE_TYPE` and `DTD_IDENTIFIER`, per spec order) |
| `COLLATION_CHARACTER_SET_APPLICABILITY` | New table — view derived from `COLLATIONS` |

Where BE schema scanners exist (`COLLATIONS`, `SCHEMATA`) the scanner emits MySQL-equivalent values for the single `utf8_general_ci` collation StarRocks currently advertises (`PAD_ATTRIBUTE = 'PAD SPACE'`, `DEFAULT_ENCRYPTION = 'NO'`). For tables that fall through to `SchemaDummyScanner` (`STATISTICS`, `ROUTINES`) only the FE column schema is extended — they already return zero rows today. `COLLATION_CHARACTER_SET_APPLICABILITY` gets a dedicated BE scanner that mirrors the single row from `COLLATIONS`, so client joins behave consistently.

Fixes #73372

## Discussion points

1. **Are the new columns/tables gated by `mysql_server_version`?**
   Partially.

   Gated (v5 fallback served when `Config.mysql_server_version` starts with `5.`):
   - `ROUTINES` — 8 return-type columns are *inserted* between `ROUTINE_TYPE` and `DTD_IDENTIFIER`, shifting trailing columns; v5 layout omits them. Implemented via `RoutinesSystemTable.createV5` + lookup in `InfoSchemaDb.getTable()`.
   - `STATISTICS` — `IS_VISIBLE` lands between `INDEX_COMMENT` and `EXPRESSION` (and `EXPRESSION` itself is MySQL-8-only); v5 layout omits both.

   Unconditional (appended / additive, no positional impact for legacy clients):
   - `COLLATIONS.PAD_ATTRIBUTE` — appended at the end.
   - `SCHEMATA.DEFAULT_ENCRYPTION` — appended at the end.
   - `COLLATION_CHARACTER_SET_APPLICABILITY` — new table, additive.

   `Config.mysql_server_version` is `@ConfField(mutable=true)`, so the gate is evaluated per query and switches via `ADMIN SET CONFIG` without restart.

2. **Two non-spec columns in `information_schema.COLUMNS`.** `COLUMN_SIZE` and `DECIMAL_DIGITS` have lived in `ColumnsSystemTable` since the initial repo commit (`5fa55b8199f`) with no message, no comment, and no MySQL counterpart. They sit between `COLUMN_COMMENT` and `GENERATION_EXPRESSION` — out of scope for this PR, but flagging for context: do maintainers know why they're there, and are they safe to drop in a follow-up?

3. **Entire MySQL 8 tables absent from StarRocks.** The audit also surfaced MySQL 8 tables we do not register at all (`COLUMN_STATISTICS`, `CHECK_CONSTRAINTS`, `PARAMETERS`, `VIEW_ROUTINE_USAGE`, `VIEW_TABLE_USAGE`, `PROFILING`, `FILES`, `TABLESPACES`, `OPTIMIZER_TRACE`, `PLUGINS`, role/grant variants, `USER_ATTRIBUTES`, `RESOURCE_GROUPS`). They are deliberately **not** in this PR — see #73372 for the full list and rationale. Happy to follow up with FE-only stubs for the ones that are honestly empty in StarRocks (e.g. `COLUMN_STATISTICS`, `CHECK_CONSTRAINTS`, `PARAMETERS`) if maintainers want them.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

