### PR TITLE
[Enhancement] Add guard to avoid row explosion in skew join rewrite (backport #72918)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -443,6 +443,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_STATS_TO_OPTIMIZE_SKEW_JOIN = "enable_stats_to_optimize_skew_join";
     public static final String SKEW_JOIN_OPTIMIZE_USE_MCV_COUNT = "skew_join_use_mcv_count";
     public static final String SKEW_JOIN_DATA_SKEW_THRESHOLD = "skew_join_data_skew_threshold";
+    public static final String SKEW_JOIN_MAX_OTHER_SIDE_OVERLAP_ROW_COUNT = "skew_join_max_other_side_overlap_row_count";
 
     public static final String CHOOSE_EXECUTE_INSTANCES_MODE = "choose_execute_instances_mode";
 
@@ -2683,6 +2684,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = SKEW_JOIN_DATA_SKEW_THRESHOLD, flag = VariableMgr.INVISIBLE)
     private double skewJoinDataSkewThreshold = 0.2;
+
+    // Maximum number of overlapping MCV rows on the other side of the join. When exceeding the overlap,
+    // the skew join optimization is skipped as this can lead to a row explosion.
+    // With the default value of `skewJoinRandRange` = 1000, an overlap of 1M leads to 1Bn rows.
+    @VarAttr(name = SKEW_JOIN_MAX_OTHER_SIDE_OVERLAP_ROW_COUNT, flag = VariableMgr.INVISIBLE)
+    private long skewJoinMaxOtherSideOverlapRowCount = 1_000_000;
 
     @VarAttr(name = LARGE_DECIMAL_UNDERLYING_TYPE)
     private String largeDecimalUnderlyingType = SessionVariableConstants.PANIC;
@@ -5078,6 +5085,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setSkewJoinDataSkewThreshold(double skewJoinDataSkewThreshold) {
         this.skewJoinDataSkewThreshold = skewJoinDataSkewThreshold;
+    }
+
+    public long getSkewJoinMaxOtherSideOverlapRowCount() {
+        return skewJoinMaxOtherSideOverlapRowCount;
+    }
+
+    public void setSkewJoinMaxOtherSideOverlapRowCount(long skewJoinMaxOtherSideOverlapRowCount) {
+        this.skewJoinMaxOtherSideOverlapRowCount = skewJoinMaxOtherSideOverlapRowCount;
     }
 
     public boolean isEnableStrictOrderBy() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
@@ -166,7 +166,8 @@ public class SkewJoinOptimizeRule extends TransformationRule {
         // Idea: the most frequent composite tuple (k_1, k_2, ..., k_n) is bounded by the most
         // frequent value of each individual key. If any key k_i is not skewed (no value exceeds
         // the threshold), then no composite tuple can exceed it either, so no partition is skewed.
-        record PredicateSkewInfo(ColumnRefOperator column, DataSkew.SkewInfo skewInfo) {}
+        record PredicateSkewInfo(ColumnRefOperator column, ColumnRefOperator otherColumn, DataSkew.SkewInfo skewInfo) {
+        }
 
         List<PredicateSkewInfo> skewedPredicates = new ArrayList<>();
         for (BinaryPredicateOperator equalConj : equalConjs) {
@@ -178,7 +179,10 @@ public class SkewJoinOptimizeRule extends TransformationRule {
             if (!skewInfoOpt.get().isSkewed()) {
                 return false;
             }
-            skewedPredicates.add(new PredicateSkewInfo(columnOpt.get(), skewInfoOpt.get()));
+            final var leftCol = (ColumnRefOperator) equalConj.getChild(0);
+            final var rightCol = (ColumnRefOperator) equalConj.getChild(1);
+            final var otherColumn = columnOpt.get().equals(leftCol) ? rightCol : leftCol;
+            skewedPredicates.add(new PredicateSkewInfo(columnOpt.get(), otherColumn, skewInfoOpt.get()));
         }
 
         for (final var skewPredicate : skewedPredicates) {
@@ -206,6 +210,24 @@ public class SkewJoinOptimizeRule extends TransformationRule {
                 }
             } else {
                 throw new StarRocksPlannerException("Did not handle skew type in SkewOptimizeRule", ErrorType.INTERNAL_ERROR);
+            }
+
+            // Check how many rows on the other side would be affected by salting, as this can lead to a
+            // cardinality blow up. We only check for MCVs since for NULLs this is not an issue as NULL does not join.
+            final var skewInfoMcvs = skewInfo.getMcvs();
+            if (skewInfo.type() == DataSkew.SkewType.SKEWED_MCV && skewInfoMcvs.isPresent()) {
+                final var rightChildStats = input.inputAt(1).getStatistics();
+                if (rightChildStats != null && rightChildStats.getColumnStatistics().containsKey(skewPredicate.otherColumn)) {
+                    final var otherColumnStats = rightChildStats.getColumnStatistic(skewPredicate.otherColumn);
+                    if (otherColumnStats != null && otherColumnStats.getHistogram() != null) {
+                        final var maxOverlapRowCount = context.getSessionVariable().getSkewJoinMaxOtherSideOverlapRowCount();
+                        final var overlapRows = DataSkew.getOverlappingMcvRowCount(otherColumnStats.getHistogram().getMCV(),
+                                skewInfoMcvs.get());
+                        if (overlapRows > maxOverlapRowCount) {
+                            continue;
+                        }
+                    }
+                }
             }
 
             joinOperator.setSkewColumn(skewJoinColumn);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 public class DataSkew {
@@ -62,12 +63,13 @@ public class DataSkew {
             this(type, additionalInfo, Optional.empty());
         }
 
-        public SkewInfo(SkewType type, Optional<List<Pair<String, Long>>> maybeMcvs) {
-            this(type, AdditionalInfo.NONE, maybeMcvs);
-        }
-
         public boolean isSkewed() {
             return type != SkewType.NOT_SKEWED;
+        }
+
+        public Optional<Map<String, Long>> getMcvs() {
+            return maybeMcvs.map(mcvs -> mcvs.stream() //
+                    .collect(Collectors.toMap(pair -> pair.first, pair -> pair.second)));
         }
     }
 
@@ -148,7 +150,8 @@ public class DataSkew {
      */
     public static SkewInfo getColumnSkewInfo(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
                                              Thresholds thresholds) {
-        if (statistics.isTableRowCountMayInaccurate() || statistics.getOutputRowCount() < 1) {
+        final var rowCount = statistics.getOutputRowCount();
+        if (statistics.isTableRowCountMayInaccurate() || rowCount < 1) {
             // Without sufficient information we can not make a decision.
             return new SkewInfo(SkewType.NOT_SKEWED, AdditionalInfo.INACCURATE_ROW_COUNT);
         }
@@ -188,5 +191,16 @@ public class DataSkew {
     /* Always using default thresholds */
     public static boolean isColumnSkewed(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic) {
         return isColumnSkewed(statistics, columnStatistic, DEFAULT_THRESHOLDS);
+    }
+
+    public static long getOverlappingMcvRowCount(Map<String, Long> mcvs, Map<String, Long> otherMcvs) {
+        if (mcvs == null || mcvs.isEmpty() || otherMcvs == null || otherMcvs.isEmpty()) {
+            return 0;
+        }
+
+        return mcvs.entrySet().stream() //
+                .filter(mcv -> otherMcvs.containsKey(mcv.getKey())) //
+                .mapToLong(Map.Entry::getValue) //
+                .sum();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -276,12 +276,11 @@ public class SkewJoinTest extends PlanTestBase {
 
     @Test
     public void testSkewJoinWithStats() throws Exception {
-        String sql = "select * from test.customer join test.part on c_mktsegment = p_name and c_custkey = p_partkey ";
+        String sql = "select * from test.customer join test.part on c_mktsegment = p_name ";
         String sqlPlan = getFragmentPlan(sql);
         // rewrite success
         assertCContains(sqlPlan, "equal join conjunct: 20: rand_col = 27: rand_col\n" +
-                "  |  equal join conjunct: 7: C_MKTSEGMENT = 11: P_NAME\n" +
-                "  |  equal join conjunct: 1: C_CUSTKEY = 10: P_PARTKEY");
+                "  |  equal join conjunct: 7: C_MKTSEGMENT = 11: P_NAME");
 
         int skewJoinUseMCVCount = connectContext.getSessionVariable().getSkewJoinOptimizeUseMCVCount();
         double skewDataThreshold = connectContext.getSessionVariable().getSkewJoinDataSkewThreshold();
@@ -289,15 +288,13 @@ public class SkewJoinTest extends PlanTestBase {
         connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(0.3);
         sqlPlan = getFragmentPlan(sql);
         // not rewrite because of the skewJoinUseMCVCount and skewDataThreshold
-        assertCContains(sqlPlan, "equal join conjunct: 7: C_MKTSEGMENT = 11: P_NAME\n" +
-                "  |  equal join conjunct: 1: C_CUSTKEY = 10: P_PARTKEY");
+        assertCContains(sqlPlan, "equal join conjunct: 7: C_MKTSEGMENT = 11: P_NAME");
         connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(skewDataThreshold);
         connectContext.getSessionVariable().setSkewJoinOptimizeUseMCVCount(skewJoinUseMCVCount);
 
-        sql = "select * from test.customer join test.part on trim(c_mktsegment) = p_name and c_custkey = p_partkey ";
+        sql = "select * from test.customer join test.part on trim(c_mktsegment) = p_name ";
         sqlPlan = getFragmentPlan(sql);
-        assertCContains(sqlPlan, "equal join conjunct: 20: trim = 11: P_NAME\n" +
-                "  |  equal join conjunct: 1: C_CUSTKEY = 10: P_PARTKEY");
+        assertCContains(sqlPlan, "equal join conjunct: 20: trim = 11: P_NAME");
 
         sql = "select c_custkey, sum(p_retailprice) from (select c_custkey, c_mktsegment from test.customer) c" +
                 " join (select p_name,p_retailprice from test.part) p on c.c_mktsegment = p.p_name group by c_custkey";
@@ -305,11 +302,10 @@ public class SkewJoinTest extends PlanTestBase {
         assertCContains(sqlPlan, "equal join conjunct: 21: rand_col = 28: rand_col\n" +
                 "  |  equal join conjunct: 7: C_MKTSEGMENT = 11: P_NAME");
 
-        sql = "select * from test.customer join test.part on p_name = c_mktsegment and p_partkey = c_custkey";
+        sql = "select * from test.customer join test.part on p_name = c_mktsegment";
         sqlPlan = getFragmentPlan(sql);
         assertCContains(sqlPlan, "equal join conjunct: 20: rand_col = 27: rand_col\n" +
-                "  |  equal join conjunct: 7: C_MKTSEGMENT = 11: P_NAME\n" +
-                "  |  equal join conjunct: 1: C_CUSTKEY = 10: P_PARTKEY");
+                "  |  equal join conjunct: 7: C_MKTSEGMENT = 11: P_NAME");
     }
 
     @Test
@@ -324,19 +320,28 @@ public class SkewJoinTest extends PlanTestBase {
 
     @Test
     public void testIntSkewColumnVarchar() throws Exception {
-        connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(0);
-        ((MockHistogramStatisticStorage) connectContext.getGlobalStateMgr()
-                .getStatisticStorage()).addHistogramStatistis("c_nationkey", Type.INT, 100);
+        double oldThreshold = connectContext.getSessionVariable().getSkewJoinDataSkewThreshold();
+        long oldMaxOverlap = connectContext.getSessionVariable().getSkewJoinMaxOtherSideOverlapRowCount();
+        try {
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(0.0);
+            connectContext.getSessionVariable().setSkewJoinMaxOtherSideOverlapRowCount(Long.MAX_VALUE);
+            ((MockHistogramStatisticStorage) connectContext.getGlobalStateMgr()
+                    .getStatisticStorage()).addHistogramStatistis("c_nationkey", Type.INT, 100);
 
-        String sql = "select * from test.customer join test.part on P_SIZE = C_NATIONKEY and p_partkey = c_custkey";
-        String sqlPlan = getFragmentPlan(sql);
-        assertCContains(sqlPlan, "C_NATIONKEY IN (22, 23, 24, 10, 11)");
+            String sql = "select * from test.customer join test.part on P_SIZE = C_NATIONKEY and p_partkey = c_custkey";
+            String sqlPlan = getFragmentPlan(sql);
+            assertCContains(sqlPlan, "C_NATIONKEY IN (22, 23, 24, 10, 11)");
+        } finally {
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(oldThreshold);
+            connectContext.getSessionVariable().setSkewJoinMaxOtherSideOverlapRowCount(oldMaxOverlap);
+        }
     }
 
     @Test
     void testSkewJoinWithNullOnlySkewByStats() throws Exception {
         final var oldStatisticsStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
         final double oldThreshold = connectContext.getSessionVariable().getSkewJoinDataSkewThreshold();
+        final boolean oldEnableStats = connectContext.getSessionVariable().isEnableStatsToOptimizeSkewJoin();
         try {
             final var emptyStatisticsStorage = new EmptyStatisticStorage() {
                 @Override
@@ -356,7 +361,6 @@ public class SkewJoinTest extends PlanTestBase {
             connectContext.getGlobalStateMgr().setStatisticStorage(emptyStatisticsStorage);
             connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(0.1);
             connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(true);
-            connectContext.getSessionVariable().setEnableOptimizerSkewJoinByQueryRewrite(true);
 
             // Important to use a LEFT JOIN here so NULLs are preserved.
             String sql = "select * from t0 left join t1 on t0.v1 = t1.v4";
@@ -373,8 +377,8 @@ public class SkewJoinTest extends PlanTestBase {
                       |  <slot 9> : [NULL]
                     """);
         } finally {
-            // Restore threshold
             connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(oldThreshold);
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(oldEnableStats);
             connectContext.getGlobalStateMgr().setStatisticStorage(oldStatisticsStorage);
         }
     }
@@ -383,6 +387,7 @@ public class SkewJoinTest extends PlanTestBase {
     void testSkewJoinWithNullOnlySkewAndMcvSkew() throws Exception {
         final var oldStatisticsStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
         final double oldThreshold = connectContext.getSessionVariable().getSkewJoinDataSkewThreshold();
+        final boolean oldEnableStats = connectContext.getSessionVariable().isEnableStatsToOptimizeSkewJoin();
         try {
             final var emptyStatisticsStorage = new EmptyStatisticStorage() {
                 @Override
@@ -395,11 +400,12 @@ public class SkewJoinTest extends PlanTestBase {
                     }
 
                     return ColumnStatistic.builder() //
-                            .setNullsFraction(0.1) //
+                            .setNullsFraction(0.0) //
                             .build();
                 }
             };
             setTableStatistics(getOlapTable("t0"), 1337);
+            setTableStatistics(getOlapTable("t1"), 1337);
             connectContext.getGlobalStateMgr().setStatisticStorage(emptyStatisticsStorage);
             connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(0.1);
             connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(true);
@@ -423,8 +429,105 @@ public class SkewJoinTest extends PlanTestBase {
                       |  <slot 9> : [11,22]
                     """);
         } finally {
-            // Restore threshold
             connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(oldThreshold);
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(oldEnableStats);
+            connectContext.getGlobalStateMgr().setStatisticStorage(oldStatisticsStorage);
+        }
+    }
+
+    @Test
+    void testSkewJoinNoRewriteWhenBothSidesSkewedOnSameValues() throws Exception {
+        // GIVEN
+        final var oldStatisticsStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        final double oldThreshold = connectContext.getSessionVariable().getSkewJoinDataSkewThreshold();
+        final boolean oldEnableStats = connectContext.getSessionVariable().isEnableStatsToOptimizeSkewJoin();
+        final long oldMaxOverlap = connectContext.getSessionVariable().getSkewJoinMaxOtherSideOverlapRowCount();
+        try {
+            final long totalRows = 10_000;
+            final var statisticsStorage = new EmptyStatisticStorage() {
+                @Override
+                public ColumnStatistic getColumnStatistic(Table table, String column) {
+                    // Both sides share the same heavy-hitter MCV values.
+                    if ((table.getName().equalsIgnoreCase("t0") && column.equalsIgnoreCase("v1"))
+                            || (table.getName().equalsIgnoreCase("t1") && column.equalsIgnoreCase("v4"))) {
+                        return ColumnStatistic.builder()
+                                .setNullsFraction(0.0)
+                                .setHistogram(new Histogram(List.of(),
+                                        Map.of("11", 4000L, "22", 3000L))) // 70% of rows in MCVs
+                                .build();
+                    }
+                    return ColumnStatistic.builder().setNullsFraction(0.0).build();
+                }
+            };
+            setTableStatistics(getOlapTable("t0"), totalRows);
+            setTableStatistics(getOlapTable("t1"), totalRows);
+            connectContext.getGlobalStateMgr().setStatisticStorage(statisticsStorage);
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(0.1);
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(true);
+            // Overlapping rows on other side = 4000 + 3000 = 7000, set guard threshold below that.
+            connectContext.getSessionVariable().setSkewJoinMaxOtherSideOverlapRowCount(5000);
+
+            // WHEN
+            String sql = "select * from t0 join t1 on t0.v1 = t1.v4";
+            String plan = getFragmentPlan(sql);
+
+            // THEN
+            assertNotContains(plan, "rand_col");
+            assertNotContains(plan, "generate_serials");
+        } finally {
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(oldThreshold);
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(oldEnableStats);
+            connectContext.getSessionVariable().setSkewJoinMaxOtherSideOverlapRowCount(oldMaxOverlap);
+            connectContext.getGlobalStateMgr().setStatisticStorage(oldStatisticsStorage);
+        }
+    }
+
+    @Test
+    void testSkewJoinRewriteWhenDifferentValuesAreSkewedOnBothSides() throws Exception {
+        // GIVEN
+        final var oldStatisticsStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        final double oldThreshold = connectContext.getSessionVariable().getSkewJoinDataSkewThreshold();
+        final boolean oldEnableStats = connectContext.getSessionVariable().isEnableStatsToOptimizeSkewJoin();
+        final long oldMaxOverlap = connectContext.getSessionVariable().getSkewJoinMaxOtherSideOverlapRowCount();
+        try {
+            final long totalRows = 10_000;
+            final var statisticsStorage = new EmptyStatisticStorage() {
+                @Override
+                public ColumnStatistic getColumnStatistic(Table table, String column) {
+                    if (table.getName().equalsIgnoreCase("t0") && column.equalsIgnoreCase("v1")) {
+                        return ColumnStatistic.builder()
+                                .setNullsFraction(0.0)
+                                .setHistogram(new Histogram(List.of(),
+                                        Map.of("11", 4000L, "22", 3000L)))
+                                .build();
+                    }
+                    if (table.getName().equalsIgnoreCase("t1") && column.equalsIgnoreCase("v4")) {
+                        return ColumnStatistic.builder()
+                                .setNullsFraction(0.0)
+                                .setHistogram(new Histogram(List.of(),
+                                        Map.of("33", 4000L, "44", 3000L))) // different MCVs
+                                .build();
+                    }
+                    return ColumnStatistic.builder().setNullsFraction(0.0).build();
+                }
+            };
+            setTableStatistics(getOlapTable("t0"), totalRows);
+            setTableStatistics(getOlapTable("t1"), totalRows);
+            connectContext.getGlobalStateMgr().setStatisticStorage(statisticsStorage);
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(0.1);
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(true);
+
+            // WHEN
+            String sql = "select * from t0 join t1 on t0.v1 = t1.v4";
+            String plan = getFragmentPlan(sql);
+
+            // THEN
+            assertCContains(plan, "rand_col");
+            assertCContains(plan, "generate_serials");
+        } finally {
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(oldThreshold);
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(oldEnableStats);
+            connectContext.getSessionVariable().setSkewJoinMaxOtherSideOverlapRowCount(oldMaxOverlap);
             connectContext.getGlobalStateMgr().setStatisticStorage(oldStatisticsStorage);
         }
     }


### PR DESCRIPTION
Backport of #72918 to `branch-3.5-cc`.

Original commit: e5c84ce5c57c45b0bfe379902b1da0c4dff39f75
Original PR: https://github.com/StarRocks/starrocks/pull/72918

---

<!-- Original PR description below -->

## Why I'm doing:

When doing the join skew V1 rewrite, we add 1000 rows (default value) of salting to the "other side" of the join per row that contains a skewed value. We do this for every value that has been detected as skewed on the "skew side". If the "other side" also has a lot of rows with skewed values, this blows up the join massively. Assume the "other side" has 1m rows that correspond that match the skew value, the join would blow up by `1m rows * 1000 salting rows = 1bn rows`. This quickly makes the join uncomputable.

## What I'm doing:
I am adding a guard that skips the optimization if the "other side" of the join has overlapping skew values exceeding a threshold defined in a session variable (default 1M rows which would lead to a 1bn row blowup).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
