### PR TITLE
[Tool] ai-sr-skills: parse Recommended reviewer line for Slack notify

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -24,7 +24,8 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     if: >
       github.event.action == 'opened' &&
-      !startsWith(github.head_ref, 'mergify/')
+      !startsWith(github.head_ref, 'mergify/') &&
+      !contains(github.head_ref, '-sync-pr-')
     steps:
       - name: Compute skip rule
         id: gate

--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -136,22 +136,16 @@ jobs:
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool
           cd ci-tool && git pull
 
-          # Parse who AI actually decided to assign from the skill's output.
-          # The skill prints: "Assigned reviewers: <comma-separated logins>" on success
-          # (see starrocks-skills/starrocks-assign-pr-reviewer/SKILL.md step 7).
-          # This catches the "AI picked someone already-assigned" case that a
-          # before/after diff on reviewRequests would miss.
+          # Parse the primary reviewer from the skill's output.
+          # The skill prints: "Recommended reviewer: <login>"
+          # (see starrocks-skills/starrocks-assign-pr-reviewer/SKILL.md "Output Template").
           ai_output="${RUNNER_TEMP}/ai_output.txt"
           reviewers=""
           if [ -f "$ai_output" ]; then
-            assigned_line=$(grep -iE 'assigned reviewers?:' "$ai_output" | tail -1 || true)
-            if [ -n "$assigned_line" ]; then
-              reviewers=$(echo "$assigned_line" \
-                | sed -E 's/^.*[Aa]ssigned [Rr]eviewers?:[[:space:]]*//' \
-                | tr ',，' '\n' \
-                | sed 's/^[[:space:]@]*//; s/[[:space:]]*$//' \
-                | grep -v '^$' || true)
-            fi
+            reviewers=$(grep -iE '^Recommended reviewer:' "$ai_output" | tail -1 \
+              | sed -E 's/^[Rr]ecommended reviewer:[[:space:]]*//' \
+              | sed -E 's/^[[:space:]@]*//; s/[[:space:]].*$//; s/[[:space:]]*$//' \
+              | grep -v '^$' || true)
           fi
 
           if [ -z "$reviewers" ]; then

--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -140,13 +140,16 @@ jobs:
           # Parse the primary reviewer from the skill's output.
           # The skill prints: "Recommended reviewer: <login>"
           # (see starrocks-skills/starrocks-assign-pr-reviewer/SKILL.md "Output Template").
+          # The LLM often wraps the line/value in markdown bold or italics
+          # (e.g. **Recommended reviewer: kevincai**, Recommended reviewer: **kevincai**).
+          # Tolerate optional leading *, then extract only valid GitHub login chars
+          # ([A-Za-z0-9-]) to drop @, **, backticks, etc.
           ai_output="${RUNNER_TEMP}/ai_output.txt"
           reviewers=""
           if [ -f "$ai_output" ]; then
-            reviewers=$(grep -iE '^Recommended reviewer:' "$ai_output" | tail -1 \
-              | sed -E 's/^[Rr]ecommended reviewer:[[:space:]]*//' \
-              | sed -E 's/^[[:space:]@]*//; s/[[:space:]].*$//; s/[[:space:]]*$//' \
-              | grep -v '^$' || true)
+            reviewers=$(grep -iE '^\**Recommended reviewer:' "$ai_output" | tail -1 \
+              | sed -E 's/^\**[Rr]ecommended reviewer:\**[[:space:]]*//' \
+              | grep -oE '[A-Za-z0-9][A-Za-z0-9-]*' | head -1 || true)
           fi
 
           if [ -z "$reviewers" ]; then


### PR DESCRIPTION
## Why I'm doing:

After the reviewer skill (`starrocks-assign-pr-reviewer`) was translated to English, its output template no longer prints `Assigned reviewers: <list>`. The new template emits:

```
Recommended reviewer: <primary>
Optional backup reviewer: <secondary or none>
Additional reviewer (behavior change notification): wangsimo0
```

The Notify Slack step in `ai-sr-skills.yml` still greps for `Assigned reviewers?:`, so it now extracts nothing and silently skips the Slack notification.

## What I'm doing:

Update the Notify Slack step to grep the new `Recommended reviewer:` line and extract the primary reviewer's GitHub login (drops leading `@`, trims trailing whitespace/words). Only the primary reviewer is sent to Slack; backup and additional reviewers do not trigger a Slack mention.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4