### PR TITLE
[BugFix] Disable COW optimization due to design flaws causing crashes

### DIFF
--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -320,16 +320,6 @@ public:
     void set_extra_data(ChunkExtraDataPtr data) { this->_extra_data = std::move(data); }
     bool has_extra_data() const { return this->_extra_data != nullptr; }
 
-    // Deprecated, use raw pointers instead
-    MutableColumns mutable_columns() const {
-        size_t num_columns = _columns.size();
-        MutableColumns mutable_columns(num_columns);
-        for (size_t i = 0; i < num_columns; ++i) {
-            mutable_columns[i] = std::move(*(_columns[i])).mutate();
-        }
-        return mutable_columns;
-    }
-
 private:
     void rebuild_cid_index();
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -39,7 +39,7 @@
 namespace starrocks::config {
 // Enable cow optimization for column operations, used to avoid the overhead of reference counting when accessing
 // columns.
-CONF_mBool(enable_cow_optimization, "true");
+CONF_mBool(enable_cow_optimization, "false");
 // The diagnose level for cow optimization, 0 means no diagnose, 1 means diagnose when use_count > 1, 2 means
 // diagnose when use_count > 2.
 CONF_Int32(cow_optimization_diagnose_level, "0");

--- a/be/src/common/config_cow_fwd.h
+++ b/be/src/common/config_cow_fwd.h
@@ -22,7 +22,7 @@
 namespace starrocks::config {
 // Enable cow optimization for column operations, used to avoid the overhead of reference counting when accessing
 // columns.
-CONF_mBool(enable_cow_optimization, "true");
+CONF_mBool(enable_cow_optimization, "false");
 
 // The diagnose level for cow optimization, 0 means no diagnose, 1 means diagnose when use_count > 1, 2 means
 // diagnose when use_count > 2.

--- a/be/test/column/chunk_test.cpp
+++ b/be/test/column/chunk_test.cpp
@@ -255,10 +255,9 @@ TEST_F(ChunkTest, test_copy_one_row) {
 
     ASSERT_EQ(new_chunk->num_rows(), chunk->num_rows());
     for (size_t i = 0; i < chunk->columns().size(); ++i) {
-        ASSERT_EQ(chunk->mutable_columns()[i]->size(), new_chunk->mutable_columns()[i]->size());
-        for (size_t j = 0; j < chunk->mutable_columns()[i]->size(); ++j) {
-            ASSERT_EQ(chunk->mutable_columns()[i]->get(j).get_int32(),
-                      new_chunk->mutable_columns()[i]->get(j).get_int32());
+        ASSERT_EQ(chunk->columns()[i]->size(), new_chunk->columns()[i]->size());
+        for (size_t j = 0; j < chunk->columns()[i]->size(); ++j) {
+            ASSERT_EQ(chunk->columns()[i]->get(j).get_int32(), new_chunk->columns()[i]->get(j).get_int32());
         }
     }
 }
@@ -314,7 +313,7 @@ TEST_F(ChunkTest, test_append_chunk_safe) {
     chunk_1->append_safe(*chunk_2);
 
     for (size_t i = 0; i < chunk_1->num_columns(); i++) {
-        auto column = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(chunk_1->mutable_columns()[i].get());
+        auto column = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(chunk_1->columns()[i].get());
         ASSERT_EQ(column->size(), 200);
         for (size_t j = 0; j < 100; j++) {
             ASSERT_EQ(column->get(j).get_int32(), j);

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -835,7 +835,7 @@ void JoinHashMapTest::check_empty_hash_map(TJoinOp::type join_type, int num_prob
                 check_int32_column(*ColumnHelper::get_data_column(result_chunk->columns()[i].get()), num_probe_rows,
                                    i * 10 + 1);
             } else {
-                check_int32_column(*result_chunk->mutable_columns()[i], num_probe_rows, i * 10 + 1);
+                check_int32_column(*result_chunk->columns()[i], num_probe_rows, i * 10 + 1);
             }
         }
         if (expect_num_colums > 3) {
@@ -1102,7 +1102,7 @@ TEST_F(JoinHashMapTest, ProbeNullOutput) {
     ASSERT_EQ(chunk->num_columns(), 3);
 
     for (size_t i = 0; i < chunk->num_columns(); i++) {
-        auto null_column = ColumnHelper::as_raw_column<NullableColumn>(chunk->mutable_columns()[i])->null_column();
+        auto null_column = ColumnHelper::as_raw_column<NullableColumn>(chunk->columns()[i])->null_column();
         for (size_t j = 0; j < 2; j++) {
             ASSERT_EQ(null_column->immutable_data()[j], 1);
         }
@@ -1136,7 +1136,7 @@ TEST_F(JoinHashMapTest, BuildDefaultOutput) {
     ASSERT_EQ(chunk->num_columns(), 3);
 
     for (size_t i = 0; i < chunk->num_columns(); i++) {
-        auto null_column = ColumnHelper::as_raw_column<NullableColumn>(chunk->mutable_columns()[i])->null_column();
+        auto null_column = ColumnHelper::as_raw_column<NullableColumn>(chunk->columns()[i])->null_column();
         for (size_t j = 0; j < 2; j++) {
             ASSERT_EQ(null_column->immutable_data()[j], 1);
         }
@@ -2069,7 +2069,7 @@ TEST_F(JoinHashMapTest, OneKeyJoinHashTable) {
     Columns probe_key_columns;
     probe_key_columns.emplace_back(probe_chunk->columns()[0]);
 
-    Columns build_keys_column{build_chunk->mutable_columns()[0]};
+    Columns build_keys_column{build_chunk->columns()[0]};
     hash_table.append_chunk(build_chunk, build_keys_column);
     (void)hash_table.build(_runtime_state.get());
 
@@ -2121,7 +2121,7 @@ TEST_F(JoinHashMapTest, OneNullableKeyJoinHashTable) {
     probe_key_columns.emplace_back(probe_chunk->columns()[0]);
 
     Columns build_key_columns;
-    build_key_columns.emplace_back(build_chunk->mutable_columns()[0]);
+    build_key_columns.emplace_back(build_chunk->columns()[0]);
     hash_table.append_chunk(build_chunk, build_key_columns);
     (void)hash_table.build(_runtime_state.get());
 
@@ -2174,7 +2174,7 @@ TEST_F(JoinHashMapTest, FixedSizeJoinHashTable) {
     probe_key_columns.emplace_back(probe_chunk->columns()[0]);
     probe_key_columns.emplace_back(probe_chunk->columns()[1]);
 
-    Columns build_key_columns{build_chunk->mutable_columns()[0], build_chunk->mutable_columns()[1]};
+    Columns build_key_columns{build_chunk->columns()[0], build_chunk->columns()[1]};
     hash_table.append_chunk(build_chunk, build_key_columns);
     (void)hash_table.build(_runtime_state.get());
 
@@ -2225,7 +2225,7 @@ TEST_F(JoinHashMapTest, SerializeJoinHashTable) {
     probe_key_columns.emplace_back(probe_chunk->columns()[0]);
     probe_key_columns.emplace_back(probe_chunk->columns()[1]);
 
-    Columns build_key_columns{build_chunk->mutable_columns()[0], build_chunk->mutable_columns()[1]};
+    Columns build_key_columns{build_chunk->columns()[0], build_chunk->columns()[1]};
     hash_table.append_chunk(build_chunk, build_key_columns);
     (void)hash_table.build(_runtime_state.get());
 
@@ -2649,9 +2649,9 @@ TEST_F(JoinHashMapTest, NormalHashMapTestLazyOutputAll) {
 
     // prepare data
     auto build_chunk = create_int32_build_chunk(num_build_rows, 0, false);
-    Columns build_key_columns{build_chunk->mutable_columns()[0]};
+    Columns build_key_columns{build_chunk->columns()[0]};
     auto probe_chunk = create_int32_probe_chunk(num_probe_rows, 0, false);
-    Columns probe_key_columns = {probe_chunk->mutable_columns()[0]};
+    Columns probe_key_columns = {probe_chunk->columns()[0]};
     ChunkPtr result_chunk = std::make_shared<Chunk>();
 
     // create param
@@ -2721,9 +2721,9 @@ TEST_F(JoinHashMapTest, NormalHashMapTestLazyOutputPart) {
 
     // prepare data
     auto build_chunk = create_int32_build_chunk(num_build_rows, 0, false);
-    Columns key_columns{build_chunk->mutable_columns()[0]};
+    Columns key_columns{build_chunk->columns()[0]};
     auto probe_chunk = create_int32_probe_chunk(num_probe_rows, 0, false);
-    Columns probe_key_columns = {probe_chunk->mutable_columns()[0]};
+    Columns probe_key_columns = {probe_chunk->columns()[0]};
     ChunkPtr result_chunk = std::make_shared<Chunk>();
 
     // create param
@@ -2793,10 +2793,10 @@ TEST_F(JoinHashMapTest, NormalHashMapTestLazyOutputPartRemain) {
 
     // prepare data
     ChunkPtr build_chunk = create_int32_build_chunk(num_build_rows, 1, false);
-    Columns build_key_columns = {build_chunk->mutable_columns()[0]};
+    Columns build_key_columns = {build_chunk->columns()[0]};
     ChunkPtr probe_chunk = create_int32_probe_chunk(num_probe_rows, 0, false);
     ChunkPtr result_chunk = std::make_shared<Chunk>();
-    Columns probe_key_columns = {probe_chunk->mutable_columns()[0]};
+    Columns probe_key_columns = {probe_chunk->columns()[0]};
 
     // create param
     auto param = create_table_param_int(TJoinOp::RIGHT_OUTER_JOIN, 3);

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -624,7 +624,7 @@ void GroupReaderTest::_check_double_column(Column* column, size_t start, size_t 
 void GroupReaderTest::_check_chunk(GroupReaderParam* param, const ChunkPtr& chunk, size_t start, size_t count) {
     ASSERT_EQ(param->read_cols.size(), chunk->num_columns());
     for (size_t i = 0; i < param->read_cols.size(); i++) {
-        auto column = chunk->mutable_columns()[i].get();
+        auto column = chunk->columns()[i]->as_mutable_ptr().get();
         auto _type = param->read_cols[i].type_in_parquet;
         size_t num_rows = count;
 

--- a/be/test/runtime/merge_cascade_test.cpp
+++ b/be/test/runtime/merge_cascade_test.cpp
@@ -84,12 +84,14 @@ TEST(MergeCascadeTest, merge_cursor_test) {
 
         size_t chunk_size = 4096;
         auto l = chunk->clone_unique();
-        l->mutable_columns()[0]->append_datum(Datum(1));
-        l->mutable_columns()[0]->assign(chunk_size, 0);
+        auto* l_col = l->get_column_by_index(0)->as_mutable_raw_ptr();
+        l_col->append_datum(Datum(1));
+        l_col->assign(chunk_size, 0);
 
         auto r = chunk->clone_unique();
-        r->mutable_columns()[0]->append_datum(Datum(9999));
-        r->mutable_columns()[0]->assign(chunk_size, 0);
+        auto* r_col = r->get_column_by_index(0)->as_mutable_raw_ptr();
+        r_col->append_datum(Datum(9999));
+        r_col->assign(chunk_size, 0);
 
         l_chunk_channel.emplace(l->clone_unique());
         r_chunk_channel.emplace(r->clone_unique());
@@ -132,12 +134,14 @@ TEST(MergeCascadeTest, merge_cursor_test) {
 
         size_t chunk_size = 4096;
         auto l = chunk->clone_unique();
-        l->mutable_columns()[0]->append_datum(Datum(1));
-        l->mutable_columns()[0]->assign(chunk_size, 0);
+        auto* l_col = l->get_column_by_index(0)->as_mutable_raw_ptr();
+        l_col->append_datum(Datum(1));
+        l_col->assign(chunk_size, 0);
 
         auto r = chunk->clone_unique();
-        r->mutable_columns()[0]->append_datum(Datum(1));
-        r->mutable_columns()[0]->assign(chunk_size, 0);
+        auto* r_col = r->get_column_by_index(0)->as_mutable_raw_ptr();
+        r_col->append_datum(Datum(1));
+        r_col->assign(chunk_size, 0);
 
         l_chunk_channel.emplace(l->clone_unique());
         r_chunk_channel.emplace(r->clone_unique());
@@ -198,14 +202,14 @@ TEST(MergeCascadeTest, merge_sorted_chunks) {
         {
             auto l0 = chunk->clone_unique();
             for (size_t i = 0; i < chunk_size; ++i) {
-                l0->mutable_columns()[0]->append_datum(Datum((int)(i * 2)));
+                l0->columns()[0]->as_mutable_ptr()->append_datum(Datum((int)(i * 2)));
             }
             MergedRun lrun0;
             ASSIGN_OR_ASSERT_FAIL(lrun0, MergedRun::build(std::move(l0), sort_expr));
 
             auto l1 = chunk->clone_unique();
             for (size_t i = 0; i < chunk_size; ++i) {
-                l1->mutable_columns()[0]->append_datum(Datum((int)(i * 2 + 4096)));
+                l1->columns()[0]->as_mutable_ptr()->append_datum(Datum((int)(i * 2 + 4096)));
             }
             MergedRun lrun1;
             ASSIGN_OR_ASSERT_FAIL(lrun1, MergedRun::build(std::move(l1), sort_expr));
@@ -218,7 +222,7 @@ TEST(MergeCascadeTest, merge_sorted_chunks) {
         {
             right = chunk->clone_unique();
             for (size_t i = 0; i < chunk_size; ++i) {
-                right->mutable_columns()[0]->append_datum(Datum((int)(i * 2 + 1)));
+                right->columns()[0]->as_mutable_ptr()->append_datum(Datum((int)(i * 2 + 1)));
             }
         }
 

--- a/be/test/storage/base_compaction_test.cpp
+++ b/be/test/storage/base_compaction_test.cpp
@@ -149,14 +149,14 @@ public:
         auto chunk = ChunkFactory::new_chunk(schema, 1024);
         for (size_t i = 0; i < 1024; ++i) {
             test_data.push_back("well" + std::to_string(i));
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
             Slice field_1(test_data[i]);
-            cols[1]->append_datum(Datum(field_1));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
             JsonValue json = JsonValue::from_string(R"({"k1":)" + std::to_string(i) + R"("k2": )" +
                                                     std::to_string(10000 + 1) + "}");
-            cols[3]->append_datum(Datum(&json));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(&json));
         }
         CHECK_OK(writer->add_chunk(*chunk));
     }

--- a/be/test/storage/binlog_manager_test.cpp
+++ b/be/test/storage/binlog_manager_test.cpp
@@ -92,8 +92,8 @@ protected:
             std::unique_ptr<SegmentPB> segment;
             auto chunk = ChunkFactory::new_chunk(_schema, num_rows);
             for (int i = total_rows; i < num_rows + total_rows; i++) {
-                auto cols = chunk->mutable_columns();
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+                auto cols = chunk->columns();
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
             }
             ASSERT_OK(rowset_writer->flush_chunk(*chunk, segment.get()));
             total_rows += num_rows;

--- a/be/test/storage/binlog_reader_test.cpp
+++ b/be/test/storage/binlog_reader_test.cpp
@@ -143,10 +143,10 @@ void BinlogReaderTest::create_rowset(int32_t* start_key, RowsetInfo& rowset_info
         std::vector<uint32_t> column_indexes{0, 1, 2};
         auto chunk = ChunkFactory::new_chunk(_schema, num_rows);
         for (int i = *start_key; i < num_rows + *start_key; i++) {
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(Slice(std::to_string(i))));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(Slice(std::to_string(i))));
         }
         ASSERT_OK(rowset_writer->flush_chunk(*chunk));
         *start_key += num_rows;

--- a/be/test/storage/compaction_parallelization_test.cpp
+++ b/be/test/storage/compaction_parallelization_test.cpp
@@ -146,11 +146,11 @@ public:
             auto chunk = ChunkFactory::new_chunk(schema, 128);
             for (size_t i = 0; i < 128; ++i) {
                 test_data.push_back("well" + std::to_string(i));
-                auto cols = chunk->mutable_columns();
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+                auto cols = chunk->columns();
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
                 Slice field_1(test_data[i]);
-                cols[1]->append_datum(Datum(field_1));
-                cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+                cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
             }
             CHECK_OK(writer->add_chunk(*chunk));
         }

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -243,11 +243,11 @@ public:
             auto chunk = ChunkFactory::new_chunk(schema, 128);
             for (size_t i = 0; i < 128; ++i) {
                 test_data.push_back("well" + std::to_string(i));
-                auto cols = chunk->mutable_columns();
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+                auto cols = chunk->columns();
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
                 Slice field_1(test_data[i]);
-                cols[1]->append_datum(Datum(field_1));
-                cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+                cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
             }
             CHECK_OK(writer->add_chunk(*chunk));
         }

--- a/be/test/storage/default_compaction_policy_test.cpp
+++ b/be/test/storage/default_compaction_policy_test.cpp
@@ -200,11 +200,11 @@ public:
             auto chunk = ChunkFactory::new_chunk(schema, 128);
             for (size_t i = 0; i < 128; ++i) {
                 test_data.push_back("well" + std::to_string(i));
-                auto cols = chunk->mutable_columns();
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+                auto cols = chunk->columns();
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
                 Slice field_1(test_data[i]);
-                cols[1]->append_datum(Datum(field_1));
-                cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+                cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
             }
             CHECK_OK(writer->add_chunk(*chunk));
         }

--- a/be/test/storage/fast_schema_evolution_test.cpp
+++ b/be/test/storage/fast_schema_evolution_test.cpp
@@ -90,12 +90,12 @@ public:
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         size_t size = keys.size();
         for (size_t i = 0; i < size; i++) {
-            cols[0]->append_datum(Datum(keys[i]));
-            cols[1]->append_datum(Datum((int16_t)(keys[i] % size + 1)));
-            cols[2]->append_datum(Datum((int32_t)(keys[i] % size + 2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(keys[i] % size + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(keys[i] % size + 2)));
         }
         if (one_delete == nullptr && !keys.empty()) {
             CHECK_OK(writer->flush_chunk(*chunk));

--- a/be/test/storage/get_use_pk_index_test.cpp
+++ b/be/test/storage/get_use_pk_index_test.cpp
@@ -68,11 +68,11 @@ public:
         for (size_t i = 0; i < segments.size(); i++) {
             auto& segment = segments[i];
             auto chunk = ChunkFactory::new_chunk(schema, segment.size());
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto& row : segment) {
                 CHECK(cols.size() == row.size());
                 for (size_t j = 0; j < row.size(); j++) {
-                    cols[j]->append_datum(row[j]);
+                    cols[j]->as_mutable_ptr()->append_datum(row[j]);
                 }
             }
             CHECK_OK(writer->flush_chunk(*chunk));

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -450,14 +450,14 @@ protected:
 
         auto chunk = ChunkFactory::new_chunk(ChunkHelper::convert_schema(write_schema), ids.size());
         for (auto id : ids) {
-            chunk->mutable_columns()[0]->append_datum(Datum(id));
+            chunk->columns()[0]->as_mutable_ptr()->append_datum(Datum(id));
         }
         for (const auto& vec : vectors) {
             DatumArray arr;
             for (float v : vec) {
                 arr.emplace_back(Datum(v));
             }
-            chunk->mutable_columns()[1]->append_datum(Datum(arr));
+            chunk->columns()[1]->as_mutable_ptr()->append_datum(Datum(arr));
         }
 
         RETURN_IF_ERROR(writer.init());

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -183,23 +183,23 @@ public:
         }
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
             if (schema.num_key_fields() == 1) {
-                cols[0]->append_datum(Datum(key));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
             } else {
-                cols[0]->append_datum(Datum(key));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
                 string v = fmt::to_string(key * 234234342345);
-                cols[1]->append_datum(Datum(Slice(v)));
-                cols[2]->append_datum(Datum((int32_t)key));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)key));
             }
             int vcol_start = schema.num_key_fields();
-            cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[vcol_start]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
             if (cols[vcol_start + 1]->is_binary()) {
                 string v = fmt::to_string(key % 1000 + 2);
-                cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+                cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
             } else {
-                cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+                cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
             }
         }
         if (one_delete == nullptr && !keys.empty()) {

--- a/be/test/storage/memtable_flush_executor_test.cpp
+++ b/be/test/storage/memtable_flush_executor_test.cpp
@@ -167,7 +167,7 @@ static const std::vector<SlotDescriptor*>* create_tuple_desc_slots(RuntimeState*
 
 static shared_ptr<Chunk> gen_chunk(const std::vector<SlotDescriptor*>& slots, size_t size) {
     shared_ptr<Chunk> ret = RuntimeChunkHelper::new_chunk(slots, size);
-    auto cols = ret->mutable_columns();
+    auto cols = ret->columns();
     for (int ci = 0; ci < cols.size(); ci++) {
         auto& c = cols[ci];
         Datum v;
@@ -183,7 +183,7 @@ static shared_ptr<Chunk> gen_chunk(const std::vector<SlotDescriptor*>& slots, si
             } else if (type == TYPE_INT) {
                 v.set_int32(i + 3);
             } else if (type == TYPE_BIGINT) {
-                v.set_int16(i * 3);
+                v.set_int64(i * 3);
             } else if (type == TYPE_FLOAT) {
                 v.set_float(i * 4);
             } else if (type == TYPE_DOUBLE) {
@@ -194,7 +194,7 @@ static shared_ptr<Chunk> gen_chunk(const std::vector<SlotDescriptor*>& slots, si
             } else {
                 CHECK(false) << "gen_chunk type not supported";
             }
-            c->append_datum(v);
+            c->as_mutable_ptr()->append_datum(v);
         }
     }
     return ret;

--- a/be/test/storage/memtable_test.cpp
+++ b/be/test/storage/memtable_test.cpp
@@ -173,9 +173,9 @@ static const std::vector<SlotDescriptor*>* create_tuple_desc_slots(RuntimeState*
 
 static shared_ptr<Chunk> gen_chunk(const std::vector<SlotDescriptor*>& slots, size_t size) {
     shared_ptr<Chunk> ret = RuntimeChunkHelper::new_chunk(slots, size);
-    auto cols = ret->mutable_columns();
+    auto cols = ret->columns();
     for (int ci = 0; ci < cols.size(); ci++) {
-        MutableColumnPtr& c = cols[ci];
+        MutableColumnPtr c = cols[ci]->as_mutable_ptr();
         Datum v;
         string strv;
         for (size_t i = 0; i < size; i++) {
@@ -189,7 +189,7 @@ static shared_ptr<Chunk> gen_chunk(const std::vector<SlotDescriptor*>& slots, si
             } else if (type == TYPE_INT) {
                 v.set_int32(i + 3);
             } else if (type == TYPE_BIGINT) {
-                v.set_int16(i * 3);
+                v.set_int64(i * 3);
             } else if (type == TYPE_FLOAT) {
                 v.set_float(i * 4);
             } else if (type == TYPE_DOUBLE) {

--- a/be/test/storage/olap_meta_reader_test.cpp
+++ b/be/test/storage/olap_meta_reader_test.cpp
@@ -103,12 +103,12 @@ protected:
 
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
 
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-            cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
         }
 
         if (!keys.empty()) {
@@ -139,12 +139,12 @@ protected:
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         for (const auto& keys : keys_by_segment) {
             auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
 
             for (int64_t key : keys) {
-                cols[0]->append_datum(Datum(key));
-                cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-                cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+                cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
             }
 
             if (!keys.empty()) {

--- a/be/test/storage/persistent_index_load_executor_test.cpp
+++ b/be/test/storage/persistent_index_load_executor_test.cpp
@@ -126,11 +126,11 @@ public:
         for (size_t i = 0; i < segments.size(); i++) {
             auto& segment = segments[i];
             auto chunk = ChunkFactory::new_chunk(schema, segment.size());
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto& row : segment) {
                 CHECK(cols.size() == row.size());
                 for (size_t j = 0; j < row.size(); j++) {
-                    cols[j]->append_datum(row[j]);
+                    cols[j]->as_mutable_ptr()->append_datum(row[j]);
                 }
             }
             CHECK_OK(writer->flush_chunk(*chunk));

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1479,18 +1479,18 @@ RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_
     size_t size = (tablet->tablet_schema()->column(0).type() == TYPE_VARCHAR) ? varlen_keys.size() : keys.size();
     LOG(INFO) << "key column type: " << tablet->tablet_schema()->column(0).type() << ", size: " << size;
     auto chunk = ChunkFactory::new_chunk(schema, size);
-    auto cols = chunk->mutable_columns();
+    auto cols = chunk->columns();
     if (tablet->tablet_schema()->column(0).type() == TYPE_VARCHAR) {
         for (size_t i = 0; i < size; i++) {
-            cols[0]->append_datum(Datum(varlen_keys[i]));
-            cols[1]->append_datum(Datum((int16_t)(i + 1)));
-            cols[2]->append_datum(Datum((int32_t)(i + 2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(varlen_keys[i]));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(i + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(i + 2)));
         }
     } else {
         for (size_t i = 0; i < size; i++) {
-            cols[0]->append_datum(Datum(keys[i]));
-            cols[1]->append_datum(Datum((int16_t)(keys[i] % size + 1)));
-            cols[2]->append_datum(Datum((int32_t)(keys[i] % size + 2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(keys[i] % size + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(keys[i] % size + 2)));
         }
     }
     if (one_delete == nullptr && (size > 0)) {

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -56,7 +56,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeInt32) {
     for (int i = 0; i < n; i++) {
         Datum tmp;
         tmp.set_int32(i * 2343);
-        pchunk->mutable_columns()[0]->append_datum(tmp);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
     }
     PrimaryKeyEncoder::encode(*sc, *pchunk, 0, n, dest.get(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     auto dchunk = pchunk->clone_empty_with_schema();
@@ -77,7 +77,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeInt128) {
     for (int i = 0; i < n; i++) {
         Datum tmp;
         tmp.set_int128(i * 2343);
-        pchunk->mutable_columns()[0]->append_datum(tmp);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
     }
     vector<uint32_t> indexes;
     for (int i = 0; i < n; i++) {
@@ -103,18 +103,18 @@ TEST(PrimaryKeyEncoderTest, testEncodeComposite) {
     for (int i = 0; i < n; i++) {
         Datum tmp;
         tmp.set_int32(i * 2343);
-        pchunk->mutable_columns()[0]->append_datum(tmp);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
         string tmpstr = StringPrintf("slice000%d", i * 17);
         if (i % 5 == 0) {
             // set some '\0'
             tmpstr[rand() % tmpstr.size()] = '\0';
         }
         tmp.set_slice(tmpstr);
-        pchunk->mutable_columns()[1]->append_datum(tmp);
+        pchunk->columns()[1]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_int16(i);
-        pchunk->mutable_columns()[2]->append_datum(tmp);
+        pchunk->columns()[2]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_uint8(i % 2);
-        pchunk->mutable_columns()[3]->append_datum(tmp);
+        pchunk->columns()[3]->as_mutable_ptr()->append_datum(tmp);
     }
     vector<uint32_t> indexes;
     for (int i = 0; i < n; i++) {
@@ -144,15 +144,15 @@ TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
         auto pchunk = ChunkFactory::new_chunk(*sc, n);
         Datum tmp;
         tmp.set_int32(42);
-        pchunk->mutable_columns()[0]->append_datum(tmp);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
         string tmpstr("slice0000");
         tmpstr[tmpstr.size() - 1] = '\0';
         tmp.set_slice(tmpstr);
-        pchunk->mutable_columns()[1]->append_datum(tmp);
+        pchunk->columns()[1]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_int16(10);
-        pchunk->mutable_columns()[2]->append_datum(tmp);
+        pchunk->columns()[2]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_uint8(1);
-        pchunk->mutable_columns()[3]->append_datum(tmp);
+        pchunk->columns()[3]->as_mutable_ptr()->append_datum(tmp);
         EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 10,
                                                            PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
         EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
@@ -165,15 +165,15 @@ TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
         auto pchunk = ChunkFactory::new_chunk(*sc, n);
         Datum tmp;
         tmp.set_int32(42);
-        pchunk->mutable_columns()[0]->append_datum(tmp);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
         string tmpstr(128, 's');
         tmpstr[tmpstr.size() - 1] = '\0';
         tmp.set_slice(tmpstr);
-        pchunk->mutable_columns()[1]->append_datum(tmp);
+        pchunk->columns()[1]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_int16(10);
-        pchunk->mutable_columns()[2]->append_datum(tmp);
+        pchunk->columns()[2]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_uint8(1);
-        pchunk->mutable_columns()[3]->append_datum(tmp);
+        pchunk->columns()[3]->as_mutable_ptr()->append_datum(tmp);
         EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
                                                            PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
@@ -187,12 +187,12 @@ TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
         Datum tmp;
         string tmpstr("slice00000");
         tmp.set_slice(tmpstr);
-        pchunk->mutable_columns()[0]->append_datum(tmp);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
         tmpstr = "slice000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
                  "0000"
                  "00000000000000000000000000000000000";
         tmp.set_slice(tmpstr);
-        pchunk->mutable_columns()[0]->append_datum(tmp);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
         EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
                                                            PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
@@ -201,10 +201,10 @@ TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
         Datum tmp;
         string tmpstr("slice00000");
         tmp.set_slice(tmpstr);
-        pchunk->mutable_columns()[0]->append_datum(tmp);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
         tmpstr = "slice00000000000000000000000000000000000";
         tmp.set_slice(tmpstr);
-        pchunk->mutable_columns()[0]->append_datum(tmp);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
         EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
                                                             PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
@@ -225,7 +225,7 @@ TEST(PrimaryKeyEncoderTest, testSingleIntV2EncodingRoundTripAndColumnType) {
     for (int32_t v : values) {
         Datum d;
         d.set_int32(v);
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
 
     PrimaryKeyEncoder::encode(*sc, *pchunk, 0, pchunk->num_rows(), v2_dest.get(),
@@ -268,7 +268,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForInt) {
     for (int32_t v : sorted_values) {
         Datum d;
         d.set_int32(v);
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
     PrimaryKeyEncoder::encode(*sc, *pchunk, 0, pchunk->num_rows(), dest.get(),
                               PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
@@ -295,7 +295,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForBigint) {
     for (int64_t v : sorted_values) {
         Datum d;
         d.set_int64(v);
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
     PrimaryKeyEncoder::encode(*sc, *pchunk, 0, pchunk->num_rows(), dest.get(),
                               PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
@@ -361,7 +361,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForBoolean) {
     for (uint8_t v : {(uint8_t)0, (uint8_t)1}) {
         Datum d;
         d.set_uint8(v);
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
     verify_v2_sort_order_preserved(*sc, *pchunk, 2);
     verify_v2_round_trip(*sc, *pchunk);
@@ -375,7 +375,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForTinyint) {
     for (int8_t v : sorted_values) {
         Datum d;
         d.set_int8(v);
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
     verify_v2_sort_order_preserved(*sc, *pchunk, sorted_values.size());
     verify_v2_round_trip(*sc, *pchunk);
@@ -389,7 +389,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForSmallint) {
     for (int16_t v : sorted_values) {
         Datum d;
         d.set_int16(v);
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
     verify_v2_sort_order_preserved(*sc, *pchunk, sorted_values.size());
     verify_v2_round_trip(*sc, *pchunk);
@@ -404,7 +404,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForLargeint) {
     for (int128_t v : sorted_values) {
         Datum d;
         d.set_int128(v);
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
     verify_v2_sort_order_preserved(*sc, *pchunk, sorted_values.size());
     verify_v2_round_trip(*sc, *pchunk);
@@ -421,7 +421,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForDate) {
         dv.from_string(s.c_str(), s.size());
         Datum d;
         d.set_date(dv);
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
     verify_v2_sort_order_preserved(*sc, *pchunk, 3);
     verify_v2_round_trip(*sc, *pchunk);
@@ -437,7 +437,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForDatetime) {
         tv.from_string(s.c_str(), s.size());
         Datum d;
         d.set_timestamp(tv);
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
     verify_v2_sort_order_preserved(*sc, *pchunk, 3);
     verify_v2_round_trip(*sc, *pchunk);
@@ -450,7 +450,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingRoundTripForSingleVarchar) {
     for (const auto& s : values) {
         Datum d;
         d.set_slice(Slice(s));
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
     verify_v2_round_trip(*sc, *pchunk);
 }
@@ -463,7 +463,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForSingleVarchar) {
     for (const auto& s : sorted_values) {
         Datum d;
         d.set_slice(Slice(s));
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     }
     verify_v2_sort_order_preserved(*sc, *pchunk, sorted_values.size());
 }
@@ -475,7 +475,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingRoundTripForCompositeIntVarchar) {
     for (int i = 0; i < n; i++) {
         Datum d_int;
         d_int.set_int32(i * 100 - 500);
-        pchunk->mutable_columns()[0]->append_datum(d_int);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d_int);
 
         Datum d_str;
         std::string s = StringPrintf("key_%04d", i);
@@ -484,7 +484,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingRoundTripForCompositeIntVarchar) {
             s[2] = '\0';
         }
         d_str.set_slice(Slice(s));
-        pchunk->mutable_columns()[1]->append_datum(d_str);
+        pchunk->columns()[1]->as_mutable_ptr()->append_datum(d_str);
     }
     verify_v2_round_trip(*sc, *pchunk);
 }
@@ -498,8 +498,8 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForCompositeIntInt) 
         Datum d1, d2;
         d1.set_int32(v1);
         d2.set_int64(v2);
-        pchunk->mutable_columns()[0]->append_datum(d1);
-        pchunk->mutable_columns()[1]->append_datum(d2);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d1);
+        pchunk->columns()[1]->as_mutable_ptr()->append_datum(d2);
     }
     verify_v2_sort_order_preserved(*sc, *pchunk, sorted_pairs.size());
     verify_v2_round_trip(*sc, *pchunk);
@@ -514,8 +514,8 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForCompositeVarcharI
         Datum d_str, d_int;
         d_str.set_slice(Slice(s));
         d_int.set_int32(v);
-        pchunk->mutable_columns()[0]->append_datum(d_str);
-        pchunk->mutable_columns()[1]->append_datum(d_int);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d_str);
+        pchunk->columns()[1]->as_mutable_ptr()->append_datum(d_int);
     }
     verify_v2_sort_order_preserved(*sc, *pchunk, sorted_pairs.size());
     verify_v2_round_trip(*sc, *pchunk);
@@ -528,23 +528,23 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingRoundTripForCompositeAllTypes) {
     for (int i = 0; i < n; i++) {
         Datum d;
         d.set_uint8(i % 2);
-        pchunk->mutable_columns()[0]->append_datum(d);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
 
         d.set_int8(static_cast<int8_t>(i * 10 - 20));
-        pchunk->mutable_columns()[1]->append_datum(d);
+        pchunk->columns()[1]->as_mutable_ptr()->append_datum(d);
 
         d.set_int16(static_cast<int16_t>(i * 100 - 200));
-        pchunk->mutable_columns()[2]->append_datum(d);
+        pchunk->columns()[2]->as_mutable_ptr()->append_datum(d);
 
         d.set_int32(i * 1000 - 2000);
-        pchunk->mutable_columns()[3]->append_datum(d);
+        pchunk->columns()[3]->as_mutable_ptr()->append_datum(d);
 
         d.set_int64(static_cast<int64_t>(i) * 10000 - 20000);
-        pchunk->mutable_columns()[4]->append_datum(d);
+        pchunk->columns()[4]->as_mutable_ptr()->append_datum(d);
 
         std::string s = StringPrintf("val_%d", i);
         d.set_slice(Slice(s));
-        pchunk->mutable_columns()[5]->append_datum(d);
+        pchunk->columns()[5]->as_mutable_ptr()->append_datum(d);
     }
     verify_v2_round_trip(*sc, *pchunk);
 }
@@ -556,11 +556,11 @@ TEST(PrimaryKeyEncoderTest, testV2EncodeSelectiveRoundTrip) {
     for (int i = 0; i < n; i++) {
         Datum d_int;
         d_int.set_int32(i * 111);
-        pchunk->mutable_columns()[0]->append_datum(d_int);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(d_int);
         Datum d_str;
         std::string s = StringPrintf("s%d", i);
         d_str.set_slice(Slice(s));
-        pchunk->mutable_columns()[1]->append_datum(d_str);
+        pchunk->columns()[1]->as_mutable_ptr()->append_datum(d_str);
     }
 
     // Select only even indices: 0, 2, 4
@@ -589,14 +589,14 @@ TEST(PrimaryKeyEncoderTest, testV2EncodeExceedLimitForComposite) {
     auto pchunk = ChunkFactory::new_chunk(*sc, n);
     Datum d;
     d.set_int32(42);
-    pchunk->mutable_columns()[0]->append_datum(d);
+    pchunk->columns()[0]->as_mutable_ptr()->append_datum(d);
     // VARCHAR with \0 byte to test escape overhead calculation
     std::string s(100, 'x');
     s[50] = '\0';
     d.set_slice(Slice(s));
-    pchunk->mutable_columns()[1]->append_datum(d);
+    pchunk->columns()[1]->as_mutable_ptr()->append_datum(d);
     d.set_int16(10);
-    pchunk->mutable_columns()[2]->append_datum(d);
+    pchunk->columns()[2]->as_mutable_ptr()->append_datum(d);
 
     // 4 (int) + 100 (varchar) + 1 (escape for \0) + 2 (separator) + 2 (smallint) = 109
     EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,

--- a/be/test/storage/publish_version_manager_test.cpp
+++ b/be/test/storage/publish_version_manager_test.cpp
@@ -120,23 +120,23 @@ public:
         }
         auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
             if (schema.num_key_fields() == 1) {
-                cols[0]->append_datum(Datum(key));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
             } else {
-                cols[0]->append_datum(Datum(key));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
                 string v = fmt::to_string(key * 234234342345);
-                cols[1]->append_datum(Datum(Slice(v)));
-                cols[2]->append_datum(Datum((int32_t)key));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)key));
             }
             int vcol_start = schema.num_key_fields();
-            cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[vcol_start]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
             if (cols[vcol_start + 1]->is_binary()) {
                 string v = fmt::to_string(key % 1000 + 2);
-                cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+                cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
             } else {
-                cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+                cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
             }
         }
         if (one_delete == nullptr && !keys.empty()) {

--- a/be/test/storage/publish_version_task_test.cpp
+++ b/be/test/storage/publish_version_task_test.cpp
@@ -158,11 +158,11 @@ public:
         auto chunk = ChunkFactory::new_chunk(schema, 1024);
         for (size_t i = 0; i < 1024; ++i) {
             test_data.push_back("well" + std::to_string(i));
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
             Slice field_1(test_data[i]);
-            cols[1]->append_datum(Datum(field_1));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
         }
         auto st = writer->add_chunk(*chunk);
         ASSERT_TRUE(st.ok()) << st.to_string() << ", version:" << writer->version();
@@ -235,11 +235,11 @@ TEST_F(PublishVersionTaskTest, test_publish_version) {
         for (size_t i = 0; i < 1024; ++i) {
             indexes.push_back(i);
             test_data.push_back("well" + std::to_string(i));
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
             Slice field_1(test_data[i]);
-            cols[1]->append_datum(Datum(field_1));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
         }
         auto st = delta_writer->write(*chunk, indexes.data(), 0, indexes.size());
         ASSERT_TRUE(st.ok()) << st.to_string();
@@ -338,11 +338,11 @@ TEST_F(PublishVersionTaskTest, test_publish_version2) {
         for (size_t i = 0; i < 1024; ++i) {
             indexes.push_back(i);
             test_data.push_back("well" + std::to_string(i));
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
             Slice field_1(test_data[i]);
-            cols[1]->append_datum(Datum(field_1));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
         }
         auto st = delta_writer->write(*chunk, indexes.data(), 0, indexes.size());
         ASSERT_TRUE(st.ok()) << st.to_string();
@@ -426,11 +426,11 @@ TEST_F(PublishVersionTaskTest, test_publish_version_cancellation) {
         for (size_t i = 0; i < 128; ++i) {
             indexes.push_back(i);
             test_data.push_back("well" + std::to_string(i));
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
             Slice field_1(test_data[i]);
-            cols[1]->append_datum(Datum(field_1));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
         }
         auto st = delta_writer->write(*chunk, indexes.data(), 0, indexes.size());
         ASSERT_TRUE(st.ok()) << st.to_string();
@@ -578,12 +578,12 @@ TEST_F(PublishVersionTaskTest, test_publish_version_overwrite_failed) {
         indexes.reserve(8);
         for (size_t i = 0; i < 8; ++i) {
             indexes.push_back(i);
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
             std::string s_str = std::string("owf") + std::to_string(i);
             Slice s(s_str);
-            cols[1]->append_datum(Datum(s));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(s));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
         }
         ASSERT_TRUE(delta_writer->write(*chunk, indexes.data(), 0, indexes.size()).ok());
         ASSERT_TRUE(delta_writer->close().ok());
@@ -693,12 +693,12 @@ TEST_F(PublishVersionTaskTest, test_publish_version_tablet_dropped) {
         indexes.reserve(8);
         for (size_t i = 0; i < 8; ++i) {
             indexes.push_back(i);
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
             std::string s_str = std::string("dropped") + std::to_string(i);
             Slice s(s_str);
-            cols[1]->append_datum(Datum(s));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(s));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
         }
         ASSERT_TRUE(delta_writer->write(*chunk, indexes.data(), 0, indexes.size()).ok());
         ASSERT_TRUE(delta_writer->close().ok());

--- a/be/test/storage/replication_txn_manager_test.cpp
+++ b/be/test/storage/replication_txn_manager_test.cpp
@@ -147,23 +147,23 @@ public:
         }
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
             if (schema.num_key_fields() == 1) {
-                cols[0]->append_datum(Datum(key));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
             } else {
-                cols[0]->append_datum(Datum(key));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
                 string v = fmt::to_string(key * 234234342345);
-                cols[1]->append_datum(Datum(Slice(v)));
-                cols[2]->append_datum(Datum((int32_t)key));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)key));
             }
             int vcol_start = schema.num_key_fields();
-            cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[vcol_start]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
             if (cols[vcol_start + 1]->is_binary()) {
                 string v = fmt::to_string(key % 1000 + 2);
-                cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+                cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
             } else {
-                cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+                cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
             }
         }
         if (one_delete == nullptr && !keys.empty()) {

--- a/be/test/storage/row_store_encoder_test.cpp
+++ b/be/test/storage/row_store_encoder_test.cpp
@@ -115,22 +115,23 @@ TEST(RowStoreEncoderTest, testEncodeFullRowColumn) {
     // fill chunk
     const int n = 2;
     auto pchunk = ChunkFactory::new_chunk(*schema, n);
-    auto obj_column = down_cast<ObjectColumn<BitmapValue>*>(pchunk->mutable_columns()[6].get());
+    auto obj_column = down_cast<ObjectColumn<BitmapValue>*>(pchunk->columns()[6]->as_mutable_ptr().get());
     size_t ss = 0;
     for (int i = 0; i < n; i++) {
         Datum tmp;
         string tmpstr = StringPrintf("slice000%d", i * 17);
         tmp.set_int32(i * 2343);
-        pchunk->mutable_columns()[0]->append_datum(tmp);
+        pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_slice(tmpstr);
-        pchunk->mutable_columns()[1]->append_datum(tmp);
+        pchunk->columns()[1]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_int32(i * 2343);
-        pchunk->mutable_columns()[2]->append_datum(tmp);
+        pchunk->columns()[2]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_uint8(i % 2);
-        pchunk->mutable_columns()[3]->append_datum(tmp);
-        down_cast<ObjectColumn<HyperLogLog>*>(pchunk->mutable_columns()[4].get())->append(HyperLogLog(1));
-        down_cast<ObjectColumn<PercentileValue>*>(pchunk->mutable_columns()[5].get())->append(PercentileValue());
-        down_cast<ObjectColumn<BitmapValue>*>(pchunk->mutable_columns()[6].get())->append(BitmapValue());
+        pchunk->columns()[3]->as_mutable_ptr()->append_datum(tmp);
+        down_cast<ObjectColumn<HyperLogLog>*>(pchunk->columns()[4]->as_mutable_ptr().get())->append(HyperLogLog(1));
+        down_cast<ObjectColumn<PercentileValue>*>(pchunk->columns()[5]->as_mutable_ptr().get())
+                ->append(PercentileValue());
+        down_cast<ObjectColumn<BitmapValue>*>(pchunk->columns()[6]->as_mutable_ptr().get())->append(BitmapValue());
         ss += obj_column->byte_size(i);
     }
     EXPECT_EQ(ss, obj_column->byte_size(0, n));

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -122,11 +122,11 @@ public:
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-            cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
         }
         EXPECT_TRUE(writer->flush_chunk(*chunk).ok());
         return *writer->build();

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -283,13 +283,13 @@ void RowsetTest::test_final_merge(bool has_merge_condition = false) {
 
     {
         auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = 0; i < rows_per_segment; i++) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(1)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(1)));
-            cols[4]->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[4]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
         }
         ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
         ASSERT_OK(rowset_writer->flush());
@@ -297,13 +297,13 @@ void RowsetTest::test_final_merge(bool has_merge_condition = false) {
 
     {
         auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = rows_per_segment / 2; i < rows_per_segment + rows_per_segment / 2; i++) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(2)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(2)));
-            cols[4]->append_datum(Datum(static_cast<int32_t>(2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(2)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(2)));
+            cols[4]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(2)));
         }
         ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
         ASSERT_OK(rowset_writer->flush());
@@ -311,13 +311,13 @@ void RowsetTest::test_final_merge(bool has_merge_condition = false) {
 
     {
         auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = rows_per_segment; i < rows_per_segment * 2; i++) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(3)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(3)));
-            cols[4]->append_datum(Datum(static_cast<int32_t>(3)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(3)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(3)));
+            cols[4]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(3)));
         }
         ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
         ASSERT_OK(rowset_writer->flush());
@@ -451,13 +451,13 @@ TEST_F(RowsetTest, FinalMergeVerticalTest) {
 
     {
         auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = 0; i < rows_per_segment; i++) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(1)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(1)));
-            cols[4]->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[4]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
         }
         ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
         ASSERT_OK(rowset_writer->flush());
@@ -465,13 +465,13 @@ TEST_F(RowsetTest, FinalMergeVerticalTest) {
 
     {
         auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = rows_per_segment / 2; i < rows_per_segment + rows_per_segment / 2; i++) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(2)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(2)));
-            cols[4]->append_datum(Datum(static_cast<int32_t>(2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(2)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(2)));
+            cols[4]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(2)));
         }
         ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
         ASSERT_OK(rowset_writer->flush());
@@ -479,13 +479,13 @@ TEST_F(RowsetTest, FinalMergeVerticalTest) {
 
     {
         auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = rows_per_segment; i < rows_per_segment * 2; i++) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(3)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(3)));
-            cols[4]->append_datum(Datum(static_cast<int32_t>(3)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(3)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(3)));
+            cols[4]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(3)));
         }
         ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
         ASSERT_OK(rowset_writer->flush());
@@ -589,24 +589,24 @@ TEST_F(RowsetTest, FinalMergeVerticalTest) {
 
 static ssize_t read_and_compare(const ChunkIteratorPtr& iter, int64_t nkeys) {
     auto full_chunk = ChunkFactory::new_chunk(iter->schema(), nkeys);
-    auto cols = full_chunk->mutable_columns();
+    auto cols = full_chunk->columns();
     for (size_t i = 0; i < nkeys / 4; i++) {
-        cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-        cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-        cols[2]->append_datum(Datum(static_cast<int32_t>(1)));
-        cols[3]->append_datum(Datum(static_cast<int32_t>(1)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+        cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
+        cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
     }
     for (size_t i = nkeys / 4; i < nkeys / 2; i++) {
-        cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-        cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-        cols[2]->append_datum(Datum(static_cast<int32_t>(2)));
-        cols[3]->append_datum(Datum(static_cast<int32_t>(2)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+        cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(2)));
+        cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(2)));
     }
     for (size_t i = nkeys / 2; i < nkeys; i++) {
-        cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-        cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-        cols[2]->append_datum(Datum(static_cast<int32_t>(3)));
-        cols[3]->append_datum(Datum(static_cast<int32_t>(3)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+        cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(3)));
+        cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(3)));
     }
     size_t count = 0;
     auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
@@ -658,12 +658,12 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
 
     {
         auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = 0; i < rows_per_segment; i++) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(1)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
         }
         ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
         ASSERT_OK(rowset_writer->flush());
@@ -671,12 +671,12 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
 
     {
         auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = rows_per_segment / 2; i < rows_per_segment + rows_per_segment / 2; i++) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(2)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(2)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(2)));
         }
         ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
         ASSERT_OK(rowset_writer->flush());
@@ -684,12 +684,12 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
 
     {
         auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = rows_per_segment; i < rows_per_segment * 2; i++) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(3)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(3)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(3)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(3)));
         }
         ASSERT_OK(rowset_writer->add_chunk(*chunk.get()));
         ASSERT_OK(rowset_writer->flush());
@@ -727,10 +727,10 @@ TEST_F(RowsetTest, VerticalWriteTest) {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-                cols[1]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
             }
             ASSERT_OK(rowset_writer->add_columns(*chunk, column_indexes, true));
         }
@@ -744,9 +744,9 @@ TEST_F(RowsetTest, VerticalWriteTest) {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
             }
             ASSERT_OK(rowset_writer->add_columns(*chunk, column_indexes, false));
         }
@@ -809,11 +809,11 @@ TEST_F(RowsetTest, LoadFailedTest) {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows / chunk_size + 1; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-                cols[1]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
-                cols[2]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
             }
             seg_infos.emplace_back(std::make_unique<SegmentPB>());
             ASSERT_OK(rowset_writer->flush_chunk(*chunk, seg_infos.back().get()));
@@ -855,11 +855,11 @@ TEST_F(RowsetTest, SegmentWriteTest) {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows / chunk_size + 1; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-                cols[1]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
-                cols[2]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
             }
             seg_infos.emplace_back(std::make_unique<SegmentPB>());
             ASSERT_OK(rowset_writer->flush_chunk(*chunk, seg_infos.back().get()));
@@ -977,11 +977,11 @@ TEST_F(RowsetTest, SegmentRewriterAutoIncrementTest) {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows / chunk_size + 1; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-                cols[1]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
-                cols[2]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
             }
             seg_infos.emplace_back(std::make_unique<SegmentPB>());
             ASSERT_OK(rowset_writer->flush_chunk(*chunk, seg_infos.back().get()));
@@ -1042,13 +1042,13 @@ TEST_F(RowsetTest, SegmentDeleteWriteTest) {
     std::unique_ptr<SegmentPB> seg_info = std::make_unique<SegmentPB>();
     {
         auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = 0; i < num_rows; i++) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(1)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(1)));
-            cols[4]->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
+            cols[4]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
             if (i % 2 == 1) {
                 deletes.append(i);
             }

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -129,9 +129,9 @@ struct TabletDataBuilder {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(provider(static_cast<int32_t>(i * chunk_size + j)));
+                cols[0]->as_mutable_ptr()->append_datum(provider(static_cast<int32_t>(i * chunk_size + j)));
             }
             RETURN_IF_ERROR(writer.append_chunk(*chunk));
         }
@@ -791,10 +791,10 @@ TEST_F(SegmentIteratorTest, testCharToVarcharZoneMapFilter) {
 
     // Fill the chunk with data
     chunk->reset();
-    auto cols = chunk->mutable_columns();
+    auto cols = chunk->columns();
     for (int i = 0; i < 4; ++i) {
-        cols[0]->append_datum(int_provider(i));
-        cols[1]->append_datum(char_provider(i));
+        cols[0]->as_mutable_ptr()->append_datum(int_provider(i));
+        cols[1]->as_mutable_ptr()->append_datum(char_provider(i));
     }
     ASSERT_OK(writer.append_chunk(*chunk));
 

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -85,11 +85,11 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
 
     for (auto i = 0; i < num_rows % chunk_size; ++i) {
         partial_chunk->reset();
-        auto cols = partial_chunk->mutable_columns();
+        auto cols = partial_chunk->columns();
         for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 3)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 3)));
         }
         ASSERT_OK(writer.append_chunk(*partial_chunk));
     }
@@ -119,7 +119,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
         auto column = ChunkFactory::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
         write_columns[i] = column->clone_empty();
         for (auto j = 0; j < num_rows; ++j) {
-            write_columns[i]->append_datum(Datum(static_cast<int32_t>(j + read_column_ids[i])));
+            write_columns[i]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(j + read_column_ids[i])));
         }
     }
 

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -99,10 +99,10 @@ protected:
         auto schema = ChunkHelper::convert_schema(build_schema);
         auto chunk = ChunkFactory::new_chunk(schema, nrows);
         for (size_t rid = 0; rid < nrows; ++rid) {
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (int cid = 0; cid < build_schema->num_columns(); ++cid) {
                 int row_block_id = rid / opts.num_rows_per_block;
-                cols[cid]->append_datum(generator(rid, cid, row_block_id));
+                cols[cid]->as_mutable_ptr()->append_datum(generator(rid, cid, row_block_id));
             }
         }
         ASSERT_OK(writer.append_chunk(*chunk));
@@ -146,9 +146,9 @@ TEST_F(SegmentReaderWriterTest, estimate_segment_size) {
     auto schema = ChunkHelper::convert_schema(tablet_schema);
     auto chunk = ChunkFactory::new_chunk(schema, nrows);
     for (size_t rid = 0; rid < nrows; ++rid) {
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int cid = 0; cid < tablet_schema->num_columns(); ++cid) {
-            cols[cid]->append_datum(Datum(static_cast<int32_t>(rid * 10 + cid)));
+            cols[cid]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(rid * 10 + cid)));
         }
     }
     ASSERT_OK(writer.append_chunk(*chunk));
@@ -204,12 +204,12 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
     auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
     for (auto i = 0; i < num_rows % chunk_size; ++i) {
         chunk->reset();
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
-            cols[3]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 3)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
+            cols[3]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 3)));
         }
         ASSERT_OK(writer.append_chunk(*chunk));
     }
@@ -313,10 +313,10 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-                cols[1]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
             }
             ASSERT_OK(writer.append_chunk(*chunk));
         }
@@ -331,9 +331,9 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
             }
             ASSERT_OK(writer.append_chunk(*chunk));
         }
@@ -348,9 +348,9 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 3)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 3)));
             }
             ASSERT_OK(writer.append_chunk(*chunk));
         }
@@ -430,10 +430,10 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-                cols[1]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
             }
             ASSERT_OK(writer.append_chunk(*chunk));
         }
@@ -448,9 +448,9 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
         auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
         for (auto i = 0; i < num_rows % chunk_size; ++i) {
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(data_strs[j % 8]));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(data_strs[j % 8]));
             }
             ASSERT_OK(writer.append_chunk(*chunk));
         }
@@ -506,10 +506,10 @@ TEST_F(SegmentReaderWriterTest, TestTypeConversion) {
     auto chunk = ChunkFactory::new_chunk(write_schema, chunk_size);
     for (auto i = 0; i < num_rows / chunk_size; ++i) {
         chunk->reset();
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto j = 0; j < chunk_size; ++j) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
         }
         ASSERT_OK(writer.append_chunk(*chunk));
     }
@@ -595,10 +595,10 @@ TEST_F(SegmentReaderWriterTest, TestCheckColumnUniqueIdUniqueness) {
     auto schema = ChunkHelper::convert_schema(tablet_schema);
     auto chunk = ChunkFactory::new_chunk(schema, 100);
     for (size_t rid = 0; rid < 100; ++rid) {
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int cid = 0; cid < tablet_schema->num_columns(); ++cid) {
             int row_block_id = rid / opts.num_rows_per_block;
-            cols[cid]->append_datum(DefaultIntGenerator(rid, cid, row_block_id));
+            cols[cid]->as_mutable_ptr()->append_datum(DefaultIntGenerator(rid, cid, row_block_id));
         }
     }
     ASSERT_OK(writer.append_chunk(*chunk));

--- a/be/test/storage/rowset/segment_writer_sort_key_sampling_test.cpp
+++ b/be/test/storage/rowset/segment_writer_sort_key_sampling_test.cpp
@@ -68,10 +68,10 @@ protected:
     ChunkUniquePtr make_increasing_chunk(int64_t n, int32_t start_key) {
         auto s = ChunkHelper::convert_schema(_schema);
         auto chunk = ChunkFactory::new_chunk(s, n);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t i = 0; i < n; ++i) {
-            cols[0]->append_datum(Datum(static_cast<int32_t>(start_key + i)));
-            cols[1]->append_datum(Datum(static_cast<int32_t>(0)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(start_key + i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(0)));
         }
         return chunk;
     }
@@ -164,14 +164,14 @@ TEST_F(SegmentWriterSortKeySamplingTest, leading_min_duplicate_samples) {
 
     auto s = ChunkHelper::convert_schema(_schema);
     auto chunk = ChunkFactory::new_chunk(s, num_rows);
-    auto cols = chunk->mutable_columns();
+    auto cols = chunk->columns();
     for (int64_t i = 0; i < leading; ++i) {
-        cols[0]->append_datum(Datum(static_cast<int32_t>(0)));
-        cols[1]->append_datum(Datum(static_cast<int32_t>(0)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(0)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(0)));
     }
     for (int64_t i = 0; i < trailing; ++i) {
-        cols[0]->append_datum(Datum(static_cast<int32_t>(1 + i)));
-        cols[1]->append_datum(Datum(static_cast<int32_t>(0)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1 + i)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(0)));
     }
     ASSERT_OK(w->append_chunk(*chunk));
 
@@ -191,10 +191,10 @@ TEST_F(SegmentWriterSortKeySamplingTest, all_identical_key) {
 
     auto s = ChunkHelper::convert_schema(_schema);
     auto chunk = ChunkFactory::new_chunk(s, num_rows);
-    auto cols = chunk->mutable_columns();
+    auto cols = chunk->columns();
     for (int64_t i = 0; i < num_rows; ++i) {
-        cols[0]->append_datum(Datum(static_cast<int32_t>(42)));
-        cols[1]->append_datum(Datum(static_cast<int32_t>(0)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(42)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(0)));
     }
     ASSERT_OK(w->append_chunk(*chunk));
 
@@ -222,7 +222,7 @@ TEST_F(SegmentWriterSortKeySamplingTest, vertical_writer_reinit_preserves_sample
     // Append key-column-only chunks.
     auto key_schema_view = ChunkHelper::convert_schema(_schema, key_cols);
     auto key_chunk = ChunkFactory::new_chunk(key_schema_view, num_rows);
-    auto* key_col = key_chunk->mutable_columns()[0].get();
+    auto* key_col = key_chunk->columns()[0]->as_mutable_ptr().get();
     for (int64_t i = 0; i < num_rows; ++i) {
         key_col->append_datum(Datum(static_cast<int32_t>(i)));
     }

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -89,13 +89,13 @@ public:
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-            cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
             if (add_v3) {
-                cols[3]->append_datum(Datum((int32_t)(key % 1000 + 3)));
+                cols[3]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 3)));
             }
         }
         if (!keys.empty()) {

--- a/be/test/storage/rowset_column_update_state_test.cpp
+++ b/be/test/storage/rowset_column_update_state_test.cpp
@@ -150,10 +150,10 @@ public:
 
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
         EXPECT_TRUE(2 == chunk->num_columns());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 3)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 3)));
         }
         for (int i = 0; i < segment_num; i++) {
             CHECK_OK(writer->flush_chunk(*chunk));

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -127,11 +127,11 @@ public:
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-            cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
         }
         if (one_delete == nullptr && !keys.empty()) {
             CHECK_OK(writer->flush_chunk(*chunk));

--- a/be/test/storage/rowset_update_state_test.cpp
+++ b/be/test/storage/rowset_update_state_test.cpp
@@ -166,10 +166,10 @@ public:
 
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
         EXPECT_TRUE(2 == chunk->num_columns());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 3)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 3)));
         }
         CHECK_OK(writer->flush_chunk(*chunk));
         RowsetSharedPtr partial_rowset = *writer->build();
@@ -340,11 +340,11 @@ TEST_F(RowsetUpdateStateTest, check_conflict) {
     EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
     auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
     auto chunk = ChunkFactory::new_chunk(schema, N);
-    auto cols = chunk->mutable_columns();
+    auto cols = chunk->columns();
     for (uint64_t i = 0; i < N; i++) {
-        cols[0]->append_datum(Datum(i));
-        cols[1]->append_datum(Datum((int16_t)(i % 100 + 1)));
-        cols[2]->append_datum(Datum((int32_t)(i % 1000 + 3)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(i));
+        cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(i % 100 + 1)));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(i % 1000 + 3)));
     }
     CHECK_OK(writer->flush_chunk(*chunk));
     RowsetSharedPtr new_rowset = *writer->build();

--- a/be/test/storage/segment_flush_executor_test.cpp
+++ b/be/test/storage/segment_flush_executor_test.cpp
@@ -165,7 +165,7 @@ public:
         auto schema = ChunkHelper::convert_schema(tablet->tablet_schema(), column_indexes);
         auto chunk = ChunkFactory::new_chunk(schema, num_rows);
         for (auto i = 0; i < num_rows; ++i) {
-            chunk->mutable_columns()[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            chunk->columns()[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
         }
         ASSERT_OK(rowset_writer->flush_chunk(*chunk, segment_pb));
         rowset = rowset_writer->build().value();

--- a/be/test/storage/size_tiered_compaction_policy_test.cpp
+++ b/be/test/storage/size_tiered_compaction_policy_test.cpp
@@ -64,11 +64,11 @@ public:
         auto chunk = ChunkFactory::new_chunk(schema, 1024);
         for (size_t i = 0; i < 1500 * pow(config::size_tiered_level_multiple + 3, level - 2); ++i) {
             test_data.emplace_back("well" + std::to_string(id++));
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(id++)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(id++)));
             Slice field_1(test_data[i]);
-            cols[1]->append_datum(Datum(field_1));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + id++)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + id++)));
         }
         CHECK_OK(writer->add_chunk(*chunk));
     }

--- a/be/test/storage/table_reader_remote_test.cpp
+++ b/be/test/storage/table_reader_remote_test.cpp
@@ -71,12 +71,12 @@ public:
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, data.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int pos = start_pos; pos < end_pos; pos++) {
             const DatumTuple& row = data[pos];
             DatumTuple tmp_row;
             for (size_t i = 0; i < row.size(); i++) {
-                cols[i]->append_datum(row.get(i));
+                cols[i]->as_mutable_ptr()->append_datum(row.get(i));
             }
         }
         CHECK_OK(writer->flush_chunk(*chunk));

--- a/be/test/storage/table_reader_test.cpp
+++ b/be/test/storage/table_reader_test.cpp
@@ -73,12 +73,12 @@ public:
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, data.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int pos = start_pos; pos < end_pos; pos++) {
             const DatumTuple& row = data[pos];
             DatumTuple tmp_row;
             for (size_t i = 0; i < row.size(); i++) {
-                cols[i]->append_datum(row.get(i));
+                cols[i]->as_mutable_ptr()->append_datum(row.get(i));
             }
         }
         CHECK_OK(writer->flush_chunk(*chunk));

--- a/be/test/storage/tablet_binlog_test.cpp
+++ b/be/test/storage/tablet_binlog_test.cpp
@@ -83,10 +83,10 @@ public:
         for (int32_t i = 0, total_rows = 0; i < num_rows_per_segment.size(); i++) {
             int32_t num_rows = num_rows_per_segment[i];
             chunk->reset();
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (int32_t j = total_rows; j < total_rows + num_rows; j++) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(j)));
-                cols[1]->append_datum(Datum(static_cast<int32_t>(j + 1)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(j)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(j + 1)));
             }
             total_rows += num_rows;
             CHECK_OK(writer->flush_chunk(*chunk));

--- a/be/test/storage/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet_mgr_test.cpp
@@ -371,11 +371,11 @@ static void rowset_writer_add_rows(std::unique_ptr<RowsetWriter>& writer, const 
     auto chunk = ChunkFactory::new_chunk(schema, 1024);
     for (size_t i = 0; i < 1024; ++i) {
         test_data.push_back("well" + std::to_string(i));
-        auto cols = chunk->mutable_columns();
-        cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+        auto cols = chunk->columns();
+        cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
         Slice field_1(test_data[i]);
-        cols[1]->append_datum(Datum(field_1));
-        cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+        cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
     }
     auto st = writer->add_chunk(*chunk);
     ASSERT_TRUE(st.ok()) << st.to_string() << ", version:" << writer->version();

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -2079,11 +2079,11 @@ void TabletUpdatesTest::test_load_snapshot_incremental_with_merge_condition(bool
         CHECK_OK(RowsetFactory::create_rowset_writer(writer_context, &writer));
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (size_t i = 0; i < keys.size(); i++) {
-            cols[0]->append_datum(Datum(keys[i]));
-            cols[1]->append_datum(Datum((int16_t)(keys[i] % 100 + 1)));
-            cols[2]->append_datum(Datum(v2_data[i]));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(keys[i] % 100 + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(v2_data[i]));
         }
         CHECK_OK(writer->flush_chunk(*chunk));
         return *writer->build();

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -78,11 +78,11 @@ static ChunkIteratorPtr create_tablet_iterator(TabletReader& reader, Schema& sch
 static ssize_t read_and_compare(const ChunkIteratorPtr& iter, const vector<int64_t>& keys) {
     auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
     auto full_chunk = ChunkFactory::new_chunk(iter->schema(), keys.size());
-    auto cols = full_chunk->mutable_columns();
+    auto cols = full_chunk->columns();
     for (int64_t key : keys) {
-        cols[0]->append_datum(Datum(key));
-        cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-        cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+        cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
     }
     size_t count = 0;
     while (true) {
@@ -178,12 +178,12 @@ ssize_t read_tablet_and_compare_schema_changed(const TabletSharedPtr& tablet, in
         return -1;
     }
     auto full_chunk = ChunkFactory::new_chunk(iter->schema(), keys.size());
-    auto cols = full_chunk->mutable_columns();
+    auto cols = full_chunk->columns();
     for (int64_t key : keys) {
-        cols[0]->append_datum(Datum((int64_t)key));
-        cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum((int64_t)key));
+        cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
         auto v = std::to_string((int64_t)(key % 1000 + 2));
-        cols[2]->append_datum(Datum(Slice{v}));
+        cols[2]->as_mutable_ptr()->append_datum(Datum(Slice{v}));
     }
     auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
     size_t count = 0;
@@ -214,11 +214,11 @@ ssize_t read_tablet_and_compare_schema_changed_sort_key1(const TabletSharedPtr& 
     }
     const auto nkeys = keys.size();
     auto full_chunk = ChunkFactory::new_chunk(iter->schema(), nkeys);
-    auto cols = full_chunk->mutable_columns();
+    auto cols = full_chunk->columns();
     for (int64_t key : keys) {
-        cols[0]->append_datum(Datum((int64_t)(nkeys - 1 - key)));
-        cols[1]->append_datum(Datum((int16_t)key));
-        cols[2]->append_datum(Datum((int32_t)(nkeys - 1 - key)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum((int64_t)(nkeys - 1 - key)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)key));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(nkeys - 1 - key)));
     }
     auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
     size_t count = 0;
@@ -249,11 +249,11 @@ ssize_t read_tablet_and_compare_schema_changed_sort_key2(const TabletSharedPtr& 
     }
     const auto nkeys = keys.size();
     auto full_chunk = ChunkFactory::new_chunk(iter->schema(), nkeys);
-    auto cols = full_chunk->mutable_columns();
+    auto cols = full_chunk->columns();
     for (int64_t key : keys) {
-        cols[0]->append_datum(Datum((int64_t)key));
-        cols[1]->append_datum(Datum((int16_t)(nkeys - 1 - key)));
-        cols[2]->append_datum(Datum((int32_t)key));
+        cols[0]->as_mutable_ptr()->append_datum(Datum((int64_t)key));
+        cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(nkeys - 1 - key)));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)key));
     }
     auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
     size_t count = 0;
@@ -283,11 +283,11 @@ static ssize_t read_tablet_and_compare_sort_key_error_encode_case(const TabletSh
         return -1;
     }
     auto full_chunk = ChunkFactory::new_chunk(iter->schema(), keys.size());
-    auto cols = full_chunk->mutable_columns();
+    auto cols = full_chunk->columns();
     for (auto i = 0; i < keys.size(); ++i) {
-        cols[0]->append_datum(Datum((int64_t)keys[i]));
-        cols[1]->append_datum(Datum((int16_t)1));
-        cols[2]->append_datum(Datum((int32_t)i));
+        cols[0]->as_mutable_ptr()->append_datum(Datum((int64_t)keys[i]));
+        cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)1));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)i));
     }
     auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
     size_t count = 0;
@@ -318,11 +318,11 @@ static ssize_t read_tablet_and_compare_nullable_sort_key(const TabletSharedPtr& 
     }
     const auto keys_size = all_cols[0].size();
     auto full_chunk = ChunkFactory::new_chunk(iter->schema(), keys_size);
-    auto cols = full_chunk->mutable_columns();
+    auto cols = full_chunk->columns();
     for (auto i = 0; i < keys_size; ++i) {
-        append_datum_func(cols[0], static_cast<int64_t>(all_cols[0][i]));
-        append_datum_func(cols[1], static_cast<int16_t>(all_cols[1][i]));
-        append_datum_func(cols[2], static_cast<int32_t>(all_cols[2][i]));
+        append_datum_func(cols[0]->as_mutable_ptr(), static_cast<int64_t>(all_cols[0][i]));
+        append_datum_func(cols[1]->as_mutable_ptr(), static_cast<int16_t>(all_cols[1][i]));
+        append_datum_func(cols[2]->as_mutable_ptr(), static_cast<int32_t>(all_cols[2][i]));
     }
     auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
     size_t count = 0;
@@ -1552,12 +1552,12 @@ TEST_F(TabletUpdatesTest, horizontal_compaction_with_sort_key) {
 
     auto schema = ChunkHelper::convert_schema(_tablet->thread_safe_get_tablet_schema());
     auto sk_chunk = ChunkFactory::new_chunk(schema, loop);
-    auto cols = sk_chunk->mutable_columns();
+    auto cols = sk_chunk->columns();
     for (int i = 0; i < loop; i++) {
         int64_t key = sorted_keys[i * 100];
-        cols[0]->append_datum(Datum(key));
-        cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-        cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+        cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
     }
     std::vector<RowsetSharedPtr> rowsets;
     ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(loop + 1, &rowsets).ok());
@@ -1887,12 +1887,12 @@ TEST_F(TabletUpdatesTest, vertical_compaction_with_sort_key) {
 
     auto schema = ChunkHelper::convert_schema(_tablet->thread_safe_get_tablet_schema());
     auto sk_chunk = ChunkFactory::new_chunk(schema, loop);
-    auto cols = sk_chunk->mutable_columns();
+    auto cols = sk_chunk->columns();
     for (int i = 0; i < loop; i++) {
         int64_t key = sorted_keys[i * 100];
-        cols[0]->append_datum(Datum(key));
-        cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-        cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+        cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
     }
     std::vector<RowsetSharedPtr> rowsets;
     ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(loop + 1, &rowsets).ok());
@@ -3473,11 +3473,11 @@ TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
         }
         auto schema = ChunkHelper::convert_schema(_tablet->thread_safe_get_tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 2)));
-            cols[2]->append_datum(Datum((int32_t)(key % 100 + 3)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 2)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 100 + 3)));
         }
         CHECK_OK(writer->flush_chunk(*chunk));
     }
@@ -3495,11 +3495,11 @@ TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
 
         auto schema = ChunkHelper::convert_schema(_tablet->thread_safe_get_tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-            cols[2]->append_datum(Datum((int32_t)(key % 100 + 2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 100 + 2)));
         }
         CHECK_OK(writer->flush_chunk_with_deletes(*chunk, deletes));
     }
@@ -3529,17 +3529,17 @@ TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
     }
     auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
     auto full_chunk = ChunkFactory::new_chunk(iter->schema(), keys.size());
-    auto cols = full_chunk->mutable_columns();
+    auto cols = full_chunk->columns();
     for (int i = 0; i < 50; i++) {
-        cols[0]->append_datum(Datum(keys[i]));
-        cols[1]->append_datum(Datum((int16_t)(keys[i] % 100 + 2)));
-        cols[2]->append_datum(Datum((int32_t)(keys[i] % 100 + 3)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
+        cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(keys[i] % 100 + 2)));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(keys[i] % 100 + 3)));
     }
 
     for (int i = 50; i < 100; i++) {
-        cols[0]->append_datum(Datum(keys[i]));
-        cols[1]->append_datum(Datum((int16_t)(keys[i] % 100 + 1)));
-        cols[2]->append_datum(Datum((int32_t)(keys[i] % 100 + 2)));
+        cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
+        cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(keys[i] % 100 + 1)));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(keys[i] % 100 + 2)));
     }
 
     size_t count = 0;

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -60,7 +60,7 @@ enum PartialUpdateCloneCase {
 };
 
 template <class T>
-static void append_datum_func(MutableColumnPtr& col, T val) {
+static void append_datum_func(const MutableColumnPtr& col, T val) {
     if (val == -1) {
         col->append_nulls(1);
     } else {
@@ -94,23 +94,23 @@ public:
         }
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
             if (schema.num_key_fields() == 1) {
-                cols[0]->append_datum(Datum(key));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
             } else {
-                cols[0]->append_datum(Datum(key));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
                 string v = fmt::to_string(key * 234234342345);
-                cols[1]->append_datum(Datum(Slice(v)));
-                cols[2]->append_datum(Datum((int32_t)key));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)key));
             }
             int vcol_start = schema.num_key_fields();
-            cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[vcol_start]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
             if (cols[vcol_start + 1]->is_binary()) {
                 string v = fmt::to_string(key % 1000 + 2);
-                cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+                cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
             } else {
-                cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+                cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
             }
         }
         if (one_delete == nullptr && !keys.empty()) {
@@ -150,23 +150,23 @@ public:
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         for (int i = 0; i < keys_by_segment.size(); i++) {
             auto chunk = ChunkFactory::new_chunk(schema, keys_by_segment[i].size());
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (int64_t key : keys_by_segment[i]) {
                 if (schema.num_key_fields() == 1) {
-                    cols[0]->append_datum(Datum(key));
+                    cols[0]->as_mutable_ptr()->append_datum(Datum(key));
                 } else {
-                    cols[0]->append_datum(Datum(key));
+                    cols[0]->as_mutable_ptr()->append_datum(Datum(key));
                     string v = fmt::to_string(key * 234234342345);
-                    cols[1]->append_datum(Datum(Slice(v)));
-                    cols[2]->append_datum(Datum((int32_t)key));
+                    cols[1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
+                    cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)key));
                 }
                 int vcol_start = schema.num_key_fields();
-                cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+                cols[vcol_start]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
                 if (cols[vcol_start + 1]->is_binary()) {
                     string v = fmt::to_string(key % 1000 + 2);
-                    cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+                    cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
                 } else {
-                    cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+                    cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
                 }
             }
             if (one_delete == nullptr && !keys_by_segment[i].empty()) {
@@ -206,10 +206,10 @@ public:
         if (keys.size() > 0) {
             auto chunk = ChunkFactory::new_chunk(schema, keys.size());
             EXPECT_TRUE(2 == chunk->num_columns());
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (int64_t key : keys) {
-                cols[0]->append_datum(Datum(key));
-                cols[1]->append_datum(Datum((int16_t)(key % 100 + 3)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+                cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 3)));
             }
             CHECK_OK(writer->flush_chunk(*chunk));
         }
@@ -237,11 +237,11 @@ public:
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         for (std::size_t written_rows = 0; written_rows < keys.size(); written_rows += max_rows_per_segment) {
             auto chunk = ChunkFactory::new_chunk(schema, max_rows_per_segment);
-            auto cols = chunk->mutable_columns();
+            auto cols = chunk->columns();
             for (size_t i = 0; i < max_rows_per_segment; i++) {
-                cols[0]->append_datum(Datum(keys[written_rows + i]));
-                cols[1]->append_datum(Datum((int16_t)(keys[written_rows + i] % 100 + 1)));
-                cols[2]->append_datum(Datum((int32_t)(keys[written_rows + i] % 1000 + 2)));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(keys[written_rows + i]));
+                cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(keys[written_rows + i] % 100 + 1)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(keys[written_rows + i] % 1000 + 2)));
             }
             CHECK_OK(writer->flush_chunk(*chunk));
         }
@@ -266,11 +266,11 @@ public:
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         const auto nkeys = keys.size();
         auto chunk = ChunkFactory::new_chunk(schema, nkeys);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(nkeys - 1 - key)));
-            cols[2]->append_datum(Datum((int32_t)(key)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(nkeys - 1 - key)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key)));
         }
         CHECK_OK(writer->flush_chunk(*chunk));
         return *writer->build();
@@ -309,11 +309,11 @@ public:
         } else {
             varchar_value = std::string(1024, 'a');
         }
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(nkeys - 1 - key)));
-            cols[2]->append_datum(Datum(Slice(varchar_value)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(nkeys - 1 - key)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(Slice(varchar_value)));
         }
         RETURN_IF_ERROR(writer->flush_chunk(*chunk));
         return *writer->build();
@@ -338,11 +338,11 @@ public:
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         const auto nkeys = keys.size();
         auto chunk = ChunkFactory::new_chunk(schema, nkeys);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = 0; i < nkeys; ++i) {
-            cols[0]->append_datum(Datum(keys[i]));
-            cols[1]->append_datum(Datum((int16_t)1));
-            cols[2]->append_datum(Datum((int32_t)(keys[nkeys - 1 - i])));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)1));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(keys[nkeys - 1 - i])));
         }
         CHECK_OK(writer->flush_chunk(*chunk));
         return *writer->build();
@@ -367,11 +367,11 @@ public:
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         const auto keys_size = all_cols[0].size();
         auto chunk = ChunkFactory::new_chunk(schema, keys_size);
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (auto i = 0; i < keys_size; ++i) {
-            append_datum_func(cols[0], static_cast<int64_t>(all_cols[0][i]));
-            append_datum_func(cols[1], static_cast<int16_t>(all_cols[1][i]));
-            append_datum_func(cols[2], static_cast<int32_t>(all_cols[2][i]));
+            append_datum_func(cols[0]->as_mutable_ptr(), static_cast<int64_t>(all_cols[0][i]));
+            append_datum_func(cols[1]->as_mutable_ptr(), static_cast<int16_t>(all_cols[1][i]));
+            append_datum_func(cols[2]->as_mutable_ptr(), static_cast<int32_t>(all_cols[2][i]));
         }
 
         CHECK_OK(writer->flush_chunk(*chunk));

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -114,23 +114,23 @@ public:
 
         auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
             if (schema.num_key_fields() == 1) {
-                cols[0]->append_datum(Datum(key));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
             } else {
-                cols[0]->append_datum(Datum(key));
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
                 string v = fmt::to_string(key * 234234342345);
-                cols[1]->append_datum(Datum(Slice(v)));
-                cols[2]->append_datum(Datum((int32_t)key));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)key));
             }
             int vcol_start = schema.num_key_fields();
-            cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[vcol_start]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
             if (cols[vcol_start + 1]->is_binary()) {
                 string v = fmt::to_string(key % 1000 + 2);
-                cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+                cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
             } else {
-                cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+                cols[vcol_start + 1]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
             }
         }
         if (!keys.empty()) {
@@ -271,11 +271,11 @@ public:
         auto chunk = ChunkFactory::new_chunk(schema, 1024);
         for (size_t i = 0; i < 1024; ++i) {
             test_data.push_back("well" + std::to_string(i));
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
             Slice field_1(test_data[i]);
-            cols[1]->append_datum(Datum(field_1));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
         }
         auto st = writer->add_chunk(*chunk);
         ASSERT_TRUE(st.ok()) << st.to_string() << ", version:" << writer->version();
@@ -485,11 +485,11 @@ TEST_F(EngineStorageMigrationTaskTest, test_concurrent_ingestion_and_migration) 
         for (size_t i = 0; i < 1024; ++i) {
             indexes.push_back(i);
             test_data.push_back("well" + std::to_string(i));
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
             Slice field_1(test_data[i]);
-            cols[1]->append_datum(Datum(field_1));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(10000 + i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(field_1));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(10000 + i)));
         }
         auto st = delta_writer->write(*chunk, indexes.data(), 0, indexes.size());
         ASSERT_TRUE(st.ok());
@@ -563,10 +563,10 @@ TEST_F(EngineStorageMigrationTaskTest, test_concurrent_ingestion_and_migration_p
         indexes.reserve(1024);
         for (size_t i = 0; i < 1024; ++i) {
             indexes.push_back(i);
-            auto cols = chunk->mutable_columns();
-            cols[0]->append_datum(Datum(static_cast<int64_t>(i)));
-            cols[1]->append_datum(Datum(static_cast<int16_t>(i + 1)));
-            cols[2]->append_datum(Datum(static_cast<int32_t>(i + 2)));
+            auto cols = chunk->columns();
+            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int64_t>(i)));
+            cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int16_t>(i + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i + 2)));
         }
         auto st = delta_writer->write(*chunk, indexes.data(), 0, indexes.size());
         ASSERT_TRUE(st.ok());

--- a/be/test/storage/update_manager_test.cpp
+++ b/be/test/storage/update_manager_test.cpp
@@ -68,11 +68,11 @@ public:
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
         auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->mutable_columns();
+        auto cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-            cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
         }
         if (one_delete == nullptr) {
             CHECK_OK(writer->flush_chunk(*chunk));

--- a/be/test/udf/java/java_data_converter_test.cpp
+++ b/be/test/udf/java/java_data_converter_test.cpp
@@ -153,10 +153,13 @@ TEST_F(DataConverterTest, cast_to_jval) {
         tdesc.children.emplace_back(ta);
 
         auto keys = Int32Column::create();
-        auto& elements_data = keys->get_data();
-        elements_data.resize(20);
-        for (size_t i = 0; i < elements_data.size(); ++i) {
-            elements_data[i] = i;
+        size_t num_elements = 20;
+        {
+            auto& elements_data = keys->get_data();
+            elements_data.resize(num_elements);
+            for (size_t i = 0; i < elements_data.size(); ++i) {
+                elements_data[i] = i;
+            }
         }
         auto nullable = NullableColumn::wrap_if_necessary(std::move(keys));
         auto offsets = UInt32Column::create();
@@ -169,9 +172,9 @@ TEST_F(DataConverterTest, cast_to_jval) {
 
         auto values = Int32Column::create();
         auto& values_data = values->get_data();
-        values_data.resize(elements_data.size());
-        for (size_t i = 0; i < elements_data.size(); ++i) {
-            values_data[i] = elements_data.size() - i;
+        values_data.resize(num_elements);
+        for (size_t i = 0; i < num_elements; ++i) {
+            values_data[i] = num_elements - i;
         }
         auto vnullable = NullableColumn::wrap_if_necessary(std::move(values));
         auto map_column = MapColumn::create(std::move(nullable), std::move(vnullable), std::move(offsets));

--- a/test/sql/test_map/R/test_map_function_cow
+++ b/test/sql/test_map/R/test_map_function_cow
@@ -1,0 +1,21 @@
+-- name: test_map_function_cow
+CREATE TABLE test_map
+    (c1 int,
+    c2 map<varchar(8), int>)
+    PRIMARY KEY(c1)
+    DISTRIBUTED BY HASH(c1)
+    BUCKETS 1
+    PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into test_map SELECT generate_series, map(generate_series, generate_series) FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+select count(c1),count(c2),count(mp) from ( select* from (select*,map_keys(l.c2) mp from test_map l ) t where mp[1] + c1 < 1000 and mp[1] + c1 > 100) t;
+-- result:
+449	449	449
+-- !result
+select count(c1),count(c2),count(mp) from ( select* from (select*,map_values(l.c2) mp from test_map l ) t where mp[1] + c1 < 1000 and mp[1] + c1 > 100) t;
+-- result:
+449	449	449
+-- !result

--- a/test/sql/test_map/T/test_map_function_cow
+++ b/test/sql/test_map/T/test_map_function_cow
@@ -1,0 +1,16 @@
+-- name: test_map_function_cow
+
+-- mini reproduce case for wrong column reuse
+
+CREATE TABLE test_map
+    (c1 int,
+    c2 map<varchar(8), int>)
+    PRIMARY KEY(c1)
+    DISTRIBUTED BY HASH(c1)
+    BUCKETS 1
+    PROPERTIES ("replication_num" = "1");
+
+insert into test_map SELECT generate_series, map(generate_series, generate_series) FROM TABLE(generate_series(1,  4096));
+-- crash when cow optimization enabled.
+select count(c1),count(c2),count(mp) from ( select* from (select*,map_keys(l.c2) mp from test_map l ) t where mp[1] + c1 < 1000 and mp[1] + c1 > 100) t;
+select count(c1),count(c2),count(mp) from ( select* from (select*,map_values(l.c2) mp from test_map l ) t where mp[1] + c1 < 1000 and mp[1] + c1 > 100) t;


### PR DESCRIPTION
## Why I'm doing:

reproduce case see test_map_function_cow

```
query_id:019e3eda-a406-7eb7-b404-197c0d7e1957, fragment_instance:019e3eda-a406-7eb7-b404-197c0d7e1958, plan_node_id:-1
*** Aborted at 1779170976 (unix time) try "date -d @1779170976" if you are using GNU date ***
PC: @     0x7ffb680f39fc pthread_kill
*** SIGABRT (@0x3eb001733bf) received by PID 1520575 (TID 0x7ff84b139640) LWP(1521418) from PID 1520575; stack trace: ***
    @         0x3164fc47 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7ffb680f6ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x3164f446 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7ffb6809f520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7ffb680f39fc pthread_kill
    @     0x7ffb6809f476 raise
    @     0x7ffb680857f3 abort
    @         0x299d407f starrocks::failure_function()
    @         0x3164349d google::LogMessage::Fail()
    @         0x31644584 google::LogMessageFatal::~LogMessageFatal()
    @         0x2ca5baf0 starrocks::BinaryColumnBase<unsigned int>::check_or_die() const
    @         0x2cac5ccb starrocks::NullableColumn::check_or_die() const
    @         0x2c8b8f9c starrocks::MapColumn::check_or_die() const
    @         0x2cac5ccb starrocks::NullableColumn::check_or_die() const
    @         0x2c7f802e starrocks::Chunk::check_or_die()
    @         0x1f22e012 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1f1e3f37 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x1f1e260a starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x1f1ed426 void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x1f1ec8b2 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @         0x1f1ec24b std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x1c7925ca std::function<void ()>::operator()() const
    @         0x2cf07efc starrocks::FunctionRunnable::run()
    @         0x2cf01f23 starrocks::ThreadPool::dispatch_thread()
    @         0x2cf2319c void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2cf21b3a std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2cf205ae void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x2cf1ec0a void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x2cf1ce90 void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @         0x2cf1a793 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool:@
    @         0x2cf16029 std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
```

for example:
```
StatusOr<ColumnPtr> MapFunctions::map_keys(FunctionContext* context, const Columns& columns) {
    DCHECK_EQ(1, columns.size());
    RETURN_IF_COLUMNS_ONLY_NULL(columns);

    auto arg0 = ColumnHelper::unpack_and_duplicate_const_column(columns[0]->size(), columns[0]);
    const auto* col_map = down_cast<const MapColumn*>(ColumnHelper::get_data_column(arg0.get()));
    const auto& map_keys = col_map->keys_column(); // >>> use count = 1
    auto map_keys_array = ArrayColumn::create(std::move(*map_keys).mutate(),  // >>> use count = 1, will not clone
                                              UInt32Column::static_pointer_cast(col_map->offsets_column()->clone()));
    // >>> use count = 2  column reuse between columns[0] and return columns 
    if (arg0->has_null()) {
        return NullableColumn::create(
                std::move(map_keys_array),
                NullColumn::static_pointer_cast(down_cast<const NullableColumn*>(arg0.get())->null_column()->clone()));
    } else {
        return map_keys_array;
    }
```


## What I'm doing:

disable cow opt from branch-4.1. I will refactor them in next PRs

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
