### PR TITLE
[Enhancement] Introduce light_weight_tablet_creation table property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -487,21 +487,31 @@ public class CatalogUtils {
         return backendNum;
     }
 
-    public static int calPhysicalPartitionBucketNum() {
+    // Count compute nodes for bucket sizing. Light-weight tablet creation can succeed
+    // without any alive CN, so when invoked from that path (useTotalNodes = true) we
+    // include configured-but-offline CNs so auto-bucket still produces a sensible value.
+    // Regular CREATE TABLE keeps the original "only count alive CNs" behavior.
+    private static int computeNodeCountForBucketSizing(boolean useTotalNodes) {
+        return useTotalNodes
+                ? GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalComputeNodeNumber()
+                : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAliveComputeNodeNumber();
+    }
+
+    public static int calPhysicalPartitionBucketNum(boolean lightWeight) {
         int backendNum = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds().size();
 
         if (RunMode.isSharedDataMode()) {
-            backendNum = backendNum + GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAliveComputeNodeNumber();
+            backendNum = backendNum + computeNodeCountForBucketSizing(lightWeight);
         }
 
         return divisibleBucketNum(backendNum);
     }
 
-    public static int calBucketNumAccordingToBackends() {
+    public static int calBucketNumAccordingToBackends(boolean lightWeight) {
         int backendNum = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds().size();
 
         if (RunMode.isSharedDataMode()) {
-            backendNum = backendNum + GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAliveComputeNodeNumber();
+            backendNum = backendNum + computeNodeCountForBucketSizing(lightWeight);
         }
 
         // When POC, the backends is not greater than three most of the time.
@@ -525,7 +535,7 @@ public class CatalogUtils {
         //    Or the Config.enable_auto_tablet_distribution is disabled
         int bucketNum = 0;
         if (olapTable.getPartitions().size() < recentPartitionNum || !enableAutoTabletDistribution) {
-            bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+            bucketNum = CatalogUtils.calBucketNumAccordingToBackends(olapTable.isLightWeightTabletCreation());
             // If table is not partitioned, the bucketNum should be at least DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM
             if (!olapTable.getPartitionInfo().isPartitioned()) {
                 bucketNum = bucketNum > FeConstants.DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM ?
@@ -544,7 +554,7 @@ public class CatalogUtils {
             }
         }
 
-        bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+        bucketNum = CatalogUtils.calBucketNumAccordingToBackends(olapTable.isLightWeightTabletCreation());
         if (!dataImported) {
             return bucketNum;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -290,7 +290,7 @@ public class ColocateTableIndex implements Writable {
                     if (!(tbl instanceof ExternalOlapTable)) {
                         // Colocate table should keep the same bucket number across the partitions
                         if (hashDistInfo.getBucketNum() == 0) {
-                            int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+                            int bucketNum = CatalogUtils.calBucketNumAccordingToBackends(tbl.isLightWeightTabletCreation());
                             hashDistInfo.setBucketNum(bucketNum);
                         }
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -2220,7 +2220,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 }
             }
             if (inferredBucketNum == 0) {
-                inferredBucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+                inferredBucketNum = CatalogUtils.calBucketNumAccordingToBackends(isLightWeightTabletCreation());
             }
             info.setBucketNum(inferredBucketNum);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1207,7 +1207,7 @@ public class OlapTable extends Table {
             if (numBucket > 0) {
                 info.setBucketNum((int) numBucket);
             } else if (info.getBucketNum() == 0) {
-                numBucket = CatalogUtils.calPhysicalPartitionBucketNum();
+                numBucket = CatalogUtils.calPhysicalPartitionBucketNum(isLightWeightTabletCreation());
                 info.setBucketNum((int) numBucket);
             }
         } else if (info.getType() == DistributionInfo.DistributionInfoType.RANGE) {
@@ -2064,6 +2064,16 @@ public class OlapTable extends Table {
 
     public Boolean enablePersistentIndex() {
         return tableProperty.enablePersistentIndex();
+    }
+
+    public boolean isLightWeightTabletCreation() {
+        return tableProperty.lightWeightTabletCreation();
+    }
+
+    public void setLightWeightTabletCreation(boolean lightWeightTabletCreation) {
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION,
+                Boolean.valueOf(lightWeightTabletCreation).toString());
+        tableProperty.buildLightWeightTabletCreation();
     }
 
     public int primaryIndexCacheExpireSec() {
@@ -3019,6 +3029,11 @@ public class OlapTable extends Table {
         if (getCompactionStrategy() != TCompactionStrategy.DEFAULT) {
             properties.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY,
                     TableProperty.compactionStrategyToString(getCompactionStrategy()));
+        }
+
+        if (isCloudNativeTable()) {
+            properties.put(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION,
+                    Boolean.toString(isLightWeightTabletCreation()));
         }
 
         // lake_compaction_max_parallel (only for cloud native table, only show when not default)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -252,6 +252,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // Only meaningful when enablePersistentIndex = true.
     TPersistentIndexType persistentIndexType;
 
+    @SerializedName(value = "lightWeightTabletCreation")
+    private boolean lightWeightTabletCreation = false;
+
     private int primaryIndexCacheExpireSec = 0;
 
     /*
@@ -383,6 +386,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         this.mvTransparentRewriteMode = other.mvTransparentRewriteMode;
         this.enablePersistentIndex = other.enablePersistentIndex;
         this.persistentIndexType = other.persistentIndexType;
+        this.lightWeightTabletCreation = other.lightWeightTabletCreation;
         this.primaryIndexCacheExpireSec = other.primaryIndexCacheExpireSec;
         this.storageVolume = other.storageVolume;
         this.storageCoolDownTTL = other.storageCoolDownTTL;
@@ -879,6 +883,12 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildLightWeightTabletCreation() {
+        lightWeightTabletCreation = Boolean.parseBoolean(
+                properties.getOrDefault(PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION, "false"));
+        return this;
+    }
+
     public TableProperty buildPrimaryIndexCacheExpireSec() {
         primaryIndexCacheExpireSec = Integer.parseInt(properties.getOrDefault(
                 PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC, "0"));
@@ -1207,6 +1217,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public boolean enablePersistentIndex() {
         return enablePersistentIndex;
+    }
+
+    public boolean lightWeightTabletCreation() {
+        return lightWeightTabletCreation;
     }
 
     public boolean isFileBundling() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3765,6 +3765,14 @@ public class Config extends ConfigBase {
     public static boolean enable_cloud_native_persistent_index_by_default = true;
 
     /**
+     * Whether to enable light-weight tablet creation by default for newly created cloud native tables.
+     * When enabled, DDL operations skip CreateReplicaTask and no version 1 metadata is written to
+     * object storage during tablet creation. The initial metadata is fetched from FE on demand.
+     */
+    @ConfField(mutable = true)
+    public static boolean lake_enable_light_weight_tablet_creation = false;
+
+    /**
      * timeout for external table commit
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -157,6 +157,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_ENABLE_PERSISTENT_INDEX = "enable_persistent_index";
 
+    public static final String PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION = "light_weight_tablet_creation";
+
     public static final String PROPERTIES_LABELS_LOCATION = "labels.location";
 
     public static final String PROPERTIES_PERSISTENT_INDEX_TYPE = "persistent_index_type";

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2033,7 +2033,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 }
             }
         }
-        if (numAliveNodes == 0) {
+        if (numAliveNodes == 0 && !table.isLightWeightTabletCreation()) {
             if (RunMode.isSharedDataMode()) {
                 throw new DdlException("no alive compute nodes");
             } else {
@@ -2272,7 +2272,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(index.getId()));
         final long warehouseId = computeResource.getWarehouseId();
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-        if (!warehouseManager.isResourceAvailable(computeResource)) {
+        // light-weight tablet creation skips CreateReplicaTask and does not need a live CN,
+        // so skip checking compute resource to allow table creation when all CNs are down.
+        if (!table.isLightWeightTabletCreation() && !warehouseManager.isResourceAvailable(computeResource)) {
             Warehouse warehouse = warehouseManager.getWarehouse(warehouseId);
             throw ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -404,6 +404,13 @@ public class OlapTableFactory implements AbstractTableFactory {
             }
 
             if (table.isCloudNativeTable()) {
+                boolean lightWeightTabletCreation = PropertyAnalyzer.analyzeBooleanProp(
+                        properties, PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION,
+                        Config.lake_enable_light_weight_tablet_creation);
+                table.setLightWeightTabletCreation(lightWeightTabletCreation);
+            }
+
+            if (table.isCloudNativeTable()) {
                 TCompactionStrategy compactionStrategy;
                 try {
                     compactionStrategy = PropertyAnalyzer.analyzecompactionStrategy(properties);
@@ -809,7 +816,17 @@ public class OlapTableFactory implements AbstractTableFactory {
             ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
             if (ConnectContext.get() != null) {
                 ConnectContext connectContext = ConnectContext.get();
-                computeResource = connectContext.getCurrentComputeResource();
+                if (table.isLightWeightTabletCreation()) {
+                    // Light-weight tablet creation tolerates a missing CN, so we cannot go
+                    // through getCurrentComputeResource() (which throws when no compute
+                    // resource is available).
+                    computeResource = connectContext.getCurrentComputeResourceNoAcquire();
+                    if (computeResource == null) {
+                        computeResource = WarehouseManager.DEFAULT_RESOURCE;
+                    }
+                } else {
+                    computeResource = connectContext.getCurrentComputeResource();
+                }
             }
 
             // do not create partition for external table

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -91,6 +91,9 @@ public class TabletTaskExecutor {
                                                    int numBackends,
                                                    ComputeResource computeResource,
                                                    CreateTabletOption option) throws DdlException {
+        if (table.isLightWeightTabletCreation()) {
+            return;
+        }
         // Try to bundle at least 200 CreateReplicaTask's in a single AgentBatchTask.
         // The number 200 is just an experiment value that seems to work without obvious problems, feel free to
         // change it if you have a better choice.
@@ -122,6 +125,9 @@ public class TabletTaskExecutor {
                                                    int numBackends,
                                                    ComputeResource computeResource,
                                                    CreateTabletOption option) throws DdlException {
+        if (table.isLightWeightTabletCreation()) {
+            return;
+        }
         long start = System.currentTimeMillis();
         int timeout = Math.max(1, numReplicas / numBackends) * Config.tablet_create_timeout_second;
         int numIndexes = partitions.stream().mapToInt(

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -540,6 +540,7 @@ public class CreateLakeTableTest {
                 "\"datacache.enable\" = \"true\",\n" +
                 "\"enable_async_write_back\" = \"false\",\n" +
                 "\"file_bundling\" = \"true\",\n" +
+                "\"light_weight_tablet_creation\" = \"false\",\n" +
                 "\"partition_retention_condition\" = \"dt > current_date() - interval 1 month\",\n" +
                 "\"replication_num\" = \"1\",\n" +
                 "\"storage_volume\" = \"builtin_storage_volume\"\n" +
@@ -806,5 +807,58 @@ public class CreateLakeTableTest {
         TBatchGetTabletMetadataResponse batchResp = impl.getTabletMetadata(batchReq);
         Assertions.assertEquals(TStatusCode.NOT_IMPLEMENTED_ERROR, batchResp.getStatus().getStatus_code());
         Assertions.assertFalse(batchResp.isSetResponses());
+    }
+
+    @Test
+    public void testLightWeightTabletCreation() throws Exception {
+        boolean saved = Config.lake_enable_light_weight_tablet_creation;
+        try {
+            // Config.lake_enable_light_weight_tablet_creation = true: new tables default to light-weight.
+            Config.lake_enable_light_weight_tablet_creation = true;
+            ExceptionChecker.expectThrowsNoException(() -> createTable(
+                    "create table lake_test.light_weight_default\n" +
+                            "(c0 int, c1 string)\n" +
+                            "duplicate key(c0)\n" +
+                            "distributed by hash(c0) buckets 2"));
+            Assertions.assertTrue(getLakeTable("lake_test", "light_weight_default").isLightWeightTabletCreation());
+
+            // Explicit false overrides the cluster default.
+            ExceptionChecker.expectThrowsNoException(() -> createTable(
+                    "create table lake_test.light_weight_false\n" +
+                            "(c0 int, c1 string)\n" +
+                            "duplicate key(c0)\n" +
+                            "distributed by hash(c0) buckets 2\n" +
+                            "properties('light_weight_tablet_creation' = 'false')"));
+            Assertions.assertFalse(getLakeTable("lake_test", "light_weight_false").isLightWeightTabletCreation());
+
+            // Config off: new tables default to non-light-weight.
+            Config.lake_enable_light_weight_tablet_creation = false;
+            ExceptionChecker.expectThrowsNoException(() -> createTable(
+                    "create table lake_test.light_weight_config_off\n" +
+                            "(c0 int, c1 string)\n" +
+                            "duplicate key(c0)\n" +
+                            "distributed by hash(c0) buckets 2"));
+            Assertions.assertFalse(getLakeTable("lake_test", "light_weight_config_off").isLightWeightTabletCreation());
+
+            // Explicit true overrides the cluster default.
+            ExceptionChecker.expectThrowsNoException(() -> createTable(
+                    "create table lake_test.light_weight_true\n" +
+                            "(c0 int, c1 string)\n" +
+                            "duplicate key(c0)\n" +
+                            "distributed by hash(c0) buckets 2\n" +
+                            "properties('light_weight_tablet_creation' = 'true')"));
+            Assertions.assertTrue(getLakeTable("lake_test", "light_weight_true").isLightWeightTabletCreation());
+
+            // SHOW CREATE TABLE surfaces the property.
+            String sql = "show create table lake_test.light_weight_true";
+            ShowCreateTableStmt showCreateTableStmt =
+                    (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            ShowResultSet resultSet = ShowExecutor.execute(showCreateTableStmt, connectContext);
+            List<List<String>> result = resultSet.getResultRows();
+            Assertions.assertFalse(result.isEmpty());
+            Assertions.assertTrue(result.get(0).get(1).contains("\"light_weight_tablet_creation\" = \"true\""));
+        } finally {
+            Config.lake_enable_light_weight_tablet_creation = saved;
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Introduce the table-level switch for the Light-Weight Tablet Creation feature so DDL on cloud-native tables can opt out of dispatching CreateReplicaTask and writing version 1 metadata to object storage at table-creation time. The CN-side fallback that constructs the initial metadata on demand from FE is already on main (see #72270 and #72364); this PR wires the FE switch and the CREATE TABLE skip behind it.

## What I'm doing:

**Property infrastructure**
* `TableProperty.lightWeightTabletCreation` with the standard `buildProperty` / getter pattern. `buildLightWeightTabletCreation()` defaults the field to `false` on deserialization regardless of the current cluster toggle, so reloads of legacy tables (whose properties map does not carry this key) stay backward compatible.
* `OlapTable.isLightWeightTabletCreation()` / `setLightWeightTabletCreation()` exposed, and the property is surfaced in `SHOW CREATE TABLE` for cloud-native tables.
* `PropertyAnalyzer.PROPERTIES_LIGHT_WEIGHT_TABLET_CREATION` registered.
* `Config.lake_enable_light_weight_tablet_creation` defaults to `false`. The cluster toggle is consulted only when creating a new cloud-native table (in `OlapTableFactory`), which then writes the resolved value back into the properties map; the toggle does not retroactively flip existing tables on FE restart.

**CREATE TABLE plumbing**
* `TabletTaskExecutor.buildPartitionsSequentially` / `buildPartitionsConcurrently` early-return for light-weight tables (no CreateReplicaTask sent).
* `LocalMetastore.createLakeTablets` skips both the alive-node check and the `isResourceAvailable` check for light-weight tables so CREATE TABLE works when no CN is live.
* `OlapTableFactory` parses the property (defaulting via the cluster toggle), sets it on the table, and for light-weight tables resolves the compute resource via `ConnectContext.getCurrentComputeResourceNoAcquire()` so the session's already-acquired resource (including the cngroup binding used by multi-cngroup deployments) is reused without going through `getCurrentComputeResource()`'s live-CN availability check. Falls back to `WarehouseManager.DEFAULT_RESOURCE` only when the session has not acquired a resource yet.
* `CatalogUtils.calBucketNumAccordingToBackends` and `calPhysicalPartitionBucketNum` now take a `lightWeight` flag. Light-weight tables size buckets against `getTotalComputeNodeNumber` so auto-bucket works even when CNs are temporarily down; regular tables keep using `getAliveComputeNodeNumber`. Callers in `OlapTable`, `MaterializedView`, and `ColocateTableIndex` pass the table's own property value.

Alter-table support (`ALTER TABLE SET ("light_weight_tablet_creation" = ...)` and the corresponding skip in `LakeTableSchemaChangeJob` / `LakeRollupJob`) lands in a follow-up PR.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: opt-in property + cluster-level toggle (defaults to off); the user-visible CREATE TABLE behavior only changes when the property is true.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4