### PR TITLE
[Tool] enhance ai-sr-skills: skip rules, skill sync, Slack notify

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -26,7 +26,84 @@ jobs:
       github.event.action == 'opened' &&
       !startsWith(github.head_ref, 'mergify/')
     steps:
+      - name: Compute skip rule
+        id: gate
+        env:
+          PR: ${{ github.event.number }}
+          REPO: ${{ github.repository }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -x
+          # Skip AI reviewer assignment for small/test-only PRs to reduce noise.
+          # Adjust BUGFIX_LINE_THRESHOLD as needed (non-test add+del lines).
+          BUGFIX_LINE_THRESHOLD=30
+          TEST_PATTERN='(Test\.(java|kt)$|_test\.(cpp|cc|h)$|/test/|^test/|^fe-test/|^regression-test/|/__test__/)'
+
+          skip=false
+          reason=""
+
+          # Rule 1: [UT] / [Doc] title prefix
+          if echo "$TITLE" | grep -qE '^\[(UT|Doc)\]'; then
+            skip=true
+            reason="title prefix [UT] or [Doc]"
+          fi
+
+          # Rule 2: all changed files match test pattern
+          if [ "$skip" = "false" ]; then
+            files=$(gh pr diff "$PR" -R "$REPO" --name-only 2>/dev/null || true)
+            total=$(echo "$files" | grep -cv '^$' || true)
+            non_test=$(echo "$files" | grep -v '^$' | grep -cvE "$TEST_PATTERN" || true)
+            if [ "$total" -gt 0 ] && [ "$non_test" -eq 0 ]; then
+              skip=true
+              reason="all $total changed files are tests"
+            fi
+          fi
+
+          # Rule 3: [BugFix] with non-test add+del < threshold
+          # NOTE: jq's regex needs \\. for a literal dot (the pattern must match TEST_PATTERN above).
+          if [ "$skip" = "false" ] && echo "$TITLE" | grep -qE '^\[BugFix\]'; then
+            non_test_lines=$(gh pr view "$PR" -R "$REPO" --json files --jq '
+              [.files[]
+               | select(.path | test("(Test\\.(java|kt)$|_test\\.(cpp|cc|h)$|/test/|^test/|^fe-test/|^regression-test/|/__test__/)") | not)
+               | (.additions + .deletions)]
+              | add // 0
+            ' 2>/dev/null || echo 0)
+            if [ "${non_test_lines:-0}" -lt "$BUGFIX_LINE_THRESHOLD" ]; then
+              skip=true
+              reason="[BugFix] non-test lines=$non_test_lines < $BUGFIX_LINE_THRESHOLD"
+            fi
+          fi
+
+          echo "skip=$skip"     >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "=== gate result: skip=$skip, reason='$reason' ==="
+
+      - name: Sync skills to latest
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          set -e
+          SKILL_REPO="$HOME/starrocks-skills"
+          SKILL_DEST="$HOME/.claude/skills"
+
+          if [ -d "$SKILL_REPO/.git" ]; then
+            cd "$SKILL_REPO" && git pull --ff-only --quiet \
+              || echo "WARN: git pull failed, using current checkout"
+          else
+            echo "WARN: $SKILL_REPO is not a git checkout, skip pull"
+          fi
+
+          mkdir -p "$SKILL_DEST"
+          for skill_dir in "$SKILL_REPO"/*/; do
+            [ -d "$skill_dir" ] || continue
+            name=$(basename "$skill_dir")
+            rsync -a --delete "$skill_dir" "$SKILL_DEST/$name/"
+          done
+
+          echo "Skills synced to $SKILL_DEST:"
+          ls -1 "$SKILL_DEST"
+
       - name: Assign PR Reviewer
+        if: steps.gate.outputs.skip != 'true'
         run: |
           echo "=== DEBUG ==="
           echo "PR: ${{ github.event.number }}"
@@ -36,8 +113,69 @@ jobs:
           echo "CLAUDE_CODE_OAUTH_TOKEN length: ${#CLAUDE_CODE_OAUTH_TOKEN}"
           echo "GITHUB_TOKEN length: ${#GITHUB_TOKEN}"
           echo "=== RUN ==="
+          # tee captures the skill's stdout for the Notify Slack step to parse
           docker exec -i -u claudeuser \
             -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
             -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
             claude-cli claude --dangerously-skip-permissions \
-            -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}" || true
+            -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}" \
+            2>&1 | tee "${RUNNER_TEMP}/ai_output.txt" || true
+
+      - name: Notify Slack
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          PR: ${{ github.event.number }}
+          REPO: ${{ github.repository }}
+          TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          CHANNEL_ID: C0B4GU36HJN
+        run: |
+          set -e
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool
+          cd ci-tool && git pull
+
+          # Parse who AI actually decided to assign from the skill's output.
+          # The skill prints: "Assigned reviewers: <comma-separated logins>" on success
+          # (see starrocks-skills/starrocks-assign-pr-reviewer/SKILL.md step 7).
+          # This catches the "AI picked someone already-assigned" case that a
+          # before/after diff on reviewRequests would miss.
+          ai_output="${RUNNER_TEMP}/ai_output.txt"
+          reviewers=""
+          if [ -f "$ai_output" ]; then
+            assigned_line=$(grep -iE 'assigned reviewers?:' "$ai_output" | tail -1 || true)
+            if [ -n "$assigned_line" ]; then
+              reviewers=$(echo "$assigned_line" \
+                | sed -E 's/^.*[Aa]ssigned [Rr]eviewers?:[[:space:]]*//' \
+                | tr ',，' '\n' \
+                | sed 's/^[[:space:]@]*//; s/[[:space:]]*$//' \
+                | grep -v '^$' || true)
+            fi
+          fi
+
+          if [ -z "$reviewers" ]; then
+            echo "Could not extract AI-assigned reviewers from output, skip Slack notification"
+            exit 0
+          fi
+          echo "AI assigned: $(echo "$reviewers" | tr '\n' ' ')"
+
+          # GitHub login -> Slack ID; unmapped users fall back to plain @login
+          mentions=""
+          while IFS= read -r login; do
+            [ -z "$login" ] && continue
+            slack_id=$(jq -r --arg k "$login" '.[$k] // empty' conf/member_slack.json)
+            if [ -n "$slack_id" ]; then
+              mentions="${mentions}<@${slack_id}> "
+            else
+              mentions="${mentions}@${login} "
+            fi
+          done <<< "$reviewers"
+
+          text="${mentions}You were assigned as reviewer for <${PR_URL}|#${PR} ${TITLE}>"
+
+          python3 lib/slack_notify.py \
+            --mode channel \
+            --token "$SLACK_BOT_TOKEN" \
+            --channel "$CHANNEL_ID" \
+            --text "$text"


### PR DESCRIPTION
## Why I'm doing:

The `ai-sr-skills.yml` workflow only had a single step that invoked the Claude CLI to assign a PR reviewer. Three gaps showed up in practice:

1. AI was invoked even for PRs where reviewer assignment adds no value ([UT], [Doc], test-only changes, tiny BugFix PRs), wasting both reviewer attention and Claude API spend.
2. The starrocks-skills repo is updated frequently, but the runner's `~/.claude/skills/` was not kept in sync — workflow runs could execute against a stale version of the skill.
3. After successful assignment there was no out-of-band signal to the reviewer; they only saw the GitHub email/notification, and the team had no shared visibility into who got assigned to what.

## What I'm doing:

Three additions to `ai-sr-skills.yml`, all gated behind the existing `pull_request_target: opened/reopened` trigger:

**1. Compute skip rule** — new gate step that sets `outputs.skip=true` for any of these cases, short-circuiting the downstream steps:
   - Title starts with `[UT]` or `[Doc]`
   - All changed files match a test path pattern (`Test.java|kt`, `_test.cpp|cc|h`, `/test/`, `^test/`, `^fe-test/`, `^regression-test/`, `/__test__/`)
   - Title starts with `[BugFix]` AND non-test add+del lines < 30

**2. Sync skills to latest** — `git pull --ff-only` on `~/starrocks-skills` and `rsync --delete` into `~/.claude/skills/` before each AI invocation. Ensures every workflow run uses current main of the skill repo. Iterates all subdirectories so newly added skills are picked up without workflow changes.

**3. Notify Slack** — after the AI step, parse the skill's `Assigned reviewers: <list>` confirmation line from captured stdout (skill contract documented in `starrocks-assign-pr-reviewer/SKILL.md` step 7), look up each login in `ci-tool/conf/member_slack.json`, and post `<@SLACK_ID> You were assigned as reviewer for <PR_URL|#N TITLE>` to channel `C0B4GU36HJN` (int-ph-ci-review). Skips cleanly when AI didn't assign anyone or output can't be parsed. Unmapped GitHub logins fall back to plain `@login` text (no real ping, but the notification still posts).

The `Assign PR Reviewer` step now pipes output through `tee "$RUNNER_TEMP/ai_output.txt"` so the Slack step can parse the skill's actual decision. This is more reliable than diffing PR reviewer state, which would miss the case where AI re-picks a reviewer already added by CODEOWNERS.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4