### PR TITLE
[Enhancement] Mask UDF file paths in SHOW FUNCTIONS

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -39,10 +39,14 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Writable;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.sql.ast.CreateFunctionStmt;
 import com.starrocks.sql.ast.HdfsURI;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.common.TypeManager;
@@ -69,6 +73,8 @@ import java.util.stream.Collectors;
  * Base class for all functions.
  */
 public class Function implements Writable {
+    private static final String MASKED_LOCATION = "***";
+
     // Enum for how to compare function signatures.
     // For decimal types, the type in the function can be a wildcard, i.e. decimal(*,*).
     // The wildcard can *only* exist as function type, the caller will always be a
@@ -887,7 +893,35 @@ public class Function implements Writable {
         return "";
     }
 
+    public String getProperties(boolean hideLocation) {
+        if (!hideLocation) {
+            return getProperties();
+        }
+
+        String properties = getProperties();
+        if (properties == null || properties.isEmpty()) {
+            return properties;
+        }
+
+        try {
+            JsonObject propertyObject = JsonParser.parseString(properties).getAsJsonObject();
+            if (propertyObject.has(CreateFunctionStmt.FILE_KEY)) {
+                propertyObject.addProperty(CreateFunctionStmt.FILE_KEY, MASKED_LOCATION);
+            }
+            if (propertyObject.has("object_file")) {
+                propertyObject.addProperty("object_file", MASKED_LOCATION);
+            }
+            return new Gson().toJson(propertyObject);
+        } catch (RuntimeException e) {
+            return properties;
+        }
+    }
+
     public List<Comparable> getInfo(boolean isVerbose) {
+        return getInfo(isVerbose, false);
+    }
+
+    public List<Comparable> getInfo(boolean isVerbose, boolean hideLocation) {
         List<Comparable> row = Lists.newArrayList();
         if (isVerbose) {
             // signature
@@ -917,7 +951,7 @@ public class Function implements Writable {
                 row.add("NULL");
             }
             // property
-            row.add(getProperties());
+            row.add(getProperties(hideLocation));
         } else {
             row.add(functionName());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1147,37 +1147,47 @@ public class ShowExecutor {
         @Override
         public ShowResultSet visitShowFunctionsStatement(ShowFunctionsStmt statement, ConnectContext context) {
             List<Function> functions;
+            boolean canShowFullAddress = false;
+            String dbName = statement.getDbName();
             if (statement.getIsBuiltin()) {
                 functions = context.getGlobalStateMgr().getBuiltinFunctions();
             } else if (statement.getIsGlobal()) {
                 functions = context.getGlobalStateMgr().getGlobalFunctionMgr().getFunctions();
+                canShowFullAddress = canShowFullGlobalFunctionAddress(context);
             } else {
-                Database db = context.getGlobalStateMgr().getLocalMetastore().getDb(statement.getDbName());
-                MetaUtils.checkDbNullAndReport(db, statement.getDbName());
+                Database db = context.getGlobalStateMgr().getLocalMetastore().getDb(dbName);
+                MetaUtils.checkDbNullAndReport(db, dbName);
+                dbName = db.getFullName();
                 functions = db.getFunctions();
+                canShowFullAddress = canShowFullFunctionAddress(context, dbName);
             }
 
             List<List<Comparable>> rowSet = Lists.newArrayList();
             for (Function function : functions) {
-                List<Comparable> row = function.getInfo(statement.getIsVerbose());
                 // like predicate
                 if (statement.getWild() == null || statement.like(function.functionName())) {
+                    boolean hideFunctionAddress = false;
                     if (statement.getIsGlobal()) {
-                        try {
-                            Authorizer.checkAnyActionOnGlobalFunction(context, function);
-                        } catch (AccessDeniedException e) {
-                            continue;
+                        if (!canShowFullAddress) {
+                            try {
+                                Authorizer.checkAnyActionOnGlobalFunction(context, function);
+                            } catch (AccessDeniedException e) {
+                                continue;
+                            }
+                            hideFunctionAddress = true;
                         }
                     } else if (!statement.getIsBuiltin()) {
-                        Database db = context.getGlobalStateMgr().getLocalMetastore().getDb(statement.getDbName());
-                        try {
-                            Authorizer.checkAnyActionOnFunction(context, db.getFullName(), function);
-                        } catch (AccessDeniedException e) {
-                            continue;
+                        if (!canShowFullAddress) {
+                            try {
+                                Authorizer.checkAnyActionOnFunction(context, dbName, function);
+                            } catch (AccessDeniedException e) {
+                                continue;
+                            }
+                            hideFunctionAddress = true;
                         }
                     }
 
-                    rowSet.add(row);
+                    rowSet.add(function.getInfo(statement.getIsVerbose(), hideFunctionAddress));
                 }
             }
 
@@ -1207,6 +1217,25 @@ public class ShowExecutor {
                     ShowResultSetMetaData.builder()
                             .addColumn(new Column("Function Name", TypeFactory.createVarcharType(256))).build();
             return new ShowResultSet(showMetaData, resultRowSet);
+        }
+
+        private boolean canShowFullFunctionAddress(ConnectContext context, String dbName) {
+            try {
+                Authorizer.checkDbAction(context, InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName,
+                        PrivilegeType.CREATE_FUNCTION);
+                return true;
+            } catch (AccessDeniedException e) {
+                return false;
+            }
+        }
+
+        private boolean canShowFullGlobalFunctionAddress(ConnectContext context) {
+            try {
+                Authorizer.checkSystemAction(context, PrivilegeType.CREATE_GLOBAL_FUNCTION);
+                return true;
+            } catch (AccessDeniedException e) {
+                return false;
+            }
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RBACExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RBACExecutorTest.java
@@ -239,6 +239,11 @@ public class RBACExecutorTest {
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         Assertions.assertEquals("[[my_udf_json_get]]", resultSet.getResultRows().toString());
 
+        stmt = new ShowFunctionsStmt("db", false, false, true, null, null);
+        resultSet = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals(1, resultSet.getResultRows().size());
+        Assertions.assertTrue(resultSet.getResultRows().get(0).get(4).contains("\"file\":\"objectFile\""));
+
         ctx.setCurrentUserIdentity(new UserIdentity("u1", "%"));
         stmt = new ShowFunctionsStmt("db", false, false, false, null, null);
         resultSet = ShowExecutor.execute(stmt, ctx);
@@ -249,6 +254,61 @@ public class RBACExecutorTest {
         stmt = new ShowFunctionsStmt("db", false, false, false, null, null);
         resultSet = ShowExecutor.execute(stmt, ctx);
         Assertions.assertEquals("[[my_udf_json_get]]", resultSet.getResultRows().toString());
+
+        stmt = new ShowFunctionsStmt("db", false, false, true, null, null);
+        resultSet = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals(1, resultSet.getResultRows().size());
+        Assertions.assertTrue(resultSet.getResultRows().get(0).get(4).contains("\"file\":\"***\""));
+        Assertions.assertFalse(resultSet.getResultRows().get(0).get(4).contains("objectFile"));
+
+        ctx.setCurrentUserIdentity(new UserIdentity("u2", "%"));
+        stmt = new ShowFunctionsStmt("db", false, false, true, null, null);
+        resultSet = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals("[]", resultSet.getResultRows().toString());
+
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "grant CREATE FUNCTION on DATABASE db to u2", ctx), ctx);
+        stmt = new ShowFunctionsStmt("db", false, false, true, null, null);
+        resultSet = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals(1, resultSet.getResultRows().size());
+        Assertions.assertTrue(resultSet.getResultRows().get(0).get(4).contains("\"file\":\"objectFile\""));
+
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        String createGlobalSql = "CREATE GLOBAL FUNCTION GLOBAL_UDF_JSON_GET(int) RETURNS int " +
+                "properties ( " +
+                "'symbol' = 'com.starrocks.udf.sample.UDFSplit', 'object_file' = 'test' " +
+                ")";
+        CreateFunctionStmt globalStatement =
+                (CreateFunctionStmt) UtFrameUtils.parseStmtWithNewParser(createGlobalSql, ctx);
+        FunctionName globalFunctionName = FunctionName.createFnName("GLOBAL_UDF_JSON_GET");
+        globalFunctionName.setAsGlobalFunction();
+        Function globalFunction = ScalarFunction.createUdf(globalFunctionName, arg, IntegerType.INT,
+                false, TFunctionBinaryType.SRJAR,
+                "globalObjectFile", "globalMainClass.getCanonicalName()", "", "", null);
+        globalFunction.setChecksum("checksum");
+        globalStatement.setFunction(globalFunction);
+        DDLStmtExecutor.execute(globalStatement, ctx);
+
+        ctx.setCurrentUserIdentity(new UserIdentity("u3", "%"));
+        stmt = new ShowFunctionsStmt(null, false, true, true, null, null);
+        resultSet = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals("[]", resultSet.getResultRows().toString());
+
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "grant usage on global function global_udf_json_get(int) to u3", ctx), ctx);
+        stmt = new ShowFunctionsStmt(null, false, true, true, null, null);
+        resultSet = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals(1, resultSet.getResultRows().size());
+        Assertions.assertTrue(resultSet.getResultRows().get(0).get(4).contains("\"file\":\"***\""));
+        Assertions.assertFalse(resultSet.getResultRows().get(0).get(4).contains("globalObjectFile"));
+
+        ctx.setCurrentUserIdentity(new UserIdentity("u4", "%"));
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "grant CREATE GLOBAL FUNCTION on system to u4", ctx), ctx);
+        stmt = new ShowFunctionsStmt(null, false, true, true, null, null);
+        resultSet = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertEquals(1, resultSet.getResultRows().size());
+        Assertions.assertTrue(resultSet.getResultRows().get(0).get(4).contains("\"file\":\"globalObjectFile\""));
 
         stmt = new ShowFunctionsStmt("db", true, false, false, null, null);
         resultSet = ShowExecutor.execute(stmt, ctx);

--- a/test/sql/test_udf/R/test_show_udf_address_privilege
+++ b/test/sql/test_udf/R/test_show_udf_address_privilege
@@ -1,0 +1,153 @@
+-- name: test_show_udf_address_privilege @no_arrow_flight_sql
+create database db_udf_priv_${uuid0};
+-- result:
+-- !result
+use db_udf_priv_${uuid0};
+-- result:
+-- !result
+drop user if exists u_udf_usage_${uuid0};
+-- result:
+-- !result
+drop user if exists u_udf_create_${uuid0};
+-- result:
+-- !result
+drop user if exists u_global_drop_${uuid0};
+-- result:
+-- !result
+drop user if exists u_global_create_${uuid0};
+-- result:
+-- !result
+create user u_udf_usage_${uuid0};
+-- result:
+-- !result
+create user u_udf_create_${uuid0};
+-- result:
+-- !result
+create user u_global_drop_${uuid0};
+-- result:
+-- !result
+create user u_global_create_${uuid0};
+-- result:
+-- !result
+grant impersonate on user root to u_udf_usage_${uuid0};
+-- result:
+-- !result
+grant impersonate on user root to u_udf_create_${uuid0};
+-- result:
+-- !result
+grant impersonate on user root to u_global_drop_${uuid0};
+-- result:
+-- !result
+grant impersonate on user root to u_global_create_${uuid0};
+-- result:
+-- !result
+CREATE FUNCTION udf_priv_echo_${uuid0}(int)
+RETURNS int
+symbol = "Echoint"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc/udf.jar";
+-- result:
+-- !result
+CREATE GLOBAL FUNCTION global_udf_priv_echo_${uuid0}(int)
+RETURNS int
+symbol = "Echoint"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc/udf.jar";
+-- result:
+-- !result
+show full functions from db_udf_priv_${uuid0} like 'udf_priv_echo_${uuid0}';
+-- result:
+[REGEX]udf_priv_echo_[0-9a-f]+\(INT\)\tINT\tScalar\tNULL\t.*"file":"[^"]*starrocks-jdbc/udf.jar".*
+-- !result
+show full global functions like 'global_udf_priv_echo_${uuid0}';
+-- result:
+[REGEX]global_udf_priv_echo_[0-9a-f]+\(INT\)\tINT\tScalar\tNULL\t.*"file":"[^"]*starrocks-jdbc/udf.jar".*
+-- !result
+execute as u_udf_usage_${uuid0} with no revert;
+-- result:
+-- !result
+show full functions from db_udf_priv_${uuid0} like 'udf_priv_echo_${uuid0}';
+-- result:
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+grant usage on function db_udf_priv_${uuid0}.udf_priv_echo_${uuid0}(int) to u_udf_usage_${uuid0};
+-- result:
+-- !result
+grant create function on database db_udf_priv_${uuid0} to u_udf_create_${uuid0};
+-- result:
+-- !result
+execute as u_udf_usage_${uuid0} with no revert;
+-- result:
+-- !result
+show full functions from db_udf_priv_${uuid0} like 'udf_priv_echo_${uuid0}';
+-- result:
+[REGEX]udf_priv_echo_[0-9a-f]+\(INT\)\tINT\tScalar\tNULL\t.*"file":"\*\*\*".*
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+execute as u_udf_create_${uuid0} with no revert;
+-- result:
+-- !result
+show full functions from db_udf_priv_${uuid0} like 'udf_priv_echo_${uuid0}';
+-- result:
+[REGEX]udf_priv_echo_[0-9a-f]+\(INT\)\tINT\tScalar\tNULL\t.*"file":"[^"]*starrocks-jdbc/udf.jar".*
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+execute as u_global_drop_${uuid0} with no revert;
+-- result:
+-- !result
+show full global functions like 'global_udf_priv_echo_${uuid0}';
+-- result:
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+grant drop on global function global_udf_priv_echo_${uuid0}(int) to u_global_drop_${uuid0};
+-- result:
+-- !result
+grant create global function on system to u_global_create_${uuid0};
+-- result:
+-- !result
+execute as u_global_drop_${uuid0} with no revert;
+-- result:
+-- !result
+show full global functions like 'global_udf_priv_echo_${uuid0}';
+-- result:
+[REGEX]global_udf_priv_echo_[0-9a-f]+\(INT\)\tINT\tScalar\tNULL\t.*"file":"\*\*\*".*
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+execute as u_global_create_${uuid0} with no revert;
+-- result:
+-- !result
+show full global functions like 'global_udf_priv_echo_${uuid0}';
+-- result:
+[REGEX]global_udf_priv_echo_[0-9a-f]+\(INT\)\tINT\tScalar\tNULL\t.*"file":"[^"]*starrocks-jdbc/udf.jar".*
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+drop global function global_udf_priv_echo_${uuid0}(int);
+-- result:
+-- !result
+drop database db_udf_priv_${uuid0} force;
+-- result:
+-- !result
+drop user u_udf_usage_${uuid0};
+-- result:
+-- !result
+drop user u_udf_create_${uuid0};
+-- result:
+-- !result
+drop user u_global_drop_${uuid0};
+-- result:
+-- !result
+drop user u_global_create_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_udf/T/test_show_udf_address_privilege
+++ b/test/sql/test_udf/T/test_show_udf_address_privilege
@@ -1,0 +1,70 @@
+-- name: test_show_udf_address_privilege @no_arrow_flight_sql
+create database db_udf_priv_${uuid0};
+use db_udf_priv_${uuid0};
+
+drop user if exists u_udf_usage_${uuid0};
+drop user if exists u_udf_create_${uuid0};
+drop user if exists u_global_drop_${uuid0};
+drop user if exists u_global_create_${uuid0};
+
+create user u_udf_usage_${uuid0};
+create user u_udf_create_${uuid0};
+create user u_global_drop_${uuid0};
+create user u_global_create_${uuid0};
+
+grant impersonate on user root to u_udf_usage_${uuid0};
+grant impersonate on user root to u_udf_create_${uuid0};
+grant impersonate on user root to u_global_drop_${uuid0};
+grant impersonate on user root to u_global_create_${uuid0};
+
+CREATE FUNCTION udf_priv_echo_${uuid0}(int)
+RETURNS int
+symbol = "Echoint"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc/udf.jar";
+
+CREATE GLOBAL FUNCTION global_udf_priv_echo_${uuid0}(int)
+RETURNS int
+symbol = "Echoint"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc/udf.jar";
+
+show full functions from db_udf_priv_${uuid0} like 'udf_priv_echo_${uuid0}';
+show full global functions like 'global_udf_priv_echo_${uuid0}';
+
+execute as u_udf_usage_${uuid0} with no revert;
+show full functions from db_udf_priv_${uuid0} like 'udf_priv_echo_${uuid0}';
+
+execute as root with no revert;
+grant usage on function db_udf_priv_${uuid0}.udf_priv_echo_${uuid0}(int) to u_udf_usage_${uuid0};
+grant create function on database db_udf_priv_${uuid0} to u_udf_create_${uuid0};
+
+execute as u_udf_usage_${uuid0} with no revert;
+show full functions from db_udf_priv_${uuid0} like 'udf_priv_echo_${uuid0}';
+
+execute as root with no revert;
+execute as u_udf_create_${uuid0} with no revert;
+show full functions from db_udf_priv_${uuid0} like 'udf_priv_echo_${uuid0}';
+
+execute as root with no revert;
+execute as u_global_drop_${uuid0} with no revert;
+show full global functions like 'global_udf_priv_echo_${uuid0}';
+
+execute as root with no revert;
+grant drop on global function global_udf_priv_echo_${uuid0}(int) to u_global_drop_${uuid0};
+grant create global function on system to u_global_create_${uuid0};
+
+execute as u_global_drop_${uuid0} with no revert;
+show full global functions like 'global_udf_priv_echo_${uuid0}';
+
+execute as root with no revert;
+execute as u_global_create_${uuid0} with no revert;
+show full global functions like 'global_udf_priv_echo_${uuid0}';
+
+execute as root with no revert;
+drop global function global_udf_priv_echo_${uuid0}(int);
+drop database db_udf_priv_${uuid0} force;
+drop user u_udf_usage_${uuid0};
+drop user u_udf_create_${uuid0};
+drop user u_global_drop_${uuid0};
+drop user u_global_create_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`SHOW FULL FUNCTIONS` should not expose full UDF file locations to users that only have function-level privileges. Full local UDF addresses should be visible with database `CREATE FUNCTION`, and full global UDF addresses should be visible with system `CREATE GLOBAL FUNCTION`; function-level privileges should only expose masked addresses.

## What I'm doing:

- Mask UDF `file` and `object_file` properties as `***` when the caller can see the function through function-level privileges but lacks create-function scope privilege.
- Allow database `CREATE FUNCTION` holders to see full local UDF addresses, and system `CREATE GLOBAL FUNCTION` holders to see full global UDF addresses.
- Add FE RBAC coverage and a SQL regression case under `test_udf`.

Fixes: N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Testing:

- `git diff --check`
- `awk 'length($0) > 130 { print FILENAME ":" FNR ":" length($0) }' <changed files>`
- `./run-fe-ut.sh --test com.starrocks.qe.RBACExecutorTest`
  - `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0`
  - `BUILD SUCCESS`
- `cd test && source /home/disk2/owen/venv/bin/activate && python3 run.py -l -d sql/test_udf/R/test_show_udf_address_privilege`
  - `case num: 1`
  - `OK`
- Not validated locally: `python3 run.py -d sql/test_udf/R/test_show_udf_address_privilege -v` because the current dev FE has `enable_udf=false`; `enable_udf` is not mutable through `ADMIN SET FRONTEND CONFIG`.
