### PR TITLE
[Enhancement] Move tablet-reshard StarOS shard creation out of factory

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -58,11 +58,11 @@ import java.util.Set;
  *
  * <p>Leader-state is gated at the manager level: {@code TabletReshardJobMgr} is only started
  * inside {@code GlobalStateMgr.startLeaderOnlyDaemonThreads}, so the checker never runs on a
- * brand-new follower. For the demoted-leader edge case, the per-RPC
- * {@link GlobalStateMgr#isLeaderWorkAdmissionOpen() admission} check inside
- * {@link SplitTabletJobFactory#forColocateAlignment} (and inside {@link
- * ColocateTableIndex#markAllGroupsWithSameColocateGroupIdStable}'s journal write) is the
- * safety net.
+ * brand-new follower. For the demoted-leader edge case, the alignment job's StarOS shard
+ * creation is journal-first (runs in {@link SplitTabletJob#runPendingJob} after the job is
+ * persisted), and the journal write inside {@link
+ * ColocateTableIndex#markAllGroupsWithSameColocateGroupIdStable} is admission-gated — these
+ * together prevent shard-leak on demotion.
  *
  * <h3>What a cycle does</h3>
  * Iterates every unstable range-colocate {@code colocateGroupId}; for each peer {@link
@@ -236,16 +236,9 @@ public class ColocateChecker {
             return alignedSoFar;
         }
 
-        // Re-validate leader admission immediately before the side-effecting factory call:
-        // forColocateAlignment creates StarOS shards BEFORE addTabletReshardJob writes the
-        // admission-guarded journal record. If demotion started since the cycle began,
-        // proceeding would leak external shards.
-        if (!GlobalStateMgr.getCurrentState().isLeaderWorkAdmissionOpen()) {
-            LOG.info("leader admission closed before submitting alignment job for {}.{}, "
-                            + "deferring to next cycle", db.getFullName(), table.getName());
-            return false;
-        }
-
+        // The factory now only builds local state and journals the job; the StarOS shard
+        // creation runs in SplitTabletJob.runPendingJob (after the journal write), so a
+        // leader demotion at this point cannot leak external shards.
         TabletReshardJob job = SplitTabletJobFactory.forColocateAlignment(db, table, alignmentMap);
         GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().addTabletReshardJob(job);
         LOG.info("submitted SplitTabletJob {} for table {}.{} covering {} partitions",

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -29,8 +29,10 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
 import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.metric.MetricRepo;
@@ -38,6 +40,7 @@ import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletReshardJobsItem;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -46,6 +49,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -111,10 +115,11 @@ public class MergeTabletJob extends TabletReshardJob {
     /*
      * 1. Set table state to TABLET_RESHARD
      * 2. Begin transaction (allocate transaction id)
-     * 3. Commit transaction (update next version)
-     * 4. Add new tablets to inverted index
-     * 5. Register resharding tablets
-     * 6. Set job state to PREPARING
+     * 3. Create new shards on StarOS
+     * 4. Commit transaction (update next version)
+     * 5. Add new tablets to inverted index
+     * 6. Register resharding tablets
+     * 7. Set job state to PREPARING
      * Job cannot be cancelled after this step
      */
     @Override
@@ -127,18 +132,26 @@ public class MergeTabletJob extends TabletReshardJob {
         transactionId = globalStateMgr.getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
         gtid = globalStateMgr.getGtidGenerator().nextGtid();
 
-        // 3. Commit transaction (update next version)
+        // 3. Create new shards on StarOS — the last "abortable" step before the no-abort
+        //    boundary below. No table lock needed: setTableState above already moved the
+        //    table to TABLET_RESHARD, which blocks concurrent DDL. If this throws, run()
+        //    catches, abort() fires (state still PENDING), runAbortingJob unwinds the
+        //    FE-side mutations, and any orphan staros shards from a partial RPC are reaped
+        //    by StarMgrMetaSyncer's diff-and-purge cycle.
+        createShardsOnStarOS();
+
+        // 4. Commit transaction (update next version)
         // NOTE: After updateNextVersions(), the table's next version is advanced.
         // From this point the job must not abort or throw, because the run() wrapper would attempt to abort.
         updateNextVersions();
 
-        // 4. Add new tablets to inverted index
+        // 5. Add new tablets to inverted index
         addTabletsToInvertedIndex();
 
-        // 5. Register resharding tablets
+        // 6. Register resharding tablets
         registerReshardingTablets();
 
-        // 6. Set job state to PREPARING
+        // 7. Set job state to PREPARING
         setJobState(JobState.PREPARING);
     }
 
@@ -148,7 +161,6 @@ public class MergeTabletJob extends TabletReshardJob {
      */
     @Override
     protected void runPreparingJob() {
-        // 1. Wait for previous versions published
         try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.READ)) {
             OlapTable olapTable = lockedTable.get();
             for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
@@ -157,8 +169,6 @@ public class MergeTabletJob extends TabletReshardJob {
                 if (physicalPartition == null) {
                     continue;
                 }
-
-                // Wait for previous versions published
                 long commitVersion = reshardingPhysicalPartition.getCommitVersion();
                 long visibleVersion = physicalPartition.getVisibleVersion();
                 if (commitVersion != visibleVersion + 1) {
@@ -170,7 +180,6 @@ public class MergeTabletJob extends TabletReshardJob {
             }
         }
 
-        // 2. Set job state to RUNNING
         setJobState(JobState.RUNNING);
     }
 
@@ -323,6 +332,8 @@ public class MergeTabletJob extends TabletReshardJob {
             removeTabletsFromInvertedIndex();
 
             // 3. Set table state to NORMAL
+            //    Any orphan staros shards from a partial createShardsOnStarOS in
+            //    runPendingJob are reaped by StarMgrMetaSyncer's diff-and-purge cycle.
             setTableState(null, OlapTable.OlapTableState.NORMAL);
         } catch (Exception e) {
             LOG.warn("Ignore exception when aborting tablet reshard job. {}. ", this, e);
@@ -614,16 +625,17 @@ public class MergeTabletJob extends TabletReshardJob {
     }
 
     private LockedObject<OlapTable> getLockedTable(LockType lockType) {
+        return new LockedObject<>(dbId, List.of(tableId), lockType, getOlapTable());
+    }
+
+    private OlapTable getOlapTable() {
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, tableId);
         if (table == null) { // Table is dropped
             errorMessage = "Table not found";
             setJobState(JobState.ABORTING);
             throw new TabletReshardException("Table not found. " + this);
         }
-
-        OlapTable olapTable = (OlapTable) table;
-
-        return new LockedObject<>(dbId, List.of(tableId), lockType, olapTable);
+        return (OlapTable) table;
     }
 
     private void registerReshardingTablets() {
@@ -653,6 +665,54 @@ public class MergeTabletJob extends TabletReshardJob {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Create StarOS shards for this merge job.
+     *
+     * <p>Called from {@link #runPendingJob} as the last "abortable" step, immediately
+     * before {@code updateNextVersions} (the no-abort boundary). A failure surfaces as
+     * a {@link TabletReshardException} that {@code run()} catches and abort()s on;
+     * {@link #runAbortingJob} unwinds the FE-side mutations and any orphan staros
+     * shards from a partial RPC are reaped by {@code StarMgrMetaSyncer}'s
+     * diff-and-purge cycle.
+     */
+    void createShardsOnStarOS() {
+        OlapTable table = getOlapTable();
+        try {
+            for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
+                long physicalPartitionId = reshardingPhysicalPartition.getPhysicalPartitionId();
+                for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
+                        .getReshardingIndexes().values()) {
+                    MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
+                    // LinkedHashMap so the CreateShardInfo list within each (partition, index)
+                    // RPC payload follows the ReshardingTablet iteration order; the same batch
+                    // produced by a leader-switch re-run emits a byte-equivalent payload.
+                    Map<Long, List<Long>> newToOldTabletIds = new LinkedHashMap<>();
+                    for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
+                        List<Long> oldTabletIds = reshardingTablet.getOldTabletIds();
+                        for (long newTabletId : reshardingTablet.getNewTabletIds()) {
+                            newToOldTabletIds.put(newTabletId, oldTabletIds);
+                        }
+                    }
+
+                    Map<String, String> properties = new HashMap<>();
+                    properties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(table.getId()));
+                    properties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
+                    properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
+
+                    GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForMerge(
+                            newToOldTabletIds,
+                            table.getPartitionFilePathInfo(physicalPartitionId),
+                            table.getPartitionFileCacheInfo(physicalPartitionId),
+                            newIndex.getShardGroupId(),
+                            properties, WarehouseManager.DEFAULT_RESOURCE);
+                }
+            }
+        } catch (StarRocksException e) {
+            throw new TabletReshardException(
+                    "Failed to create new shards on StarOS: " + e.getMessage(), e);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJobFactory.java
@@ -30,7 +30,6 @@ import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.MergeTabletClause;
 import com.starrocks.sql.ast.TabletGroupList;
 
@@ -77,8 +76,6 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
             throw new StarRocksException("No tablets need to merge in table "
                     + db.getFullName() + '.' + table.getName());
         }
-
-        createNewShards(reshardingPhysicalPartitions);
 
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         return new MergeTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
@@ -396,36 +393,6 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
         }
 
         return newIndex;
-    }
-
-    private void createNewShards(Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions)
-            throws StarRocksException {
-        for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
-            long physicalPartitionId = reshardingPhysicalPartition.getPhysicalPartitionId();
-            for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
-                    .getReshardingIndexes().values()) {
-                MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
-                Map<Long, List<Long>> newToOldTabletIds = new HashMap<>();
-                for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
-                    List<Long> oldTabletIds = reshardingTablet.getOldTabletIds();
-                    for (long newTabletId : reshardingTablet.getNewTabletIds()) {
-                        newToOldTabletIds.put(newTabletId, oldTabletIds);
-                    }
-                }
-
-                Map<String, String> properties = new HashMap<>();
-                properties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(table.getId()));
-                properties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
-                properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
-
-                GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForMerge(
-                        newToOldTabletIds,
-                        table.getPartitionFilePathInfo(physicalPartitionId),
-                        table.getPartitionFileCacheInfo(physicalPartitionId),
-                        newIndex.getShardGroupId(),
-                        properties, WarehouseManager.DEFAULT_RESOURCE);
-            }
-        }
     }
 
     private static MergingTablet createMergingTablet(List<Long> oldTabletIds) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -38,8 +38,10 @@ import com.starrocks.catalog.Tuple;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Range;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
 import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.metric.MetricRepo;
@@ -47,6 +49,7 @@ import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletReshardJobsItem;
@@ -56,6 +59,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -123,10 +127,11 @@ public class SplitTabletJob extends TabletReshardJob {
     /*
      * 1. Set table state to TABLET_RESHARD
      * 2. Begin transaction (allocate transaction id)
-     * 3. Commit transaction (update next version)
-     * 4. Add new tablets to inverted index
-     * 5. Register resharding tablets
-     * 6. Set job state to PREPARING
+     * 3. Create new shards on StarOS
+     * 4. Commit transaction (update next version)
+     * 5. Add new tablets to inverted index
+     * 6. Register resharding tablets
+     * 7. Set job state to PREPARING
      * Job cannot be cancelled after this step
      */
     @Override
@@ -139,18 +144,26 @@ public class SplitTabletJob extends TabletReshardJob {
         transactionId = globalStateMgr.getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
         gtid = globalStateMgr.getGtidGenerator().nextGtid();
 
-        // 3. Commit transaction (update next version)
+        // 3. Create new shards on StarOS — the last "abortable" step before the no-abort
+        //    boundary below. No table lock needed: setTableState above already moved the
+        //    table to TABLET_RESHARD, which blocks concurrent DDL. If this throws, run()
+        //    catches, abort() fires (state still PENDING), runAbortingJob unwinds the
+        //    FE-side mutations, and any orphan staros shards from a partial RPC are reaped
+        //    by StarMgrMetaSyncer's diff-and-purge cycle.
+        createShardsOnStarOS();
+
+        // 4. Commit transaction (update next version)
         // NOTE: After updateNextVersions(), the table's next version is advanced.
         // From this point the job must not abort or throw, because the run() wrapper would attempt to abort.
         updateNextVersions();
 
-        // 4. Add new tablets to inverted index
+        // 5. Add new tablets to inverted index
         addTabletsToInvertedIndex();
 
-        // 5. Register resharding tablets
+        // 6. Register resharding tablets
         registerReshardingTablets();
 
-        // 6. Set job state to PREPARING
+        // 7. Set job state to PREPARING
         setJobState(JobState.PREPARING);
     }
 
@@ -160,7 +173,6 @@ public class SplitTabletJob extends TabletReshardJob {
      */
     @Override
     protected void runPreparingJob() {
-        // 1. Wait for previous versions published
         try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.READ)) {
             OlapTable olapTable = lockedTable.get();
             for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
@@ -169,8 +181,6 @@ public class SplitTabletJob extends TabletReshardJob {
                 if (physicalPartition == null) {
                     continue;
                 }
-
-                // Wait for previous versions published
                 long commitVersion = reshardingPhysicalPartition.getCommitVersion();
                 long visibleVersion = physicalPartition.getVisibleVersion();
                 if (commitVersion != visibleVersion + 1) {
@@ -182,7 +192,6 @@ public class SplitTabletJob extends TabletReshardJob {
             }
         }
 
-        // 2. Set job state to RUNNING
         setJobState(JobState.RUNNING);
     }
 
@@ -345,6 +354,9 @@ public class SplitTabletJob extends TabletReshardJob {
      * 3. Set table state to NORMAL
      * 4. Update metrics
      * 5. Set job state to ABORTED
+     *
+     * Any orphan staros shards from a partial createShardsOnStarOS in runPendingJob are
+     * reaped by StarMgrMetaSyncer's diff-and-purge cycle; no explicit deleteShards here.
      */
     @Override
     protected void runAbortingJob() {
@@ -751,16 +763,17 @@ public class SplitTabletJob extends TabletReshardJob {
     }
 
     private LockedObject<OlapTable> getLockedTable(LockType lockType) {
+        return new LockedObject<>(dbId, List.of(tableId), lockType, getOlapTable());
+    }
+
+    private OlapTable getOlapTable() {
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, tableId);
         if (table == null) { // Table is dropped
             errorMessage = "Table not found";
             setJobState(JobState.ABORTING);
             throw new TabletReshardException("Table not found. " + this);
         }
-
-        OlapTable olapTable = (OlapTable) table;
-
-        return new LockedObject<>(dbId, List.of(tableId), lockType, olapTable);
+        return (OlapTable) table;
     }
 
     private void registerReshardingTablets() {
@@ -791,5 +804,138 @@ public class SplitTabletJob extends TabletReshardJob {
                 }
             }
         }
+    }
+
+    /**
+     * Create StarOS shards for this split job.
+     *
+     * <p>Called from {@link #runPendingJob} as the last "abortable" step, immediately
+     * before {@code updateNextVersions} (the no-abort boundary). A failure surfaces as
+     * a {@link TabletReshardException} that {@code run()} catches and abort()s on;
+     * {@link #runAbortingJob} unwinds the FE-side mutations and any orphan staros
+     * shards from a partial RPC are reaped by {@code StarMgrMetaSyncer}'s
+     * diff-and-purge cycle.
+     */
+    void createShardsOnStarOS() {
+        OlapTable table = getOlapTable();
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateTableIndex.GroupId rangeColocateGroupId =
+                colocateTableIndex.getRangeColocateGroupId(table.getId());
+        // Snapshot colocate ranges once: the createShard RPCs in the inner loop only ever
+        // read the same grpId, and the ranges list is stable for the duration of this DDL.
+        List<ColocateRange> colocateRanges = rangeColocateGroupId == null ? null
+                : colocateTableIndex.getColocateRangeMgr().getColocateRanges(rangeColocateGroupId.grpId);
+        int colocateColumnCount = rangeColocateGroupId == null ? 0
+                : colocateTableIndex.getGroupSchema(rangeColocateGroupId).getColocateColumnCount();
+
+        try {
+            for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
+                PhysicalPartition physicalPartition =
+                        table.getPhysicalPartition(reshardingPhysicalPartition.getPhysicalPartitionId());
+                if (physicalPartition == null) {
+                    continue;
+                }
+                for (ReshardingMaterializedIndex reshardingIndex :
+                        reshardingPhysicalPartition.getReshardingIndexes().values()) {
+                    createShardsForOneIndex(table, physicalPartition, reshardingIndex,
+                            colocateRanges, colocateColumnCount);
+                }
+            }
+        } catch (StarRocksException e) {
+            throw new TabletReshardException(
+                    "Failed to create new shards on StarOS: " + e.getMessage(), e);
+        }
+    }
+
+    private void createShardsForOneIndex(OlapTable table,
+                                         PhysicalPartition physicalPartition,
+                                         ReshardingMaterializedIndex reshardingIndex,
+                                         List<ColocateRange> colocateRanges,
+                                         int colocateColumnCount) throws StarRocksException {
+        MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
+        MaterializedIndex oldIndex = physicalPartition.getIndex(reshardingIndex.getMaterializedIndexId());
+        if (colocateRanges != null) {
+            // Range-colocate invariant (P1): the old MaterializedIndex must exist so we can
+            // derive each tablet's TabletRange for the PACK lookup.
+            Preconditions.checkState(oldIndex != null,
+                    "Missing old MaterializedIndex for range-colocate split");
+        }
+
+        // LinkedHashMap so the CreateShardInfo list within each (partition, index) RPC
+        // payload follows the ReshardingTablet iteration order; the same batch produced
+        // by a leader-switch re-run emits a byte-equivalent payload.
+        Map<Long, Long> newToOldShardId = new LinkedHashMap<>();
+        Map<Long, List<Long>> newShardIdToGroupIds = new LinkedHashMap<>();
+        for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
+            addShardPlacementsForTablet(reshardingTablet, oldIndex, newIndex,
+                    colocateRanges, colocateColumnCount,
+                    newToOldShardId, newShardIdToGroupIds);
+        }
+        if (newToOldShardId.isEmpty()) {
+            return;
+        }
+
+        long physicalPartitionId = physicalPartition.getId();
+        Map<String, String> shardProperties = new HashMap<>();
+        shardProperties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(table.getId()));
+        shardProperties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
+        shardProperties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
+
+        GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForSplit(
+                newToOldShardId,
+                newShardIdToGroupIds,
+                table.getPartitionFilePathInfo(physicalPartitionId),
+                table.getPartitionFileCacheInfo(physicalPartitionId),
+                shardProperties, WarehouseManager.DEFAULT_RESOURCE);
+    }
+
+    private static void addShardPlacementsForTablet(ReshardingTablet reshardingTablet,
+                                                    MaterializedIndex oldIndex,
+                                                    MaterializedIndex newIndex,
+                                                    List<ColocateRange> colocateRanges,
+                                                    int colocateColumnCount,
+                                                    Map<Long, Long> newToOldShardId,
+                                                    Map<Long, List<Long>> newShardIdToGroupIds) {
+        long oldTabletId = reshardingTablet.getFirstOldTabletId();
+        List<Long> newTabletIds = reshardingTablet.getNewTabletIds();
+        SplittingTablet splittingTablet = reshardingTablet.getSplittingTablet();
+        List<TabletRange> perNewTabletRanges = splittingTablet != null
+                ? splittingTablet.getNewTabletRanges()
+                : List.of();
+
+        Tablet oldTablet = null;
+        if (colocateRanges != null) {
+            oldTablet = oldIndex.getTablet(oldTabletId);
+            // Range-colocate invariant (P1): every tablet of a range-colocate table has a
+            // TabletRange. Fail fast rather than fall back to prefix=null, which would
+            // silently route new shards into the first ColocateRange's PACK group — wrong
+            // once the group has multiple ranges.
+            Preconditions.checkState(oldTablet != null && oldTablet.getRange() != null,
+                    "Old tablet %s in range-colocate group has no TabletRange", oldTabletId);
+        }
+
+        for (int i = 0; i < newTabletIds.size(); i++) {
+            long newTabletId = newTabletIds.get(i);
+            List<Long> groupIds = new ArrayList<>(2);
+            groupIds.add(newIndex.getShardGroupId()); // SPREAD group is unchanged
+            if (colocateRanges != null) {
+                Range<Tuple> rangeForPackLookup = i < perNewTabletRanges.size()
+                        ? perNewTabletRanges.get(i).getRange()
+                        : oldTablet.getRange().getRange();
+                groupIds.add(lookupPackGroupId(colocateRanges, colocateColumnCount,
+                        rangeForPackLookup, newTabletId));
+            }
+            newToOldShardId.put(newTabletId, oldTabletId);
+            newShardIdToGroupIds.put(newTabletId, groupIds);
+        }
+    }
+
+    private static long lookupPackGroupId(List<ColocateRange> colocateRanges, int colocateColumnCount,
+                                          Range<Tuple> range, long newTabletId) {
+        Tuple prefix = ColocateRangeUtils.extractColocatePrefix(range, colocateColumnCount);
+        int colocateRangeIndex = ColocateRangeMgr.indexOf(colocateRanges, prefix);
+        Preconditions.checkState(colocateRangeIndex >= 0,
+                "Tablet %s has no covering ColocateRange for prefix %s", newTabletId, prefix);
+        return colocateRanges.get(colocateRangeIndex).getShardGroupId();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -32,13 +32,11 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.common.Config;
-import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.SplitTabletClause;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -98,8 +96,6 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
             throw new StarRocksException("No tablets need to split in table "
                     + db.getFullName() + '.' + table.getName());
         }
-
-        createNewShards(table, reshardingPhysicalPartitions);
 
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
@@ -211,10 +207,54 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                     new ReshardingPhysicalPartition(physicalPartition.getId(), reshardingIndexes));
         }
 
-        createNewShards(table, reshardingPhysicalPartitions);
+        // Surface bad caller-supplied ranges synchronously, before the job is journaled
+        // and mutates table state. SplitTabletJob.runPendingJob would otherwise hit a
+        // Preconditions failure in createShardsOnStarOS, abort the job, and force the
+        // operator to fish the error out of SHOW TABLET RESHARD JOBS instead of seeing
+        // it on the DDL statement itself.
+        verifyNewTabletRanges(table, reshardingPhysicalPartitions);
 
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
+    }
+
+    /**
+     * For range-colocate tables, verify every FE-supplied new-tablet range has a covering
+     * {@link ColocateRange} so the PACK lookup in {@link SplitTabletJob#createShardsOnStarOS}
+     * will succeed. No-op when the table is not range-colocate or when no per-new-tablet
+     * ranges were supplied (user-facing path).
+     */
+    private static void verifyNewTabletRanges(OlapTable table,
+            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) throws StarRocksException {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateTableIndex.GroupId groupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
+        if (groupId == null) {
+            return;
+        }
+        List<ColocateRange> colocateRanges = colocateTableIndex.getColocateRangeMgr().getColocateRanges(groupId.grpId);
+        int colocateColumnCount = colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
+        for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
+            for (ReshardingMaterializedIndex reshardingIndex
+                    : reshardingPhysicalPartition.getReshardingIndexes().values()) {
+                for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
+                    SplittingTablet splittingTablet = reshardingTablet.getSplittingTablet();
+                    if (splittingTablet == null) {
+                        continue;
+                    }
+                    for (TabletRange newTabletRange : splittingTablet.getNewTabletRanges()) {
+                        Tuple prefix = ColocateRangeUtils.extractColocatePrefix(
+                                newTabletRange.getRange(), colocateColumnCount);
+                        if (ColocateRangeMgr.indexOf(colocateRanges, prefix) < 0) {
+                            throw new StarRocksException(
+                                    "Tablet " + reshardingTablet.getFirstOldTabletId()
+                                            + " split: new tablet range has no covering ColocateRange"
+                                            + " for colocate prefix " + prefix
+                                            + " in range-colocate group " + groupId.grpId);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /*
@@ -422,69 +462,6 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         return newIndex;
     }
 
-    private static void createNewShards(OlapTable table,
-            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) throws StarRocksException {
-        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
-        ColocateTableIndex.GroupId groupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
-        // Snapshot colocate ranges once: createShards inside the loop only reads the same
-        // grpId, and the ranges list is stable for the duration of this DDL (the unstable
-        // guard above blocks concurrent splits).
-        List<ColocateRange> colocateRanges = groupId == null ? null
-                : colocateTableIndex.getColocateRangeMgr().getColocateRanges(groupId.grpId);
-        int colocateColumnCount = groupId == null ? 0
-                : colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
-
-        for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
-            long physicalPartitionId = reshardingPhysicalPartition.getPhysicalPartitionId();
-            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
-            for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
-                    .getReshardingIndexes().values()) {
-                MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
-                MaterializedIndex oldIndex = physicalPartition == null
-                        ? null
-                        : physicalPartition.getIndex(reshardingIndex.getMaterializedIndexId());
-                Map<Long, List<Long>> oldToNewTabletIds = new HashMap<>();
-                Map<Long, List<Long>> oldShardIdToGroupIds = new HashMap<>();
-                for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
-                    long oldTabletId = reshardingTablet.getFirstOldTabletId();
-                    oldToNewTabletIds.put(oldTabletId, reshardingTablet.getNewTabletIds());
-                    List<Long> groupIds = new ArrayList<>(2);
-                    groupIds.add(newIndex.getShardGroupId()); // SPREAD group is unchanged
-                    if (colocateRanges != null) {
-                        // Range-colocate invariant (P1): every tablet of a range-colocate table
-                        // has a TabletRange. Fail fast rather than fall back to prefix=null,
-                        // which would silently route new shards into the first ColocateRange's
-                        // PACK group — wrong once the group has multiple ranges.
-                        Preconditions.checkState(oldIndex != null,
-                                "Missing old MaterializedIndex for range-colocate split");
-                        Tablet oldTablet = oldIndex.getTablet(oldTabletId);
-                        Preconditions.checkState(oldTablet != null && oldTablet.getRange() != null,
-                                "Old tablet %s in range-colocate group has no TabletRange", oldTabletId);
-                        Tuple prefix = ColocateRangeUtils.extractColocatePrefix(
-                                oldTablet.getRange().getRange(), colocateColumnCount);
-                        int idx = ColocateRangeMgr.indexOf(colocateRanges, prefix);
-                        Preconditions.checkState(idx >= 0,
-                                "Old tablet %s has no covering ColocateRange", oldTabletId);
-                        groupIds.add(colocateRanges.get(idx).getShardGroupId());
-                    }
-                    oldShardIdToGroupIds.put(oldTabletId, groupIds);
-                }
-
-                Map<String, String> properties = new HashMap<>();
-                properties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(table.getId()));
-                properties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
-                properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
-
-                GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForSplit(
-                        oldShardIdToGroupIds,
-                        oldToNewTabletIds,
-                        table.getPartitionFilePathInfo(physicalPartitionId),
-                        table.getPartitionFileCacheInfo(physicalPartitionId),
-                        properties, WarehouseManager.DEFAULT_RESOURCE);
-            }
-        }
-    }
-
     private static SplittingTablet createSplittingTablet(long oldTabletId, int newTabletCount) {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         List<Long> newTabletIds = new ArrayList<>(newTabletCount);
@@ -515,20 +492,18 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
      * Checker-only entry for {@link ColocateChecker}. Builds one
      * {@link SplitTabletJob} covering every misaligned (partition, visible index, tablet)
      * tuple in {@code alignmentMap}, using FE-supplied per-new-tablet ranges so the BE
-     * dispatches to the external boundaries external-boundaries path on publish.
+     * dispatches to the external-boundaries path on publish.
      *
      * <p>Differs from the user-facing {@link #createTabletReshardJob} and the load-time
-     * external boundaries {@link #forExternalBoundaries} entries in two ways:
-     * <ul>
-     * <li><b>Unstable-guard bypass.</b> The checker IS the unstable-state resolver — if it
-     *     refused to act on unstable groups, the group would stay unstable forever.</li>
-     * <li><b>Per-new-tablet PACK assignment.</b> Each child of an alignment split lands in
-     *     a different {@link ColocateRange} (that's the whole point of the alignment), so
-     *     its PACK shard group differs from its siblings'. Uses the per-new-shard StarOS
-     *     overload {@link com.starrocks.lake.StarOSAgent#createShardsForSplitPerNewShard}
-     *     instead of the per-old-shard {@code createShardsForSplit} that the user-facing
-     *     and load-time paths use.</li>
-     * </ul>
+     * {@link #forExternalBoundaries} entries in one essential way: the
+     * <b>unstable-guard is bypassed</b>. The checker IS the unstable-state resolver — if it
+     * refused to act on unstable groups, the group would stay unstable forever.
+     *
+     * <p>Per-new-tablet PACK assignment is no longer a property of this entry. The unified
+     * {@link SplitTabletJob#createShardsOnStarOS} method derives each new shard's PACK
+     * group from its own FE-supplied range when one exists, falling back to the parent
+     * old tablet's range otherwise; alignment is the case where per-new-tablet PACK groups
+     * actually diverge from a per-parent lookup.
      *
      * @param alignmentMap {@code physicalPartitionId → indexId → oldTabletId → ranges that
      *                     tile the old tablet's range exactly}. Caller ensures every range
@@ -600,114 +575,8 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                     + db.getFullName() + '.' + table.getName());
         }
 
-        createNewShardsForColocateAlignment(table, reshardingPhysicalPartitions);
-
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
     }
 
-    /**
-     * Alignment-path variant of {@link #createNewShards}: each new tablet's PACK shard
-     * group is derived from the lower bound of its assigned range (looked up in
-     * {@link ColocateRangeMgr}) — sibling children of the same old tablet can land in
-     * different PACK groups when the alignment split crosses a colocate boundary.
-     *
-     * <p>Identical tablets inherit the old tablet's PACK group via the same prefix lookup,
-     * matching how user-driven splits keep identical tablets in their existing groups.
-     */
-    private static void createNewShardsForColocateAlignment(OlapTable table,
-            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) throws StarRocksException {
-        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
-        ColocateTableIndex.GroupId groupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
-        Preconditions.checkState(groupId != null,
-                "alignment split called for non-range-colocate table %s", table.getName());
-        List<ColocateRange> colocateRanges =
-                colocateTableIndex.getColocateRangeMgr().getColocateRanges(groupId.grpId);
-        int colocateColumnCount = colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
-
-        for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
-            long physicalPartitionId = reshardingPhysicalPartition.getPhysicalPartitionId();
-            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
-            if (physicalPartition == null) {
-                continue;
-            }
-            for (ReshardingMaterializedIndex reshardingIndex :
-                    reshardingPhysicalPartition.getReshardingIndexes().values()) {
-                MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
-                MaterializedIndex oldIndex = physicalPartition.getIndex(reshardingIndex.getMaterializedIndexId());
-                if (oldIndex == null) {
-                    continue;
-                }
-                Map<Long, Long> newToOldShardId = new HashMap<>();
-                Map<Long, List<Long>> newShardIdToGroupIds = new HashMap<>();
-                for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
-                    long firstOldTabletId = reshardingTablet.getFirstOldTabletId();
-                    Tablet oldTablet = oldIndex.getTablet(firstOldTabletId);
-                    Preconditions.checkState(oldTablet != null && oldTablet.getRange() != null,
-                            "old tablet %s missing range during alignment", firstOldTabletId);
-                    SplittingTablet splittingTablet = reshardingTablet.getSplittingTablet();
-                    if (splittingTablet == null) {
-                        // IdenticalTablet — single new shard, inherits old tablet's PACK group.
-                        long newTabletId = reshardingTablet.getFirstNewTabletId();
-                        List<Long> groupIds = findPlacementGroupIdsForRange(
-                                colocateRanges, newIndex.getShardGroupId(),
-                                oldTablet.getRange().getRange(), colocateColumnCount);
-                        newToOldShardId.put(newTabletId, firstOldTabletId);
-                        newShardIdToGroupIds.put(newTabletId, groupIds);
-                        continue;
-                    }
-                    List<TabletRange> newRanges = splittingTablet.getNewTabletRanges();
-                    List<Long> newTabletIds = splittingTablet.getNewTabletIds();
-                    Preconditions.checkState(!newRanges.isEmpty()
-                                    && newRanges.size() == newTabletIds.size(),
-                            "alignment splitting tablet %s has %s ranges but %s ids",
-                            firstOldTabletId, newRanges.size(), newTabletIds.size());
-                    for (int i = 0; i < newTabletIds.size(); i++) {
-                        long newTabletId = newTabletIds.get(i);
-                        List<Long> groupIds = findPlacementGroupIdsForRange(
-                                colocateRanges, newIndex.getShardGroupId(),
-                                newRanges.get(i).getRange(), colocateColumnCount);
-                        newToOldShardId.put(newTabletId, firstOldTabletId);
-                        newShardIdToGroupIds.put(newTabletId, groupIds);
-                    }
-                }
-                if (newToOldShardId.isEmpty()) {
-                    continue;
-                }
-                // Defense-in-depth: re-validate leader admission immediately before each StarOS
-                // RPC. The checker already gated at submit time, but the loop spans many
-                // partitions / indexes and demotion can fire mid-iteration.
-                if (!GlobalStateMgr.getCurrentState().isLeaderWorkAdmissionOpen()) {
-                    throw new StarRocksException(
-                            "leader work admission closed mid-alignment; aborting before StarOS shard creation");
-                }
-                Map<String, String> properties = new HashMap<>();
-                properties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(table.getId()));
-                properties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
-                properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
-                GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForSplitPerNewShard(
-                        newToOldShardId,
-                        newShardIdToGroupIds,
-                        table.getPartitionFilePathInfo(physicalPartitionId),
-                        table.getPartitionFileCacheInfo(physicalPartitionId),
-                        properties, WarehouseManager.DEFAULT_RESOURCE);
-            }
-        }
-    }
-
-    /**
-     * Returns the {@code [SPREAD, PACK]} placement group ids for the {@link ColocateRange}
-     * that owns the colocate prefix of {@code range}'s lower bound. The SPREAD group is shared
-     * across all new shards of an index; the PACK group is looked up from {@link ColocateRangeMgr}
-     * so each new shard joins the PACK group of its target {@link ColocateRange}.
-     */
-    private static List<Long> findPlacementGroupIdsForRange(List<ColocateRange> colocateRanges, long spreadGroupId,
-                                                     Range<Tuple> range,
-                                                     int colocateColumnCount) {
-        Tuple prefix = ColocateRangeUtils.extractColocatePrefix(range, colocateColumnCount);
-        int rangeIndex = ColocateRangeMgr.indexOf(colocateRanges, prefix);
-        Preconditions.checkState(rangeIndex >= 0,
-                "alignment child has no covering ColocateRange for prefix %s", prefix);
-        return List.of(spreadGroupId, colocateRanges.get(rangeIndex).getShardGroupId());
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -627,60 +627,8 @@ public class StarOSAgent {
     /**
      * Create shards for a tablet split.
      *
-     * <p>{@code oldShardIdToGroupIds} carries one entry per old tablet, mapping that old tablet's
-     * id to the list of group ids each new shard spawned from it should join. For non-colocate
-     * range tables this is a single-element list with the SPREAD shard group; for range-colocate
-     * tables it is {@code [SPREAD, <old-tablet's PACK shard group>]} per old tablet, and the PACK
-     * group differs per old tablet once the colocate group has multiple ranges.
-     */
-    public void createShardsForSplit(Map<Long, List<Long>> oldShardIdToGroupIds,
-                                     Map<Long, List<Long>> oldToNewShardIds,
-                                     FilePathInfo pathInfo,
-                                     FileCacheInfo cacheInfo,
-                                     @NotNull Map<String, String> properties,
-                                     ComputeResource computeResource) throws DdlException {
-        long workerGroupId = computeResource.getWorkerGroupId();
-        prepare();
-        List<ShardInfo> shardInfos = null;
-        try {
-            CreateShardInfo.Builder builder = CreateShardInfo.newBuilder();
-            builder.setReplicaCount(1)
-                    .setPathInfo(pathInfo)
-                    .setCacheInfo(cacheInfo)
-                    .putAllShardProperties(properties)
-                    .setScheduleToWorkerGroup(workerGroupId);
-
-            List<CreateShardInfo> createShardInfoList = new ArrayList<>(oldToNewShardIds.size() * 2);
-            for (Map.Entry<Long, List<Long>> entry : oldToNewShardIds.entrySet()) {
-                builder.clearPlacementPreferences();
-                builder.clearGroupIds();
-                List<Long> groupIds = oldShardIdToGroupIds.get(entry.getKey());
-                Preconditions.checkArgument(groupIds != null && !groupIds.isEmpty(),
-                        "Missing group ids for old shard " + entry.getKey());
-                builder.addAllGroupIds(groupIds);
-                PlacementPreference preference = PlacementPreference.newBuilder()
-                        .setPlacementPolicy(PlacementPolicy.PACK)
-                        .setPlacementRelationship(PlacementRelationship.WITH_SHARD)
-                        .setRelationshipTargetId(entry.getKey())
-                        .build();
-                builder.addPlacementPreferences(preference);
-                for (Long newShardId : entry.getValue()) {
-                    builder.setShardId(newShardId);
-                    createShardInfoList.add(builder.build());
-                }
-            }
-            shardInfos = client.createShard(serviceId, createShardInfoList);
-            Preconditions.checkState(shardInfos.size() == createShardInfoList.size());
-            LOG.debug("Create shards success. shard infos: {}", shardInfos);
-        } catch (Exception e) {
-            throw new DdlException("Failed to create shards. error: " + e.getMessage());
-        }
-    }
-
-    /**
-     * Per-new-shard variant of {@link #createShardsForSplit} used by the colocate checker.
-     * Each new shard joins its own list of group ids (PACK group per
-     * colocate range), while still pinning placement to its old shard via
+     * <p>Each new shard joins its own list of group ids (PACK group per colocate range),
+     * while still pinning placement to its old shard via
      * {@code PlacementRelationship.WITH_SHARD}.
      *
      * <p>{@code newToOldShardId} maps each new shard id to its parent old shard id.
@@ -688,7 +636,7 @@ public class StarOSAgent {
      * (typically {@code [SPREAD, PACK-for-this-shard's-ColocateRange]}). Both maps must
      * have the same key set; the call fails if a new shard has no group assignment.
      */
-    public void createShardsForSplitPerNewShard(Map<Long, Long> newToOldShardId,
+    public void createShardsForSplit(Map<Long, Long> newToOldShardId,
                                                  Map<Long, List<Long>> newShardIdToGroupIds,
                                                  FilePathInfo pathInfo,
                                                  FileCacheInfo cacheInfo,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -15,6 +15,8 @@
 package com.starrocks.alter.reshard;
 
 import com.google.common.base.Preconditions;
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
@@ -27,11 +29,13 @@ import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.Utils;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.PublishVersionRequest;
@@ -526,6 +530,12 @@ public class MergeTabletJobTest {
         MaterializedIndex materializedIndex = physicalPartition.getLatestBaseIndex();
         long oldVersion = physicalPartition.getVisibleVersion();
 
+        // Replay paths do not call createShardsOnStarOS, but in production the original
+        // leader's runPendingJob did. Mirror that here so every tablet inserted into the
+        // FE catalog by replay has a backing staros shard for the subsequent tests
+        // sharing the static table fixture.
+        mergeJob.createShardsOnStarOS();
+
         Assertions.assertEquals(TabletReshardJob.JobState.PENDING, mergeJob.getJobState());
         mergeJob.replay();
 
@@ -930,8 +940,10 @@ public class MergeTabletJobTest {
         reshardingPartitions.put(physicalPartition.getId(),
                 new ReshardingPhysicalPartition(physicalPartition.getId(), reshardingIndexes));
 
-        createNewShards(physicalPartition, newIndex, reshardingTablets);
-
+        // Do not pre-create new shards on StarOS here; MergeTabletJob.runPendingJob calls
+        // createShardsOnStarOS as part of the run-state machine. Tests that bypass run()
+        // (replay-only) must call mergeJob.createShardsOnStarOS() explicitly to simulate
+        // the original leader's PENDING step.
         return new MergeTabletJob(GlobalStateMgr.getCurrentState().getNextId(),
                 db.getId(), table.getId(), reshardingPartitions);
     }
@@ -958,6 +970,34 @@ public class MergeTabletJobTest {
                 table.getPartitionFileCacheInfo(physicalPartition.getId()),
                 newIndex.getShardGroupId(),
                 properties, WarehouseManager.DEFAULT_RESOURCE);
+    }
+
+    /**
+     * createShardsOnStarOS wraps any StarRocksException from the StarOS RPC as a
+     * TabletReshardException so the run() catch-and-abort wrapper can fire cleanly.
+     */
+    @Test
+    public void testCreateShardsOnStarOSWrapsStarRocksException() throws Exception {
+        MergeTabletJob mergeJob = createMergeTabletReshardJob();
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void createShardsForMerge(Map<Long, List<Long>> newToOldTabletIds,
+                                             FilePathInfo pathInfo,
+                                             FileCacheInfo cacheInfo,
+                                             long groupId,
+                                             Map<String, String> properties,
+                                             ComputeResource computeResource) throws DdlException {
+                throw new DdlException("simulated StarOS failure");
+            }
+        };
+
+        TabletReshardException thrown = Assertions.assertThrows(TabletReshardException.class,
+                mergeJob::createShardsOnStarOS);
+        Assertions.assertTrue(thrown.getMessage().contains("Failed to create new shards on StarOS"),
+                "expected wrap message, got: " + thrown.getMessage());
+        Assertions.assertTrue(thrown.getMessage().contains("simulated StarOS failure"),
+                "expected original cause message, got: " + thrown.getMessage());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
@@ -430,5 +431,68 @@ public class SplitTabletJobColocateTest {
         for (int i = 0; i < 5 && job.getJobState() != TabletReshardJob.JobState.FINISHED; i++) {
             job.run();
         }
+    }
+
+    /**
+     * verifyNewTabletRanges accepts every FE-supplied range whose colocate prefix is
+     * covered by some ColocateRange. The default single (-inf, +inf) ColocateRange
+     * covers everything, so any reasonable external-boundaries plan passes.
+     */
+    @Test
+    public void testForExternalBoundariesAcceptsCoveredRangeColocateInput() throws Exception {
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex materializedIndex = physicalPartition.getLatestBaseIndex();
+        Tablet oldTablet = materializedIndex.getTablets().get(0);
+        long oldTabletId = oldTablet.getId();
+        oldTablet.setRange(new TabletRange());
+
+        Tuple boundaryPrefix = new Tuple(Arrays.asList(Variant.of(IntegerType.INT, "100")));
+        List<TabletRange> newTabletRanges = Arrays.asList(
+                new TabletRange(Range.lt(boundaryPrefix)),
+                new TabletRange(Range.ge(boundaryPrefix)));
+
+        // No exception expected — the default ColocateRange covers every colocate prefix.
+        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(
+                db, table, oldTabletId, newTabletRanges);
+        Assertions.assertNotNull(job);
+    }
+
+    /**
+     * verifyNewTabletRanges throws synchronously when an FE-supplied child range's
+     * colocate prefix has no covering ColocateRange. Models the failure mode where a
+     * BE supplies bad boundaries on a range-colocate table whose ColocateRangeMgr does
+     * not extend over the full key space.
+     */
+    @Test
+    public void testForExternalBoundariesRejectsUncoveredColocateRange() throws Exception {
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex materializedIndex = physicalPartition.getLatestBaseIndex();
+        Tablet oldTablet = materializedIndex.getTablets().get(0);
+        long oldTabletId = oldTablet.getId();
+        oldTablet.setRange(new TabletRange());
+
+        // Truncate ColocateRangeMgr to (-inf, prefix50) only — anything with prefix >= 50
+        // has no covering ColocateRange.
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateRangeMgr rangeMgr = idx.getColocateRangeMgr();
+        long shardGroupId = rangeMgr.getColocateRanges(groupId.grpId).get(0).getShardGroupId();
+        Tuple prefix50 = new Tuple(Arrays.asList(Variant.of(IntegerType.INT, "50")));
+        rangeMgr.setColocateRanges(groupId.grpId, Arrays.asList(
+                new ColocateRange(Range.lt(prefix50), shardGroupId)));
+
+        // Middle child range has lower-bound prefix 100, which falls outside the truncated
+        // ColocateRangeMgr coverage and must be rejected.
+        Tuple prefix100 = new Tuple(Arrays.asList(Variant.of(IntegerType.INT, "100")));
+        Tuple prefix200 = new Tuple(Arrays.asList(Variant.of(IntegerType.INT, "200")));
+        List<TabletRange> newTabletRanges = Arrays.asList(
+                new TabletRange(Range.lt(prefix100)),
+                new TabletRange(Range.of(prefix100, prefix200, true, false)),
+                new TabletRange(Range.ge(prefix200)));
+
+        StarRocksException thrown = Assertions.assertThrows(StarRocksException.class,
+                () -> SplitTabletJobFactory.forExternalBoundaries(
+                        db, table, oldTabletId, newTabletRanges));
+        Assertions.assertTrue(thrown.getMessage().contains("no covering ColocateRange"),
+                "expected 'no covering ColocateRange' in message, got: " + thrown.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.alter.reshard;
 
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -24,9 +26,11 @@ import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.Utils;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.PublishVersionRequest;
@@ -182,6 +186,13 @@ public class SplitTabletJobTest {
 
         TabletReshardJob tabletReshardJob = createTabletReshardJob();
         Assertions.assertNotNull(tabletReshardJob);
+
+        // In production the original leader's runPendingJob calls createShardsOnStarOS
+        // before the followers ever replay this job, so the new shards exist on staros
+        // at replay time. Mirror that here so subsequent tests (which reuse the shared
+        // static table fixture) find every tablet in the FE catalog backed by a real
+        // staros shard.
+        ((SplitTabletJob) tabletReshardJob).createShardsOnStarOS();
 
         Assertions.assertEquals(TabletReshardJob.JobState.PENDING, tabletReshardJob.getJobState());
         tabletReshardJob.replay();
@@ -645,5 +656,33 @@ public class SplitTabletJobTest {
         Assertions.assertNotNull(tabletReshardJob.getInfo());
 
         return tabletReshardJob;
+    }
+
+    /**
+     * createShardsOnStarOS wraps any StarRocksException from the StarOS RPC as a
+     * TabletReshardException so the run() catch-and-abort wrapper can fire cleanly.
+     */
+    @Test
+    public void testCreateShardsOnStarOSWrapsStarRocksException() throws Exception {
+        SplitTabletJob job = (SplitTabletJob) createTabletReshardJob();
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void createShardsForSplit(Map<Long, Long> newToOldShardId,
+                                             Map<Long, List<Long>> newShardIdToGroupIds,
+                                             FilePathInfo pathInfo,
+                                             FileCacheInfo cacheInfo,
+                                             Map<String, String> properties,
+                                             ComputeResource computeResource) throws DdlException {
+                throw new DdlException("simulated StarOS failure");
+            }
+        };
+
+        TabletReshardException thrown = Assertions.assertThrows(TabletReshardException.class,
+                job::createShardsOnStarOS);
+        Assertions.assertTrue(thrown.getMessage().contains("Failed to create new shards on StarOS"),
+                "expected wrap message, got: " + thrown.getMessage());
+        Assertions.assertTrue(thrown.getMessage().contains("simulated StarOS failure"),
+                "expected original cause message, got: " + thrown.getMessage());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`SplitTabletJobFactory` / `MergeTabletJobFactory` currently issue `createShards*` RPCs to StarOS **before** `TabletReshardJobMgr.addTabletReshardJob` writes the journal. A leader-demote between the RPC and the journal flush orphans new shards on StarOS without an FE-side record — they will not be cleaned up by replay on the new leader.

This PR closes that shard-leak window.

## What I'm doing:

- Merge `SplitTabletJobFactory`'s two static helpers (`createNewShards` + `createNewShardsForColocateAlignment`) into a single instance method `SplitTabletJob.createShardsOnStarOS` that always dispatches to `createShardsForSplitPerNewShard`. The per-new-shard variant is a strict superset of the per-old-shard variant — identical group ids per child of one old shard produces a byte-equivalent `CreateShardInfo` list. Delete the now-unused per-old-shard `StarOSAgent.createShardsForSplit`. Mirror for merge.
- Move the StarOS RPC out of factory time into `SplitTabletJob.runPendingJob` / `MergeTabletJob.runPendingJob` as the last "abortable" step, immediately before `updateNextVersions` (the no-abort boundary). PENDING is the only abortable state — a thrown `TabletReshardException` is caught by `run()`, `abort()` fires, `runAbortingJob` unwinds the FE-side mutations. Orphan staros shards from a partial RPC are reaped by `StarMgrMetaSyncer`'s diff-and-purge cycle; no explicit `deleteShards` in the abort path.
- No table lock around the RPC: `setTableState(NORMAL→TABLET_RESHARD)` in step 1 already blocks concurrent DDL.
- Drop the per-RPC `isLeaderWorkAdmissionOpen()` re-checks in `SplitTabletJobFactory` and `ColocateChecker` (no longer load-bearing once the RPC is journal-first).
- `SplitTabletJobFactory.forExternalBoundaries` gains `verifyNewTabletRanges`: synchronously validates every BE-supplied new tablet range has a covering `ColocateRange` on range-colocate tables. Without it, bad input surfaces only via `SHOW TABLET RESHARD JOBS` instead of on the DDL statement.
- `SplitTabletJob.createShardsOnStarOS` extracted into `createShardsForOneIndex` + `addShardPlacementsForTablet` + `lookupPackGroupId`. Accumulator maps are `LinkedHashMap` so each RPC payload follows the `ReshardingTablet` iteration order byte-equivalently across leader-switch re-runs.
- `TabletReshardJob`: extracted `getOlapTable` helper used by `getLockedTable` and by `createShardsOnStarOS`.

The rare crash-recovery path (leader demote or process crash mid-RPC) depends on a cross-repo follow-up: StarOS-side `createShard` treating an equivalent caller-supplied-id collision as success. In-progress in the staros repo. Until that lands, the rare retry case surfaces as an aborted job — the operator re-issues the DDL.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5