### PR TITLE
[BugFix] Bump tenann to v0.5.1-beta.3

### DIFF
--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -40,15 +40,15 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux-el7-aarch64"
 JINDOSDK_MD5SUM="27a4e2cd9a403c6e21079a866287d88b"
 
 # tenann
-TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.2/tenann-v0.5.1-beta.2-nosve-arm64.tar.gz"
-TENANN_NAME="tenann-v0.5.1-beta.2-nosve-arm64.tar.gz"
-TENANN_SOURCE="tenann-v0.5.1-beta.2-nosve"
-TENANN_MD5SUM="70c12d229bec5e40bbe5f704f1a43d1f"
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.3/tenann-v0.5.1-beta.3-nosve-arm64.tar.gz"
+TENANN_NAME="tenann-v0.5.1-beta.3-nosve-arm64.tar.gz"
+TENANN_SOURCE="tenann-v0.5.1-beta.3-nosve"
+TENANN_MD5SUM="c9db2e3e34577ea5fdeca467fc13a514"
 # uncomment this for SVE version for better performance on ARM servers with SVE support
-#TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.2/tenann-v0.5.1-beta.2-arm64.tar.gz"
-#TENANN_NAME="tenann-v0.5.1-beta.2-arm64.tar.gz"
-#TENANN_SOURCE="tenann-v0.5.1-beta.2"
-#TENANN_MD5SUM="6df6bf495013407c75d7a8b4b388cd00"
+#TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.3/tenann-v0.5.1-beta.3-arm64.tar.gz"
+#TENANN_NAME="tenann-v0.5.1-beta.3-arm64.tar.gz"
+#TENANN_SOURCE="tenann-v0.5.1-beta.3"
+#TENANN_MD5SUM="2050a74ff3bfb7a526ce8093ab2bbb3f"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc1/starcache-centos7_arm64.tar.gz"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -40,10 +40,10 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux"
 JINDOSDK_MD5SUM="5436e4fe39c4dfdc942e41821f1dd8a9"
 
 # tenann
-TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.2/tenann-v0.5.1-beta.2-x86_64.tar.gz"
-TENANN_NAME="tenann-v0.5.1-beta.2-x86_64.tar.gz"
-TENANN_SOURCE="tenann-v0.5.1-beta.2"
-TENANN_MD5SUM="56755766d8c19b32517833f0f55c04d8"
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.3/tenann-v0.5.1-beta.3-x86_64.tar.gz"
+TENANN_NAME="tenann-v0.5.1-beta.3-x86_64.tar.gz"
+TENANN_SOURCE="tenann-v0.5.1-beta.3"
+TENANN_MD5SUM="a34fa3c131c204e3e76de4b9d266bd9f"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc1/starcache-centos7_amd64.tar.gz"


### PR DESCRIPTION
## Why I'm doing:

Fix BE link failure on glibc-2.17 hosts (CentOS 7 dev-env, daily-release image, etc.) due to undefined reference to `__libc_single_threaded`:

```
undefined reference to `__libc_single_threaded'
collect2: error: ld returned 1 exit status
```

Root cause: the v0.5.1-beta.2 tenann release tarballs introduced in #72398 were built in a glibc ≥ 2.32 + GCC 12+ container. GCC 12+'s libstdc++ optimizes `std::shared_ptr` refcounting with a reference to `__libc_single_threaded`, which is a glibc 2.32+ symbol. That undefined reference is baked into `libtenann-bundle*.a` (notably `InvertedLists.cpp.o`), so linking `starrocks_be` on a glibc 2.17 host fails.

StarRocks' own code is unaffected because `gcc-toolset-10` keeps a glibc-2.17 sysroot, so its libstdc++ does not introduce the symbol. The breakage is entirely inside the prebuilt tenann static lib.

## What I'm doing:

Rebuilt v0.5.1-beta.3 tenann tarballs in `starrocks/toolchains-centos7:main-20251029` (GCC 14.3.0 + glibc-2.17 sysroot) so the archives carry no `__libc_single_threaded` undefined references. Bump the pin in `thirdparty/vars-x86_64.sh` and `thirdparty/vars-aarch64.sh` (both nosve and sve variants).

Verified locally:

```
nm output/lib/libtenann-bundle*.a | grep __libc_single_threaded   # → empty
```


Fixes https://github.com/StarRocks/StarRocksTest/issues/11319

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5