### PR TITLE
[BugFix] Fix Avro complex-type decoding for pruned children and nested nullable schemas

### DIFF
--- a/be/src/formats/avro/cpp/avro_reader.cpp
+++ b/be/src/formats/avro/cpp/avro_reader.cpp
@@ -597,8 +597,7 @@ Status AvroReader::init(std::unique_ptr<avro::InputStream> input_stream, const s
                 // The ResolvingDecoder will then skip unwanted fields at the binary level,
                 // saving CPU deserialization work — the Trino-equivalent of maskColumnsFromTableSchema.
                 projected = build_projected_schema(reader_schema, needed_cols);
-                using_projection =
-                        !needed_cols.empty() && projected.root()->leaves() < reader_schema.root()->leaves();
+                using_projection = !needed_cols.empty() && projected.root()->leaves() < reader_schema.root()->leaves();
             }
 
             if (using_projection) {

--- a/be/src/formats/avro/cpp/avro_reader.cpp
+++ b/be/src/formats/avro/cpp/avro_reader.cpp
@@ -562,10 +562,12 @@ Status AvroReader::init(std::unique_ptr<avro::InputStream> input_stream, const s
 
         // Collect the column names that actually need to be decoded.
         std::set<std::string> needed_cols;
+        bool has_complex_projection = false;
         if (slot_descs != nullptr) {
             for (const auto* slot : *slot_descs) {
                 if (slot != nullptr) {
                     needed_cols.insert(std::string(slot->col_name()));
+                    has_complex_projection |= slot->type().is_complex_type();
                 }
             }
         }
@@ -583,11 +585,21 @@ Status AvroReader::init(std::unique_ptr<avro::InputStream> input_stream, const s
             _base_reader = std::move(base);
             _base_reader->init();
         } else {
-            // Build a projected reader schema that contains only the needed columns.
-            // The ResolvingDecoder will then skip unwanted fields at the binary level,
-            // saving CPU deserialization work — the Trino-equivalent of maskColumnsFromTableSchema.
-            avro::ValidSchema projected = build_projected_schema(reader_schema, needed_cols);
-            bool using_projection = !needed_cols.empty() && projected.root()->leaves() < reader_schema.root()->leaves();
+            // Only apply top-level reader-schema projection to scalar-only scans.
+            // Complex slots (map/array/struct) may embed nullable named types, and
+            // avrocpp's resolving decoder can fail when a projected reader schema
+            // is used for those nested shapes. In that case, keep the full writer
+            // schema and rely on the generic row reader to materialize only the
+            // requested top-level slots.
+            avro::ValidSchema projected = reader_schema;
+            bool using_projection = false;
+            if (!has_complex_projection) {
+                // The ResolvingDecoder will then skip unwanted fields at the binary level,
+                // saving CPU deserialization work — the Trino-equivalent of maskColumnsFromTableSchema.
+                projected = build_projected_schema(reader_schema, needed_cols);
+                using_projection =
+                        !needed_cols.empty() && projected.root()->leaves() < reader_schema.root()->leaves();
+            }
 
             if (using_projection) {
                 _file_reader = std::make_unique<avro::DataFileReader<avro::GenericDatum>>(std::move(base), projected);

--- a/be/src/formats/avro/cpp/binary_column_reader.cpp
+++ b/be/src/formats/avro/cpp/binary_column_reader.cpp
@@ -20,7 +20,11 @@
 namespace starrocks::avrocpp {
 
 Status BinaryColumnReader::read_datum(const avro::GenericDatum& datum, Column* column) {
-    auto binary_column = down_cast<BinaryColumn*>(column);
+    auto* binary_column = dynamic_cast<BinaryColumn*>(column);
+    if (UNLIKELY(binary_column == nullptr)) {
+        return Status::InternalError(fmt::format("Avro binary reader expected BinaryColumn but got {}. column: {}",
+                                                 column == nullptr ? "null" : column->get_name(), _col_name));
+    }
 
     switch (datum.type()) {
     case avro::AVRO_INT:

--- a/be/src/formats/avro/cpp/column_reader.cpp
+++ b/be/src/formats/avro/cpp/column_reader.cpp
@@ -97,8 +97,14 @@ ColumnReaderUniquePtr ColumnReader::get_nullable_column_reader(const std::string
     }
 
     case TYPE_MAP: {
-        auto key_reader = get_nullable_column_reader(col_name, type_desc.children[0], timezone, invalid_as_null);
-        auto value_reader = get_nullable_column_reader(col_name, type_desc.children[1], timezone, invalid_as_null);
+        ColumnReaderUniquePtr key_reader = nullptr;
+        ColumnReaderUniquePtr value_reader = nullptr;
+        if (!type_desc.children[0].is_unknown_type()) {
+            key_reader = get_nullable_column_reader(col_name, type_desc.children[0], timezone, invalid_as_null);
+        }
+        if (!type_desc.children[1].is_unknown_type()) {
+            value_reader = get_nullable_column_reader(col_name, type_desc.children[1], timezone, invalid_as_null);
+        }
         reader = std::make_unique<MapColumnReader>(col_name, type_desc, std::move(key_reader), std::move(value_reader));
         break;
     }

--- a/be/src/formats/avro/cpp/column_reader.cpp
+++ b/be/src/formats/avro/cpp/column_reader.cpp
@@ -83,15 +83,22 @@ ColumnReaderUniquePtr ColumnReader::get_nullable_column_reader(const std::string
         std::vector<ColumnReaderUniquePtr> field_readers;
         field_readers.reserve(type_desc.children.size());
         for (size_t i = 0; i < type_desc.children.size(); ++i) {
-            field_readers.emplace_back(get_nullable_column_reader(type_desc.field_names[i], type_desc.children[i],
-                                                                  timezone, invalid_as_null));
+            if (type_desc.children[i].is_unknown_type()) {
+                field_readers.emplace_back(nullptr);
+            } else {
+                field_readers.emplace_back(get_nullable_column_reader(type_desc.field_names[i], type_desc.children[i],
+                                                                      timezone, invalid_as_null));
+            }
         }
         reader = std::make_unique<StructColumnReader>(col_name, type_desc, std::move(field_readers));
         break;
     }
 
     case TYPE_ARRAY: {
-        auto element_reader = get_nullable_column_reader(col_name, type_desc.children[0], timezone, invalid_as_null);
+        ColumnReaderUniquePtr element_reader = nullptr;
+        if (!type_desc.children[0].is_unknown_type()) {
+            element_reader = get_nullable_column_reader(col_name, type_desc.children[0], timezone, invalid_as_null);
+        }
         reader = std::make_unique<ArrayColumnReader>(col_name, type_desc, std::move(element_reader));
         break;
     }

--- a/be/src/formats/avro/cpp/complex_column_reader.cpp
+++ b/be/src/formats/avro/cpp/complex_column_reader.cpp
@@ -82,8 +82,6 @@ Status MapColumnReader::read_datum(const avro::GenericDatum& datum, Column* colu
 
     auto map_column = down_cast<MapColumn*>(column);
     auto keys_column = down_cast<NullableColumn*>(map_column->keys_column_raw_ptr());
-    auto* keys_null_column = keys_column->null_column_raw_ptr();
-    auto keys_data_column = down_cast<BinaryColumn*>(keys_column->data_column_raw_ptr());
     auto* values_column = map_column->values_column_raw_ptr();
     auto* offsets_column = map_column->offsets_column_raw_ptr();
 
@@ -93,6 +91,8 @@ Status MapColumnReader::read_datum(const avro::GenericDatum& datum, Column* colu
     uint32_t n = 0;
     for (auto& p : map_values) {
         if (_key_reader != nullptr) {
+            auto* keys_null_column = keys_column->null_column_raw_ptr();
+            auto* keys_data_column = down_cast<BinaryColumn*>(keys_column->data_column_raw_ptr());
             const auto& key = p.first;
             if (UNLIKELY(key.size() > _type_desc.children[0].len)) {
                 return Status::DataQualityError(

--- a/be/src/formats/avro/cpp/complex_column_reader.cpp
+++ b/be/src/formats/avro/cpp/complex_column_reader.cpp
@@ -38,7 +38,9 @@ Status StructColumnReader::read_datum(const avro::GenericDatum& datum, Column* c
         const auto& field_name = _type_desc.field_names[i];
         ASSIGN_OR_RETURN(auto* field_column, struct_column->field_column_raw_ptr(field_name));
 
-        if (record.hasField(field_name)) {
+        if (_field_readers[i] == nullptr) {
+            field_column->append_nulls(1);
+        } else if (record.hasField(field_name)) {
             const auto& field = record.field(field_name);
             auto* field_reader = down_cast<NullableColumnReader*>(_field_readers[i].get());
             RETURN_IF_ERROR(field_reader->read_datum(field, field_column));
@@ -52,8 +54,6 @@ Status StructColumnReader::read_datum(const avro::GenericDatum& datum, Column* c
 Status ArrayColumnReader::read_datum(const avro::GenericDatum& datum, Column* column) {
     DCHECK_EQ(datum.type(), avro::AVRO_ARRAY);
 
-    auto* element_reader = down_cast<NullableColumnReader*>(_element_reader.get());
-
     auto array_column = down_cast<ArrayColumn*>(column);
     auto* elements_column = array_column->elements_column_raw_ptr();
     auto* offsets_column = array_column->offsets_column_raw_ptr();
@@ -63,7 +63,12 @@ Status ArrayColumnReader::read_datum(const avro::GenericDatum& datum, Column* co
 
     uint32_t n = 0;
     for (auto& value : array_values) {
-        RETURN_IF_ERROR(element_reader->read_datum(value, elements_column));
+        if (_element_reader != nullptr) {
+            auto* element_reader = down_cast<NullableColumnReader*>(_element_reader.get());
+            RETURN_IF_ERROR(element_reader->read_datum(value, elements_column));
+        } else {
+            elements_column->append_nulls(1);
+        }
         ++n;
     }
 

--- a/be/src/formats/avro/cpp/complex_column_reader.cpp
+++ b/be/src/formats/avro/cpp/complex_column_reader.cpp
@@ -75,8 +75,6 @@ Status ArrayColumnReader::read_datum(const avro::GenericDatum& datum, Column* co
 Status MapColumnReader::read_datum(const avro::GenericDatum& datum, Column* column) {
     DCHECK_EQ(datum.type(), avro::AVRO_MAP);
 
-    auto* value_reader = down_cast<NullableColumnReader*>(_value_reader.get());
-
     auto map_column = down_cast<MapColumn*>(column);
     auto keys_column = down_cast<NullableColumn*>(map_column->keys_column_raw_ptr());
     auto* keys_null_column = keys_column->null_column_raw_ptr();
@@ -89,16 +87,26 @@ Status MapColumnReader::read_datum(const avro::GenericDatum& datum, Column* colu
 
     uint32_t n = 0;
     for (auto& p : map_values) {
-        const auto& key = p.first;
-        if (UNLIKELY(key.size() > _type_desc.children[0].len)) {
-            return Status::DataQualityError(fmt::format("Value length is beyond the capacity. column: {}, capacity: {}",
-                                                        _col_name, _type_desc.children[0].len));
+        if (_key_reader != nullptr) {
+            const auto& key = p.first;
+            if (UNLIKELY(key.size() > _type_desc.children[0].len)) {
+                return Status::DataQualityError(
+                        fmt::format("Value length is beyond the capacity. column: {}, capacity: {}", _col_name,
+                                    _type_desc.children[0].len));
+            }
+            keys_data_column->append(Slice(key));
+            keys_null_column->append(0);
+        } else {
+            keys_column->append_nulls(1);
         }
-        keys_data_column->append(Slice(key));
-        keys_null_column->append(0);
 
-        const auto& value = p.second;
-        RETURN_IF_ERROR(value_reader->read_datum(value, values_column));
+        if (_value_reader != nullptr) {
+            auto* value_reader = down_cast<NullableColumnReader*>(_value_reader.get());
+            const auto& value = p.second;
+            RETURN_IF_ERROR(value_reader->read_datum(value, values_column));
+        } else {
+            values_column->append_nulls(1);
+        }
 
         ++n;
     }

--- a/be/src/formats/avro/cpp/nullable_column_reader.cpp
+++ b/be/src/formats/avro/cpp/nullable_column_reader.cpp
@@ -14,6 +14,8 @@
 
 #include "formats/avro/cpp/nullable_column_reader.h"
 
+#include <fmt/format.h>
+
 #include "column/adaptive_nullable_column.h"
 #include "column/nullable_column.h"
 
@@ -29,7 +31,12 @@ Status NullableColumnReader::read_datum_for_adaptive_column(const avro::GenericD
         return read_datum_for_adaptive_column(union_value.datum(), column);
     }
 
-    auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
+    auto* nullable_column = dynamic_cast<AdaptiveNullableColumn*>(column);
+    if (UNLIKELY(nullable_column == nullptr)) {
+        return Status::InternalError(
+                fmt::format("Avro adaptive nullable reader expected AdaptiveNullableColumn but got {}",
+                            column == nullptr ? "null" : column->get_name()));
+    }
     auto* data_column = nullable_column->begin_append_not_default_value();
     auto st = _base_reader->read_datum(datum, data_column);
     if (st.ok()) {
@@ -51,7 +58,11 @@ Status NullableColumnReader::read_datum(const avro::GenericDatum& datum, Column*
         return read_datum(union_value.datum(), column);
     }
 
-    auto nullable_column = down_cast<NullableColumn*>(column);
+    auto* nullable_column = dynamic_cast<NullableColumn*>(column);
+    if (UNLIKELY(nullable_column == nullptr)) {
+        return Status::InternalError(fmt::format("Avro nullable reader expected NullableColumn but got {}",
+                                                 column == nullptr ? "null" : column->get_name()));
+    }
     auto* data_column = nullable_column->data_column_raw_ptr();
     auto st = _base_reader->read_datum(datum, data_column);
     if (st.ok()) {

--- a/be/test/formats/avro/cpp/avro_reader_test.cpp
+++ b/be/test/formats/avro/cpp/avro_reader_test.cpp
@@ -471,6 +471,36 @@ TEST_F(AvroReaderTest, test_column_projection) {
     ASSERT_TRUE(avro_reader->read_chunk(chunk, 2).is_end_of_file());
 }
 
+TEST_F(AvroReaderTest, test_complex_projection_falls_back_to_full_writer_schema) {
+    std::string filename = "complex_nest.avro";
+
+    auto schema_reader = create_avro_reader(filename);
+    std::vector<SlotDescriptor> all_descs;
+    ASSERT_OK(schema_reader->get_schema(&all_descs));
+    ASSERT_EQ(13, all_descs.size());
+
+    std::vector<SlotDescriptor*> slot_descs = {&all_descs[12]};
+    ASSERT_EQ("map_array_record", slot_descs[0]->col_name());
+    ASSERT_TRUE(slot_descs[0]->type().is_complex_type());
+    create_column_readers(slot_descs, _timezone, false);
+
+    auto file_or = FileSystem::Default()->new_random_access_file(_test_exec_dir + filename);
+    ASSERT_OK(file_or.status());
+    auto avro_reader = std::make_unique<AvroReader>();
+    ASSERT_OK(avro_reader->init(std::make_unique<AvroBufferInputStream>(
+                                        std::move(file_or.value()), config::avro_reader_buffer_size_bytes, _counter),
+                                filename, _state.get(), _counter, &slot_descs, &_column_readers,
+                                /*col_not_found_as_null=*/false));
+    ASSERT_FALSE(avro_reader->TEST_use_direct_path());
+
+    auto chunk = create_src_chunk(slot_descs);
+    ASSERT_OK(avro_reader->read_chunk(chunk, 2));
+    materialize_src_chunk_adaptive_nullable_column(chunk);
+
+    ASSERT_EQ(1, chunk->num_rows());
+    ASSERT_EQ("[{'group':[{score:99.9},{score:88.8}]}]", chunk->debug_row(0));
+}
+
 TEST_F(AvroReaderTest, test_direct_path_skips_complex_fields) {
     std::string filename = "complex.avro";
 

--- a/be/test/formats/avro/cpp/complex_column_reader_test.cpp
+++ b/be/test/formats/avro/cpp/complex_column_reader_test.cpp
@@ -143,4 +143,137 @@ TEST_F(ComplexColumnReaderTest, test_map) {
     ASSERT_EQ("[{'abc':10,'def':11}]", column->debug_string());
 }
 
+TEST_F(ComplexColumnReaderTest, test_map_nullable_date_values) {
+    avro::LogicalType date_type(avro::LogicalType::DATE);
+    auto date_node = avro::NodePtr(new avro::NodePrimitive(avro::AVRO_INT));
+    date_node->setLogicalType(date_type);
+
+    avro::MultiLeaves union_nodes;
+    union_nodes.add(avro::NodePtr(new avro::NodePrimitive(avro::AVRO_NULL)));
+    union_nodes.add(date_node);
+    auto union_schema = avro::NodePtr(new avro::NodeUnion(union_nodes));
+
+    auto map_schema = avro::NodePtr(new avro::NodeMap(avro::SingleLeaf(union_schema)));
+    auto map_datum = avro::GenericMap(map_schema);
+    auto& map_value = map_datum.value();
+    {
+        avro::GenericUnion null_union(union_schema);
+        null_union.selectBranch(0);
+        map_value.emplace_back("abc", avro::GenericDatum(union_schema, null_union));
+    }
+    {
+        avro::GenericUnion date_union(union_schema);
+        date_union.selectBranch(1);
+        date_union.datum() = avro::GenericDatum(avro::AVRO_INT, date_type, days_since_epoch("2026-05-19"));
+        map_value.emplace_back("def", avro::GenericDatum(union_schema, date_union));
+    }
+
+    auto datum = avro::GenericDatum(map_schema, map_datum);
+
+    TypeDescriptor type_desc;
+    CHECK_OK(get_avro_type(map_schema, &type_desc));
+    ASSERT_EQ(TYPE_MAP, type_desc.type);
+    ASSERT_EQ(TYPE_DATE, type_desc.children[1].type);
+
+    auto column = create_adaptive_nullable_column(type_desc);
+    auto reader = get_column_reader(type_desc, false);
+
+    CHECK_OK(reader->read_datum_for_adaptive_column(datum, column.get()));
+
+    ASSERT_EQ(1, column->size());
+    ASSERT_EQ("[{'abc':NULL,'def':2026-05-19}]", column->debug_string());
+}
+
+TEST_F(ComplexColumnReaderTest, test_map_nullable_timestamp_values) {
+    avro::LogicalType ts_type(avro::LogicalType::TIMESTAMP_MILLIS);
+    auto ts_node = avro::NodePtr(new avro::NodePrimitive(avro::AVRO_LONG));
+    ts_node->setLogicalType(ts_type);
+
+    avro::MultiLeaves union_nodes;
+    union_nodes.add(avro::NodePtr(new avro::NodePrimitive(avro::AVRO_NULL)));
+    union_nodes.add(ts_node);
+    auto union_schema = avro::NodePtr(new avro::NodeUnion(union_nodes));
+
+    auto map_schema = avro::NodePtr(new avro::NodeMap(avro::SingleLeaf(union_schema)));
+    auto map_datum = avro::GenericMap(map_schema);
+    auto& map_value = map_datum.value();
+    {
+        avro::GenericUnion null_union(union_schema);
+        null_union.selectBranch(0);
+        map_value.emplace_back("true", avro::GenericDatum(union_schema, null_union));
+    }
+    {
+        avro::GenericUnion ts_union(union_schema);
+        ts_union.selectBranch(1);
+        ts_union.datum() =
+                avro::GenericDatum(avro::AVRO_LONG, ts_type, milliseconds_since_epoch("2026-05-19 12:03:01.000"));
+        map_value.emplace_back("false", avro::GenericDatum(union_schema, ts_union));
+    }
+
+    auto datum = avro::GenericDatum(map_schema, map_datum);
+
+    TypeDescriptor type_desc;
+    CHECK_OK(get_avro_type(map_schema, &type_desc));
+    ASSERT_EQ(TYPE_MAP, type_desc.type);
+    ASSERT_EQ(TYPE_DATETIME, type_desc.children[1].type);
+
+    auto column = create_adaptive_nullable_column(type_desc);
+    auto reader = get_column_reader(type_desc, false);
+
+    CHECK_OK(reader->read_datum_for_adaptive_column(datum, column.get()));
+
+    ASSERT_EQ(1, column->size());
+    ASSERT_EQ("[{'true':NULL,'false':2026-05-19 12:03:01}]", column->debug_string());
+}
+
+TEST_F(ComplexColumnReaderTest, test_adaptive_reader_rejects_non_adaptive_column) {
+    auto type_desc = TypeDescriptor::from_logical_type(TYPE_INT);
+    auto reader = get_column_reader(type_desc, false);
+    auto column = ColumnHelper::create_column(type_desc, true, false, 0, false);
+    avro::GenericDatum datum(int32_t{10});
+
+    auto st = reader->read_datum_for_adaptive_column(datum, column.get());
+    ASSERT_TRUE(st.is_internal_error());
+    ASSERT_TRUE(st.message().find("AdaptiveNullableColumn") != std::string::npos);
+}
+
+TEST_F(ComplexColumnReaderTest, test_map_unknown_value_type_skips_value_decode) {
+    avro::LogicalType ts_type(avro::LogicalType::TIMESTAMP_MILLIS);
+    auto ts_node = avro::NodePtr(new avro::NodePrimitive(avro::AVRO_LONG));
+    ts_node->setLogicalType(ts_type);
+
+    avro::MultiLeaves union_nodes;
+    union_nodes.add(avro::NodePtr(new avro::NodePrimitive(avro::AVRO_NULL)));
+    union_nodes.add(ts_node);
+    auto union_schema = avro::NodePtr(new avro::NodeUnion(union_nodes));
+
+    auto map_schema = avro::NodePtr(new avro::NodeMap(avro::SingleLeaf(union_schema)));
+    auto map_datum = avro::GenericMap(map_schema);
+    auto& map_value = map_datum.value();
+    {
+        avro::GenericUnion null_union(union_schema);
+        null_union.selectBranch(0);
+        map_value.emplace_back("true", avro::GenericDatum(union_schema, null_union));
+    }
+    {
+        avro::GenericUnion ts_union(union_schema);
+        ts_union.selectBranch(1);
+        ts_union.datum() =
+                avro::GenericDatum(avro::AVRO_LONG, ts_type, milliseconds_since_epoch("2026-05-19 12:03:01.000"));
+        map_value.emplace_back("false", avro::GenericDatum(union_schema, ts_union));
+    }
+
+    auto datum = avro::GenericDatum(map_schema, map_datum);
+
+    TypeDescriptor type_desc = TypeDescriptor::create_map_type(
+            TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH), TypeDescriptor(TYPE_UNKNOWN));
+    auto column = create_adaptive_nullable_column(type_desc);
+    auto reader = get_column_reader(type_desc, false);
+
+    CHECK_OK(reader->read_datum_for_adaptive_column(datum, column.get()));
+
+    ASSERT_EQ(1, column->size());
+    ASSERT_EQ("[{'true':NULL,'false':NULL}]", column->debug_string());
+}
+
 } // namespace starrocks::avrocpp

--- a/be/test/formats/avro/cpp/complex_column_reader_test.cpp
+++ b/be/test/formats/avro/cpp/complex_column_reader_test.cpp
@@ -330,7 +330,8 @@ TEST_F(ComplexColumnReaderTest, test_struct_unknown_field_type_skips_field_decod
 
     std::vector<avro::GenericDatum> datums;
     datums.emplace_back(avro::GenericDatum(int32_t{10}));
-    datums.emplace_back(avro::GenericDatum(avro::AVRO_LONG, ts_type, milliseconds_since_epoch("2026-05-19 12:03:01.000")));
+    datums.emplace_back(
+            avro::GenericDatum(avro::AVRO_LONG, ts_type, milliseconds_since_epoch("2026-05-19 12:03:01.000")));
 
     auto record_schema =
             avro::NodePtr(new avro::NodeRecord(avro::HasName(avro::Name(_col_name)), field_nodes, field_names, datums));

--- a/be/test/formats/avro/cpp/complex_column_reader_test.cpp
+++ b/be/test/formats/avro/cpp/complex_column_reader_test.cpp
@@ -276,4 +276,81 @@ TEST_F(ComplexColumnReaderTest, test_map_unknown_value_type_skips_value_decode) 
     ASSERT_EQ("[{'true':NULL,'false':NULL}]", column->debug_string());
 }
 
+TEST_F(ComplexColumnReaderTest, test_array_unknown_element_type_skips_element_decode) {
+    avro::LogicalType ts_type(avro::LogicalType::TIMESTAMP_MILLIS);
+    auto ts_node = avro::NodePtr(new avro::NodePrimitive(avro::AVRO_LONG));
+    ts_node->setLogicalType(ts_type);
+
+    avro::MultiLeaves union_nodes;
+    union_nodes.add(avro::NodePtr(new avro::NodePrimitive(avro::AVRO_NULL)));
+    union_nodes.add(ts_node);
+    auto union_schema = avro::NodePtr(new avro::NodeUnion(union_nodes));
+
+    auto array_schema = avro::NodePtr(new avro::NodeArray(avro::SingleLeaf(union_schema)));
+    auto array_datum = avro::GenericArray(array_schema);
+    auto& array_value = array_datum.value();
+    {
+        avro::GenericUnion null_union(union_schema);
+        null_union.selectBranch(0);
+        array_value.emplace_back(avro::GenericDatum(union_schema, null_union));
+    }
+    {
+        avro::GenericUnion ts_union(union_schema);
+        ts_union.selectBranch(1);
+        ts_union.datum() =
+                avro::GenericDatum(avro::AVRO_LONG, ts_type, milliseconds_since_epoch("2026-05-19 12:03:01.000"));
+        array_value.emplace_back(avro::GenericDatum(union_schema, ts_union));
+    }
+
+    auto datum = avro::GenericDatum(array_schema, array_datum);
+
+    TypeDescriptor reader_type_desc = TypeDescriptor::create_array_type(TypeDescriptor(TYPE_UNKNOWN));
+    TypeDescriptor column_type_desc = TypeDescriptor::create_array_type(TypeDescriptor{TYPE_NULL});
+    auto column = create_adaptive_nullable_column(column_type_desc);
+    auto reader = get_column_reader(reader_type_desc, false);
+
+    CHECK_OK(reader->read_datum_for_adaptive_column(datum, column.get()));
+
+    ASSERT_EQ(1, column->size());
+    ASSERT_EQ("[[NULL,NULL]]", column->debug_string());
+}
+
+TEST_F(ComplexColumnReaderTest, test_struct_unknown_field_type_skips_field_decode) {
+    avro::LogicalType ts_type(avro::LogicalType::TIMESTAMP_MILLIS);
+    auto ts_node = avro::NodePtr(new avro::NodePrimitive(avro::AVRO_LONG));
+    ts_node->setLogicalType(ts_type);
+
+    avro::MultiLeaves field_nodes;
+    field_nodes.add(avro::NodePtr(new avro::NodePrimitive(avro::AVRO_INT)));
+    field_nodes.add(ts_node);
+
+    avro::LeafNames field_names;
+    field_names.add("int_col");
+    field_names.add("ts_col");
+
+    std::vector<avro::GenericDatum> datums;
+    datums.emplace_back(avro::GenericDatum(int32_t{10}));
+    datums.emplace_back(avro::GenericDatum(avro::AVRO_LONG, ts_type, milliseconds_since_epoch("2026-05-19 12:03:01.000")));
+
+    auto record_schema =
+            avro::NodePtr(new avro::NodeRecord(avro::HasName(avro::Name(_col_name)), field_nodes, field_names, datums));
+    auto record_datum = avro::GenericRecord(record_schema);
+    for (size_t i = 0; i < datums.size(); ++i) {
+        record_datum.setFieldAt(i, datums[i]);
+    }
+    auto datum = avro::GenericDatum(record_schema, record_datum);
+
+    TypeDescriptor reader_type_desc = TypeDescriptor::create_struct_type(
+            {"int_col", "ts_col"}, {TypeDescriptor::from_logical_type(TYPE_INT), TypeDescriptor(TYPE_UNKNOWN)});
+    TypeDescriptor column_type_desc = TypeDescriptor::create_struct_type(
+            {"int_col", "ts_col"}, {TypeDescriptor::from_logical_type(TYPE_INT), TypeDescriptor{TYPE_NULL}});
+    auto column = create_adaptive_nullable_column(column_type_desc);
+    auto reader = get_column_reader(reader_type_desc, false);
+
+    CHECK_OK(reader->read_datum_for_adaptive_column(datum, column.get()));
+
+    ASSERT_EQ(1, column->size());
+    ASSERT_EQ("[{int_col:10,ts_col:NULL}]", column->debug_string());
+}
+
 } // namespace starrocks::avrocpp


### PR DESCRIPTION
## Why I'm doing:
Avro scans could fail in two valid execution scenarios.

First, when the optimizer pruned part of a complex type to `UNKNOWN_TYPE`, the Avro reader still tried to build or use concrete child readers, which could lead to BE crashes or internal errors.

Second, nested complex Avro schemas with nullable array/map/struct children could fail during schema resolution in the generic reader path. This showed up on Hive Avro tables whose nested values are encoded as unions like `["null", record]`.

## What I'm doing:
I tightened Avro complex-type handling in both the decode path and the generic reader initialization path.

At a high level:

```text
old behavior
  complex child pruned -> still decode child
  nested complex projection -> projected reader schema may fail to resolve

new behavior
  complex child pruned -> skip decode and fill NULL placeholders
  complex projection -> keep full writer schema in generic path
```

Fixes https://github.com/StarRocks/StarRocksTest/issues/11312

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
