### PR TITLE
[Enhancement] Complete Iceberg timestamptz partition transform support by filling the sink path gap

### DIFF
--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -523,7 +523,7 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_datetime(FunctionContext* cont
 }
 
 StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_timestamptz_datetime(FunctionContext* context,
-                                                                        const Columns& columns) {
+                                                                       const Columns& columns) {
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
     const int size = columns[0]->size();

--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -31,11 +31,47 @@
 #include "exprs/expr.h"
 #include "exprs/function_helper.h"
 #include "exprs/math_functions.h"
+#include "runtime/runtime_state.h"
+#include "types/datetime_value.h"
 
 namespace starrocks {
 
 static std::uniform_real_distribution<double> distribution(0.0, 1.0);
 static thread_local std::mt19937_64 generator{std::random_device{}()};
+
+namespace {
+
+int64_t iceberg_datetime_to_epoch_microseconds(const TimestampValue& timestamp) {
+    auto ts = timestamp.timestamp();
+    int64_t value = timestamp::to_julian(ts);
+    value *= SECS_PER_DAY;
+    value -= timestamp::UNIX_EPOCH_SECONDS;
+    value *= 1000000L;
+    value += timestamp::to_time(ts);
+    return value;
+}
+
+bool iceberg_timestamptz_to_epoch_microseconds(FunctionContext* context, const TimestampValue& timestamp,
+                                               int64_t* value) {
+    cctz::time_zone timezone = cctz::utc_time_zone();
+    if (context != nullptr && context->state() != nullptr) {
+        timezone = context->state()->timezone_obj();
+    }
+
+    int year, month, day, hour, minute, second, usec;
+    timestamp.to_timestamp(&year, &month, &day, &hour, &minute, &second, &usec);
+    DateTimeValue datetime(TIME_DATETIME, year, month, day, hour, minute, second, usec);
+
+    int64_t unix_second;
+    if (!datetime.unix_timestamp(&unix_second, timezone)) {
+        return false;
+    }
+
+    *value = unix_second * 1000000L + usec;
+    return true;
+}
+
+} // namespace
 
 // ==== basic check rules =========
 DEFINE_UNARY_FN_WITH_IMPL(NegativeCheck, value) {
@@ -477,12 +513,33 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_datetime(FunctionContext* cont
         if (viewer.is_null(i)) {
             builder.append_null();
         } else {
-            auto ts = viewer.value(i).timestamp();
-            int64_t val = timestamp::to_julian(ts);
-            val *= SECS_PER_DAY;
-            val -= timestamp::UNIX_EPOCH_SECONDS;
-            val *= 1000000L;
-            val += timestamp::to_time(ts);
+            int64_t val = iceberg_datetime_to_epoch_microseconds(viewer.value(i));
+            int32_t hash;
+            murmur_hash3_x86_32(&val, sizeof(int64_t), 0, &hash);
+            builder.append(static_cast<int32_t>((hash & INT_MAX) % width));
+        }
+    }
+    return builder.build(ColumnHelper::is_all_const(columns));
+}
+
+StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_timestamptz_datetime(FunctionContext* context,
+                                                                        const Columns& columns) {
+    RETURN_IF_COLUMNS_ONLY_NULL(columns);
+
+    const int size = columns[0]->size();
+    ColumnViewer<TYPE_DATETIME> viewer(columns[0]);
+    int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+
+    ColumnBuilder<TYPE_INT> builder(size);
+    for (int i = 0; i < size; i++) {
+        if (viewer.is_null(i)) {
+            builder.append_null();
+        } else {
+            int64_t val;
+            if (!iceberg_timestamptz_to_epoch_microseconds(context, viewer.value(i), &val)) {
+                builder.append_null();
+                continue;
+            }
             int32_t hash;
             murmur_hash3_x86_32(&val, sizeof(int64_t), 0, &hash);
             builder.append(static_cast<int32_t>((hash & INT_MAX) % width));

--- a/be/src/exprs/math_functions.h
+++ b/be/src/exprs/math_functions.h
@@ -234,6 +234,7 @@ public:
     DEFINE_VECTORIZED_FN(iceberg_bucket_string);
     DEFINE_VECTORIZED_FN(iceberg_bucket_date);
     DEFINE_VECTORIZED_FN(iceberg_bucket_datetime);
+    DEFINE_VECTORIZED_FN(iceberg_bucket_timestamptz_datetime);
     template <typename T>
     static vector<uint8_t> int_to_byte_array(T value);
     DEFINE_VECTORIZED_FN_TEMPLATE(iceberg_bucket_decimal);

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -178,6 +178,75 @@ Status TimeFunctions::convert_tz_close(FunctionContext* context, FunctionContext
     return Status::OK();
 }
 
+namespace {
+
+cctz::time_zone get_iceberg_timestamptz_session_timezone(FunctionContext* context) {
+    if (context != nullptr && context->state() != nullptr) {
+        return context->state()->timezone_obj();
+    }
+    return cctz::utc_time_zone();
+}
+
+bool should_use_iceberg_timestamptz_utc_fast_path(const cctz::time_zone& timezone) {
+    if (timezone == cctz::utc_time_zone()) {
+        return true;
+    }
+
+    auto epoch = cctz::time_point<cctz::seconds>();
+    cctz::time_zone::civil_transition transition;
+    return timezone.lookup(epoch).offset == 0 && !timezone.next_transition(epoch, &transition);
+}
+
+bool normalize_iceberg_timestamptz_to_utc(FunctionContext* context, const TimestampValue& timestamp,
+                                          TimestampValue* normalized_timestamp) {
+    int year, month, day, hour, minute, second, usec;
+    timestamp.to_timestamp(&year, &month, &day, &hour, &minute, &second, &usec);
+    DateTimeValue datetime(TIME_DATETIME, year, month, day, hour, minute, second, usec);
+
+    int64_t unix_second;
+    if (!datetime.unix_timestamp(&unix_second, get_iceberg_timestamptz_session_timezone(context))) {
+        return false;
+    }
+
+    normalized_timestamp->from_unix_second(unix_second, usec);
+    return true;
+}
+
+template <typename TransformFn>
+StatusOr<ColumnPtr> evaluate_iceberg_timestamptz_transform(FunctionContext* context, const Columns& columns,
+                                                           TransformFn transform_fn) {
+    DCHECK_EQ(columns.size(), 1);
+
+    auto datetime_viewer = ColumnViewer<TYPE_DATETIME>(columns[0]);
+    auto size = columns[0]->size();
+    ColumnBuilder<TYPE_BIGINT> result(size);
+    bool use_utc_fast_path = should_use_iceberg_timestamptz_utc_fast_path(get_iceberg_timestamptz_session_timezone(context));
+
+    for (int row = 0; row < size; ++row) {
+        if (datetime_viewer.is_null(row)) {
+            result.append_null();
+            continue;
+        }
+
+        if (use_utc_fast_path) {
+            result.append(transform_fn(datetime_viewer.value(row)));
+            continue;
+        }
+
+        TimestampValue normalized_timestamp;
+        if (!normalize_iceberg_timestamptz_to_utc(context, datetime_viewer.value(row), &normalized_timestamp)) {
+            result.append_null();
+            continue;
+        }
+
+        result.append(transform_fn(normalized_timestamp));
+    }
+
+    return result.build(ColumnHelper::is_all_const(columns));
+}
+
+} // namespace
+
 StatusOr<ColumnPtr> TimeFunctions::convert_tz_general(FunctionContext* context, const Columns& columns) {
     auto time_viewer = ColumnViewer<TYPE_DATETIME>(columns[0]);
     auto from_str = ColumnViewer<TYPE_VARCHAR>(columns[1]);
@@ -3286,6 +3355,13 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_years_since_epoch_datetime(FunctionCo
             VECTORIZED_FN_ARGS(0));
 }
 
+StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_years_since_epoch_datetime(FunctionContext* context,
+                                                                                   const starrocks::Columns& columns) {
+    return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
+        return years_diff_v2Impl::apply<TimestampValue, TimestampValue, int64_t>(timestamp, TimeFunctions::unix_epoch);
+    });
+}
+
 DEFINE_UNARY_FN_WITH_IMPL(iceberg_months_since_epoch_dateImpl, v) {
     int y, m, d;
     ((DateValue)v).to_date(&y, &m, &d);
@@ -3307,6 +3383,13 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_months_since_epoch_datetime(FunctionC
                                                                        const starrocks::Columns& columns) {
     return VectorizedStrictUnaryFunction<iceberg_months_since_epoch_datetimeImpl>::evaluate<TYPE_DATETIME, TYPE_BIGINT>(
             VECTORIZED_FN_ARGS(0));
+}
+
+StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_months_since_epoch_datetime(
+        FunctionContext* context, const starrocks::Columns& columns) {
+    return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
+        return months_diff_v2Impl::apply<TimestampValue, TimestampValue, int64_t>(timestamp, TimeFunctions::unix_epoch);
+    });
 }
 
 DEFINE_UNARY_FN_WITH_IMPL(iceberg_days_since_epoch_dateImpl, v) {
@@ -3332,6 +3415,13 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_days_since_epoch_datetime(FunctionCon
             VECTORIZED_FN_ARGS(0));
 }
 
+StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(
+        FunctionContext* context, const starrocks::Columns& columns) {
+    return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
+        return days_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(timestamp, TimeFunctions::unix_epoch);
+    });
+}
+
 DEFINE_UNARY_FN_WITH_IMPL(iceberg_hours_since_epoch_datetimeImpl, v) {
     return hours_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(v, TimeFunctions::unix_epoch);
 }
@@ -3340,6 +3430,13 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_hours_since_epoch_datetime(FunctionCo
                                                                       const starrocks::Columns& columns) {
     return VectorizedStrictUnaryFunction<iceberg_hours_since_epoch_datetimeImpl>::evaluate<TYPE_DATETIME, TYPE_BIGINT>(
             VECTORIZED_FN_ARGS(0));
+}
+
+StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(
+        FunctionContext* context, const starrocks::Columns& columns) {
+    return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
+        return hours_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(timestamp, TimeFunctions::unix_epoch);
+    });
 }
 
 // used as start point of time_slice.

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -202,8 +202,29 @@ bool normalize_iceberg_timestamptz_to_utc(FunctionContext* context, const Timest
         return false;
     }
 
-    normalized_timestamp->from_unix_second(unix_second, usec);
+    normalized_timestamp->from_unixtime(unix_second, usec, cctz::utc_time_zone());
     return true;
+}
+
+int64_t floor_div_microseconds(int64_t micros, int64_t unit_micros) {
+    int64_t quotient = micros / unit_micros;
+    int64_t remainder = micros % unit_micros;
+    if (remainder != 0 && ((remainder < 0) != (unit_micros < 0))) {
+        --quotient;
+    }
+    return quotient;
+}
+
+int64_t iceberg_microseconds_since_epoch(const TimestampValue& timestamp) {
+    return timestamp.diff_microsecond(TimeFunctions::unix_epoch);
+}
+
+int64_t iceberg_days_since_epoch(const TimestampValue& timestamp) {
+    return floor_div_microseconds(iceberg_microseconds_since_epoch(timestamp), USECS_PER_DAY);
+}
+
+int64_t iceberg_hours_since_epoch(const TimestampValue& timestamp) {
+    return floor_div_microseconds(iceberg_microseconds_since_epoch(timestamp), USECS_PER_HOUR);
 }
 
 template <typename TransformFn>
@@ -3391,11 +3412,11 @@ DEFINE_UNARY_FN_WITH_IMPL(iceberg_days_since_epoch_dateImpl, v) {
     int y, m, d;
     ((DateValue)v).to_date(&y, &m, &d);
     auto ts = TimestampValue::create(y, m, d, 0, 0, 0, 0);
-    return days_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(ts, TimeFunctions::unix_epoch);
+    return iceberg_days_since_epoch(ts);
 }
 
 DEFINE_UNARY_FN_WITH_IMPL(iceberg_days_since_epoch_datetimeImpl, v) {
-    return days_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(v, TimeFunctions::unix_epoch);
+    return iceberg_days_since_epoch(v);
 }
 
 StatusOr<ColumnPtr> TimeFunctions::iceberg_days_since_epoch_date(FunctionContext* context,
@@ -3413,12 +3434,12 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_days_since_epoch_datetime(FunctionCon
 StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(FunctionContext* context,
                                                                                  const starrocks::Columns& columns) {
     return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
-        return days_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(timestamp, TimeFunctions::unix_epoch);
+        return iceberg_days_since_epoch(timestamp);
     });
 }
 
 DEFINE_UNARY_FN_WITH_IMPL(iceberg_hours_since_epoch_datetimeImpl, v) {
-    return hours_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(v, TimeFunctions::unix_epoch);
+    return iceberg_hours_since_epoch(v);
 }
 
 StatusOr<ColumnPtr> TimeFunctions::iceberg_hours_since_epoch_datetime(FunctionContext* context,
@@ -3428,9 +3449,9 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_hours_since_epoch_datetime(FunctionCo
 }
 
 StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(FunctionContext* context,
-                                                                                  const starrocks::Columns& columns) {
+                                                                                   const starrocks::Columns& columns) {
     return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
-        return hours_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(timestamp, TimeFunctions::unix_epoch);
+        return iceberg_hours_since_epoch(timestamp);
     });
 }
 

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -220,7 +220,8 @@ StatusOr<ColumnPtr> evaluate_iceberg_timestamptz_transform(FunctionContext* cont
     auto datetime_viewer = ColumnViewer<TYPE_DATETIME>(columns[0]);
     auto size = columns[0]->size();
     ColumnBuilder<TYPE_BIGINT> result(size);
-    bool use_utc_fast_path = should_use_iceberg_timestamptz_utc_fast_path(get_iceberg_timestamptz_session_timezone(context));
+    bool use_utc_fast_path =
+            should_use_iceberg_timestamptz_utc_fast_path(get_iceberg_timestamptz_session_timezone(context));
 
     for (int row = 0; row < size; ++row) {
         if (datetime_viewer.is_null(row)) {
@@ -3356,7 +3357,7 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_years_since_epoch_datetime(FunctionCo
 }
 
 StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_years_since_epoch_datetime(FunctionContext* context,
-                                                                                   const starrocks::Columns& columns) {
+                                                                                  const starrocks::Columns& columns) {
     return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
         return years_diff_v2Impl::apply<TimestampValue, TimestampValue, int64_t>(timestamp, TimeFunctions::unix_epoch);
     });
@@ -3385,8 +3386,8 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_months_since_epoch_datetime(FunctionC
             VECTORIZED_FN_ARGS(0));
 }
 
-StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_months_since_epoch_datetime(
-        FunctionContext* context, const starrocks::Columns& columns) {
+StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_months_since_epoch_datetime(FunctionContext* context,
+                                                                                   const starrocks::Columns& columns) {
     return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
         return months_diff_v2Impl::apply<TimestampValue, TimestampValue, int64_t>(timestamp, TimeFunctions::unix_epoch);
     });
@@ -3415,8 +3416,8 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_days_since_epoch_datetime(FunctionCon
             VECTORIZED_FN_ARGS(0));
 }
 
-StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(
-        FunctionContext* context, const starrocks::Columns& columns) {
+StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(FunctionContext* context,
+                                                                                 const starrocks::Columns& columns) {
     return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
         return days_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(timestamp, TimeFunctions::unix_epoch);
     });
@@ -3432,8 +3433,8 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_hours_since_epoch_datetime(FunctionCo
             VECTORIZED_FN_ARGS(0));
 }
 
-StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(
-        FunctionContext* context, const starrocks::Columns& columns) {
+StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(FunctionContext* context,
+                                                                                  const starrocks::Columns& columns) {
     return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
         return hours_diffImpl::apply<TimestampValue, TimestampValue, int64_t>(timestamp, TimeFunctions::unix_epoch);
     });

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -3433,9 +3433,8 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_days_since_epoch_datetime(FunctionCon
 
 StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(FunctionContext* context,
                                                                                  const starrocks::Columns& columns) {
-    return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
-        return iceberg_days_since_epoch(timestamp);
-    });
+    return evaluate_iceberg_timestamptz_transform(
+            context, columns, [](const TimestampValue& timestamp) { return iceberg_days_since_epoch(timestamp); });
 }
 
 DEFINE_UNARY_FN_WITH_IMPL(iceberg_hours_since_epoch_datetimeImpl, v) {
@@ -3449,10 +3448,9 @@ StatusOr<ColumnPtr> TimeFunctions::iceberg_hours_since_epoch_datetime(FunctionCo
 }
 
 StatusOr<ColumnPtr> TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(FunctionContext* context,
-                                                                                   const starrocks::Columns& columns) {
-    return evaluate_iceberg_timestamptz_transform(context, columns, [](const TimestampValue& timestamp) {
-        return iceberg_hours_since_epoch(timestamp);
-    });
+                                                                                  const starrocks::Columns& columns) {
+    return evaluate_iceberg_timestamptz_transform(
+            context, columns, [](const TimestampValue& timestamp) { return iceberg_hours_since_epoch(timestamp); });
 }
 
 // used as start point of time_slice.

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -188,13 +188,7 @@ cctz::time_zone get_iceberg_timestamptz_session_timezone(FunctionContext* contex
 }
 
 bool should_use_iceberg_timestamptz_utc_fast_path(const cctz::time_zone& timezone) {
-    if (timezone == cctz::utc_time_zone()) {
-        return true;
-    }
-
-    auto epoch = cctz::time_point<cctz::seconds>();
-    cctz::time_zone::civil_transition transition;
-    return timezone.lookup(epoch).offset == 0 && !timezone.next_transition(epoch, &transition);
+    return timezone == cctz::utc_time_zone();
 }
 
 bool normalize_iceberg_timestamptz_to_utc(FunctionContext* context, const TimestampValue& timestamp,

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -872,6 +872,10 @@ public:
     DEFINE_VECTORIZED_FN(iceberg_days_since_epoch_date);
     DEFINE_VECTORIZED_FN(iceberg_days_since_epoch_datetime);
     DEFINE_VECTORIZED_FN(iceberg_hours_since_epoch_datetime);
+    DEFINE_VECTORIZED_FN(iceberg_timestamptz_years_since_epoch_datetime);
+    DEFINE_VECTORIZED_FN(iceberg_timestamptz_months_since_epoch_datetime);
+    DEFINE_VECTORIZED_FN(iceberg_timestamptz_days_since_epoch_datetime);
+    DEFINE_VECTORIZED_FN(iceberg_timestamptz_hours_since_epoch_datetime);
 
 private:
     DEFINE_VECTORIZED_FN_TEMPLATE(_t_from_unix_to_datetime);

--- a/be/test/exprs/math_functions_test.cpp
+++ b/be/test/exprs/math_functions_test.cpp
@@ -26,6 +26,8 @@
 #include "exprs/binary_functions.h"
 #include "exprs/mock_vectorized_expr.h"
 #include "exprs/time_functions.h"
+#include "gen_cpp/InternalService_types.h"
+#include "runtime/runtime_state.h"
 
 #define PI acos(-1)
 
@@ -1787,6 +1789,65 @@ TEST_F(VecMathFunctionsTest, IcbergTransTest) {
         ASSERT_FALSE(result->is_nullable());
         auto v = ColumnHelper::as_column<Int32Column>(result);
         ASSERT_EQ(0, v->get_data()[0]);
+    }
+
+    {
+        TQueryGlobals globals;
+        globals.__set_time_zone("UTC");
+        auto state = std::make_unique<RuntimeState>(globals);
+        std::unique_ptr<FunctionContext> ctx_with_state(FunctionContext::create_test_context());
+        ctx_with_state->set_runtime_state(state.get());
+
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        auto col2 = Int32Column::create();
+        col1->append(TimestampValue::create(2000, 1, 1, 12, 12, 12));
+        col2->append(10);
+        auto const_col1 = ConstColumn::create(std::move(col1), 1);
+        columns_const.emplace_back(std::move(const_col1));
+        columns_const.emplace_back(std::move(col2));
+
+        ColumnPtr result = MathFunctions::iceberg_bucket_timestamptz_datetime(ctx_with_state.get(), columns_const).value();
+        ASSERT_TRUE(result->is_numeric());
+        ASSERT_FALSE(result->is_nullable());
+        auto v = ColumnHelper::as_column<Int32Column>(result);
+        ASSERT_EQ(0, v->get_data()[0]);
+    }
+
+    {
+        TQueryGlobals globals;
+        globals.__set_time_zone("Asia/Shanghai");
+        auto state = std::make_unique<RuntimeState>(globals);
+        std::unique_ptr<FunctionContext> ctx_with_state(FunctionContext::create_test_context());
+        ctx_with_state->set_runtime_state(state.get());
+
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        auto col2 = Int32Column::create();
+        col1->append(TimestampValue::create(1970, 1, 1, 1, 0, 0));
+        col2->append(10);
+        auto const_col1 = ConstColumn::create(std::move(col1), 1);
+        columns_const.emplace_back(std::move(const_col1));
+        columns_const.emplace_back(std::move(col2));
+
+        ColumnPtr result = MathFunctions::iceberg_bucket_timestamptz_datetime(ctx_with_state.get(), columns_const).value();
+
+        Columns normalized_columns_const;
+        auto normalized_col1 = TimestampColumn::create();
+        auto normalized_col2 = Int32Column::create();
+        normalized_col1->append(TimestampValue::create(1969, 12, 31, 17, 0, 0));
+        normalized_col2->append(10);
+        auto normalized_const_col1 = ConstColumn::create(std::move(normalized_col1), 1);
+        normalized_columns_const.emplace_back(std::move(normalized_const_col1));
+        normalized_columns_const.emplace_back(std::move(normalized_col2));
+
+        std::unique_ptr<FunctionContext> utc_ctx(FunctionContext::create_test_context());
+        ColumnPtr expected = MathFunctions::iceberg_bucket_datetime(utc_ctx.get(), normalized_columns_const).value();
+
+        ASSERT_TRUE(result->is_numeric());
+        ASSERT_FALSE(result->is_nullable());
+        ASSERT_EQ(ColumnHelper::as_column<Int32Column>(expected)->get_data()[0],
+                ColumnHelper::as_column<Int32Column>(result)->get_data()[0]);
     }
 
     {

--- a/be/test/exprs/math_functions_test.cpp
+++ b/be/test/exprs/math_functions_test.cpp
@@ -1807,7 +1807,8 @@ TEST_F(VecMathFunctionsTest, IcbergTransTest) {
         columns_const.emplace_back(std::move(const_col1));
         columns_const.emplace_back(std::move(col2));
 
-        ColumnPtr result = MathFunctions::iceberg_bucket_timestamptz_datetime(ctx_with_state.get(), columns_const).value();
+        ColumnPtr result =
+                MathFunctions::iceberg_bucket_timestamptz_datetime(ctx_with_state.get(), columns_const).value();
         ASSERT_TRUE(result->is_numeric());
         ASSERT_FALSE(result->is_nullable());
         auto v = ColumnHelper::as_column<Int32Column>(result);
@@ -1830,7 +1831,8 @@ TEST_F(VecMathFunctionsTest, IcbergTransTest) {
         columns_const.emplace_back(std::move(const_col1));
         columns_const.emplace_back(std::move(col2));
 
-        ColumnPtr result = MathFunctions::iceberg_bucket_timestamptz_datetime(ctx_with_state.get(), columns_const).value();
+        ColumnPtr result =
+                MathFunctions::iceberg_bucket_timestamptz_datetime(ctx_with_state.get(), columns_const).value();
 
         Columns normalized_columns_const;
         auto normalized_col1 = TimestampColumn::create();
@@ -1847,7 +1849,7 @@ TEST_F(VecMathFunctionsTest, IcbergTransTest) {
         ASSERT_TRUE(result->is_numeric());
         ASSERT_FALSE(result->is_nullable());
         ASSERT_EQ(ColumnHelper::as_column<Int32Column>(expected)->get_data()[0],
-                ColumnHelper::as_column<Int32Column>(result)->get_data()[0]);
+                  ColumnHelper::as_column<Int32Column>(result)->get_data()[0]);
     }
 
     {

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -4147,7 +4147,8 @@ TEST_F(TimeFunctionsTest, IcebergTimestamptzTransTest) {
         col1->append(TimestampValue::create(2022, 2, 2, 12, 22, 22, 345678));
         columns_const.emplace_back(std::move(col1));
 
-        ColumnPtr result = TimeFunctions::iceberg_timestamptz_years_since_epoch_datetime(ctx.get(), columns_const).value();
+        ColumnPtr result =
+                TimeFunctions::iceberg_timestamptz_years_since_epoch_datetime(ctx.get(), columns_const).value();
         auto v = ColumnHelper::as_column<Int64Column>(result);
         ASSERT_EQ(2022 - 1970, v->get_data()[0]);
     }
@@ -4158,7 +4159,8 @@ TEST_F(TimeFunctionsTest, IcebergTimestamptzTransTest) {
         col1->append(TimestampValue::create(1970, 2, 2, 12, 22, 22, 1));
         columns_const.emplace_back(std::move(col1));
 
-        ColumnPtr result = TimeFunctions::iceberg_timestamptz_months_since_epoch_datetime(ctx.get(), columns_const).value();
+        ColumnPtr result =
+                TimeFunctions::iceberg_timestamptz_months_since_epoch_datetime(ctx.get(), columns_const).value();
         auto v = ColumnHelper::as_column<Int64Column>(result);
         ASSERT_EQ(1, v->get_data()[0]);
     }
@@ -4169,7 +4171,8 @@ TEST_F(TimeFunctionsTest, IcebergTimestamptzTransTest) {
         col1->append(TimestampValue::create(1970, 1, 2, 0, 0, 0, 999999));
         columns_const.emplace_back(std::move(col1));
 
-        ColumnPtr result = TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(ctx.get(), columns_const).value();
+        ColumnPtr result =
+                TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(ctx.get(), columns_const).value();
         auto v = ColumnHelper::as_column<Int64Column>(result);
         ASSERT_EQ(1, v->get_data()[0]);
     }
@@ -4180,7 +4183,8 @@ TEST_F(TimeFunctionsTest, IcebergTimestamptzTransTest) {
         col1->append(TimestampValue::create(1970, 1, 1, 23, 59, 59, 999999));
         columns_const.emplace_back(std::move(col1));
 
-        ColumnPtr result = TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(ctx.get(), columns_const).value();
+        ColumnPtr result =
+                TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(ctx.get(), columns_const).value();
         auto v = ColumnHelper::as_column<Int64Column>(result);
         ASSERT_EQ(23, v->get_data()[0]);
     }
@@ -4196,7 +4200,9 @@ TEST_F(TimeFunctionsTest, IcebergTimestamptzTransTest) {
         col1->append(TimestampValue::create(1970, 1, 1, 1, 0, 0));
         columns_const.emplace_back(std::move(col1));
 
-        ColumnPtr result = TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+        ColumnPtr result =
+                TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const)
+                        .value();
         auto v = ColumnHelper::as_column<Int64Column>(result);
         ASSERT_EQ(1, v->get_data()[0]);
     }
@@ -4212,7 +4218,9 @@ TEST_F(TimeFunctionsTest, IcebergTimestamptzTransTest) {
         col1->append(TimestampValue::create(1970, 1, 1, 23, 0, 0, 654321));
         columns_const.emplace_back(std::move(col1));
 
-        ColumnPtr result = TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+        ColumnPtr result =
+                TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const)
+                        .value();
         auto v = ColumnHelper::as_column<Int64Column>(result);
         ASSERT_EQ(23, v->get_data()[0]);
     }
@@ -4229,12 +4237,14 @@ TEST_F(TimeFunctionsTest, IcebergTimestamptzTransTest) {
         columns_const.emplace_back(std::move(col1));
 
         ColumnPtr day_result =
-                TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+                TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(_utils->get_fn_ctx(), columns_const)
+                        .value();
         auto days = ColumnHelper::as_column<Int64Column>(day_result);
         ASSERT_EQ(-1, days->get_data()[0]);
 
         ColumnPtr hour_result =
-                TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+                TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const)
+                        .value();
         auto hours = ColumnHelper::as_column<Int64Column>(hour_result);
         ASSERT_EQ(-7, hours->get_data()[0]);
     }

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -4250,6 +4250,34 @@ TEST_F(TimeFunctionsTest, IcebergTimestamptzTransTest) {
     }
 }
 
+TEST_F(TimeFunctionsTest, IcebergPreEpochDayHourTransformTest) {
+    {
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1969, 12, 31, 23, 0, 0));
+        col1->append(TimestampValue::create(1969, 12, 31, 0, 0, 0));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_days_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(-1, v->get_data()[0]);
+        ASSERT_EQ(-1, v->get_data()[1]);
+    }
+
+    {
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1969, 12, 31, 23, 0, 0));
+        col1->append(TimestampValue::create(1969, 12, 31, 22, 59, 59, 999999));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(-1, v->get_data()[0]);
+        ASSERT_EQ(-2, v->get_data()[1]);
+    }
+}
+
 TEST_F(TimeFunctionsTest, unixtimeToDatetimeInvalidArgCount) {
     {
         TQueryGlobals globals;

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -4258,7 +4258,8 @@ TEST_F(TimeFunctionsTest, IcebergPreEpochDayHourTransformTest) {
         col1->append(TimestampValue::create(1969, 12, 31, 0, 0, 0));
         columns_const.emplace_back(std::move(col1));
 
-        ColumnPtr result = TimeFunctions::iceberg_days_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+        ColumnPtr result =
+                TimeFunctions::iceberg_days_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
         auto v = ColumnHelper::as_column<Int64Column>(result);
         ASSERT_EQ(-1, v->get_data()[0]);
         ASSERT_EQ(-1, v->get_data()[1]);
@@ -4271,7 +4272,8 @@ TEST_F(TimeFunctionsTest, IcebergPreEpochDayHourTransformTest) {
         col1->append(TimestampValue::create(1969, 12, 31, 22, 59, 59, 999999));
         columns_const.emplace_back(std::move(col1));
 
-        ColumnPtr result = TimeFunctions::iceberg_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+        ColumnPtr result =
+                TimeFunctions::iceberg_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
         auto v = ColumnHelper::as_column<Int64Column>(result);
         ASSERT_EQ(-1, v->get_data()[0]);
         ASSERT_EQ(-2, v->get_data()[1]);

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -4210,7 +4210,7 @@ TEST_F(TimeFunctionsTest, IcebergTimestamptzTransTest) {
     {
         RuntimeState* state = _utils->get_fn_ctx()->state();
         std::string prev_timezone = state->timezone();
-        ASSERT_TRUE(state->set_timezone("+00:00"));
+        ASSERT_TRUE(state->set_timezone("Etc/UTC"));
         DeferOp defer([&]() { state->set_timezone(prev_timezone); });
 
         Columns columns_const;

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -4138,6 +4138,108 @@ TEST_F(TimeFunctionsTest, IcbergTransTest) {
     }
 }
 
+TEST_F(TimeFunctionsTest, IcebergTimestamptzTransTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    {
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(2022, 2, 2, 12, 22, 22, 345678));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_timestamptz_years_since_epoch_datetime(ctx.get(), columns_const).value();
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(2022 - 1970, v->get_data()[0]);
+    }
+
+    {
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1970, 2, 2, 12, 22, 22, 1));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_timestamptz_months_since_epoch_datetime(ctx.get(), columns_const).value();
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(1, v->get_data()[0]);
+    }
+
+    {
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1970, 1, 2, 0, 0, 0, 999999));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(ctx.get(), columns_const).value();
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(1, v->get_data()[0]);
+    }
+
+    {
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1970, 1, 1, 23, 59, 59, 999999));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(ctx.get(), columns_const).value();
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(23, v->get_data()[0]);
+    }
+
+    {
+        RuntimeState* state = _utils->get_fn_ctx()->state();
+        std::string prev_timezone = state->timezone();
+        ASSERT_TRUE(state->set_timezone("UTC"));
+        DeferOp defer([&]() { state->set_timezone(prev_timezone); });
+
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1970, 1, 1, 1, 0, 0));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(1, v->get_data()[0]);
+    }
+
+    {
+        RuntimeState* state = _utils->get_fn_ctx()->state();
+        std::string prev_timezone = state->timezone();
+        ASSERT_TRUE(state->set_timezone("+00:00"));
+        DeferOp defer([&]() { state->set_timezone(prev_timezone); });
+
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1970, 1, 1, 23, 0, 0, 654321));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr result = TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+        auto v = ColumnHelper::as_column<Int64Column>(result);
+        ASSERT_EQ(23, v->get_data()[0]);
+    }
+
+    {
+        RuntimeState* state = _utils->get_fn_ctx()->state();
+        std::string prev_timezone = state->timezone();
+        ASSERT_TRUE(state->set_timezone("Asia/Shanghai"));
+        DeferOp defer([&]() { state->set_timezone(prev_timezone); });
+
+        Columns columns_const;
+        auto col1 = TimestampColumn::create();
+        col1->append(TimestampValue::create(1970, 1, 1, 1, 0, 0, 123456));
+        columns_const.emplace_back(std::move(col1));
+
+        ColumnPtr day_result =
+                TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+        auto days = ColumnHelper::as_column<Int64Column>(day_result);
+        ASSERT_EQ(-1, days->get_data()[0]);
+
+        ColumnPtr hour_result =
+                TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime(_utils->get_fn_ctx(), columns_const).value();
+        auto hours = ColumnHelper::as_column<Int64Column>(hour_result);
+        ASSERT_EQ(-7, hours->get_data()[0]);
+    }
+}
+
 TEST_F(TimeFunctionsTest, unixtimeToDatetimeInvalidArgCount) {
     {
         TQueryGlobals globals;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -133,6 +133,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -317,9 +318,9 @@ public class InsertPlanner {
                     && IcebergRowLineageUtils.shouldWriteRowLineageColumns(insertStmt, (IcebergTable) targetTable);
             Set<String> columnsToFilter = preserveRowLineage
                     ? IcebergTable.ICEBERG_META_COLUMNS.stream()
-                            .filter(col -> !col.equals(IcebergTable.ROW_ID)
-                                    && !col.equals(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER))
-                            .collect(Collectors.toSet())
+                    .filter(col -> !col.equals(IcebergTable.ROW_ID)
+                            && !col.equals(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER))
+                    .collect(Collectors.toSet())
                     : IcebergTable.ICEBERG_META_COLUMNS;
             outputBaseSchema = outputBaseSchema.stream().filter(col ->
                     !columnsToFilter.contains(col.getName())).toList();
@@ -1010,6 +1011,8 @@ public class InsertPlanner {
 
         for (PartitionField field : spec.fields()) {
             String sourceColumnName = icebergSchema.findColumnName(field.sourceId());
+            boolean isTimestampWithZone =
+                    icebergSchema.findType(field.sourceId()).equals(Types.TimestampType.withZone());
             int sourceColumnIndex = -1;
             for (int i = 0; i < fullSchema.size(); i++) {
                 if (fullSchema.get(i).getName().equalsIgnoreCase(sourceColumnName)) {
@@ -1034,7 +1037,7 @@ public class InsertPlanner {
                 case DAY:
                 case HOUR: {
                     String funcName = FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX +
-                            transform.name().toLowerCase();
+                            (isTimestampWithZone ? "timestamptz_" : "") + transform.name().toLowerCase();
                     Type[] argTypes = new Type[] {sourceRef.getType()};
                     Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
                             Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -1060,7 +1060,9 @@ public class InsertPlanner {
                         partitionColumnIDs.add(sourceRef.getId());
                         break;
                     }
-                    String funcName = FunctionSet.ICEBERG_TRANSFORM_BUCKET;
+                    String funcName = isTimestampWithZone
+                            ? FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX + "timestamptz_bucket"
+                            : FunctionSet.ICEBERG_TRANSFORM_BUCKET;
                     Type[] argTypes = new Type[] {sourceRef.getType(), com.starrocks.type.IntegerType.INT};
                     Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
                             Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -39,7 +39,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
-import com.starrocks.connector.iceberg.IcebergPartitionTransform;
 import com.starrocks.connector.iceberg.IcebergRowLineageUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
@@ -210,20 +209,6 @@ public class InsertAnalyzer {
                     if (isUnSupportedPartitionColumnType(column.getType())) {
                         throw new SemanticException("Unsupported partition column type [%s] for %s table sink",
                                 column.getType().canonicalName(), table.getType());
-                    }
-                }
-            } else {
-                for (PartitionField field : ((IcebergTable) table).getNativeTable().spec().fields()) {
-                    org.apache.iceberg.types.Type type = ((IcebergTable) table).getNativeTable()
-                            .schema().findType(field.sourceId());
-                    if (type instanceof org.apache.iceberg.types.Types.TimestampType
-                            && ((org.apache.iceberg.types.Types.TimestampType) type).shouldAdjustToUTC()) {
-                        IcebergPartitionTransform transform =
-                                IcebergPartitionTransform.fromString(field.transform().toString());
-                        if (transform == IcebergPartitionTransform.TRUNCATE) {
-                            throw new SemanticException("Partition column %s with timezone does not support " +
-                                    "truncate transform for sink now", field.name());
-                        }
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -65,7 +65,6 @@ import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
-import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -65,7 +65,6 @@ import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
-import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -209,17 +208,6 @@ public class InsertAnalyzer {
                     if (isUnSupportedPartitionColumnType(column.getType())) {
                         throw new SemanticException("Unsupported partition column type [%s] for %s table sink",
                                 column.getType().canonicalName(), table.getType());
-                    }
-                }
-            } else {
-                for (PartitionField field : ((IcebergTable) table).getNativeTable().spec().fields()) {
-                    org.apache.iceberg.types.Type type = ((IcebergTable) table).getNativeTable()
-                            .schema().findType(field.sourceId());
-                    if (type instanceof org.apache.iceberg.types.Types.TimestampType) {
-                        if (((org.apache.iceberg.types.Types.TimestampType) type).shouldAdjustToUTC()) {
-                            throw new SemanticException("Partition column %s with timezone is not supported for sink now",
-                                    field.name());
-                        }
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -39,6 +39,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.connector.iceberg.IcebergPartitionTransform;
 import com.starrocks.connector.iceberg.IcebergRowLineageUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
@@ -65,6 +66,7 @@ import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -165,7 +167,7 @@ public class InsertAnalyzer {
                 checkStaticKeyPartitionInsert(insertStmt, table, targetPartitionNames);
             } else {
                 if ((insertStmt.isOverwrite() && session.getSessionVariable().isDynamicOverwrite())
-                            && olapTable.supportedAutomaticPartition()) {
+                        && olapTable.supportedAutomaticPartition()) {
                     insertStmt.setIsDynamicOverwrite(true);
                 } else {
                     for (Partition partition : olapTable.getPartitions()) {
@@ -208,6 +210,20 @@ public class InsertAnalyzer {
                     if (isUnSupportedPartitionColumnType(column.getType())) {
                         throw new SemanticException("Unsupported partition column type [%s] for %s table sink",
                                 column.getType().canonicalName(), table.getType());
+                    }
+                }
+            } else {
+                for (PartitionField field : ((IcebergTable) table).getNativeTable().spec().fields()) {
+                    org.apache.iceberg.types.Type type = ((IcebergTable) table).getNativeTable()
+                            .schema().findType(field.sourceId());
+                    if (type instanceof org.apache.iceberg.types.Types.TimestampType
+                            && ((org.apache.iceberg.types.Types.TimestampType) type).shouldAdjustToUTC()) {
+                        IcebergPartitionTransform transform =
+                                IcebergPartitionTransform.fromString(field.transform().toString());
+                        if (transform == IcebergPartitionTransform.TRUNCATE) {
+                            throw new SemanticException("Partition column %s with timezone does not support " +
+                                    "truncate transform for sink now", field.name());
+                        }
                     }
                 }
             }
@@ -285,7 +301,7 @@ public class InsertAnalyzer {
                         String missingKeyColumns = String.join(",", requiredKeyColumns);
                         ErrorReport.reportSemanticException(ErrorCode.ERR_MISSING_KEY_COLUMNS, missingKeyColumns);
                     }
-                    if (targetColumns.size() < olapTable.getBaseSchemaWithoutGeneratedColumn().size() && 
+                    if (targetColumns.size() < olapTable.getBaseSchemaWithoutGeneratedColumn().size() &&
                             session.getSessionVariable().isEnableInsertPartialUpdate()) {
                         insertStmt.setUsePartialUpdate();
                         // mark if partial update for auto increment column if and only if:
@@ -295,7 +311,7 @@ public class InsertAnalyzer {
                         if (olapTable.hasAutoIncrementColumn() &&
                                 !targetColumns.stream().anyMatch(col -> col.isAutoIncrement())) {
                             Column autoIncrementColumn =
-                                        table.getBaseSchema().stream().filter(Column::isAutoIncrement).findFirst().get();
+                                    table.getBaseSchema().stream().filter(Column::isAutoIncrement).findFirst().get();
                             if (!autoIncrementColumn.isKey()) {
                                 insertStmt.setAutoIncrementPartialUpdate();
                             }
@@ -410,17 +426,17 @@ public class InsertAnalyzer {
 
     /**
      * Push down target table column schema to files() table function.
-     *
+     * <p>
      * Two modes controlled by different switches:
      * 1. insert property "enable_push_down_schema" = true:
-     *    Full push-down — reshapes files() schema to match the effective SELECT list:
-     *    - SlotRef columns: type is rewritten to the matching target column type; added if missing.
-     *    - Function-expression columns: inner SlotRef columns are only ensured to exist in the schema
-     *      (defaulting to VARCHAR if absent); no type push-down, because the function itself determines
-     *      the output type.
-     *    - Extra file columns not referenced in the SELECT list are excluded.
+     * Full push-down — reshapes files() schema to match the effective SELECT list:
+     * - SlotRef columns: type is rewritten to the matching target column type; added if missing.
+     * - Function-expression columns: inner SlotRef columns are only ensured to exist in the schema
+     * (defaulting to VARCHAR if absent); no type push-down, because the function itself determines
+     * the output type.
+     * - Extra file columns not referenced in the SELECT list are excluded.
      * 2. FE config "files_enable_insert_push_down_column_type" = true (default):
-     *    Type-only push-down — only rewrites types of columns that already exist in the inferred files() schema.
+     * Type-only push-down — only rewrites types of columns that already exist in the inferred files() schema.
      */
     private static void pushDownTargetTableSchemaToFiles(InsertStmt insertStmt, ConnectContext session) {
         if (!insertStmt.isEnablePushDownSchema() && !Config.files_enable_insert_push_down_column_type) {
@@ -479,7 +495,7 @@ public class InsertAnalyzer {
      * Does not add or remove columns.
      */
     private static void rewriteFileTableColumnTypes(TableFunctionTable fileTable, InsertStmt insertStmt,
-            Table targetTable, SelectRelation selectRelation) {
+                                                    Table targetTable, SelectRelation selectRelation) {
         List<String> selectColumnNames = Lists.newArrayList();
         List<String> selectOutputNames = Lists.newArrayList();
         for (SelectListItem item : selectRelation.getSelectList().getItems()) {
@@ -546,16 +562,16 @@ public class InsertAnalyzer {
 
     /**
      * Rewrite the files() table schema by pushing down target table column names and types.
-     *
+     * <p>
      * Three kinds of SELECT items are handled:
-     *   - SELECT *: reshape files schema to exactly the target columns (by name or by position)
-     *   - SlotRef (e.g., col_a): push down the corresponding target column's type; add column if missing
-     *   - Function expr (e.g., CAST(col_b AS INT)): inner SlotRef columns are kept as VARCHAR if missing
-     *
+     * - SELECT *: reshape files schema to exactly the target columns (by name or by position)
+     * - SlotRef (e.g., col_a): push down the corresponding target column's type; add column if missing
+     * - Function expr (e.g., CAST(col_b AS INT)): inner SlotRef columns are kept as VARCHAR if missing
+     * <p>
      * The final files schema only contains columns that are actually used in the SELECT list.
      */
     private static void rewriteFileTableSchema(TableFunctionTable fileTable, InsertStmt insertStmt,
-            Table targetTable, SelectRelation selectRelation) {
+                                               Table targetTable, SelectRelation selectRelation) {
         List<String> targetColumnNames = insertStmt.getTargetColumnNames();
         if (targetColumnNames == null) {
             targetColumnNames = ((OlapTable) targetTable).getBaseSchemaWithoutGeneratedColumn().stream()
@@ -645,7 +661,7 @@ public class InsertAnalyzer {
      * BY POSITION: use file column names trimmed or extended to match target column count.
      */
     private static void expandStarColumns(List<String> selectColumnNames, List<String> selectOutputNames,
-            InsertStmt insertStmt, List<String> targetColumnNames, TableFunctionTable fileTable) {
+                                          InsertStmt insertStmt, List<String> targetColumnNames, TableFunctionTable fileTable) {
         if (insertStmt.isColumnMatchByName()) {
             selectColumnNames.addAll(targetColumnNames);
             selectOutputNames.addAll(targetColumnNames);
@@ -666,7 +682,7 @@ public class InsertAnalyzer {
      * Skips complex types which may fail to convert in the scanner.
      */
     private static void pushDownColumnType(String fileColName, Column targetCol,
-            Map<String, Column> fileColumns) {
+                                           Map<String, Column> fileColumns) {
         Column newCol = targetCol.deepCopy();
         if (newCol.getType().isComplexType()) {
             return;
@@ -694,12 +710,12 @@ public class InsertAnalyzer {
 
     /**
      * Build the final file schema containing only columns used in the SELECT list:
-     *   1. Non-null entries in selectColumnNames (SlotRefs and star-expanded columns), in order.
-     *   2. Inner SlotRef columns from function expressions, appended after.
+     * 1. Non-null entries in selectColumnNames (SlotRefs and star-expanded columns), in order.
+     * 2. Inner SlotRef columns from function expressions, appended after.
      * Duplicate column names are deduplicated (case-insensitive).
      */
     private static List<Column> buildNewFileSchema(List<String> selectColumnNames,
-            List<Expr> funcExprs, Map<String, Column> fileColumns) {
+                                                   List<Expr> funcExprs, Map<String, Column> fileColumns) {
         Set<String> seen = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         List<Column> schema = Lists.newArrayList();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -1070,6 +1070,78 @@ public class InsertPlanTest extends PlanTestBase {
     }
 
     @Test
+    public void testInsertIcebergWithGlobalShuffleYearTransformPartitionForTimestampWithZone() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "ts", Types.TimestampType.withZone()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec yearSpec = PartitionSpec.builderFor(icebergSchema).year("ts").build();
+        Column ts = new Column("ts", DateType.DATETIME);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform_year_tz", "iceberg_year_tz_table", 12345573, icebergSchema, yearSpec,
+                Lists.newArrayList(ts, k2), Lists.newArrayList(ts), Arrays.asList(0),
+                "select ts, id from iceberg_shuffle_src");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_timestamptz_year");
+        Assertions.assertFalse(actualRes.contains("__iceberg_transform_year("),
+                "Timestamptz partition should not use NTZ year transform:\n" + actualRes);
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffleMonthTransformPartitionForTimestampWithZone() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "ts", Types.TimestampType.withZone()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec monthSpec = PartitionSpec.builderFor(icebergSchema).month("ts").build();
+        Column ts = new Column("ts", DateType.DATETIME);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform_month_tz", "iceberg_month_tz_table", 12345574, icebergSchema, monthSpec,
+                Lists.newArrayList(ts, k2), Lists.newArrayList(ts), Arrays.asList(0),
+                "select ts, id from iceberg_shuffle_src");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_timestamptz_month");
+        Assertions.assertFalse(actualRes.contains("__iceberg_transform_month("),
+                "Timestamptz partition should not use NTZ month transform:\n" + actualRes);
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffleDayTransformPartitionForTimestampWithZone() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "ts", Types.TimestampType.withZone()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec daySpec = PartitionSpec.builderFor(icebergSchema).day("ts").build();
+        Column ts = new Column("ts", DateType.DATETIME);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform_day_tz", "iceberg_day_tz_table", 12345575, icebergSchema, daySpec,
+                Lists.newArrayList(ts, k2), Lists.newArrayList(ts), Arrays.asList(0),
+                "select ts, id from iceberg_shuffle_src");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_timestamptz_day");
+        Assertions.assertFalse(actualRes.contains("__iceberg_transform_day("),
+                "Timestamptz partition should not use NTZ day transform:\n" + actualRes);
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffleHourTransformPartitionForTimestampWithZone() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "ts", Types.TimestampType.withZone()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec hourSpec = PartitionSpec.builderFor(icebergSchema).hour("ts").build();
+        Column ts = new Column("ts", DateType.DATETIME);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform_hour_tz", "iceberg_hour_tz_table", 12345576, icebergSchema, hourSpec,
+                Lists.newArrayList(ts, k2), Lists.newArrayList(ts), Arrays.asList(0),
+                "select ts, id from iceberg_shuffle_src");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_timestamptz_hour");
+        Assertions.assertFalse(actualRes.contains("__iceberg_transform_hour("),
+                "Timestamptz partition should not use NTZ hour transform:\n" + actualRes);
+    }
+
+    @Test
     public void testInsertIcebergWithGlobalShuffleTruncateTransformPartition() throws Exception {
         Schema icebergSchema = new Schema(
                 Types.NestedField.required(1, "data", Types.StringType.get()),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -893,6 +893,7 @@ public class InsertPlanTest extends PlanTestBase {
 
                 nativeTable.spec();
                 result = PartitionSpec.unpartitioned();
+                minTimes = 0;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -1176,24 +1176,6 @@ public class InsertPlanTest extends PlanTestBase {
         assertHashPartitionedByExpression(actualRes, "__iceberg_transform_truncate");
     }
 
-    @Test
-    public void testInsertIcebergWithGlobalShuffleTruncateTransformPartitionForTimestampWithZoneRejected()
-            throws Exception {
-        Schema icebergSchema = new Schema(
-                Types.NestedField.required(1, "ts", Types.TimestampType.withZone()),
-                Types.NestedField.required(2, "k2", Types.IntegerType.get())
-        );
-        PartitionSpec truncateSpec = PartitionSpec.builderFor(icebergSchema).truncate("ts", 5).build();
-        Column ts = new Column("ts", DateType.DATETIME);
-        Column k2 = new Column("k2", IntegerType.INT);
-        SemanticException exception = Assertions.assertThrows(SemanticException.class, () ->
-                getIcebergInsertExecPlanWithGlobalShuffle(
-                        "iceberg_catalog_transform_truncate_tz", "iceberg_truncate_tz_table", 12345578,
-                        icebergSchema, truncateSpec, Lists.newArrayList(ts, k2), Lists.newArrayList(ts),
-                        Arrays.asList(0), "select ts, id from iceberg_shuffle_src"));
-        Assertions.assertTrue(exception.getMessage().contains("truncate transform"));
-    }
-
     private String getIcebergInsertExecPlanWithGlobalShuffle(String catalogName, String tableName, long tableId,
                                                              Schema icebergSchema, PartitionSpec partitionSpec,
                                                              List<Column> fullSchema, List<Column> partitionColumns,
@@ -1296,8 +1278,15 @@ public class InsertPlanTest extends PlanTestBase {
             }
         };
 
-        return getInsertExecPlan(String.format(
-                "explain insert into %s.iceberg_db.%s %s", catalogName, tableName, selectSql));
+        boolean enableMaterializedViewRewrite =
+                connectContext.getSessionVariable().isEnableMaterializedViewRewrite();
+        connectContext.getSessionVariable().setEnableMaterializedViewRewrite(false);
+        try {
+            return getInsertExecPlan(String.format(
+                    "explain insert into %s.iceberg_db.%s %s", catalogName, tableName, selectSql));
+        } finally {
+            connectContext.getSessionVariable().setEnableMaterializedViewRewrite(enableMaterializedViewRewrite);
+        }
     }
 
     private void assertHashPartitionedByExpression(String actualRes, String expectedExpr) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -1007,6 +1007,24 @@ public class InsertPlanTest extends PlanTestBase {
     }
 
     @Test
+    public void testInsertIcebergWithGlobalShuffleBucketTransformPartitionForTimestampWithZone() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "ts", Types.TimestampType.withZone()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec bucketSpec = PartitionSpec.builderFor(icebergSchema).bucket("ts", 10).build();
+        Column ts = new Column("ts", DateType.DATETIME);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform_bucket_tz", "iceberg_bucket_tz_table", 12345577, icebergSchema, bucketSpec,
+                Lists.newArrayList(ts, k2), Lists.newArrayList(ts), Arrays.asList(0),
+                "select ts, id from iceberg_shuffle_src");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_timestamptz_bucket");
+        Assertions.assertFalse(actualRes.contains("__iceberg_transform_bucket("),
+                "Timestamptz partition should not use NTZ bucket transform:\n" + actualRes);
+    }
+
+    @Test
     public void testInsertIcebergWithGlobalShuffleYearTransformPartition() throws Exception {
         Schema icebergSchema = new Schema(
                 Types.NestedField.required(1, "ts", Types.DateType.get()),
@@ -1156,6 +1174,24 @@ public class InsertPlanTest extends PlanTestBase {
                 Lists.newArrayList(data, k2), Lists.newArrayList(data), Arrays.asList(0),
                 "select data, id from iceberg_shuffle_src");
         assertHashPartitionedByExpression(actualRes, "__iceberg_transform_truncate");
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffleTruncateTransformPartitionForTimestampWithZoneRejected()
+            throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "ts", Types.TimestampType.withZone()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec truncateSpec = PartitionSpec.builderFor(icebergSchema).truncate("ts", 5).build();
+        Column ts = new Column("ts", DateType.DATETIME);
+        Column k2 = new Column("k2", IntegerType.INT);
+        SemanticException exception = Assertions.assertThrows(SemanticException.class, () ->
+                getIcebergInsertExecPlanWithGlobalShuffle(
+                        "iceberg_catalog_transform_truncate_tz", "iceberg_truncate_tz_table", 12345578,
+                        icebergSchema, truncateSpec, Lists.newArrayList(ts, k2), Lists.newArrayList(ts),
+                        Arrays.asList(0), "select ts, id from iceberg_shuffle_src"));
+        Assertions.assertTrue(exception.getMessage().contains("truncate transform"));
     }
 
     private String getIcebergInsertExecPlanWithGlobalShuffle(String catalogName, String tableName, long tableId,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -33,6 +33,7 @@ import com.starrocks.sql.InsertPlanner;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.IcebergRewriteStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.MetaUtils;
@@ -425,6 +426,15 @@ public class InsertPlanTest extends PlanTestBase {
 
         String ret = execPlan.getExplainString(TExplainLevel.NORMAL);
         return ret;
+    }
+
+    private static String getInsertExecPlan(StatementBase statementBase, String originStmt) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
+        connectContext.getDumpInfo().setOriginStmt(originStmt);
+        ExecPlan execPlan = new StatementPlanner().plan(statementBase, connectContext);
+        return execPlan.getExplainString(TExplainLevel.NORMAL);
     }
 
     public static void containsKeywords(String plan, String... keywords) throws Exception {
@@ -940,6 +950,116 @@ public class InsertPlanTest extends PlanTestBase {
                 "     constant exprs: \n" +
                 "         NULL\n";
         Assertions.assertEquals(expected, actualRes);
+    }
+
+    @Test
+    public void testInsertIcebergRewritePreservesRowLineageColumns() throws Exception {
+        String createIcebergCatalogStmt = "create external catalog iceberg_catalog_lineage properties " +
+                "(\"type\"=\"iceberg\", " +
+                "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")";
+        starRocksAssert.withCatalog(createIcebergCatalogStmt);
+        MetadataMgr metadata = starRocksAssert.getCtx().getGlobalStateMgr().getMetadataMgr();
+
+        Table nativeTable = new BaseTable(null, null);
+
+        Column k1 = new Column("k1", IntegerType.INT);
+        Column k2 = new Column("k2", IntegerType.INT);
+        Column rowId = new Column(IcebergTable.ROW_ID, IntegerType.BIGINT);
+        Column lastUpdatedSequenceNumber =
+                new Column(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER, IntegerType.BIGINT);
+        Column filePath = new Column(IcebergTable.FILE_PATH, StringType.STRING, true);
+
+        IcebergTable.Builder builder = IcebergTable.builder();
+        builder.setCatalogName("iceberg_catalog_lineage");
+        builder.setCatalogDBName("iceberg_db");
+        builder.setCatalogTableName("iceberg_lineage_table");
+        builder.setSrTableName("iceberg_lineage_table");
+        builder.setFullSchema(Lists.newArrayList(k1, k2, rowId, lastUpdatedSequenceNumber, filePath));
+        builder.setNativeTable(nativeTable);
+        IcebergTable icebergTable = builder.build();
+
+        new Expectations(icebergTable) {
+            {
+                icebergTable.getUUID();
+                result = 12345578;
+                minTimes = 0;
+
+                icebergTable.isUnPartitioned();
+                result = true;
+                minTimes = 0;
+
+                icebergTable.getPartitionColumnNames();
+                result = new ArrayList<>();
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = new ArrayList<>();
+                minTimes = 0;
+
+                icebergTable.getFormatVersion();
+                result = 3;
+                minTimes = 0;
+            }
+        };
+
+        new Expectations(nativeTable) {
+            {
+                nativeTable.sortOrder();
+                result = SortOrder.unsorted();
+                minTimes = 0;
+
+                nativeTable.location();
+                result = "hdfs://fake_location";
+                minTimes = 0;
+
+                nativeTable.properties();
+                result = new HashMap<String, String>();
+                minTimes = 0;
+
+                nativeTable.io();
+                result = new HadoopFileIO();
+                minTimes = 0;
+
+                nativeTable.spec();
+                result = PartitionSpec.unpartitioned();
+                minTimes = 0;
+            }
+        };
+
+        new Expectations(metadata) {
+            {
+                metadata.getDb((ConnectContext) any, "iceberg_catalog_lineage", "iceberg_db");
+                result = new Database(12345578, "iceberg_db");
+                minTimes = 0;
+
+                metadata.getTable((ConnectContext) any, "iceberg_catalog_lineage", "iceberg_db",
+                        "iceberg_lineage_table");
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public Database getDatabase(String catalogName, String tableName) {
+                return new Database(12345578, "iceberg_db");
+            }
+
+            @Mock
+            public com.starrocks.catalog.Table getSessionAwareTable(
+                    ConnectContext context, Database database, TableName tableName) {
+                return icebergTable;
+            }
+        };
+
+        String sql = "insert into iceberg_catalog_lineage.iceberg_db.iceberg_lineage_table select 1, 2, 3, 4";
+        InsertStmt insertStmt = (InsertStmt) SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(insertStmt, true, true);
+
+        String actualRes = getInsertExecPlan(rewriteStmt, sql);
+        Assertions.assertTrue(actualRes.contains(IcebergTable.ROW_ID), actualRes);
+        Assertions.assertTrue(actualRes.contains(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER), actualRes);
+        Assertions.assertFalse(actualRes.contains(IcebergTable.FILE_PATH), actualRes);
     }
 
     @Test

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -678,11 +678,19 @@ vectorized_functions = [
 
     [50620, '__iceberg_transform_year', True, False, 'BIGINT', ['DATE'], 'TimeFunctions::iceberg_years_since_epoch_date'],
     [50621, '__iceberg_transform_year', True, False, 'BIGINT', ['DATETIME'], 'TimeFunctions::iceberg_years_since_epoch_datetime'],
+    [50622, '__iceberg_transform_timestamptz_year', True, False, 'BIGINT', ['DATETIME'],
+     'TimeFunctions::iceberg_timestamptz_years_since_epoch_datetime'],
     [50630, '__iceberg_transform_month', True, False, 'BIGINT', ['DATE'], 'TimeFunctions::iceberg_months_since_epoch_date'],
     [50631, '__iceberg_transform_month', True, False, 'BIGINT', ['DATETIME'], 'TimeFunctions::iceberg_months_since_epoch_datetime'],
+    [50632, '__iceberg_transform_timestamptz_month', True, False, 'BIGINT', ['DATETIME'],
+     'TimeFunctions::iceberg_timestamptz_months_since_epoch_datetime'],
     [50640, '__iceberg_transform_day', True, False, 'BIGINT', ['DATE'], 'TimeFunctions::iceberg_days_since_epoch_date'],
     [50641, '__iceberg_transform_day', True, False, 'BIGINT', ['DATETIME'], 'TimeFunctions::iceberg_days_since_epoch_datetime'],
+    [50642, '__iceberg_transform_timestamptz_day', True, False, 'BIGINT', ['DATETIME'],
+     'TimeFunctions::iceberg_timestamptz_days_since_epoch_datetime'],
     [50650, '__iceberg_transform_hour', True, False, 'BIGINT', ['DATETIME'], 'TimeFunctions::iceberg_hours_since_epoch_datetime'],
+    [50651, '__iceberg_transform_timestamptz_hour', True, False, 'BIGINT', ['DATETIME'],
+     'TimeFunctions::iceberg_timestamptz_hours_since_epoch_datetime'],
 
     # 60xxx: like predicate
     # important ref: LikePredicate.java, must keep name equals LikePredicate.Operator

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -212,6 +212,8 @@ vectorized_functions = [
     [10351, '__iceberg_transform_bucket', True, False, 'INT', ['BIGINT', 'INT'], 'MathFunctions::iceberg_bucket_int<TYPE_BIGINT>'],
     [10352, '__iceberg_transform_bucket', True, False, 'INT', ['DATE', 'INT'], 'MathFunctions::iceberg_bucket_date'],
     [10353, '__iceberg_transform_bucket', True, False, 'INT', ['DATETIME', 'INT'], 'MathFunctions::iceberg_bucket_datetime'],
+    [10359, '__iceberg_transform_timestamptz_bucket', True, False, 'INT', ['DATETIME', 'INT'],
+     'MathFunctions::iceberg_bucket_timestamptz_datetime'],
     [10354, '__iceberg_transform_bucket', True, False, 'INT', ['VARCHAR', 'INT'], 'MathFunctions::iceberg_bucket_string'],
     [10355, '__iceberg_transform_bucket', True, False, 'INT', ['VARBINARY', 'INT'], 'MathFunctions::iceberg_bucket_string'],
     [10356, '__iceberg_transform_bucket', True, False, 'INT', ['DECIMAL32', 'INT'], 'MathFunctions::iceberg_bucket_decimal<TYPE_DECIMAL32>'],


### PR DESCRIPTION
## Why I'm doing:
StarRocks already has read-path handling for Iceberg `timestamptz` / `withZone()` values, including partition value normalization and predicate conversion. However, the sink path still only supported partition transforms correctly for timestamp without time zone.

This left a gap for users with existing Iceberg tables partitioned on `timestamptz` columns: reads were already timezone-aware, but writes could not route records through `year/month/day/hour` transforms with correct `timestamptz` semantics.

The tricky part is that sink partition routing must be based on the absolute instant represented by the value, not on the session-local wall clock.

## What I'm doing:
This PR completes the end-to-end story by filling the missing sink-side support for Iceberg `timestamptz` partition transforms, while keeping the existing read-path behavior unchanged.

At a high level:

```text
Read path
  already supports withZone() handling

Write path
  FE planner detects withZone()
    -> uses __iceberg_transform_timestamptz_*
    -> BE evaluates transform from the UTC instant
    -> sink writes to the correct Iceberg partition
```

Specifically:
- Keep the existing read path as-is and make the PR scope explicit: the missing piece was sink partition routing.
- Add dedicated internal transform functions for Iceberg `timestamptz` partition transforms.
- Update FE planning so `withZone()` columns use the timestamptz transform path instead of the NTZ path.
- Remove the previous FE sink-side rejection for timezone partition columns.
- Implement BE evaluation so `year/month/day/hour` are computed from the normalized UTC instant, not from session-local wall clock values.
- Add a UTC fast path to avoid unnecessary normalization when the session timezone is effectively UTC.
- Add FE and BE unit tests to cover planner selection and timezone-sensitive transform semantics.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
