### PR TITLE
[Refactor] Move Arrow column conversion planning out of Parquet scanner

### DIFF
--- a/be/src/column/arrow/arrow_to_starrocks_converter.cpp
+++ b/be/src/column/arrow/arrow_to_starrocks_converter.cpp
@@ -16,15 +16,18 @@
 
 #include <arrow/array.h>
 #include <arrow/compute/api.h>
+#include <fmt/format.h>
 
 #include "arrow/array/array_binary.h"
 #include "arrow/array/array_nested.h"
 #include "arrow/scalar.h"
 #include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
+#include "base/decimal_types.h"
 #include "base/utility/pred_guard.h"
 #include "column/array_column.h"
 #include "column/arrow/arrow_to_json_converter.h"
+#include "column/column_helper.h"
 #include "column/map_column.h"
 #include "column/nullable_column.h"
 #include "column/runtime_type_traits.h"
@@ -1191,6 +1194,149 @@ LogicalType get_strict_type(ArrowTypeId at) {
         return lt_it->second;
     }
     return TYPE_UNKNOWN;
+}
+
+// Build the arrow-column conversion plan used when the first batch determines
+// the physical destination type. An Arrow type AT loading into StarRocks type LT
+// is converted in two phases:
+// 1. AT -> LT0 by ConvertFuncTree, where LT0 is either LT or a strict raw type.
+// 2. LT0 -> LT by a higher-layer expression when a cast is needed.
+//
+// Nested ARRAY/MAP/STRUCT types build child plans recursively. This function
+// owns only phase 1: raw type selection and ConvertFuncTree construction.
+Status build_arrow_column_convert_plan(const arrow::DataType* arrow_type, const TypeDescriptor* type_desc,
+                                       bool is_nullable, TypeDescriptor* raw_type_desc, ConvertFuncTree* conv_func,
+                                       bool& need_cast, bool strict_mode) {
+    if (arrow_type->id() == ArrowTypeId::DICTIONARY) {
+        auto* dictionary_type = down_cast<const arrow::DictionaryType*>(arrow_type);
+        return build_arrow_column_convert_plan(dictionary_type->value_type().get(), type_desc, is_nullable,
+                                               raw_type_desc, conv_func, need_cast, strict_mode);
+    }
+
+    auto at = arrow_type->id();
+    auto lt = type_desc->type;
+    conv_func->func = get_arrow_converter(at, lt, is_nullable, strict_mode);
+    conv_func->children.clear();
+
+    switch (lt) {
+    case TYPE_ARRAY: {
+        if (at != ArrowTypeId::LIST && at != ArrowTypeId::LARGE_LIST && at != ArrowTypeId::FIXED_SIZE_LIST) {
+            return Status::InternalError(
+                    fmt::format("Apache Arrow type (nested) {} does not match the type {} in StarRocks",
+                                arrow_type->name(), type_to_string(lt)));
+        }
+        raw_type_desc->type = TYPE_ARRAY;
+        TypeDescriptor type;
+        auto cf = std::make_unique<ConvertFuncTree>();
+        auto sub_at = arrow_type->field(0)->type();
+        RETURN_IF_ERROR(build_arrow_column_convert_plan(sub_at.get(), &type_desc->children[0], true, &type, cf.get(),
+                                                        need_cast, strict_mode));
+        raw_type_desc->children.emplace_back(std::move(type));
+        conv_func->children.emplace_back(std::move(cf));
+        break;
+    }
+    case TYPE_MAP: {
+        if (at != ArrowTypeId::MAP) {
+            return Status::InternalError(
+                    fmt::format("Apache Arrow type (nested) {} does not match the type {} in StarRocks",
+                                arrow_type->name(), type_to_string(lt)));
+        }
+
+        raw_type_desc->type = TYPE_MAP;
+        for (auto i = 0; i < 2; i++) {
+            TypeDescriptor type;
+            auto cf = std::make_unique<ConvertFuncTree>();
+            auto sub_at = i == 0 ? down_cast<const arrow::MapType*>(arrow_type)->key_type()
+                                 : down_cast<const arrow::MapType*>(arrow_type)->item_type();
+            RETURN_IF_ERROR(build_arrow_column_convert_plan(sub_at.get(), &type_desc->children[i], true, &type,
+                                                            cf.get(), need_cast, strict_mode));
+            raw_type_desc->children.emplace_back(std::move(type));
+            conv_func->children.emplace_back(std::move(cf));
+        }
+        break;
+    }
+    case TYPE_STRUCT: {
+        if (at != ArrowTypeId::STRUCT) {
+            return Status::InternalError(
+                    fmt::format("Apache Arrow type (nested) {} does not match the type {} in StarRocks",
+                                arrow_type->name(), type_to_string(lt)));
+        }
+        auto field_size = type_desc->children.size();
+        auto arrow_field_size = arrow_type->num_fields();
+
+        raw_type_desc->type = TYPE_STRUCT;
+        raw_type_desc->field_names = type_desc->field_names;
+        conv_func->field_names = type_desc->field_names;
+        for (auto i = 0; i < field_size; i++) {
+            TypeDescriptor type;
+            auto cf = std::make_unique<ConvertFuncTree>();
+            auto sub_at = i >= arrow_field_size ? arrow::null() : arrow_type->field(i)->type();
+            RETURN_IF_ERROR(build_arrow_column_convert_plan(sub_at.get(), &type_desc->children[i], true, &type,
+                                                            cf.get(), need_cast, strict_mode));
+            raw_type_desc->children.emplace_back(std::move(type));
+            conv_func->children.emplace_back(std::move(cf));
+        }
+        break;
+    }
+    default: {
+        if (conv_func->func == nullptr) {
+            need_cast = true;
+            Status error = illegal_converting_error(arrow_type->name(), type_desc->debug_string());
+            auto strict_pt = get_strict_type(at);
+            if (strict_pt == TYPE_UNKNOWN) {
+                return error;
+            }
+            auto strict_conv_func = get_arrow_converter(at, strict_pt, is_nullable, strict_mode);
+            if (strict_conv_func == nullptr) {
+                return error;
+            }
+            conv_func->func = strict_conv_func;
+            raw_type_desc->type = strict_pt;
+            switch (strict_pt) {
+            case TYPE_DECIMAL128:
+            case TYPE_DECIMAL256: {
+                const auto* decimal_type = down_cast<const arrow::DecimalType*>(arrow_type);
+                auto precision = decimal_type->precision();
+                auto scale = decimal_type->scale();
+                auto max_precision = strict_pt == TYPE_DECIMAL256 ? decimal_precision_limit<int256_t>
+                                                                  : decimal_precision_limit<int128_t>;
+                if (precision < 1 || precision > max_precision || scale < 0 || scale > precision) {
+                    return Status::InternalError(
+                            strings::Substitute("Decimal($0, $1) is out of range.", precision, scale));
+                }
+                raw_type_desc->precision = precision;
+                raw_type_desc->scale = scale;
+                break;
+            }
+            case TYPE_VARCHAR: {
+                raw_type_desc->len = TypeDescriptor::MAX_VARCHAR_LENGTH;
+                break;
+            }
+            case TYPE_CHAR: {
+                raw_type_desc->len = TypeDescriptor::MAX_CHAR_LENGTH;
+                break;
+            }
+            case TYPE_DECIMALV2:
+            case TYPE_DECIMAL32:
+            case TYPE_DECIMAL64: {
+                return Status::InternalError(
+                        strings::Substitute("Apache Arrow type($0) does not match the type($1) in StarRocks",
+                                            arrow_type->name(), type_to_string(strict_pt)));
+            }
+            default:
+                break;
+            }
+        } else {
+            *raw_type_desc = *type_desc;
+        }
+    }
+    }
+    return Status::OK();
+}
+
+MutableColumnPtr create_arrow_column_convert_dest(const TypeDescriptor& type_desc, const TypeDescriptor& raw_type_desc,
+                                                  bool need_cast, bool is_nullable) {
+    return ColumnHelper::create_column(need_cast ? raw_type_desc : type_desc, is_nullable);
 }
 
 } // namespace starrocks

--- a/be/src/column/arrow/arrow_to_starrocks_converter.h
+++ b/be/src/column/arrow/arrow_to_starrocks_converter.h
@@ -95,4 +95,11 @@ struct ConvertFuncTree {
     std::vector<std::unique_ptr<ConvertFuncTree>> children;
 };
 
+Status build_arrow_column_convert_plan(const arrow::DataType* arrow_type, const TypeDescriptor* type_desc,
+                                       bool is_nullable, TypeDescriptor* raw_type_desc, ConvertFuncTree* conv_func,
+                                       bool& need_cast, bool strict_mode);
+
+MutableColumnPtr create_arrow_column_convert_dest(const TypeDescriptor& type_desc, const TypeDescriptor& raw_type_desc,
+                                                  bool need_cast, bool is_nullable);
+
 } // namespace starrocks

--- a/be/src/exec/benchmark_scanner.cpp
+++ b/be/src/exec/benchmark_scanner.cpp
@@ -14,14 +14,16 @@
 
 #include "exec/benchmark_scanner.h"
 
+#include <arrow/record_batch.h>
+
 #include <algorithm>
 
 #include "base/utility/arrow_utils.h"
 #include "benchgen/benchmark_suite.h"
 #include "benchgen/record_batch_iterator_factory.h"
+#include "column/arrow/arrow_to_starrocks_converter.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
-#include "exec/file_scanner/parquet_scanner.h"
 #include "exprs/cast_expr.h"
 #include "exprs/column_ref.h"
 #include "runtime/runtime_state.h"
@@ -140,8 +142,9 @@ Status BenchmarkScanner::_init_converters(const std::shared_ptr<arrow::Schema>& 
         auto raw_type_desc = std::make_unique<TypeDescriptor>();
         auto conv_func = std::make_unique<ConvertFuncTree>();
         bool need_cast = false;
-        RETURN_IF_ERROR(ParquetScanner::build_dest(field->type().get(), &slot_desc->type(), slot_desc->is_nullable(),
-                                                   raw_type_desc.get(), conv_func.get(), need_cast, false));
+        RETURN_IF_ERROR(build_arrow_column_convert_plan(field->type().get(), &slot_desc->type(),
+                                                        slot_desc->is_nullable(), raw_type_desc.get(), conv_func.get(),
+                                                        need_cast, false));
 
         Expr* expr = nullptr;
         if (!need_cast) {

--- a/be/src/exec/file_scanner/parquet_scanner.cpp
+++ b/be/src/exec/file_scanner/parquet_scanner.cpp
@@ -14,8 +14,6 @@
 
 #include "exec/file_scanner/parquet_scanner.h"
 
-#include <fmt/format.h>
-
 #include "base/simd/simd.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
@@ -173,169 +171,23 @@ Status ParquetScanner::finalize_src_chunk(ChunkPtr* chunk) {
     return Status::OK();
 }
 
-// when first batch is accumulated into a column whose propre type must be
-// selected. Two concepts used to depict this selection is explained at first:
-// 1. arrow-column convertible:  an arrow type can convert to a column directly, e.g. HalfFloatArray -> FloatColumn
-// 2. inter-column convertible:  a column can convert to another column, e.g. BinaryColumn -> FloatColumn
-// An arrow type AT loading into column type LT is undergoes this steps:
-// AT ===[arrow-column convert]===> LT0 ===[inter-column convert]===> LT
-// case#0: convert recursively for nested types: TYPE_ARRAY, TYPE_MAP, TYPE_STRUCT
-// case#1: if an optimized conv_func provided for AT converting to LT, then convert AT to LT directly
-//  AT ===[conv_func] ===> LT ===[ColumnRef expr]===> LT
-// case#2: if no optimized conv_func is provided, then convert AT to a strict LT, then use CastExpr for
-//  inter-column converting.
-//  AT ===[conv_func]===> strict LT ===[VectorizedCastExpr]===> LT
-// case#3: otherwise, AT to LT is inconvertible and InterError is reported.
-
-// build convert function tree, raw type desc to get cast function and create dest column,
-Status ParquetScanner::build_dest(const arrow::DataType* arrow_type, const TypeDescriptor* type_desc, bool is_nullable,
-                                  TypeDescriptor* raw_type_desc, ConvertFuncTree* conv_func, bool& need_cast,
-                                  bool strict_mode) {
-    if (arrow_type->id() == ArrowTypeId::DICTIONARY) {
-        auto* dictionary_type = down_cast<const arrow::DictionaryType*>(arrow_type);
-        return build_dest(dictionary_type->value_type().get(), type_desc, is_nullable, raw_type_desc, conv_func,
-                          need_cast, strict_mode);
-    }
-
-    auto at = arrow_type->id();
-    auto lt = type_desc->type;
-    conv_func->func = get_arrow_converter(at, lt, is_nullable, strict_mode);
-    conv_func->children.clear();
-
-    switch (lt) {
-    case TYPE_ARRAY: {
-        if (at != ArrowTypeId::LIST && at != ArrowTypeId::LARGE_LIST && at != ArrowTypeId::FIXED_SIZE_LIST) {
-            return Status::InternalError(
-                    fmt::format("Apache Arrow type (nested) {} does not match the type {} in StarRocks",
-                                arrow_type->name(), type_to_string(lt)));
-        }
-        raw_type_desc->type = TYPE_ARRAY;
-        TypeDescriptor type;
-        auto cf = std::make_unique<ConvertFuncTree>();
-        auto sub_at = arrow_type->field(0)->type();
-        RETURN_IF_ERROR(
-                build_dest(sub_at.get(), &type_desc->children[0], true, &type, cf.get(), need_cast, strict_mode));
-        raw_type_desc->children.emplace_back(std::move(type));
-        conv_func->children.emplace_back(std::move(cf));
-        break;
-    }
-    case TYPE_MAP: {
-        if (at != ArrowTypeId::MAP) {
-            return Status::InternalError(
-                    fmt::format("Apache Arrow type (nested) {} does not match the type {} in StarRocks",
-                                arrow_type->name(), type_to_string(lt)));
-        }
-
-        raw_type_desc->type = TYPE_MAP;
-        for (auto i = 0; i < 2; i++) {
-            TypeDescriptor type;
-            auto cf = std::make_unique<ConvertFuncTree>();
-            auto sub_at = i == 0 ? down_cast<const arrow::MapType*>(arrow_type)->key_type()
-                                 : down_cast<const arrow::MapType*>(arrow_type)->item_type();
-            RETURN_IF_ERROR(
-                    build_dest(sub_at.get(), &type_desc->children[i], true, &type, cf.get(), need_cast, strict_mode));
-            raw_type_desc->children.emplace_back(std::move(type));
-            conv_func->children.emplace_back(std::move(cf));
-        }
-        break;
-    }
-    case TYPE_STRUCT: {
-        if (at != ArrowTypeId::STRUCT) {
-            return Status::InternalError(
-                    fmt::format("Apache Arrow type (nested) {} does not match the type {} in StarRocks",
-                                arrow_type->name(), type_to_string(lt)));
-        }
-        auto field_size = type_desc->children.size();
-        auto arrow_field_size = arrow_type->num_fields();
-
-        raw_type_desc->type = TYPE_STRUCT;
-        raw_type_desc->field_names = type_desc->field_names;
-        conv_func->field_names = type_desc->field_names;
-        for (auto i = 0; i < field_size; i++) {
-            TypeDescriptor type;
-            auto cf = std::make_unique<ConvertFuncTree>();
-            auto sub_at = i >= arrow_field_size ? arrow::null() : arrow_type->field(i)->type();
-            RETURN_IF_ERROR(
-                    build_dest(sub_at.get(), &type_desc->children[i], true, &type, cf.get(), need_cast, strict_mode));
-            raw_type_desc->children.emplace_back(std::move(type));
-            conv_func->children.emplace_back(std::move(cf));
-        }
-        break;
-    }
-    default: {
-        if (conv_func->func == nullptr) {
-            need_cast = true;
-            Status error = illegal_converting_error(arrow_type->name(), type_desc->debug_string());
-            auto strict_pt = get_strict_type(at);
-            if (strict_pt == TYPE_UNKNOWN) {
-                return error;
-            }
-            auto strict_conv_func = get_arrow_converter(at, strict_pt, is_nullable, strict_mode);
-            if (strict_conv_func == nullptr) {
-                return error;
-            }
-            conv_func->func = strict_conv_func;
-            raw_type_desc->type = strict_pt;
-            switch (strict_pt) {
-            case TYPE_DECIMAL128:
-            case TYPE_DECIMAL256: {
-                const auto* decimal_type = down_cast<const arrow::DecimalType*>(arrow_type);
-                auto precision = decimal_type->precision();
-                auto scale = decimal_type->scale();
-                auto max_precision = strict_pt == TYPE_DECIMAL256 ? decimal_precision_limit<int256_t>
-                                                                  : decimal_precision_limit<int128_t>;
-                if (precision < 1 || precision > max_precision || scale < 0 || scale > precision) {
-                    return Status::InternalError(
-                            strings::Substitute("Decimal($0, $1) is out of range.", precision, scale));
-                }
-                raw_type_desc->precision = precision;
-                raw_type_desc->scale = scale;
-                break;
-            }
-            case TYPE_VARCHAR: {
-                raw_type_desc->len = TypeDescriptor::MAX_VARCHAR_LENGTH;
-                break;
-            }
-            case TYPE_CHAR: {
-                raw_type_desc->len = TypeDescriptor::MAX_CHAR_LENGTH;
-                break;
-            }
-            case TYPE_DECIMALV2:
-            case TYPE_DECIMAL32:
-            case TYPE_DECIMAL64: {
-                return Status::InternalError(
-                        strings::Substitute("Apache Arrow type($0) does not match the type($1) in StarRocks",
-                                            arrow_type->name(), type_to_string(strict_pt)));
-            }
-            default:
-                break;
-            }
-        } else {
-            *raw_type_desc = *type_desc;
-        }
-    }
-    }
-    return Status::OK();
-}
-
 Status ParquetScanner::new_column(const arrow::DataType* arrow_type, const SlotDescriptor* slot_desc,
                                   MutableColumnPtr* column, ConvertFuncTree* conv_func, Expr** expr, ObjectPool& pool,
                                   bool strict_mode) {
     auto& type_desc = slot_desc->type();
-    auto* raw_type_desc = pool.add(new TypeDescriptor());
+    TypeDescriptor raw_type_desc;
     bool need_cast = false;
-    RETURN_IF_ERROR(build_dest(arrow_type, &type_desc, slot_desc->is_nullable(), raw_type_desc, conv_func, need_cast,
-                               strict_mode));
+    RETURN_IF_ERROR(build_arrow_column_convert_plan(arrow_type, &type_desc, slot_desc->is_nullable(), &raw_type_desc,
+                                                    conv_func, need_cast, strict_mode));
+    *column = create_arrow_column_convert_dest(type_desc, raw_type_desc, need_cast, slot_desc->is_nullable());
     if (!need_cast) {
         *expr = pool.add(new ColumnRef(slot_desc));
-        (*column) = ColumnHelper::create_column(type_desc, slot_desc->is_nullable());
     } else {
         auto slot = pool.add(new ColumnRef(slot_desc));
-        *expr = VectorizedCastExprFactory::from_type(*raw_type_desc, slot_desc->type(), slot, &pool);
+        *expr = VectorizedCastExprFactory::from_type(raw_type_desc, slot_desc->type(), slot, &pool);
         if ((*expr) == nullptr) {
             return illegal_converting_error(arrow_type->name(), type_desc.debug_string());
         }
-        *column = ColumnHelper::create_column(*raw_type_desc, slot_desc->is_nullable());
     }
 
     return Status::OK();

--- a/be/src/exec/file_scanner/parquet_scanner.h
+++ b/be/src/exec/file_scanner/parquet_scanner.h
@@ -53,10 +53,6 @@ public:
                              MutableColumnPtr* column, ConvertFuncTree* conv_func, Expr** expr, ObjectPool& pool,
                              bool strict_mode);
 
-    static Status build_dest(const arrow::DataType* arrow_type, const TypeDescriptor* type_desc, bool is_nullable,
-                             TypeDescriptor* raw_type_desc, ConvertFuncTree* conv_func, bool& need_cast,
-                             bool strict_mode);
-
 private:
     // Read next buffer from reader
     Status open_next_reader();

--- a/be/test/column/arrow_to_starrocks_converter_test.cpp
+++ b/be/test/column/arrow_to_starrocks_converter_test.cpp
@@ -214,6 +214,127 @@ std::tuple<bool, Status> get_conv_func(const TypeDescriptor& type, const TypeDes
     return {false, build_convert_tree_for_test(arrow_type.get(), type, is_nullable, &cf)};
 }
 
+TEST_F(ArrowConverterTest, BuildArrowColumnConvertPlanDirectScalar) {
+    auto arrow_type = arrow::int32();
+    TypeDescriptor type_desc(TYPE_INT);
+    TypeDescriptor raw_type_desc;
+    ConvertFuncTree conv_func;
+    bool need_cast = false;
+
+    ASSERT_STATUS_OK(build_arrow_column_convert_plan(arrow_type.get(), &type_desc, true, &raw_type_desc, &conv_func,
+                                                     need_cast, false));
+    ASSERT_FALSE(need_cast);
+    ASSERT_EQ(TYPE_INT, raw_type_desc.type);
+    ASSERT_NE(nullptr, conv_func.func);
+
+    auto column = create_arrow_column_convert_dest(type_desc, raw_type_desc, need_cast, true);
+    ASSERT_TRUE(column->is_nullable());
+}
+
+TEST_F(ArrowConverterTest, BuildArrowColumnConvertPlanCastNeededScalar) {
+    auto arrow_type = arrow::utf8();
+    TypeDescriptor type_desc(TYPE_INT);
+    TypeDescriptor raw_type_desc;
+    ConvertFuncTree conv_func;
+    bool need_cast = false;
+
+    ASSERT_STATUS_OK(build_arrow_column_convert_plan(arrow_type.get(), &type_desc, false, &raw_type_desc, &conv_func,
+                                                     need_cast, false));
+    ASSERT_TRUE(need_cast);
+    ASSERT_EQ(TYPE_VARCHAR, raw_type_desc.type);
+    ASSERT_EQ(TypeDescriptor::MAX_VARCHAR_LENGTH, raw_type_desc.len);
+    ASSERT_NE(nullptr, conv_func.func);
+
+    auto column = create_arrow_column_convert_dest(type_desc, raw_type_desc, need_cast, false);
+    ASSERT_TRUE(column->is_binary());
+}
+
+TEST_F(ArrowConverterTest, BuildArrowColumnConvertPlanUnwrapsDictionary) {
+    auto arrow_type = arrow::dictionary(arrow::int8(), arrow::int32());
+    TypeDescriptor type_desc(TYPE_INT);
+    TypeDescriptor raw_type_desc;
+    ConvertFuncTree conv_func;
+    bool need_cast = false;
+
+    ASSERT_STATUS_OK(build_arrow_column_convert_plan(arrow_type.get(), &type_desc, true, &raw_type_desc, &conv_func,
+                                                     need_cast, false));
+    ASSERT_FALSE(need_cast);
+    ASSERT_EQ(TYPE_INT, raw_type_desc.type);
+    ASSERT_NE(nullptr, conv_func.func);
+}
+
+TEST_F(ArrowConverterTest, BuildArrowColumnConvertPlanArray) {
+    auto arrow_type = arrow::list(arrow::int32());
+    TypeDescriptor type_desc(TYPE_ARRAY);
+    type_desc.children.emplace_back(TYPE_INT);
+    TypeDescriptor raw_type_desc;
+    ConvertFuncTree conv_func;
+    bool need_cast = false;
+
+    ASSERT_STATUS_OK(build_arrow_column_convert_plan(arrow_type.get(), &type_desc, true, &raw_type_desc, &conv_func,
+                                                     need_cast, false));
+    ASSERT_FALSE(need_cast);
+    ASSERT_EQ(TYPE_ARRAY, raw_type_desc.type);
+    ASSERT_EQ(1, raw_type_desc.children.size());
+    ASSERT_EQ(TYPE_INT, raw_type_desc.children[0].type);
+    ASSERT_EQ(1, conv_func.children.size());
+}
+
+TEST_F(ArrowConverterTest, BuildArrowColumnConvertPlanMap) {
+    auto arrow_type = arrow::map(arrow::int32(), arrow::utf8());
+    TypeDescriptor type_desc(TYPE_MAP);
+    type_desc.children.emplace_back(TYPE_INT);
+    type_desc.children.emplace_back(TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH));
+    TypeDescriptor raw_type_desc;
+    ConvertFuncTree conv_func;
+    bool need_cast = false;
+
+    ASSERT_STATUS_OK(build_arrow_column_convert_plan(arrow_type.get(), &type_desc, true, &raw_type_desc, &conv_func,
+                                                     need_cast, false));
+    ASSERT_FALSE(need_cast);
+    ASSERT_EQ(TYPE_MAP, raw_type_desc.type);
+    ASSERT_EQ(2, raw_type_desc.children.size());
+    ASSERT_EQ(TYPE_INT, raw_type_desc.children[0].type);
+    ASSERT_EQ(TYPE_VARCHAR, raw_type_desc.children[1].type);
+    ASSERT_EQ(2, conv_func.children.size());
+}
+
+TEST_F(ArrowConverterTest, BuildArrowColumnConvertPlanStruct) {
+    auto arrow_type = arrow::struct_({arrow::field("c0", arrow::int32()), arrow::field("c1", arrow::utf8())});
+    TypeDescriptor type_desc(TYPE_STRUCT);
+    type_desc.children.emplace_back(TYPE_INT);
+    type_desc.children.emplace_back(TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH));
+    type_desc.field_names = {"c0", "c1"};
+    TypeDescriptor raw_type_desc;
+    ConvertFuncTree conv_func;
+    bool need_cast = false;
+
+    ASSERT_STATUS_OK(build_arrow_column_convert_plan(arrow_type.get(), &type_desc, true, &raw_type_desc, &conv_func,
+                                                     need_cast, false));
+    ASSERT_FALSE(need_cast);
+    ASSERT_EQ(TYPE_STRUCT, raw_type_desc.type);
+    ASSERT_EQ(type_desc.field_names, raw_type_desc.field_names);
+    ASSERT_EQ(type_desc.field_names, conv_func.field_names);
+    ASSERT_EQ(2, raw_type_desc.children.size());
+    ASSERT_EQ(TYPE_INT, raw_type_desc.children[0].type);
+    ASSERT_EQ(TYPE_VARCHAR, raw_type_desc.children[1].type);
+    ASSERT_EQ(2, conv_func.children.size());
+}
+
+TEST_F(ArrowConverterTest, BuildArrowColumnConvertPlanRejectsInvalidNestedType) {
+    auto arrow_type = arrow::int32();
+    TypeDescriptor type_desc(TYPE_ARRAY);
+    type_desc.children.emplace_back(TYPE_INT);
+    TypeDescriptor raw_type_desc;
+    ConvertFuncTree conv_func;
+    bool need_cast = false;
+
+    auto st = build_arrow_column_convert_plan(arrow_type.get(), &type_desc, true, &raw_type_desc, &conv_func, need_cast,
+                                              false);
+    ASSERT_FALSE(st.ok());
+    ASSERT_NE(std::string::npos, st.message().find("does not match"));
+}
+
 template <typename ArrowType, bool is_nullable = false, typename CType = typename arrow::TypeTraits<ArrowType>::CType,
           typename BuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType>
 static inline std::shared_ptr<arrow::Array> create_constant_array(int64_t num_elements, CType value, size_t& counter) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
