### PR TITLE
[BugFix] Preserve declared VARCHAR length in CTAS

### DIFF
--- a/docs/en/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/FE_parameters/shared_lake_other.md
@@ -1424,6 +1424,6 @@ This topic introduces the following types of FE configurations:
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: Whether to prefer string type for fixed length varchar columns in materialized view creation and CTAS operations.
+- Description: Whether to prefer string type for fixed length char/varchar columns in materialized view creation.
 - Introduced in: v4.0.0
 

--- a/docs/ja/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/FE_parameters/shared_lake_other.md
@@ -1384,3 +1384,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 単位：-
 - 変更可能：Yes
 - 説明：関連するマテリアライズドビューを持つテーブルに「非ロック」最適化を StarRocks がいつ適用するかを制御します。この項目
+
+### `transform_type_prefer_string_for_varchar`
+
+- デフォルト：true
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：マテリアライズドビュー作成時、固定長の char/varchar 列に string 型を優先するかどうか。
+- 導入時期：v4.0.0

--- a/docs/zh/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/FE_parameters/shared_lake_other.md
@@ -1423,5 +1423,5 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: Boolean
 - 单位: -
 - 是否可变: Yes
-- 描述: 在物化视图创建和 CTAS 操作中，是否更倾向于为固定长度的 varchar 列使用 string 类型。
+- 描述: 在物化视图创建中，是否更倾向于为固定长度的 char/varchar 列使用 string 类型。
 - 引入版本: v4.0.0

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1712,8 +1712,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The interval of create partition batch, to avoid too frequent")
     public static long mv_create_partition_batch_interval_ms = 1000;
 
-    @ConfField(mutable = true, comment = "Whether to prefer string type for fixed length varchar column " +
-            "in materialized view creation/ctas")
+    @ConfField(mutable = true, comment = "Whether to prefer string type for fixed length char/varchar column " +
+            "in materialized view creation")
     public static boolean transform_type_prefer_string_for_varchar = true;
 
     @ConfField(mutable = true, comment = "Whether materialized view rewrite should consider underlying table data layout " +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1352,11 +1352,16 @@ public class AnalyzerUtils {
         return transformTableColumnType(srcType, true);
     }
 
+    public static Type transformTableColumnType(Type srcType, boolean convertDouble) {
+        return transformTableColumnType(srcType, convertDouble, Config.transform_type_prefer_string_for_varchar);
+    }
+
     // For char and varchar types, use the inferred length if the length can be inferred,
-    // otherwise (include null type) use the longest varchar value.
+    // otherwise (include null type) use the longest varchar value. When preferStringForVarchar
+    // is true, every fixed-length varchar/char is widened to the OLAP max varchar length instead.
     // For double and float types, since they may be selected as key columns,
     // the key column must be an exact value, so we unified into a default decimal type.
-    public static Type transformTableColumnType(Type srcType, boolean convertDouble) {
+    public static Type transformTableColumnType(Type srcType, boolean convertDouble, boolean preferStringForVarchar) {
         Type newType = srcType;
         if (srcType.isScalarType()) {
             if (PrimitiveType.VARCHAR == srcType.getPrimitiveType() ||
@@ -1365,8 +1370,8 @@ public class AnalyzerUtils {
                 int len = TypeFactory.getOlapMaxVarcharLength();
                 if (srcType instanceof ScalarType) {
                     ScalarType scalarType = (ScalarType) srcType;
-                    if (Config.transform_type_prefer_string_for_varchar) {
-                        // always use max varchar length for varchar type if transform_type_prefer_string_for_varchar is set.
+                    if (preferStringForVarchar) {
+                        // always use max varchar length for char/varchar types if preferStringForVarchar is set.
                         len = TypeFactory.getOlapMaxVarcharLength();
                     } else {
                         if (scalarType.getLength() > 0) {
@@ -1391,14 +1396,18 @@ public class AnalyzerUtils {
                 newType = TypeFactory.createType(srcType.getPrimitiveType());
             }
         } else if (srcType.isArrayType()) {
-            newType = new ArrayType(transformTableColumnType(((ArrayType) srcType).getItemType(), convertDouble));
+            newType = new ArrayType(transformTableColumnType(((ArrayType) srcType).getItemType(),
+                    convertDouble, preferStringForVarchar));
         } else if (srcType.isMapType()) {
-            newType = new MapType(transformTableColumnType(((MapType) srcType).getKeyType(), convertDouble),
-                    transformTableColumnType(((MapType) srcType).getValueType(), convertDouble));
+            newType = new MapType(transformTableColumnType(((MapType) srcType).getKeyType(),
+                    convertDouble, preferStringForVarchar),
+                    transformTableColumnType(((MapType) srcType).getValueType(),
+                            convertDouble, preferStringForVarchar));
         } else if (srcType.isStructType()) {
             StructType structType = (StructType) srcType;
             List<StructField> mappingFields = structType.getFields().stream()
-                    .map(x -> new StructField(x.getName(), transformTableColumnType(x.getType(), convertDouble),
+                    .map(x -> new StructField(x.getName(),
+                            transformTableColumnType(x.getType(), convertDouble, preferStringForVarchar),
                             x.getComment()))
                     .collect(Collectors.toList());
             newType = new StructType(mappingFields, structType.isNamed());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
@@ -98,7 +98,7 @@ public class CTASAnalyzer {
 
         for (int i = 0; i < allFields.size(); i++) {
             Type type = AnalyzerUtils.transformTableColumnType(allFields.get(i).getType(),
-                    createTableStmt.isOlapEngine());
+                    createTableStmt.isOlapEngine(), /* preferStringForVarchar */ false);
             Expr originExpression = allFields.get(i).getOriginExpression();
             ColumnDef columnDef = new ColumnDef(finalColumnNames.get(i), new TypeDef(type), false,
                     null, null, originExpression.isNullable(), ColumnDef.DefaultValueDef.NOT_SET, "");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
@@ -119,6 +119,46 @@ public class AnalyzerUtilsTest {
     }
 
     @Test
+    public void testTransformVarcharPreferStringFalseKeepsDeclaredLength() {
+        ScalarType narrow = TypeFactory.createVarcharType(64);
+        ScalarType result = (ScalarType) AnalyzerUtils.transformTableColumnType(narrow, true, false);
+        Assertions.assertEquals(64, result.getLength());
+    }
+
+    @Test
+    public void testTransformVarcharPreferStringTrueWidensToMax() {
+        ScalarType narrow = TypeFactory.createVarcharType(64);
+        ScalarType result = (ScalarType) AnalyzerUtils.transformTableColumnType(narrow, true, true);
+        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), result.getLength());
+    }
+
+    @Test
+    public void testTransformUnboundedVarcharWidensRegardlessOfPreferString() {
+        ScalarType unbounded = TypeFactory.createVarcharType(-1);
+        ScalarType keepLen = (ScalarType) AnalyzerUtils.transformTableColumnType(unbounded, true, false);
+        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), keepLen.getLength());
+        ScalarType preferStr = (ScalarType) AnalyzerUtils.transformTableColumnType(unbounded, true, true);
+        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), preferStr.getLength());
+    }
+
+    @Test
+    public void testTransformTwoArgOverloadFollowsConfigFlag() {
+        ScalarType narrow = TypeFactory.createVarcharType(64);
+        boolean saved = Config.transform_type_prefer_string_for_varchar;
+        try {
+            Config.transform_type_prefer_string_for_varchar = true;
+            ScalarType widened = (ScalarType) AnalyzerUtils.transformTableColumnType(narrow, true);
+            Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), widened.getLength());
+
+            Config.transform_type_prefer_string_for_varchar = false;
+            ScalarType preserved = (ScalarType) AnalyzerUtils.transformTableColumnType(narrow, true);
+            Assertions.assertEquals(64, preserved.getLength());
+        } finally {
+            Config.transform_type_prefer_string_for_varchar = saved;
+        }
+    }
+
+    @Test
     public void testCopyOlapTable() throws Exception {
         {
             String sql = "select count(*) from bill_detail;";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -30,10 +30,14 @@ import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RandomDistributionDesc;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.StatisticStorage;
 import com.starrocks.statistic.StatsConstants;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.StringType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -479,6 +483,44 @@ public class CTASAnalyzerTest {
             Assertions.assertFalse(col1.isNullable());
             starRocksAssert.dropTable("emps");
         }
+    }
+
+    @Test
+    public void testCTASPreservesDeclaredVarcharLength() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        boolean savedFlag = Config.transform_type_prefer_string_for_varchar;
+        try {
+            Config.transform_type_prefer_string_for_varchar = true;
+
+            String fromColumnSql = "create table test_varchar_from_column as select c1 from test;";
+            CreateTableAsSelectStmt fromColumnStmt =
+                    (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewParser(fromColumnSql, ctx);
+            List<ColumnDef> fromColumnDefs = fromColumnStmt.getCreateTableStmt().getColumnDefs();
+            Assertions.assertEquals(1, fromColumnDefs.size());
+            assertVarcharLength(fromColumnDefs.get(0).getTypeDef(), 10);
+
+            String castSql = "create table test_varchar_from_cast as select cast('abc' as varchar(64)) as c;";
+            CreateTableAsSelectStmt castStmt =
+                    (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewParser(castSql, ctx);
+            List<ColumnDef> castColumnDefs = castStmt.getCreateTableStmt().getColumnDefs();
+            Assertions.assertEquals(1, castColumnDefs.size());
+            assertVarcharLength(castColumnDefs.get(0).getTypeDef(), 64);
+
+            String stringSql = "create table test_varchar_from_string as select cast(c1 as string) as c from test;";
+            CreateTableAsSelectStmt stringStmt =
+                    (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewParser(stringSql, ctx);
+            List<ColumnDef> stringColumnDefs = stringStmt.getCreateTableStmt().getColumnDefs();
+            Assertions.assertEquals(1, stringColumnDefs.size());
+            assertVarcharLength(stringColumnDefs.get(0).getTypeDef(), StringType.DEFAULT_STRING_LENGTH);
+        } finally {
+            Config.transform_type_prefer_string_for_varchar = savedFlag;
+        }
+    }
+
+    private static void assertVarcharLength(TypeDef typeDef, int expectedLength) {
+        ScalarType scalarType = (ScalarType) typeDef.getType();
+        Assertions.assertEquals(PrimitiveType.VARCHAR, scalarType.getPrimitiveType());
+        Assertions.assertEquals(expectedLength, scalarType.getLength());
     }
 
     @Test

--- a/test/sql/test_automatic_partition/R/test_multi_expr
+++ b/test/sql/test_automatic_partition/R/test_multi_expr
@@ -403,7 +403,7 @@ show create table multi_level_expr_par_tbl_1;
 -- result:
 multi_level_expr_par_tbl_1	CREATE TABLE `multi_level_expr_par_tbl_1` (
   `c1` bigint(20) NOT NULL COMMENT "",
-  `c2` varchar(1048576) NULL COMMENT "",
+  `c2` varchar(65533) NULL COMMENT "",
   `c3` date NULL COMMENT ""
 ) ENGINE=OLAP 
 PRIMARY KEY(`c1`)
@@ -448,8 +448,8 @@ show create table multi_level_expr_par_tbl_2;
 multi_level_expr_par_tbl_2	CREATE TABLE `multi_level_expr_par_tbl_2` (
   `k1` date NOT NULL COMMENT "",
   `k2` datetime NOT NULL COMMENT "",
-  `k3` varchar(1048576) NOT NULL COMMENT "",
-  `k4` varchar(1048576) NOT NULL COMMENT "",
+  `k3` varchar(20) NOT NULL COMMENT "",
+  `k4` varchar(20) NOT NULL COMMENT "",
   `k5` boolean NOT NULL COMMENT "",
   `k6` tinyint(4) NULL COMMENT "",
   `k7` smallint(6) NULL COMMENT "",

--- a/test/sql/test_files/R/test_files_schema_insert
+++ b/test/sql/test_files/R/test_files_schema_insert
@@ -43,7 +43,7 @@ as select * from files(
 desc ctas_target;
 -- result:
 k2	bigint	YES	true	None	
-k7	varchar(1048576)	YES	true	None	
+k7	varchar(64)	YES	true	None	
 -- !result
 select count(*) from ctas_target;
 -- result:

--- a/test/sql/test_files/R/test_orc_struct
+++ b/test/sql/test_files/R/test_orc_struct
@@ -34,7 +34,7 @@ create table t1 as select col_int, col_struct, col_struct.c_date from files("pat
 desc t1;
 -- result:
 col_int	int	YES	true	None	
-col_struct	struct<`c_int` int(11), `c_float` decimal(38, 9), `c_double` decimal(38, 9), `c_char` varchar(1048576), `c_varchar` varchar(1048576), `c_date` date, `c_timestamp` datetime, `c_boolean` boolean>	YES	false	None	
+col_struct	struct<`c_int` int(11), `c_float` decimal(38, 9), `c_double` decimal(38, 9), `c_char` varchar(30), `c_varchar` varchar(200), `c_date` date, `c_timestamp` datetime, `c_boolean` boolean>	YES	false	None	
 c_date	date	YES	false	None	
 -- !result
 select count(*) from t1;


### PR DESCRIPTION
## Why I'm doing:

`VARCHAR(N)` in StarRocks is an enforced constraint: at INSERT the sink validates each value's byte length against the declared `N` (`OlapTableSink::_validate_data`, `enable_check_string_lengths=true` by default) and, under default strict mode (`enable_insert_strict=true`), fails the statement on overflow with a clear error. CTAS projections that surface an explicit user length (catalog column reference, `CAST AS VARCHAR(N)`, or a string literal) must keep that constraint in the new table's DDL.

The `transform_type_prefer_string_for_varchar` flag (default `true` since 3.5.15 / 4.0 — set in #62476 as a follow-up to #61996) currently overrides those lengths and writes `VARCHAR(1048576)` into the new table. That:

- makes the declared length constraint unenforceable for any subsequent `INSERT`,
- breaks dbt schema contracts (expected vs actual types diverge),
- misaligns `INFORMATION_SCHEMA` consumers and migration scripts that mirror types.

The flag was introduced to widen MV materialization columns so that refresh never trips on a too-narrow inferred type. That bias is fine for MVs — their schema is rarely a user contract and silent refresh failure is the larger risk. CTAS does not share that asymmetry.

The original deduction bug the flag was added for (`CASE WHEN` with one unbounded branch collapsing to narrow varchar) is already fixed surgically inside `TypeManager.getCompatibleTypeForCaseWhen` (#61996) and active regardless of this flag. Every other string-valued built-in (`concat`, `substring`, `lpad`, `replace`, `lower`, `if`, `ifnull`, `coalesce`, `nullif`, …) is declared as `'VARCHAR'` in `gensrc/script/functions.py` and materializes as `VarcharType(-1)`, which already widens to `VARCHAR(MAX)` in `transformTableColumnType` independently of the flag.

## What I'm doing:

Split the call site in `AnalyzerUtils.transformTableColumnType` so the choice can be made per-caller:

- Add a 3-arg overload `transformTableColumnType(srcType, convertDouble, preferStringForVarchar)`. The recursive Array/Map/Struct cases propagate the new parameter.
- The existing 2-arg overload keeps reading `Config.transform_type_prefer_string_for_varchar`, so MV creation, MV add-column, sync MV, IVM, and AggStateDesc paths are unchanged.
- `CTASAnalyzer` now passes `preferStringForVarchar=false` explicitly. CTAS preserves declared `VARCHAR(N)` lengths regardless of the global flag.

Added tests:

- `AnalyzerUtilsTest`: 3-arg overload preserves declared length when `preferStringForVarchar=false`; widens when `true`; unbounded varchar widens regardless; 2-arg overload still follows the config flag.
- `CTASAnalyzerTest.testCTASPreservesDeclaredVarcharLength`: with the global flag flipped on, CTAS still keeps `VARCHAR(10)` from a column reference and `VARCHAR(64)` from an explicit cast; `cast(c1 as string)` preserves `VARCHAR(65533)` (the parser-level `DEFAULT_STRING_LENGTH`).

Fixes #73374

## Behavior change to call out explicitly

The same flag was also incidentally widening `STRING` projections in CTAS. As written, this PR reverts them too. The shape of the behavior change:

| Source in a CTAS projection | Pre-3.5.15 | 3.5.15+ (flag default `true`) | This PR |
|---|---|---|---|
| `VARCHAR(N)` (catalog column / explicit cast / literal) | `VARCHAR(N)` | `VARCHAR(1048576)` | `VARCHAR(N)` |
| `CAST(x AS STRING)` (parser → `VarcharType(65533)`) | `VARCHAR(65533)` | `VARCHAR(1048576)` | `VARCHAR(65533)` |
| Catalog column declared as `STRING` (= `VARCHAR(65533)`) | `VARCHAR(65533)` | `VARCHAR(1048576)` | `VARCHAR(65533)` |

The branch-3.5 backport of the flag-flip landed on **2026-03-13** (#70229, released in 3.5.15). main / 4.0 received it on 2025-09-01 (#62476).

**Question for maintainers — what should `STRING` mean in OLAP tables produced by CTAS, 65 KB or 1 MiB?**

For consistency, `STRING` in a CTAS projection probably should resolve to whatever `CREATE TABLE t (c STRING)` resolves to. That has always been `VARCHAR(65533)` in StarRocks (`TypeParser.java:197` → `StringType.DEFAULT_STRING`). On that reading, this PR is correct as written and the 3.5.15+ widening of `STRING` to 1 MiB was an incidental regression in the column-type contract, not just for `VARCHAR(N)`.

If the answer is that CTAS `STRING` should give 1 MiB while `CREATE TABLE STRING` keeps giving 65 KB, we'll add explicit special-casing for `StringType` in `transformTableColumnType` and a separate test. Easy follow-up — we'd just like the call made deliberately rather than inheriting whatever the global flag's default happened to be.

Users who actually need a `VARCHAR(1048576)` column in either case can write `CAST(x AS VARCHAR(1048576))` explicitly.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5