### PR TITLE
[Enhancement] Consider outer side join key null fractions (unmatched keys) in addition to selectivity

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1297,13 +1297,13 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 outputRowCount = max(innerRowCount, leftRowCount);
                 joinStatsBuilder.setOutputRowCount(outputRowCount);
                 computeNullFractionForOuterJoin(leftRowCount, innerRowCount, outputRowCount,
-                        leftStatistics, rightStatistics, eqOnPredicates, joinStatsBuilder);
+                        leftStatistics, rightStatistics, eqOnPredicates, hasUnknownColumnStatistics, joinStatsBuilder);
                 break;
             case ASOF_LEFT_OUTER_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
                 joinStatsBuilder.setOutputRowCount(leftRowCount);
                 computeNullFractionForOuterJoin(leftRowCount, innerRowCount, leftRowCount, leftStatistics, rightStatistics,
-                        eqOnPredicates, joinStatsBuilder);
+                        eqOnPredicates, hasUnknownColumnStatistics, joinStatsBuilder);
                 break;
             case LEFT_SEMI_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(StatisticsEstimateUtils.adjustStatisticsByRowCount(
@@ -1325,7 +1325,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 outputRowCount = max(innerRowCount, rightRowCount);
                 joinStatsBuilder.setOutputRowCount(outputRowCount);
                 computeNullFractionForOuterJoin(rightRowCount, innerRowCount, outputRowCount,
-                        rightStatistics, leftStatistics, eqOnPredicates, joinStatsBuilder);
+                        rightStatistics, leftStatistics, eqOnPredicates, hasUnknownColumnStatistics, joinStatsBuilder);
                 break;
             case RIGHT_ANTI_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
@@ -1341,9 +1341,9 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                         max(leftRowCount, max(rightRowCount, max(innerRowCount, leftRowCount + rightRowCount - innerRowCount)));
                 joinStatsBuilder.setOutputRowCount(outputRowCount);
                 computeNullFractionForOuterJoin(leftRowCount, innerRowCount, outputRowCount,
-                        leftStatistics, rightStatistics, eqOnPredicates, joinStatsBuilder);
+                        leftStatistics, rightStatistics, eqOnPredicates, hasUnknownColumnStatistics, joinStatsBuilder);
                 computeNullFractionForOuterJoin(rightRowCount, innerRowCount, outputRowCount,
-                        rightStatistics, leftStatistics, eqOnPredicates, joinStatsBuilder);
+                        rightStatistics, leftStatistics, eqOnPredicates, hasUnknownColumnStatistics, joinStatsBuilder);
                 break;
             default:
                 throw new StarRocksPlannerException("Not support join type : " + joinType,
@@ -1446,7 +1446,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     private void computeNullFractionForOuterJoin(double outerSideRowCount, double innerRowCount,
                                                  double outputRowCount, Statistics outerSideStatistics,
                                                  Statistics innerSideStatistics, List<BinaryPredicateOperator> eqOnPredicates,
-                                                 Statistics.Builder builder) {
+                                                 boolean hasUncertainSelectivity, Statistics.Builder builder) {
         // Collect the eq-join column refs that belong to the outer (preserved) side.
         // Only these columns had their null fractions zeroed during inner join estimation.
         final var outerColumns = outerSideStatistics.getUsedColumns();
@@ -1480,24 +1480,28 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         // Compute new null fractions for the inner (nullable) side's columns.
         // Two sources of NULLs for inner-side columns after an outer join:
-        // 1. Unmatched rows: outerSideRowCount - innerRowCount (row-count based)
-        // 2. Null-key rows: outer-side rows whose join key is NULL can never match,
+        // 1. Unmatched rows: outerSideRowCount - innerRowCount (row-count based, from selectivity)
+        // 2. Null-key rows: outer-side rows whose join key is NULL can never match under normal =,
         //    so inner-side columns are NULL for those rows regardless of row-count estimates.
-        // We use the maximum of the two as a lower bound on the null row count.
-        // For EQ_FOR_NULL (<=>) predicates, NULL keys can match, so we must exclude those columns from the null-key adjustment.
-        final var eqForNullJoinKeyColumns = getEqForNullJoinKeyColumns(eqOnPredicates);
-        final double maxOuterKeyNullFraction = outerEqJoinColumns.stream() //
-                .filter(col -> !eqForNullJoinKeyColumns.contains(col)) //
-                .map(outerSideStatistics::getColumnStatistic) //
-                .filter(Objects::nonNull) //
-                .filter(stat -> !stat.isUnknown()) //
-                .map(ColumnStatistic::getNullsFraction) //
-                .max(Double::compareTo) //
-                .orElse(0.0);
-
-        double nullRowsFromSelectivity = Math.max(0, outerSideRowCount - innerRowCount);
-        double nullRowsFromNullKey = maxOuterKeyNullFraction * outerSideRowCount;
-        double effectiveNullRowCount = Math.max(nullRowsFromSelectivity, nullRowsFromNullKey);
+        //
+        // Source (2) is only used as a fallback when the computed selectivity is uncertain, making the
+        // selectivity-based estimate (1) unreliable.
+        final double nullRowsFromSelectivity = Math.max(0, outerSideRowCount - innerRowCount);
+        double effectiveNullRowCount = nullRowsFromSelectivity;
+        if (hasUncertainSelectivity) {
+            // For EQ_FOR_NULL (<=>) predicates, NULL keys can match, so we exclude those columns.
+            final var eqForNullJoinKeyColumns = getEqForNullJoinKeyColumns(eqOnPredicates);
+            final double maxOuterKeyNullFraction = outerEqJoinColumns.stream() //
+                    .filter(col -> !eqForNullJoinKeyColumns.contains(col)) //
+                    .map(outerSideStatistics::getColumnStatistic) //
+                    .filter(Objects::nonNull) //
+                    .filter(stat -> !stat.isUnknown()) //
+                    .map(ColumnStatistic::getNullsFraction) //
+                    .max(Double::compareTo) //
+                    .orElse(0.0);
+            final double nullRowsFromNullKey = maxOuterKeyNullFraction * outerSideRowCount;
+            effectiveNullRowCount = Math.max(nullRowsFromSelectivity, nullRowsFromNullKey);
+        }
 
         if (effectiveNullRowCount > 0 && outputRowCount > 0) {
             for (final var entry : innerSideStatistics.getColumnStatistics().entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1278,6 +1278,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         }
 
         Statistics.Builder joinStatsBuilder;
+        double outputRowCount;
         switch (joinType) {
             case CROSS_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(crossJoinStats);
@@ -1292,9 +1293,10 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 break;
             case LEFT_OUTER_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
-                joinStatsBuilder.setOutputRowCount(max(innerRowCount, leftRowCount));
-                computeNullFractionForOuterJoin(leftRowCount, innerRowCount, leftStatistics, rightStatistics,
-                        eqOnPredicates, joinStatsBuilder);
+                outputRowCount = max(innerRowCount, leftRowCount);
+                joinStatsBuilder.setOutputRowCount(outputRowCount);
+                computeNullFractionForOuterJoin(leftRowCount, innerRowCount, outputRowCount,
+                        leftStatistics, rightStatistics, eqOnPredicates, joinStatsBuilder);
                 break;
             case ASOF_LEFT_OUTER_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
@@ -1319,9 +1321,10 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 break;
             case RIGHT_OUTER_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
-                joinStatsBuilder.setOutputRowCount(max(innerRowCount, rightRowCount));
-                computeNullFractionForOuterJoin(rightRowCount, innerRowCount, rightStatistics, leftStatistics,
-                        eqOnPredicates, joinStatsBuilder);
+                outputRowCount = max(innerRowCount, rightRowCount);
+                joinStatsBuilder.setOutputRowCount(outputRowCount);
+                computeNullFractionForOuterJoin(rightRowCount, innerRowCount, outputRowCount,
+                        rightStatistics, leftStatistics, eqOnPredicates, joinStatsBuilder);
                 break;
             case RIGHT_ANTI_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
@@ -1331,11 +1334,15 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 break;
             case FULL_OUTER_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
-                joinStatsBuilder.setOutputRowCount(max(1, leftRowCount + rightRowCount - innerRowCount));
-                computeNullFractionForOuterJoin(leftRowCount + rightRowCount, innerRowCount, leftStatistics,
-                        leftStatistics, eqOnPredicates, joinStatsBuilder);
-                computeNullFractionForOuterJoin(leftRowCount + rightRowCount, innerRowCount, rightStatistics,
-                        rightStatistics, eqOnPredicates, joinStatsBuilder);
+                // A full outer join preserves all rows from both sides and includes all inner-join matches,
+                // so its output must be at least as large as either input and the inner-join row count.
+                outputRowCount =
+                        max(leftRowCount, max(rightRowCount, max(innerRowCount, leftRowCount + rightRowCount - innerRowCount)));
+                joinStatsBuilder.setOutputRowCount(outputRowCount);
+                computeNullFractionForOuterJoin(leftRowCount, innerRowCount, outputRowCount,
+                        leftStatistics, rightStatistics, eqOnPredicates, joinStatsBuilder);
+                computeNullFractionForOuterJoin(rightRowCount, innerRowCount, outputRowCount,
+                        rightStatistics, leftStatistics, eqOnPredicates, joinStatsBuilder);
                 break;
             default:
                 throw new StarRocksPlannerException("Not support join type : " + joinType,
@@ -1420,15 +1427,24 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         return builder.build();
     }
 
+    private Set<ColumnRefOperator> getEqForNullJoinKeyColumns(List<BinaryPredicateOperator> eqOnPredicates) {
+        return eqOnPredicates.stream() //
+                .filter(pred -> pred.getBinaryType() == BinaryType.EQ_FOR_NULL) //
+                .flatMap(pred -> pred.getChildren().stream()) //
+                .filter(ScalarOperator::isColumnRef) //
+                .map(col -> (ColumnRefOperator) col) //
+                .collect(Collectors.toSet());
+    }
+
     // In an outer join, all rows from the outer (preserved) side are kept, including those with NULLs
     // in the join key. The inner join estimation sets the null fraction to 0 for eq-join columns,
     // which is correct for inner joins but not for the outer side of outer joins.
     // This method first restores the original null fractions for the outer side's eq-join columns
     // (the only columns whose null fractions are zeroed by the inner join estimation), then computes
     // the new null fractions for the inner (nullable) side's columns to account for additional null rows.
-    private void computeNullFractionForOuterJoin(double outerTableRowCount, double innerJoinRowCount,
-                                                 Statistics outerSideStatistics, Statistics innerSideStatistics,
-                                                 List<BinaryPredicateOperator> eqOnPredicates,
+    private void computeNullFractionForOuterJoin(double outerSideRowCount, double innerRowCount,
+                                                 double outputRowCount, Statistics outerSideStatistics,
+                                                 Statistics innerSideStatistics, List<BinaryPredicateOperator> eqOnPredicates,
                                                  Statistics.Builder builder) {
         // Collect the eq-join column refs that belong to the outer (preserved) side.
         // Only these columns had their null fractions zeroed during inner join estimation.
@@ -1443,30 +1459,53 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         }
 
         // Restore the original null fractions for the outer side's eq-join columns only.
-        // When outerTableRowCount < innerJoinRowCount (e.g. one-to-many matches), the output
+        // When outerSideRowCount < outputRowCount (e.g. one-to-many matches), the output
         // has more rows than the original outer table, so scale proportionally.
         for (final var outerEqJoinColumn : outerEqJoinColumns) {
             final var originalStat = outerSideStatistics.getColumnStatistic(outerEqJoinColumn);
             final var currentStat = builder.getColumnStatistics(outerEqJoinColumn);
             if (currentStat != null) {
-                double adjustedNullFraction = (outerTableRowCount < innerJoinRowCount)
-                        ? originalStat.getNullsFraction() * outerTableRowCount / Math.max(1, innerJoinRowCount)
+                double adjustedNullFraction = (outerSideRowCount < outputRowCount)
+                        ? originalStat.getNullsFraction() * outerSideRowCount / Math.max(1, outputRowCount)
                         : originalStat.getNullsFraction();
+                // In the case of a full outer join, we might already have set the value in the builder to a higher null
+                // fraction. So we'll max the adjusted and the already set value.
+                double maxNullFraction = Math.max(adjustedNullFraction, currentStat.getNullsFraction());
                 builder.addColumnStatistic(outerEqJoinColumn, buildFrom(currentStat) //
-                        .setNullsFraction(adjustedNullFraction) //
+                        .setNullsFraction(maxNullFraction) //
                         .build());
             }
         }
 
-        // Compute new null fractions for the inner (nullable) side's columns
-        if (outerTableRowCount > innerJoinRowCount) {
-            double nullRowCount = outerTableRowCount - innerJoinRowCount;
-            for (Map.Entry<ColumnRefOperator, ColumnStatistic> entry : innerSideStatistics.getColumnStatistics().entrySet()) {
-                ColumnStatistic columnStatistic = entry.getValue();
-                double columnNullCount = columnStatistic.getNullsFraction() * innerJoinRowCount;
-                double newNullFraction = (columnNullCount + nullRowCount) / outerTableRowCount;
+        // Compute new null fractions for the inner (nullable) side's columns.
+        // Two sources of NULLs for inner-side columns after an outer join:
+        // 1. Unmatched rows: outerSideRowCount - innerRowCount (row-count based)
+        // 2. Null-key rows: outer-side rows whose join key is NULL can never match,
+        //    so inner-side columns are NULL for those rows regardless of row-count estimates.
+        // We use the maximum of the two as a lower bound on the null row count.
+        // For EQ_FOR_NULL (<=>) predicates, NULL keys can match, so we must exclude those columns from the null-key adjustment.
+        final var eqForNullJoinKeyColumns = getEqForNullJoinKeyColumns(eqOnPredicates);
+        final double maxOuterKeyNullFraction = outerEqJoinColumns.stream() //
+                .filter(col -> !eqForNullJoinKeyColumns.contains(col)) //
+                .map(outerSideStatistics::getColumnStatistic) //
+                .filter(Objects::nonNull) //
+                .filter(stat -> !stat.isUnknown()) //
+                .map(ColumnStatistic::getNullsFraction) //
+                .max(Double::compareTo) //
+                .orElse(0.0);
+
+        double nullRowsFromSelectivity = Math.max(0, outerSideRowCount - innerRowCount);
+        double nullRowsFromNullKey = maxOuterKeyNullFraction * outerSideRowCount;
+        double effectiveNullRowCount = Math.max(nullRowsFromSelectivity, nullRowsFromNullKey);
+
+        if (effectiveNullRowCount > 0 && outputRowCount > 0) {
+            for (final var entry : innerSideStatistics.getColumnStatistics().entrySet()) {
+                final var innerStat = entry.getValue();
+                final double matchedRows = outputRowCount - effectiveNullRowCount;
+                final double matchNullCount = innerStat.getNullsFraction() * Math.max(0, matchedRows);
+                final double newNullFraction = Math.min(1.0, (matchNullCount + effectiveNullRowCount) / outputRowCount);
                 builder.addColumnStatistic(entry.getKey(),
-                        buildFrom(columnStatistic).setNullsFraction(newNullFraction).build());
+                        buildFrom(innerStat).setNullsFraction(newNullFraction).build());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -48,6 +48,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.DateLiteral;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.MaxLiteral;
@@ -1301,7 +1302,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             case ASOF_LEFT_OUTER_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
                 joinStatsBuilder.setOutputRowCount(leftRowCount);
-                computeNullFractionForOuterJoin(leftRowCount, innerRowCount, leftStatistics, rightStatistics,
+                computeNullFractionForOuterJoin(leftRowCount, innerRowCount, leftRowCount, leftStatistics, rightStatistics,
                         eqOnPredicates, joinStatsBuilder);
                 break;
             case LEFT_SEMI_JOIN:

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -786,6 +786,125 @@ public class StatisticsCalculatorTest {
     }
 
 
+    @ParameterizedTest
+    @EnumSource(value = OuterJoin.class)
+    public void testOuterJoinEqForNullDoesNotTreatNullKeysAsUnmatched(OuterJoin outerJoin) {
+        // GIVEN
+        final var outerJoinKey = columnRefFactory.create("outer_key", Type.INT, true);
+        final var outerOtherCol = columnRefFactory.create("outer_other_col", Type.INT, true);
+
+        final double outerNullFraction = 0.6;
+        final var outerBuilder = Statistics.builder();
+        outerBuilder.setOutputRowCount(100000);
+        outerBuilder.addColumnStatistics(ImmutableMap.of(
+                outerJoinKey, new ColumnStatistic(1, 1000, outerNullFraction, 8, 500)));
+        outerBuilder.addColumnStatistics(ImmutableMap.of(
+                outerOtherCol, new ColumnStatistic(0, 100, 0.1, 8, 50)));
+
+        final var outerGroup = new Group(0);
+        outerGroup.setStatistics(outerBuilder.build());
+        outerGroup.setLogicalProperty(new LogicalProperty(
+                new ColumnRefSet(Lists.newArrayList(outerJoinKey, outerOtherCol))));
+
+        final var innerKey = columnRefFactory.create("inner_id", Type.INT, true);
+        final var innerVal = columnRefFactory.create("inner_val", Type.INT, true);
+
+        final var innerBuilder = Statistics.builder();
+        innerBuilder.setOutputRowCount(80000);
+        innerBuilder.addColumnStatistics(ImmutableMap.of(
+                innerKey, new ColumnStatistic(1, 1000, 0.1, 8, 500)));
+        innerBuilder.addColumnStatistics(ImmutableMap.of(
+                innerVal, new ColumnStatistic(0, 100, 0, 8, 50)));
+
+        final var innerGroup = new Group(1);
+        innerGroup.setStatistics(innerBuilder.build());
+        innerGroup.setLogicalProperty(new LogicalProperty(new ColumnRefSet(Lists.newArrayList(innerKey, innerVal))));
+
+        JoinOperator joinType;
+        if (outerJoin == OuterJoin.LEFT_OUTER_JOIN) {
+            joinType = JoinOperator.LEFT_OUTER_JOIN;
+        } else {
+            joinType = JoinOperator.RIGHT_OUTER_JOIN;
+        }
+
+        BinaryPredicateOperator joinPred;
+        GroupExpression groupExpr;
+        if (joinType == JoinOperator.LEFT_OUTER_JOIN) {
+            joinPred = new BinaryPredicateOperator(BinaryType.EQ_FOR_NULL, outerJoinKey, innerKey);
+        } else {
+            joinPred = new BinaryPredicateOperator(BinaryType.EQ_FOR_NULL, innerKey, outerJoinKey);
+        }
+
+        final var joinOp = new LogicalJoinOperator(joinType, joinPred);
+
+        if (joinType == JoinOperator.LEFT_OUTER_JOIN) {
+            groupExpr = new GroupExpression(joinOp, Lists.newArrayList(outerGroup, innerGroup));
+        } else {
+            groupExpr = new GroupExpression(joinOp, Lists.newArrayList(innerGroup, outerGroup));
+        }
+
+        final var joinGroup = new Group(2);
+        groupExpr.setGroup(joinGroup);
+        final var exprCtx = new ExpressionContext(groupExpr);
+        final var calc = new StatisticsCalculator(exprCtx, columnRefFactory, optimizerContext);
+
+        // WHEN
+        calc.estimatorStats();
+        final var joinStats = exprCtx.getStatistics();
+        final var innerValStatAfterJoin = joinStats.getColumnStatistic(innerVal);
+
+        // THEN
+        Assertions.assertTrue(innerValStatAfterJoin.getNullsFraction() < outerNullFraction);
+    }
+
+    @Test
+    public void testLeftJoinInnerSideNullFractionReflectsResultNulls() {
+        // GIVEN
+        // LEFT JOIN where outer key has high null fraction and inner has UNKNOWN stats on one eq col,
+        // triggering innerRowCount = outerRowCount. Inner-side null fraction should still reflect the high null fraction.
+        final var outerKey = columnRefFactory.create("outer_key", Type.BIGINT, true);
+        final var outerCol = columnRefFactory.create("outer_col", Type.BIGINT, true);
+        final var innerKey = columnRefFactory.create("inner_key", Type.BIGINT, true);
+        final var innerCol = columnRefFactory.create("inner_col", Type.BIGINT, true);
+        final var innerVal = columnRefFactory.create("val", Type.VARCHAR, true);
+
+        final double outerKeyNullFraction = 0.95;
+        final var outerBuilder = Statistics.builder();
+        outerBuilder.setOutputRowCount(1000);
+        outerBuilder.addColumnStatistics(ImmutableMap.of(
+                outerKey, new ColumnStatistic(1, 1000, outerKeyNullFraction, 8, 500),
+                outerCol, new ColumnStatistic(0, 100, 0, 8, 1000)));
+        final var outerGroup = new Group(0);
+        outerGroup.setStatistics(outerBuilder.build());
+        outerGroup.setLogicalProperty(new LogicalProperty(new ColumnRefSet(Lists.newArrayList(outerKey, outerCol))));
+
+        final var innerBuilder = Statistics.builder();
+        innerBuilder.setOutputRowCount(500);
+        innerBuilder.addColumnStatistics(ImmutableMap.of(
+                innerKey, new ColumnStatistic(1, 1000, 0, 8, 500),
+                innerCol, ColumnStatistic.unknown(),
+                innerVal, new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 0.001, 10, 100)));
+        final var innerGroup = new Group(1);
+        innerGroup.setStatistics(innerBuilder.build());
+        innerGroup.setLogicalProperty(new LogicalProperty(new ColumnRefSet(Lists.newArrayList(innerKey, innerCol, innerVal))));
+
+        final var joinPred = Utils.compoundAnd(
+                new BinaryPredicateOperator(BinaryType.EQ, outerCol, innerCol),
+                new BinaryPredicateOperator(BinaryType.EQ, outerKey, innerKey));
+        final var joinOp = new LogicalJoinOperator(JoinOperator.LEFT_OUTER_JOIN, joinPred);
+        final var groupExpr = new GroupExpression(joinOp, Lists.newArrayList(outerGroup, innerGroup));
+        groupExpr.setGroup(new Group(2));
+
+        final var ctx = new ExpressionContext(groupExpr);
+
+        // WHEN
+        new StatisticsCalculator(ctx, columnRefFactory, optimizerContext).estimatorStats();
+        final var valStat = ctx.getStatistics().getColumnStatistic(innerVal);
+
+        // THEN
+        Assertions.assertTrue(valStat.getNullsFraction() >= outerKeyNullFraction - 0.01);
+    }
+
     private static File newFolder(File root, String... subDirs) throws IOException {
         String subFolder = String.join("/", subDirs);
         File result = new File(root, subFolder);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -906,6 +906,224 @@ public class StatisticsCalculatorTest {
         Assertions.assertTrue(valStat.getNullsFraction() >= outerKeyNullFraction - 0.01);
     }
 
+    /**
+     * LEFT OUTER JOIN with left=1M, right=950K, actual null frac on join key=5%, but
+     * estimated null frac=15%. The null fraction for inner-side columns should reflect only the row-count gap (~5%) since
+     * selectivity estimation should be preferred.
+     */
+    @ParameterizedTest
+    @EnumSource(value = OuterJoin.class)
+    public void testOuterJoinKnownStatsUsesSelectivityNotNullKeyFraction(OuterJoin outerJoin) {
+        // GIVEN
+        final var outerKey = columnRefFactory.create("outer_key", IntegerType.BIGINT, true);
+        final var innerKey = columnRefFactory.create("inner_key", IntegerType.BIGINT, true);
+        final var innerVal = columnRefFactory.create("inner_val", IntegerType.BIGINT, true);
+
+        // Outer side: 1M rows, join key has 15% null fraction (stale/overestimated)
+        final double staleOuterKeyNullFraction = 0.15;
+        final var outerBuilder = Statistics.builder();
+        outerBuilder.setOutputRowCount(1_000_000);
+        outerBuilder.addColumnStatistics(ImmutableMap.of(
+                outerKey, new ColumnStatistic(1, 1_000_000, staleOuterKeyNullFraction, 8, 800_000)));
+        final var outerGroup = new Group(0);
+        outerGroup.setStatistics(outerBuilder.build());
+        outerGroup.setLogicalProperty(new LogicalProperty(new ColumnRefSet(Lists.newArrayList(outerKey))));
+
+        // Inner side: 950K rows, known stats on join key
+        final var innerBuilder = Statistics.builder();
+        innerBuilder.setOutputRowCount(950_000);
+        innerBuilder.addColumnStatistics(ImmutableMap.of(
+                innerKey, new ColumnStatistic(1, 1_000_000, 0.0, 8, 800_000),
+                innerVal, new ColumnStatistic(0, 100, 0.02, 8, 50)));
+        final var innerGroup = new Group(1);
+        innerGroup.setStatistics(innerBuilder.build());
+        innerGroup.setLogicalProperty(new LogicalProperty(new ColumnRefSet(Lists.newArrayList(innerKey, innerVal))));
+
+        JoinOperator joinType;
+        BinaryPredicateOperator joinPred;
+        GroupExpression groupExpr;
+        if (outerJoin == OuterJoin.LEFT_OUTER_JOIN) {
+            joinType = JoinOperator.LEFT_OUTER_JOIN;
+            joinPred = new BinaryPredicateOperator(BinaryType.EQ, outerKey, innerKey);
+            groupExpr = new GroupExpression(
+                    new LogicalJoinOperator(joinType, joinPred), Lists.newArrayList(outerGroup, innerGroup));
+        } else {
+            joinType = JoinOperator.RIGHT_OUTER_JOIN;
+            joinPred = new BinaryPredicateOperator(BinaryType.EQ, innerKey, outerKey);
+            groupExpr = new GroupExpression(
+                    new LogicalJoinOperator(joinType, joinPred), Lists.newArrayList(innerGroup, outerGroup));
+        }
+        groupExpr.setGroup(new Group(2));
+
+        final var ctx = new ExpressionContext(groupExpr);
+
+        // WHEN
+        new StatisticsCalculator(ctx, columnRefFactory, optimizerContext).estimatorStats();
+        final var valStat = ctx.getStatistics().getColumnStatistic(innerVal);
+
+        // THEN — null fraction should be modest (driven by selectivity, not by the 15% null fraction)
+        Assertions.assertTrue(valStat.getNullsFraction() < staleOuterKeyNullFraction);
+    }
+
+    /**
+     * Selectivity path: When outer has MORE rows than inner and all stats are known,
+     * the inner-side null fraction should reflect the unmatched-row gap.
+     */
+    @Test
+    public void testLeftJoinKnownStatsWithUnmatchedRows() {
+        // GIVEN
+        final var outerKey = columnRefFactory.create("outer_key", IntegerType.BIGINT, true);
+        final var innerKey = columnRefFactory.create("inner_key", IntegerType.BIGINT, true);
+        final var innerVal = columnRefFactory.create("inner_val", IntegerType.BIGINT, true);
+
+        final var outerBuilder = Statistics.builder();
+        outerBuilder.setOutputRowCount(1000);
+        outerBuilder.addColumnStatistics(ImmutableMap.of(
+                outerKey, new ColumnStatistic(1, 1000, 0, 8, 500)));
+        final var outerGroup = new Group(0);
+        outerGroup.setStatistics(outerBuilder.build());
+        outerGroup.setLogicalProperty(new LogicalProperty(new ColumnRefSet(Lists.newArrayList(outerKey))));
+
+        final var innerBuilder = Statistics.builder();
+        innerBuilder.setOutputRowCount(200);
+        innerBuilder.addColumnStatistics(ImmutableMap.of(
+                innerKey, new ColumnStatistic(1, 500, 0, 8, 200),
+                innerVal, new ColumnStatistic(0, 100, 0.0, 8, 50)));
+        final var innerGroup = new Group(1);
+        innerGroup.setStatistics(innerBuilder.build());
+        innerGroup.setLogicalProperty(new LogicalProperty(new ColumnRefSet(Lists.newArrayList(innerKey, innerVal))));
+
+        final var joinPred = new BinaryPredicateOperator(BinaryType.EQ, outerKey, innerKey);
+        final var joinOp = new LogicalJoinOperator(JoinOperator.LEFT_OUTER_JOIN, joinPred);
+        final var groupExpr = new GroupExpression(joinOp, Lists.newArrayList(outerGroup, innerGroup));
+        groupExpr.setGroup(new Group(2));
+
+        final var ctx = new ExpressionContext(groupExpr);
+
+        // WHEN
+        new StatisticsCalculator(ctx, columnRefFactory, optimizerContext).estimatorStats();
+        final var valStat = ctx.getStatistics().getColumnStatistic(innerVal);
+
+        // THEN — inner-side null fraction should be positive (some outer rows unmatched)
+        Assertions.assertTrue(valStat.getNullsFraction() > 0,
+                "Inner-side column should have non-zero null fraction due to unmatched outer rows");
+    }
+
+    /**
+     * Unknown stats fallback path: When inner-side join key has UNKNOWN stats,
+     * innerRowCount defaults to max(left, right), making selectivity-based null count = 0.
+     * The fallback should use the outer-side key null fraction instead.
+     */
+    @ParameterizedTest
+    @EnumSource(value = OuterJoin.class)
+    public void testOuterJoinUnknownStatsUsesNullKeyFallback(OuterJoin outerJoin) {
+        // GIVEN
+        final var outerKey = columnRefFactory.create("outer_key", IntegerType.BIGINT, true);
+        final var outerCol = columnRefFactory.create("outer_col", IntegerType.BIGINT, true);
+        final var innerKey = columnRefFactory.create("inner_key", IntegerType.BIGINT, true);
+        final var innerVal = columnRefFactory.create("inner_val", IntegerType.BIGINT, true);
+
+        // Outer side (preserved): 1000 rows, high null fraction on join key
+        final double outerKeyNullFraction = 0.90;
+        final var outerBuilder = Statistics.builder();
+        outerBuilder.setOutputRowCount(1000);
+        outerBuilder.addColumnStatistics(ImmutableMap.of(
+                outerKey, new ColumnStatistic(1, 1000, outerKeyNullFraction, 8, 500),
+                outerCol, new ColumnStatistic(0, 100, 0, 8, 100)));
+        final var outerGroup = new Group(0);
+        outerGroup.setStatistics(outerBuilder.build());
+        outerGroup.setLogicalProperty(new LogicalProperty(
+                new ColumnRefSet(Lists.newArrayList(outerKey, outerCol))));
+
+        // Inner side: 500 rows, UNKNOWN stats on the join key
+        final var innerBuilder = Statistics.builder();
+        innerBuilder.setOutputRowCount(500);
+        innerBuilder.addColumnStatistics(ImmutableMap.of(
+                innerKey, ColumnStatistic.unknown(),
+                innerVal, new ColumnStatistic(0, 100, 0.001, 8, 50)));
+        final var innerGroup = new Group(1);
+        innerGroup.setStatistics(innerBuilder.build());
+        innerGroup.setLogicalProperty(new LogicalProperty(
+                new ColumnRefSet(Lists.newArrayList(innerKey, innerVal))));
+
+        JoinOperator joinType;
+        BinaryPredicateOperator joinPred;
+        GroupExpression groupExpr;
+        if (outerJoin == OuterJoin.LEFT_OUTER_JOIN) {
+            joinType = JoinOperator.LEFT_OUTER_JOIN;
+            joinPred = new BinaryPredicateOperator(BinaryType.EQ, outerKey, innerKey);
+            groupExpr = new GroupExpression(
+                    new LogicalJoinOperator(joinType, joinPred), Lists.newArrayList(outerGroup, innerGroup));
+        } else {
+            joinType = JoinOperator.RIGHT_OUTER_JOIN;
+            joinPred = new BinaryPredicateOperator(BinaryType.EQ, innerKey, outerKey);
+            groupExpr = new GroupExpression(
+                    new LogicalJoinOperator(joinType, joinPred), Lists.newArrayList(innerGroup, outerGroup));
+        }
+        groupExpr.setGroup(new Group(2));
+
+        final var ctx = new ExpressionContext(groupExpr);
+
+        // WHEN
+        new StatisticsCalculator(ctx, columnRefFactory, optimizerContext).estimatorStats();
+        final var innerValStat = ctx.getStatistics().getColumnStatistic(innerVal);
+
+        // THEN — inner-side null fraction should reflect the outer key's null fraction
+        Assertions.assertTrue(innerValStat.getNullsFraction() >= outerKeyNullFraction - 0.01,
+                "With unknown stats, inner-side null fraction (" + innerValStat.getNullsFraction()
+                        + ") should reflect outer key null fraction (" + outerKeyNullFraction
+                        + ") for " + outerJoin);
+    }
+
+    /**
+     * Unknown stats fallback path: FULL OUTER JOIN where one side has UNKNOWN key stats.
+     * Both sides' non-join columns should get elevated null fractions.
+     */
+    @Test
+    public void testFullOuterJoinUnknownStatsUsesNullKeyFallback() {
+        // GIVEN
+        final var leftKey = columnRefFactory.create("left_key", IntegerType.BIGINT, true);
+        final var leftVal = columnRefFactory.create("left_val", IntegerType.BIGINT, true);
+        final var rightKey = columnRefFactory.create("right_key", IntegerType.BIGINT, true);
+        final var rightVal = columnRefFactory.create("right_val", IntegerType.BIGINT, true);
+
+        // Left: 1000 rows, 80% null fraction on key
+        final double leftKeyNullFraction = 0.80;
+        final var leftBuilder = Statistics.builder();
+        leftBuilder.setOutputRowCount(1000);
+        leftBuilder.addColumnStatistics(ImmutableMap.of(
+                leftKey, new ColumnStatistic(1, 1000, leftKeyNullFraction, 8, 200),
+                leftVal, new ColumnStatistic(0, 100, 0.01, 8, 50)));
+        final var leftGroup = new Group(0);
+        leftGroup.setStatistics(leftBuilder.build());
+        leftGroup.setLogicalProperty(new LogicalProperty(new ColumnRefSet(Lists.newArrayList(leftKey, leftVal))));
+
+        // Right: 500 rows, UNKNOWN stats on key
+        final var rightBuilder = Statistics.builder();
+        rightBuilder.setOutputRowCount(500);
+        rightBuilder.addColumnStatistics(ImmutableMap.of(
+                rightKey, ColumnStatistic.unknown(),
+                rightVal, new ColumnStatistic(0, 100, 0.02, 8, 30)));
+        final var rightGroup = new Group(1);
+        rightGroup.setStatistics(rightBuilder.build());
+        rightGroup.setLogicalProperty(new LogicalProperty(new ColumnRefSet(Lists.newArrayList(rightKey, rightVal))));
+
+        final var joinPred = new BinaryPredicateOperator(BinaryType.EQ, leftKey, rightKey);
+        final var joinOp = new LogicalJoinOperator(JoinOperator.FULL_OUTER_JOIN, joinPred);
+        final var groupExpr = new GroupExpression(joinOp, Lists.newArrayList(leftGroup, rightGroup));
+        groupExpr.setGroup(new Group(2));
+
+        final var ctx = new ExpressionContext(groupExpr);
+
+        // WHEN
+        new StatisticsCalculator(ctx, columnRefFactory, optimizerContext).estimatorStats();
+        final var rightValStat = ctx.getStatistics().getColumnStatistic(rightVal);
+
+        // THEN — right side is nullable from left's perspective, and left key has 80% nulls
+        // With unknown stats fallback, the right-side null fraction should reflect the left key's null fraction
+        Assertions.assertTrue(rightValStat.getNullsFraction() >= leftKeyNullFraction - 0.05);
+    }
+
     private static File newFolder(File root, String... subDirs) throws IOException {
         String subFolder = String.join("/", subDirs);
         File result = new File(root, subFolder);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -52,6 +52,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -790,8 +791,8 @@ public class StatisticsCalculatorTest {
     @EnumSource(value = OuterJoin.class)
     public void testOuterJoinEqForNullDoesNotTreatNullKeysAsUnmatched(OuterJoin outerJoin) {
         // GIVEN
-        final var outerJoinKey = columnRefFactory.create("outer_key", Type.INT, true);
-        final var outerOtherCol = columnRefFactory.create("outer_other_col", Type.INT, true);
+        final var outerJoinKey = columnRefFactory.create("outer_key", IntegerType.INT, true);
+        final var outerOtherCol = columnRefFactory.create("outer_other_col", IntegerType.INT, true);
 
         final double outerNullFraction = 0.6;
         final var outerBuilder = Statistics.builder();
@@ -806,8 +807,8 @@ public class StatisticsCalculatorTest {
         outerGroup.setLogicalProperty(new LogicalProperty(
                 new ColumnRefSet(Lists.newArrayList(outerJoinKey, outerOtherCol))));
 
-        final var innerKey = columnRefFactory.create("inner_id", Type.INT, true);
-        final var innerVal = columnRefFactory.create("inner_val", Type.INT, true);
+        final var innerKey = columnRefFactory.create("inner_id", IntegerType.INT, true);
+        final var innerVal = columnRefFactory.create("inner_val", IntegerType.INT, true);
 
         final var innerBuilder = Statistics.builder();
         innerBuilder.setOutputRowCount(80000);
@@ -862,11 +863,11 @@ public class StatisticsCalculatorTest {
         // GIVEN
         // LEFT JOIN where outer key has high null fraction and inner has UNKNOWN stats on one eq col,
         // triggering innerRowCount = outerRowCount. Inner-side null fraction should still reflect the high null fraction.
-        final var outerKey = columnRefFactory.create("outer_key", Type.BIGINT, true);
-        final var outerCol = columnRefFactory.create("outer_col", Type.BIGINT, true);
-        final var innerKey = columnRefFactory.create("inner_key", Type.BIGINT, true);
-        final var innerCol = columnRefFactory.create("inner_col", Type.BIGINT, true);
-        final var innerVal = columnRefFactory.create("val", Type.VARCHAR, true);
+        final var outerKey = columnRefFactory.create("outer_key", IntegerType.BIGINT, true);
+        final var outerCol = columnRefFactory.create("outer_col", IntegerType.BIGINT, true);
+        final var innerKey = columnRefFactory.create("inner_key", IntegerType.BIGINT, true);
+        final var innerCol = columnRefFactory.create("inner_col", IntegerType.BIGINT, true);
+        final var innerVal = columnRefFactory.create("val", VarcharType.VARCHAR, true);
 
         final double outerKeyNullFraction = 0.95;
         final var outerBuilder = Statistics.builder();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -774,7 +774,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 + "  |  equal join conjunct: [1: PS_PARTKEY, INT, true] = [7: P_PARTKEY, INT, true]\n"
                 + "  |  other predicates: [1: PS_PARTKEY, INT, true] IS NULL\n"
                 + "  |  output columns: 1, 2\n"
-                + "  |  cardinality: 4000000");
+                + "  |  cardinality: 8000000");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
@@ -204,7 +204,7 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
                 Arguments.of("Q87", 8, 14, true, 20, true, 14, true, 17, true),
                 Arguments.of("Q89", 2, 2, false, 4, true, 4, true, 4, true),
                 Arguments.of("Q91", 2, 4, true, 4, true, 4, true, 4, true),
-                Arguments.of("Q97", 5, 5, false, 11, true, 9, true, 11, true),
+                Arguments.of("Q97", 6, 6, false, 12, true, 10, true, 12, true),
                 Arguments.of("Q98", 2, 2, false, 4, true, 4, true, 4, true),
         };
 


### PR DESCRIPTION
## Why I'm doing:

For outer joins, we did not look at the null fractions of the outer join key column when calculating the resulting null fractions of the join. We only determined the resulting null fractions by looking into the estimated inner row count. If the estimated inner row count is inaccurate (for example due to unknown stats of the inner join key column, we assume `innerRowCount = outerRowCount`) we underestimate the resulting null fractions. We should also look at the null fractions of the outer join key column and take these into consideration to avoid an underestimation.

## What I'm doing:

Instead of only relying on the estimated row count of the join (`nullsRows = outerSideRowCount - innerRowCount`), we also take the null fractions of the outer join columns into consideration (`nullsRows = maxOuterKeyNullFraction * outerSideRowCount`) and take the `max` of both to avoid an underestimation.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
