### PR TITLE
[Feature] Iceberg footer prefetch via CACHE SELECT

### DIFF
--- a/be/src/cache/datacache_metrics.cpp
+++ b/be/src/cache/datacache_metrics.cpp
@@ -56,6 +56,8 @@ void DataCacheMetrics::install(MetricRegistry* registry) {
     registry->register_metric("datacache_meta_used_bytes", &datacache_meta_used_bytes);
     registry->register_metric("block_cache_hit_bytes", &block_cache_hit_bytes);
     registry->register_metric("block_cache_miss_bytes", &block_cache_miss_bytes);
+    registry->register_metric("datacache_block_cache_write_bytes", &datacache_block_cache_write_bytes);
+    registry->register_metric("datacache_block_cache_evict_bytes", &datacache_block_cache_evict_bytes);
 }
 
 void DataCacheMetrics::enable_update_hook(bool use_same_instance) {
@@ -99,6 +101,18 @@ void DataCacheMetrics::update() {
     datacache_disk_quota_bytes.set_value(disk_metrics.disk_quota_bytes);
     datacache_disk_used_bytes.set_value(disk_metrics.disk_used_bytes);
     datacache_meta_used_bytes.set_value(meta_used_bytes);
+
+    // Starcache detail_l2 carries cumulative populate (write_bytes) and eviction (remove_bytes)
+    // totals. Sample them so dashboards can derive eviction pressure (evict-rate vs write-rate)
+    // without scraping the HTTP /api/datacache/stat endpoint.
+    if (local_disk_cache != nullptr && local_disk_cache->is_initialized()) {
+        auto* starcache = static_cast<StarCacheEngine*>(local_disk_cache);
+        auto detail_metrics = starcache->starcache_metrics(2);
+        if (detail_metrics.detail_l2 != nullptr) {
+            datacache_block_cache_write_bytes.set_value(detail_metrics.detail_l2->write_bytes);
+            datacache_block_cache_evict_bytes.set_value(detail_metrics.detail_l2->remove_bytes);
+        }
+    }
 
     // Update hit rate metrics from DataCacheHitRateCounter
     auto* hit_rate_counter = DataCacheHitRateCounter::instance();

--- a/be/src/cache/datacache_metrics.h
+++ b/be/src/cache/datacache_metrics.h
@@ -44,6 +44,12 @@ public:
     METRIC_DEFINE_INT_GAUGE(datacache_meta_used_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_ATOMIC_COUNTER(block_cache_hit_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_ATOMIC_COUNTER(block_cache_miss_bytes, MetricUnit::BYTES);
+    // Starcache-internal cumulative populate/eviction byte totals (detail_l2). Snapshot semantics:
+    // gauges set to absolute cumulative bytes; Prom rate() over them gives per-second populate
+    // and eviction pressure for datacache health dashboards (alerts when evict-rate approaches
+    // write-rate, indicating cache churn).
+    METRIC_DEFINE_INT_GAUGE(datacache_block_cache_write_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(datacache_block_cache_evict_bytes, MetricUnit::BYTES);
 
 private:
     MetricRegistry* _registry = nullptr;

--- a/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
@@ -20,6 +20,7 @@
 #include "formats/parquet/file_reader.h"
 #include "fs/fs.h"
 #include "io/shared_buffered_input_stream.h"
+#include "runtime/runtime_state.h"
 
 namespace starrocks {
 
@@ -68,7 +69,10 @@ Status CacheSelectScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* ch
     }
 
     // handle iceberg delete files
-    if (!_scanner_params.deletes.empty()) {
+    // Skip delete-file fetching in footer-only warm-up mode: this path is the iceberg metadata
+    // refresh footer prefetch, which only needs the parquet footer in block_cache. Delete files
+    // are read by real query execution as needed.
+    if (!_scanner_params.deletes.empty() && !runtime_state->query_options().cache_select_footer_only) {
         RETURN_IF_ERROR(_fetch_iceberg_delete_files());
     }
 
@@ -87,6 +91,14 @@ Status CacheSelectScanner::_fetch_orc() {
     } catch (std::exception& e) {
         return Status::InternalError(
                 strings::Substitute("CacheSelectScanner::_fetch_orc failed. reason = $0", e.what()));
+    }
+
+    // Footer-only warm-up: createReader above already read the ORC postscript + file footer
+    // through the wrapping CacheInputStream, populating block_cache. Stripe data ranges are not
+    // needed; skip the per-column resolution and stripe IO collection. Symmetric to the
+    // parquet branch.
+    if (_runtime_state->query_options().cache_select_footer_only) {
+        return Status::OK();
     }
 
     // prepare SlotDescriptor
@@ -184,6 +196,15 @@ Status CacheSelectScanner::_fetch_parquet() {
 
     RETURN_IF_ERROR(reader->init(&_scanner_ctx));
 
+    // Footer-only warm-up for the iceberg metadata refresh prefetch path: reader->init above
+    // already read the footer through the CacheInputStream wrapping _file (created in
+    // HdfsScanner::create_random_access_file when enable_cache_select is on), which populates
+    // block_cache with the footer bytes. Column ranges are not needed; skip the per-column
+    // io-range collection and explicit _write_disk_ranges.
+    if (_runtime_state->query_options().cache_select_footer_only) {
+        return Status::OK();
+    }
+
     std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
     RETURN_IF_ERROR(reader->collect_scan_io_ranges(&io_ranges));
 
@@ -198,6 +219,13 @@ Status CacheSelectScanner::_fetch_parquet() {
 
 // Split text into multiply disk ranges, then fetch it
 Status CacheSelectScanner::_fetch_textfile() {
+    // Footer-only warm-up has no meaning for row-oriented text files (there is no footer to
+    // populate). The flag is set by the iceberg metadata refresh prefetch path, which only ever
+    // targets parquet/orc; skip entirely if it leaks onto a text format.
+    if (_runtime_state->query_options().cache_select_footer_only) {
+        return Status::OK();
+    }
+
     // If it's compressed file, we only handle scan range whose offset == 0.
     if (get_compression_type_from_path(_scanner_params.path) != UNKNOWN_COMPRESSION &&
         _scanner_params.scan_range->offset != 0) {

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -24,6 +24,7 @@
 #include "common/config_scan_io_fwd.h"
 #include "connector/deletion_vector/deletion_vector.h"
 #include "exec/pipeline/fragment_context.h"
+#include "exec/query_scan_metrics.h"
 #include "exprs/chunk_predicate_evaluator.h"
 #include "fs/hdfs/fs_hdfs.h"
 #include "io/cache_select_input_stream.hpp"
@@ -35,6 +36,7 @@
 #include "storage/type_info_allocator_adapter.h"
 #include "storage/types.h"
 #include "types/timestamp_value.h"
+
 namespace starrocks {
 
 static const std::string kCountOptColumnName = "___count___";
@@ -376,6 +378,22 @@ StatusOr<std::unique_ptr<RandomAccessFile>> HdfsScanner::create_random_access_fi
         if (datacache_options.enable_cache_select) {
             cache_input_stream = std::make_shared<io::CacheSelectInputStream>(
                     shared_buffered_input_stream, filename, file_size, datacache_options.modification_time);
+            // CacheSelectInputStream is probe-only — its _read_block_from_local checks existence
+            // without copying bytes and _read_blocks_from_remote populates without filling `out`.
+            // It cannot serve real reads. Wrap input_stream in a regular CacheInputStream so
+            // reads through _file (e.g. parquet reader->init footer read) actually return bytes
+            // AND populate the block_cache. Without this, CACHE SELECT only populates the column
+            // ranges explicitly fed to CacheSelectInputStream via _write_disk_ranges; the footer
+            // read goes straight to raw storage every time.
+            auto populate_stream = std::make_shared<io::CacheInputStream>(
+                    shared_buffered_input_stream, filename, file_size, datacache_options.modification_time);
+            populate_stream->set_enable_populate_cache(datacache_options.enable_populate_datacache);
+            populate_stream->set_enable_async_populate_mode(datacache_options.enable_datacache_async_populate_mode);
+            populate_stream->set_enable_cache_io_adaptor(datacache_options.enable_datacache_io_adaptor);
+            populate_stream->set_enable_block_buffer(config::datacache_block_buffer_enable);
+            populate_stream->set_priority(datacache_options.datacache_priority);
+            populate_stream->set_ttl_seconds(datacache_options.datacache_ttl_seconds);
+            input_stream = populate_stream;
         } else {
             cache_input_stream = std::make_shared<io::CacheInputStream>(shared_buffered_input_stream, filename,
                                                                         file_size, datacache_options.modification_time);
@@ -543,6 +561,15 @@ void HdfsScanner::update_counter() {
 
     DataCacheHitRateCounter::instance()->update_page_cache_stat(_app_stats.page_cache_read_counter,
                                                                 _app_stats.page_read_counter);
+
+    // Per-scan parquet footer hit/miss → BE-global counters. footer_cache_read_count is hits
+    // (page-cache lookup returned cached FileMetaData); footer_cache_write_count is misses that
+    // resulted in a parse + populate; footer_cache_write_fail_count is a miss that failed to
+    // populate. All three count as "had to go through _parse_footer", so both write counters
+    // contribute to the miss aggregate.
+    QueryScanMetrics::instance()->parquet_footer_cache_hit_count.increment(_app_stats.footer_cache_read_count);
+    QueryScanMetrics::instance()->parquet_footer_cache_miss_count.increment(_app_stats.footer_cache_write_count +
+                                                                            _app_stats.footer_cache_write_fail_count);
 
     if (_scanner_params.datacache_options.enable_datacache && _cache_input_stream) {
         const io::CacheInputStream::Stats& stats = _cache_input_stream->stats();

--- a/be/src/exec/query_scan_metrics.cpp
+++ b/be/src/exec/query_scan_metrics.cpp
@@ -35,6 +35,8 @@ void QueryScanMetrics::install(MetricRegistry* registry) {
     registry->register_metric("query_scan_bytes", &query_scan_bytes);
     registry->register_metric("query_scan_rows", &query_scan_rows);
     registry->register_metric("query_scan_bytes_per_second", &query_scan_bytes_per_second);
+    registry->register_metric("parquet_footer_cache_hit_count", &parquet_footer_cache_hit_count);
+    registry->register_metric("parquet_footer_cache_miss_count", &parquet_footer_cache_miss_count);
 }
 
 } // namespace starrocks

--- a/be/src/exec/query_scan_metrics.h
+++ b/be/src/exec/query_scan_metrics.h
@@ -31,6 +31,12 @@ public:
     METRIC_DEFINE_INT_GAUGE(query_scan_bytes_per_second, MetricUnit::BYTES);
     METRIC_DEFINE_INT_COUNTER(query_scan_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_COUNTER(query_scan_rows, MetricUnit::ROWS);
+    // Parquet footer page-cache hit/miss counts, aggregated from per-scan HdfsScanStats. Lets
+    // dashboards observe footer hit-rate independently of other page-cache users (column
+    // indexes, ORC stripe footers, etc.) and verify the iceberg metadata refresh footer
+    // prefetch feature actually warmed the cache before the first user query.
+    METRIC_DEFINE_INT_COUNTER(parquet_footer_cache_hit_count, MetricUnit::OPERATIONS);
+    METRIC_DEFINE_INT_COUNTER(parquet_footer_cache_miss_count, MetricUnit::OPERATIONS);
 
 private:
     MetricRegistry* _registry = nullptr;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -19,6 +19,7 @@ import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.Weigher;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.Config;
@@ -66,6 +67,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -85,6 +87,10 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     private final ExecutorService backgroundExecutor;
 
     private final IcebergCatalogProperties icebergProperties;
+    // Single-thread daemon executor for fire-and-forget cache_select dispatch from
+    // IcebergMetadataRefreshFooterPrefetcher.warmup. cache_select itself blocks on
+    // coordinator.join, so we must not run it inline on the refresh thread.
+    private final ExecutorService footerPrefetchOrchestratorExecutor;
     private final com.github.benmanes.caffeine.cache.Cache<String, Set<DataFile>> dataFileCache;
     private final com.github.benmanes.caffeine.cache.Cache<String, Set<DeleteFile>> deleteFileCache;
     private final Map<IcebergTableName, Set<String>> metaFileCacheMap = new ConcurrentHashMap<>(); // table -> metadata file paths
@@ -107,6 +113,9 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         this.databases = newCacheBuilderWithMaximumSize(
                 icebergProperties.getIcebergMetaCacheTtlSec(),
                 NEVER_CACHE, DEFAULT_CACHE_NUM).build();
+        ThreadFactoryBuilder tfb = new ThreadFactoryBuilder().setDaemon(true);
+        this.footerPrefetchOrchestratorExecutor = Executors.newSingleThreadExecutor(
+                tfb.setNameFormat("iceberg-footer-prefetch-" + catalogName).build());
         this.tables = newCacheBuilder(
                 icebergProperties.getIcebergMetaCacheTtlSec(),
                 icebergProperties.getIcebergTableCacheRefreshIntervalSec())
@@ -402,6 +411,11 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         Table cachedTable = tables.getIfPresent(icebergTableName);
         if (cachedTable == null) {
             partitionCache.invalidate(icebergTableName);
+            // Cold-start path: table wasn't cached yet (first refresh after FE restart).
+            // Trigger footer warmup here too so the first user query doesn't pay S3 for the
+            // footer. Skips internally if the session var is off.
+            IcebergMetadataRefreshFooterPrefetcher.warmup(
+                    catalogName, dbName, tableName, ctx, footerPrefetchOrchestratorExecutor);
         } else {
             BaseTable currentTable = (BaseTable) cachedTable;
             BaseTable updateTable = (BaseTable) delegate.getTable(ctx, dbName, tableName);
@@ -479,6 +493,9 @@ public class CachingIcebergCatalog implements IcebergCatalog {
 
         tableLatestRefreshTime.put(new IcebergTableName(dbName, tableName), System.currentTimeMillis());
         LOG.info("Refreshed {} iceberg manifests on the table [{}.{}]", manifestFiles.size(), dbName, tableName);
+
+        IcebergMetadataRefreshFooterPrefetcher.warmup(
+                catalogName, dbName, tableName, ctx, footerPrefetchOrchestratorExecutor);
     }
 
     public void refreshCatalog() {
@@ -531,6 +548,12 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         if (paths != null && !paths.isEmpty()) {
             dataFileCache.invalidateAll(paths);
             deleteFileCache.invalidateAll(paths);
+        }
+    }
+
+    public void shutdown() {
+        if (footerPrefetchOrchestratorExecutor != null) {
+            footerPrefetchOrchestratorExecutor.shutdown();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -170,6 +170,9 @@ public class IcebergConnector implements Connector {
     public void shutdown() {
         GlobalStateMgr.getCurrentState().getConnectorTableMetadataProcessor()
                 .unRegisterCachingIcebergCatalog(catalogName);
+        if (icebergNativeCatalog instanceof CachingIcebergCatalog) {
+            ((CachingIcebergCatalog) icebergNativeCatalog).shutdown();
+        }
         if (icebergJobPlanningExecutor != null) {
             icebergJobPlanningExecutor.shutdown();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataRefreshFooterPrefetcher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataRefreshFooterPrefetcher.java
@@ -1,0 +1,163 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import com.starrocks.authorization.PrivilegeBuiltinConstants;
+import com.starrocks.catalog.TableName;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.datacache.DataCacheSelectExecutor;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.DataCacheSelectStatement;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectList;
+import com.starrocks.sql.ast.SelectListItem;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.parser.NodePosition;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+
+// Fires a CACHE SELECT against the freshly-refreshed Iceberg table to warm BE block_cache with
+// parquet/orc footers. The feature is gated by the public session variable
+// enable_iceberg_metadata_refresh_footer_prefetch on the caller's ConnectContext (FE-only knob,
+// not propagated to BE).
+//
+// The actual block_cache populate happens through the same scan path real queries use:
+// DataCacheSelectExecutor → StmtExecutor → Coordinator → HDFSBackendSelector → CacheSelectScanner.
+// Inside buildContext we force the INVISIBLE session var cache_select_footer_only=true on the
+// cloned SessionVariable; that is the only signal BE reads (via TQueryOptions). CacheSelectScanner
+// then stops after reader->init in _fetch_parquet/_fetch_orc (which populates the footer through
+// CacheInputStream) and skips Iceberg delete files. Placement matches what real SELECT queries on
+// this table will compute, by construction.
+//
+// The two knobs are deliberately split so a user opting into the public feature does not
+// accidentally turn their own ad-hoc CACHE SELECT into a footer-only no-op.
+//
+// Submitted fire-and-forget to the caller-provided single-thread executor so the refresh thread
+// returns immediately; a failed warm-up only logs a warning and never propagates.
+public class IcebergMetadataRefreshFooterPrefetcher {
+    private static final Logger LOG = LogManager.getLogger(IcebergMetadataRefreshFooterPrefetcher.class);
+
+    // Coalesce duplicate triggers on the same (catalog, db, table, warehouse): if a warmup is
+    // already pending in the orchestrator queue or currently running, drop the new one. The
+    // in-flight run resolves the table's current snapshot at exec time and will cover the dropped
+    // trigger. The key is removed in the worker's finally block (or in the submit-rejected catch).
+    private static final Set<String> INFLIGHT = ConcurrentHashMap.newKeySet();
+
+    public static void warmup(String catalogName, String dbName, String tableName,
+                              ConnectContext callerCtx, ExecutorService executor) {
+        if (executor == null || catalogName == null || dbName == null || tableName == null) {
+            return;
+        }
+        SessionVariable callerSv = callerCtx != null ? callerCtx.getSessionVariable() : null;
+        if (callerSv == null || !callerSv.isEnableIcebergMetadataRefreshFooterPrefetch()) {
+            return;
+        }
+        // Capture the caller's warehouse so the cache_select runs on the same warehouse the user
+        // queries will hit. Falling back to default would warm a different warehouse and leave
+        // the caller's warehouse cold on first user query.
+        final String warehouseName = callerCtx.getCurrentWarehouseName() != null
+                ? callerCtx.getCurrentWarehouseName()
+                : WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+        final String inflightKey = catalogName + "::" + dbName + "::" + tableName + "::" + warehouseName;
+        if (!INFLIGHT.add(inflightKey)) {
+            return;
+        }
+        final SessionVariable clonedSv = (SessionVariable) callerSv.clone();
+        try {
+            executor.submit(() -> {
+                try {
+                    runWarmup(catalogName, dbName, tableName, clonedSv, warehouseName);
+                } finally {
+                    INFLIGHT.remove(inflightKey);
+                }
+            });
+        } catch (Exception e) {
+            INFLIGHT.remove(inflightKey);
+            LOG.warn("FooterPrefetch: executor rejected warmup for {}.{}.{}",
+                    catalogName, dbName, tableName, e);
+        }
+    }
+
+    private static void runWarmup(String catalogName, String dbName, String tableName,
+                                  SessionVariable clonedSv, String warehouseName) {
+        try {
+            ConnectContext ctx = buildContext(catalogName, dbName, clonedSv, warehouseName);
+            DataCacheSelectStatement stmt = buildStatement(catalogName, dbName, tableName);
+            DataCacheSelectExecutor.cacheSelect(stmt, ctx);
+        } catch (Throwable t) {
+            LOG.warn("FooterPrefetch: warmup failed for {}.{}.{}",
+                    catalogName, dbName, tableName, t);
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    private static ConnectContext buildContext(String catalogName, String dbName,
+                                                SessionVariable clonedSv, String warehouseName) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        // Force the internal footer-only signal on for this cache_select run so
+        // CacheSelectScanner skips column data and Iceberg delete-file fetches. This is a
+        // private, INVISIBLE session var — users opting into the feature with the public
+        // enable_iceberg_metadata_refresh_footer_prefetch knob must not see footer-only mode
+        // leak into their own CACHE SELECT statements.
+        clonedSv.setCacheSelectFooterOnly(true);
+        // Stamp the warehouse name onto the cloned session var directly. We must NOT call
+        // ctx.setCurrentWarehouse(): that helper replaces sessionVariable with a fresh default,
+        // discarding cacheSelectFooterOnly and every caller setting we just cloned.
+        clonedSv.setWarehouseName(warehouseName);
+        ctx.setSessionVariable(clonedSv);
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setQualifiedUser(UserIdentity.ROOT.getUser());
+        // ROOT user's UserPrivilegeCollection has no direct grants; all privileges flow through
+        // ROOT_ROLE_ID. AuthorizationMgr.loadPrivilegeCollection does retainAll(currentRoleIds) on
+        // user roles — an empty set here would silently strip ROOT_ROLE_ID and warmup would auth-
+        // fail through native access control (Ranger has a ROOT bypass; native does not).
+        ctx.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+        ctx.setCurrentCatalog(catalogName);
+        ctx.setDatabase(dbName);
+        UUID queryId = UUIDUtil.genUUID();
+        ctx.setQueryId(queryId);
+        ctx.setExecutionId(UUIDUtil.toTUniqueId(queryId));
+        ctx.setThreadLocalInfo();
+        return ctx;
+    }
+
+    private static DataCacheSelectStatement buildStatement(String catalogName, String dbName, String tableName) {
+        TableName tn = new TableName(catalogName, dbName, tableName);
+        TableRelation tableRelation = new TableRelation(tn);
+        SelectListItem starItem = new SelectListItem((TableName) null);
+        SelectList selectList = new SelectList(ImmutableList.of(starItem), false);
+        SelectRelation queryRelation = new SelectRelation(
+                selectList, tableRelation, null, null, null, NodePosition.ZERO);
+        QueryStatement queryStatement = new QueryStatement(queryRelation);
+        InsertStmt insertStmt = new InsertStmt(queryStatement, NodePosition.ZERO);
+        return new DataCacheSelectStatement(insertStmt, new HashMap<>(), NodePosition.ZERO);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -742,6 +742,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String PAIMON_FORCE_JNI_READER = "paimon_force_jni_reader";
     public static final String AVRO_USE_JNI_READER = "avro_use_jni_reader";
     public static final String ENABLE_DYNAMIC_PRUNE_SCAN_RANGE = "enable_dynamic_prune_scan_range";
+    public static final String ENABLE_ICEBERG_METADATA_REFRESH_FOOTER_PREFETCH =
+            "enable_iceberg_metadata_refresh_footer_prefetch";
+    // Internal, set only by IcebergMetadataRefreshFooterPrefetcher.warmup() on its own cloned
+    // ConnectContext to tell BE CacheSelectScanner to stop after the file footer is in
+    // block_cache and skip the column data + Iceberg delete-file fetch. Users opting into the
+    // feature via `enable_iceberg_metadata_refresh_footer_prefetch` must not affect plain
+    // CACHE SELECT semantics for ordinary queries on their session.
+    public static final String CACHE_SELECT_FOOTER_ONLY = "cache_select_footer_only";
     public static final String IO_TASKS_PER_SCAN_OPERATOR = "io_tasks_per_scan_operator";
     public static final String CONNECTOR_IO_TASKS_PER_SCAN_OPERATOR = "connector_io_tasks_per_scan_operator";
     public static final String ENABLE_CONNECTOR_ADAPTIVE_IO_TASKS = "enable_connector_adaptive_io_tasks";
@@ -2722,6 +2730,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     private boolean enableCacheSelect = false;
 
+    @VariableMgr.VarAttr(name = ENABLE_ICEBERG_METADATA_REFRESH_FOOTER_PREFETCH)
+    private boolean enableIcebergMetadataRefreshFooterPrefetch = false;
+
+    @VariableMgr.VarAttr(name = CACHE_SELECT_FOOTER_ONLY, flag = VariableMgr.INVISIBLE)
+    private boolean cacheSelectFooterOnly = false;
+
     @VariableMgr.VarAttr(name = ENABLE_DYNAMIC_PRUNE_SCAN_RANGE)
     private boolean enableDynamicPruneScanRange = true;
 
@@ -3717,6 +3731,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableCacheSelect() {
         return enableCacheSelect;
+    }
+
+    public void setEnableIcebergMetadataRefreshFooterPrefetch(boolean v) {
+        this.enableIcebergMetadataRefreshFooterPrefetch = v;
+    }
+
+    public boolean isEnableIcebergMetadataRefreshFooterPrefetch() {
+        return enableIcebergMetadataRefreshFooterPrefetch;
+    }
+
+    public void setCacheSelectFooterOnly(boolean v) {
+        this.cacheSelectFooterOnly = v;
+    }
+
+    public boolean isCacheSelectFooterOnly() {
+        return cacheSelectFooterOnly;
     }
 
     public void setConnectorIoTasksPerScanOperator(int connectorIoTasksPerScanOperator) {
@@ -6421,6 +6451,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setDatacache_priority(datacachePriority);
         tResult.setDatacache_ttl_seconds(datacacheTTLSeconds);
         tResult.setEnable_cache_select(enableCacheSelect);
+        tResult.setCache_select_footer_only(cacheSelectFooterOnly);
         tResult.setEnable_file_metacache(enableFileMetaCache);
         tResult.setEnable_file_pagecache(enableFilePageCache);
         tResult.setHudi_mor_force_jni_reader(hudiMORForceJNIReader);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -390,6 +390,13 @@ struct TQueryOptions {
   215: optional string http_request_host_allowlist_regexp = "";
   216: optional bool http_request_allow_private_in_allowlist = false;
   217: optional bool enable_cache_udaf = false;
+
+  // When true, CacheSelectScanner stops after the file footer is in block_cache and skips the
+  // column data + Iceberg delete-file fetch. Set only by
+  // IcebergMetadataRefreshFooterPrefetcher.warmup on its own cloned ConnectContext, never by
+  // user sessions — the public user-facing knob is the FE-only Session var
+  // enable_iceberg_metadata_refresh_footer_prefetch.
+  220: optional bool cache_select_footer_only = false;
 }
 
 // A scan range plus the parameters needed to execute that scan.


### PR DESCRIPTION
## Why I'm doing it

When CachingIcebergCatalog refreshes a table's metadata, the freshly-known
data files are not yet present in BE/CN block_cache. The first user query
on the table pays a 50–150ms S3 round-trip per file to read the parquet
footer, multiplied across all files in the scan. On wide cold scans this
dominates first-query latency.

## What I'm doing

Fire-and-forget a CACHE SELECT against the just-refreshed table from inside
`CachingIcebergCatalog.refreshTable` (both the cold-start path and the
metadata-change path). The CACHE SELECT runs through the same scan path as
real queries — `DataCacheSelectExecutor` → `StmtExecutor` → `Coordinator`
→ `HDFSBackendSelector` → `CacheSelectScanner` — so file→node placement
matches what real SELECTs from the same session would compute.

Dispatched onto a per-catalog single-thread daemon executor; duplicate
triggers on the same `(catalog, db, table, warehouse)` are coalesced.

Knobs:
- `enable_iceberg_metadata_refresh_footer_prefetch` (session var, default
  `false`, FE-only — not propagated to BE). Set globally to enable for
  background refresh.
- `cache_select_footer_only` (INVISIBLE session var, only set internally
  by the prefetcher). BE branch in `_fetch_parquet`, `_fetch_orc`,
  `_fetch_textfile`, plus the iceberg-delete-files skip in `do_get_next`.

Generic fix (not feature-gated): `HdfsScanner::create_random_access_file`
now wraps `_file` in a regular `CacheInputStream` for cache_select mode
too. Without this, the parquet `reader->init` footer read went straight
to raw storage even during CACHE SELECT — only the column ranges
explicitly fed to `CacheSelectInputStream` via `_write_disk_ranges` were
populating block_cache. Now the footer read also populates.

New thrift field: `TQueryOptions.cache_select_footer_only` at ordinal 220
(optional, default false).

Metrics:
- `parquet_footer_cache_hit_count` / `parquet_footer_cache_miss_count`
  on `QueryScanMetrics`.
- `datacache_block_cache_write_bytes` / `datacache_block_cache_evict_bytes`
  gauges on `DataCacheMetrics` (sampled from starcache `detail_l2`).

## What type of PR is it

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Default-off feature gate; no existing knob's behaviour or default changes.

## Does this PR need documentation update?

- [ ] No.
- [x] Yes.

New session variable `enable_iceberg_metadata_refresh_footer_prefetch` to
document.

## Backport to release branches

- [ ] 4.0
- [ ] 3.5
- [ ] 3.4
- [ ] 3.3
- [ ] 3.2
- [ ] 3.1
- [ ] 3.0

## Tests

- [ ] Unit tests
- [ ] Manual test on a dev cluster
- [ ] Bench

## Refer issue

Fixes #73401
