### PR TITLE
[BugFix] Fix concurrent SegmentFlushTask race in DeltaWriter::commit()

### DIFF
--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -199,6 +199,35 @@ Status LocalTabletsChannel::open(const PTabletWriterOpenRequest& params, PTablet
 
 void LocalTabletsChannel::add_segment(brpc::Controller* cntl, const PTabletWriterAddSegmentRequest* request,
                                       PTabletWriterAddSegmentResult* response, google::protobuf::Closure* done) const {
+    // NOTE: This entrypoint does NOT deduplicate duplicate RPCs (unlike
+    // add_chunk below, which dedups by packet_seq sliding window).
+    // Duplicate tablet_writer_add_segment requests - whether from brpc
+    // framework retries, InternalServiceRecoverableStub reconnects, or
+    // primary-side application retries - are forwarded straight to the
+    // per-tablet DeltaWriter, and the SegmentFlushToken dispatches them
+    // concurrently because CONCURRENT mode is the designed parallelism
+    // for segment replication throughput.
+    //
+    // Downstream code MUST therefore remain correct and thread-safe under
+    // concurrent processing of identical RPCs. The invariants currently
+    // relied on are:
+    //   - DeltaWriter::write_segment creates the segment file with
+    //     MUST_CREATE, so same-seg_id duplicates fail at the disk layer
+    //     and the writer is cancelled (benign abort, no crash).
+    //   - DeltaWriter::close is idempotent: returns OK when already in
+    //     kClosed state.
+    //   - DeltaWriter::commit serialises concurrent callers via a
+    //     std::call_once over the commit body (see delta_writer.cpp).
+    //     The first caller runs the body; concurrent duplicates block
+    //     inside call_once until it finishes and then return the same
+    //     captured Status. The wait-and-return-final-state design is
+    //     required so that duplicate callers (notably
+    //     SegmentFlushTask::run, which unconditionally cancels the
+    //     writer on any non-OK commit status) do not turn a successful
+    //     commit into an aborted one.
+    // If you change any of those invariants - or add a new method that
+    // mutates per-writer state from this path - you must keep the
+    // duplicate-RPC contract intact.
     std::shared_lock<bthreads::BThreadSharedMutex> lk(_rw_mtx);
     ClosureGuard closure_guard(done);
     auto it = _delta_writers.find(request->tablet_id());

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/delta_writer.h"
 
+#include <mutex>
 #include <utility>
 
 #include "column/raw_data_visitor.h"
@@ -744,6 +745,23 @@ Status DeltaWriter::commit() {
         break;
     }
 
+    // Exactly one thread runs the commit body. Two SegmentFlushTask threads
+    // can reach this point concurrently for the same DeltaWriter when the
+    // upstream sends a duplicate tablet_writer_add_segment(eos=true) (e.g.
+    // a brpc retry on an unstable peer link) and SegmentFlushToken
+    // dispatches the duplicates in parallel. Concurrent duplicate callers
+    // block inside std::call_once until the first invocation completes
+    // and then return the captured _commit_result. This makes duplicate
+    // commit() calls observably idempotent: both threads return OK on
+    // success, or both return the same error on failure, with no transient
+    // "in progress" status leaking to callers such as SegmentFlushTask::run
+    // (which would otherwise cancel the writer on any non-OK return and
+    // convert a successful commit into a reported failure on the primary).
+    std::call_once(_commit_once, [this] { _commit_result = _do_commit_body(); });
+    return _commit_result;
+}
+
+Status DeltaWriter::_do_commit_body() {
     MonotonicStopWatch watch;
     watch.start();
     if (auto st = _flush_token->wait(); UNLIKELY(!st.ok())) {

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "column/vectorized_fwd.h"
 #include "common/tracer_fwd.h"
 #include "gen_cpp/internal_service.pb.h"
@@ -250,9 +252,29 @@ private:
 
     void _set_state(State state, const Status& st);
 
+    // Body of commit() executed exactly once across concurrent duplicate
+    // callers via std::call_once on _commit_once. The result is captured
+    // in _commit_result. Not directly callable from outside commit().
+    Status _do_commit_body();
+
     State _state{kUninitialized};
     Status _err_status;
     mutable std::mutex _state_lock;
+    // Serialises the body of commit(). The first caller to enter
+    // std::call_once runs the body; concurrent duplicate callers (e.g.
+    // retried tablet_writer_add_segment(eos=true) arriving on the
+    // secondary replica) block inside call_once until the body finishes,
+    // and then read _commit_result. This makes duplicate RPCs observably
+    // idempotent at the API level and prevents callers such as
+    // SegmentFlushTask::run from cancelling the writer on a transient
+    // status (see the comment in LocalTabletsChannel::add_segment for
+    // the larger duplicate-RPC contract).
+    std::once_flag _commit_once;
+    // Outcome of the single commit body invocation. Written exactly once
+    // from inside the std::call_once callable; readable by all callers
+    // after the call_once returns (the standard library establishes the
+    // happens-before relationship).
+    Status _commit_result;
 
     ReplicaState _replica_state;
     DeltaWriterOptions _opt;

--- a/be/test/storage/segment_flush_executor_test.cpp
+++ b/be/test/storage/segment_flush_executor_test.cpp
@@ -17,6 +17,8 @@
 #include <brpc/controller.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <thread>
 #include <utility>
 
 #include "base/testutil/assert.h"
@@ -312,4 +314,100 @@ TEST_F(SegmentFlushExecutorTest, test_abort) {
     async_delta_writer->abort();
     ASSERT_EQ(kAborted, async_delta_writer->writer()->get_state());
 }
+
+// Regression test for the duplicate-eos race fixed by serialising the body
+// of DeltaWriter::commit() with std::call_once.
+//
+// In the original code path, two SegmentFlushTask threads servicing
+// duplicate tablet_writer_add_segment(eos=true) RPCs would both call
+// DeltaWriter::commit() concurrently. Both would observe state == kClosed
+// outside _state_lock, fall through into _rowset_writer->build(), race on
+// the destination TabletSchemaPB's RepeatedPtrField via concurrent
+// add_column() calls, and the loser would crash on a garbage ColumnPB*
+// returned by the corrupted Add().
+//
+// With the fix in place, exactly one caller runs the body; concurrent
+// duplicates block inside std::call_once until the body finishes and then
+// return the same captured Status. Both calls therefore return Status::OK()
+// for a successful commit, which is what SegmentFlushTask relies on (any
+// non-OK from commit() triggers _writer->cancel()).
+TEST_F(SegmentFlushExecutorTest, test_concurrent_commit_is_serialized) {
+    ASSERT_OK(prepare_primary_tablet_segment_dir(
+            "./ut_dir/SegmentFlushExecutorTest_test_concurrent_commit_is_serialized"));
+    std::shared_ptr<AsyncDeltaWriter> async_delta_writer =
+            create_delta_writer(_tablet->tablet_id(), _tablet->schema_hash(), _mem_tracker.get());
+    DeltaWriter* delta_writer = async_delta_writer->writer();
+
+    // After open() the inner writer is in kWriting. Transition to kClosed
+    // (the state that allows commit() to enter its body and made the race
+    // reachable in production).
+    ASSERT_OK(delta_writer->close());
+    ASSERT_EQ(kClosed, delta_writer->get_state());
+
+    // Two threads race into commit(). A spin-barrier maximises the window
+    // for the race; if either thread reached _rowset_writer->build()
+    // concurrently with the other under the old code it would corrupt the
+    // protobuf and crash. Under the new code exactly one thread runs the
+    // body inside std::call_once; the other blocks inside call_once and
+    // then reads the same captured Status.
+    std::atomic<int> num_ok{0};
+    std::atomic<int> num_other{0};
+    std::atomic<int> ready{0};
+    auto commit_fn = [&] {
+        ready.fetch_add(1, std::memory_order_acq_rel);
+        while (ready.load(std::memory_order_acquire) < 2) {
+            // spin until the sibling has also entered
+        }
+        Status st = delta_writer->commit();
+        if (st.ok()) {
+            num_ok.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            num_other.fetch_add(1, std::memory_order_relaxed);
+        }
+    };
+    std::thread t1(commit_fn);
+    std::thread t2(commit_fn);
+    t1.join();
+    t2.join();
+
+    // Both threads must observe Status::OK() for a successful commit: the
+    // one that ran the body from running it, the other from reading the
+    // captured _commit_result after call_once returns. No transient or
+    // duplicate status is allowed to leak out, since SegmentFlushTask
+    // would otherwise cancel the writer on any non-OK return.
+    ASSERT_EQ(num_ok.load(), 2) << "both threads must return OK; got num_ok=" << num_ok.load()
+                                << " num_other=" << num_other.load();
+    ASSERT_EQ(num_other.load(), 0);
+    ASSERT_EQ(kCommitted, delta_writer->get_state());
+
+    ASSERT_OK(StorageEngine::instance()->txn_manager()->delete_txn(_partition_id, _tablet, delta_writer->txn_id()));
+}
+
+// Sequential variant of the above: a duplicate commit() that arrives after
+// the first one has already succeeded must short-circuit to Status::OK()
+// via the top-of-function state switch (case kCommitted -> OK). After the
+// first commit() returns, _state is kCommitted; subsequent callers observe
+// it at the head of commit() and never reach the std::call_once.
+TEST_F(SegmentFlushExecutorTest, test_duplicate_commit_after_committed_returns_ok) {
+    ASSERT_OK(prepare_primary_tablet_segment_dir(
+            "./ut_dir/SegmentFlushExecutorTest_test_duplicate_commit_after_committed_returns_ok"));
+    std::shared_ptr<AsyncDeltaWriter> async_delta_writer =
+            create_delta_writer(_tablet->tablet_id(), _tablet->schema_hash(), _mem_tracker.get());
+    DeltaWriter* delta_writer = async_delta_writer->writer();
+
+    ASSERT_OK(delta_writer->close());
+    ASSERT_EQ(kClosed, delta_writer->get_state());
+
+    ASSERT_OK(delta_writer->commit());
+    ASSERT_EQ(kCommitted, delta_writer->get_state());
+
+    // The second commit() must be a no-op success: a duplicate
+    // tablet_writer_add_segment(eos=true) that arrives after the first
+    // already finished should not error or alter state.
+    ASSERT_OK(delta_writer->commit());
+    ASSERT_EQ(kCommitted, delta_writer->get_state());
+
+    ASSERT_OK(StorageEngine::instance()->txn_manager()->delete_txn(_partition_id, _tablet, delta_writer->txn_id()));
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Two SegmentFlushTask threads can reach DeltaWriter::commit() concurrently
on the same DeltaWriter when the upstream sends a duplicate
tablet_writer_add_segment(eos=true) RPC (e.g. a brpc retry on an
unstable peer link) and SegmentFlushToken dispatches the duplicates in
parallel. Without serialization the two commit() invocations race
inside RowsetWriter::build(): one moves _rowset_meta_pb into a new
RowsetMeta while the other is still iterating
TabletSchema::to_schema_pb(ts_pb) on the same TabletSchemaPB.
Concurrent calls to RepeatedPtrField::Add() corrupt the column field
(current_size_ > total_size_, observed as 45 vs 32 in the captured
core) and a subsequent add_column() returns a garbage ColumnPB* that
the next mutable_name() dereferences, producing SIGSEGV inside
InternalMetadata::PtrTag.

The previous state guard in commit() reads _state without _state_lock
and the kClosed -> kCommitted transition is only protected at the end
of the function. Two callers that both observe state == kClosed
cleanly fall past the existing switch and into the unsynchronised
body.

Serialise commit() by extracting its body into a private
_do_commit_body() helper and invoking it through std::call_once on a
per-writer std::once_flag. Exactly one caller runs the body;
concurrent duplicates block inside call_once until the body completes
and then return the captured _commit_result. This makes duplicate
commit() calls observably idempotent at the API level: both threads
return OK on success, or both return the same error on failure, with
no spurious "in progress" / AlreadyExist status leaking to callers
such as SegmentFlushTask::run (which would otherwise convert a
successful commit into an aborted one by calling _writer->cancel() on
any non-OK return).

The head-of-function state switch is unchanged and remains the fast
path for any subsequent commit() invocation: once the first call
returns, _state is kCommitted (or kAborted) and the switch returns
directly without entering call_once.

A doc comment is added at LocalTabletsChannel::add_segment describing
the no-dedup contract at the RPC entrypoint and the matching
guarantees the per-writer code is required to provide; the
SegmentFlushTask path relies on those guarantees and must not be
"helped" by adding dedup upstream without revisiting them.

## Why I'm doing:

```
*** Aborted at 1778639067 (unix time) try "date -d @1778639067" if you are using GNU date ***
PC: @          0x7896b1b starrocks::TabletColumn::to_schema_pb(starrocks::ColumnPB*) const
*** SIGSEGV (@0x0) received by PID 2279730 (TID 0x1528895fe700) LWP(2280453) from PID 0; stack trace: ***
    @     0x15291a36e20b __pthread_once_slow
    @          0xbe2b194 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x15291a377630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x7896b1b starrocks::TabletColumn::to_schema_pb(starrocks::ColumnPB*) const
    @          0x7897317 starrocks::TabletSchema::to_schema_pb(starrocks::TabletSchemaPB*) const
    @          0x84bf944 starrocks::RowsetWriter::build()
    @          0x84c8ea4 starrocks::HorizontalRowsetWriter::build()
    @          0x7b489f6 starrocks::DeltaWriter::commit()
    @          0x7767cc3 starrocks::SegmentFlushTask::run()
    @          0x45d2a07 starrocks::ThreadPool::dispatch_thread()
    @          0x45c8ef0 starrocks::Thread::supervise_thread(void*)
    @     0x15291a36fea5 start_thread
    @     0x15291922cb0d __clone
[1778639067.410][thread: 23263847638784] je_mallctl execute purge success
[1778639067.410][thread: 23263847638784] je_mallctl execute dontdump success
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
