### PR TITLE
[BugFix] Fall back to rand sampling for sub-percent histogram collection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -81,7 +81,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
                     "   $columnName as column_key, " +
                     "   count($columnName) as column_value " +
                     "FROM `$dbName`.`$tableName` $sampleClause " +
-                    "WHERE $columnName is not null " +
+                    "WHERE $randFilter and $columnName is not null " +
                     "GROUP BY $columnName " +
                     "ORDER BY count($columnName) desc limit $topN ) t";
 
@@ -165,14 +165,32 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         context.put("tableName", table.getName());
         context.put("topN", topN);
 
-        if (sampleRatio > 0.0 && sampleRatio < 1.0) {
-            String sample = String.format("SAMPLE('percent'='%d')", (int) (sampleRatio * 100));
-            context.put("sampleClause", sample);
-        } else {
-            context.put("sampleClause", "");
-        }
+        addSampleContext(context, sampleRatio);
 
         return build(context, COLLECT_MCV_STATISTIC_TEMPLATE);
+    }
+
+    private void addSampleContext(VelocityContext context, double sampleRatio) {
+        if (canUseTableSample(sampleRatio)) {
+            context.put("sampleClause", String.format("SAMPLE('percent'='%d')", (int) (sampleRatio * 100)));
+            context.put("randFilter", "TRUE");
+        } else {
+            context.put("sampleClause", "");
+            context.put("randFilter", buildRandFilter(sampleRatio));
+        }
+    }
+
+    private boolean canUseTableSample(double sampleRatio) {
+        // sampleRatio * 100 must be between 1 and 100 to use SAMPLE statement
+        return Config.enable_use_table_sample_collect_statistics &&
+                sampleRatio >= 0.01 && sampleRatio < 1.0;
+    }
+
+    private String buildRandFilter(double sampleRatio) {
+        if (sampleRatio > 0.0 && sampleRatio < 1.0) {
+            return String.format("rand() <= %f", sampleRatio);
+        }
+        return "TRUE";
     }
 
     private String buildInsertIntoHistogramStatistics(String query) {
@@ -262,16 +280,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
                 withSampleNdv));
         context.put("totalRows", Config.histogram_max_sample_row_count);
 
-        // TODO: use it by default and remove this switch
-        if (Config.enable_use_table_sample_collect_statistics && sampleRatio > 0.0 && sampleRatio < 1.0) {
-            String sampleClause = String.format("SAMPLE('percent'='%d')", (int) (sampleRatio * 100));
-            context.put("sampleClause", sampleClause);
-            context.put("randFilter", "TRUE");
-        } else {
-            String randFilter = String.format(" rand() <= %f", sampleRatio);
-            context.put("randFilter", randFilter);
-            context.put("sampleClause", "");
-        }
+        addSampleContext(context, sampleRatio);
 
         addMcvToContext(context, mostCommonValues);
         addMcvExcludeToContext(context, mostCommonValues, columnName, columnType);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -544,7 +544,24 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 " as db_id, " + t0StatsTableId +
                 " as table_id, `v2` as column_key, count(`v2`) as column_value from `test`.`t0_stats` sample" +
                 "('percent'='10') " +
-                "where `v2` is not null group by `v2` order by count(`v2`) desc limit 100 ) t"), normalize.apply(sql));
+                "where true and `v2` is not null group by `v2` order by count(`v2`) desc limit 100 ) t"),
+                normalize.apply(sql));
+
+        sql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectMCV",
+                db, olapTable, 100L, "v2", 0.00637);
+        Assertions.assertFalse(sql.contains("SAMPLE('percent'='0')"));
+        Assertions.assertEquals(normalize.apply("select cast(version as INT), cast(db_id as BIGINT), cast(table_id as " +
+                "BIGINT), " +
+                "cast(column_key as varchar), cast(column_value as varchar) from (select 2 as version, " + dbid +
+                " as db_id, " + t0StatsTableId +
+                " as table_id, `v2` as column_key, count(`v2`) as column_value from `test`.`t0_stats` " +
+                "where rand() <= 0.006370 and `v2` is not null group by `v2` order by count(`v2`) desc limit 100 ) t"),
+                normalize.apply(sql));
+
+        sql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectHistogram",
+                db, olapTable, 0.00637, 64L, Maps.newHashMap(), "v2", IntegerType.BIGINT, false);
+        Assertions.assertFalse(sql.contains("SAMPLE('percent'='0')"));
+        Assertions.assertTrue(normalize.apply(sql).contains("where rand() <= 0.006370 and `v2` is not null"));
 
         mostCommonValues = new HashMap<>();
         mostCommonValues.put("1", "10");


### PR DESCRIPTION
## Why I'm doing:

Histogram collection can reduce the effective sample ratio below 1% when histogram_max_sample_row_count caps sampling for very large tables. The TABLE SAMPLE path converts the ratio to an integer percent, which can produce SAMPLE('percent'='0') and fail analysis with "invalid percent which should in (0, 100)".

E.g. for a table with 1,5 billion rows and histogram_max_sample_row_count with default 10 million the sampleRatio will be 0,00666 which will be rounded to 0 and produces SAMPLE('percent'='0') statement.

## What I'm doing:

Use TABLE SAMPLE only when the effective ratio is at least 1%. For smaller positive ratios, use a rand() filter instead so histogram and MCV collection can still sample up to the configured row cap.

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.1
  - [X] 4.0
  - [X] 3.5
  - [ ] 3.4
