### PR TITLE
[Refactor] Centralize refresh-other-FE concurrency management in GlobalStateMgr

### DIFF
--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -1255,7 +1255,7 @@ This topic introduces the following types of FE configurations:
 - Type: Integer
 - Unit: -
 - Is mutable: Yes
-- Description: The number of threads in the FE-global dispatch executor for asynchronous "refresh other FE" jobs. These threads only schedule background refresh tasks from connector write paths. They do not send peer FE refresh RPCs directly.
+- Description: The number of threads in the FE-global dispatch executor for asynchronous "refresh other FE" jobs. These threads only schedule background refresh tasks from connector write paths. They do not send peer FE refresh RPCs directly. Changes take effect on running FEs without restart.
 - Introduced in: -
 
 ### `refresh_other_fe_rpc_executor_thread_num`
@@ -1264,7 +1264,7 @@ This topic introduces the following types of FE configurations:
 - Type: Integer
 - Unit: -
 - Is mutable: Yes
-- Description: The number of threads in the FE-global RPC executor for "refresh other FE" fan-out. This executor bounds the number of concurrent refresh RPCs sent to peer FEs for both synchronous and asynchronous external table refresh flows.
+- Description: The number of threads in the FE-global RPC executor for "refresh other FE" fan-out. This executor bounds the number of concurrent refresh RPCs sent to peer FEs for both synchronous and asynchronous external table refresh flows. Changes take effect on running FEs without restart.
 - Introduced in: -
 
 ### `enable_collect_query_detail_info`

--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -1249,6 +1249,24 @@ This topic introduces the following types of FE configurations:
 - Description: Whether to enable the periodic Hive metadata cache refresh. After it is enabled, StarRocks polls the metastore (Hive Metastore or AWS Glue) of your Hive cluster, and refreshes the cached metadata of the frequently accessed Hive catalogs to perceive data changes. `true` indicates to enable the Hive metadata cache refresh, and `false` indicates to disable it.
 - Introduced in: v2.5.5
 
+### `refresh_other_fe_dispatch_executor_thread_num`
+
+- Default: 4
+- Type: Integer
+- Unit: -
+- Is mutable: Yes
+- Description: The number of threads in the FE-global dispatch executor for asynchronous "refresh other FE" jobs. These threads only schedule background refresh tasks from connector write paths. They do not send peer FE refresh RPCs directly.
+- Introduced in: -
+
+### `refresh_other_fe_rpc_executor_thread_num`
+
+- Default: 4
+- Type: Integer
+- Unit: -
+- Is mutable: Yes
+- Description: The number of threads in the FE-global RPC executor for "refresh other FE" fan-out. This executor bounds the number of concurrent refresh RPCs sent to peer FEs for both synchronous and asynchronous external table refresh flows.
+- Introduced in: -
+
 ### `enable_collect_query_detail_info`
 
 - Default: false

--- a/docs/ja/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/FE_parameters/log_server_meta.md
@@ -1240,6 +1240,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：定期的な Hive メタデータキャッシュ更新を有効にするかどうか。有効にすると、StarRocks は Hive クラスターのメタストア (Hive Metastore または AWS Glue) をポーリングし、頻繁にアクセスされる Hive カタログのキャッシュされたメタデータを更新してデータ変更を認識します。`true` は Hive メタデータキャッシュ更新を有効にすることを示し、`false` は無効にすることを示します。
 - 導入時期：v2.5.5
 
+### `refresh_other_fe_dispatch_executor_thread_num`
+
+- デフォルト：4
+- タイプ：Integer
+- 単位：-
+- 変更可能：Yes
+- 説明：Connector の書き込みパスから実行される非同期の "refresh other FE" バックグラウンドジョブをスケジュールする、FE グローバルのディスパッチ実行プール内のスレッド数です。これらのスレッドはバックグラウンド更新タスクを起動するだけで、他の FE に対して更新 RPC を直接送信しません。
+- 導入時期：-
+
+### `refresh_other_fe_rpc_executor_thread_num`
+
+- デフォルト：4
+- タイプ：Integer
+- 単位：-
+- 変更可能：Yes
+- 説明： "refresh other FE" の fan-out に使用される、FE グローバルの RPC 実行プール内のスレッド数です。この実行プールにより、同期および非同期の外部テーブル更新フローで他の FE に同時送信される更新 RPC の数が制限されます。
+- 導入時期：-
+
 ### `enable_collect_query_detail_info`
 
 - デフォルト：false

--- a/docs/ja/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/FE_parameters/log_server_meta.md
@@ -1246,7 +1246,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - タイプ：Integer
 - 単位：-
 - 変更可能：Yes
-- 説明：Connector の書き込みパスから実行される非同期の "refresh other FE" バックグラウンドジョブをスケジュールする、FE グローバルのディスパッチ実行プール内のスレッド数です。これらのスレッドはバックグラウンド更新タスクを起動するだけで、他の FE に対して更新 RPC を直接送信しません。
+- 説明：Connector の書き込みパスから実行される非同期の "refresh other FE" バックグラウンドジョブをスケジュールする、FE グローバルのディスパッチ実行プール内のスレッド数です。これらのスレッドはバックグラウンド更新タスクを起動するだけで、他の FE に対して更新 RPC を直接送信しません。変更は再起動なしで実行中の FE に反映されます。
 - 導入時期：-
 
 ### `refresh_other_fe_rpc_executor_thread_num`
@@ -1255,7 +1255,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - タイプ：Integer
 - 単位：-
 - 変更可能：Yes
-- 説明： "refresh other FE" の fan-out に使用される、FE グローバルの RPC 実行プール内のスレッド数です。この実行プールにより、同期および非同期の外部テーブル更新フローで他の FE に同時送信される更新 RPC の数が制限されます。
+- 説明： "refresh other FE" の fan-out に使用される、FE グローバルの RPC 実行プール内のスレッド数です。この実行プールにより、同期および非同期の外部テーブル更新フローで他の FE に同時送信される更新 RPC の数が制限されます。変更は再起動なしで実行中の FE に反映されます。
 - 導入時期：-
 
 ### `enable_collect_query_detail_info`

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -1254,7 +1254,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: Integer
 - 单位: -
 - 是否可变: Yes
-- 描述: FE 全局异步调度线程池中的线程数，用于处理来自 Connector 写入路径的 “refresh other FE” 后台任务。这些线程仅负责调度后台刷新任务，不会直接向其他 FE 发送刷新 RPC。
+- 描述: FE 全局异步调度线程池中的线程数，用于处理来自 Connector 写入路径的 “refresh other FE” 后台任务。这些线程仅负责调度后台刷新任务，不会直接向其他 FE 发送刷新 RPC。修改后可在运行中的 FE 上动态生效，无需重启。
 - 引入版本: -
 
 ### `refresh_other_fe_rpc_executor_thread_num`
@@ -1263,7 +1263,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: Integer
 - 单位: -
 - 是否可变: Yes
-- 描述: FE 全局 RPC 线程池中的线程数，用于执行 “refresh other FE” 的 fan-out 调用。该线程池限制同步和异步外表刷新流程中，向其他 FE 并发发送刷新 RPC 的数量。
+- 描述: FE 全局 RPC 线程池中的线程数，用于执行 “refresh other FE” 的 fan-out 调用。该线程池限制同步和异步外表刷新流程中，向其他 FE 并发发送刷新 RPC 的数量。修改后可在运行中的 FE 上动态生效，无需重启。
 - 引入版本: -
 
 ### `enable_collect_query_detail_info`

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -1248,6 +1248,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 是否启用周期性 Hive 元数据缓存刷新。启用后，StarRocks 会轮询 Hive 集群的 metastore（Hive Metastore 或 AWS Glue），并刷新频繁访问的 Hive Catalog 的缓存元数据，以感知数据变化。`true` 表示启用 Hive 元数据缓存刷新，`false` 表示禁用。
 - 引入版本: v2.5.5
 
+### `refresh_other_fe_dispatch_executor_thread_num`
+
+- 默认值: 4
+- 类型: Integer
+- 单位: -
+- 是否可变: Yes
+- 描述: FE 全局异步调度线程池中的线程数，用于处理来自 Connector 写入路径的 “refresh other FE” 后台任务。这些线程仅负责调度后台刷新任务，不会直接向其他 FE 发送刷新 RPC。
+- 引入版本: -
+
+### `refresh_other_fe_rpc_executor_thread_num`
+
+- 默认值: 4
+- 类型: Integer
+- 单位: -
+- 是否可变: Yes
+- 描述: FE 全局 RPC 线程池中的线程数，用于执行 “refresh other FE” 的 fan-out 调用。该线程池限制同步和异步外表刷新流程中，向其他 FE 并发发送刷新 RPC 的数量。
+- 引入版本: -
+
 ### `enable_collect_query_detail_info`
 
 - 默认值: false

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2807,6 +2807,20 @@ public class Config extends ConfigBase {
     public static int background_refresh_file_metadata_concurrency = 4;
 
     /**
+     * Number of threads used to dispatch asynchronous "refresh other FE" jobs from connector write paths.
+     * These threads do not issue peer RPCs directly; they only run the top-level background refresh task.
+     */
+    @ConfField(mutable = true)
+    public static int refresh_other_fe_dispatch_executor_thread_num = 4;
+
+    /**
+     * Number of threads used to fan out "refresh other FE" RPCs to peer FEs.
+     * This pool bounds cross-FE refresh concurrency for both synchronous and asynchronous callers.
+     */
+    @ConfField(mutable = true)
+    public static int refresh_other_fe_rpc_executor_thread_num = 4;
+
+    /**
      * Background refresh external table metadata interval in milliseconds.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2809,6 +2809,7 @@ public class Config extends ConfigBase {
     /**
      * Number of threads used to dispatch asynchronous "refresh other FE" jobs from connector write paths.
      * These threads do not issue peer RPCs directly; they only run the top-level background refresh task.
+     * Updates take effect on running FEs through ConfigRefreshDaemon without restart.
      */
     @ConfField(mutable = true)
     public static int refresh_other_fe_dispatch_executor_thread_num = 4;
@@ -2816,6 +2817,7 @@ public class Config extends ConfigBase {
     /**
      * Number of threads used to fan out "refresh other FE" RPCs to peer FEs.
      * This pool bounds cross-FE refresh concurrency for both synchronous and asynchronous callers.
+     * Updates take effect on running FEs through ConfigRefreshDaemon without restart.
      */
     @ConfField(mutable = true)
     public static int refresh_other_fe_rpc_executor_thread_num = 4;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.TableName;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Version;
 import com.starrocks.common.profile.Timer;
@@ -64,12 +63,10 @@ import static java.util.Objects.requireNonNull;
 public class HiveCommitter {
     private static final Logger LOG = LogManager.getLogger(HiveCommitter.class);
     private static final int PARTITION_COMMIT_BATCH_SIZE = 20;
-    private static final String BACKGROUND_THREAD_NAME_PREFIX = "background-refresh-others-fe-metadata-";
     private final HiveTable table;
     private final HiveMetastoreOperations hmsOps;
     private final RemoteFileOperations fileOps;
     private final Executor updateStatsExecutor;
-    private final Executor refreshOthersFeExecutor;
     private final AtomicBoolean fsTaskCancelled = new AtomicBoolean(false);
     private final List<CompletableFuture<?>> fsTaskFutures = new ArrayList<>();
     private final Queue<DirectoryCleanUpTask> clearTasksForAbort = new ConcurrentLinkedQueue<>();
@@ -82,13 +79,18 @@ public class HiveCommitter {
     private final Path stagingDir;
 
     public HiveCommitter(HiveMetastoreOperations hmsOps, RemoteFileOperations fileOps, Executor updateStatsExecutor,
-                         Executor refreshOthersFeExecutor, HiveTable table, Path stagingDir) {
+                         HiveTable table, Path stagingDir) {
         this.hmsOps = hmsOps;
         this.fileOps = fileOps;
         this.updateStatsExecutor = updateStatsExecutor;
-        this.refreshOthersFeExecutor = refreshOthersFeExecutor;
         this.table = table;
         this.stagingDir = stagingDir;
+    }
+
+    @Deprecated
+    public HiveCommitter(HiveMetastoreOperations hmsOps, RemoteFileOperations fileOps, Executor updateStatsExecutor,
+                         Executor refreshOthersFeExecutor, HiveTable table, Path stagingDir) {
+        this(hmsOps, fileOps, updateStatsExecutor, table, stagingDir);
     }
 
     public void commit(List<PartitionUpdate> partitionUpdates) {
@@ -170,19 +172,10 @@ public class HiveCommitter {
                     .collect(Collectors.toList());
         }
 
-        refreshOthersFeExecutor.execute(() -> {
-            LOG.info("Start to refresh others fe hive metadata cache on {}.{}.{}.{}",
-                    catalogName, dbName, tableName, partitionNames);
-            try {
-                GlobalStateMgr.getCurrentState().refreshOthersFeTable(
-                        new TableName(catalogName, dbName, tableName), partitionNames, false);
-            } catch (DdlException e) {
-                LOG.error("Failed to refresh others fe hive metdata cache", e);
-                throw new StarRocksConnectorException(e.getMessage());
-            }
-            LOG.info("Finish to refresh others fe hive metadata cache on {}.{}.{}.{}",
-                    catalogName, dbName, tableName, partitionNames);
-        });
+        LOG.info("Submit async refresh others fe hive metadata cache on {}.{}.{}.{}",
+                catalogName, dbName, tableName, partitionNames);
+        GlobalStateMgr.getCurrentState().refreshOthersFeTableAsync(
+                new TableName(catalogName, dbName, tableName), partitionNames);
     }
 
     private void prepareAppendTable(PartitionUpdate pu, HivePartitionStats updateStats) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
@@ -66,7 +66,6 @@ public class HiveConnector implements Connector {
                 internalMgr.getPullRemoteFileExecutor(),
                 internalMgr.getupdateRemoteFilesExecutor(),
                 internalMgr.getUpdateStatisticsExecutor(),
-                internalMgr.getRefreshOthersFeExecutor(),
                 internalMgr.isSearchRecursive(),
                 internalMgr.enableHmsEventsIncrementalSync(),
                 hdfsEnvironment,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -183,12 +183,6 @@ public class HiveConnectorInternalMgr {
         return new ReentrantExecutor(baseExecutor, remoteFileConf.getRefreshMaxThreadNum());
     }
 
-    public Executor getRefreshOthersFeExecutor() {
-        Executor baseExecutor = Executors.newCachedThreadPool(
-                new ThreadFactoryBuilder().setNameFormat("refresh-others-fe-hive-metadata-cache-%d").build());
-        return new ReentrantExecutor(baseExecutor, remoteFileConf.getRefreshMaxThreadNum());
-    }
-
     public boolean isSearchRecursive() {
         return isRecursive;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -108,7 +108,6 @@ public class HiveMetadata implements ConnectorMetadata {
     private final HiveStatisticsProvider statisticsProvider;
     private final Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor;
     private Executor updateExecutor;
-    private Executor refreshOthersFeExecutor;
     private final ConnectorProperties properties;
 
     public HiveMetadata(String catalogName,
@@ -118,7 +117,6 @@ public class HiveMetadata implements ConnectorMetadata {
                         HiveStatisticsProvider statisticsProvider,
                         Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor,
                         Executor updateExecutor,
-                        Executor refreshOthersFeExecutor,
                         ConnectorProperties properties) {
         this.catalogName = catalogName;
         this.hdfsEnvironment = hdfsEnvironment;
@@ -127,8 +125,21 @@ public class HiveMetadata implements ConnectorMetadata {
         this.statisticsProvider = statisticsProvider;
         this.cacheUpdateProcessor = cacheUpdateProcessor;
         this.updateExecutor = updateExecutor;
-        this.refreshOthersFeExecutor = refreshOthersFeExecutor;
         this.properties = properties;
+    }
+
+    @Deprecated
+    public HiveMetadata(String catalogName,
+                        HdfsEnvironment hdfsEnvironment,
+                        HiveMetastoreOperations hmsOps,
+                        RemoteFileOperations fileOperations,
+                        HiveStatisticsProvider statisticsProvider,
+                        Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor,
+                        Executor updateExecutor,
+                        Executor refreshOthersFeExecutor,
+                        ConnectorProperties properties) {
+        this(catalogName, hdfsEnvironment, hmsOps, fileOperations, statisticsProvider, cacheUpdateProcessor,
+                updateExecutor, properties);
     }
 
     @Override
@@ -568,7 +579,7 @@ public class HiveMetadata implements ConnectorMetadata {
         }
 
         HiveCommitter committer = new HiveCommitter(
-                hmsOps, fileOps, updateExecutor, refreshOthersFeExecutor, table, new Path(stagingDir));
+                hmsOps, fileOps, updateExecutor, table, new Path(stagingDir));
         String writeType = isOverwrite ? "overwrite" : "insert";
         long startMs = System.currentTimeMillis();
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "HIVE.SINK.commit")) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
@@ -39,7 +39,6 @@ public class HiveMetadataFactory {
     private final ExecutorService pullRemoteFileExecutor;
     private final Executor updateRemoteFilesExecutor;
     private final Executor updateStatisticsExecutor;
-    private final Executor refreshOthersFeExecutor;
     private final boolean isRecursive;
     private final boolean enableHmsEventsIncrementalSync;
     private final HdfsEnvironment hdfsEnvironment;
@@ -54,7 +53,6 @@ public class HiveMetadataFactory {
                                ExecutorService pullRemoteFileExecutor,
                                Executor updateRemoteFilesExecutor,
                                Executor updateStatisticsExecutor,
-                               Executor refreshOthersFeExecutor,
                                boolean isRecursive,
                                boolean enableHmsEventsIncrementalSync,
                                HdfsEnvironment hdfsEnvironment,
@@ -68,7 +66,6 @@ public class HiveMetadataFactory {
         this.pullRemoteFileExecutor = pullRemoteFileExecutor;
         this.updateRemoteFilesExecutor = updateRemoteFilesExecutor;
         this.updateStatisticsExecutor = updateStatisticsExecutor;
-        this.refreshOthersFeExecutor = refreshOthersFeExecutor;
         this.isRecursive = isRecursive;
         this.enableHmsEventsIncrementalSync = enableHmsEventsIncrementalSync;
         this.hdfsEnvironment = hdfsEnvironment;
@@ -93,7 +90,7 @@ public class HiveMetadataFactory {
 
         Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
         return new HiveMetadata(catalogName, hdfsEnvironment, hiveMetastoreOperations, remoteFileOperations,
-                statisticsProvider, cacheUpdateProcessor, updateStatisticsExecutor, refreshOthersFeExecutor,
+                statisticsProvider, cacheUpdateProcessor, updateStatisticsExecutor,
                 connectorProperties);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
@@ -37,7 +37,6 @@ public class IcebergCatalogProperties {
     public static final String ICEBERG_META_CACHE_TTL = "iceberg_meta_cache_ttl_sec"; // implicit for user
     public static final String ICEBERG_TABLE_CACHE_REFRESH_INVERVAL_SEC = "iceberg_table_cache_refresh_interval_sec";
     public static final String ICEBERG_JOB_PLANNING_THREAD_NUM = "iceberg_job_planning_thread_num";
-    public static final String REFRESH_OTHER_FE_ICEBERG_CACHE_THREAD_NUM = "refresh_other_fe_iceberg_cache_thread_num";
     public static final String BACKGROUND_ICEBERG_JOB_PLANNING_THREAD_NUM = "background_iceberg_job_planning_thread_num";
     public static final String ICEBERG_MANIFEST_CACHE_WITH_COLUMN_STATISTICS = "iceberg_manifest_cache_with_column_statistics";
     public static final String ICEBERG_MANIFEST_CACHE_MAX_NUM = "iceberg_manifest_cache_max_num";
@@ -59,7 +58,6 @@ public class IcebergCatalogProperties {
     private long icebergMetaCacheTtlSec;
     private int icebergJobPlanningThreadNum;
     private int backgroundIcebergJobPlanningThreadNum;
-    private int refreshOtherFeIcebergCacheThreadNum;
     private boolean icebergManifestCacheWithColumnStatistics;
     private long refreshIcebergManifestMinLength;
     private long localPlanningMaxSlotBytes;
@@ -119,8 +117,6 @@ public class IcebergCatalogProperties {
     private void initThreadPoolNum() {
         this.icebergJobPlanningThreadNum = Math.max(2,
                 PropertyUtil.propertyAsInt(properties, ICEBERG_JOB_PLANNING_THREAD_NUM, Config.iceberg_worker_num_threads));
-        this.refreshOtherFeIcebergCacheThreadNum = Math.max(2,
-                PropertyUtil.propertyAsInt(properties, REFRESH_OTHER_FE_ICEBERG_CACHE_THREAD_NUM, 4));
         this.backgroundIcebergJobPlanningThreadNum =
                 PropertyUtil.propertyAsInt(properties, BACKGROUND_ICEBERG_JOB_PLANNING_THREAD_NUM,
                         Math.max(2, Runtime.getRuntime().availableProcessors() / 8));
@@ -155,10 +151,6 @@ public class IcebergCatalogProperties {
 
     public int getIcebergJobPlanningThreadNum() {
         return icebergJobPlanningThreadNum;
-    }
-
-    public int getRefreshOtherFeIcebergCacheThreadNum() {
-        return refreshOtherFeIcebergCacheThreadNum;
     }
 
     public int getBackgroundIcebergJobPlanningThreadNum() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -52,7 +52,6 @@ public class IcebergConnector implements Connector {
     private final String catalogName;
     private IcebergCatalog icebergNativeCatalog;
     private ExecutorService icebergJobPlanningExecutor;
-    private ExecutorService refreshOtherFeExecutor;
     private final IcebergCatalogProperties icebergCatalogProperties;
     private final ConnectorProperties connectorProperties;
     private final IcebergProcedureRegistry procedureRegistry;
@@ -119,7 +118,7 @@ public class IcebergConnector implements Connector {
     @Override
     public ConnectorMetadata getMetadata() {
         return new IcebergMetadata(catalogName, hdfsEnvironment, getNativeCatalog(),
-                buildIcebergJobPlanningExecutor(), buildRefreshOtherFeExecutor(), icebergCatalogProperties,
+                buildIcebergJobPlanningExecutor(), icebergCatalogProperties,
                 connectorProperties, procedureRegistry, commitQueueManager);
     }
 
@@ -149,14 +148,6 @@ public class IcebergConnector implements Connector {
         return icebergJobPlanningExecutor;
     }
 
-    public ExecutorService buildRefreshOtherFeExecutor() {
-        if (refreshOtherFeExecutor == null) {
-            refreshOtherFeExecutor = newWorkerPool(catalogName + "-refresh-others-fe-iceberg-metadata-cache",
-                    icebergCatalogProperties.getRefreshOtherFeIcebergCacheThreadNum());
-        }
-        return refreshOtherFeExecutor;
-    }
-
     private ExecutorService buildBackgroundJobPlanningExecutor() {
         return newWorkerPool(catalogName + "-background-iceberg-worker-pool",
                 icebergCatalogProperties.getBackgroundIcebergJobPlanningThreadNum());
@@ -172,9 +163,6 @@ public class IcebergConnector implements Connector {
                 .unRegisterCachingIcebergCatalog(catalogName);
         if (icebergJobPlanningExecutor != null) {
             icebergJobPlanningExecutor.shutdown();
-        }
-        if (refreshOtherFeExecutor != null) {
-            refreshOtherFeExecutor.shutdown();
         }
         if (commitQueueManager != null) {
             commitQueueManager.shutdownAll();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -231,7 +231,6 @@ public class IcebergMetadata implements ConnectorMetadata {
     // FileScanTaskSchema -> Pair<schema_string, partition_string>
     private final Map<FileScanTaskSchema, Pair<String, String>> fileScanTaskSchemas = new ConcurrentHashMap<>();
     private final ExecutorService jobPlanningExecutor;
-    private final ExecutorService refreshOtherFeExecutor;
     private final IcebergCatalogProperties catalogProperties;
     private final ConnectorProperties properties;
     private final IcebergProcedureRegistry procedureRegistry;
@@ -240,30 +239,29 @@ public class IcebergMetadata implements ConnectorMetadata {
     private final IcebergCommitQueueManager commitQueueManager;
 
     public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog,
-                           ExecutorService jobPlanningExecutor, ExecutorService refreshOtherFeExecutor,
+                           ExecutorService jobPlanningExecutor,
                            IcebergCatalogProperties catalogProperties) {
-        this(catalogName, hdfsEnvironment, icebergCatalog, jobPlanningExecutor, refreshOtherFeExecutor,
+        this(catalogName, hdfsEnvironment, icebergCatalog, jobPlanningExecutor,
                 catalogProperties, new ConnectorProperties(ConnectorType.ICEBERG), new IcebergProcedureRegistry(),
                 null);
     }
 
     public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog,
-                           ExecutorService jobPlanningExecutor, ExecutorService refreshOtherFeExecutor,
+                           ExecutorService jobPlanningExecutor,
                            IcebergCatalogProperties catalogProperties, ConnectorProperties properties,
                            IcebergProcedureRegistry procedureRegistry) {
-        this(catalogName, hdfsEnvironment, icebergCatalog, jobPlanningExecutor, refreshOtherFeExecutor,
+        this(catalogName, hdfsEnvironment, icebergCatalog, jobPlanningExecutor,
                 catalogProperties, properties, procedureRegistry, null);
     }
 
     public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog,
-                           ExecutorService jobPlanningExecutor, ExecutorService refreshOtherFeExecutor,
+                           ExecutorService jobPlanningExecutor,
                            IcebergCatalogProperties catalogProperties, ConnectorProperties properties,
                            IcebergProcedureRegistry procedureRegistry, IcebergCommitQueueManager commitQueueManager) {
         this.catalogName = catalogName;
         this.hdfsEnvironment = hdfsEnvironment;
         this.icebergCatalog = icebergCatalog;
         this.jobPlanningExecutor = jobPlanningExecutor;
-        this.refreshOtherFeExecutor = refreshOtherFeExecutor;
         this.catalogProperties = catalogProperties;
         this.properties = properties;
         this.procedureRegistry = procedureRegistry;
@@ -276,6 +274,31 @@ public class IcebergMetadata implements ConnectorMetadata {
         } else {
             LOG.info("IcebergMetadata will use direct commit (no queue) for catalog {}", catalogName);
         }
+    }
+
+    @Deprecated
+    public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog,
+                           ExecutorService jobPlanningExecutor, ExecutorService refreshOtherFeExecutor,
+                           IcebergCatalogProperties catalogProperties) {
+        this(catalogName, hdfsEnvironment, icebergCatalog, jobPlanningExecutor, catalogProperties);
+    }
+
+    @Deprecated
+    public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog,
+                           ExecutorService jobPlanningExecutor, ExecutorService refreshOtherFeExecutor,
+                           IcebergCatalogProperties catalogProperties, ConnectorProperties properties,
+                           IcebergProcedureRegistry procedureRegistry) {
+        this(catalogName, hdfsEnvironment, icebergCatalog, jobPlanningExecutor, catalogProperties, properties,
+                procedureRegistry);
+    }
+
+    @Deprecated
+    public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog,
+                           ExecutorService jobPlanningExecutor, ExecutorService refreshOtherFeExecutor,
+                           IcebergCatalogProperties catalogProperties, ConnectorProperties properties,
+                           IcebergProcedureRegistry procedureRegistry, IcebergCommitQueueManager commitQueueManager) {
+        this(catalogName, hdfsEnvironment, icebergCatalog, jobPlanningExecutor, catalogProperties, properties,
+                procedureRegistry, commitQueueManager);
     }
 
     @Override
@@ -2070,17 +2093,9 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     private void asyncRefreshOthersFeMetadataCache(String dbName, String tableName) {
-        refreshOtherFeExecutor.execute(() -> {
-            LOG.info("Start to refresh others fe iceberg metadata cache on {}.{}.{}", catalogName, dbName, tableName);
-            try {
-                GlobalStateMgr.getCurrentState().refreshOthersFeTable(
-                        new TableName(catalogName, dbName, tableName), new ArrayList<>(), false);
-            } catch (DdlException e) {
-                LOG.error("Failed to refresh others fe iceberg metadata cache {}.{}.{}", catalogName, dbName, tableName, e);
-                throw new StarRocksConnectorException(e.getMessage());
-            }
-            LOG.info("Finish to refresh others fe iceberg metadata cache on {}.{}.{}", catalogName, dbName, tableName);
-        });
+        LOG.info("Submit async refresh others fe iceberg metadata cache on {}.{}.{}", catalogName, dbName, tableName);
+        GlobalStateMgr.getCurrentState().refreshOthersFeTableAsync(
+                new TableName(catalogName, dbName, tableName), new ArrayList<>());
     }
 
     public BatchWrite getBatchWrite(Transaction transaction, boolean isOverwrite, boolean isRewrite) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -281,7 +281,6 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -543,6 +542,8 @@ public class GlobalStateMgr {
     private final DDLStmtExecutor ddlStmtExecutor;
     private final ShowExecutor showExecutor;
     private final ExecutorService queryDeployExecutor;
+    private final ExecutorService refreshOtherFeDispatchExecutor;
+    private final ExecutorService refreshOtherFeRpcExecutor;
     private final WarehouseIdleChecker warehouseIdleChecker;
 
     private final ClusterSnapshotMgr clusterSnapshotMgr;
@@ -893,6 +894,16 @@ public class GlobalStateMgr {
         this.queryDeployExecutor =
                 ThreadPoolManager.newDaemonFixedThreadPool(Config.query_deploy_threadpool_size, Integer.MAX_VALUE,
                         "query-deploy", true);
+        this.refreshOtherFeDispatchExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
+                Config.refresh_other_fe_dispatch_executor_thread_num,
+                Math.max(16, Config.refresh_other_fe_dispatch_executor_thread_num * 4),
+                "refresh-other-fe-dispatch",
+                true);
+        this.refreshOtherFeRpcExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
+                Config.refresh_other_fe_rpc_executor_thread_num,
+                Math.max(16, Config.refresh_other_fe_rpc_executor_thread_num * 4),
+                "refresh-other-fe-rpc",
+                true);
 
         this.warehouseIdleChecker = new WarehouseIdleChecker();
 
@@ -2737,6 +2748,11 @@ public class GlobalStateMgr {
         refreshOthersFeTable(tableName, partitionNames, true);
     }
 
+    /**
+     * Refresh external table metadata on every peer FE and wait for all peer RPCs to finish.
+     * This method is synchronous from the caller's perspective, while the per-peer RPC fan-out
+     * is still bounded by {@code refreshOtherFeRpcExecutor}.
+     */
     public void refreshOthersFeTable(TableName tableName, List<String> partitions, boolean isSync) throws DdlException {
         List<Frontend> allFrontends = GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(null);
         if (allFrontends.size() == 0) {
@@ -2748,8 +2764,8 @@ public class GlobalStateMgr {
                 continue;
             }
 
-            resultMap.put(fe.getHost(), refreshOtherFesTable(
-                    new TNetworkAddress(fe.getHost(), fe.getRpcPort()), tableName, partitions));
+            resultMap.put(fe.getHost(), refreshOtherFeRpcExecutor.submit(
+                    () -> refreshOtherFeTableRpc(new TNetworkAddress(fe.getHost(), fe.getRpcPort()), tableName, partitions)));
         }
 
         String errMsg = "";
@@ -2777,8 +2793,25 @@ public class GlobalStateMgr {
         }
     }
 
-    public Future<TStatus> refreshOtherFesTable(TNetworkAddress thriftAddress, TableName tableName,
-                                                List<String> partitions) {
+    /**
+     * Enqueue a background "refresh other FE" job and return immediately to the caller.
+     * The dispatched task eventually reuses {@link #refreshOthersFeTable(TableName, List, boolean)}
+     * so asynchronous and synchronous refreshes share the same peer RPC concurrency limit.
+     */
+    public Future<?> refreshOthersFeTableAsync(TableName tableName, List<String> partitions) {
+        List<String> partitionsSnapshot = partitions == null ? List.of() : new ArrayList<>(partitions);
+        return refreshOtherFeDispatchExecutor.submit(() -> {
+            try {
+                refreshOthersFeTable(tableName, partitionsSnapshot, false);
+            } catch (Throwable t) {
+                LOG.error("Async refresh others fe failed on {}.{}.{} with partitions {}",
+                        tableName.getCatalog(), tableName.getDb(), tableName.getTbl(), partitionsSnapshot, t);
+            }
+        });
+    }
+
+    private TStatus refreshOtherFeTableRpc(TNetworkAddress thriftAddress, TableName tableName,
+                                           List<String> partitions) {
         int timeout;
         if (ConnectContext.get() == null || ConnectContext.get().getSessionVariable() == null) {
             timeout = Config.thrift_rpc_timeout_ms * 10;
@@ -2786,30 +2819,24 @@ public class GlobalStateMgr {
             timeout = ConnectContext.get().getExecTimeout() * 1000 + Config.thrift_rpc_timeout_ms;
         }
 
-        FutureTask<TStatus> task = new FutureTask<TStatus>(() -> {
-            TRefreshTableRequest request = new TRefreshTableRequest();
-            request.setCatalog_name(tableName.getCatalog());
-            request.setDb_name(tableName.getDb());
-            request.setTable_name(tableName.getTbl());
-            request.setPartitions(partitions);
-            try {
-                TRefreshTableResponse response = ThriftRPCRequestExecutor.call(
-                        ThriftConnectionPool.frontendPool,
-                        thriftAddress,
-                        timeout,
-                        client -> client.refreshTable(request));
-                return response.getStatus();
-            } catch (Exception e) {
-                LOG.warn("call fe {} refreshTable rpc method failed", thriftAddress, e);
-                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
-                status.setError_msgs(Lists.newArrayList(e.getMessage()));
-                return status;
-            }
-        });
-
-        new Thread(task).start();
-
-        return task;
+        TRefreshTableRequest request = new TRefreshTableRequest();
+        request.setCatalog_name(tableName.getCatalog());
+        request.setDb_name(tableName.getDb());
+        request.setTable_name(tableName.getTbl());
+        request.setPartitions(partitions);
+        try {
+            TRefreshTableResponse response = ThriftRPCRequestExecutor.call(
+                    ThriftConnectionPool.frontendPool,
+                    thriftAddress,
+                    timeout,
+                    client -> client.refreshTable(request));
+            return response.getStatus();
+        } catch (Exception e) {
+            LOG.warn("call fe {} refreshTable rpc method failed", thriftAddress, e);
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            return status;
+        }
     }
 
     private boolean supportRefreshTableType(Table table) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -279,8 +279,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -2787,8 +2789,7 @@ public class GlobalStateMgr {
                 continue;
             }
 
-            resultMap.put(fe.getHost(), refreshOtherFeRpcExecutor.submit(
-                    () -> refreshOtherFeTableRpc(new TNetworkAddress(fe.getHost(), fe.getRpcPort()), tableName, partitions)));
+            resultMap.put(fe.getHost(), submitRefreshOtherFeRpc(fe, tableName, partitions));
         }
 
         String errMsg = "";
@@ -2823,14 +2824,36 @@ public class GlobalStateMgr {
      */
     public Future<?> refreshOthersFeTableAsync(TableName tableName, List<String> partitions) {
         List<String> partitionsSnapshot = partitions == null ? List.of() : new ArrayList<>(partitions);
-        return refreshOtherFeDispatchExecutor.submit(() -> {
-            try {
-                refreshOthersFeTable(tableName, partitionsSnapshot, false);
-            } catch (Throwable t) {
-                LOG.error("Async refresh others fe failed on {}.{}.{} with partitions {}",
-                        tableName.getCatalog(), tableName.getDb(), tableName.getTbl(), partitionsSnapshot, t);
-            }
-        });
+        try {
+            return refreshOtherFeDispatchExecutor.submit(() -> {
+                try {
+                    refreshOthersFeTable(tableName, partitionsSnapshot, false);
+                } catch (Throwable t) {
+                    LOG.error("Async refresh others fe failed on {}.{}.{} with partitions {}",
+                            tableName.getCatalog(), tableName.getDb(), tableName.getTbl(), partitionsSnapshot, t);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            LOG.error("Async refresh others fe dispatch rejected on {}.{}.{} with partitions {}",
+                    tableName.getCatalog(), tableName.getDb(), tableName.getTbl(), partitionsSnapshot, e);
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    private Future<TStatus> submitRefreshOtherFeRpc(Frontend fe, TableName tableName, List<String> partitions) {
+        TNetworkAddress thriftAddress = new TNetworkAddress(fe.getHost(), fe.getRpcPort());
+        try {
+            return refreshOtherFeRpcExecutor.submit(() -> refreshOtherFeTableRpc(thriftAddress, tableName, partitions));
+        } catch (RejectedExecutionException e) {
+            LOG.warn("Refresh other FE rpc enqueue rejected for {}", thriftAddress, e);
+            return CompletableFuture.completedFuture(buildRefreshOtherFeRejectedStatus(e));
+        }
+    }
+
+    private TStatus buildRefreshOtherFeRejectedStatus(RejectedExecutionException e) {
+        TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+        status.setError_msgs(Lists.newArrayList(e.getMessage()));
+        return status;
     }
 
     private TStatus refreshOtherFeTableRpc(TNetworkAddress thriftAddress, TableName tableName,

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -542,8 +542,8 @@ public class GlobalStateMgr {
     private final DDLStmtExecutor ddlStmtExecutor;
     private final ShowExecutor showExecutor;
     private final ExecutorService queryDeployExecutor;
-    private final ExecutorService refreshOtherFeDispatchExecutor;
-    private final ExecutorService refreshOtherFeRpcExecutor;
+    private final ThreadPoolExecutor refreshOtherFeDispatchExecutor;
+    private final ThreadPoolExecutor refreshOtherFeRpcExecutor;
     private final WarehouseIdleChecker warehouseIdleChecker;
 
     private final ClusterSnapshotMgr clusterSnapshotMgr;
@@ -904,6 +904,7 @@ public class GlobalStateMgr {
                 Math.max(16, Config.refresh_other_fe_rpc_executor_thread_num * 4),
                 "refresh-other-fe-rpc",
                 true);
+        getConfigRefreshDaemon().registerListener(this::refreshOtherFeExecutorConfig);
 
         this.warehouseIdleChecker = new WarehouseIdleChecker();
 
@@ -913,6 +914,28 @@ public class GlobalStateMgr {
         this.jwkMgr = new JwkMgr();
 
         this.tabletReshardJobMgr = new TabletReshardJobMgr();
+    }
+
+    private void refreshOtherFeExecutorConfig() {
+        try {
+            if (Config.refresh_other_fe_dispatch_executor_thread_num > 0) {
+                ThreadPoolManager.setFixedThreadPoolSize(
+                        refreshOtherFeDispatchExecutor, Config.refresh_other_fe_dispatch_executor_thread_num);
+            } else {
+                LOG.warn("ignore invalid config refresh_other_fe_dispatch_executor_thread_num={}",
+                        Config.refresh_other_fe_dispatch_executor_thread_num);
+            }
+
+            if (Config.refresh_other_fe_rpc_executor_thread_num > 0) {
+                ThreadPoolManager.setFixedThreadPoolSize(
+                        refreshOtherFeRpcExecutor, Config.refresh_other_fe_rpc_executor_thread_num);
+            } else {
+                LOG.warn("ignore invalid config refresh_other_fe_rpc_executor_thread_num={}",
+                        Config.refresh_other_fe_rpc_executor_thread_num);
+            }
+        } catch (Exception e) {
+            LOG.warn("failed to refresh refresh-other-FE executor config", e);
+        }
     }
 
     public static void destroyCheckpoint() {

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -89,6 +89,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -56,13 +56,8 @@ import com.starrocks.persist.EditLog;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.OperationType;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.sql.ast.ModifyFrontendAddressClause;
 import com.starrocks.system.Frontend;
-import com.starrocks.thrift.TNetworkAddress;
-import com.starrocks.thrift.TRefreshTableResponse;
-import com.starrocks.thrift.TStatus;
-import com.starrocks.thrift.TStatusCode;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -86,10 +81,11 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -528,145 +524,6 @@ public class GlobalStateMgrTest {
     }
 
     @Test
-    public void testRefreshOthersFeTableSuccess() throws Exception {
-        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(Config.refresh_other_fe_rpc_executor_thread_num);
-        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
-                     Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS);
-                MockedStatic<ThriftRPCRequestExecutor> thriftMock =
-                        Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
-            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
-            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
-                            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
-                    .thenAnswer(invocation -> new TRefreshTableResponse(new TStatus(TStatusCode.OK)));
-
-            globalStateMgr.refreshOthersFeTable(new TableName("c", "d", "t"), List.of("p1"), true);
-        } finally {
-            shutdownRefreshOtherFeExecutors(globalStateMgr);
-        }
-    }
-
-    @Test
-    public void testRefreshOthersFeTableAggregatesNonOkStatus() throws Exception {
-        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(Config.refresh_other_fe_rpc_executor_thread_num);
-        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
-                     Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS);
-                MockedStatic<ThriftRPCRequestExecutor> thriftMock =
-                        Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
-            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
-            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
-                            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
-                    .thenAnswer(invocation -> {
-                        Frontend target = findFrontendByRpcPort(globalStateMgr.getNodeMgr().getFrontends(null),
-                                ((TNetworkAddress) invocation.getArgument(1)).getPort());
-                        if ("127.0.0.2".equals(target.getHost())) {
-                            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
-                            status.setError_msgs(List.of("fe2 failed"));
-                            return new TRefreshTableResponse(status);
-                        }
-                        return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
-                    });
-
-            DdlException exception = assertThrows(DdlException.class,
-                    () -> globalStateMgr.refreshOthersFeTable(new TableName("c", "d", "t"), List.of("p1"), true));
-            Assertions.assertTrue(exception.getMessage().contains("127.0.0.2"));
-            Assertions.assertTrue(exception.getMessage().contains("fe2 failed"));
-        } finally {
-            shutdownRefreshOtherFeExecutors(globalStateMgr);
-        }
-    }
-
-    @Test
-    public void testRefreshOthersFeTableConvertsRpcExceptionToStatus() throws Exception {
-        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(Config.refresh_other_fe_rpc_executor_thread_num);
-        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
-                     Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS);
-                MockedStatic<ThriftRPCRequestExecutor> thriftMock =
-                        Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
-            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
-            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
-                            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
-                    .thenAnswer(invocation -> {
-                        Frontend target = findFrontendByRpcPort(globalStateMgr.getNodeMgr().getFrontends(null),
-                                ((TNetworkAddress) invocation.getArgument(1)).getPort());
-                        if ("127.0.0.2".equals(target.getHost())) {
-                            throw new RuntimeException("rpc failed");
-                        }
-                        return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
-                    });
-
-            DdlException exception = assertThrows(DdlException.class,
-                    () -> globalStateMgr.refreshOthersFeTable(new TableName("c", "d", "t"), List.of("p1"), true));
-            Assertions.assertTrue(exception.getMessage().contains("127.0.0.2"));
-            Assertions.assertTrue(exception.getMessage().contains("rpc failed"));
-        } finally {
-            shutdownRefreshOtherFeExecutors(globalStateMgr);
-        }
-    }
-
-    @Test
-    public void testRefreshOthersFeTableUsesBoundedExecutor() throws Exception {
-        int originalThreadNum = Config.refresh_other_fe_rpc_executor_thread_num;
-        Config.refresh_other_fe_rpc_executor_thread_num = 1;
-        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1);
-        CopyOnWriteArrayList<String> threadNames = new CopyOnWriteArrayList<>();
-        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
-                     Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS);
-                MockedStatic<ThriftRPCRequestExecutor> thriftMock =
-                        Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
-            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
-            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
-                            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
-                    .thenAnswer(invocation -> {
-                        threadNames.add(Thread.currentThread().getName());
-                        return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
-                    });
-
-            globalStateMgr.refreshOthersFeTable(new TableName("c", "d", "t"), List.of(), true);
-
-            ThreadPoolExecutor executor = getRefreshOtherFeExecutor(globalStateMgr);
-            Assertions.assertEquals(1, executor.getCorePoolSize());
-            Assertions.assertFalse(threadNames.isEmpty());
-            Assertions.assertTrue(threadNames.stream().allMatch(name -> name.startsWith("refresh-other-fe-rpc-")));
-        } finally {
-            Config.refresh_other_fe_rpc_executor_thread_num = originalThreadNum;
-            shutdownRefreshOtherFeExecutors(globalStateMgr);
-        }
-    }
-
-    @Test
-    public void testRefreshOthersFeTableAsyncUsesDedicatedDispatcher() throws Exception {
-        int originalThreadNum = Config.refresh_other_fe_rpc_executor_thread_num;
-        int originalAsyncThreadNum = Config.refresh_other_fe_dispatch_executor_thread_num;
-        Config.refresh_other_fe_rpc_executor_thread_num = 1;
-        Config.refresh_other_fe_dispatch_executor_thread_num = 1;
-        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1, 1);
-        CopyOnWriteArrayList<String> threadNames = new CopyOnWriteArrayList<>();
-        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
-                     Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS);
-                MockedStatic<ThriftRPCRequestExecutor> thriftMock =
-                        Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
-            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
-            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
-                            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
-                    .thenAnswer(invocation -> {
-                        threadNames.add(Thread.currentThread().getName());
-                        return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
-                    });
-
-            globalStateMgr.refreshOthersFeTableAsync(new TableName("c", "d", "t"), List.of()).get();
-
-            ThreadPoolExecutor asyncExecutor = getRefreshOtherFeAsyncExecutor(globalStateMgr);
-            Assertions.assertEquals(1, asyncExecutor.getCorePoolSize());
-            Assertions.assertFalse(threadNames.isEmpty());
-            Assertions.assertTrue(threadNames.stream().allMatch(name -> name.startsWith("refresh-other-fe-rpc-")));
-        } finally {
-            Config.refresh_other_fe_rpc_executor_thread_num = originalThreadNum;
-            Config.refresh_other_fe_dispatch_executor_thread_num = originalAsyncThreadNum;
-            shutdownRefreshOtherFeExecutors(globalStateMgr);
-        }
-    }
-
-    @Test
     public void testRefreshOtherFeExecutorsResizeAfterConfigRefresh() throws Exception {
         int originalThreadNum = Config.refresh_other_fe_rpc_executor_thread_num;
         int originalAsyncThreadNum = Config.refresh_other_fe_dispatch_executor_thread_num;
@@ -696,14 +553,26 @@ public class GlobalStateMgrTest {
 
     @Test
     public void testRefreshOthersFeTableAggregatesRpcSubmitRejection() throws Exception {
-        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(Config.refresh_other_fe_rpc_executor_thread_num);
-        try {
-            getRefreshOtherFeExecutor(globalStateMgr).shutdownNow();
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1, 1);
+        CountDownLatch latch = new CountDownLatch(1);
+        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
+                Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS)) {
+            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            ThreadPoolExecutor executor = getRefreshOtherFeExecutor(globalStateMgr);
+            executor.setRejectedExecutionHandler((r, e) -> {
+                throw new RejectedExecutionException("forced rejection");
+            });
+            executor.submit(() -> awaitLatch(latch));
+            int queueCapacity = executor.getQueue().remainingCapacity();
+            for (int i = 0; i < queueCapacity; i++) {
+                executor.submit(() -> awaitLatch(latch));
+            }
 
             DdlException exception = assertThrows(DdlException.class,
                     () -> globalStateMgr.refreshOthersFeTable(new TableName("c", "d", "t"), List.of("p1"), true));
-            Assertions.assertTrue(exception.getMessage().contains("rejected"));
+            Assertions.assertTrue(exception.getMessage().contains("forced rejection"));
         } finally {
+            latch.countDown();
             shutdownRefreshOtherFeExecutors(globalStateMgr);
         }
     }
@@ -711,13 +580,23 @@ public class GlobalStateMgrTest {
     @Test
     public void testRefreshOthersFeTableAsyncDoesNotThrowOnDispatchRejection() throws Exception {
         GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1, 1);
+        CountDownLatch latch = new CountDownLatch(1);
         try {
-            getRefreshOtherFeAsyncExecutor(globalStateMgr).shutdownNow();
+            ThreadPoolExecutor executor = getRefreshOtherFeAsyncExecutor(globalStateMgr);
+            executor.setRejectedExecutionHandler((r, e) -> {
+                throw new RejectedExecutionException("forced rejection");
+            });
+            executor.submit(() -> awaitLatch(latch));
+            int queueCapacity = executor.getQueue().remainingCapacity();
+            for (int i = 0; i < queueCapacity; i++) {
+                executor.submit(() -> awaitLatch(latch));
+            }
 
             Future<?> future = globalStateMgr.refreshOthersFeTableAsync(new TableName("c", "d", "t"), List.of("p1"));
             Assertions.assertTrue(future.isDone());
             Assertions.assertThrows(ExecutionException.class, future::get);
         } finally {
+            latch.countDown();
             shutdownRefreshOtherFeExecutors(globalStateMgr);
         }
     }
@@ -784,13 +663,6 @@ public class GlobalStateMgrTest {
         field.set(nodeMgr, role);
     }
 
-    private Frontend findFrontendByRpcPort(List<Frontend> frontends, int rpcPort) {
-        return frontends.stream()
-                .filter(frontend -> frontend.getRpcPort() == rpcPort)
-                .findFirst()
-                .orElseThrow();
-    }
-
     private ThreadPoolExecutor getRefreshOtherFeExecutor(GlobalStateMgr globalStateMgr) throws Exception {
         Field field = GlobalStateMgr.class.getDeclaredField("refreshOtherFeRpcExecutor");
         field.setAccessible(true);
@@ -819,5 +691,13 @@ public class GlobalStateMgrTest {
         Method method = ConfigRefreshDaemon.class.getDeclaredMethod("runAfterCatalogReady");
         method.setAccessible(true);
         method.invoke(configRefreshDaemon);
+    }
+
+    private void awaitLatch(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -44,6 +44,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
+import com.starrocks.common.ConfigRefreshDaemon;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.ha.BDBHA;
@@ -663,6 +664,34 @@ public class GlobalStateMgrTest {
         }
     }
 
+    @Test
+    public void testRefreshOtherFeExecutorsResizeAfterConfigRefresh() throws Exception {
+        int originalThreadNum = Config.refresh_other_fe_rpc_executor_thread_num;
+        int originalAsyncThreadNum = Config.refresh_other_fe_dispatch_executor_thread_num;
+        Config.refresh_other_fe_rpc_executor_thread_num = 1;
+        Config.refresh_other_fe_dispatch_executor_thread_num = 1;
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1, 1);
+        try {
+            ThreadPoolExecutor rpcExecutor = getRefreshOtherFeExecutor(globalStateMgr);
+            ThreadPoolExecutor dispatchExecutor = getRefreshOtherFeAsyncExecutor(globalStateMgr);
+            Assertions.assertEquals(1, rpcExecutor.getCorePoolSize());
+            Assertions.assertEquals(1, dispatchExecutor.getCorePoolSize());
+
+            Config.refresh_other_fe_rpc_executor_thread_num = 2;
+            Config.refresh_other_fe_dispatch_executor_thread_num = 3;
+            triggerConfigRefresh(globalStateMgr.getConfigRefreshDaemon());
+
+            Assertions.assertEquals(2, rpcExecutor.getCorePoolSize());
+            Assertions.assertEquals(2, rpcExecutor.getMaximumPoolSize());
+            Assertions.assertEquals(3, dispatchExecutor.getCorePoolSize());
+            Assertions.assertEquals(3, dispatchExecutor.getMaximumPoolSize());
+        } finally {
+            Config.refresh_other_fe_rpc_executor_thread_num = originalThreadNum;
+            Config.refresh_other_fe_dispatch_executor_thread_num = originalAsyncThreadNum;
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
     private GlobalStateMgr createRefreshTestGlobalStateMgr(int refreshThreadNum) throws Exception {
         int originalThreadNum = Config.refresh_other_fe_rpc_executor_thread_num;
         int originalAsyncThreadNum = Config.refresh_other_fe_dispatch_executor_thread_num;
@@ -754,5 +783,11 @@ public class GlobalStateMgrTest {
         field.setAccessible(true);
         ExecutorService executor = (ExecutorService) field.get(globalStateMgr);
         executor.shutdownNow();
+    }
+
+    private void triggerConfigRefresh(ConfigRefreshDaemon configRefreshDaemon) throws Exception {
+        Method method = ConfigRefreshDaemon.class.getDeclaredMethod("runAfterCatalogReady");
+        method.setAccessible(true);
+        method.invoke(configRefreshDaemon);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -41,6 +41,7 @@ import com.sleepycat.je.rep.ReplicaStateException;
 import com.sleepycat.je.rep.UnknownMasterException;
 import com.sleepycat.je.rep.util.ReplicationGroupAdmin;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -54,8 +55,13 @@ import com.starrocks.persist.EditLog;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.OperationType;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.sql.ast.ModifyFrontendAddressClause;
 import com.starrocks.system.Frontend;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TRefreshTableResponse;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -67,6 +73,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -78,6 +85,9 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -512,5 +522,237 @@ public class GlobalStateMgrTest {
         Method stop = GlobalStateMgr.class.getDeclaredMethod("stopLeaderOnlyDaemonThreads");
         stop.setAccessible(true);
         stop.invoke(mgr);
+    }
+
+    @Test
+    public void testRefreshOthersFeTableSuccess() throws Exception {
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(Config.refresh_other_fe_rpc_executor_thread_num);
+        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
+                     Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                        Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenAnswer(invocation -> new TRefreshTableResponse(new TStatus(TStatusCode.OK)));
+
+            globalStateMgr.refreshOthersFeTable(new TableName("c", "d", "t"), List.of("p1"), true);
+        } finally {
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    @Test
+    public void testRefreshOthersFeTableAggregatesNonOkStatus() throws Exception {
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(Config.refresh_other_fe_rpc_executor_thread_num);
+        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
+                     Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                        Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenAnswer(invocation -> {
+                        Frontend target = findFrontendByRpcPort(globalStateMgr.getNodeMgr().getFrontends(null),
+                                ((TNetworkAddress) invocation.getArgument(1)).getPort());
+                        if ("127.0.0.2".equals(target.getHost())) {
+                            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+                            status.setError_msgs(List.of("fe2 failed"));
+                            return new TRefreshTableResponse(status);
+                        }
+                        return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
+                    });
+
+            DdlException exception = assertThrows(DdlException.class,
+                    () -> globalStateMgr.refreshOthersFeTable(new TableName("c", "d", "t"), List.of("p1"), true));
+            Assertions.assertTrue(exception.getMessage().contains("127.0.0.2"));
+            Assertions.assertTrue(exception.getMessage().contains("fe2 failed"));
+        } finally {
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    @Test
+    public void testRefreshOthersFeTableConvertsRpcExceptionToStatus() throws Exception {
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(Config.refresh_other_fe_rpc_executor_thread_num);
+        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
+                     Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                        Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenAnswer(invocation -> {
+                        Frontend target = findFrontendByRpcPort(globalStateMgr.getNodeMgr().getFrontends(null),
+                                ((TNetworkAddress) invocation.getArgument(1)).getPort());
+                        if ("127.0.0.2".equals(target.getHost())) {
+                            throw new RuntimeException("rpc failed");
+                        }
+                        return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
+                    });
+
+            DdlException exception = assertThrows(DdlException.class,
+                    () -> globalStateMgr.refreshOthersFeTable(new TableName("c", "d", "t"), List.of("p1"), true));
+            Assertions.assertTrue(exception.getMessage().contains("127.0.0.2"));
+            Assertions.assertTrue(exception.getMessage().contains("rpc failed"));
+        } finally {
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    @Test
+    public void testRefreshOthersFeTableUsesBoundedExecutor() throws Exception {
+        int originalThreadNum = Config.refresh_other_fe_rpc_executor_thread_num;
+        Config.refresh_other_fe_rpc_executor_thread_num = 1;
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1);
+        CopyOnWriteArrayList<String> threadNames = new CopyOnWriteArrayList<>();
+        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
+                     Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                        Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenAnswer(invocation -> {
+                        threadNames.add(Thread.currentThread().getName());
+                        return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
+                    });
+
+            globalStateMgr.refreshOthersFeTable(new TableName("c", "d", "t"), List.of(), true);
+
+            ThreadPoolExecutor executor = getRefreshOtherFeExecutor(globalStateMgr);
+            Assertions.assertEquals(1, executor.getCorePoolSize());
+            Assertions.assertFalse(threadNames.isEmpty());
+            Assertions.assertTrue(threadNames.stream().allMatch(name -> name.startsWith("refresh-other-fe-rpc-")));
+        } finally {
+            Config.refresh_other_fe_rpc_executor_thread_num = originalThreadNum;
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    @Test
+    public void testRefreshOthersFeTableAsyncUsesDedicatedDispatcher() throws Exception {
+        int originalThreadNum = Config.refresh_other_fe_rpc_executor_thread_num;
+        int originalAsyncThreadNum = Config.refresh_other_fe_dispatch_executor_thread_num;
+        Config.refresh_other_fe_rpc_executor_thread_num = 1;
+        Config.refresh_other_fe_dispatch_executor_thread_num = 1;
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1, 1);
+        CopyOnWriteArrayList<String> threadNames = new CopyOnWriteArrayList<>();
+        try (MockedStatic<GlobalStateMgr> globalStateMgrMock =
+                     Mockito.mockStatic(GlobalStateMgr.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                        Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            globalStateMgrMock.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenAnswer(invocation -> {
+                        threadNames.add(Thread.currentThread().getName());
+                        return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
+                    });
+
+            globalStateMgr.refreshOthersFeTableAsync(new TableName("c", "d", "t"), List.of()).get();
+
+            ThreadPoolExecutor asyncExecutor = getRefreshOtherFeAsyncExecutor(globalStateMgr);
+            Assertions.assertEquals(1, asyncExecutor.getCorePoolSize());
+            Assertions.assertFalse(threadNames.isEmpty());
+            Assertions.assertTrue(threadNames.stream().allMatch(name -> name.startsWith("refresh-other-fe-rpc-")));
+        } finally {
+            Config.refresh_other_fe_rpc_executor_thread_num = originalThreadNum;
+            Config.refresh_other_fe_dispatch_executor_thread_num = originalAsyncThreadNum;
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    private GlobalStateMgr createRefreshTestGlobalStateMgr(int refreshThreadNum) throws Exception {
+        int originalThreadNum = Config.refresh_other_fe_rpc_executor_thread_num;
+        int originalAsyncThreadNum = Config.refresh_other_fe_dispatch_executor_thread_num;
+        Config.refresh_other_fe_rpc_executor_thread_num = refreshThreadNum;
+        Config.refresh_other_fe_dispatch_executor_thread_num = refreshThreadNum;
+        try {
+            return createRefreshTestGlobalStateMgr(refreshThreadNum, refreshThreadNum);
+        } finally {
+            Config.refresh_other_fe_rpc_executor_thread_num = originalThreadNum;
+            Config.refresh_other_fe_dispatch_executor_thread_num = originalAsyncThreadNum;
+        }
+    }
+
+    private GlobalStateMgr createRefreshTestGlobalStateMgr(int refreshThreadNum, int refreshAsyncThreadNum)
+            throws Exception {
+        int originalThreadNum = Config.refresh_other_fe_rpc_executor_thread_num;
+        int originalAsyncThreadNum = Config.refresh_other_fe_dispatch_executor_thread_num;
+        Config.refresh_other_fe_rpc_executor_thread_num = refreshThreadNum;
+        Config.refresh_other_fe_dispatch_executor_thread_num = refreshAsyncThreadNum;
+        try {
+            NodeMgr nodeMgr = new NodeMgr();
+            setFrontends(nodeMgr, List.of(
+                    createFrontend(FrontendNodeType.LEADER, "fe1", "127.0.0.1", 9010, 9020),
+                    createFrontend(FrontendNodeType.FOLLOWER, "fe2", "127.0.0.2", 9011, 9021),
+                    createFrontend(FrontendNodeType.FOLLOWER, "fe3", "127.0.0.3", 9012, 9022)));
+            setSelfNode(nodeMgr, new Pair<>("127.0.0.1", 9010));
+            setRole(nodeMgr, FrontendNodeType.LEADER);
+            return new GlobalStateMgr(nodeMgr);
+        } finally {
+            Config.refresh_other_fe_rpc_executor_thread_num = originalThreadNum;
+            Config.refresh_other_fe_dispatch_executor_thread_num = originalAsyncThreadNum;
+        }
+    }
+
+    private Frontend createFrontend(FrontendNodeType type, String name, String host, int editLogPort, int rpcPort) {
+        Frontend frontend = new Frontend(type, name, host, editLogPort);
+        frontend.setRpcPort(rpcPort);
+        return frontend;
+    }
+
+    private void setFrontends(NodeMgr nodeMgr, List<Frontend> frontendList) throws Exception {
+        Field field = nodeMgr.getClass().getDeclaredField("frontends");
+        field.setAccessible(true);
+        ConcurrentHashMap<String, Frontend> frontends = new ConcurrentHashMap<>();
+        for (Frontend frontend : frontendList) {
+            frontends.put(frontend.getNodeName(), frontend);
+        }
+        field.set(nodeMgr, frontends);
+    }
+
+    private void setSelfNode(NodeMgr nodeMgr, Pair<String, Integer> selfNode) throws Exception {
+        Field field = nodeMgr.getClass().getDeclaredField("selfNode");
+        field.setAccessible(true);
+        field.set(nodeMgr, selfNode);
+    }
+
+    private void setRole(NodeMgr nodeMgr, FrontendNodeType role) throws Exception {
+        Field field = nodeMgr.getClass().getDeclaredField("role");
+        field.setAccessible(true);
+        field.set(nodeMgr, role);
+    }
+
+    private Frontend findFrontendByRpcPort(List<Frontend> frontends, int rpcPort) {
+        return frontends.stream()
+                .filter(frontend -> frontend.getRpcPort() == rpcPort)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private ThreadPoolExecutor getRefreshOtherFeExecutor(GlobalStateMgr globalStateMgr) throws Exception {
+        Field field = GlobalStateMgr.class.getDeclaredField("refreshOtherFeRpcExecutor");
+        field.setAccessible(true);
+        return (ThreadPoolExecutor) field.get(globalStateMgr);
+    }
+
+    private ThreadPoolExecutor getRefreshOtherFeAsyncExecutor(GlobalStateMgr globalStateMgr) throws Exception {
+        Field field = GlobalStateMgr.class.getDeclaredField("refreshOtherFeDispatchExecutor");
+        field.setAccessible(true);
+        return (ThreadPoolExecutor) field.get(globalStateMgr);
+    }
+
+    private void shutdownRefreshOtherFeExecutors(GlobalStateMgr globalStateMgr) throws Exception {
+        shutdownExecutor(globalStateMgr, "refreshOtherFeRpcExecutor");
+        shutdownExecutor(globalStateMgr, "refreshOtherFeDispatchExecutor");
+    }
+
+    private void shutdownExecutor(GlobalStateMgr globalStateMgr, String fieldName) throws Exception {
+        Field field = GlobalStateMgr.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        ExecutorService executor = (ExecutorService) field.get(globalStateMgr);
+        executor.shutdownNow();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -56,8 +56,13 @@ import com.starrocks.persist.EditLog;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.OperationType;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.sql.ast.ModifyFrontendAddressClause;
 import com.starrocks.system.Frontend;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TRefreshTableResponse;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -552,6 +557,48 @@ public class GlobalStateMgrTest {
     }
 
     @Test
+    public void testRefreshOtherFeExecutorsIgnoreInvalidConfigRefresh() throws Exception {
+        int originalThreadNum = Config.refresh_other_fe_rpc_executor_thread_num;
+        int originalAsyncThreadNum = Config.refresh_other_fe_dispatch_executor_thread_num;
+        Config.refresh_other_fe_rpc_executor_thread_num = 1;
+        Config.refresh_other_fe_dispatch_executor_thread_num = 1;
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1, 1);
+        try {
+            ThreadPoolExecutor rpcExecutor = getRefreshOtherFeExecutor(globalStateMgr);
+            ThreadPoolExecutor dispatchExecutor = getRefreshOtherFeAsyncExecutor(globalStateMgr);
+            Config.refresh_other_fe_rpc_executor_thread_num = 0;
+            Config.refresh_other_fe_dispatch_executor_thread_num = -1;
+
+            triggerConfigRefresh(globalStateMgr.getConfigRefreshDaemon());
+
+            Assertions.assertEquals(1, rpcExecutor.getCorePoolSize());
+            Assertions.assertEquals(1, rpcExecutor.getMaximumPoolSize());
+            Assertions.assertEquals(1, dispatchExecutor.getCorePoolSize());
+            Assertions.assertEquals(1, dispatchExecutor.getMaximumPoolSize());
+        } finally {
+            Config.refresh_other_fe_rpc_executor_thread_num = originalThreadNum;
+            Config.refresh_other_fe_dispatch_executor_thread_num = originalAsyncThreadNum;
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    @Test
+    public void testRefreshOthersFeTableAsyncSwallowsWorkerThrowable() throws Exception {
+        GlobalStateMgr globalStateMgr = Mockito.spy(createRefreshTestGlobalStateMgr(1, 1));
+        try {
+            Mockito.doThrow(new RuntimeException("boom"))
+                    .when(globalStateMgr)
+                    .refreshOthersFeTable(Mockito.any(), Mockito.anyList(), Mockito.eq(false));
+
+            Future<?> future = globalStateMgr.refreshOthersFeTableAsync(new TableName("c", "d", "t"), List.of("p1"));
+            future.get();
+            Assertions.assertTrue(future.isDone());
+        } finally {
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    @Test
     public void testRefreshOthersFeTableAggregatesRpcSubmitRejection() throws Exception {
         GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1, 1);
         CountDownLatch latch = new CountDownLatch(1);
@@ -597,6 +644,52 @@ public class GlobalStateMgrTest {
             Assertions.assertThrows(ExecutionException.class, future::get);
         } finally {
             latch.countDown();
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    @Test
+    public void testSubmitRefreshOtherFeRpcReturnsStatus() throws Exception {
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1, 1);
+        new MockUp<ThriftRPCRequestExecutor>() {
+            @Mock
+            public <RESULT, SERVER_CLIENT extends org.apache.thrift.TServiceClient> RESULT call(
+                    com.starrocks.rpc.ThriftConnectionPool<SERVER_CLIENT> genericPool,
+                    TNetworkAddress address,
+                    int timeoutMs,
+                    ThriftRPCRequestExecutor.MethodCallable<SERVER_CLIENT, RESULT> callable) {
+                return (RESULT) new TRefreshTableResponse(new TStatus(TStatusCode.OK));
+            }
+        };
+        try {
+            Future<TStatus> future = submitRefreshOtherFeRpc(globalStateMgr,
+                    createFrontend(FrontendNodeType.FOLLOWER, "fe2", "127.0.0.2", 9011, 9021),
+                    new TableName("c", "d", "t"), List.of("p1"));
+            Assertions.assertEquals(TStatusCode.OK, future.get().getStatus_code());
+        } finally {
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    @Test
+    public void testRefreshOtherFeTableRpcReturnsInternalErrorOnException() throws Exception {
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1, 1);
+        new MockUp<ThriftRPCRequestExecutor>() {
+            @Mock
+            public <RESULT, SERVER_CLIENT extends org.apache.thrift.TServiceClient> RESULT call(
+                    com.starrocks.rpc.ThriftConnectionPool<SERVER_CLIENT> genericPool,
+                    TNetworkAddress address,
+                    int timeoutMs,
+                    ThriftRPCRequestExecutor.MethodCallable<SERVER_CLIENT, RESULT> callable) {
+                throw new RuntimeException("rpc failed");
+            }
+        };
+        try {
+            TStatus status = refreshOtherFeTableRpc(globalStateMgr, new TNetworkAddress("127.0.0.2", 9021),
+                    new TableName("c", "d", "t"), List.of("p1"));
+            Assertions.assertEquals(TStatusCode.INTERNAL_ERROR, status.getStatus_code());
+            Assertions.assertTrue(status.getError_msgs().contains("rpc failed"));
+        } finally {
             shutdownRefreshOtherFeExecutors(globalStateMgr);
         }
     }
@@ -699,5 +792,22 @@ public class GlobalStateMgrTest {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Future<TStatus> submitRefreshOtherFeRpc(GlobalStateMgr globalStateMgr, Frontend fe,
+                                                    TableName tableName, List<String> partitions) throws Exception {
+        Method method = GlobalStateMgr.class.getDeclaredMethod(
+                "submitRefreshOtherFeRpc", Frontend.class, TableName.class, List.class);
+        method.setAccessible(true);
+        return (Future<TStatus>) method.invoke(globalStateMgr, fe, tableName, partitions);
+    }
+
+    private TStatus refreshOtherFeTableRpc(GlobalStateMgr globalStateMgr, TNetworkAddress thriftAddress,
+                                           TableName tableName, List<String> partitions) throws Exception {
+        Method method = GlobalStateMgr.class.getDeclaredMethod(
+                "refreshOtherFeTableRpc", TNetworkAddress.class, TableName.class, List.class);
+        method.setAccessible(true);
+        return (TStatus) method.invoke(globalStateMgr, thriftAddress, tableName, partitions);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -87,6 +87,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -688,6 +689,34 @@ public class GlobalStateMgrTest {
         } finally {
             Config.refresh_other_fe_rpc_executor_thread_num = originalThreadNum;
             Config.refresh_other_fe_dispatch_executor_thread_num = originalAsyncThreadNum;
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    @Test
+    public void testRefreshOthersFeTableAggregatesRpcSubmitRejection() throws Exception {
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(Config.refresh_other_fe_rpc_executor_thread_num);
+        try {
+            getRefreshOtherFeExecutor(globalStateMgr).shutdownNow();
+
+            DdlException exception = assertThrows(DdlException.class,
+                    () -> globalStateMgr.refreshOthersFeTable(new TableName("c", "d", "t"), List.of("p1"), true));
+            Assertions.assertTrue(exception.getMessage().contains("rejected"));
+        } finally {
+            shutdownRefreshOtherFeExecutors(globalStateMgr);
+        }
+    }
+
+    @Test
+    public void testRefreshOthersFeTableAsyncDoesNotThrowOnDispatchRejection() throws Exception {
+        GlobalStateMgr globalStateMgr = createRefreshTestGlobalStateMgr(1, 1);
+        try {
+            getRefreshOtherFeAsyncExecutor(globalStateMgr).shutdownNow();
+
+            Future<?> future = globalStateMgr.refreshOthersFeTableAsync(new TableName("c", "d", "t"), List.of("p1"));
+            Assertions.assertTrue(future.isDone());
+            Assertions.assertThrows(ExecutionException.class, future::get);
+        } finally {
             shutdownRefreshOtherFeExecutors(globalStateMgr);
         }
     }


### PR DESCRIPTION
## Why I'm doing:
Refreshing external table metadata on peer FEs previously mixed two concerns:

1. background dispatch from connector write paths
2. per-peer RPC fan-out to other FEs

Those concerns were partially implemented inside individual connectors, and some paths created ad hoc threads for each refresh. This made concurrency harder to reason about, harder to tune globally, and less efficient when multiple catalogs were active.

This change makes the refresh path easier to manage by moving the concurrency control into `GlobalStateMgr`, so FE-wide capacity is bounded and shared consistently.

## What I'm doing:
- Centralize "refresh other FE" execution in `GlobalStateMgr`.
- Split the flow into two explicit stages with two FE-global executors:
  - dispatch executor: runs background refresh jobs asynchronously
  - rpc executor: fans out bounded refresh RPCs to peer FEs
- Keep both sync and async entry points in `GlobalStateMgr`:
  - sync callers wait for peer refresh completion
  - async callers return immediately and reuse the same bounded RPC fan-out path
- Remove per-catalog refresh executor usage from Hive and Iceberg write paths, so connectors no longer manage this concurrency themselves.
- Add FE config knobs and comments for the new global executors.
- Add unit tests covering success, failure aggregation, RPC exception handling, and executor usage.

High-level flow after this change:

```text
async connector path
    |
    +--> GlobalStateMgr.refreshOthersFeTableAsync(...)
             |
             +--> dispatch executor
                      |
                      +--> refreshOthersFeTable(...)
                               |
                               +--> rpc executor
                                        |
                                        +--> refresh peer FE #1
                                        +--> refresh peer FE #2
                                        +--> refresh peer FE #3
```

This keeps behavior the same at a functional level, but makes resource control FE-global instead of per-catalog.

## Config Notes

This change introduces two FE-level dynamic configs for managing "refresh other FE" concurrency:

- `refresh_other_fe_dispatch_executor_thread_num`
  Controls the size of the global dispatch executor used by asynchronous refresh requests from connector write paths.
  These threads only schedule background refresh work and do not directly send peer FE RPCs.

- `refresh_other_fe_rpc_executor_thread_num`
  Controls the size of the global RPC fan-out executor used to send refresh requests to peer FEs.
  This is the actual concurrency cap for cross-FE refresh RPCs, and it is shared by both synchronous and asynchronous refresh flows.

High-level config behavior:

```text
async connector path
    -> dispatch executor
    -> refresh orchestration
    -> rpc executor
    -> peer FE refresh RPCs

sync DDL path
    -> refresh orchestration
    -> rpc executor
    -> peer FE refresh RPCs
```

In short:
- `dispatch_executor_thread_num` limits how many background refresh jobs can be started at once.
- `rpc_executor_thread_num` limits how many peer FE refresh RPCs can run concurrently.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4