### PR TITLE
[BugFix] Atomically publish proc profile tar.gz to avoid partial-read race

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
@@ -28,6 +28,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -138,20 +141,38 @@ public class ProcProfileCollector extends FrontendDaemon {
 
     private void compressFile(String fileName) throws IOException {
         File sourceFile = new File(profileLogDir + "/" + fileName);
-        try (FileOutputStream fileOutputStream = new FileOutputStream(profileLogDir + "/" + fileName + ".tar.gz");
-                GzipCompressorOutputStream gzipOutputStream = new GzipCompressorOutputStream(fileOutputStream);
-                TarArchiveOutputStream tarArchive = new TarArchiveOutputStream(gzipOutputStream);
-                FileInputStream fileInputStream = new FileInputStream(sourceFile)) {
-            TarArchiveEntry tarEntry = new TarArchiveEntry(sourceFile, sourceFile.getName());
-            tarArchive.putArchiveEntry(tarEntry);
+        File targetFile = new File(profileLogDir + "/" + fileName + ".tar.gz");
+        // Write to a temporary file first and atomically rename it to the final name on success,
+        // so consumers (e.g. /proc_profile listing/download endpoints) never observe a
+        // partially-written .tar.gz file.
+        File tmpFile = new File(profileLogDir + "/" + fileName + ".tar.gz.tmp");
+        try {
+            try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+                    GzipCompressorOutputStream gzipOutputStream = new GzipCompressorOutputStream(fileOutputStream);
+                    TarArchiveOutputStream tarArchive = new TarArchiveOutputStream(gzipOutputStream);
+                    FileInputStream fileInputStream = new FileInputStream(sourceFile)) {
+                TarArchiveEntry tarEntry = new TarArchiveEntry(sourceFile, sourceFile.getName());
+                tarArchive.putArchiveEntry(tarEntry);
 
-            byte[] buffer = new byte[1024];
-            int len;
-            while ((len = fileInputStream.read(buffer)) > 0) {
-                tarArchive.write(buffer, 0, len);
+                byte[] buffer = new byte[1024];
+                int len;
+                while ((len = fileInputStream.read(buffer)) > 0) {
+                    tarArchive.write(buffer, 0, len);
+                }
+                tarArchive.closeArchiveEntry();
+                tarArchive.finish();
             }
-            tarArchive.closeArchiveEntry();
-            tarArchive.finish();
+
+            try {
+                Files.move(tmpFile.toPath(), targetFile.toPath(),
+                        StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(tmpFile.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            if (tmpFile.exists()) {
+                tmpFile.delete();
+            }
         }
 
         sourceFile.delete();


### PR DESCRIPTION
## Why I'm doing:


ProcProfileCollector.compressFile wrote the gzip+tar stream directly into the final cpu-profile-*.html.tar.gz path. While compression was in progress, the partially-written file was visible to both the listing endpoint (/proc_profile) and the download endpoint (/proc_profile/file), which would then fail to parse the incomplete gzip/tar and return an empty 500 response. This caused intermittent failures in test_proc_profile_multi_node where the test scrapes the newest file from the listing and then downloads it.

Write to a sibling .tar.gz.tmp file first and atomically rename it to the final name on success, so consumers never observe a partial file.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
