### PR TITLE
[Refactor] Decouple ArrowConvertContext from runtime state

### DIFF
--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -34,15 +34,30 @@
 #include "common/statusor.h"
 #include "gutil/strings/fastmem.h"
 #include "gutil/strings/substitute.h"
-#include "runtime/descriptors.h"
-#include "runtime/runtime_state.h"
-#include "runtime/runtime_state_helper.h"
 #include "types/datetime_value.h"
 #include "types/logical_type.h"
 #include "types/type_descriptor.h"
 #include "types/value_generator.h"
 
 namespace starrocks {
+
+static std::string_view current_column_name_or_null(const ArrowConvertContext* ctx) {
+    if (ctx == nullptr || ctx->current_column_name.empty()) {
+        return "null";
+    }
+    return ctx->current_column_name;
+}
+
+static bool has_arrow_convert_error_reporter(const ArrowConvertContext* ctx) {
+    return ctx != nullptr && ctx->report_error_message != nullptr;
+}
+
+static void report_arrow_convert_error(ArrowConvertContext* ctx, const std::string& reason,
+                                       const std::string& raw_data) {
+    if (has_arrow_convert_error_reporter(ctx)) {
+        ctx->report_error_message(reason, raw_data);
+    }
+}
 
 Status illegal_converting_error(const std::string& arrow_type_name, const std::string& type_name) {
     return Status::InternalError(strings::Substitute("Illegal converting from arrow type($0) to StarRocks type($1)",
@@ -100,7 +115,7 @@ void fill_filter(const arrow::Array* array, size_t array_start_idx, size_t num_e
         all_invalid &= filter_data[i];
     }
     if (UNLIKELY(!all_invalid)) {
-        ctx->report_error_message("column type is not null but data is null", "");
+        report_arrow_convert_error(ctx, "column type is not null but data is null", "");
     }
 }
 
@@ -124,7 +139,9 @@ Status convert_arrow_array_to_column(ConvertFuncTree* conv_func, size_t num_elem
     if (array->type_id() == ArrowTypeId::TIMESTAMP) {
         auto* timestamp_type = down_cast<arrow::TimestampType*>(array->type().get());
         auto& mutable_timezone = (std::string&)timestamp_type->timezone();
-        mutable_timezone = conv_ctx->state->timezone();
+        if (conv_ctx != nullptr && !conv_ctx->timezone.empty()) {
+            mutable_timezone = conv_ctx->timezone;
+        }
     }
 
     uint8_t* null_data;
@@ -306,11 +323,8 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
         auto concrete_column = down_cast<ColumnType*>(column);
         auto* filter_data = (&chunk_filter->front()) + column_start_idx;
         size_t max_length = binary_max_length<LT>;
-        if (ctx != nullptr) {
-            size_t type_len = ctx->current_slot->type().len;
-            if (type_len > 0) {
-                max_length = type_len;
-            }
+        if (ctx != nullptr && ctx->current_type_length > 0) {
+            max_length = ctx->current_type_length;
         }
 
         if constexpr (AT == ArrowTypeId::FIXED_SIZE_BINARY) {
@@ -328,11 +342,11 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
                     //filter all
                     std::fill_n(filter_data, num_elements, 0);
 
-                    if (ctx != nullptr) {
+                    if (has_arrow_convert_error_reporter(ctx)) {
                         std::string raw_data = "arrow data is fixed size binary type";
                         std::string reason = strings::Substitute("type length $0 exceeds max length $1", width,
                                                                  binary_max_length<LT>);
-                        ctx->report_error_message(reason, raw_data);
+                        report_arrow_convert_error(ctx, reason, raw_data);
                     }
                 }
                 return Status::OK();
@@ -359,14 +373,14 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
                     } else {
                         filter_data[i - array_start_idx] = 0;
 
-                        if (ctx != nullptr && !repeated) {
+                        if (!repeated && has_arrow_convert_error_reporter(ctx)) {
                             repeated = true;
                             ArrowOffsetType s_size = 0;
                             const char* s_data = reinterpret_cast<const char*>(concrete_array->GetValue(i, &s_size));
                             std::string raw_data = std::string(s_data, s_size);
                             std::string reason =
                                     strings::Substitute("string length $0 exceeds max length $1", s_size, max_length);
-                            ctx->report_error_message(reason, raw_data);
+                            report_arrow_convert_error(ctx, reason, raw_data);
                         }
                     }
                 }
@@ -421,11 +435,8 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, StringViewATGuard<AT>, Str
         auto* concrete_column = down_cast<ColumnType*>(column);
         auto* filter_data = (&chunk_filter->front()) + column_start_idx;
         size_t max_length = binary_max_length<LT>;
-        if (ctx != nullptr) {
-            size_t type_len = ctx->current_slot->type().len;
-            if (type_len > 0) {
-                max_length = type_len;
-            }
+        if (ctx != nullptr && ctx->current_type_length > 0) {
+            max_length = ctx->current_type_length;
         }
 
         concrete_column->reserve(concrete_column->size() + num_elements);
@@ -467,11 +478,11 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, StringViewATGuard<AT>, Str
                     null_data[i] = DATUM_NULL;
                 } else {
                     filter_data[i] = 0;
-                    if (ctx != nullptr && !repeated) {
+                    if (!repeated && has_arrow_convert_error_reporter(ctx)) {
                         repeated = true;
                         std::string reason =
                                 strings::Substitute("string length $0 exceeds max length $1", sv.size(), max_length);
-                        ctx->report_error_message(reason, std::string(sv));
+                        report_arrow_convert_error(ctx, reason, std::string(sv));
                     }
                 }
             } else {
@@ -851,7 +862,9 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, DateOrDateTimeATGuard<AT>,
                 /// column or datetime value.
 
                 // When the parquet timezone is empty, populate data with runtime timezone instead.
-                timezone = ctx->state->timezone();
+                if (ctx != nullptr && !ctx->timezone.empty()) {
+                    timezone = ctx->timezone;
+                }
             }
 
             cctz::time_zone ctz;
@@ -1064,7 +1077,8 @@ Status null_converter(const arrow::Array* array, size_t array_start_idx, size_t 
                       size_t column_start_idx, uint8_t* null_data, [[maybe_unused]] Filter* chunk_filter,
                       ArrowConvertContext* ctx, [[maybe_unused]] ConvertFuncTree* conv_func) {
     if (null_data == nullptr) {
-        return Status::InvalidArgument(fmt::format("The column ({}) must be nullable", ctx->current_slot->col_name()));
+        return Status::InvalidArgument(
+                fmt::format("The column ({}) must be nullable", current_column_name_or_null(ctx)));
     }
     for (size_t i = 0; i < num_elements; i++) {
         null_data[column_start_idx + i] = 1;
@@ -1177,18 +1191,6 @@ LogicalType get_strict_type(ArrowTypeId at) {
         return lt_it->second;
     }
     return TYPE_UNKNOWN;
-}
-
-static const int MAX_ERROR_MESSAGE_COUNTER = 100;
-
-void ArrowConvertContext::report_error_message(const std::string& reason, const std::string& raw_data) {
-    if (state == nullptr) return;
-    if (error_message_counter > MAX_ERROR_MESSAGE_COUNTER) return;
-    error_message_counter += 1;
-    std::string error_msg =
-            strings::Substitute("file = $0, column = $1, raw data = $2", current_file,
-                                (current_slot == nullptr) ? "null" : current_slot->col_name(), raw_data);
-    RuntimeStateHelper::append_error_msg_to_file(state, error_msg, reason);
 }
 
 } // namespace starrocks

--- a/be/src/exec/arrow_to_starrocks_converter.h
+++ b/be/src/exec/arrow_to_starrocks_converter.h
@@ -17,6 +17,10 @@
 #include <arrow/array.h>
 #include <arrow/status.h>
 
+#include <functional>
+#include <string>
+#include <string_view>
+
 #include "base/utility/meta_macro.h"
 #include "column/array_column.h"
 #include "column/arrow/arrow_type_traits.h"
@@ -30,16 +34,22 @@
 #include "types/type_descriptor.h"
 
 namespace starrocks {
-class RuntimeState;
-class SlotDescriptor;
 struct ConvertFuncTree;
 
 struct ArrowConvertContext {
-    class RuntimeState* state;
-    class SlotDescriptor* current_slot;
+    using ErrorReporter = std::function<void(const std::string& reason, const std::string& raw_data)>;
+
+    std::string timezone;
     std::string current_file;
+    std::string current_column_name;
+    size_t current_type_length = 0;
     int error_message_counter = 0;
-    void report_error_message(const std::string& reason, const std::string& raw_data);
+    ErrorReporter report_error_message = nullptr;
+
+    void set_current_column(std::string_view column_name, const TypeDescriptor& type) {
+        current_column_name = std::string(column_name);
+        current_type_length = type.len > 0 ? static_cast<size_t>(type.len) : 0;
+    }
 };
 
 // fill null_column's range [column_start_idx, column_start_idx + num_elements) with

--- a/be/src/exec/benchmark_scanner.cpp
+++ b/be/src/exec/benchmark_scanner.cpp
@@ -32,7 +32,7 @@ BenchmarkScanner::BenchmarkScanner(BenchmarkScannerParam param, const TupleDescr
         : _param(std::move(param)), _slot_descs(tuple_desc->slots()) {}
 
 Status BenchmarkScanner::open(RuntimeState* state) {
-    _conv_ctx.state = state;
+    _conv_ctx.timezone = state->timezone();
     _conv_ctx.current_file = _param.table_name;
     if (_param.options.chunk_size <= 0) {
         _param.options.chunk_size = state->chunk_size();
@@ -92,7 +92,7 @@ Status BenchmarkScanner::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eo
             return Status::NotFound("Benchmark column " + col + " not found in schema");
         }
 
-        _conv_ctx.current_slot = slot_desc;
+        _conv_ctx.set_current_column(slot_desc->col_name(), slot_desc->type());
         RETURN_IF_ERROR(convert_arrow_array_to_column(_conv_funcs[i].get(), num_elements, array.get(),
                                                       raw_chunk->get_column_raw_ptr_by_slot_id(slot_desc->id()),
                                                       _batch_start_idx, 0, &_chunk_filter, &_conv_ctx));

--- a/be/src/exec/file_scanner/parquet_scanner.cpp
+++ b/be/src/exec/file_scanner/parquet_scanner.cpp
@@ -25,10 +25,13 @@
 #include "fs/fs_broker.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
+#include "runtime/runtime_state_helper.h"
 #include "runtime/stream_load/load_stream_mgr.h"
 #include "runtime/stream_load/stream_load_pipe.h"
 
 namespace starrocks {
+
+static const int MAX_ERROR_MESSAGE_COUNTER = 100;
 
 ParquetScanner::ParquetScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
                                ScannerCounter* counter, bool schema_only)
@@ -40,7 +43,15 @@ ParquetScanner::ParquetScanner(RuntimeState* state, RuntimeProfile* profile, con
           _max_chunk_size(state->chunk_size() ? state->chunk_size() : 4096) {
     _file_format_str = "parquet";
     _chunk_filter.reserve(_max_chunk_size);
-    _conv_ctx.state = state;
+    _conv_ctx.timezone = state->timezone();
+    _conv_ctx.report_error_message = [state, ctx = &_conv_ctx](const std::string& reason, const std::string& raw_data) {
+        if (ctx->error_message_counter > MAX_ERROR_MESSAGE_COUNTER) return;
+        ctx->error_message_counter += 1;
+        std::string error_msg =
+                strings::Substitute("file = $0, column = $1, raw data = $2", ctx->current_file,
+                                    ctx->current_column_name.empty() ? "null" : ctx->current_column_name, raw_data);
+        RuntimeStateHelper::append_error_msg_to_file(state, error_msg, reason);
+    };
 }
 
 ParquetScanner::~ParquetScanner() = default;
@@ -107,7 +118,7 @@ Status ParquetScanner::append_batch_to_src_chunk(ChunkPtr* chunk) {
         if (slot_desc == nullptr) {
             continue;
         }
-        _conv_ctx.current_slot = slot_desc;
+        _conv_ctx.set_current_column(slot_desc->col_name(), slot_desc->type());
         auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(slot_desc->id());
         auto array_ptr = _batch->GetColumnByName(std::string(slot_desc->col_name()));
         if (array_ptr == nullptr) {

--- a/be/test/exec/arrow_converter_test.cpp
+++ b/be/test/exec/arrow_converter_test.cpp
@@ -32,7 +32,6 @@
 #include "column/vectorized_fwd.h"
 #include "exec/arrow_to_starrocks_converter.h"
 #include "exec/file_scanner/parquet_scanner.h"
-#include "runtime/descriptors.h"
 #include "types/datetime_value.h"
 #include "util/arrow/row_batch.h"
 
@@ -963,6 +962,23 @@ PARALLEL_TEST(ArrowConverterTest, test_timestamp_to_datetime) {
         test_datetime<ArrowTypeId::TIMESTAMP, TYPE_DATETIME, arrow::TimestampType>(type, test_cases);
         test_nullable_datetime<ArrowTypeId::TIMESTAMP, TYPE_DATETIME, arrow::TimestampType>(type, test_cases);
     }
+}
+
+PARALLEL_TEST(ArrowConverterTest, test_timestamp_convert_uses_context_timezone) {
+    auto type = std::make_shared<arrow::TimestampType>(arrow::TimeUnit::SECOND, "UTC");
+    size_t counter = 0;
+    auto array = create_constant_datetime_array<arrow::TimestampType, false>(1, 0, type, counter);
+    ConvertFuncTree cf(get_arrow_converter(ArrowTypeId::TIMESTAMP, TYPE_DATETIME, false, false));
+    ASSERT_TRUE(cf.func != nullptr);
+
+    ArrowConvertContext ctx;
+    ctx.timezone = "Asia/Shanghai";
+    auto column = TimestampColumn::create();
+    Filter filter(1, 1);
+    ASSERT_STATUS_OK(
+            convert_arrow_array_to_column(&cf, array->length(), array.get(), column.get(), 0, 0, &filter, &ctx));
+
+    ASSERT_EQ(column->get_data()[0], string_to_datetime<TYPE_DATETIME>("1970-01-01 08:00:00"));
 }
 
 template <bool is_nullable>
@@ -1919,8 +1935,27 @@ PARALLEL_TEST(ArrowConverterTest, test_string_view_nullable_non_strict_overflow)
     }
 }
 
-// Strict overflow with ArrowConvertContext — exercises ctx->current_slot->type().len
-// (lines 379-380) and ctx->report_error_message() (lines 425-429).
+PARALLEL_TEST(ArrowConverterTest, test_arrow_convert_context_uses_single_error_reporter_callback) {
+    ArrowConvertContext ctx;
+    ctx.current_file = "test_file.parquet";
+    ctx.set_current_column("test_col", TypeDescriptor::create_varchar_type(5));
+
+    std::string reported_reason;
+    std::string reported_raw_data;
+    std::string reported_column;
+    ctx.report_error_message = [&](const std::string& reason, const std::string& raw_data) {
+        reported_reason = reason;
+        reported_raw_data = raw_data;
+        reported_column = ctx.current_column_name;
+    };
+    ctx.report_error_message("too long", "abcdef");
+
+    ASSERT_EQ(reported_reason, "too long");
+    ASSERT_EQ(reported_raw_data, "abcdef");
+    ASSERT_EQ(reported_column, "test_col");
+}
+
+// Strict overflow with ArrowConvertContext primitive metadata.
 PARALLEL_TEST(ArrowConverterTest, test_string_view_strict_overflow_with_ctx) {
     // CHAR(10): strings > 10 bytes should be rejected
     std::vector<std::string> values = {
@@ -1931,11 +1966,10 @@ PARALLEL_TEST(ArrowConverterTest, test_string_view_strict_overflow_with_ctx) {
     };
     auto array = create_string_view_array(values);
 
-    // Build ArrowConvertContext with a CHAR(10) SlotDescriptor
-    SlotDescriptor slot(0, "test_col", TypeDescriptor::create_char_type(10));
+    // Build ArrowConvertContext with CHAR(10) metadata.
+    TypeDescriptor char_type = TypeDescriptor::create_char_type(10);
     ArrowConvertContext ctx;
-    ctx.state = nullptr;
-    ctx.current_slot = &slot;
+    ctx.set_current_column("test_col", char_type);
 
     auto conv_func = get_arrow_converter(ArrowTypeId::STRING_VIEW, TYPE_CHAR, false, true);
     ASSERT_TRUE(conv_func != nullptr);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
