### PR TITLE
[BugFix] Fix some column range simplify fail case

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AndRangePredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AndRangePredicate.java
@@ -116,7 +116,32 @@ public class AndRangePredicate extends RangePredicate {
                 return null;
             }
         } else {
+            // eg: src = AND(pt=20251212, OR(gmv>0, id>0)), target = OR(gmv>0, id>0)
+            // Check if any child of AND can cover the OR target (returns TRUE),
+            // in which case the compensation is the remaining AND children.
             OrRangePredicate orRangePredicate = (OrRangePredicate) other;
+            boolean matchedByChild = false;
+            for (RangePredicate childRangePredicate : childPredicates) {
+                ScalarOperator child = childRangePredicate.simplify(orRangePredicate);
+                if (ConstantOperator.TRUE.equals(child)) {
+                    // this child covers the OR target entirely; compensation = other AND children
+                    matchedByChild = true;
+                    for (RangePredicate sibling : childPredicates) {
+                        if (sibling == childRangePredicate) {
+                            continue;
+                        }
+                        ScalarOperator siblingScalar = sibling.toScalarOperator();
+                        if (siblingScalar != null && !siblingScalar.equals(ConstantOperator.TRUE)) {
+                            simpliedPredicates.add(siblingScalar);
+                        }
+                    }
+                    break;
+                }
+            }
+            if (matchedByChild) {
+                return Utils.compoundAnd(simpliedPredicates);
+            }
+            // fallback: try original logic - let AND simplify each OR child
             for (RangePredicate rangePredicate : orRangePredicate.getChildPredicates()) {
                 ScalarOperator simplied = simplify(rangePredicate);
                 if (simplied != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnRangePredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnRangePredicate.java
@@ -352,6 +352,10 @@ public class ColumnRangePredicate extends RangePredicate {
         } else if (other instanceof AndRangePredicate) {
             return null;
         } else {
+            // e.g. this=gmv>0, other=OR(gmv>0, id>0): OR(gmv>0, id>0) encloses gmv>0 → return gmv>0
+            if (other.enclose(this)) {
+                return toScalarOperator();
+            }
             OrRangePredicate orRangePredicate = (OrRangePredicate) other;
             for (RangePredicate rangePredicate : orRangePredicate.getChildPredicates()) {
                 ScalarOperator simplied = simplify(rangePredicate);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnRangePredicateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnRangePredicateTest.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.DateType;
+import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
@@ -226,4 +227,65 @@ public class ColumnRangePredicateTest {
         Assertions.assertEquals("1: col > 9223372036854775807", s, s);
     }
 
+    /**
+     * Scenario 1: query WHERE = AND(pt=20251212, OR(gmv>0, id>0)), target WHERE = OR(gmv>0, id>0)
+     * should be pt=20251212
+     * Scenario 2: query WHERE = AND(pt=20251212, gmv>0), target WHERE = OR(gmv>0, id>0)
+     * should be pt=20251212
+     */
+    @Test
+    public void testColumnRangeSimplifyOrRangeEncloses() {
+        // pt=20251212
+        ColumnRefOperator pt = new ColumnRefOperator(2, DateType.DATE, "pt", false);
+        ConstantOperator ptVal = ConstantOperator.createDate(java.time.LocalDateTime.of(2025, 12, 12, 0, 0));
+        TreeRangeSet<ConstantOperator> ptRangeSet = TreeRangeSet.create();
+        ptRangeSet.add(Range.singleton(ptVal));
+        ColumnRangePredicate ptRange = new ColumnRangePredicate(pt, ptRangeSet);
+
+        // gmv>0
+        ColumnRefOperator gmv = new ColumnRefOperator(3, FloatType.DOUBLE, "gmv", true);
+        TreeRangeSet<ConstantOperator> gmvRangeSet = TreeRangeSet.create();
+        gmvRangeSet.add(Range.greaterThan(ConstantOperator.createDouble(0)));
+        ColumnRangePredicate gmvRange = new ColumnRangePredicate(gmv, gmvRangeSet);
+
+        // id>0
+        ColumnRefOperator id = new ColumnRefOperator(1, IntegerType.INT, "id", true);
+        TreeRangeSet<ConstantOperator> idRangeSet = TreeRangeSet.create();
+        idRangeSet.add(Range.greaterThan(ConstantOperator.createInt(0)));
+        ColumnRangePredicate idRange = new ColumnRangePredicate(id, idRangeSet);
+
+        // OR(gmv>0, id>0)
+        OrRangePredicate orRange = new OrRangePredicate(Lists.newArrayList(gmvRange, idRange));
+        {
+            // gmv>0
+            // target is OR(gmv>0, id>0)
+            // simplify should be gmv>0
+            Assertions.assertEquals(gmvRange.toScalarOperator(), gmvRange.simplify(orRange));
+            // id>0
+            // target is OR(gmv>0, id>0)
+            // simplify should be id>0
+            Assertions.assertEquals(idRange.toScalarOperator(), idRange.simplify(orRange));
+        }
+        {
+            // AND(pt=20251212, OR(gmv>0,id>0))
+            // target is OR(gmv>0, id>0)
+            // simplify should be pt=2025-12-12
+            AndRangePredicate andRange = new AndRangePredicate(Lists.newArrayList(ptRange, orRange));
+            ScalarOperator result = andRange.simplify(orRange);
+            Assertions.assertNotNull(result);
+            Assertions.assertNotEquals(ConstantOperator.TRUE, result);
+            Assertions.assertTrue(result.toString().contains("2: pt"));
+        }
+        {
+            // AND(pt=20251212, gmv>0)
+            // target is OR(gmv>0, id>0)
+            // simplify should be pt=2025-12-12
+            AndRangePredicate andRange = new AndRangePredicate(Lists.newArrayList(ptRange, gmvRange));
+            ScalarOperator result = andRange.simplify(orRange);
+            Assertions.assertNotNull(result);
+            Assertions.assertNotEquals(ConstantOperator.TRUE, result);
+            Assertions.assertTrue(result.toString().contains("2: pt"));
+        }
+    }
 }
+


### PR DESCRIPTION
## Why I'm doing:

mv: `where (gmv>0 or id>0)`
query1: `where (gmv>0 or id>0) and pt='20260101'`
query2: `where (gmv>0) and pt='20260101'`
query3: `where (id>0)  and pt='20260101'`

mv should be used

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
