### PR TITLE
[BugFix] Lazily initialize LocationProvider in SerializableTable to fix read failure on tables with custom LocationProvider

### DIFF
--- a/be/src/exprs/variant_functions.cpp
+++ b/be/src/exprs/variant_functions.cpp
@@ -78,8 +78,6 @@ Status VariantFunctions::variant_segments_prepare(FunctionContext* context, Func
     auto variant_path_status = VariantPathParser::parse(path_string);
     RETURN_IF(!variant_path_status.ok(), variant_path_status.status());
     context->set_function_state(scope, new VariantPath(std::move(variant_path_status.value())));
-    VLOG(10) << "Preloaded variant path: " << path_string;
-
     return Status::OK();
 }
 

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/SerializableTable.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/SerializableTable.java
@@ -65,9 +65,6 @@ import java.util.Map;
 import java.util.UUID;
 
 public class SerializableTable implements Table, Serializable, HasTableOperations {
-
-    private static final long serialVersionUID = 1L;
-
     private final String name;
     private final String location;
     private final UUID uuid;

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/SerializableTable.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/SerializableTable.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.IncrementalChangelogScan;
+import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.ManageSnapshots;
 import org.apache.iceberg.OverwriteFiles;
 import org.apache.iceberg.PartitionSpec;
@@ -76,8 +77,9 @@ public class SerializableTable implements Table, Serializable, HasTableOperation
     private final String sortOrderAsJson;
     private final FileIO io;
     private final EncryptionManager encryption;
-    private final LocationProvider locationProvider;
     private final Map<String, SnapshotRef> refs;
+
+    private transient volatile LocationProvider lazyLocationProvider;
 
     private transient volatile Table lazyTable = null;
     private transient volatile Schema lazySchema = null;
@@ -98,7 +100,6 @@ public class SerializableTable implements Table, Serializable, HasTableOperation
         this.sortOrderAsJson = SortOrderParser.toJson(table.sortOrder());
         this.io = fileIO(fileIO);
         this.encryption = table.encryption();
-        this.locationProvider = table.locationProvider();
         this.refs = SerializableMap.copyOf(table.refs());
     }
 
@@ -129,7 +130,7 @@ public class SerializableTable implements Table, Serializable, HasTableOperation
                     }
 
                     TableOperations ops =
-                            new StaticTableOperations(metadataFileLocation, io, locationProvider);
+                            new StaticTableOperations(metadataFileLocation, io);
                     this.lazyTable = newTable(ops, name);
                 }
             }
@@ -239,7 +240,14 @@ public class SerializableTable implements Table, Serializable, HasTableOperation
 
     @Override
     public LocationProvider locationProvider() {
-        return locationProvider;
+        if (lazyLocationProvider == null) {
+            synchronized (this) {
+                if (lazyLocationProvider == null) {
+                    this.lazyLocationProvider = LocationProviders.locationsFor(location, properties);
+                }
+            }
+        }
+        return lazyLocationProvider;
     }
 
     @Override

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/SerializableTable.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/SerializableTable.java
@@ -66,6 +66,8 @@ import java.util.UUID;
 
 public class SerializableTable implements Table, Serializable, HasTableOperations {
 
+    private static final long serialVersionUID = 1L;
+
     private final String name;
     private final String location;
     private final UUID uuid;

--- a/java-extensions/hadoop-ext/src/test/java/com/starrocks/connector/share/iceberg/SerializableTableTest.java
+++ b/java-extensions/hadoop-ext/src/test/java/com/starrocks/connector/share/iceberg/SerializableTableTest.java
@@ -1,0 +1,92 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.share.iceberg;
+
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SerializableTableTest {
+
+    private static final Schema SCHEMA = new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get())
+    );
+
+    @Test
+    public void testConstructionSucceedsWithUnresolvableLocationProvider() {
+        // Regression test for https://github.com/StarRocks/starrocks/issues/73471
+        // SerializableTable should not eagerly load the LocationProvider at construction time.
+        // Custom LocationProvider JARs are write-path only and not available in FE classpath.
+        Map<String, String> props = new HashMap<>();
+        props.put("write.location-provider.impl", "com.nonexistent.CustomLocationProvider");
+
+        Table table = createTable(props);
+        InMemoryFileIO fileIO = new InMemoryFileIO();
+
+        // Should not throw ClassNotFoundException even though the provider class doesn't exist
+        SerializableTable serializable = assertDoesNotThrow(
+                () -> new SerializableTable(table, fileIO),
+                "SerializableTable construction must not trigger LocationProvider loading");
+
+        assertNotNull(serializable.schema());
+        assertNotNull(serializable.spec());
+        assertNotNull(serializable.refs());
+    }
+
+    @Test
+    public void testLocationProviderThrowsOnAccess() {
+        // When explicitly accessed, locationProvider() should throw because the class doesn't exist.
+        Map<String, String> props = new HashMap<>();
+        props.put("write.location-provider.impl", "com.nonexistent.CustomLocationProvider");
+
+        Table table = createTable(props);
+        SerializableTable serializable = new SerializableTable(table, new InMemoryFileIO());
+
+        assertThrows(IllegalArgumentException.class, serializable::locationProvider,
+                "locationProvider() should throw when the impl class is not in classpath");
+    }
+
+    @Test
+    public void testConstructionSucceedsWithNoCustomLocationProvider() {
+        Table table = createTable(new HashMap<>());
+        SerializableTable serializable = assertDoesNotThrow(
+                () -> new SerializableTable(table, new InMemoryFileIO()));
+
+        assertNotNull(serializable.schema());
+        assertNotNull(serializable.locationProvider());
+    }
+
+    private Table createTable(Map<String, String> properties) {
+        InMemoryCatalog catalog = new InMemoryCatalog();
+        catalog.initialize("test", new HashMap<>());
+        catalog.createNamespace(Namespace.of("db"));
+        TableIdentifier id = TableIdentifier.of("db", "tbl");
+        return catalog.createTable(id, SCHEMA, PartitionSpec.unpartitioned(), properties);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
When an Iceberg table is configured with a custom `LocationProvider` (via `write.location-provider.impl`), StarRocks fails even on simple SELECT queries with a `ClassNotFoundException`. The custom provider JAR only exists in the user's write environment, not in StarRocks FE's classpath — and since `LocationProvider` is purely a write-path concern (it decides where to place new data files), there is no reason a read query should ever touch it.

## What I'm doing:
Previously, `SerializableTable` eagerly called `table.locationProvider()` in its constructor, which attempted to instantiate the custom class and immediately crashed.

The fix defers initialization entirely:

```
Before:
  SerializableTable(table)
    └─ table.locationProvider()   ← crashes here if class not in classpath
         └─ LocationProviders.locationsFor(location, props)
              └─ Class.forName("com.company.CustomLocationProvider") ← ClassNotFoundException

After:
  SerializableTable(table)        ← succeeds, no LocationProvider loaded

  SELECT query read path:
    newScan() / currentSnapshot()
      └─ lazyTable()
           └─ StaticTableOperations(metadataFile, io)  ← no LocationProvider passed
                └─ (scan proceeds, locationProvider never called) ← ✓

  locationProvider() [only if explicitly called, e.g. writes]:
    └─ LocationProviders.locationsFor(location, props)  ← lazy, on-demand
```

Two specific changes make this safe:
1. `locationProvider` field changed to `transient volatile` and initialized lazily in the `locationProvider()` getter via `LocationProviders.locationsFor(location, props)`.
2. `lazyTable()` switched to the 2-arg `StaticTableOperations(metadataFile, io)` constructor so that scan operations never implicitly trigger location provider loading.

Since `SerializableTable` is read-only by design (all write methods throw `UnsupportedOperationException`), the lazy `locationProvider()` path is effectively dead code for normal query execution.

Fixes #73471. Related upstream fixes: apache/iceberg#9029, apache/iceberg#14280.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
