### PR TITLE
[BugFix] Allow NULL constants in CASE WHEN THEN clauses for sync MV rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/IsNoCallChildrenValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/IsNoCallChildrenValidator.java
@@ -92,8 +92,8 @@ public class IsNoCallChildrenValidator extends ScalarOperatorVisitor<Boolean, Vo
             }
             ScalarOperator thenClause = operator.getThenClause(i);
             if (!Utils.extractColumnRef(thenClause).stream().allMatch(aggregateColumns::contains) ||
-                    (thenClause.isConstantRef() && !((ConstantOperator) thenClause).isNull()) ||
-                    thenClause.isConstant()) {
+                    (thenClause.isConstant() &&
+                            !(thenClause.isConstantRef() && ((ConstantOperator) thenClause).isNull()))) {
                 return false;
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRuleTest.java
@@ -25,9 +25,11 @@ import com.starrocks.planner.OlapScanNode;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -144,5 +146,43 @@ public class MaterializedViewRuleTest extends PlanTestBase {
         } catch (NoSuchElementException e) {
             Assertions.assertTrue(false);
         }
+    }
+
+    // Regression test for: NULL constant in CASE WHEN THEN clause was incorrectly rejected by
+    // IsNoCallChildrenValidator because isConstant() returned true for NULL, conflicting with the
+    // documented invariant that THEN clauses may be a column ref or NULL.
+    @Test
+    public void testCaseWhenNullThenClauseAllowed() {
+        ColumnRefFactory factory = new ColumnRefFactory();
+        ColumnRefOperator keyCol = factory.create("k", Type.INT, false);
+        ColumnRefOperator aggCol = factory.create("v", Type.BIGINT, false);
+
+        ColumnRefSet keyColumns = new ColumnRefSet();
+        keyColumns.union(keyCol);
+        ColumnRefSet aggregateColumns = new ColumnRefSet();
+        aggregateColumns.union(aggCol);
+
+        IsNoCallChildrenValidator validator = new IsNoCallChildrenValidator(keyColumns, aggregateColumns);
+
+        // CASE WHEN k=1 THEN NULL END  →  valid: NULL in THEN is allowed
+        CaseWhenOperator nullThen = new CaseWhenOperator(
+                Type.BIGINT, null, null,
+                Lists.newArrayList(keyCol, ConstantOperator.createNull(Type.BIGINT)));
+        Assertions.assertTrue(validator.visitCaseWhenOperator(nullThen, null),
+                "THEN NULL should be accepted");
+
+        // CASE WHEN k=1 THEN 1 END  →  invalid: non-null constant in THEN is not allowed
+        CaseWhenOperator nonNullThen = new CaseWhenOperator(
+                Type.BIGINT, null, null,
+                Lists.newArrayList(keyCol, ConstantOperator.createInt(1)));
+        Assertions.assertFalse(validator.visitCaseWhenOperator(nonNullThen, null),
+                "THEN <non-null constant> should be rejected");
+
+        // CASE WHEN k=1 THEN v END  →  valid: aggregate column ref in THEN is allowed
+        CaseWhenOperator aggColThen = new CaseWhenOperator(
+                Type.BIGINT, null, null,
+                Lists.newArrayList(keyCol, aggCol));
+        Assertions.assertTrue(validator.visitCaseWhenOperator(aggColThen, null),
+                "THEN <aggregate column> should be accepted");
     }
 }


### PR DESCRIPTION
## What problem does this PR solve?


Fixes #71603

`IsNoCallChildrenValidator` incorrectly rejected `CASE WHEN` expressions where a `THEN` clause was `NULL`. The condition `thenClause.isConstant()` fired for all constants including `NULL`, contradicting the documented invariant that `THEN` clauses may be a column ref **or NULL**.

Queries using aggregate functions with `CASE WHEN ... THEN NULL` patterns (a common conditional aggregation idiom) would fail MV rewrite and fall back to base table scans, or throw in `force_or_error` mode.

## Root cause

In `IsNoCallChildrenValidator.java` the original two-condition check was:
```java
(thenClause.isConstantRef() && !((ConstantOperator) thenClause).isNull()) ||
thenClause.isConstant()
```
The second condition (`isConstant()`) shadowed the first, catching `NULL` constants as well as non-null ones and returning `false` for both.

## Fix

Collapse to a single condition that explicitly exempts `NULL` `ConstantOperator` leaves:
```java
(thenClause.isConstant() &&
        !(thenClause.isConstantRef() && ((ConstantOperator) thenClause).isNull()))
```

## Tests

Added unit tests in `MaterializedViewRuleTest` covering:
- `THEN NULL` → accepted
- `THEN <non-null constant>` → rejected
- `THEN <aggregate column ref>` → accepted

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4