### PR TITLE
[BugFix] Handle multi-statement transactions in lake publish_log_version

### DIFF
--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -657,8 +657,7 @@ void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std:
     // Multi-statement transactions cache the .log under the 4-segment key; use the
     // same path here so the cache entry actually drops.
     if (txn_log.has_load_id()) {
-        tablet_mgr->metacache()->erase(
-                tablet_mgr->txn_log_location(tablet_id, txn_log.txn_id(), txn_log.load_id()));
+        tablet_mgr->metacache()->erase(tablet_mgr->txn_log_location(tablet_id, txn_log.txn_id(), txn_log.load_id()));
     } else {
         tablet_mgr->metacache()->erase(tablet_mgr->txn_log_location(tablet_id, txn_log.txn_id()));
     }

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -508,7 +508,83 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, std::sp
                            const int64_t* log_versions) {
     auto files_to_delete = std::vector<std::string>{};
     for (int i = 0; i < txn_infos.size(); i++) {
-        if (!txn_infos[i].combined_txn_log()) {
+        if (txn_infos[i].load_ids_size() > 0) {
+            // Multi-statement transaction: each statement writes its own .log file at the
+            // 4-segment path that encodes load_id. Read every per-load_id .log via
+            // load_txn_log (which already understands this layout) and merge them into a
+            // single TxnLog before persisting as the version-keyed .vlog.
+            //
+            // Without this branch, publish_log_version would fall back to the 2-segment
+            // path and fail with NotFound during schema change, leaving the txn stuck in
+            // COMMITTED and blocking the alter at FINISHED_REWRITING (see RCA: schema
+            // change deadlock on publish_log_version load_ids).
+            auto txn_id = txn_infos[i].txn_id();
+            auto log_version = log_versions[i];
+            ASSIGN_OR_RETURN(auto txn_logs_vector, load_txn_log(tablet_mgr, {tablet_id}, txn_infos[i]));
+            auto& txn_logs = txn_logs_vector[0];
+
+            if (txn_logs.empty()) {
+                // All per-load_id source files are missing. This is the same idempotent
+                // situation the non-load_id branch below guards against: if the target
+                // .vlog already exists treat the call as a no-op, otherwise surface
+                // NotFound so FE retries / fails the publish deterministically.
+                auto txn_vlog_path = tablet_mgr->txn_vlog_location(tablet_id, log_version);
+                ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(txn_vlog_path));
+                auto check_st = fs->path_exists(txn_vlog_path);
+                if (check_st.ok()) {
+                    continue;
+                }
+                LOG_IF(WARNING, !check_st.is_not_found())
+                        << "Fail to check the existance of " << txn_vlog_path << ": " << check_st;
+                return Status::NotFound(
+                        fmt::format("no per-load_id txn log found for tablet {} txn {} ({} load_ids checked)",
+                                    tablet_id, txn_id, txn_infos[i].load_ids_size()));
+            }
+
+            auto merged = std::make_shared<TxnLogPB>(*txn_logs[0]);
+            // The materialized .vlog spans every per-load_id source log, so the
+            // single load_id field carried over from the first source no longer applies.
+            merged->clear_load_id();
+            if (txn_logs.size() > 1) {
+                // MergeFrom appends repeated fields (segments, dels, segment_size, ...)
+                // and recursively merges optional message fields, which is what we want
+                // for the per-segment lists. But it overwrites scalar accumulators with
+                // the last source's value, so sum num_rows / data_size / num_dels back
+                // up afterwards to reflect the full transaction.
+                for (size_t k = 1; k < txn_logs.size(); ++k) {
+                    merged->MergeFrom(*txn_logs[k]);
+                }
+                merged->clear_load_id();
+                if (merged->has_op_write() && merged->op_write().has_rowset()) {
+                    auto* rowset = merged->mutable_op_write()->mutable_rowset();
+                    int64_t num_rows = 0;
+                    int64_t data_size = 0;
+                    int64_t num_dels = 0;
+                    for (const auto& log : txn_logs) {
+                        if (log->has_op_write() && log->op_write().has_rowset()) {
+                            const auto& src = log->op_write().rowset();
+                            num_rows += src.num_rows();
+                            data_size += src.data_size();
+                            num_dels += src.num_dels();
+                        }
+                    }
+                    rowset->set_num_rows(num_rows);
+                    rowset->set_data_size(data_size);
+                    rowset->set_num_dels(num_dels);
+                    rowset->set_overlapped(rowset->segments_size() > 1);
+                }
+            }
+
+            RETURN_IF_ERROR(tablet_mgr->put_txn_vlog(merged, log_version));
+
+            // Stage every per-load_id source .log for async deletion, mirroring what
+            // publish_version does for the non-shadow path on the same txn shape.
+            for (const auto& load_id : txn_infos[i].load_ids()) {
+                auto txn_log_path = tablet_mgr->txn_log_location(tablet_id, txn_id, load_id);
+                files_to_delete.emplace_back(txn_log_path);
+                tablet_mgr->metacache()->erase(txn_log_path);
+            }
+        } else if (!txn_infos[i].combined_txn_log()) {
             auto txn_id = txn_infos[i].txn_id();
             auto log_version = log_versions[i];
             auto txn_log_path = tablet_mgr->txn_log_location(tablet_id, txn_id);
@@ -578,7 +654,14 @@ void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std:
         }
     }
 
-    tablet_mgr->metacache()->erase(tablet_mgr->txn_log_location(tablet_id, txn_log.txn_id()));
+    // Multi-statement transactions cache the .log under the 4-segment key; use the
+    // same path here so the cache entry actually drops.
+    if (txn_log.has_load_id()) {
+        tablet_mgr->metacache()->erase(
+                tablet_mgr->txn_log_location(tablet_id, txn_log.txn_id(), txn_log.load_id()));
+    } else {
+        tablet_mgr->metacache()->erase(tablet_mgr->txn_log_location(tablet_id, txn_log.txn_id()));
+    }
     tablet_mgr->update_mgr()->try_remove_cache(tablet_id, txn_log.txn_id());
 }
 
@@ -594,7 +677,24 @@ void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, std::span<const Txn
             clear_remote_snapshot_async(tablet_mgr, tablet_id, txn_id, &files_to_delete);
         }
 
-        if (!txns[i].combined_txn_log()) {
+        if (txns[i].load_ids_size() > 0) {
+            // Multi-statement transaction: each statement's .log lives at the
+            // 4-segment load_id path. Walking only the 2-segment path here would
+            // silently leak per-statement .log files plus every segment / del they
+            // reference, mirroring the shape of the publish_log_version bug.
+            for (const auto& load_id : txns[i].load_ids()) {
+                auto log_path = tablet_mgr->txn_log_location(tablet_id, txn_id, load_id);
+                auto txn_log_or = tablet_mgr->get_txn_log(log_path, false);
+                if (!txn_log_or.ok()) {
+                    LOG_IF(WARNING, !txn_log_or.status().is_not_found())
+                            << "Fail to get txn log " << log_path << ": " << txn_log_or.status();
+                    continue;
+                }
+                TxnLogPtr txn_log = std::move(txn_log_or).value();
+                collect_files_in_log(tablet_mgr, *txn_log, &files_to_delete);
+                files_to_delete.emplace_back(log_path);
+            }
+        } else if (!txns[i].combined_txn_log()) {
             auto log_path = tablet_mgr->txn_log_location(tablet_id, txn_id);
             auto txn_log_or = tablet_mgr->get_txn_log(log_path, false);
             if (!txn_log_or.ok()) {

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -520,25 +520,35 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, std::sp
             // change deadlock on publish_log_version load_ids).
             auto txn_id = txn_infos[i].txn_id();
             auto log_version = log_versions[i];
+            auto expected_count = txn_infos[i].load_ids_size();
             ASSIGN_OR_RETURN(auto txn_logs_vector, load_txn_log(tablet_mgr, {tablet_id}, txn_infos[i]));
             auto& txn_logs = txn_logs_vector[0];
 
-            if (txn_logs.empty()) {
-                // All per-load_id source files are missing. This is the same idempotent
-                // situation the non-load_id branch below guards against: if the target
-                // .vlog already exists treat the call as a no-op, otherwise surface
-                // NotFound so FE retries / fails the publish deterministically.
+            if (static_cast<int>(txn_logs.size()) < expected_count) {
+                // load_txn_log silently skips per-load_id files that are NotFound, so any
+                // shortfall here means either (a) an idempotent retry where the target
+                // .vlog has already been written and (some of) the source .log files have
+                // been vacuumed, or (b) shared-storage corruption / silent data loss.
+                // Distinguish by checking the .vlog: if it already exists, accept this as
+                // the idempotent path and clean up any leftover .log files; otherwise
+                // surface NotFound so FE retries / fails the publish instead of advancing
+                // visibility with incomplete statement data.
                 auto txn_vlog_path = tablet_mgr->txn_vlog_location(tablet_id, log_version);
                 ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(txn_vlog_path));
                 auto check_st = fs->path_exists(txn_vlog_path);
                 if (check_st.ok()) {
+                    for (const auto& load_id : txn_infos[i].load_ids()) {
+                        auto stale_path = tablet_mgr->txn_log_location(tablet_id, txn_id, load_id);
+                        files_to_delete.emplace_back(stale_path);
+                        tablet_mgr->metacache()->erase(stale_path);
+                    }
                     continue;
                 }
                 LOG_IF(WARNING, !check_st.is_not_found())
                         << "Fail to check the existance of " << txn_vlog_path << ": " << check_st;
-                return Status::NotFound(
-                        fmt::format("no per-load_id txn log found for tablet {} txn {} ({} load_ids checked)",
-                                    tablet_id, txn_id, txn_infos[i].load_ids_size()));
+                return Status::NotFound(fmt::format(
+                        "incomplete per-load_id txn logs for tablet {} txn {}: loaded {} of {} expected",
+                        tablet_id, txn_id, txn_logs.size(), expected_count));
             }
 
             auto merged = std::make_shared<TxnLogPB>(*txn_logs[0]);

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -546,9 +546,9 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, std::sp
                 }
                 LOG_IF(WARNING, !check_st.is_not_found())
                         << "Fail to check the existance of " << txn_vlog_path << ": " << check_st;
-                return Status::NotFound(fmt::format(
-                        "incomplete per-load_id txn logs for tablet {} txn {}: loaded {} of {} expected",
-                        tablet_id, txn_id, txn_logs.size(), expected_count));
+                return Status::NotFound(
+                        fmt::format("incomplete per-load_id txn logs for tablet {} txn {}: loaded {} of {} expected",
+                                    tablet_id, txn_id, txn_logs.size(), expected_count));
             }
 
             auto merged = std::make_shared<TxnLogPB>(*txn_logs[0]);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2509,6 +2509,209 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
     }
 }
 
+// Regression coverage for the schema-change deadlock caused by
+// publish_log_version ignoring TxnInfoPB.load_ids: when an explicit
+// (BEGIN; INSERT; COMMIT;) transaction lands on a shadow tablet during
+// alter, each statement persists its .log at the 4-segment path that
+// encodes load_id. publish_log_version must follow load_ids to find them,
+// merge the per-statement logs into a single .vlog, and clean up the
+// sources -- otherwise FE retries forever and the alter never finishes.
+TEST_F(LakeServiceTest, test_publish_log_version_with_load_ids) {
+    auto txn_id = next_id();
+    PUniqueId load_id_1;
+    load_id_1.set_hi(0x1111111111111111LL);
+    load_id_1.set_lo(0x2222222222222222LL);
+    PUniqueId load_id_2;
+    load_id_2.set_hi(0x3333333333333333LL);
+    load_id_2.set_lo(0x4444444444444444LL);
+
+    // Two per-statement .log files for the same (tablet, txn) pair, routed to
+    // the 4-segment path via the load_id-aware put_txn_log overload.
+    {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.mutable_load_id()->CopyFrom(load_id_1);
+        log.mutable_op_write()->mutable_rowset()->set_overlapped(false);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(11);
+        log.mutable_op_write()->mutable_rowset()->set_data_size(110);
+        log.mutable_op_write()->mutable_rowset()->add_segments("stmt1_seg1.dat");
+        log.mutable_op_write()->mutable_rowset()->add_segments("stmt1_seg2.dat");
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+    }
+    {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.mutable_load_id()->CopyFrom(load_id_2);
+        log.mutable_op_write()->mutable_rowset()->set_overlapped(false);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(22);
+        log.mutable_op_write()->mutable_rowset()->set_data_size(220);
+        log.mutable_op_write()->mutable_rowset()->add_segments("stmt2_seg1.dat");
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+    }
+
+    // Sanity: the source files live at the 4-segment path, NOT the 2-segment one.
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_1)));
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_2)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id)));
+
+    const int64_t version = 20;
+    {
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_version(version);
+        auto* txn_info = request.mutable_txn_info();
+        txn_info->set_txn_id(txn_id);
+        txn_info->set_combined_txn_log(false);
+        txn_info->set_txn_type(TXN_NORMAL);
+        txn_info->set_commit_time(::time(nullptr));
+        txn_info->add_load_ids()->CopyFrom(load_id_1);
+        txn_info->add_load_ids()->CopyFrom(load_id_2);
+
+        brpc::Controller cntl;
+        _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(0, response.failed_tablets_size());
+    }
+
+    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+
+    // The materialized .vlog must exist and contain the merged segments and
+    // accumulated counters across both statements.
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, version)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_1)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_2)));
+
+    _tablet_mgr->prune_metacache();
+    ASSIGN_OR_ABORT(auto vlog, _tablet_mgr->get_txn_vlog(_tablet_id, version));
+    ASSERT_EQ(_tablet_id, vlog->tablet_id());
+    ASSERT_EQ(txn_id, vlog->txn_id());
+    EXPECT_FALSE(vlog->has_load_id());
+    ASSERT_TRUE(vlog->has_op_write());
+    ASSERT_TRUE(vlog->op_write().has_rowset());
+    const auto& rowset = vlog->op_write().rowset();
+    EXPECT_EQ(33, rowset.num_rows());
+    EXPECT_EQ(330, rowset.data_size());
+    ASSERT_EQ(3, rowset.segments_size());
+    EXPECT_EQ("stmt1_seg1.dat", rowset.segments(0));
+    EXPECT_EQ("stmt1_seg2.dat", rowset.segments(1));
+    EXPECT_EQ("stmt2_seg1.dat", rowset.segments(2));
+    EXPECT_TRUE(rowset.overlapped());
+
+    // Replaying the same request after the sources have been deleted should be a
+    // no-op (FE retries should not see spurious failures).
+    {
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_version(version);
+        auto* txn_info = request.mutable_txn_info();
+        txn_info->set_txn_id(txn_id);
+        txn_info->set_combined_txn_log(false);
+        txn_info->set_txn_type(TXN_NORMAL);
+        txn_info->set_commit_time(::time(nullptr));
+        txn_info->add_load_ids()->CopyFrom(load_id_1);
+        txn_info->add_load_ids()->CopyFrom(load_id_2);
+
+        brpc::Controller cntl;
+        _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(0, response.failed_tablets_size());
+    }
+
+    // Calling for a fresh version where no source .log files ever existed
+    // should report failure cleanly (NotFound surfaced to FE).
+    {
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_version(version + 1);
+        auto* txn_info = request.mutable_txn_info();
+        txn_info->set_txn_id(next_id());
+        txn_info->set_combined_txn_log(false);
+        txn_info->set_txn_type(TXN_NORMAL);
+        txn_info->set_commit_time(::time(nullptr));
+        txn_info->add_load_ids()->CopyFrom(load_id_1);
+
+        brpc::Controller cntl;
+        _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+    }
+}
+
+// abort_txn shares the same load_ids anti-pattern as publish_log_version:
+// without walking the 4-segment paths it silently leaks the per-statement
+// .log files plus every segment they reference into shared storage.
+TEST_F(LakeServiceTest, test_abort_with_load_ids) {
+    auto txn_id = next_id();
+    PUniqueId load_id_1;
+    load_id_1.set_hi(0xAAAA000000000001LL);
+    load_id_1.set_lo(0xBBBB000000000001LL);
+    PUniqueId load_id_2;
+    load_id_2.set_hi(0xAAAA000000000002LL);
+    load_id_2.set_lo(0xBBBB000000000002LL);
+
+    std::string seg_a = generate_segment_file(txn_id);
+    std::string seg_b = generate_segment_file(txn_id);
+    std::string seg_c = generate_segment_file(txn_id);
+
+    {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.mutable_load_id()->CopyFrom(load_id_1);
+        log.mutable_op_write()->mutable_rowset()->add_segments(seg_a);
+        log.mutable_op_write()->mutable_rowset()->add_segments(seg_b);
+        log.mutable_op_write()->mutable_rowset()->set_data_size(4096);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(101);
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+    }
+    {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.mutable_load_id()->CopyFrom(load_id_2);
+        log.mutable_op_write()->mutable_rowset()->add_segments(seg_c);
+        log.mutable_op_write()->mutable_rowset()->set_data_size(2048);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(50);
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+    }
+
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, seg_a)));
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, seg_b)));
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, seg_c)));
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_1)));
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_2)));
+
+    AbortTxnRequest request;
+    request.add_tablet_ids(_tablet_id);
+    request.set_skip_cleanup(false);
+    auto* txn_info = request.add_txn_infos();
+    txn_info->set_txn_id(txn_id);
+    txn_info->set_combined_txn_log(false);
+    txn_info->set_txn_type(TXN_NORMAL);
+    txn_info->set_commit_time(::time(nullptr));
+    txn_info->add_load_ids()->CopyFrom(load_id_1);
+    txn_info->add_load_ids()->CopyFrom(load_id_2);
+
+    AbortTxnResponse response;
+    _lake_service.abort_txn(nullptr, &request, &response, nullptr);
+
+    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+
+    // Every per-load_id .log file and every segment they referenced must be
+    // gone -- nothing should be left in shared storage from this txn.
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_1)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_2)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, seg_a)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, seg_b)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, seg_c)));
+}
+
 TEST_F(LakeServiceTest, test_publish_log_version_batch) {
     {
         TxnLog txnlog;

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2643,6 +2643,103 @@ TEST_F(LakeServiceTest, test_publish_log_version_with_load_ids) {
     }
 }
 
+// Partial per-load_id .log sets must NOT silently produce a .vlog from
+// incomplete data -- load_txn_log skips NotFound files, so a corruption /
+// lost-file scenario would otherwise let FE advance visibleVersion with
+// dropped statement data. publish_log_version must require every expected
+// per-load_id file (or fall back to an existing .vlog for idempotent retry).
+TEST_F(LakeServiceTest, test_publish_log_version_with_load_ids_partial) {
+    auto txn_id = next_id();
+    PUniqueId load_id_1;
+    load_id_1.set_hi(0x5555555555555551LL);
+    load_id_1.set_lo(0x6666666666666661LL);
+    PUniqueId load_id_2;
+    load_id_2.set_hi(0x5555555555555552LL);
+    load_id_2.set_lo(0x6666666666666662LL);
+
+    // Write only ONE of the two per-statement .log files -- simulate the
+    // case where one statement's flush is lost / the file vanished.
+    {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.mutable_load_id()->CopyFrom(load_id_1);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(7);
+        log.mutable_op_write()->mutable_rowset()->set_data_size(70);
+        log.mutable_op_write()->mutable_rowset()->add_segments("partial_seg.dat");
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+    }
+
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_1)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_2)));
+
+    const int64_t version = 30;
+
+    // Without an existing .vlog, the partial set must fail loudly. The
+    // failing tablet ends up in failed_tablets and crucially NO .vlog gets
+    // written (otherwise a later retry would silently treat this as success).
+    {
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_version(version);
+        auto* txn_info = request.mutable_txn_info();
+        txn_info->set_txn_id(txn_id);
+        txn_info->set_combined_txn_log(false);
+        txn_info->set_txn_type(TXN_NORMAL);
+        txn_info->set_commit_time(::time(nullptr));
+        txn_info->add_load_ids()->CopyFrom(load_id_1);
+        txn_info->add_load_ids()->CopyFrom(load_id_2);
+
+        brpc::Controller cntl;
+        _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, version)));
+        // The single source .log must remain so the operator can recover.
+        EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_1)));
+    }
+
+    // If the target .vlog already exists (a previous successful publish), a
+    // partial source set must be treated as an idempotent retry: succeed and
+    // sweep up the orphan .log so it doesn't linger until vacuum.
+    {
+        // Hand-craft a .vlog at the target path to simulate a prior success.
+        auto vlog = std::make_shared<TxnLog>();
+        vlog->set_tablet_id(_tablet_id);
+        vlog->set_txn_id(txn_id);
+        vlog->mutable_op_write()->mutable_rowset()->set_num_rows(99);
+        vlog->mutable_op_write()->mutable_rowset()->set_data_size(990);
+        vlog->mutable_op_write()->mutable_rowset()->add_segments("already_published.dat");
+        ASSERT_OK(_tablet_mgr->put_txn_vlog(vlog, version));
+        EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, version)));
+
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_version(version);
+        auto* txn_info = request.mutable_txn_info();
+        txn_info->set_txn_id(txn_id);
+        txn_info->set_combined_txn_log(false);
+        txn_info->set_txn_type(TXN_NORMAL);
+        txn_info->set_commit_time(::time(nullptr));
+        txn_info->add_load_ids()->CopyFrom(load_id_1);
+        txn_info->add_load_ids()->CopyFrom(load_id_2);
+
+        brpc::Controller cntl;
+        _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(0, response.failed_tablets_size());
+
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        // The pre-existing .vlog stays intact and the stale .log is cleaned.
+        EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, version)));
+        EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id, load_id_1)));
+    }
+}
+
 // abort_txn shares the same load_ids anti-pattern as publish_log_version:
 // without walking the 4-segment paths it silently leaks the per-statement
 // .log files plus every segment they reference into shared storage.

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2740,6 +2740,124 @@ TEST_F(LakeServiceTest, test_publish_log_version_with_load_ids_partial) {
     }
 }
 
+// MergeFrom on the merged op_write must accumulate every parallel repeated
+// field (segments / segment_size / segment_encryption_metas / dels /
+// del_encryption_metas) and sum the scalar accumulators across all
+// per-load_id source logs. A regression here would silently strip dels or
+// encryption metadata from the materialized .vlog, leaving later reads
+// unable to decrypt segments or apply tombstones.
+TEST_F(LakeServiceTest, test_publish_log_version_merge_repeated_fields) {
+    auto txn_id = next_id();
+    PUniqueId load_id_1;
+    load_id_1.set_hi(0xCAFE000000000001LL);
+    load_id_1.set_lo(0xBABE000000000001LL);
+    PUniqueId load_id_2;
+    load_id_2.set_hi(0xCAFE000000000002LL);
+    load_id_2.set_lo(0xBABE000000000002LL);
+
+    {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.mutable_load_id()->CopyFrom(load_id_1);
+        auto* op_write = log.mutable_op_write();
+        auto* rs = op_write->mutable_rowset();
+        rs->add_segments("a1.dat");
+        rs->add_segments("a2.dat");
+        rs->add_segment_size(100);
+        rs->add_segment_size(200);
+        rs->add_segment_encryption_metas("enc_a1");
+        rs->add_segment_encryption_metas("enc_a2");
+        rs->set_num_rows(10);
+        rs->set_data_size(300);
+        rs->set_num_dels(2);
+        op_write->add_dels("del_a1");
+        op_write->add_dels("del_a2");
+        op_write->add_del_encryption_metas("denc_a1");
+        op_write->add_del_encryption_metas("denc_a2");
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+    }
+    {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.mutable_load_id()->CopyFrom(load_id_2);
+        auto* op_write = log.mutable_op_write();
+        auto* rs = op_write->mutable_rowset();
+        rs->add_segments("b1.dat");
+        rs->add_segment_size(500);
+        rs->add_segment_encryption_metas("enc_b1");
+        rs->set_num_rows(20);
+        rs->set_data_size(500);
+        rs->set_num_dels(3);
+        op_write->add_dels("del_b1");
+        op_write->add_del_encryption_metas("denc_b1");
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+    }
+
+    const int64_t version = 40;
+    {
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_version(version);
+        auto* txn_info = request.mutable_txn_info();
+        txn_info->set_txn_id(txn_id);
+        txn_info->set_combined_txn_log(false);
+        txn_info->set_txn_type(TXN_NORMAL);
+        txn_info->set_commit_time(::time(nullptr));
+        txn_info->add_load_ids()->CopyFrom(load_id_1);
+        txn_info->add_load_ids()->CopyFrom(load_id_2);
+
+        brpc::Controller cntl;
+        _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(0, response.failed_tablets_size());
+    }
+
+    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    _tablet_mgr->prune_metacache();
+
+    ASSIGN_OR_ABORT(auto vlog, _tablet_mgr->get_txn_vlog(_tablet_id, version));
+    ASSERT_TRUE(vlog->has_op_write());
+    const auto& ow = vlog->op_write();
+    ASSERT_TRUE(ow.has_rowset());
+    const auto& rs = ow.rowset();
+
+    // Scalar accumulators are summed across both sources, not left as the
+    // last log's value (which is what protobuf MergeFrom would leave behind).
+    EXPECT_EQ(30, rs.num_rows());
+    EXPECT_EQ(800, rs.data_size());
+    EXPECT_EQ(5, rs.num_dels());
+    EXPECT_TRUE(rs.overlapped());
+
+    // Repeated parallel arrays inside rowset are appended in source order.
+    ASSERT_EQ(3, rs.segments_size());
+    EXPECT_EQ("a1.dat", rs.segments(0));
+    EXPECT_EQ("a2.dat", rs.segments(1));
+    EXPECT_EQ("b1.dat", rs.segments(2));
+    ASSERT_EQ(3, rs.segment_size_size());
+    EXPECT_EQ(100u, rs.segment_size(0));
+    EXPECT_EQ(200u, rs.segment_size(1));
+    EXPECT_EQ(500u, rs.segment_size(2));
+    ASSERT_EQ(3, rs.segment_encryption_metas_size());
+    EXPECT_EQ("enc_a1", rs.segment_encryption_metas(0));
+    EXPECT_EQ("enc_a2", rs.segment_encryption_metas(1));
+    EXPECT_EQ("enc_b1", rs.segment_encryption_metas(2));
+
+    // dels / del_encryption_metas live directly on op_write (not on rowset)
+    // and must also accumulate, otherwise tombstones from later statements
+    // would be silently dropped from the materialized .vlog.
+    ASSERT_EQ(3, ow.dels_size());
+    EXPECT_EQ("del_a1", ow.dels(0));
+    EXPECT_EQ("del_a2", ow.dels(1));
+    EXPECT_EQ("del_b1", ow.dels(2));
+    ASSERT_EQ(3, ow.del_encryption_metas_size());
+    EXPECT_EQ("denc_a1", ow.del_encryption_metas(0));
+    EXPECT_EQ("denc_a2", ow.del_encryption_metas(1));
+    EXPECT_EQ("denc_b1", ow.del_encryption_metas(2));
+}
+
 // abort_txn shares the same load_ids anti-pattern as publish_log_version:
 // without walking the 4-segment paths it silently leaks the per-statement
 // .log files plus every segment they reference into shared storage.
@@ -2978,6 +3096,118 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
             }
         }
     }
+}
+
+// publish_log_version_batch must dispatch each TxnInfoPB's branch
+// independently: load_ids txns merge from the 4-segment path while
+// non-load_ids txns keep using the legacy 2-segment copy_file path. A
+// regression in either branch selection would either deadlock alter for
+// multi-statement txns or break ordinary single-statement loads in the
+// same batch.
+TEST_F(LakeServiceTest, test_publish_log_version_batch_with_load_ids) {
+    auto txn_with_loads = next_id();
+    auto txn_no_loads = next_id();
+    PUniqueId load_id_1;
+    load_id_1.set_hi(0xFADE000000000001LL);
+    load_id_1.set_lo(0xCEDE000000000001LL);
+    PUniqueId load_id_2;
+    load_id_2.set_hi(0xFADE000000000002LL);
+    load_id_2.set_lo(0xCEDE000000000002LL);
+
+    // Multi-statement txn -> two 4-segment .log files for the same (tablet, txn).
+    {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_with_loads);
+        log.mutable_load_id()->CopyFrom(load_id_1);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(3);
+        log.mutable_op_write()->mutable_rowset()->set_data_size(30);
+        log.mutable_op_write()->mutable_rowset()->add_segments("batch_a.dat");
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+    }
+    {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_with_loads);
+        log.mutable_load_id()->CopyFrom(load_id_2);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(5);
+        log.mutable_op_write()->mutable_rowset()->set_data_size(50);
+        log.mutable_op_write()->mutable_rowset()->add_segments("batch_b.dat");
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+    }
+    // Single-statement txn -> one 2-segment .log file (no load_id set).
+    {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_no_loads);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(7);
+        log.mutable_op_write()->mutable_rowset()->set_data_size(70);
+        log.mutable_op_write()->mutable_rowset()->add_segments("batch_c.dat");
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+    }
+
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_with_loads, load_id_1)));
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_with_loads, load_id_2)));
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_no_loads)));
+
+    const int64_t version_a = 50;
+    const int64_t version_b = 51;
+    {
+        PublishLogVersionBatchRequest request;
+        PublishLogVersionResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.add_versions(version_a);
+        request.add_versions(version_b);
+
+        auto* info_a = request.add_txn_infos();
+        info_a->set_txn_id(txn_with_loads);
+        info_a->set_combined_txn_log(false);
+        info_a->set_txn_type(TXN_NORMAL);
+        info_a->set_commit_time(::time(nullptr));
+        info_a->add_load_ids()->CopyFrom(load_id_1);
+        info_a->add_load_ids()->CopyFrom(load_id_2);
+
+        auto* info_b = request.add_txn_infos();
+        info_b->set_txn_id(txn_no_loads);
+        info_b->set_combined_txn_log(false);
+        info_b->set_txn_type(TXN_NORMAL);
+        info_b->set_commit_time(::time(nullptr));
+
+        brpc::Controller cntl;
+        _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(0, response.failed_tablets_size());
+    }
+
+    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+
+    // Both .vlogs land; every source .log -- 4-segment for the multi-statement
+    // txn, 2-segment for the single one -- is cleaned up by its own branch.
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, version_a)));
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, version_b)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_with_loads, load_id_1)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_with_loads, load_id_2)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_no_loads)));
+
+    _tablet_mgr->prune_metacache();
+
+    // load_ids txn: merged rowset has both statements' rows and segments.
+    ASSIGN_OR_ABORT(auto vlog_a, _tablet_mgr->get_txn_vlog(_tablet_id, version_a));
+    EXPECT_FALSE(vlog_a->has_load_id());
+    ASSERT_TRUE(vlog_a->has_op_write());
+    ASSERT_TRUE(vlog_a->op_write().has_rowset());
+    EXPECT_EQ(8, vlog_a->op_write().rowset().num_rows());
+    EXPECT_EQ(80, vlog_a->op_write().rowset().data_size());
+    ASSERT_EQ(2, vlog_a->op_write().rowset().segments_size());
+
+    // Non-load_ids txn: straight copy of the source TxnLog, no merge involved.
+    ASSIGN_OR_ABORT(auto vlog_b, _tablet_mgr->get_txn_vlog(_tablet_id, version_b));
+    ASSERT_TRUE(vlog_b->has_op_write());
+    ASSERT_TRUE(vlog_b->op_write().has_rowset());
+    EXPECT_EQ(7, vlog_b->op_write().rowset().num_rows());
+    EXPECT_EQ(70, vlog_b->op_write().rowset().data_size());
+    ASSERT_EQ(1, vlog_b->op_write().rowset().segments_size());
+    EXPECT_EQ("batch_c.dat", vlog_b->op_write().rowset().segments(0));
 }
 
 TEST_F(LakeServiceTest, test_publish_version_empty_txn_log) {


### PR DESCRIPTION



## Why I'm doing:
publish_log_version() only handled the 2-segment and combined_txn_log paths, ignoring TxnInfoPB.load_ids. During Schema Change, an explicit transaction (BEGIN; INSERT ...; COMMIT;) double-writes to shadow tablets via delta_writer with load_id set, so each statement's .log file lands at the 4-segment path (tablet_txn_loadHi_loadLo.log). BE looked at the 2-segment path, returned NotFound, and FE's publishPartition treated it as a hard failure -- the transaction stayed COMMITTED, visibleVersion was frozen, and Schema Change deadlocked at FINISHED_REWRITING (CANCEL ALTER is rejected in that state).

## What I'm doing:

This change adds the missing load_ids branch:

- publish_log_version: read every per-load_id .log via load_txn_log, merge them into one TxnLogPB (protobuf MergeFrom for repeated fields + manual sum for num_rows/data_size/num_dels accumulators), persist as the version-keyed .vlog, and stage the source .log files for deletion. An empty result falls back to the same idempotent .vlog-exists check as the non-load_id branch.

- abort_txn shares the same anti-pattern -- without walking load_ids it leaks the per-statement .log files plus every segment they reference into shared storage. Add the same branch so aborts clean up correctly.

- collect_files_in_log used the 2-segment path to erase the metacache entry even when the TxnLog was loaded from the 4-segment path, leaving a stale cache entry. Use the load_id-aware path when has_load_id() is true.

Adds regression coverage for both publish_log_version and abort_txn with load_ids set (merged .vlog contents, idempotent re-publish, NotFound on fresh version, full segment cleanup on abort).


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
