### PR TITLE
[BugFix] Preserve current_timestamp generator on ALTER ADD COLUMN

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1204,6 +1204,9 @@ public class SchemaChangeHandler extends AlterHandler {
             fastSchemaEvolution = false;
         }
         if (newColumn.getDefaultExpr() != null && newColumn.getDefaultValueType() == Column.DefaultValueType.CONST) {
+            // For current_timestamp/now() this freezes ALTER-time into defaultValue so BE can backfill pre-existing
+            // rows. New rows still resolve through defaultExpr (calculatedDefaultValue checks the expr first), and
+            // metadata display is handled in getMetaDefaultValue.
             long startTime = ConnectContext.get().getStartTime();
             newColumn.setDefaultValue(newColumn.calculatedDefaultValueWithTime(startTime));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -820,23 +820,26 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     }
 
     public String getMetaDefaultValue(List<String> extras) {
+        // Generator expressions must win over any materialized defaultValue: schema-change paths freeze
+        // ALTER-time into defaultValue so BE can backfill existing rows, but metadata callers (DESCRIBE,
+        // information_schema.columns) must still report the generator, not the frozen literal.
+        if (defaultExpr != null && isEmptyDefaultTimeFunction(defaultExpr)) {
+            if (extras != null) {
+                extras.add("DEFAULT_GENERATED");
+            }
+            return "CURRENT_TIMESTAMP";
+        }
         if (defaultValue != null) {
             return defaultValue;
-        } else if (defaultExpr != null) {
-            if (isEmptyDefaultTimeFunction(defaultExpr)) {
-                if (extras != null) {
-                    extras.add("DEFAULT_GENERATED");
-                }
-                return "CURRENT_TIMESTAMP";
-            } else {
-                if (defaultExpr.hasExprObject()) {
-                    return defaultExpr.toSql();
-                }
-                if (extras != null) {
-                    extras.add("DEFAULT_GENERATED");
-                }
-                return defaultExpr.getExpr();
+        }
+        if (defaultExpr != null) {
+            if (defaultExpr.hasExprObject()) {
+                return defaultExpr.toSql();
             }
+            if (extras != null) {
+                extras.add("DEFAULT_GENERATED");
+            }
+            return defaultExpr.getExpr();
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
@@ -46,7 +46,12 @@ public class DefaultExpr implements GsonPreProcessable, GsonPostProcessable {
     @SerializedName("expr")
     private String expr;
 
-    private final boolean hasArguments;
+    // StarRocks Gson skips fields without @SerializedName (see HiddenAnnotationExclusionStrategy).
+    // Without persistence this flag flipped to false after FE restart / edit-log replay, which made
+    // isEmptyDefaultTimeFunction misclassify "current_timestamp(N)" as the empty form and silently
+    // dropped its precision argument.
+    @SerializedName("hasArguments")
+    private boolean hasArguments;
 
     @SerializedName("serializedExpr")
     private String serializedExpr;
@@ -104,6 +109,15 @@ public class DefaultExpr implements GsonPreProcessable, GsonPostProcessable {
                 exprObject = SqlParser.parseSqlToExpr(serializedExpr, SqlModeHelper.MODE_DEFAULT);
             } catch (Exception e) {
                 LOG.warn("Failed to restore expr object from SQL: {}", serializedExpr, e);
+            }
+        }
+        // Backfill hasArguments for columns persisted before the @SerializedName annotation existed:
+        // the field deserialized to the primitive default false. The argument list is observable from
+        // the expr string itself - a valid time-function default with a non-empty paren means args.
+        if (!hasArguments && expr != null) {
+            String trimmed = expr.trim();
+            if (isValidDefaultTimeFunction(trimmed) && !trimmed.endsWith("()")) {
+                hasArguments = true;
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -871,6 +871,46 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     }
 
     @Test
+    public void testAlterTableAddColumnDefaultCurrentTimestampPreservesGenerator() throws Exception {
+        String createTableStmt = "CREATE TABLE test.test_alter_add_now (\n" +
+                "id BIGINT NOT NULL\n" +
+                ") PRIMARY KEY(id)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "    'replication_num' = '1',\n" +
+                "    'fast_schema_evolution' = 'true'\n" +
+                ");";
+        createTable(createTableStmt);
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) db.getTable("test_alter_add_now");
+        Assertions.assertNotNull(table);
+
+        String alterSql = "ALTER TABLE test.test_alter_add_now ADD COLUMN ts DATETIME DEFAULT current_timestamp";
+        AlterTableStmt alterStmt = (AlterTableStmt) parseAndAnalyzeStmt(alterSql);
+        Assertions.assertDoesNotThrow(() -> {
+            SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+            handler.process(alterStmt.getAlterClauseList(), db, table);
+        });
+        jobSize++;
+
+        Column tsCol = table.getColumn("ts");
+        Assertions.assertNotNull(tsCol);
+        Assertions.assertNotNull(tsCol.getDefaultExpr());
+        // ALTER-time string is preserved on defaultValue so BE can backfill pre-existing rows.
+        Assertions.assertNotNull(tsCol.getDefaultValue(),
+                "ALTER-time materialization must be kept for BE backfill of pre-existing rows");
+        Assertions.assertEquals(Column.DefaultValueType.CONST, tsCol.getDefaultValueType());
+
+        // Metadata callers (DESCRIBE, information_schema.columns) must surface the generator, not the
+        // frozen literal stashed in defaultValue by the schema-change backfill path.
+        List<String> extras = Lists.newArrayList();
+        Assertions.assertEquals("CURRENT_TIMESTAMP", tsCol.getMetaDefaultValue(extras));
+        Assertions.assertTrue(extras.contains("DEFAULT_GENERATED"),
+                "current_timestamp default must be reported as DEFAULT_GENERATED");
+    }
+
+    @Test
     public void testSortKeyUpdatedAfterAddKeyColumnAgg() throws Exception {
         createTable("CREATE TABLE test.sc_agg_sort_key (\n"
                 + "k0 INT,\n"

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnGsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnGsonSerializationTest.java
@@ -41,7 +41,10 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -76,6 +79,72 @@ public class ColumnGsonSerializationTest {
             Text.writeString(out, json);
         }
 
+    }
+
+    @Test
+    public void testSerializeDefaultExprHasArgumentsPreserved() {
+        // current_timestamp(3) — hasArguments must survive a Gson roundtrip.
+        FunctionCallExpr ctsExpr = new FunctionCallExpr("current_timestamp",
+                Lists.newArrayList(new IntLiteral(3L, IntegerType.INT)));
+        Column tsCol = new Column("ts", DateType.DATETIME, false, null, true,
+                new ColumnDef.DefaultValueDef(true, true, ctsExpr), "");
+
+        Assertions.assertNotNull(tsCol.getDefaultExpr());
+        Assertions.assertTrue(tsCol.getDefaultExpr().hasArgs(),
+                "parser-built DefaultExpr for current_timestamp(3) must carry hasArguments=true");
+
+        String json = GsonUtils.GSON.toJson(tsCol);
+        Column restored = GsonUtils.GSON.fromJson(json, Column.class);
+
+        Assertions.assertNotNull(restored.getDefaultExpr());
+        Assertions.assertTrue(restored.getDefaultExpr().hasArgs(),
+                "hasArguments must persist across Gson roundtrip");
+        // VARY rather than CONST: precision-bearing time functions are not 'empty' generators.
+        Assertions.assertEquals(Column.DefaultValueType.VARY, restored.getDefaultValueType(),
+                "current_timestamp(N) must stay classified as VARY after roundtrip");
+    }
+
+    @Test
+    public void testLegacyDefaultExprWithoutHasArgumentsRestoresFromString() {
+        // Columns persisted before @SerializedName("hasArguments") existed wrote JSON without the field.
+        // Simulate that by stripping "hasArguments":true from the serialized form and verify that
+        // gsonPostProcess recovers the flag from the expr string.
+        FunctionCallExpr ctsExpr = new FunctionCallExpr("current_timestamp",
+                Lists.newArrayList(new IntLiteral(3L, IntegerType.INT)));
+        Column tsCol = new Column("ts", DateType.DATETIME, false, null, true,
+                new ColumnDef.DefaultValueDef(true, true, ctsExpr), "");
+        String legacyJson = GsonUtils.GSON.toJson(tsCol).replaceAll(",\"hasArguments\":(true|false)", "");
+        Assertions.assertFalse(legacyJson.contains("hasArguments"),
+                "test precondition: hasArguments must be absent from the simulated legacy JSON");
+
+        Column restored = GsonUtils.GSON.fromJson(legacyJson, Column.class);
+
+        Assertions.assertNotNull(restored.getDefaultExpr());
+        Assertions.assertEquals("current_timestamp(3)", restored.getDefaultExpr().getExpr());
+        Assertions.assertTrue(restored.getDefaultExpr().hasArgs(),
+                "legacy persisted current_timestamp(3) must recover hasArguments via gsonPostProcess");
+        Assertions.assertEquals(Column.DefaultValueType.VARY, restored.getDefaultValueType());
+
+        // An empty-arg form persisted under the same legacy schema must stay empty.
+        FunctionCallExpr emptyExpr = new FunctionCallExpr("current_timestamp", Lists.newArrayList());
+        Column tsEmpty = new Column("ts", DateType.DATETIME, false, null, true,
+                new ColumnDef.DefaultValueDef(true, false, emptyExpr), "");
+        String legacyEmptyJson =
+                GsonUtils.GSON.toJson(tsEmpty).replaceAll(",\"hasArguments\":(true|false)", "");
+        Column restoredEmpty = GsonUtils.GSON.fromJson(legacyEmptyJson, Column.class);
+        Assertions.assertFalse(restoredEmpty.getDefaultExpr().hasArgs(),
+                "legacy current_timestamp() must remain hasArguments=false");
+        Assertions.assertEquals(Column.DefaultValueType.CONST, restoredEmpty.getDefaultValueType());
+
+        // Same empty form but with trailing whitespace in the persisted expr string. The regex
+        // pre-check trims, so without symmetric trimming on the endsWith("()") guard the backfill
+        // would misclassify this as having args. Both checks must operate on the trimmed value.
+        String legacyEmptyWithSpaces = legacyEmptyJson.replace(
+                "\"expr\":\"current_timestamp()\"", "\"expr\":\"current_timestamp() \"");
+        Column restoredEmptyWithSpaces = GsonUtils.GSON.fromJson(legacyEmptyWithSpaces, Column.class);
+        Assertions.assertFalse(restoredEmptyWithSpaces.getDefaultExpr().hasArgs(),
+                "legacy current_timestamp() with trailing whitespace must remain hasArguments=false");
+        Assertions.assertEquals(Column.DefaultValueType.CONST, restoredEmptyWithSpaces.getDefaultValueType());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/persist/TableColumnAlterInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/TableColumnAlterInfoTest.java
@@ -14,10 +14,21 @@
 
 package com.starrocks.persist;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class TableColumnAlterInfoTest {
     @Test
@@ -40,6 +51,34 @@ public class TableColumnAlterInfoTest {
         Assertions.assertEquals(info, info2);
         Assertions.assertNotNull(info.toString());
 
+    }
+
+    @Test
+    public void testEditLogRoundtripPreservesCurrentTimestampPrecision() {
+        // Edit-log replay path: TableColumnAlterInfo carries the new schema as List<Column>, written via
+        // GsonUtils.GSON.toJson and read back symmetrically. A Column whose default is current_timestamp(3)
+        // must come out the other side with hasArguments still true, otherwise replay silently demotes the
+        // precision-bearing generator to current_timestamp().
+        FunctionCallExpr ctsExpr = new FunctionCallExpr("current_timestamp",
+                Lists.newArrayList(new IntLiteral(3L, IntegerType.INT)));
+        Column tsCol = new Column("ts", DateType.DATETIME, false, null, true,
+                new ColumnDef.DefaultValueDef(true, true, ctsExpr), "");
+        Assertions.assertTrue(tsCol.getDefaultExpr().hasArgs());
+
+        Map<Long, List<Column>> indexSchemaMap = new HashMap<>();
+        indexSchemaMap.put(100L, Lists.newArrayList(tsCol));
+
+        TableColumnAlterInfo info = new TableColumnAlterInfo(1, 1,
+                indexSchemaMap, Collections.emptyList(), 0, 1, Collections.emptyMap());
+
+        String json = GsonUtils.GSON.toJson(info);
+        TableColumnAlterInfo replayed = GsonUtils.GSON.fromJson(json, TableColumnAlterInfo.class);
+
+        Column replayedTs = replayed.getIndexSchemaMap().get(100L).get(0);
+        Assertions.assertNotNull(replayedTs.getDefaultExpr());
+        Assertions.assertTrue(replayedTs.getDefaultExpr().hasArgs(),
+                "edit-log replay must preserve hasArguments for current_timestamp(3)");
+        Assertions.assertEquals(Column.DefaultValueType.VARY, replayedTs.getDefaultValueType());
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:

Two related bugs around `current_timestamp` / `now()` defaults are addressed
in one branch, one commit per bug.

### #73417 — generator surfaced as a frozen literal after ALTER ADD COLUMN

`ALTER TABLE ... ADD COLUMN <col> DATETIME DEFAULT current_timestamp` makes
`SchemaChangeHandler.addColumnInternal` materialize `now()` into
`Column.defaultValue` (an ALTER-time string) so BE can backfill pre-existing
rows. That materialization is needed for backfill, but it also poisoned
`Column.getMetaDefaultValue`, which preferred `defaultValue` over
`defaultExpr`. DESCRIBE / `information_schema.columns` started reporting the
frozen string instead of `CURRENT_TIMESTAMP` with `DEFAULT_GENERATED`.
INSERT-time resolution already went through `calculatedDefaultValue`, which
prefers `defaultExpr` for the empty-time-function case, so new rows received
fresh timestamps; only metadata display was wrong.

### #73459 — `DefaultExpr.hasArguments` not persisted

`DefaultExpr.hasArguments` was declared without `@SerializedName`. The
StarRocks Gson configuration (`HiddenAnnotationExclusionStrategy` in
`GsonUtils`) skips every unannotated field, so the flag was dropped on
every serialization and deserialized to the Java primitive default `false`.
After an FE restart or any edit-log replay carrying a `Column` (e.g. fast
schema evolution through `TableColumnAlterInfo`), a column with
`DEFAULT current_timestamp(3)` came back classified as the empty time
function — `getDefaultValueType` flipped `VARY → CONST`,
`Load.buildLoadDefaultExpr` took the `CONST` branch, and the precision
argument was silently dropped.

## What I'm doing:

Two commits, one per bug:

1. **`[BugFix] Preserve current_timestamp generator on ALTER TABLE ADD COLUMN`**
   Reorder `Column.getMetaDefaultValue`: when `defaultExpr` is
   `now()` / `current_timestamp()` without args, return `CURRENT_TIMESTAMP`
   with the `DEFAULT_GENERATED` marker regardless of any materialized
   `defaultValue`. Keep the existing `SchemaChangeHandler` materialization —
   BE still needs `default_value` in `TColumn` for backfill of pre-existing
   rows.

2. **`[BugFix] Persist DefaultExpr.hasArguments so current_timestamp(N) keeps its precision`**
   Annotate `hasArguments` with `@SerializedName` so Gson persists it. For
   columns already on disk without the field, `gsonPostProcess` recovers the
   flag by inspecting the expr string: a valid time-function default whose
   expr does not end with `()` carries arguments.

## Tests

- `SchemaChangeHandlerTest.testAlterTableAddColumnDefaultCurrentTimestampPreservesGenerator`
  runs the failing DDL and asserts that after ALTER:
  - `column.getDefaultExpr()` stays populated;
  - `column.getDefaultValue()` is non-null (ALTER-time backfill string kept);
  - `column.getMetaDefaultValue()` returns `CURRENT_TIMESTAMP` with the
    `DEFAULT_GENERATED` extra.
- `ColumnGsonSerializationTest.testSerializeDefaultExprHasArgumentsPreserved`
  — Gson roundtrip on a Column built from the parser.
- `ColumnGsonSerializationTest.testLegacyDefaultExprWithoutHasArgumentsRestoresFromString`
  — strips `hasArguments` from a freshly serialized Column to simulate the
  legacy schema, verifies `gsonPostProcess` fallback recovers it; empty-arg
  form stays empty.
- `TableColumnAlterInfoTest.testEditLogRoundtripPreservesCurrentTimestampPrecision`
  — full edit-log entity roundtrip (the journal payload used by fast schema
  evolution).

Fixes #73417
Fixes #73459

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
