### PR TITLE
[BugFix] Include underlying cause in HdfsFsManager copy error messages

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1219,10 +1219,10 @@ public class HdfsFsManager {
         } catch (InterruptedIOException e) {
             Thread.interrupted(); // clear interrupted flag
             LOG.error("Interrupted while copy {} to local {} ", srcPath, destPath, e);
-            throw new StarRocksException("Failed to copy " + srcPath + "to local " + destPath, e);
+            throw new StarRocksException("Failed to copy " + srcPath + " to local " + destPath + ": " + e.getMessage(), e);
         } catch (Exception e) {
             LOG.error("Exception while copy {} to local {} ", srcPath, destPath, e);
-            throw new StarRocksException("Failed to copy " + srcPath + "to local " + destPath, e);
+            throw new StarRocksException("Failed to copy " + srcPath + " to local " + destPath + ": " + e.getMessage(), e);
         }
     }
 
@@ -1235,10 +1235,10 @@ public class HdfsFsManager {
         } catch (InterruptedIOException e) {
             Thread.interrupted(); // clear interrupted flag
             LOG.error("Interrupted while copy local {} to {} ", srcPath, destPath, e);
-            throw new StarRocksException("Failed to copy local " + srcPath + " to " + destPath, e);
+            throw new StarRocksException("Failed to copy local " + srcPath + " to " + destPath + ": " + e.getMessage(), e);
         } catch (Exception e) {
             LOG.error("Exception while copy local {} to {} ", srcPath, destPath, e);
-            throw new StarRocksException("Failed to copy local " + srcPath  + " to " + destPath, e);
+            throw new StarRocksException("Failed to copy local " + srcPath + " to " + destPath + ": " + e.getMessage(), e);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/fs/hdfs/HdfsFsManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/hdfs/HdfsFsManagerTest.java
@@ -31,10 +31,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -613,6 +616,81 @@ public class HdfsFsManagerTest {
         Assertions.assertTrue(ex.getMessage().contains("Failed to copy local " + nonExistentSrc
                         + " to s3a://bucket/key"),
                 "wrapper message must include both paths: " + ex.getMessage());
+    }
+
+    /**
+     * Covers the {@link InterruptedIOException} branch of copyToLocal: the cause's
+     * message must still be visible in the wrapper, and the catch clears the
+     * thread's interrupt flag so callers don't observe spurious interruption.
+     */
+    @Test
+    public void testCopyToLocalInterruptedIncludesCauseMessage() throws Exception {
+        HdfsFsManager mgr = Mockito.spy(fileSystemManager);
+        FileSystem fs = Mockito.mock(FileSystem.class);
+        HdfsFs hdfs = Mockito.mock(HdfsFs.class);
+        Mockito.when(hdfs.getDFSFileSystem()).thenReturn(fs);
+        Mockito.doReturn(hdfs).when(mgr)
+                .getFileSystem(Mockito.anyString(), Mockito.anyMap(), Mockito.isNull());
+
+        String causeMsg = "interrupted during S3 GET";
+        Mockito.doThrow(new InterruptedIOException(causeMsg))
+                .when(fs).copyToLocalFile(Mockito.anyBoolean(), Mockito.any(Path.class),
+                        Mockito.any(Path.class), Mockito.anyBoolean());
+
+        try {
+            StarRocksException ex = Assertions.assertThrows(StarRocksException.class,
+                    () -> mgr.copyToLocal("s3a://bucket/key", "/tmp/dest", new HashMap<>()));
+            Assertions.assertTrue(ex.getMessage().contains(causeMsg),
+                    "wrapper message must include cause: " + ex.getMessage());
+            Assertions.assertTrue(ex.getMessage().contains(
+                            "Failed to copy s3a://bucket/key to local /tmp/dest"),
+                    "wrapper message must include both paths: " + ex.getMessage());
+            Assertions.assertInstanceOf(InterruptedIOException.class, ex.getCause(),
+                    "cause must be the InterruptedIOException");
+        } finally {
+            // Defensive: the catch calls Thread.interrupted() to clear the flag.
+            Thread.interrupted();
+        }
+    }
+
+    /**
+     * Covers the {@link InterruptedIOException} branch of copyFromLocal. Uses a
+     * real local source file so FileUtil.copy reaches the destination
+     * FileSystem.create(...) call, where we inject the interrupt.
+     */
+    @Test
+    public void testCopyFromLocalInterruptedIncludesCauseMessage() throws Exception {
+        HdfsFsManager mgr = Mockito.spy(fileSystemManager);
+        FileSystem fs = Mockito.mock(FileSystem.class);
+        HdfsFs hdfs = Mockito.mock(HdfsFs.class);
+        Mockito.when(hdfs.getDFSFileSystem()).thenReturn(fs);
+        Mockito.doReturn(hdfs).when(mgr)
+                .getFileSystem(Mockito.anyString(), Mockito.anyMap(), Mockito.isNull());
+
+        File srcFile = Files.createTempFile("hdfs-fs-mgr-test-", ".bin").toFile();
+        try {
+            Files.write(srcFile.toPath(), new byte[] {1, 2, 3});
+
+            String causeMsg = "interrupted during S3 PUT";
+            // FileUtil.copy ends up calling FileSystem.create(Path) — stub that overload directly
+            // (the (Path, boolean) overload isn't reached because Mockito short-circuits at the mocked
+            // create(Path) method without delegating to its real implementation).
+            Mockito.doThrow(new InterruptedIOException(causeMsg))
+                    .when(fs).create(Mockito.any(Path.class));
+
+            StarRocksException ex = Assertions.assertThrows(StarRocksException.class,
+                    () -> mgr.copyFromLocal(srcFile.getAbsolutePath(), "s3a://bucket/key", new HashMap<>()));
+            Assertions.assertTrue(ex.getMessage().contains(causeMsg),
+                    "wrapper message must include cause: " + ex.getMessage());
+            Assertions.assertTrue(ex.getMessage().contains(
+                            "Failed to copy local " + srcFile.getAbsolutePath() + " to s3a://bucket/key"),
+                    "wrapper message must include both paths: " + ex.getMessage());
+            Assertions.assertInstanceOf(InterruptedIOException.class, ex.getCause(),
+                    "cause must be the InterruptedIOException");
+        } finally {
+            srcFile.delete();
+            Thread.interrupted();
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/fs/hdfs/HdfsFsManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/hdfs/HdfsFsManagerTest.java
@@ -560,6 +560,62 @@ public class HdfsFsManagerTest {
     }
 
     /**
+     * Regression for cluster snapshot upload error reporting: copyToLocal wraps the
+     * underlying Hadoop exception in a StarRocksException, and the wrapper message
+     * must include the cause's message so callers that surface only
+     * StarRocksException#getMessage (e.g. ClusterSnapshotJob.error_message) still
+     * see the real reason (AccessDenied, NoSuchBucket, timeout, etc.).
+     */
+    @Test
+    public void testCopyToLocalIncludesCauseMessage() throws Exception {
+        HdfsFsManager mgr = Mockito.spy(fileSystemManager);
+        FileSystem fs = Mockito.mock(FileSystem.class);
+        HdfsFs hdfs = Mockito.mock(HdfsFs.class);
+        Mockito.when(hdfs.getDFSFileSystem()).thenReturn(fs);
+        Mockito.doReturn(hdfs).when(mgr)
+                .getFileSystem(Mockito.anyString(), Mockito.anyMap(), Mockito.isNull());
+
+        String causeMsg = "AccessDenied: anonymous is not authorized to perform s3:GetObject";
+        Mockito.doThrow(new IOException(causeMsg))
+                .when(fs).copyToLocalFile(Mockito.anyBoolean(), Mockito.any(Path.class),
+                        Mockito.any(Path.class), Mockito.anyBoolean());
+
+        StarRocksException ex = Assertions.assertThrows(StarRocksException.class,
+                () -> mgr.copyToLocal("s3a://bucket/key", "/tmp/dest", new HashMap<>()));
+        Assertions.assertTrue(ex.getMessage().contains(causeMsg),
+                "wrapper message must include cause: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("Failed to copy s3a://bucket/key to local /tmp/dest"),
+                "wrapper message must include both paths: " + ex.getMessage());
+        Assertions.assertNotNull(ex.getCause(), "cause must still be attached");
+    }
+
+    /**
+     * Companion to {@link #testCopyToLocalIncludesCauseMessage()} for copyFromLocal.
+     * Uses a non-existent local source so FileUtil.copy throws naturally, then checks
+     * that the wrapper message preserves the underlying message.
+     */
+    @Test
+    public void testCopyFromLocalIncludesCauseMessage() throws Exception {
+        HdfsFsManager mgr = Mockito.spy(fileSystemManager);
+        FileSystem fs = Mockito.mock(FileSystem.class);
+        HdfsFs hdfs = Mockito.mock(HdfsFs.class);
+        Mockito.when(hdfs.getDFSFileSystem()).thenReturn(fs);
+        Mockito.doReturn(hdfs).when(mgr)
+                .getFileSystem(Mockito.anyString(), Mockito.anyMap(), Mockito.isNull());
+
+        String nonExistentSrc = "/this/path/should/not/exist/" + System.nanoTime();
+        StarRocksException ex = Assertions.assertThrows(StarRocksException.class,
+                () -> mgr.copyFromLocal(nonExistentSrc, "s3a://bucket/key", new HashMap<>()));
+        Assertions.assertNotNull(ex.getCause(), "cause must still be attached");
+        Assertions.assertNotNull(ex.getCause().getMessage(), "cause must carry a message");
+        Assertions.assertTrue(ex.getMessage().contains(ex.getCause().getMessage()),
+                "wrapper message must include cause's message: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("Failed to copy local " + nonExistentSrc
+                        + " to s3a://bucket/key"),
+                "wrapper message must include both paths: " + ex.getMessage());
+    }
+
+    /**
      * Fallback thread watchdog: when the close pool is full and the fallback daemon thread
      * hangs, the watchdog interrupts it after the configured timeout so stuck threads
      * don't accumulate.


### PR DESCRIPTION
## Why I'm doing:

`HdfsFsManager.copyFromLocal` / `copyToLocal` wrap the underlying Hadoop exception in a `StarRocksException` but only put the source / destination paths into the new message, dropping the cause's message.

Callers that surface only `StarRocksException#getMessage` to the user can lose all useful diagnostic information. The motivating case is automated cluster snapshot upload to remote object storage:

```
ClusterSnapshotCheckpointScheduler.java
    errMsg = "upload image failed, err msg: " + e.getMessage();
```

When the underlying S3/OSS upload fails (AccessDenied, NoSuchBucket, SocketTimeoutException, SignatureDoesNotMatch, FileAlreadyExistsException, etc.), the user only sees the following in `information_schema.cluster_snapshot_jobs.error_message`:

```
upload image failed, err msg: Failed to copy local /opt/starrocks/fe/meta/image to s3://tenant-bucket/.../meta/image/automated_cluster_snapshot_xxx
```

…with no hint of the real reason. Operators currently have to grep `fe.log` for the `Exception while copy local …` stack trace to find what actually went wrong.

## What I'm doing:

- Append `e.getMessage()` to the `StarRocksException` wrapper message in both `copyFromLocal` and `copyToLocal` (for both `InterruptedIOException` and the generic `Exception` paths), so the real cause is visible at the call site without losing the existing wrapper for log greppability.
- Drive-by: fix the missing space before `to local` in `copyToLocal`'s error string (previously produced `Failed to copy /pathto local /dest`).
- Add unit tests `testCopyToLocalIncludesCauseMessage` and `testCopyFromLocalIncludesCauseMessage` covering both methods.

The underlying cause is already attached to the `StarRocksException` and still gets logged with full stack trace via `LOG.error` — this change only adds the cause's message to the user-visible message string.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4