### PR TITLE
[Enhancement] Propagate stats for `DictMappingOperator`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -105,26 +105,48 @@ public class ExpressionStatisticCalculator {
 
         @Override
         public ColumnStatistic visitDictMappingOperator(DictMappingOperator operator, Void context) {
-            final var stringProvideOperator = operator.getStringProvideOperator();
-            final ScalarOperator sourceOperator;
-            if (stringProvideOperator != null) {
-                sourceOperator = stringProvideOperator;
-            } else {
-                sourceOperator = operator.getOriginScalaOperator();
-            }
-
-            if (!hasAllColumnStatisticsFor(sourceOperator)) {
-                // Return unknown stats in case we don't have the non-dict stats anymore.
+            if (inputStatistics == null) {
                 return ColumnStatistic.unknown();
             }
 
-            final var sourceStatistic = sourceOperator.accept(this, context);
-            if (sourceStatistic.isUnknown() || operator.getType().matchesType(sourceOperator.getType())) {
-                return sourceStatistic;
+            final var stringProvideOperator = operator.getStringProvideOperator();
+            final var originOperator = operator.getOriginScalaOperator();
+            final ColumnStatistic statistic;
+            if (stringProvideOperator != null) {
+                if (!hasAllColumnStatisticsFor(stringProvideOperator, inputStatistics)) {
+                    // Return unknown stats in case we don't have the non-dict stats anymore.
+                    return ColumnStatistic.unknown();
+                }
+
+                final var providerColumnStatistic = stringProvideOperator.accept(this, context);
+                if (providerColumnStatistic.isUnknown()) {
+                    return ColumnStatistic.unknown();
+                }
+
+                // Rewrite the input stats to contain the provider stats on the dict column to evaluate the origin operator
+                // based on the provider stats.
+                final var providerStatistics = Statistics.buildFrom(inputStatistics) //
+                        .addColumnStatistic(operator.getDictColumn(), providerColumnStatistic) //
+                        .build();
+
+                if (!hasAllColumnStatisticsFor(originOperator, providerStatistics)) {
+                    return ColumnStatistic.unknown();
+                }
+                statistic = originOperator.accept(copyWithNewStats(providerStatistics), context);
+            } else {
+                if (!hasAllColumnStatisticsFor(originOperator, inputStatistics)) {
+                    // Return unknown stats in case we don't have the non-dict stats anymore.
+                    return ColumnStatistic.unknown();
+                }
+                statistic = originOperator.accept(this, context);
+            }
+
+            if (statistic.isUnknown() || operator.getType().matchesType(originOperator.getType())) {
+                return statistic;
             }
 
             // If the dict type does not match the materialized type, we have to drop type-specific stats.
-            return ColumnStatistic.buildFrom(sourceStatistic)
+            return ColumnStatistic.buildFrom(statistic)
                     .setMinString(null) //
                     .setMaxString(null) //
                     .setMinValue(Double.NEGATIVE_INFINITY) //
@@ -134,15 +156,21 @@ public class ExpressionStatisticCalculator {
                     .build();
         }
 
-        private boolean hasAllColumnStatisticsFor(ScalarOperator operator) {
+        private boolean hasAllColumnStatisticsFor(ScalarOperator operator, Statistics statistics) {
             final var columns = operator.getColumnRefs();
             if (columns.isEmpty()) {
                 return true;
             }
-            if (inputStatistics == null) {
+            if (statistics == null) {
                 return false;
             }
-            return columns.stream().allMatch(inputStatistics.getColumnStatistics()::containsKey);
+            return columns.stream().allMatch(statistics.getColumnStatistics()::containsKey);
+        }
+
+        private ExpressionStatisticVisitor copyWithNewStats(Statistics statistics) {
+            final var copy = new ExpressionStatisticVisitor(statistics, this.rowCount);
+            copy.mappedStats.putAll(this.mappedStats);
+            return copy;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -100,6 +101,48 @@ public class ExpressionStatisticCalculator {
         @Override
         public ColumnStatistic visitLambdaFunctionOperator(LambdaFunctionOperator operator, Void context) {
             return operator.getChild(0).accept(this, context);
+        }
+
+        @Override
+        public ColumnStatistic visitDictMappingOperator(DictMappingOperator operator, Void context) {
+            final var stringProvideOperator = operator.getStringProvideOperator();
+            final ScalarOperator sourceOperator;
+            if (stringProvideOperator != null) {
+                sourceOperator = stringProvideOperator;
+            } else {
+                sourceOperator = operator.getOriginScalaOperator();
+            }
+
+            if (!hasAllColumnStatisticsFor(sourceOperator)) {
+                // Return unknown stats in case we don't have the non-dict stats anymore.
+                return ColumnStatistic.unknown();
+            }
+
+            final var sourceStatistic = sourceOperator.accept(this, context);
+            if (sourceStatistic.isUnknown() || operator.getType().matchesType(sourceOperator.getType())) {
+                return sourceStatistic;
+            }
+
+            // If the dict type does not match the materialized type, we have to drop type-specific stats.
+            return ColumnStatistic.buildFrom(sourceStatistic)
+                    .setMinString(null) //
+                    .setMaxString(null) //
+                    .setMinValue(Double.NEGATIVE_INFINITY) //
+                    .setMaxValue(Double.POSITIVE_INFINITY) //
+                    .setAverageRowSize(operator.getType().getTypeSize()) //
+                    .setHistogram(null) //
+                    .build();
+        }
+
+        private boolean hasAllColumnStatisticsFor(ScalarOperator operator) {
+            final var columns = operator.getColumnRefs();
+            if (columns.isEmpty()) {
+                return true;
+            }
+            if (inputStatistics == null) {
+                return false;
+            }
+            return columns.stream().allMatch(inputStatistics.getColumnStatistics()::containsKey);
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -28,6 +28,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.type.ArrayType;
@@ -1783,4 +1784,158 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertEquals(50L, mcv.get("2024-02-01"));
     }
 
+    @Test
+    public void testDictMappingPropagatesStats() {
+        // GIVEN
+        final var originCol = new ColumnRefOperator(0, Type.INT, "origin", true);
+        final var dictCol = new ColumnRefOperator(1, Type.INT, "dict", true);
+        final var stringProviderCol = new ColumnRefOperator(2, Type.INT, "provider", true);
+
+        final var originStats = ColumnStatistic.builder()
+                .setMinValue(10)
+                .setMaxValue(20)
+                .setDistinctValuesCount(5)
+                .setNullsFraction(0.3)
+                .setAverageRowSize(4)
+                .build();
+        final var dictStats = ColumnStatistic.builder()
+                .setMinValue(100)
+                .setMaxValue(200)
+                .setDistinctValuesCount(50)
+                .setNullsFraction(0.0)
+                .setAverageRowSize(8)
+                .build();
+        final var providerStats = ColumnStatistic.builder()
+                .setMinValue(-10)
+                .setMaxValue(-1)
+                .setDistinctValuesCount(7)
+                .setNullsFraction(0.1)
+                .setAverageRowSize(4)
+                .build();
+
+        final var statistics = Statistics.builder()
+                .setOutputRowCount(100)
+                .addColumnStatistic(originCol, originStats)
+                .addColumnStatistic(dictCol, dictStats)
+                .addColumnStatistic(stringProviderCol, providerStats)
+                .build();
+
+        final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, Type.INT);
+        final var providerBackedDictMapping = new DictMappingOperator(Type.INT, dictCol, originCol, stringProviderCol);
+
+        // WHEN
+        final var originBackedStats = ExpressionStatisticCalculator.calculate(originBackedDictMapping, statistics);
+        final var providerBackedStats = ExpressionStatisticCalculator.calculate(providerBackedDictMapping, statistics);
+
+        // THEN
+        Assertions.assertFalse(originBackedStats.isUnknown());
+        Assertions.assertEquals(originStats.getMinValue(), originBackedStats.getMinValue(), 0.001);
+        Assertions.assertEquals(originStats.getMaxValue(), originBackedStats.getMaxValue(), 0.001);
+        Assertions.assertEquals(originStats.getDistinctValuesCount(), originBackedStats.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(originStats.getNullsFraction(), originBackedStats.getNullsFraction(), 0.001);
+        Assertions.assertEquals(originStats.getAverageRowSize(), originBackedStats.getAverageRowSize(), 0.001);
+        Assertions.assertNotEquals(dictStats.getMinValue(), originBackedStats.getMinValue(), 0.001);
+
+        Assertions.assertFalse(providerBackedStats.isUnknown());
+        Assertions.assertEquals(providerStats.getMinValue(), providerBackedStats.getMinValue(), 0.001);
+        Assertions.assertEquals(providerStats.getMaxValue(), providerBackedStats.getMaxValue(), 0.001);
+        Assertions.assertEquals(providerStats.getDistinctValuesCount(), providerBackedStats.getDistinctValuesCount(),
+                0.001);
+        Assertions.assertEquals(providerStats.getNullsFraction(), providerBackedStats.getNullsFraction(), 0.001);
+        Assertions.assertEquals(providerStats.getAverageRowSize(), providerBackedStats.getAverageRowSize(), 0.001);
+        Assertions.assertNotEquals(originStats.getMinValue(), providerBackedStats.getMinValue(), 0.001);
+    }
+
+    @Test
+    public void testDictMappingResetsRepresentationSpecificStatsOnTypeMismatch() {
+        // GIVEN
+        final var originCol = new ColumnRefOperator(0, VarcharType.VARCHAR, "origin", true);
+        final var dictCol = new ColumnRefOperator(1, IntegerType.INT, "dict", true);
+        final var stringProviderCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "provider", true);
+
+        final var originStats = ColumnStatistic.builder()
+                .setMinValue(Double.NEGATIVE_INFINITY)
+                .setMaxValue(Double.POSITIVE_INFINITY)
+                .setDistinctValuesCount(5)
+                .setNullsFraction(0.3)
+                .setAverageRowSize(24)
+                .setMinString("origin_min")
+                .setMaxString("origin_max")
+                .setHistogram(new Histogram(List.of(), Collections.singletonMap("origin", 42L)))
+                .build();
+        final var providerStats = ColumnStatistic.builder()
+                .setMinValue(Double.NEGATIVE_INFINITY)
+                .setMaxValue(Double.POSITIVE_INFINITY)
+                .setDistinctValuesCount(7)
+                .setNullsFraction(0.1)
+                .setAverageRowSize(32)
+                .setMinString("provider_min")
+                .setMaxString("provider_max")
+                .setHistogram(new Histogram(List.of(), Collections.singletonMap("provider", 33L)))
+                .build();
+
+        final var statistics = Statistics.builder()
+                .setOutputRowCount(100)
+                .addColumnStatistic(originCol, originStats)
+                .addColumnStatistic(dictCol, ColumnStatistic.builder().setMinValue(1).setMaxValue(99)
+                        .setDistinctValuesCount(99).setNullsFraction(0).setAverageRowSize(4).build())
+                .addColumnStatistic(stringProviderCol, providerStats)
+                .build();
+
+        final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, Type.INT);
+        final var providerBackedDictMapping =
+                new DictMappingOperator(IntegerType.INT, dictCol, originCol, stringProviderCol);
+
+        // WHEN
+        final var originBackedStats = ExpressionStatisticCalculator.calculate(originBackedDictMapping, statistics);
+        final var providerBackedStats = ExpressionStatisticCalculator.calculate(providerBackedDictMapping, statistics);
+
+        // THEN
+        Assertions.assertFalse(originBackedStats.isUnknown());
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY, originBackedStats.getMinValue(), 0.001);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, originBackedStats.getMaxValue(), 0.001);
+        Assertions.assertEquals(originStats.getDistinctValuesCount(), originBackedStats.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(originStats.getNullsFraction(), originBackedStats.getNullsFraction(), 0.001);
+        Assertions.assertEquals(Type.INT.getTypeSize(), originBackedStats.getAverageRowSize(), 0.001);
+        Assertions.assertNull(originBackedStats.getMinString());
+        Assertions.assertNull(originBackedStats.getMaxString());
+        Assertions.assertNull(originBackedStats.getHistogram());
+
+        Assertions.assertFalse(providerBackedStats.isUnknown());
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY, providerBackedStats.getMinValue(), 0.001);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, providerBackedStats.getMaxValue(), 0.001);
+        Assertions.assertEquals(providerStats.getDistinctValuesCount(), providerBackedStats.getDistinctValuesCount(),
+                0.001);
+        Assertions.assertEquals(providerStats.getNullsFraction(), providerBackedStats.getNullsFraction(), 0.001);
+        Assertions.assertEquals(IntegerType.INT.getTypeSize(), providerBackedStats.getAverageRowSize(), 0.001);
+        Assertions.assertNull(providerBackedStats.getMinString());
+        Assertions.assertNull(providerBackedStats.getMaxString());
+        Assertions.assertNull(providerBackedStats.getHistogram());
+    }
+
+    @Test
+    public void testDictMappingReturnsUnknownWhenSourceStatsAreUnavailable() {
+        // GIVEN
+        final var originCol = new ColumnRefOperator(0, VarcharType.VARCHAR, "origin", true);
+        final var dictCol = new ColumnRefOperator(1, IntegerType.INT, "dict", true);
+
+        final var statistics = Statistics.builder()
+                .setOutputRowCount(100)
+                .addColumnStatistic(dictCol, ColumnStatistic.builder()
+                        .setMinValue(1)
+                        .setMaxValue(10)
+                        .setDistinctValuesCount(10)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(4)
+                        .build())
+                .build();
+
+        final var dictMapping = new DictMappingOperator(dictCol, originCol, Type.VARCHAR);
+
+        // WHEN
+        final var dictMappingStats = ExpressionStatisticCalculator.calculate(dictMapping, statistics);
+
+        // THEN
+        Assertions.assertTrue(dictMappingStats.isUnknown());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -1787,9 +1787,9 @@ public class ExpressionStatisticsCalculatorTest {
     @Test
     public void testDictMappingPropagatesStats() {
         // GIVEN
-        final var originCol = new ColumnRefOperator(0, Type.INT, "origin", true);
-        final var dictCol = new ColumnRefOperator(1, Type.INT, "dict", true);
-        final var stringProviderCol = new ColumnRefOperator(2, Type.INT, "provider", true);
+        final var originCol = new ColumnRefOperator(0, IntegerType.INT, "origin", true);
+        final var dictCol = new ColumnRefOperator(1, IntegerType.INT, "dict", true);
+        final var stringProviderCol = new ColumnRefOperator(2, IntegerType.INT, "provider", true);
 
         final var originStats = ColumnStatistic.builder()
                 .setMinValue(10)
@@ -1820,8 +1820,8 @@ public class ExpressionStatisticsCalculatorTest {
                 .addColumnStatistic(stringProviderCol, providerStats)
                 .build();
 
-        final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, Type.INT);
-        final var providerBackedDictMapping = new DictMappingOperator(Type.INT, dictCol, originCol, stringProviderCol);
+        final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, IntegerType.INT);
+        final var providerBackedDictMapping = new DictMappingOperator(IntegerType.INT, dictCol, originCol, stringProviderCol);
 
         // WHEN
         final var originBackedStats = ExpressionStatisticCalculator.calculate(originBackedDictMapping, statistics);
@@ -1882,7 +1882,7 @@ public class ExpressionStatisticsCalculatorTest {
                 .addColumnStatistic(stringProviderCol, providerStats)
                 .build();
 
-        final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, Type.INT);
+        final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, IntegerType.INT);
         final var providerBackedDictMapping =
                 new DictMappingOperator(IntegerType.INT, dictCol, originCol, stringProviderCol);
 
@@ -1896,7 +1896,7 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertEquals(Double.POSITIVE_INFINITY, originBackedStats.getMaxValue(), 0.001);
         Assertions.assertEquals(originStats.getDistinctValuesCount(), originBackedStats.getDistinctValuesCount(), 0.001);
         Assertions.assertEquals(originStats.getNullsFraction(), originBackedStats.getNullsFraction(), 0.001);
-        Assertions.assertEquals(Type.INT.getTypeSize(), originBackedStats.getAverageRowSize(), 0.001);
+        Assertions.assertEquals(IntegerType.INT.getTypeSize(), originBackedStats.getAverageRowSize(), 0.001);
         Assertions.assertNull(originBackedStats.getMinString());
         Assertions.assertNull(originBackedStats.getMaxString());
         Assertions.assertNull(originBackedStats.getHistogram());
@@ -1930,7 +1930,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .build())
                 .build();
 
-        final var dictMapping = new DictMappingOperator(dictCol, originCol, Type.VARCHAR);
+        final var dictMapping = new DictMappingOperator(dictCol, originCol, VarcharType.VARCHAR);
 
         // WHEN
         final var dictMappingStats = ExpressionStatisticCalculator.calculate(dictMapping, statistics);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -1200,6 +1200,40 @@ public class ExpressionStatisticsCalculatorTest {
     }
 
     @Test
+    public void testDictMappingInsideArrayMapKeepsLambdaStats() {
+        // GIVEN
+        final var arrayCol = new ColumnRefOperator(1, Type.ARRAY_INT, "arr", true);
+        final var lambdaArg = new ColumnRefOperator(10, Type.INT, "x", true, true);
+        final var dictCol = new ColumnRefOperator(20, Type.INT, "dict", true);
+
+        final var originExpr = new CallOperator(FunctionSet.ABS, Type.INT, Lists.newArrayList(lambdaArg));
+        final var dictMapping = new DictMappingOperator(Type.INT, dictCol, originExpr, ConstantOperator.createInt(0));
+        final var lambda = new LambdaFunctionOperator(List.of(lambdaArg), dictMapping, Type.INT);
+
+        final var stats = Statistics.builder()
+                .setOutputRowCount(10_000)
+                .addColumnStatistic(arrayCol, ColumnStatistic.builder()
+                        .setMinValue(-10)
+                        .setMaxValue(-1)
+                        .setNullsFraction(0.1)
+                        .setAverageRowSize(16)
+                        .setDistinctValuesCount(7)
+                        .setCollectionSize(5)
+                        .build())
+                .build();
+
+        final var arrayMap = new CallOperator(FunctionSet.ARRAY_MAP, Type.ARRAY_INT,
+                Lists.newArrayList(lambda, arrayCol));
+
+        // WHEN
+        final var exprStats = ExpressionStatisticCalculator.calculate(arrayMap, stats);
+
+        // THEN
+        Assertions.assertFalse(exprStats.isUnknown());
+        Assertions.assertEquals(10, exprStats.getDistinctValuesCount(), 0.001);
+    }
+
+    @Test
     public void testArrayMapWithIndependentLambda() {
         // GIVEN
         final var arrayCol = new ColumnRefOperator(1, ArrayType.ARRAY_INT, "arr", true);
@@ -1789,6 +1823,7 @@ public class ExpressionStatisticsCalculatorTest {
         // GIVEN
         final var originCol = new ColumnRefOperator(0, IntegerType.INT, "origin", true);
         final var dictCol = new ColumnRefOperator(1, IntegerType.INT, "dict", true);
+        final var dictValueCol = new ColumnRefOperator(dictCol.getId(), IntegerType.INT, dictCol.getName(), true);
         final var stringProviderCol = new ColumnRefOperator(2, IntegerType.INT, "provider", true);
 
         final var originStats = ColumnStatistic.builder()
@@ -1820,8 +1855,9 @@ public class ExpressionStatisticsCalculatorTest {
                 .addColumnStatistic(stringProviderCol, providerStats)
                 .build();
 
-        final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, IntegerType.INT);
-        final var providerBackedDictMapping = new DictMappingOperator(IntegerType.INT, dictCol, originCol, stringProviderCol);
+        final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, Type.INT);
+        final var providerBackedDictMapping = new DictMappingOperator(IntegerType.INT, dictCol,
+                new CallOperator(FunctionSet.ABS, IntegerType.INT, Lists.newArrayList(dictValueCol)), stringProviderCol);
 
         // WHEN
         final var originBackedStats = ExpressionStatisticCalculator.calculate(originBackedDictMapping, statistics);
@@ -1837,10 +1873,9 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertNotEquals(dictStats.getMinValue(), originBackedStats.getMinValue(), 0.001);
 
         Assertions.assertFalse(providerBackedStats.isUnknown());
-        Assertions.assertEquals(providerStats.getMinValue(), providerBackedStats.getMinValue(), 0.001);
-        Assertions.assertEquals(providerStats.getMaxValue(), providerBackedStats.getMaxValue(), 0.001);
-        Assertions.assertEquals(providerStats.getDistinctValuesCount(), providerBackedStats.getDistinctValuesCount(),
-                0.001);
+        Assertions.assertEquals(1, providerBackedStats.getMinValue(), 0.001);
+        Assertions.assertEquals(10, providerBackedStats.getMaxValue(), 0.001);
+        Assertions.assertEquals(10, providerBackedStats.getDistinctValuesCount(), 0.001);
         Assertions.assertEquals(providerStats.getNullsFraction(), providerBackedStats.getNullsFraction(), 0.001);
         Assertions.assertEquals(providerStats.getAverageRowSize(), providerBackedStats.getAverageRowSize(), 0.001);
         Assertions.assertNotEquals(originStats.getMinValue(), providerBackedStats.getMinValue(), 0.001);
@@ -1851,6 +1886,7 @@ public class ExpressionStatisticsCalculatorTest {
         // GIVEN
         final var originCol = new ColumnRefOperator(0, VarcharType.VARCHAR, "origin", true);
         final var dictCol = new ColumnRefOperator(1, IntegerType.INT, "dict", true);
+        final var dictValueCol = new ColumnRefOperator(dictCol.getId(), VarcharType.VARCHAR, dictCol.getName(), true);
         final var stringProviderCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "provider", true);
 
         final var originStats = ColumnStatistic.builder()
@@ -1884,7 +1920,7 @@ public class ExpressionStatisticsCalculatorTest {
 
         final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, IntegerType.INT);
         final var providerBackedDictMapping =
-                new DictMappingOperator(IntegerType.INT, dictCol, originCol, stringProviderCol);
+                new DictMappingOperator(IntegerType.INT, dictCol, dictValueCol, stringProviderCol);
 
         // WHEN
         final var originBackedStats = ExpressionStatisticCalculator.calculate(originBackedDictMapping, statistics);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -1202,13 +1202,13 @@ public class ExpressionStatisticsCalculatorTest {
     @Test
     public void testDictMappingInsideArrayMapKeepsLambdaStats() {
         // GIVEN
-        final var arrayCol = new ColumnRefOperator(1, Type.ARRAY_INT, "arr", true);
-        final var lambdaArg = new ColumnRefOperator(10, Type.INT, "x", true, true);
-        final var dictCol = new ColumnRefOperator(20, Type.INT, "dict", true);
+        final var arrayCol = new ColumnRefOperator(1, ArrayType.ARRAY_INT, "arr", true);
+        final var lambdaArg = new ColumnRefOperator(10, IntegerType.INT, "x", true, true);
+        final var dictCol = new ColumnRefOperator(20, IntegerType.INT, "dict", true);
 
-        final var originExpr = new CallOperator(FunctionSet.ABS, Type.INT, Lists.newArrayList(lambdaArg));
-        final var dictMapping = new DictMappingOperator(Type.INT, dictCol, originExpr, ConstantOperator.createInt(0));
-        final var lambda = new LambdaFunctionOperator(List.of(lambdaArg), dictMapping, Type.INT);
+        final var originExpr = new CallOperator(FunctionSet.ABS, IntegerType.INT, Lists.newArrayList(lambdaArg));
+        final var dictMapping = new DictMappingOperator(IntegerType.INT, dictCol, originExpr, ConstantOperator.createInt(0));
+        final var lambda = new LambdaFunctionOperator(List.of(lambdaArg), dictMapping, IntegerType.INT);
 
         final var stats = Statistics.builder()
                 .setOutputRowCount(10_000)
@@ -1222,7 +1222,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .build())
                 .build();
 
-        final var arrayMap = new CallOperator(FunctionSet.ARRAY_MAP, Type.ARRAY_INT,
+        final var arrayMap = new CallOperator(FunctionSet.ARRAY_MAP, ArrayType.ARRAY_INT,
                 Lists.newArrayList(lambda, arrayCol));
 
         // WHEN
@@ -1855,7 +1855,7 @@ public class ExpressionStatisticsCalculatorTest {
                 .addColumnStatistic(stringProviderCol, providerStats)
                 .build();
 
-        final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, Type.INT);
+        final var originBackedDictMapping = new DictMappingOperator(dictCol, originCol, IntegerType.INT);
         final var providerBackedDictMapping = new DictMappingOperator(IntegerType.INT, dictCol,
                 new CallOperator(FunctionSet.ABS, IntegerType.INT, Lists.newArrayList(dictValueCol)), stringProviderCol);
 


### PR DESCRIPTION
## Why I'm doing:
Currently, `DictMappingOperator` does not propagate any stats. 

## What I'm doing:
Implementing stats propagation for the `DictMappingOperator`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
