### PR TITLE
[Tool] CI Report: PR-aware run-name and parent-run link on the run page

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -44,6 +44,20 @@ jobs:
       BUCKET_PREFIX: ${{ steps.bucket_info.outputs.bucket_prefix }}
       SKIP_COV: ${{ steps.pr_details.outputs.SKIP_COV }}
     steps:
+      - name: Surface parent CI PIPELINE link
+        env:
+          PARENT_RUN_ID: ${{ github.event.workflow_run.id }}
+          PARENT_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          {
+            echo "## Parent CI PIPELINE run"
+            echo ""
+            printf '[Run #%s](%s) - branch `%s` @ `%s`\n' \
+              "$PARENT_RUN_ID" "$PARENT_RUN_URL" "$HEAD_BRANCH" "$HEAD_SHA"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - run: |
           sleep 10
 

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -1,5 +1,10 @@
 name: CI Report
-run-name: CI Report(#${{ github.event.workflow_run.id }})
+run-name: >-
+  CI Report —
+  ${{ github.event.workflow_run.pull_requests[0].number
+      && format('PR #{0} ({1})', github.event.workflow_run.pull_requests[0].number, github.event.workflow_run.head_branch)
+      || github.event.workflow_run.head_branch }}
+  (parent #${{ github.event.workflow_run.id }})
 
 on:
   workflow_run:


### PR DESCRIPTION
## Why I'm doing:

CI Report (`on: workflow_run`) sends "Some jobs were not successful" emails with subjects like:

> CI Report(#25918743758): Some jobs were not successful

Two issues:

1. The subject has no PR number or branch — the receiver cannot tell which PR is failing without opening the link.
2. The number in parens is the **parent CI PIPELINE** run id, but the email's "View workflow run" button leads to the **CI Report** run (different id). Once on the CI Report run page, there is no clickable path back to the parent — the parent id is plain text in the title and the user has to edit the URL by hand.

The email template is not customizable, so this is fixed in two places that we *can* control: the `run-name` (drives the email subject) and the `Summary` tab of the CI Report run (where the "View workflow run" link lands).

Fixes #73393

## What I'm doing:

Two commits in `.github/workflows/ci-report.yml`:

### 1. Make `run-name` PR-aware

Include the PR number when `workflow_run.pull_requests[0]` is populated (same-repo PRs), fall back to the head branch for cross-fork PRs, and keep the parent run id in parens for cross-reference.

Before:

```yaml
run-name: CI Report(#${{ github.event.workflow_run.id }})
```

After:

```yaml
run-name: >-
  CI Report —
  ${{ github.event.workflow_run.pull_requests[0].number
      && format('PR #{0} ({1})', github.event.workflow_run.pull_requests[0].number, github.event.workflow_run.head_branch)
      || github.event.workflow_run.head_branch }}
  (parent #${{ github.event.workflow_run.id }})
```

Resulting subjects:
- same-repo PR: `CI Report — PR #73370 (feature/mysql8-information-schema-tables) (parent #25918743758): Some jobs were not successful`
- fork PR: `CI Report — feature/mysql8-information-schema-tables (parent #25918743758): Some jobs were not successful`

### 2. Surface the parent run link on the CI Report run page

Add an early step in the `INFO` job that writes a markdown link to `$GITHUB_STEP_SUMMARY`. It appears on the `Summary` tab of every CI Report run, above the existing per-job summary blocks:

> ## Parent CI PIPELINE run
> [Run #25918743758](...) - branch `feature/mysql8-information-schema-tables` @ `e1268665fef`

So when someone clicks "View workflow run" from the email and lands in the CI Report run, the link to the actual parent is one click away on the same page.

@huailiu1122 PTAL

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
