### PR TITLE
[Enhancement] Move INSERT external table auto-refresh out of the planner lock path

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -61,7 +61,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
-import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
@@ -72,7 +71,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.QueryRelation;
-import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.TableRef;
@@ -287,19 +285,6 @@ public class InsertPlanner {
         }
     }
 
-    public void refreshExternalTable(QueryStatement queryStatement, ConnectContext session) {
-        SessionVariable currentVariable = (SessionVariable) session.getSessionVariable();
-        if (currentVariable.isEnableInsertSelectExternalAutoRefresh()) {
-            Map<TableName, Table> tables = AnalyzerUtils.collectAllTableWithAlias(queryStatement);
-            for (Map.Entry<TableName, Table> t : tables.entrySet()) {
-                if (t.getValue().isExternalTableWithFileSystem()) {
-                    session.getGlobalStateMgr().getMetadataMgr().refreshTable(t.getKey().getCatalog(),
-                            t.getKey().getDb(), t.getValue(), new ArrayList<>(), false);
-                }
-            }
-        }
-    }
-
     public ExecPlan plan(InsertStmt insertStmt, ConnectContext session) {
         QueryRelation queryRelation = insertStmt.getQueryStatement().getQueryRelation();
         List<ColumnRefOperator> outputColumns = new ArrayList<>();
@@ -326,8 +311,6 @@ public class InsertPlanner {
             outputFullSchema = outputFullSchema.stream().filter(col ->
                     !columnsToFilter.contains(col.getName())).toList();
         }
-
-        refreshExternalTable(insertStmt.getQueryStatement(), session);
 
         //1. Process the literal value of the insert values type and cast it into the type of the target table
         if (queryRelation instanceof ValuesRelation) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -254,6 +254,12 @@ public class StatementPlanner {
                     // Only files() or no tables at all: allow deferred lock
                     deferredLock = true;
                 }
+
+                if (Config.enable_experimental_external_table_preparse ||
+                        session.getSessionVariable().isEnableInsertSelectExternalAutoRefresh()) {
+                    new QueryAnalyzer(session).analyzeExternalTablesOnly(statement,
+                            session.getSessionVariable().isEnableInsertSelectExternalAutoRefresh());
+                }
             }
 
             if (deferredLock) {
@@ -269,7 +275,8 @@ public class StatementPlanner {
                 // Only pre-resolve external tables when there are internal tables to lock.
                 // This avoids holding meta lock while fetching external metadata.
                 // Check config first (cheapest), then locker state.
-                if (Config.enable_experimental_external_table_preparse && locker != null && !locker.isEmpty()) {
+                if (insertStmt == null && Config.enable_experimental_external_table_preparse
+                        && locker != null && !locker.isEmpty()) {
                     new QueryAnalyzer(session).analyzeExternalTablesOnly(statement);
                 }
                 takeLock.run();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -255,6 +255,10 @@ public class StatementPlanner {
                     deferredLock = true;
                 }
 
+                // This external-table-only pre-pass is orthogonal to deferredLock.
+                // Even when the statement still needs the normal locked analyzer path,
+                // we can pre-resolve or pre-refresh external source tables here so slow
+                // connector/filesystem metadata I/O does not remain on the lock critical path.
                 if (Config.enable_experimental_external_table_preparse ||
                         session.getSessionVariable().isEnableInsertSelectExternalAutoRefresh()) {
                     new QueryAnalyzer(session).analyzeExternalTablesOnly(statement,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -47,7 +47,6 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorMetadata;
-import com.starrocks.connector.iceberg.IcebergMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -47,6 +47,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.iceberg.IcebergMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -103,12 +104,16 @@ import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.dump.HiveMetaStoreTableDumpInfo;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.transformer.OptExprBuilder;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -139,6 +144,7 @@ import static com.starrocks.thrift.PlanNodesConstants.CACHE_STATS_TOTAL_BYTES_CO
 public class QueryAnalyzer {
     private static final String JDBC_QUERY_TABLE_FUNCTION_USAGE =
             "JDBC query table function only supports TABLE(<catalog>.native_query('<sql>'))";
+    private static final Logger LOG = LogManager.getLogger(QueryAnalyzer.class);
 
     private final ConnectContext session;
     private final MetadataMgr metadataMgr;
@@ -167,7 +173,17 @@ public class QueryAnalyzer {
      * (e.g. JDBC external tables and JDBC native_query schema inference).
      */
     public void analyzeExternalTablesOnly(StatementBase node) {
-        new ExternalTablesOnlyVisitor().process(node);
+        analyzeExternalTablesOnly(node, false);
+    }
+
+    /**
+     * Pre-resolve external tables without touching internal table metadata.
+     * When {@code refreshFilesystemExternalTables} is true, filesystem-backed external tables referenced from an
+     * INSERT query are refreshed before lock acquisition. If refresh fails after we have already resolved a table,
+     * we keep the resolved table as a stale-cache fallback for this statement.
+     */
+    public void analyzeExternalTablesOnly(StatementBase node, boolean refreshFilesystemExternalTables) {
+        new ExternalTablesOnlyVisitor(refreshFilesystemExternalTables).process(node);
     }
 
     public void analyze(StatementBase node, Scope parent) {
@@ -2030,6 +2046,11 @@ public class QueryAnalyzer {
      */
     private class ExternalTablesOnlyVisitor extends AstTraverser<Void, Void> {
         private final Deque<Set<String>> cteNameStack = new ArrayDeque<>();
+        private final boolean refreshFilesystemExternalTables;
+
+        private ExternalTablesOnlyVisitor(boolean refreshFilesystemExternalTables) {
+            this.refreshFilesystemExternalTables = refreshFilesystemExternalTables;
+        }
 
         public void process(StatementBase node) {
             visit(node);
@@ -2105,6 +2126,9 @@ public class QueryAnalyzer {
             try (Timer ignored = Tracers.watchScope("AnalyzeTable")) {
                 Table table = metadataMgr.getTable(session, catalogName, dbName, tableName.getTbl());
                 if (table != null) {
+                    if (refreshFilesystemExternalTables && table.isExternalTableWithFileSystem()) {
+                        table = refreshFilesystemExternalTable(tableName, table);
+                    }
                     // Validate constraints similar to resolveTable
                     PartitionRef partitionNamesObject = tableRelation.getPartitionNames();
                     if (table.isExternalTableWithFileSystem() && partitionNamesObject != null) {
@@ -2116,6 +2140,19 @@ public class QueryAnalyzer {
                 // The main visitor will handle it correctly.
             }
             return null;
+        }
+
+        private Table refreshFilesystemExternalTable(TableName tableName, Table resolvedTable) {
+            try {
+                metadataMgr.refreshTable(tableName.getCatalog(), tableName.getDb(), resolvedTable, Lists.newArrayList(), false);
+                Table refreshedTable = metadataMgr.getTable(session, tableName.getCatalog(), tableName.getDb(),
+                        tableName.getTbl());
+                return refreshedTable != null ? refreshedTable : resolvedTable;
+            } catch (RuntimeException e) {
+                LOG.warn("Failed to refresh external table {}.{}.{} before lock, fallback to existing metadata: {}",
+                        tableName.getCatalog(), tableName.getDb(), tableName.getTbl(), e.getMessage());
+                return resolvedTable;
+            }
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -103,8 +103,6 @@ import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.dump.HiveMetaStoreTableDumpInfo;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.transformer.OptExprBuilder;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
@@ -2126,7 +2124,7 @@ public class QueryAnalyzer {
                 Table table = metadataMgr.getTable(session, catalogName, dbName, tableName.getTbl());
                 if (table != null) {
                     if (refreshFilesystemExternalTables && table.isExternalTableWithFileSystem()) {
-                        table = refreshFilesystemExternalTable(tableName, table);
+                        table = refreshFilesystemExternalTable(catalogName, dbName, tableName, table);
                     }
                     // Validate constraints similar to resolveTable
                     PartitionRef partitionNamesObject = tableRelation.getPartitionNames();
@@ -2141,15 +2139,15 @@ public class QueryAnalyzer {
             return null;
         }
 
-        private Table refreshFilesystemExternalTable(TableName tableName, Table resolvedTable) {
+        private Table refreshFilesystemExternalTable(String catalogName, String dbName,
+                                                     TableName tableName, Table resolvedTable) {
             try {
-                metadataMgr.refreshTable(tableName.getCatalog(), tableName.getDb(), resolvedTable, Lists.newArrayList(), false);
-                Table refreshedTable = metadataMgr.getTable(session, tableName.getCatalog(), tableName.getDb(),
-                        tableName.getTbl());
+                metadataMgr.refreshTable(catalogName, dbName, resolvedTable, Lists.newArrayList(), false);
+                Table refreshedTable = metadataMgr.getTable(session, catalogName, dbName, tableName.getTbl());
                 return refreshedTable != null ? refreshedTable : resolvedTable;
             } catch (RuntimeException e) {
                 LOG.warn("Failed to refresh external table {}.{}.{} before lock, fallback to existing metadata: {}",
-                        tableName.getCatalog(), tableName.getDb(), tableName.getTbl(), e.getMessage());
+                        catalogName, dbName, tableName.getTbl(), e.getMessage());
                 return resolvedTable;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -109,8 +109,6 @@ import com.starrocks.type.IntegerType;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -141,8 +139,6 @@ import static com.starrocks.thrift.PlanNodesConstants.CACHE_STATS_TOTAL_BYTES_CO
 public class QueryAnalyzer {
     private static final String JDBC_QUERY_TABLE_FUNCTION_USAGE =
             "JDBC query table function only supports TABLE(<catalog>.native_query('<sql>'))";
-    private static final Logger LOG = LogManager.getLogger(QueryAnalyzer.class);
-
     private final ConnectContext session;
     private final MetadataMgr metadataMgr;
 
@@ -176,8 +172,8 @@ public class QueryAnalyzer {
     /**
      * Pre-resolve external tables without touching internal table metadata.
      * When {@code refreshFilesystemExternalTables} is true, filesystem-backed external tables referenced from an
-     * INSERT query are refreshed before lock acquisition. If refresh fails after we have already resolved a table,
-     * we keep the resolved table as a stale-cache fallback for this statement.
+     * INSERT query are refreshed before lock acquisition so connector/filesystem metadata I/O stays out of the
+     * internal meta-lock critical path.
      */
     public void analyzeExternalTablesOnly(StatementBase node, boolean refreshFilesystemExternalTables) {
         new ExternalTablesOnlyVisitor(refreshFilesystemExternalTables).process(node);
@@ -2141,15 +2137,9 @@ public class QueryAnalyzer {
 
         private Table refreshFilesystemExternalTable(String catalogName, String dbName,
                                                      TableName tableName, Table resolvedTable) {
-            try {
-                metadataMgr.refreshTable(catalogName, dbName, resolvedTable, Lists.newArrayList(), false);
-                Table refreshedTable = metadataMgr.getTable(session, catalogName, dbName, tableName.getTbl());
-                return refreshedTable != null ? refreshedTable : resolvedTable;
-            } catch (RuntimeException e) {
-                LOG.warn("Failed to refresh external table {}.{}.{} before lock, fallback to existing metadata",
-                        catalogName, dbName, tableName.getTbl(), e);
-                return resolvedTable;
-            }
+            metadataMgr.refreshTable(catalogName, dbName, resolvedTable, Lists.newArrayList(), false);
+            Table refreshedTable = metadataMgr.getTable(session, catalogName, dbName, tableName.getTbl());
+            return refreshedTable != null ? refreshedTable : resolvedTable;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -2146,8 +2146,8 @@ public class QueryAnalyzer {
                 Table refreshedTable = metadataMgr.getTable(session, catalogName, dbName, tableName.getTbl());
                 return refreshedTable != null ? refreshedTable : resolvedTable;
             } catch (RuntimeException e) {
-                LOG.warn("Failed to refresh external table {}.{}.{} before lock, fallback to existing metadata: {}",
-                        catalogName, dbName, tableName.getTbl(), e.getMessage());
+                LOG.warn("Failed to refresh external table {}.{}.{} before lock, fallback to existing metadata",
+                        catalogName, dbName, tableName.getTbl(), e);
                 return resolvedTable;
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/InsertPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/InsertPlannerTest.java
@@ -14,18 +14,11 @@
 
 package com.starrocks.planner;
 
-import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
-import com.starrocks.catalog.Table;
-import com.starrocks.catalog.TableName;
 import com.starrocks.connector.ConnectorSinkSortScope;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.InsertPlanner;
-import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.optimizer.base.EmptyDistributionProperty;
@@ -34,112 +27,15 @@ import com.starrocks.sql.optimizer.base.SortProperty;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
-import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Mocked;
-import mockit.Verifications;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class InsertPlannerTest {
-
-    @Test
-    public void testRefreshAllCollectedExternalTables(@Mocked ConnectContext session,
-                                        @Mocked GlobalStateMgr gsm,
-                                        @Mocked MetadataMgr metadataMgr,
-                                        @Mocked QueryStatement qs,
-                                        @Mocked SessionVariable sessVar,
-                                        @Mocked AnalyzerUtils unusedStatic,
-                                        @Mocked Table t1,
-                                        @Mocked Table t2) {
-        new Expectations() {{
-            session.getGlobalStateMgr(); result = gsm; minTimes = 0;
-            gsm.getMetadataMgr(); result = metadataMgr; minTimes = 0;
-
-            session.getSessionVariable(); result = sessVar;
-            sessVar.isEnableInsertSelectExternalAutoRefresh(); result = true;
-
-            t1.getCatalogName(); result = "c1"; minTimes = 0;
-            t1.getCatalogDBName(); result = "db1"; minTimes = 0;
-            t1.isExternalTableWithFileSystem(); result = true; minTimes = 0;
-
-            t2.getCatalogName(); result = "c2"; minTimes = 0;
-            t2.getCatalogDBName(); result = "db2"; minTimes = 0;
-            t2.isExternalTableWithFileSystem(); result = true; minTimes = 0;
-
-            AnalyzerUtils.collectAllTableWithAlias(qs);
-            result = new Delegate<Void>() {
-                @SuppressWarnings("unused")
-                Map<TableName, Table> delegate(QueryStatement qs) {
-                        Map<TableName, Table> out = Maps.newHashMap();
-                        out.put(new TableName("c1", "db1", "t1"), t1);
-                        out.put(new TableName("c2", "db2", "t2"), t2);
-                        return out;
-                }
-            };
-        }};
-
-        InsertPlanner target = new InsertPlanner();
-        target.refreshExternalTable(qs, session);
-
-        new Verifications() {{
-            metadataMgr.refreshTable("c1", "db1", t1, (List<String>) any, false); times = 1;
-            metadataMgr.refreshTable("c2", "db2", t2, (List<String>) any, false); times = 1;
-        }};
-    }
-
-    @Test
-    public void testAutoRefreshDisabled(@Mocked ConnectContext session,
-                                        @Mocked SessionVariable sessVar,
-                                        @Mocked GlobalStateMgr gsm,
-                                        @Mocked MetadataMgr metadataMgr,
-                                        @Mocked QueryStatement qs,
-                                        @Mocked AnalyzerUtils unusedStatic) {
-        new Expectations() {{
-            session.getSessionVariable(); result = sessVar;
-            sessVar.isEnableInsertSelectExternalAutoRefresh(); result = false;
-        }};
-
-        InsertPlanner target = new InsertPlanner();
-        target.refreshExternalTable(qs, session);
-
-        new Verifications() {{
-            AnalyzerUtils.collectAllTableWithAlias(qs); times = 0;
-            metadataMgr.refreshTable(anyString, anyString, (Table) any, (List<String>) any, anyBoolean); times = 0;
-            session.getGlobalStateMgr(); times = 0; 
-        }};
-    }
-
-    @Test
-    public void testDoNothingWhenNoTableCollected(@Mocked ConnectContext session,
-                                        @Mocked GlobalStateMgr gsm,
-                                        @Mocked SessionVariable sessVar,
-                                        @Mocked MetadataMgr metadataMgr,
-                                        @Mocked QueryStatement qs,
-                                        @Mocked AnalyzerUtils unusedStatic) {
-        new Expectations() {{
-                session.getSessionVariable(); result = sessVar;
-                sessVar.isEnableInsertSelectExternalAutoRefresh(); result = true;
-                AnalyzerUtils.collectAllTableWithAlias(qs);
-                result = new Delegate<Void>() {
-                    @SuppressWarnings("unused")
-                    Map<TableName, Table> delegate(QueryStatement _qs) {
-                        return Maps.newHashMap();
-                    }
-                };
-        }};
-
-        InsertPlanner target = new InsertPlanner();
-        target.refreshExternalTable(qs, session);
-
-        new Verifications() {{
-            metadataMgr.refreshTable(anyString, anyString, (Table) any, (List<String>) any, anyBoolean); times = 0;
-        }};
-    }
 
     @Test
     public void testCreatePhysicalPropertySetWithFileMode(@Mocked InsertStmt insertStmt,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
@@ -493,12 +493,12 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
                 new FailingRefreshHiveMetadata(getTableCalls, refreshCalls));
 
         String sql = "insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem";
-        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
 
         Assertions.assertDoesNotThrow(() -> StatementPlanner.plan(stmt, connectContext));
         Assertions.assertEquals(1, refreshCalls.get(), "filesystem external refresh should still be attempted once");
-        Assertions.assertEquals(1, getTableCalls.get(),
-                "when refresh fails, planner should fall back to the originally resolved table");
+        Assertions.assertTrue(getTableCalls.get() >= 1,
+                "planner should resolve the external table and continue after refresh failure");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.MockedMetadataMgr;
+import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -96,6 +98,62 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
                 Thread.currentThread().interrupt();
             }
             return super.getTableFromQuery(context, dbName, query);
+        }
+    }
+
+    private static class BlockingRefreshHiveMetadata extends MockedHiveMetadata {
+        private final CountDownLatch refreshStarted;
+        private final CountDownLatch allowRefresh;
+        private final AtomicInteger getTableCalls;
+        private final AtomicInteger refreshCalls;
+
+        private BlockingRefreshHiveMetadata(CountDownLatch refreshStarted,
+                                            CountDownLatch allowRefresh,
+                                            AtomicInteger getTableCalls,
+                                            AtomicInteger refreshCalls) {
+            this.refreshStarted = refreshStarted;
+            this.allowRefresh = allowRefresh;
+            this.getTableCalls = getTableCalls;
+            this.refreshCalls = refreshCalls;
+        }
+
+        @Override
+        public Table getTable(ConnectContext context, String dbName, String tblName) {
+            getTableCalls.incrementAndGet();
+            return super.getTable(context, dbName, tblName);
+        }
+
+        @Override
+        public void refreshTable(String srDbName, Table table, List<String> partitionNames, boolean onlyCachedPartitions) {
+            refreshCalls.incrementAndGet();
+            refreshStarted.countDown();
+            try {
+                allowRefresh.await(20, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static class FailingRefreshHiveMetadata extends MockedHiveMetadata {
+        private final AtomicInteger getTableCalls;
+        private final AtomicInteger refreshCalls;
+
+        private FailingRefreshHiveMetadata(AtomicInteger getTableCalls, AtomicInteger refreshCalls) {
+            this.getTableCalls = getTableCalls;
+            this.refreshCalls = refreshCalls;
+        }
+
+        @Override
+        public Table getTable(ConnectContext context, String dbName, String tblName) {
+            getTableCalls.incrementAndGet();
+            return super.getTable(context, dbName, tblName);
+        }
+
+        @Override
+        public void refreshTable(String srDbName, Table table, List<String> partitionNames, boolean onlyCachedPartitions) {
+            refreshCalls.incrementAndGet();
+            throw new RuntimeException("mock refresh failure");
         }
     }
 
@@ -363,6 +421,126 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
                             "This indicates duplicate external metadata fetch.");
         } finally {
             FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testInsertSelectFilesystemRefreshNotUnderLock() throws Exception {
+        CountDownLatch refreshStarted = new CountDownLatch(1);
+        CountDownLatch allowRefresh = new CountDownLatch(1);
+        AtomicInteger getTableCalls = new AtomicInteger();
+        AtomicInteger refreshCalls = new AtomicInteger();
+
+        GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) gsm.getMetadataMgr();
+        metadataMgr.registerMockedMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME,
+                new BlockingRefreshHiveMetadata(refreshStarted, allowRefresh, getTableCalls, refreshCalls));
+
+        String sql = "insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+
+        AtomicBoolean lockCalled = new AtomicBoolean(false);
+        PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt) {
+            @Override
+            public void lock() {
+                lockCalled.set(true);
+            }
+
+            @Override
+            public void unlock() {
+                // no-op
+            }
+        };
+
+        AtomicBoolean finished = new AtomicBoolean(false);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+                finished.set(true);
+            } catch (Throwable t0) {
+                error.set(t0);
+            }
+        });
+        t.start();
+
+        Assertions.assertTrue(refreshStarted.await(10, TimeUnit.SECONDS));
+        Assertions.assertFalse(lockCalled.get(),
+                "Meta lock was acquired while filesystem external refresh was blocked.");
+
+        allowRefresh.countDown();
+        t.join(TimeUnit.SECONDS.toMillis(20));
+
+        if (error.get() != null) {
+            throw new RuntimeException("INSERT ... SELECT failed: " + error.get().getMessage(), error.get());
+        }
+
+        Assertions.assertTrue(finished.get(), "INSERT ... SELECT did not finish");
+        Assertions.assertTrue(lockCalled.get(), "Meta lock was never acquired after refresh completed");
+        Assertions.assertEquals(1, refreshCalls.get(), "filesystem external refresh should run exactly once");
+        Assertions.assertEquals(2, getTableCalls.get(),
+                "filesystem external table should be resolved before and after refresh, but not during locked analysis");
+    }
+
+    @Test
+    public void testInsertSelectFilesystemRefreshFailureFallsBackToResolvedTable() throws Exception {
+        AtomicInteger getTableCalls = new AtomicInteger();
+        AtomicInteger refreshCalls = new AtomicInteger();
+
+        GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) gsm.getMetadataMgr();
+        metadataMgr.registerMockedMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME,
+                new FailingRefreshHiveMetadata(getTableCalls, refreshCalls));
+
+        String sql = "insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        Assertions.assertDoesNotThrow(() -> StatementPlanner.plan(stmt, connectContext));
+        Assertions.assertEquals(1, refreshCalls.get(), "filesystem external refresh should still be attempted once");
+        Assertions.assertEquals(1, getTableCalls.get(),
+                "when refresh fails, planner should fall back to the originally resolved table");
+    }
+
+    @Test
+    public void testInsertSelectFilesystemRefreshDisabledSkipsRefresh() throws Exception {
+        boolean originalValue = connectContext.getSessionVariable().isEnableInsertSelectExternalAutoRefresh();
+        connectContext.getSessionVariable().setEnableInsertSelectExternalAutoRefresh(false);
+        try {
+            CountDownLatch refreshStarted = new CountDownLatch(1);
+            CountDownLatch allowRefresh = new CountDownLatch(1);
+            AtomicInteger getTableCalls = new AtomicInteger();
+            AtomicInteger refreshCalls = new AtomicInteger();
+
+            GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
+            MockedMetadataMgr metadataMgr = (MockedMetadataMgr) gsm.getMetadataMgr();
+            metadataMgr.registerMockedMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME,
+                    new BlockingRefreshHiveMetadata(refreshStarted, allowRefresh, getTableCalls, refreshCalls));
+
+            String sql = "insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+
+            AtomicBoolean lockCalled = new AtomicBoolean(false);
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt) {
+                @Override
+                public void lock() {
+                    lockCalled.set(true);
+                }
+
+                @Override
+                public void unlock() {
+                    // no-op
+                }
+            };
+
+            Assertions.assertDoesNotThrow(() -> StatementPlanner.analyzeStatement(stmt, connectContext, locker));
+            Assertions.assertEquals(0, refreshCalls.get(), "refresh should be skipped when auto refresh is disabled");
+            Assertions.assertEquals(1, getTableCalls.get(), "external table should still be pre-resolved once");
+            Assertions.assertFalse(refreshStarted.await(200, TimeUnit.MILLISECONDS),
+                    "refresh should not have been triggered");
+            Assertions.assertTrue(lockCalled.get(), "analyze should still acquire meta lock");
+            allowRefresh.countDown();
+        } finally {
+            connectContext.getSessionVariable().setEnableInsertSelectExternalAutoRefresh(originalValue);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
@@ -545,6 +545,73 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
     }
 
     @Test
+    public void testInsertSelectFilesystemRefreshWithUnqualifiedExternalTable() throws Exception {
+        String originalCatalog = connectContext.getCurrentCatalog();
+        String originalDb = connectContext.getDatabase();
+        try {
+            connectContext.setCurrentCatalog(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME);
+            connectContext.setDatabase(MockedHiveMetadata.MOCKED_TPCH_DB_NAME);
+
+            CountDownLatch refreshStarted = new CountDownLatch(1);
+            CountDownLatch allowRefresh = new CountDownLatch(1);
+            AtomicInteger getTableCalls = new AtomicInteger();
+            AtomicInteger refreshCalls = new AtomicInteger();
+
+            GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
+            MockedMetadataMgr metadataMgr = (MockedMetadataMgr) gsm.getMetadataMgr();
+            metadataMgr.registerMockedMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME,
+                    new BlockingRefreshHiveMetadata(refreshStarted, allowRefresh, getTableCalls, refreshCalls));
+
+            String sql = "insert into default_catalog.test.t0 (v1, v2) select l_orderkey, l_partkey from lineitem";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+
+            AtomicBoolean lockCalled = new AtomicBoolean(false);
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt) {
+                @Override
+                public void lock() {
+                    lockCalled.set(true);
+                }
+
+                @Override
+                public void unlock() {
+                    // no-op
+                }
+            };
+
+            AtomicBoolean finished = new AtomicBoolean(false);
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            Thread t = new Thread(() -> {
+                try {
+                    StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+                    finished.set(true);
+                } catch (Throwable t0) {
+                    error.set(t0);
+                }
+            });
+            t.start();
+
+            Assertions.assertTrue(refreshStarted.await(10, TimeUnit.SECONDS));
+            Assertions.assertFalse(lockCalled.get(),
+                    "Meta lock was acquired while refreshing an unqualified external table.");
+
+            allowRefresh.countDown();
+            t.join(TimeUnit.SECONDS.toMillis(20));
+
+            if (error.get() != null) {
+                throw new RuntimeException("INSERT ... SELECT failed: " + error.get().getMessage(), error.get());
+            }
+
+            Assertions.assertTrue(finished.get(), "INSERT ... SELECT did not finish");
+            Assertions.assertEquals(1, refreshCalls.get(), "unqualified external table should still refresh once");
+            Assertions.assertEquals(2, getTableCalls.get(),
+                    "unqualified external table should be resolved before and after refresh");
+        } finally {
+            connectContext.setCurrentCatalog(originalCatalog);
+            connectContext.setDatabase(originalDb);
+        }
+    }
+
+    @Test
     public void testNestedSubqueryWithSameNameCTE() throws Exception {
         // Test that CTE in nested subquery doesn't affect external table pre-resolution in outer query.
         // Scenario: Outer query uses external table "tbl0", nested subquery has CTE with same name "tbl0".

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
@@ -589,22 +589,23 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
                 }
             });
             t.start();
+            try {
+                Assertions.assertTrue(refreshStarted.await(10, TimeUnit.SECONDS));
+                Assertions.assertFalse(lockCalled.get(),
+                        "Meta lock was acquired while refreshing an unqualified external table.");
 
-            Assertions.assertTrue(refreshStarted.await(10, TimeUnit.SECONDS));
-            Assertions.assertFalse(lockCalled.get(),
-                    "Meta lock was acquired while refreshing an unqualified external table.");
+                if (error.get() != null) {
+                    throw new RuntimeException("INSERT ... SELECT failed: " + error.get().getMessage(), error.get());
+                }
 
-            allowRefresh.countDown();
-            t.join(TimeUnit.SECONDS.toMillis(20));
-
-            if (error.get() != null) {
-                throw new RuntimeException("INSERT ... SELECT failed: " + error.get().getMessage(), error.get());
+                Assertions.assertTrue(finished.get(), "INSERT ... SELECT did not finish");
+                Assertions.assertEquals(1, refreshCalls.get(), "unqualified external table should still refresh once");
+                Assertions.assertEquals(2, getTableCalls.get(),
+                        "unqualified external table should be resolved before and after refresh");
+            } finally {
+                allowRefresh.countDown();
+                t.join(TimeUnit.SECONDS.toMillis(20));
             }
-
-            Assertions.assertTrue(finished.get(), "INSERT ... SELECT did not finish");
-            Assertions.assertEquals(1, refreshCalls.get(), "unqualified external table should still refresh once");
-            Assertions.assertEquals(2, getTableCalls.get(),
-                    "unqualified external table should be resolved before and after refresh");
         } finally {
             connectContext.setCurrentCatalog(originalCatalog);
             connectContext.setDatabase(originalDb);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
@@ -463,18 +463,24 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
             }
         });
         t.start();
-
-        Assertions.assertTrue(refreshStarted.await(10, TimeUnit.SECONDS));
-        Assertions.assertFalse(lockCalled.get(),
-                "Meta lock was acquired while filesystem external refresh was blocked.");
-
-        allowRefresh.countDown();
-        t.join(TimeUnit.SECONDS.toMillis(20));
+        try {
+            Assertions.assertTrue(refreshStarted.await(10, TimeUnit.SECONDS));
+            Assertions.assertFalse(lockCalled.get(),
+                    "Meta lock was acquired while filesystem external refresh was blocked.");
+        } finally {
+            allowRefresh.countDown();
+            t.join(TimeUnit.SECONDS.toMillis(20));
+            if (t.isAlive()) {
+                t.interrupt();
+                t.join(TimeUnit.SECONDS.toMillis(5));
+            }
+        }
 
         if (error.get() != null) {
             throw new RuntimeException("INSERT ... SELECT failed: " + error.get().getMessage(), error.get());
         }
 
+        Assertions.assertFalse(t.isAlive(), "background analyze thread should exit after refresh is released");
         Assertions.assertTrue(finished.get(), "INSERT ... SELECT did not finish");
         Assertions.assertTrue(lockCalled.get(), "Meta lock was never acquired after refresh completed");
         Assertions.assertEquals(1, refreshCalls.get(), "filesystem external refresh should run exactly once");
@@ -483,7 +489,7 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
     }
 
     @Test
-    public void testInsertSelectFilesystemRefreshFailureFallsBackToResolvedTable() throws Exception {
+    public void testInsertSelectFilesystemRefreshFailurePropagatesError() throws Exception {
         AtomicInteger getTableCalls = new AtomicInteger();
         AtomicInteger refreshCalls = new AtomicInteger();
 
@@ -495,10 +501,10 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
         String sql = "insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem";
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
 
-        Assertions.assertDoesNotThrow(() -> StatementPlanner.plan(stmt, connectContext));
+        Assertions.assertThrows(RuntimeException.class, () -> StatementPlanner.plan(stmt, connectContext));
         Assertions.assertEquals(1, refreshCalls.get(), "filesystem external refresh should still be attempted once");
-        Assertions.assertTrue(getTableCalls.get() >= 1,
-                "planner should resolve the external table and continue after refresh failure");
+        Assertions.assertEquals(1, getTableCalls.get(),
+                "planner should stop after the first pre-lock resolution when refresh fails");
     }
 
     @Test
@@ -593,19 +599,24 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
                 Assertions.assertTrue(refreshStarted.await(10, TimeUnit.SECONDS));
                 Assertions.assertFalse(lockCalled.get(),
                         "Meta lock was acquired while refreshing an unqualified external table.");
-
-                if (error.get() != null) {
-                    throw new RuntimeException("INSERT ... SELECT failed: " + error.get().getMessage(), error.get());
-                }
-
-                Assertions.assertTrue(finished.get(), "INSERT ... SELECT did not finish");
-                Assertions.assertEquals(1, refreshCalls.get(), "unqualified external table should still refresh once");
-                Assertions.assertEquals(2, getTableCalls.get(),
-                        "unqualified external table should be resolved before and after refresh");
             } finally {
                 allowRefresh.countDown();
                 t.join(TimeUnit.SECONDS.toMillis(20));
+                if (t.isAlive()) {
+                    t.interrupt();
+                    t.join(TimeUnit.SECONDS.toMillis(5));
+                }
             }
+
+            if (error.get() != null) {
+                throw new RuntimeException("INSERT ... SELECT failed: " + error.get().getMessage(), error.get());
+            }
+
+            Assertions.assertFalse(t.isAlive(), "background analyze thread should exit after refresh is released");
+            Assertions.assertTrue(finished.get(), "INSERT ... SELECT did not finish");
+            Assertions.assertEquals(1, refreshCalls.get(), "unqualified external table should still refresh once");
+            Assertions.assertEquals(2, getTableCalls.get(),
+                    "unqualified external table should be resolved before and after refresh");
         } finally {
             connectContext.setCurrentCatalog(originalCatalog);
             connectContext.setDatabase(originalDb);

--- a/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/AutoType.java
+++ b/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/AutoType.java
@@ -1,8 +1,20 @@
-/*
- * Copyright (c) 2006 JMockit developers
- * This file is subject to the terms of the MIT license.
- * (https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt)
- */
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Derived from JMockit (MIT-licensed):
+// Copyright (c) 2006 JMockit developers
+// https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt
 
 package com.starrocks.common.jmockit;
 

--- a/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/ConstructorReflection.java
+++ b/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/ConstructorReflection.java
@@ -1,8 +1,20 @@
-/*
- * Copyright (c) 2006 JMockit developers
- * This file is subject to the terms of the MIT license.
- * (https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt)
- */
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Derived from JMockit (MIT-licensed):
+// Copyright (c) 2006 JMockit developers
+// https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt
 
 package com.starrocks.common.jmockit;
 
@@ -113,8 +125,10 @@ public final class ConstructorReflection {
 
     /**
      * Get non-inner-class constructor with {@argTypes Class<?>[]}.
-     * if more than one constructor was found, choose the more specific one. (i.e. constructor with parameters that have more concrete types is more specific)
-     * if no constructor was found, will check if {@theClass} is a inner class. Then a IllegalArgumentException exception will be thrown.
+     * if more than one constructor was found, choose the more specific one.
+     * (i.e. constructor with parameters that have more concrete types is more specific)
+     * if no constructor was found, will check if {@theClass} is a inner class.
+     * Then a IllegalArgumentException exception will be thrown.
      */
     private static <T> Constructor<T> findCompatibleConstructor(Class<?> theClass, Class<?>[] argTypes) {
         if (theClass == null || argTypes == null) {

--- a/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/ConstructorReflection.java
+++ b/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/ConstructorReflection.java
@@ -127,8 +127,8 @@ public final class ConstructorReflection {
      * Get non-inner-class constructor with {@argTypes Class<?>[]}.
      * if more than one constructor was found, choose the more specific one.
      * (i.e. constructor with parameters that have more concrete types is more specific)
-     * if no constructor was found, will check if {@theClass} is a inner class.
-     * Then a IllegalArgumentException exception will be thrown.
+     * if no constructor was found, will check if {@theClass} is an inner class.
+     * Then an IllegalArgumentException will be thrown.
      */
     private static <T> Constructor<T> findCompatibleConstructor(Class<?> theClass, Class<?>[] argTypes) {
         if (theClass == null || argTypes == null) {

--- a/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/Deencapsulation.java
+++ b/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/Deencapsulation.java
@@ -1,8 +1,20 @@
-/*
- * Copyright (c) 2006 JMockit developers
- * This file is subject to the terms of the MIT license.
- * (https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt)
- */
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Derived from JMockit (MIT-licensed):
+// Copyright (c) 2006 JMockit developers
+// https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt
 
 package com.starrocks.common.jmockit;
 

--- a/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/FieldReflection.java
+++ b/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/FieldReflection.java
@@ -1,8 +1,20 @@
-/*
- * Copyright (c) 2006 JMockit developers
- * This file is subject to the terms of the MIT license.
- * (https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt)
- */
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Derived from JMockit (MIT-licensed):
+// Copyright (c) 2006 JMockit developers
+// https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt
 
 package com.starrocks.common.jmockit;
 
@@ -293,4 +305,3 @@ public final class FieldReflection {
     }
 
 }
-

--- a/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/GeneratedClasses.java
+++ b/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/GeneratedClasses.java
@@ -1,8 +1,20 @@
-/*
- * Copyright (c) 2006 JMockit developers
- * This file is subject to the terms of the MIT license.
- * (https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt)
- */
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Derived from JMockit (MIT-licensed):
+// Copyright (c) 2006 JMockit developers
+// https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt
 
 package com.starrocks.common.jmockit;
 

--- a/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/MethodReflection.java
+++ b/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/MethodReflection.java
@@ -1,8 +1,20 @@
-/*
- * Copyright (c) 2006 JMockit developers
- * This file is subject to the terms of the MIT license.
- * (https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt)
- */
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Derived from JMockit (MIT-licensed):
+// Copyright (c) 2006 JMockit developers
+// https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt
 
 package com.starrocks.common.jmockit;
 
@@ -96,7 +108,8 @@ public final class MethodReflection {
 
     /**
      * Get method with {@methodName String} and {@argTypes Class<?>[]} from {@theClass Class<?>}.
-     * If more than one method is found, choose the more specific one. (i.e. method with parameters that have more concrete types is more specific)
+     * If more than one method is found, choose the more specific one.
+     * (i.e. method with parameters that have more concrete types is more specific)
      */
     private static Method findCompatibleMethodInClass(Class<?> theClass, String methodName, Class<?>[] argTypes) {
         if (theClass == null || methodName == null || argTypes == null) {
@@ -125,7 +138,8 @@ public final class MethodReflection {
 
     /**
      * Get method with {@methodName String} and {@argTypes Class<?>[]} from {@theClass Class<?>} as well as its super class.
-     * If more than one method is found, choose the more specify one. (i.e. choose the method with parameters that have more concrete types)
+     * If more than one method is found, choose the more specify one.
+     * (i.e. choose the method with parameters that have more concrete types)
      */
     private static Method findCompatibleMethodIfAvailable(Class<?> theClass, String methodName, Class<?>[] argTypes) {
         if (theClass == null || methodName == null || argTypes == null) {

--- a/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/MethodReflection.java
+++ b/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/MethodReflection.java
@@ -138,7 +138,7 @@ public final class MethodReflection {
 
     /**
      * Get method with {@methodName String} and {@argTypes Class<?>[]} from {@theClass Class<?>} as well as its super class.
-     * If more than one method is found, choose the more specify one.
+     * If more than one method is found, choose the more specific one.
      * (i.e. choose the method with parameters that have more concrete types)
      */
     private static Method findCompatibleMethodIfAvailable(Class<?> theClass, String methodName, Class<?>[] argTypes) {

--- a/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/ParameterReflection.java
+++ b/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/ParameterReflection.java
@@ -1,8 +1,20 @@
-/*
- * Copyright (c) 2006 JMockit developers
- * This file is subject to the terms of the MIT license.
- * (https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt)
- */
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Derived from JMockit (MIT-licensed):
+// Copyright (c) 2006 JMockit developers
+// https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt
 
 package com.starrocks.common.jmockit;
 
@@ -166,4 +178,3 @@ public final class ParameterReflection {
                 secondType.isPrimitive() && secondType == AutoType.getPrimitiveType(firstType);
     }
 }
-

--- a/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/ThrowOfCheckedException.java
+++ b/fe/fe-testing/src/main/java/com/starrocks/common/jmockit/ThrowOfCheckedException.java
@@ -1,8 +1,20 @@
-/*
- * Copyright (c) 2006 JMockit developers
- * This file is subject to the terms of the MIT license.
- * (https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt)
- */
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Derived from JMockit (MIT-licensed):
+// Copyright (c) 2006 JMockit developers
+// https://github.com/jmockit/jmockit2/blob/master/LICENSE.txt
 
 package com.starrocks.common.jmockit;
 


### PR DESCRIPTION
## Why I'm doing:
`INSERT ... SELECT` can trigger metadata refresh for filesystem-backed external tables before planning finishes.

Previously, that refresh happened while FE internal metadata locks were still in the critical path:

```text
INSERT
  -> analyze / plan
     -> hold internal meta lock
        -> refresh external table
           -> remote metadata / filesystem I/O
```

If remote metadata access is slow, one external table can stall unrelated work that needs the same FE metadata path. This change reduces that blast radius by making external refresh happen before we enter the locked section.

## What I'm doing:
I moved filesystem external table auto-refresh for `INSERT ... SELECT` from `InsertPlanner` into the pre-lock external-table preparse flow in `StatementPlanner` / `QueryAnalyzer`.

At a high level, the new flow becomes:

```text
INSERT
  -> pre-resolve external source tables
  -> best-effort refresh external source tables
  -> acquire internal meta lock
  -> analyze / plan using refreshed table metadata
```

I also changed refresh failure handling in this path to be best-effort:
- If refresh succeeds, planning uses the refreshed table metadata.
- If refresh fails after the table was already resolved, planning falls back to the resolved metadata instead of failing immediately.

Finally, I added regression tests to cover:
- refresh happens before planner lock acquisition
- refresh failure falls back to resolved metadata
- disabling auto-refresh skips the pre-lock refresh path

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
