### PR TITLE
[Debug] Add 90s repro sleep in LakeTableSchemaChangeJob (pre-fix base)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -527,6 +527,18 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             span.addEvent("setWaitingTxn");
         }
 
+        // REPRO SLEEP: shadow index is now visible to new transactions (txnId > watershedTxnId).
+        // Sleep 90s here so a multi-statement transaction can commit to shadow tablets before
+        // schema change enters WAITING_TXN state, reproducing the publish_log_version NotFound bug.
+        LOG.info("REPRO: sleeping 90s after shadow index creation (watershedTxnId={}), job: {}",
+                watershedTxnId, jobId);
+        try {
+            Thread.sleep(90_000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        LOG.info("REPRO: sleep done, proceeding to WAITING_TXN, job: {}", jobId);
+
         // can't add addRollIndexToCatalog into the applier, because of the nextTxnId check.
         // But addRollIndexToCatalog is idempotent, so it's ok to re-add if Leader transferred.
         persistStateChange(this, JobState.WAITING_TXN);


### PR DESCRIPTION
Based on ab15ef1d7d (pre-fix). Sleep added after shadow index creation and watershedTxnId assignment, before transitioning to WAITING_TXN. This gives a 90s window to inject BEGIN; INSERT; INSERT; COMMIT; multi-statement transactions that write 4-segment txn logs to shadow tablets, reproducing the publish_log_version NotFound bug in the pre-fix BE.

REPRO ONLY - do not merge.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
