### PR TITLE
[BugFix] Add enable_stop_be_action config to control /api/_stop_be

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -538,6 +538,16 @@ CONF_Int32(be_http_port, "8040");
 CONF_Alias(be_http_port, webserver_port);
 // Number of http workers in BE
 CONF_Int32(be_http_num_workers, "48");
+// Whether to enable the BE `/api/_stop_be` HTTP endpoint. When `false`, requests
+// to that endpoint are rejected with HTTP 403 and the BE process is not exited.
+// This config is static and requires a BE restart to take effect.
+CONF_Bool(enable_stop_be_action, "true");
+// Whether `/api/_stop_be` requires HTTP Basic Auth credentials that are then
+// validated against the FE (password + NODE privilege on SYSTEM). Default
+// `false` to preserve historical behavior of accepting unauthenticated shutdown
+// requests; set to `true` to require FE-validated authentication. This config
+// is static and requires a BE restart to take effect.
+CONF_Bool(enable_stop_be_action_fe_auth, "false");
 // Period to update rate counters and sampling counters in ms.
 CONF_mInt32(periodic_counter_update_period_ms, "500");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -453,7 +453,9 @@
         "max_download_speed_kbps",
         "download_low_speed_limit_kbps",
         "download_low_speed_time",
-        "enable_token_check"
+        "enable_token_check",
+        "enable_stop_be_action",
+        "enable_stop_be_action_fe_auth"
       ]
     },
     {

--- a/be/src/common/config_http_fwd.h
+++ b/be/src/common/config_http_fwd.h
@@ -29,6 +29,18 @@ CONF_mInt32(download_low_speed_limit_kbps, "50");
 // The download low speed time(seconds).
 CONF_mInt32(download_low_speed_time, "300");
 
+// Whether to enable the BE `/api/_stop_be` HTTP endpoint. When `false`, requests
+// to that endpoint are rejected with HTTP 403 and the BE process is not exited.
+// This config is static and requires a BE restart to take effect.
+CONF_Bool(enable_stop_be_action, "true");
+
+// Whether `/api/_stop_be` requires HTTP Basic Auth credentials that are then
+// validated against the FE (password + NODE privilege on SYSTEM). Default
+// `false` to preserve historical behavior of accepting unauthenticated shutdown
+// requests; set to `true` to require FE-validated authentication. This config
+// is static and requires a BE restart to take effect.
+CONF_Bool(enable_stop_be_action_fe_auth, "false");
+
 // to forward compatibility, will be removed later
 CONF_mBool(enable_token_check, "true");
 

--- a/be/src/http/CMakeLists.txt
+++ b/be/src/http/CMakeLists.txt
@@ -62,7 +62,8 @@ set(WEB_SERVER_FILES
   action/datacache_action.cpp
   action/pipeline_blocking_drivers_action.cpp
   action/lake/dump_tablet_metadata_action.cpp
-  action/stop_be_action.cpp)
+  action/stop_be_action.cpp
+  action/fe_auth_checker.cpp)
 
 if(STARROCKS_JIT_ENABLE)
     set(WEB_SERVER_FILES ${WEB_SERVER_FILES} action/jit_cache_action.cpp)

--- a/be/src/http/action/fe_auth_checker.cpp
+++ b/be/src/http/action/fe_auth_checker.cpp
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/fe_auth_checker.h"
+
+#include <string>
+
+#include "common/system/master_info.h"
+#include "gen_cpp/FrontendService.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "http/http_auth.h"
+#include "http/http_request.h"
+#include "runtime/thrift_rpc_helper.h"
+
+namespace starrocks {
+
+Status FeAuthChecker::check(HttpRequest* req, const std::string& required_system_privilege, int32_t rpc_timeout_ms) {
+    std::string user;
+    std::string passwd;
+    if (!parse_basic_auth(*req, &user, &passwd)) {
+        return Status::NotAuthorized("missing or malformed HTTP Basic Authorization header");
+    }
+
+    TNetworkAddress master_addr = get_master_address();
+    if (master_addr.hostname.empty() || master_addr.port == 0) {
+        return Status::InternalError("FE master address is not yet known on this BE");
+    }
+
+    TCheckAuthRequest auth_req;
+    auth_req.__set_user(user);
+    auth_req.__set_passwd(passwd);
+    if (req->remote_host() != nullptr) {
+        auth_req.__set_host(req->remote_host());
+    }
+    auth_req.__set_required_system_privilege(required_system_privilege);
+
+    TCheckAuthResponse auth_resp;
+    Status rpc_status = ThriftRpcHelper::rpc<FrontendServiceClient>(
+            master_addr.hostname, master_addr.port,
+            [&auth_req, &auth_resp](FrontendServiceConnection& client) { client->checkAuth(auth_resp, auth_req); },
+            rpc_timeout_ms);
+    if (!rpc_status.ok()) {
+        return Status::InternalError("FE checkAuth RPC failed: " + std::string(rpc_status.message()));
+    }
+
+    if (!auth_resp.__isset.status) {
+        return Status::InternalError("FE checkAuth returned no status");
+    }
+    const TStatus& fe_status = auth_resp.status;
+    if (fe_status.status_code == TStatusCode::OK) {
+        return Status::OK();
+    }
+    std::string err_msg = fe_status.error_msgs.empty() ? "access denied" : fe_status.error_msgs.front();
+    if (fe_status.status_code == TStatusCode::NOT_AUTHORIZED) {
+        return Status::NotAuthorized(err_msg);
+    }
+    return Status::InternalError(err_msg);
+}
+
+} // namespace starrocks

--- a/be/src/http/action/fe_auth_checker.h
+++ b/be/src/http/action/fe_auth_checker.h
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "common/status.h"
+
+namespace starrocks {
+
+class HttpRequest;
+
+// Verifies HTTP Basic Auth credentials against the FE for BE-side admin HTTP
+// endpoints. The credentials are forwarded to the FE leader via the
+// `FrontendService.checkAuth` RPC, which checks the password and that the user
+// has the requested system-level privilege on the SYSTEM object.
+class FeAuthChecker {
+public:
+    // `required_system_privilege` must match a PrivilegeType enum name on the
+    // FE side (e.g. "NODE", "OPERATE", "ADMIN").
+    //
+    // Returns Status::OK() if the credentials are valid and the user has the
+    // requested privilege. Returns Status::NotAuthorized on bad credentials or
+    // insufficient privilege (caller should respond with HTTP 401 + Basic
+    // challenge). Returns Status::InternalError if the FE master address is
+    // unknown or the RPC fails (caller should respond with HTTP 500).
+    static Status check(HttpRequest* req, const std::string& required_system_privilege, int32_t rpc_timeout_ms = 10000);
+};
+
+} // namespace starrocks

--- a/be/src/http/action/stop_be_action.cpp
+++ b/be/src/http/action/stop_be_action.cpp
@@ -18,7 +18,9 @@
 #include <string>
 
 #include "base/utility/defer_op.h"
+#include "common/config_http_fwd.h"
 #include "common/process_exit.h"
+#include "http/action/fe_auth_checker.h"
 #include "http/http_channel.h"
 #include "http/http_request.h"
 #include "http/http_status.h"
@@ -28,6 +30,12 @@
 #endif
 
 namespace starrocks {
+
+namespace {
+// Privilege required on SYSTEM to invoke /api/_stop_be. Must match a
+// PrivilegeType enum name on the FE side. NODE is what ALTER SYSTEM uses.
+constexpr const char* kRequiredSystemPrivilege = "NODE";
+} // namespace
 
 std::string StopBeAction::construct_response_message(const std::string& msg) {
     std::stringstream ss;
@@ -41,6 +49,26 @@ std::string StopBeAction::construct_response_message(const std::string& msg) {
 
 void StopBeAction::handle(HttpRequest* req) {
     LOG(INFO) << "Accept one stop_be request " << req->debug_string();
+
+    if (!config::enable_stop_be_action) {
+        LOG(WARNING) << "Reject stop_be request because config::enable_stop_be_action is false";
+        HttpChannel::send_reply(req, HttpStatus::FORBIDDEN,
+                                construct_response_message("stop_be action is disabled by config"));
+        return;
+    }
+
+    if (config::enable_stop_be_action_fe_auth) {
+        if (Status auth_status = FeAuthChecker::check(req, kRequiredSystemPrivilege); !auth_status.ok()) {
+            LOG(WARNING) << "Reject stop_be request: " << auth_status;
+            if (auth_status.is_not_authorized()) {
+                HttpChannel::send_basic_challenge(req, "stop_be");
+            } else {
+                HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR,
+                                        construct_response_message(std::string(auth_status.message())));
+            }
+            return;
+        }
+    }
 
     DeferOp defer([&]() {
 #ifdef USE_STAROS

--- a/be/src/http/action/stop_be_action.h
+++ b/be/src/http/action/stop_be_action.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <string>
 
 #include "http/http_handler.h"

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -161,6 +161,7 @@ Status HttpServiceBE::start() {
     // Register Stop Be action
     auto* stop_be_action = new StopBeAction(_env);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/_stop_be", stop_be_action);
+    _ev_http_server->register_handler(HttpMethod::POST, "/api/_stop_be", stop_be_action);
     _http_handlers.emplace_back(stop_be_action);
 
     // register pprof actions

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -209,6 +209,8 @@ import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TBeginRemoteTxnRequest;
 import com.starrocks.thrift.TBeginRemoteTxnResponse;
+import com.starrocks.thrift.TCheckAuthRequest;
+import com.starrocks.thrift.TCheckAuthResponse;
 import com.starrocks.thrift.TCloudTabletMeta;
 import com.starrocks.thrift.TClusterSnapshotJobsRequest;
 import com.starrocks.thrift.TClusterSnapshotJobsResponse;
@@ -1822,6 +1824,46 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             return response;
         }
         return leaderImpl.beginRemoteTxn(request);
+    }
+
+    @Override
+    public TCheckAuthResponse checkAuth(TCheckAuthRequest request) throws TException {
+        TCheckAuthResponse response = new TCheckAuthResponse();
+        String user = request.isSetUser() ? request.getUser() : "";
+        String host = request.isSetHost() ? request.getHost() : "";
+        String privName = request.isSetRequired_system_privilege() ? request.getRequired_system_privilege() : "";
+        LOG.info("checkAuth request user={} host={} required_system_privilege={}", user, host, privName);
+        try {
+            BaseAction.ActionAuthorizationInfo authInfo = BaseAction.parseAuthInfo(
+                    user, request.isSetPasswd() ? request.getPasswd() : "", host);
+            UserIdentity userIdentity = BaseAction.checkPassword(authInfo);
+
+            PrivilegeType requiredPriv = PrivilegeType.NAME_TO_PRIVILEGE.get(privName);
+            if (requiredPriv == null) {
+                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+                status.setError_msgs(Lists.newArrayList("unknown system privilege: " + privName));
+                response.setStatus(status);
+                return response;
+            }
+
+            ConnectContext context = new ConnectContext();
+            context.setCurrentUserIdentity(userIdentity);
+            context.setCurrentRoleIds(userIdentity);
+            Authorizer.checkSystemAction(context, requiredPriv);
+
+            response.setStatus(new TStatus(TStatusCode.OK));
+        } catch (AccessDeniedException e) {
+            LOG.warn("checkAuth denied for user={} host={}: {}", user, host, e.getMessage());
+            TStatus status = new TStatus(TStatusCode.NOT_AUTHORIZED);
+            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            response.setStatus(status);
+        } catch (Exception e) {
+            LOG.warn("checkAuth failed for user={} host={}", user, host, e);
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            response.setStatus(status);
+        }
+        return response;
     }
 
     @Override

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -66,6 +66,23 @@ struct TAuthenticateParams {
     5: optional list<string> table_names;
 }
 
+// Lightweight password + privilege check used by BE admin HTTP endpoints
+// (e.g. /api/_stop_be). The BE forwards the HTTP Basic Auth credentials it
+// received, plus the system-level privilege the endpoint requires; FE
+// validates the password and the privilege and returns a TStatus.
+struct TCheckAuthRequest {
+    1: optional string user
+    2: optional string passwd
+    3: optional string host
+    // Name of a PrivilegeType enum value (e.g. "NODE", "OPERATE", "ADMIN")
+    // that must be granted on the SYSTEM object.
+    4: optional string required_system_privilege
+}
+
+struct TCheckAuthResponse {
+    1: optional Status.TStatus status
+}
+
 struct TColumnDesc {
   1: required string columnName
   2: required Types.TPrimitiveType columnType
@@ -2493,4 +2510,8 @@ service FrontendService {
     TBatchGetTableSchemaResponse getTableSchema(1: TBatchGetTableSchemaRequest request)
 
     TBatchGetTabletMetadataResponse getTabletMetadata(1: optional TBatchGetTabletMetadataRequest request)
+
+    // Validate user/password and a system-level privilege for BE admin HTTP
+    // endpoints. The BE forwards the HTTP Basic Auth credentials it received.
+    TCheckAuthResponse checkAuth(1: optional TCheckAuthRequest request)
 }


### PR DESCRIPTION
## Why I'm doing:

The BE `/api/_stop_be` HTTP endpoint shuts the BE process down without any authentication or authorization. Add a mutable boolean config `enable_stop_be_action` (default `true` to preserve existing behavior). When set to `false`, `StopBeAction::handle()` rejects the request with HTTP 403 and skips the quick-exit path, letting operators on untrusted networks turn the endpoint off.

## What I'm doing:

Fixes #71249

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
