### PR TITLE
[BugFix] Support AD range paging retrieval in LDAPGroupProvider

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -39,6 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.naming.Context;
@@ -150,28 +152,50 @@ public class LDAPGroupProvider extends GroupProvider {
     public void refreshGroups() {
         LOG.info("refresh ldap group cache for group provider: {}", name);
         Map<String, Set<String>> groups = new ConcurrentHashMap<>();
+        DirContext ctx = null;
         try {
-            DirContext ctx = createDirContextOnConnection(getLdapBindRootDn(), getLdapBindRootPwd());
+            ctx = createDirContextOnConnection(getLdapBindRootDn(), getLdapBindRootPwd());
             UserNameExtractInterface userNameExtractInterface = getUserNameExtractInterface();
 
             if (getLdapGroupFilter() != null) {
                 SearchControls searchControls = new SearchControls();
                 searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
-                NamingEnumeration<SearchResult> results = ctx.search(getLdapBaseDn(), getLdapGroupFilter(), searchControls);
+                // Explicitly request only the identifier and member attributes. This avoids
+                // the AD default attribute set behavior and ensures the server includes the
+                // member attribute (encoded in range retrieval form when the group is large)
+                // in the response.
+                searchControls.setReturningAttributes(
+                        new String[] {getLdapGroupIdentifierAttr(), getLDAPGroupMemberAttr()});
+                NamingEnumeration<SearchResult> results =
+                        ctx.search(getLdapBaseDn(), getLdapGroupFilter(), searchControls);
                 try {
                     while (results.hasMore()) {
                         SearchResult result = results.next();
-                        Attributes attributes = result.getAttributes();
-                        matchUserAndUpdateGroups(groups, attributes, userNameExtractInterface);
+                        String groupDN = extractGroupDN(result);
+                        try {
+                            matchUserAndUpdateGroups(ctx, groupDN, groups,
+                                    result.getAttributes(), userNameExtractInterface);
+                        } catch (NamingException ne) {
+                            // Isolate failure to a single group so other entries still refresh.
+                            LOG.warn("Failed to process LDAP group with DN '{}', skipping",
+                                    groupDN, ne);
+                        }
                     }
                 } catch (PartialResultException e) {
                     LOG.warn("LDAP group search partial result exception", e);
                 }
             } else if (getLdapGroupDn() != null) {
                 for (String ldapGroupDN : getLdapGroupDn()) {
-                    Attributes attributes =
-                            ctx.getAttributes(ldapGroupDN, new String[] {getLdapGroupIdentifierAttr(), getLDAPGroupMemberAttr()});
-                    matchUserAndUpdateGroups(groups, attributes, userNameExtractInterface);
+                    try {
+                        Attributes attributes = ctx.getAttributes(ldapGroupDN,
+                                new String[] {getLdapGroupIdentifierAttr(), getLDAPGroupMemberAttr()});
+                        matchUserAndUpdateGroups(ctx, ldapGroupDN, groups, attributes,
+                                userNameExtractInterface);
+                    } catch (NamingException ne) {
+                        // Isolate failure to a single group so other configured groups still refresh.
+                        LOG.warn("Failed to fetch attributes for LDAP group '{}', skipping",
+                                ldapGroupDN, ne);
+                    }
                 }
             } else {
                 LOG.warn("Neither ldap_group_filter nor ldap_group_dn exists");
@@ -179,6 +203,14 @@ public class LDAPGroupProvider extends GroupProvider {
         } catch (Exception e) {
             //Do not affect the normal login process at this time. If an error occurs, an empty group will be returned.
             LOG.error("LDAP group search failed", e);
+        } finally {
+            if (ctx != null) {
+                try {
+                    ctx.close();
+                } catch (NamingException ne) {
+                    LOG.warn("Failed to close LDAP DirContext", ne);
+                }
+            }
         }
 
         if (LOG.isDebugEnabled()) {
@@ -188,7 +220,28 @@ public class LDAPGroupProvider extends GroupProvider {
         this.userToGroupCache = groups;
     }
 
-    private void matchUserAndUpdateGroups(Map<String, Set<String>> groups,
+    /**
+     * Extract the fully-qualified DN of a group from a SearchResult. Prefer getNameInNamespace()
+     * because it returns the absolute DN in normalized form, which is required when re-issuing
+     * getAttributes() for range retrieval follow-up pages.
+     */
+    private static String extractGroupDN(SearchResult result) {
+        try {
+            String dn = result.getNameInNamespace();
+            if (dn != null && !dn.isEmpty()) {
+                return dn;
+            }
+        } catch (UnsupportedOperationException | IllegalStateException ignored) {
+            // Some LDAP providers may not support getNameInNamespace; fall through.
+        }
+        // Fall back to the (possibly relative) name. Callers must tolerate a possibly empty DN
+        // and skip range follow-up requests in that case.
+        return result.getName();
+    }
+
+    private void matchUserAndUpdateGroups(DirContext ctx,
+                                          String groupDN,
+                                          Map<String, Set<String>> groups,
                                           Attributes attributes,
                                           UserNameExtractInterface userNameExtractInterface)
             throws NamingException {
@@ -200,20 +253,12 @@ public class LDAPGroupProvider extends GroupProvider {
         }
         String groupName = (String) ldapGroupIdentifierAttr.get();
 
-        Attribute memberAttribute = attributes.get(getLDAPGroupMemberAttr());
-        if (memberAttribute == null) {
-            LOG.warn("LDAP group member attribute '{}' not found in attributes: {}", getLDAPGroupMemberAttr(), attributes);
-            return;
-        }
-
-        NamingEnumeration<?> e = memberAttribute.getAll();
-        while (e.hasMore()) {
-            String memberDN = (String) e.next();
+        collectAllMembers(ctx, groupDN, getLDAPGroupMemberAttr(), attributes, memberDN -> {
             String extractUserName = userNameExtractInterface.extract(memberDN);
 
             if (extractUserName == null) {
                 LOG.debug("Failed to extract user name from member DN: '{}'", memberDN);
-                continue;
+                return;
             }
 
             // Normalize extracted username for case-insensitive matching
@@ -225,8 +270,157 @@ public class LDAPGroupProvider extends GroupProvider {
 
             LOG.debug("Successfully extracted user '{}' from member '{}', added to group '{}'",
                     extractUserName, memberDN, groupName);
+        });
+    }
+
+    /**
+     * Collect all members from {@code initialAttrs} and, if Active Directory split the member
+     * attribute via range retrieval ({@code member;range=N-M}), iteratively fetch the remaining
+     * pages until a terminal ({@code -*}) marker is seen.
+     *
+     * <p>Errors while fetching a follow-up page are logged and the loop is broken so that
+     * members already collected from earlier pages are preserved instead of being lost.
+     */
+    @VisibleForTesting
+    static void collectAllMembers(DirContext ctx, String groupDN, String memberAttrName,
+                                    Attributes initialAttrs, Consumer<String> memberConsumer)
+            throws NamingException {
+        String currentAttrId = findMemberAttributeId(initialAttrs, memberAttrName);
+        if (currentAttrId == null) {
+            LOG.warn("LDAP group member attribute '{}' not found in attributes: {}",
+                    memberAttrName, initialAttrs);
+            return;
+        }
+        Attributes currentAttrs = initialAttrs;
+        int pageCount = 0;
+
+        while (true) {
+            Attribute attr = currentAttrs.get(currentAttrId);
+            if (attr != null) {
+                NamingEnumeration<?> e = attr.getAll();
+                while (e.hasMore()) {
+                    memberConsumer.accept((String) e.next());
+                }
+            }
+
+            RangeInfo range = parseRangeSuffix(currentAttrId);
+            if (range == null || range.isTerminal()) {
+                break;
+            }
+
+            if (++pageCount >= MAX_RANGE_PAGES) {
+                LOG.warn("LDAP group '{}' exceeded MAX_RANGE_PAGES ({}), some members may be missing",
+                        groupDN, MAX_RANGE_PAGES);
+                break;
+            }
+
+            if (groupDN == null || groupDN.isEmpty()) {
+                LOG.warn("Cannot fetch next range page: groupDN unavailable. Current attr: '{}'",
+                        currentAttrId);
+                break;
+            }
+
+            String nextAttrName = memberAttrName + ";range=" + (range.end + 1) + "-*";
+            try {
+                currentAttrs = ctx.getAttributes(groupDN, new String[] {nextAttrName});
+            } catch (PartialResultException pre) {
+                LOG.warn("PartialResultException while fetching next range page for group '{}', " +
+                        "stop paging", groupDN, pre);
+                break;
+            } catch (NamingException ne) {
+                LOG.warn("NamingException while fetching next range page for group '{}', " +
+                        "stop paging. Members already collected are preserved.", groupDN, ne);
+                break;
+            }
+
+            currentAttrId = findMemberAttributeId(currentAttrs, memberAttrName);
+            if (currentAttrId == null) {
+                LOG.warn("LDAP server did not return expected range page starting at {} for group '{}'",
+                        range.end + 1, groupDN);
+                break;
+            }
         }
     }
+
+    /**
+     * Locate the actual attribute id used for the member attribute in {@code attrs}. Active
+     * Directory may return the canonical name {@code "member"} as-is when the group is small,
+     * or encode it as {@code "member;range=0-1499"} when range retrieval is in effect. Matching
+     * is case-insensitive because the LDAP attribute namespace is case-insensitive.
+     *
+     * @return the id present in {@code attrs}, or {@code null} when no matching attribute exists.
+     */
+    @VisibleForTesting
+    static String findMemberAttributeId(Attributes attrs, String memberAttrName) throws NamingException {
+        if (attrs == null) {
+            return null;
+        }
+        // 1) Plain match first. JNDI's BasicAttributes returned over LDAP is created with
+        //    ignoreCase=true, but we still go through attrs.get(...) explicitly for clarity.
+        if (attrs.get(memberAttrName) != null) {
+            return memberAttrName;
+        }
+        // 2) Search for a range variant such as "member;range=0-1499".
+        NamingEnumeration<String> ids = attrs.getIDs();
+        while (ids.hasMore()) {
+            String id = ids.next();
+            if (id.equalsIgnoreCase(memberAttrName)) {
+                return id;
+            }
+            int semi = id.indexOf(';');
+            if (semi > 0
+                    && id.substring(0, semi).equalsIgnoreCase(memberAttrName)
+                    && id.substring(semi).toLowerCase(Locale.ROOT).startsWith(";range=")) {
+                return id;
+            }
+        }
+        return null;
+    }
+
+    private static final Pattern RANGE_PATTERN = Pattern.compile("(?i);range=(\\d+)-(\\d+|\\*)$");
+
+    /**
+     * Parse the range suffix of an attribute id such as {@code "member;range=0-1499"} or
+     * {@code "member;range=1500-*"}. Returns {@code null} when the id does not carry a valid
+     * range suffix.
+     */
+    @VisibleForTesting
+    static RangeInfo parseRangeSuffix(String attrId) {
+        if (attrId == null) {
+            return null;
+        }
+        Matcher m = RANGE_PATTERN.matcher(attrId);
+        if (!m.find()) {
+            return null;
+        }
+        String endStr = m.group(2);
+        long end = "*".equals(endStr) ? -1L : Long.parseLong(endStr);
+        return new RangeInfo(Long.parseLong(m.group(1)), end);
+    }
+
+    @VisibleForTesting
+    static final class RangeInfo {
+        final long start;
+        final long end; // -1L means "*", i.e. the terminal page.
+
+        RangeInfo(long start, long end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        boolean isTerminal() {
+            return end == -1L;
+        }
+    }
+
+    /**
+     * Hard safety limit on the number of follow-up range pages fetched per group. Prevents an
+     * unbounded loop on a misbehaving server that always advertises a non-terminal range. 100
+     * pages at the typical AD MaxValRange (1500) covers ~150k members, well above any realistic
+     * group size.
+     */
+    @VisibleForTesting
+    static int MAX_RANGE_PAGES = 100;
 
     @FunctionalInterface
     private interface UserNameExtractInterface {

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
@@ -166,12 +166,12 @@ public class LDAPGroupProvider extends GroupProvider {
                 // in the response.
                 searchControls.setReturningAttributes(
                         new String[] {getLdapGroupIdentifierAttr(), getLDAPGroupMemberAttr()});
-                NamingEnumeration<SearchResult> results =
-                        ctx.search(getLdapBaseDn(), getLdapGroupFilter(), searchControls);
+                NamingEnumeration<SearchResult> results = null;
                 try {
+                    results = ctx.search(getLdapBaseDn(), getLdapGroupFilter(), searchControls);
                     while (results.hasMore()) {
                         SearchResult result = results.next();
-                        String groupDN = extractGroupDN(result);
+                        String groupDN = extractGroupDN(result, getLdapBaseDn());
                         try {
                             matchUserAndUpdateGroups(ctx, groupDN, groups,
                                     result.getAttributes(), userNameExtractInterface);
@@ -183,6 +183,8 @@ public class LDAPGroupProvider extends GroupProvider {
                     }
                 } catch (PartialResultException e) {
                     LOG.warn("LDAP group search partial result exception", e);
+                } finally {
+                    closeNamingEnumeration(results);
                 }
             } else if (getLdapGroupDn() != null) {
                 for (String ldapGroupDN : getLdapGroupDn()) {
@@ -225,7 +227,8 @@ public class LDAPGroupProvider extends GroupProvider {
      * because it returns the absolute DN in normalized form, which is required when re-issuing
      * getAttributes() for range retrieval follow-up pages.
      */
-    private static String extractGroupDN(SearchResult result) {
+    @VisibleForTesting
+    static String extractGroupDN(SearchResult result, String baseDN) {
         try {
             String dn = result.getNameInNamespace();
             if (dn != null && !dn.isEmpty()) {
@@ -234,9 +237,29 @@ public class LDAPGroupProvider extends GroupProvider {
         } catch (UnsupportedOperationException | IllegalStateException ignored) {
             // Some LDAP providers may not support getNameInNamespace; fall through.
         }
-        // Fall back to the (possibly relative) name. Callers must tolerate a possibly empty DN
-        // and skip range follow-up requests in that case.
-        return result.getName();
+        String name = result.getName();
+        if (name == null || name.isEmpty() || !result.isRelative()) {
+            return name;
+        }
+        return qualifyRelativeDN(name, baseDN);
+    }
+
+    @VisibleForTesting
+    static String qualifyRelativeDN(String dn, String baseDN) {
+        if (Strings.isNullOrEmpty(dn) || Strings.isNullOrEmpty(baseDN)) {
+            return dn;
+        }
+        String normalizedDN = StringUtils.strip(dn.trim(), "\"'");
+        String normalizedBaseDN = StringUtils.strip(baseDN.trim(), "\"'");
+        if (normalizedDN.isEmpty() || normalizedBaseDN.isEmpty()) {
+            return normalizedDN;
+        }
+        String lowerDN = normalizedDN.toLowerCase(Locale.ROOT);
+        String lowerBaseDN = normalizedBaseDN.toLowerCase(Locale.ROOT);
+        if (lowerDN.equals(lowerBaseDN) || lowerDN.endsWith("," + lowerBaseDN)) {
+            return normalizedDN;
+        }
+        return normalizedDN + "," + normalizedBaseDN;
     }
 
     private void matchUserAndUpdateGroups(DirContext ctx,
@@ -292,14 +315,18 @@ public class LDAPGroupProvider extends GroupProvider {
             return;
         }
         Attributes currentAttrs = initialAttrs;
-        int pageCount = 0;
+        int followupPageCount = 0;
 
         while (true) {
             Attribute attr = currentAttrs.get(currentAttrId);
             if (attr != null) {
                 NamingEnumeration<?> e = attr.getAll();
-                while (e.hasMore()) {
-                    memberConsumer.accept((String) e.next());
+                try {
+                    while (e.hasMore()) {
+                        memberConsumer.accept((String) e.next());
+                    }
+                } finally {
+                    closeNamingEnumeration(e);
                 }
             }
 
@@ -308,9 +335,9 @@ public class LDAPGroupProvider extends GroupProvider {
                 break;
             }
 
-            if (++pageCount >= MAX_RANGE_PAGES) {
-                LOG.warn("LDAP group '{}' exceeded MAX_RANGE_PAGES ({}), some members may be missing",
-                        groupDN, MAX_RANGE_PAGES);
+            if (followupPageCount >= MAX_RANGE_PAGES) {
+                LOG.warn("LDAP group '{}' exceeded MAX_RANGE_PAGES ({}) follow-up pages, " +
+                        "some members may be missing", groupDN, MAX_RANGE_PAGES);
                 break;
             }
 
@@ -323,6 +350,7 @@ public class LDAPGroupProvider extends GroupProvider {
             String nextAttrName = memberAttrName + ";range=" + (range.end + 1) + "-*";
             try {
                 currentAttrs = ctx.getAttributes(groupDN, new String[] {nextAttrName});
+                followupPageCount++;
             } catch (PartialResultException pre) {
                 LOG.warn("PartialResultException while fetching next range page for group '{}', " +
                         "stop paging", groupDN, pre);
@@ -355,29 +383,67 @@ public class LDAPGroupProvider extends GroupProvider {
         if (attrs == null) {
             return null;
         }
-        // 1) Plain match first. JNDI's BasicAttributes returned over LDAP is created with
-        //    ignoreCase=true, but we still go through attrs.get(...) explicitly for clarity.
-        if (attrs.get(memberAttrName) != null) {
-            return memberAttrName;
-        }
-        // 2) Search for a range variant such as "member;range=0-1499".
+        String plainAttrId = null;
+        String plainAttrIdWithValue = null;
+        String rangeAttrId = null;
         NamingEnumeration<String> ids = attrs.getIDs();
-        while (ids.hasMore()) {
-            String id = ids.next();
-            if (id.equalsIgnoreCase(memberAttrName)) {
-                return id;
+        try {
+            while (ids.hasMore()) {
+                String id = ids.next();
+                boolean isPlainMemberAttr = id.equalsIgnoreCase(memberAttrName);
+                boolean isRangeMemberAttr = isMemberRangeAttribute(id, memberAttrName);
+                if (!isPlainMemberAttr && !isRangeMemberAttr) {
+                    continue;
+                }
+
+                Attribute attr = attrs.get(id);
+                boolean hasValue = attr != null && attr.size() > 0;
+                if (isRangeMemberAttr) {
+                    if (hasValue) {
+                        return id;
+                    }
+                    if (rangeAttrId == null) {
+                        rangeAttrId = id;
+                    }
+                } else if (hasValue) {
+                    if (plainAttrIdWithValue == null) {
+                        plainAttrIdWithValue = id;
+                    }
+                } else if (plainAttrId == null) {
+                    plainAttrId = id;
+                }
             }
-            int semi = id.indexOf(';');
-            if (semi > 0
-                    && id.substring(0, semi).equalsIgnoreCase(memberAttrName)
-                    && id.substring(semi).toLowerCase(Locale.ROOT).startsWith(";range=")) {
-                return id;
-            }
+        } finally {
+            closeNamingEnumeration(ids);
         }
-        return null;
+        if (plainAttrIdWithValue != null) {
+            return plainAttrIdWithValue;
+        }
+        if (rangeAttrId != null) {
+            return rangeAttrId;
+        }
+        return plainAttrId;
     }
 
-    private static final Pattern RANGE_PATTERN = Pattern.compile("(?i);range=(\\d+)-(\\d+|\\*)$");
+    private static boolean isMemberRangeAttribute(String attrId, String memberAttrName) {
+        int semi = attrId.indexOf(';');
+        return semi > 0
+                && attrId.substring(0, semi).equalsIgnoreCase(memberAttrName)
+                && parseRangeSuffix(attrId) != null;
+    }
+
+    private static void closeNamingEnumeration(NamingEnumeration<?> enumeration) {
+        if (enumeration != null) {
+            try {
+                enumeration.close();
+            } catch (NamingException ne) {
+                LOG.debug("Failed to close LDAP naming enumeration", ne);
+            }
+        }
+    }
+
+    private static final Pattern RANGE_PATTERN =
+            Pattern.compile("(?i)(?:^|;)range=(\\d+)-(\\d+|\\*)(?:;|$)");
 
     /**
      * Parse the range suffix of an attribute id such as {@code "member;range=0-1499"} or

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderRangeRetrievalTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderRangeRetrievalTest.java
@@ -16,15 +16,16 @@ package com.starrocks.authentication;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import javax.naming.NamingException;
-import javax.naming.directory.Attributes;
 import javax.naming.directory.BasicAttribute;
 import javax.naming.directory.BasicAttributes;
 import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchResult;
 
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.eq;
@@ -42,10 +43,14 @@ class LDAPGroupProviderRangeRetrievalTest {
 
     private int originalMaxRangePages;
 
+    @BeforeEach
+    public void setUp() {
+        originalMaxRangePages = LDAPGroupProvider.MAX_RANGE_PAGES;
+    }
+
     @AfterEach
     public void tearDown() {
-        // Restore in case a test temporarily lowered the limit.
-        LDAPGroupProvider.MAX_RANGE_PAGES = originalMaxRangePages > 0 ? originalMaxRangePages : 100;
+        LDAPGroupProvider.MAX_RANGE_PAGES = originalMaxRangePages;
     }
 
     // ---------- parseRangeSuffix ----------
@@ -116,6 +121,29 @@ class LDAPGroupProviderRangeRetrievalTest {
         attrs.put(new BasicAttribute("cn", "grp"));
 
         Assertions.assertEquals("member;range=0-1499",
+                LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeId_valuedRangePreferredOverEmptyPlainMember() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("member"));
+        BasicAttribute range = new BasicAttribute("member;range=0-1");
+        range.add("u1");
+        attrs.put(range);
+
+        Assertions.assertEquals("member;range=0-1",
+                LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeId_rangeOptionAfterOtherOptionMatched() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        BasicAttribute range = new BasicAttribute("member;lang-en;range=0-1");
+        range.add("u1");
+        attrs.put(range);
+
+        Assertions.assertEquals("member;lang-en;range=0-1",
                 LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
     }
 
@@ -196,17 +224,80 @@ class LDAPGroupProviderRangeRetrievalTest {
     }
 
     @Test
+    public void testCollectAllMembers_initialAdResponseSkipsEmptyPlainMember() throws NamingException {
+        // AD may return an empty plain "member" plus the actual ranged attribute.
+        BasicAttributes page1 = new BasicAttributes(true);
+        page1.put(new BasicAttribute("member"));
+        BasicAttribute p1Attr = new BasicAttribute("member;range=0-1");
+        p1Attr.add("u1");
+        p1Attr.add("u2");
+        page1.put(p1Attr);
+
+        BasicAttributes page2 = new BasicAttributes(true);
+        BasicAttribute p2Attr = new BasicAttribute("member;range=2-*");
+        p2Attr.add("u3");
+        page2.put(p2Attr);
+
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("CN=g"), aryEq(new String[] {"member;range=2-*"})))
+                .thenReturn(page2);
+
+        List<String> collected = new ArrayList<>();
+        LDAPGroupProvider.collectAllMembers(ctx, "CN=g", "member", page1, collected::add);
+
+        Assertions.assertEquals(List.of("u1", "u2", "u3"), collected);
+    }
+
+    @Test
+    public void testCollectAllMembers_followupAdResponseSkipsEmptyRequestedRange() throws NamingException {
+        BasicAttributes page1 = new BasicAttributes(true);
+        BasicAttribute p1Attr = new BasicAttribute("member;range=0-1");
+        p1Attr.add("u1");
+        p1Attr.add("u2");
+        page1.put(p1Attr);
+
+        // Client asks for "2-*"; AD can echo that request attribute with no values
+        // and return the server-capped real page under "2-3".
+        BasicAttributes page2 = new BasicAttributes(true);
+        page2.put(new BasicAttribute("member;range=2-*"));
+        BasicAttribute p2Attr = new BasicAttribute("member;range=2-3");
+        p2Attr.add("u3");
+        p2Attr.add("u4");
+        page2.put(p2Attr);
+
+        BasicAttributes page3 = new BasicAttributes(true);
+        BasicAttribute p3Attr = new BasicAttribute("member;range=4-*");
+        p3Attr.add("u5");
+        page3.put(p3Attr);
+
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("CN=g"), aryEq(new String[] {"member;range=2-*"})))
+                .thenReturn(page2);
+        when(ctx.getAttributes(eq("CN=g"), aryEq(new String[] {"member;range=4-*"})))
+                .thenReturn(page3);
+
+        List<String> collected = new ArrayList<>();
+        LDAPGroupProvider.collectAllMembers(ctx, "CN=g", "member", page1, collected::add);
+
+        Assertions.assertEquals(List.of("u1", "u2", "u3", "u4", "u5"), collected);
+    }
+
+    @Test
     public void testCollectAllMembers_threePagesAcrossNonTerminalMiddle() throws NamingException {
         // Server-side capped: client requests "3-*" but server replies "3-5" (still non-terminal),
         // then on the next request "6-*" replies terminal.
         BasicAttributes page1 = new BasicAttributes(true);
         BasicAttribute p1 = new BasicAttribute("member;range=0-2");
-        p1.add("u1"); p1.add("u2"); p1.add("u3");
+        p1.add("u1");
+        p1.add("u2");
+        p1.add("u3");
         page1.put(p1);
 
         BasicAttributes page2 = new BasicAttributes(true);
         BasicAttribute p2 = new BasicAttribute("member;range=3-5");
-        p2.add("u4"); p2.add("u5"); p2.add("u6");
+        p2.add("u4");
+        p2.add("u5");
+        p2.add("u6");
         page2.put(p2);
 
         BasicAttributes page3 = new BasicAttributes(true);
@@ -230,7 +321,6 @@ class LDAPGroupProviderRangeRetrievalTest {
 
     @Test
     public void testCollectAllMembers_maxRangePagesSafetyLimit() throws NamingException {
-        originalMaxRangePages = LDAPGroupProvider.MAX_RANGE_PAGES;
         LDAPGroupProvider.MAX_RANGE_PAGES = 3;
 
         // Page 0 (initial) is non-terminal: server keeps advertising non-terminal indefinitely.
@@ -266,7 +356,8 @@ class LDAPGroupProviderRangeRetrievalTest {
     public void testCollectAllMembers_followupNamingExceptionPreservesCollected() throws NamingException {
         BasicAttributes page1 = new BasicAttributes(true);
         BasicAttribute p1 = new BasicAttribute("member;range=0-1");
-        p1.add("u1"); p1.add("u2");
+        p1.add("u1");
+        p1.add("u2");
         page1.put(p1);
 
         DirContext ctx = mock(DirContext.class);
@@ -284,7 +375,8 @@ class LDAPGroupProviderRangeRetrievalTest {
     public void testCollectAllMembers_emptyGroupDNSkipsFollowupRequest() throws NamingException {
         BasicAttributes page1 = new BasicAttributes(true);
         BasicAttribute p1 = new BasicAttribute("member;range=0-1");
-        p1.add("u1"); p1.add("u2");
+        p1.add("u1");
+        p1.add("u2");
         page1.put(p1);
 
         DirContext ctx = mock(DirContext.class);
@@ -309,6 +401,24 @@ class LDAPGroupProviderRangeRetrievalTest {
         LDAPGroupProvider.collectAllMembers(ctx, "CN=g,DC=x", "member", attrs, collected::add);
 
         Assertions.assertTrue(collected.isEmpty());
+    }
+
+    // ---------- group DN extraction ----------
+
+    @Test
+    public void testExtractGroupDN_relativeNameUsesBaseDN() {
+        SearchResult result = new SearchResult("CN=g,OU=Groups", null, new BasicAttributes(), true);
+
+        Assertions.assertEquals("CN=g,OU=Groups,DC=x,DC=y",
+                LDAPGroupProvider.extractGroupDN(result, "DC=x,DC=y"));
+    }
+
+    @Test
+    public void testExtractGroupDN_absoluteNameIsNotQualifiedAgain() {
+        SearchResult result = new SearchResult("CN=g,DC=x,DC=y", null, new BasicAttributes(), false);
+
+        Assertions.assertEquals("CN=g,DC=x,DC=y",
+                LDAPGroupProvider.extractGroupDN(result, "DC=x,DC=y"));
     }
 
     // ---------- helpers ----------

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderRangeRetrievalTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderRangeRetrievalTest.java
@@ -1,0 +1,325 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.DirContext;
+
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for Active Directory range retrieval ({@code member;range=N-M}) handling in
+ * {@link LDAPGroupProvider}. The static helpers introduced for range parsing and paging are
+ * verified directly so that the regression behavior is documented as code.
+ */
+class LDAPGroupProviderRangeRetrievalTest {
+
+    private int originalMaxRangePages;
+
+    @AfterEach
+    public void tearDown() {
+        // Restore in case a test temporarily lowered the limit.
+        LDAPGroupProvider.MAX_RANGE_PAGES = originalMaxRangePages > 0 ? originalMaxRangePages : 100;
+    }
+
+    // ---------- parseRangeSuffix ----------
+
+    @Test
+    public void testParseRangeSuffix_plainAttributeReturnsNull() {
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix("member"));
+    }
+
+    @Test
+    public void testParseRangeSuffix_intermediatePage() {
+        LDAPGroupProvider.RangeInfo info = LDAPGroupProvider.parseRangeSuffix("member;range=0-1499");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(0L, info.start);
+        Assertions.assertEquals(1499L, info.end);
+        Assertions.assertFalse(info.isTerminal());
+    }
+
+    @Test
+    public void testParseRangeSuffix_terminalPage() {
+        LDAPGroupProvider.RangeInfo info = LDAPGroupProvider.parseRangeSuffix("member;range=1500-*");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(1500L, info.start);
+        Assertions.assertEquals(-1L, info.end);
+        Assertions.assertTrue(info.isTerminal());
+    }
+
+    @Test
+    public void testParseRangeSuffix_caseInsensitive() {
+        LDAPGroupProvider.RangeInfo info = LDAPGroupProvider.parseRangeSuffix("MEMBER;Range=0-1");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(0L, info.start);
+        Assertions.assertEquals(1L, info.end);
+    }
+
+    @Test
+    public void testParseRangeSuffix_malformedSuffixReturnsNull() {
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix("member;range="));
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix("member;range=abc-xyz"));
+    }
+
+    @Test
+    public void testParseRangeSuffix_unrelatedSuffixReturnsNull() {
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix("member;blah=0-1"));
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix("member;lang-en"));
+    }
+
+    @Test
+    public void testParseRangeSuffix_nullReturnsNull() {
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix(null));
+    }
+
+    // ---------- findMemberAttributeId ----------
+
+    @Test
+    public void testFindMemberAttributeId_plainMatchTakesPrecedence() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("member"));
+        attrs.put(new BasicAttribute("cn", "grp"));
+
+        Assertions.assertEquals("member", LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeId_rangeVariantMatched() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("member;range=0-1499"));
+        attrs.put(new BasicAttribute("cn", "grp"));
+
+        Assertions.assertEquals("member;range=0-1499",
+                LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeId_caseInsensitiveRangeMatch() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(false);
+        attrs.put(new BasicAttribute("MEMBER;Range=0-1"));
+
+        Assertions.assertEquals("MEMBER;Range=0-1",
+                LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeId_unrelatedAttributeIgnored() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("cn", "grp"));
+        attrs.put(new BasicAttribute("description", "test group"));
+
+        Assertions.assertNull(LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeId_nullAttributesReturnsNull() throws NamingException {
+        Assertions.assertNull(LDAPGroupProvider.findMemberAttributeId(null, "member"));
+    }
+
+    // ---------- collectAllMembers (range paging end-to-end) ----------
+
+    @Test
+    public void testCollectAllMembers_plainResponseSinglePage() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        BasicAttribute member = new BasicAttribute("member");
+        member.add("CN=u1,OU=People,DC=x,DC=y");
+        member.add("CN=u2,OU=People,DC=x,DC=y");
+        attrs.put(member);
+
+        DirContext ctx = mock(DirContext.class);
+        List<String> collected = new ArrayList<>();
+
+        LDAPGroupProvider.collectAllMembers(ctx, "CN=g,DC=x,DC=y", "member", attrs, collected::add);
+
+        Assertions.assertEquals(List.of("CN=u1,OU=People,DC=x,DC=y", "CN=u2,OU=People,DC=x,DC=y"),
+                collected);
+        // No follow-up page request expected.
+        verify(ctx, times(0)).getAttributes(eq("CN=g,DC=x,DC=y"),
+                aryEq(new String[] {"member;range=2-*"}));
+    }
+
+    @Test
+    public void testCollectAllMembers_pagedThenTerminal() throws NamingException {
+        // Page 1: member;range=0-2 with 3 entries
+        BasicAttributes page1 = new BasicAttributes(true);
+        BasicAttribute p1Attr = new BasicAttribute("member;range=0-2");
+        p1Attr.add("CN=u1,DC=x");
+        p1Attr.add("CN=u2,DC=x");
+        p1Attr.add("CN=u3,DC=x");
+        page1.put(p1Attr);
+
+        // Page 2: member;range=3-* with 2 entries (terminal)
+        BasicAttributes page2 = new BasicAttributes(true);
+        BasicAttribute p2Attr = new BasicAttribute("member;range=3-*");
+        p2Attr.add("CN=u4,DC=x");
+        p2Attr.add("CN=u5,DC=x");
+        page2.put(p2Attr);
+
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("CN=g,DC=x"), aryEq(new String[] {"member;range=3-*"})))
+                .thenReturn(page2);
+
+        List<String> collected = new ArrayList<>();
+        LDAPGroupProvider.collectAllMembers(ctx, "CN=g,DC=x", "member", page1, collected::add);
+
+        Assertions.assertEquals(
+                List.of("CN=u1,DC=x", "CN=u2,DC=x", "CN=u3,DC=x", "CN=u4,DC=x", "CN=u5,DC=x"),
+                collected);
+        verify(ctx, times(1)).getAttributes(eq("CN=g,DC=x"),
+                aryEq(new String[] {"member;range=3-*"}));
+    }
+
+    @Test
+    public void testCollectAllMembers_threePagesAcrossNonTerminalMiddle() throws NamingException {
+        // Server-side capped: client requests "3-*" but server replies "3-5" (still non-terminal),
+        // then on the next request "6-*" replies terminal.
+        BasicAttributes page1 = new BasicAttributes(true);
+        BasicAttribute p1 = new BasicAttribute("member;range=0-2");
+        p1.add("u1"); p1.add("u2"); p1.add("u3");
+        page1.put(p1);
+
+        BasicAttributes page2 = new BasicAttributes(true);
+        BasicAttribute p2 = new BasicAttribute("member;range=3-5");
+        p2.add("u4"); p2.add("u5"); p2.add("u6");
+        page2.put(p2);
+
+        BasicAttributes page3 = new BasicAttributes(true);
+        BasicAttribute p3 = new BasicAttribute("member;range=6-*");
+        p3.add("u7");
+        page3.put(p3);
+
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("CN=g"), aryEq(new String[] {"member;range=3-*"})))
+                .thenReturn(page2);
+        when(ctx.getAttributes(eq("CN=g"), aryEq(new String[] {"member;range=6-*"})))
+                .thenReturn(page3);
+
+        List<String> collected = new ArrayList<>();
+        LDAPGroupProvider.collectAllMembers(ctx, "CN=g", "member", page1, collected::add);
+
+        Assertions.assertEquals(List.of("u1", "u2", "u3", "u4", "u5", "u6", "u7"), collected);
+    }
+
+    // ---------- safety limit ----------
+
+    @Test
+    public void testCollectAllMembers_maxRangePagesSafetyLimit() throws NamingException {
+        originalMaxRangePages = LDAPGroupProvider.MAX_RANGE_PAGES;
+        LDAPGroupProvider.MAX_RANGE_PAGES = 3;
+
+        // Page 0 (initial) is non-terminal: server keeps advertising non-terminal indefinitely.
+        BasicAttributes page0 = new BasicAttributes(true);
+        BasicAttribute p0 = new BasicAttribute("member;range=0-0");
+        p0.add("u0");
+        page0.put(p0);
+
+        // Subsequent pages: always non-terminal "member;range=N-N" with one entry.
+        BasicAttributes p1 = makePagedAttrs("member;range=1-1", "u1");
+        BasicAttributes p2 = makePagedAttrs("member;range=2-2", "u2");
+        BasicAttributes p3 = makePagedAttrs("member;range=3-3", "u3");
+        BasicAttributes p4 = makePagedAttrs("member;range=4-4", "u4");
+
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("g"), aryEq(new String[] {"member;range=1-*"}))).thenReturn(p1);
+        when(ctx.getAttributes(eq("g"), aryEq(new String[] {"member;range=2-*"}))).thenReturn(p2);
+        when(ctx.getAttributes(eq("g"), aryEq(new String[] {"member;range=3-*"}))).thenReturn(p3);
+        when(ctx.getAttributes(eq("g"), aryEq(new String[] {"member;range=4-*"}))).thenReturn(p4);
+
+        List<String> collected = new ArrayList<>();
+        LDAPGroupProvider.collectAllMembers(ctx, "g", "member", page0, collected::add);
+
+        // With MAX_RANGE_PAGES=3 we expect at most 1 (initial) + 3 (follow-ups) = 4 pages
+        // consumed (u0..u3). The 4th follow-up must not be requested.
+        Assertions.assertEquals(List.of("u0", "u1", "u2", "u3"), collected);
+        verify(ctx, times(0)).getAttributes(eq("g"), aryEq(new String[] {"member;range=4-*"}));
+    }
+
+    // ---------- error resilience ----------
+
+    @Test
+    public void testCollectAllMembers_followupNamingExceptionPreservesCollected() throws NamingException {
+        BasicAttributes page1 = new BasicAttributes(true);
+        BasicAttribute p1 = new BasicAttribute("member;range=0-1");
+        p1.add("u1"); p1.add("u2");
+        page1.put(p1);
+
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("g"), aryEq(new String[] {"member;range=2-*"})))
+                .thenThrow(new NamingException("simulated transient ldap error"));
+
+        List<String> collected = new ArrayList<>();
+        LDAPGroupProvider.collectAllMembers(ctx, "g", "member", page1, collected::add);
+
+        // Members collected before the failure must be preserved.
+        Assertions.assertEquals(List.of("u1", "u2"), collected);
+    }
+
+    @Test
+    public void testCollectAllMembers_emptyGroupDNSkipsFollowupRequest() throws NamingException {
+        BasicAttributes page1 = new BasicAttributes(true);
+        BasicAttribute p1 = new BasicAttribute("member;range=0-1");
+        p1.add("u1"); p1.add("u2");
+        page1.put(p1);
+
+        DirContext ctx = mock(DirContext.class);
+        List<String> collected = new ArrayList<>();
+
+        // groupDN empty -> we cannot request the next range page, but the initial page must
+        // still be consumed.
+        LDAPGroupProvider.collectAllMembers(ctx, "", "member", page1, collected::add);
+
+        Assertions.assertEquals(List.of("u1", "u2"), collected);
+        verify(ctx, times(0)).getAttributes(eq(""), aryEq(new String[] {"member;range=2-*"}));
+    }
+
+    @Test
+    public void testCollectAllMembers_missingMemberAttributeReturnsEmpty() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("cn", "grp"));
+
+        DirContext ctx = mock(DirContext.class);
+        List<String> collected = new ArrayList<>();
+
+        LDAPGroupProvider.collectAllMembers(ctx, "CN=g,DC=x", "member", attrs, collected::add);
+
+        Assertions.assertTrue(collected.isEmpty());
+    }
+
+    // ---------- helpers ----------
+
+    private static BasicAttributes makePagedAttrs(String attrId, String... values) {
+        BasicAttributes attrs = new BasicAttributes(true);
+        BasicAttribute attr = new BasicAttribute(attrId);
+        for (String v : values) {
+            attr.add(v);
+        }
+        attrs.put(attr);
+        return attrs;
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When the LDAP group provider talks to Active Directory and a group has more
members than the server's `MaxValRange` (commonly 1500, 2500 on tuned forests),
AD does **not** return the canonical `member` attribute. Instead it splits the
response into `member;range=0-1499`, `member;range=1500-*` and so on, encoding
the page boundaries into the attribute *name* itself (MS-ADTS section
3.1.1.3.1.3.3, "Range Retrieval of Attribute Values").

The group provider was introduced in #56670 and has matched the attribute
strictly via `attrs.get("member")` ever since. The moment AD switches to
range-encoded form the entire group looks empty to StarRocks, and every user
whose login depends on such a large group is rejected with:

```
Access denied; User <name>'s group[] is not in the group_allowed_login_list
```


This was traced on a 4.0 production deployment where one LDAP group has ~2,600
members and ~1,990 users collapsed into a silent failure path even though
their DN was present within the very first paged window. None of the existing
release notes mention range retrieval being unsupported, so users hit it only
when their group crosses the server-side limit.

## What I'm doing:

`LDAPGroupProvider` now recognizes the range-encoded variant, consumes the
initial page returned with the group entry, and iteratively requests follow-up
pages (`member;range=N-*`) on the same `DirContext` until the server returns a
terminal `-*` marker. AD edge cases - an empty echo `member` attribute, an
empty range echo, and option lists like `member;lang-en;range=0-1499` - are
all handled by preferring the range attribute that actually carries values.
A hard safety limit (`MAX_RANGE_PAGES = 100` follow-ups) prevents an unbounded
loop on a misbehaving server.

Behavior for directories that do not page (OpenLDAP, small AD groups) is
unchanged - no new configuration property is introduced.

A few robustness gaps surfaced while tracing this bug and are bundled because
they touch the same code path:

- The `DirContext` and every `NamingEnumeration` opened on it are now closed
  in `finally`, instead of being leaked on every refresh.
- The `ldap_group_dn` loop and the search-result loop now catch
  `NamingException` per group, so one misbehaving entry no longer wipes the
  entire user-to-group cache.
- The `ldap_group_filter` path explicitly sets `returningAttributes` so AD
  includes the member attribute (in range-encoded form when applicable)
  deterministically instead of relying on default attribute set heuristics.
- Group DNs are resolved with `getNameInNamespace()` and fall back to
  qualifying a relative DN with `ldap_bind_base_dn`, so follow-up
  `getAttributes()` calls always receive an absolute DN.

Related PR) https://github.com/StarRocks/starrocks/pull/56670

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: a silent-failure case (range-encoded `member` attribute on large AD groups) is now handled correctly. No existing successful login flow is altered and no user-facing configuration is added.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [v] 4.1
  - [v] 4.0
  - [ ] 3.5