### PR TITLE
[BugFix] Replace de.javakaffee UnmodifiableCollectionsSerializer with Java 17-compatible version

### DIFF
--- a/java-extensions/iceberg-metadata-reader/pom.xml
+++ b/java-extensions/iceberg-metadata-reader/pom.xml
@@ -64,17 +64,6 @@
             <version>4.0.2</version>
         </dependency>
 
-        <dependency>
-            <groupId>de.javakaffee</groupId>
-            <artifactId>kryo-serializers</artifactId>
-            <version>0.45</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.esotericsoftware</groupId>
-                    <artifactId>kryo</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <dependency>
             <groupId>commons-lang</groupId>

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataScanner.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.starrocks.connector.share.iceberg.CommonMetadataBean;
 import com.starrocks.connector.share.iceberg.IcebergMetricsBean;
 import com.starrocks.jni.connector.ColumnValue;
-import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/UnmodifiableCollectionsSerializer.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/UnmodifiableCollectionsSerializer.java
@@ -1,0 +1,177 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.iceberg;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * A Java 17-compatible kryo serializer for unmodifiable collections that does NOT
+ * use reflection to access private fields (unlike de.javakaffee's version).
+ * Based on fe-core's org.apache.iceberg.UnmodifiableCollectionsSerializer, with
+ * toMutable() added to correctly handle both Collection and Map types on write.
+ */
+public class UnmodifiableCollectionsSerializer extends Serializer<Object> {
+
+    public static void registerSerializers(Kryo kryo) {
+        UnmodifiableCollectionsSerializer serializer = new UnmodifiableCollectionsSerializer();
+        for (UnmodifiableCollection item : UnmodifiableCollection.CACHED_VALUES) {
+            kryo.register(item.type, serializer);
+        }
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, Object object) {
+        UnmodifiableCollection unmodifiableCollection = UnmodifiableCollection.valueOfType(
+                object.getClass()
+        );
+        output.writeInt(unmodifiableCollection.ordinal(), true);
+        kryo.writeClassAndObject(output, unmodifiableCollection.toMutable(object));
+    }
+
+    @Override
+    public Object read(Kryo kryo, Input input, Class<Object> clazz) {
+        int ordinal = input.readInt(true);
+        UnmodifiableCollection unmodifiableCollection = UnmodifiableCollection.CACHED_VALUES[ordinal];
+        Object sourceCollection = kryo.readClassAndObject(input);
+        return unmodifiableCollection.create(sourceCollection);
+    }
+
+    @Override
+    public Object copy(Kryo kryo, Object original) {
+        UnmodifiableCollection unmodifiableCollection = UnmodifiableCollection.valueOfType(
+                original.getClass()
+        );
+        Object sourceCollectionCopy = kryo.copy(unmodifiableCollection.toMutable(original));
+        return unmodifiableCollection.create(sourceCollectionCopy);
+    }
+
+    private enum UnmodifiableCollection {
+        COLLECTION(Collections.unmodifiableCollection(Arrays.asList("")).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableCollection((Collection<?>) sourceCollection);
+            }
+
+            @Override
+            public Object toMutable(Object obj) {
+                return new ArrayList<>((Collection<?>) obj);
+            }
+        },
+        RANDOM_ACCESS_LIST(Collections.unmodifiableList(new ArrayList<Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableList((List<?>) sourceCollection);
+            }
+
+            @Override
+            public Object toMutable(Object obj) {
+                return new ArrayList<>((Collection<?>) obj);
+            }
+        },
+        LIST(Collections.unmodifiableList(new LinkedList<Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableList((List<?>) sourceCollection);
+            }
+
+            @Override
+            public Object toMutable(Object obj) {
+                return new ArrayList<>((Collection<?>) obj);
+            }
+        },
+        SET(Collections.unmodifiableSet(new HashSet<Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableSet((Set<?>) sourceCollection);
+            }
+
+            @Override
+            public Object toMutable(Object obj) {
+                return new HashSet<>((Collection<?>) obj);
+            }
+        },
+        SORTED_SET(Collections.unmodifiableSortedSet(new TreeSet<Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableSortedSet((SortedSet<?>) sourceCollection);
+            }
+
+            @Override
+            public Object toMutable(Object obj) {
+                return new TreeSet<>((Collection<?>) obj);
+            }
+        },
+        MAP(Collections.unmodifiableMap(new HashMap<Void, Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableMap((Map<?, ?>) sourceCollection);
+            }
+
+            @Override
+            public Object toMutable(Object obj) {
+                return new HashMap<>((Map<?, ?>) obj);
+            }
+        },
+        SORTED_MAP(Collections.unmodifiableSortedMap(new TreeMap<Void, Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableSortedMap((SortedMap<?, ?>) sourceCollection);
+            }
+
+            @Override
+            public Object toMutable(Object obj) {
+                return new TreeMap<>((Map<?, ?>) obj);
+            }
+        };
+
+        static final UnmodifiableCollection[] CACHED_VALUES = values();
+
+        private final Class<?> type;
+
+        UnmodifiableCollection(Class<?> type) {
+            this.type = type;
+        }
+
+        public abstract Object create(Object sourceCollection);
+
+        public abstract Object toMutable(Object obj);
+
+        static UnmodifiableCollection valueOfType(Class<?> type) {
+            for (UnmodifiableCollection item : CACHED_VALUES) {
+                if (item.type == type) {
+                    return item;
+                }
+            }
+            throw new IllegalArgumentException("The type " + type + " is not supported.");
+        }
+    }
+}


### PR DESCRIPTION

The de.javakaffee kryo-serializers library's UnmodifiableCollectionsSerializer uses reflection to access private fields in java.util.Collections, which is blocked by Java 17's module system. This causes all queries that trigger remote metadata planning via IcebergMetadataScanner to fail.

Replace it with a copy of the FE's custom UnmodifiableCollectionsSerializer (from org.apache.iceberg package) that avoids reflection by copying collection contents via public API. The serialization format is identical to the FE's deserializer, ensuring compatibility.

Remove the de.javakaffee kryo-serializers dependency entirely.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
