### PR TITLE
[Enhancement] Add SR-owned VectorIndexCache for vector index

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1673,11 +1673,9 @@ CONF_mBool(experimental_enable_lake_capture_tablet_and_rowsets, "false");
 // ranges in [1,16], default value is 4.
 CONF_mInt32(query_cache_num_lanes_per_driver, "4");
 
-// Vector index cache capacity: HNSW whole-index + IVF-PQ per-list blocks
-// share this LRU. Accepts absolute bytes (e.g. "4294967296"), units
-// ("4G", "512M"), or a percentage of the BE process memory limit (e.g.
-// "20%"). Default 20% of process memory.
-CONF_mString(vector_index_cache_limit, "20%");
+// Vector index cache total capacity (HNSW whole-index + IVF-PQ blocks share
+// the same LRU). Accepts bytes, K/M/G/T suffix, or a % of process_mem_limit.
+CONF_mString(vector_query_cache_capacity, "20%");
 
 // Used to limit buffer size of tablet send channel.
 CONF_mInt64(send_channel_buffer_limit, "67108864");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1673,8 +1673,11 @@ CONF_mBool(experimental_enable_lake_capture_tablet_and_rowsets, "false");
 // ranges in [1,16], default value is 4.
 CONF_mInt32(query_cache_num_lanes_per_driver, "4");
 
-// Used by vector query cache, 500MB in default
-CONF_Int64(vector_query_cache_capacity, "536870912");
+// Vector index cache capacity: HNSW whole-index + IVF-PQ per-list blocks
+// share this LRU. Accepts absolute bytes (e.g. "4294967296"), units
+// ("4G", "512M"), or a percentage of the BE process memory limit (e.g.
+// "20%"). Default 20% of process memory.
+CONF_mString(vector_index_cache_limit, "20%");
 
 // Used to limit buffer size of tablet send channel.
 CONF_mInt64(send_channel_buffer_limit, "67108864");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -344,7 +344,7 @@
     {
       "path": "be/src/common/config_vector_index_fwd.h",
       "configs": [
-        "vector_query_cache_capacity",
+        "vector_index_cache_limit",
         "enable_vector_index_block_cache",
         "config_vector_index_build_concurrency",
         "config_vector_index_default_build_threshold",

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -344,7 +344,7 @@
     {
       "path": "be/src/common/config_vector_index_fwd.h",
       "configs": [
-        "vector_index_cache_limit",
+        "vector_query_cache_capacity",
         "enable_vector_index_block_cache",
         "config_vector_index_build_concurrency",
         "config_vector_index_default_build_threshold",

--- a/be/src/common/config_vector_index_fwd.h
+++ b/be/src/common/config_vector_index_fwd.h
@@ -20,11 +20,9 @@
 #include "common/configbase.h"
 
 namespace starrocks::config {
-// Vector index cache capacity: HNSW whole-index + IVF-PQ per-list blocks
-// share this LRU. Accepts absolute bytes (e.g. "4294967296"), units
-// ("4G", "512M"), or a percentage of the BE process memory limit (e.g.
-// "20%"). Default 20% of process memory.
-CONF_mString(vector_index_cache_limit, "20%");
+// Vector index cache total capacity (HNSW whole-index + IVF-PQ blocks share
+// the same LRU). Accepts bytes, K/M/G/T suffix, or a % of process_mem_limit.
+CONF_mString(vector_query_cache_capacity, "20%");
 
 // vector index
 // Enable caching index blocks for IVF-family vector indexes

--- a/be/src/common/config_vector_index_fwd.h
+++ b/be/src/common/config_vector_index_fwd.h
@@ -20,8 +20,11 @@
 #include "common/configbase.h"
 
 namespace starrocks::config {
-// Used by vector query cache, 500MB in default
-CONF_Int64(vector_query_cache_capacity, "536870912");
+// Vector index cache capacity: HNSW whole-index + IVF-PQ per-list blocks
+// share this LRU. Accepts absolute bytes (e.g. "4294967296"), units
+// ("4G", "512M"), or a percentage of the BE process memory limit (e.g.
+// "20%"). Default 20% of process memory.
+CONF_mString(vector_index_cache_limit, "20%");
 
 // vector index
 // Enable caching index blocks for IVF-family vector indexes

--- a/be/src/runtime/env/global_env.cpp
+++ b/be/src/runtime/env/global_env.cpp
@@ -220,6 +220,7 @@ Status GlobalEnv::_init_mem_tracker(MetricRegistry* metrics) {
             regist_tracker(MemTrackerType::CONSISTENCY, consistency_mem_limit, process_mem_tracker());
     _datacache_mem_tracker = regist_tracker(MemTrackerType::DATACACHE, -1, process_mem_tracker());
     _replication_mem_tracker = regist_tracker(MemTrackerType::REPLICATION, -1, process_mem_tracker());
+    _vector_index_mem_tracker = regist_tracker(MemTrackerType::VECTOR_INDEX, -1, process_mem_tracker());
 
     register_hll_registers_allocator();
     if (metrics != nullptr) {

--- a/be/src/runtime/env/global_env.h
+++ b/be/src/runtime/env/global_env.h
@@ -58,6 +58,7 @@ public:
     MemTracker* bitmap_index_mem_tracker() const { return _bitmap_index_mem_tracker.get(); }
     MemTracker* bloom_filter_index_mem_tracker() const { return _bloom_filter_index_mem_tracker.get(); }
     MemTracker* builtin_inverted_index_mem_tracker() const { return _builtin_inverted_index_mem_tracker.get(); }
+    MemTracker* vector_index_mem_tracker() const { return _vector_index_mem_tracker.get(); }
     MemTracker* segment_zonemap_mem_tracker() const { return _segment_zonemap_mem_tracker.get(); }
     MemTracker* short_key_index_mem_tracker() const { return _short_key_index_mem_tracker.get(); }
     MemTracker* compaction_mem_tracker() const { return _compaction_mem_tracker.get(); }
@@ -156,6 +157,9 @@ private:
     std::shared_ptr<MemTracker> _bitmap_index_mem_tracker;
     std::shared_ptr<MemTracker> _bloom_filter_index_mem_tracker;
     std::shared_ptr<MemTracker> _builtin_inverted_index_mem_tracker;
+
+    // Memory held by the SR-owned VectorIndexCache
+    std::shared_ptr<MemTracker> _vector_index_mem_tracker;
 
     // The memory used for compaction
     std::shared_ptr<MemTracker> _compaction_mem_tracker;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -448,10 +448,10 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, ProcessMetricsRe
     // Install before any vector query runs; tear down in destroy() before
     // GlobalEnv::stop() so the entry deleter can still reach the tracker.
     const int64_t proc_mem = GlobalEnv::GetInstance()->process_mem_limit();
-    ASSIGN_OR_RETURN(int64_t vi_capacity, ParseUtil::parse_mem_spec(config::vector_index_cache_limit, proc_mem));
+    ASSIGN_OR_RETURN(int64_t vi_capacity, ParseUtil::parse_mem_spec(config::vector_query_cache_capacity, proc_mem));
     if (vi_capacity <= 0) {
-        LOG(WARNING) << "vector_index_cache_limit resolved to " << vi_capacity
-                     << " bytes (raw=" << config::vector_index_cache_limit << ", process_mem_limit=" << proc_mem
+        LOG(WARNING) << "vector_query_cache_capacity resolved to " << vi_capacity
+                     << " bytes (raw=" << config::vector_query_cache_capacity << ", process_mem_limit=" << proc_mem
                      << "); vector index cache disabled";
         vi_capacity = 0;
     }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -95,9 +95,7 @@
 #include "runtime/stream_load/load_stream_mgr.h"
 #include "runtime/stream_load/stream_load_executor.h"
 #include "runtime/stream_load/transaction_mgr.h"
-#ifdef WITH_TENANN
 #include "storage/index/vector/vector_index_cache.h"
-#endif
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/lake_persistent_index_parallel_compact_mgr.h"
 #include "storage/lake/replication_txn_manager.h"
@@ -735,8 +733,8 @@ void ExecEnv::destroy() {
     _global_env->destroy_thread_pools();
 #ifdef WITH_TENANN
     tenann::SetGlobalIndexCache(nullptr);
-    _vector_index_cache.reset();
 #endif
+    _vector_index_cache.reset();
     _query_execution_services.process_metrics = nullptr;
     _table_metrics_mgr = nullptr;
     _process_metrics_registry = nullptr;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -42,6 +42,7 @@
 #include "base/time/time.h"
 #include "common/config_exec_env_fwd.h"
 #include "common/config_lake_fwd.h"
+#include "common/config_vector_index_fwd.h"
 #include "common/logging.h"
 #include "common/metrics/process_metrics_registry.h"
 #include "common/process_exit.h"
@@ -94,6 +95,9 @@
 #include "runtime/stream_load/load_stream_mgr.h"
 #include "runtime/stream_load/stream_load_executor.h"
 #include "runtime/stream_load/transaction_mgr.h"
+#ifdef WITH_TENANN
+#include "storage/index/vector/vector_index_cache.h"
+#endif
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/lake_persistent_index_parallel_compact_mgr.h"
 #include "storage/lake/replication_txn_manager.h"
@@ -103,6 +107,9 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet_schema_map.h"
 #include "storage/update_manager.h"
+#ifdef WITH_TENANN
+#include "tenann/index/index_cache.h"
+#endif
 #include "udf/python/env.h"
 
 #ifdef USE_STAROS
@@ -439,6 +446,21 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, ProcessMetricsRe
     PythonEnvManager::getInstance().start_background_cleanup_thread();
 
     _refresh_service_contexts();
+#ifdef WITH_TENANN
+    // Install before any vector query runs; tear down in destroy() before
+    // GlobalEnv::stop() so the entry deleter can still reach the tracker.
+    const int64_t proc_mem = GlobalEnv::GetInstance()->process_mem_limit();
+    ASSIGN_OR_RETURN(int64_t vi_capacity, ParseUtil::parse_mem_spec(config::vector_index_cache_limit, proc_mem));
+    if (vi_capacity <= 0) {
+        LOG(WARNING) << "vector_index_cache_limit resolved to " << vi_capacity
+                     << " bytes (raw=" << config::vector_index_cache_limit << ", process_mem_limit=" << proc_mem
+                     << "); vector index cache disabled";
+        vi_capacity = 0;
+    }
+    _vector_index_cache = std::make_unique<VectorIndexCache>(static_cast<size_t>(vi_capacity),
+                                                             GlobalEnv::GetInstance()->vector_index_mem_tracker());
+    tenann::SetGlobalIndexCache(_vector_index_cache.get());
+#endif
 
     return Status::OK();
 }
@@ -711,6 +733,10 @@ void ExecEnv::destroy() {
     _parallel_compact_mgr.reset();
     DCHECK(_global_env != nullptr);
     _global_env->destroy_thread_pools();
+#ifdef WITH_TENANN
+    tenann::SetGlobalIndexCache(nullptr);
+    _vector_index_cache.reset();
+#endif
     _query_execution_services.process_metrics = nullptr;
     _table_metrics_mgr = nullptr;
     _process_metrics_registry = nullptr;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -731,13 +731,16 @@ void ExecEnv::destroy() {
     _parallel_compact_mgr.reset();
     DCHECK(_global_env != nullptr);
     _global_env->destroy_thread_pools();
+    _query_execution_services.process_metrics = nullptr;
+    _table_metrics_mgr = nullptr;
+    _process_metrics_registry = nullptr;
+}
+
+void ExecEnv::destroy_vector_index_cache() {
 #ifdef WITH_TENANN
     tenann::SetGlobalIndexCache(nullptr);
 #endif
     _vector_index_cache.reset();
-    _query_execution_services.process_metrics = nullptr;
-    _table_metrics_mgr = nullptr;
-    _process_metrics_registry = nullptr;
 }
 
 void ExecEnv::_wait_for_fragments_finish() {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -87,9 +87,7 @@ class GlobalSpillManager;
 
 class HeartbeatFlags;
 class DiagnoseDaemon;
-#ifdef WITH_TENANN
 class VectorIndexCache;
-#endif
 
 namespace pipeline {
 class DriverExecutor;
@@ -219,9 +217,7 @@ public:
 
     DiagnoseDaemon* diagnose_daemon() const { return _diagnose_daemon; }
 
-#ifdef WITH_TENANN
     VectorIndexCache* vector_index_cache() { return _vector_index_cache.get(); }
-#endif
 
 private:
     void _refresh_service_contexts();
@@ -283,11 +279,11 @@ private:
     QueryExecutionServices _query_execution_services;
     AdminServices _admin_services;
 
-#ifdef WITH_TENANN
     // SR-owned LRU behind tenann::IndexCache. Must be destructed before the
-    // mem tracker hierarchy (see ExecEnv::destroy()).
+    // mem tracker hierarchy (see ExecEnv::destroy()). Only constructed when
+    // WITH_TENANN is on; the type is always declared so callers don't need
+    // their own WITH_TENANN guards to hold a pointer.
     std::unique_ptr<VectorIndexCache> _vector_index_cache;
-#endif
 };
 
 } // namespace starrocks

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -87,6 +87,9 @@ class GlobalSpillManager;
 
 class HeartbeatFlags;
 class DiagnoseDaemon;
+#ifdef WITH_TENANN
+class VectorIndexCache;
+#endif
 
 namespace pipeline {
 class DriverExecutor;
@@ -216,6 +219,10 @@ public:
 
     DiagnoseDaemon* diagnose_daemon() const { return _diagnose_daemon; }
 
+#ifdef WITH_TENANN
+    VectorIndexCache* vector_index_cache() { return _vector_index_cache.get(); }
+#endif
+
 private:
     void _refresh_service_contexts();
     void _wait_for_fragments_finish();
@@ -275,6 +282,12 @@ private:
     AgentServices _agent_services;
     QueryExecutionServices _query_execution_services;
     AdminServices _admin_services;
+
+#ifdef WITH_TENANN
+    // SR-owned LRU behind tenann::IndexCache. Must be destructed before the
+    // mem tracker hierarchy (see ExecEnv::destroy()).
+    std::unique_ptr<VectorIndexCache> _vector_index_cache;
+#endif
 };
 
 } // namespace starrocks

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -122,6 +122,12 @@ public:
                 GlobalEnv* global_env, bool as_cn = false);
     void stop();
     void destroy();
+    // Tears down the SR-owned VectorIndexCache. Kept out of destroy() so the
+    // call site can be placed before GlobalEnv::stop() — the entry deleters
+    // need vector_index_mem_tracker alive to account for the release.
+    // ~VectorIndexCache itself handles the IVF-PQ self-cascade safely; see
+    // the destructor for the FUTEX_WAIT_PRIVATE deadlock the cascade triggers.
+    void destroy_vector_index_cache();
     void wait_for_finish();
 
     /// Returns the first created exec env instance. In a normal starrocks, this is

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -78,6 +78,7 @@ static std::vector<std::pair<MemTrackerType, std::string>> s_mem_types = {
         {MemTrackerType::DEL_VEC_CACHE, "del_vec_cache"},
         {MemTrackerType::COMPACTION_STATE, "compaction_state"},
         {MemTrackerType::BUILTIN_INVERTED_INDEX, "builtin_inverted_index"},
+        {MemTrackerType::VECTOR_INDEX, "vector_index"},
 };
 
 static std::map<MemTrackerType, std::string> s_type_to_label_map;

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -119,7 +119,8 @@ enum class MemTrackerType {
     INDEX_CACHE,
     DEL_VEC_CACHE,
     COMPACTION_STATE,
-    BUILTIN_INVERTED_INDEX
+    BUILTIN_INVERTED_INDEX,
+    VECTOR_INDEX
 };
 
 class MemTracker {

--- a/be/src/service/service_be/config_update_hooks.cpp
+++ b/be/src/service/service_be/config_update_hooks.cpp
@@ -21,6 +21,7 @@
 
 #include "agent/agent_common.h"
 #include "agent/agent_server.h"
+#include "base/string/parse_util.h"
 #include "cache/datacache.h"
 #include "cache/datacache_utils.h"
 #include "cache/mem_cache/page_cache.h"
@@ -37,6 +38,7 @@
 #include "common/config_staros_worker_fwd.h"
 #include "common/config_storage_fwd.h"
 #include "common/config_update_registry.h"
+#include "common/config_vector_index_fwd.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "common/system/cpu_info.h"
@@ -49,6 +51,9 @@
 #include "runtime/exec_env.h"
 #include "runtime/load_channel_mgr.h"
 #include "storage/compaction_manager.h"
+#ifdef WITH_TENANN
+#include "storage/index/vector/vector_index_cache.h"
+#endif
 #include "storage/lake/compaction_scheduler.h"
 #include "storage/lake/lake_persistent_index_parallel_compact_mgr.h"
 #include "storage/lake/tablet_manager.h"
@@ -92,6 +97,20 @@ void register_config_update_hooks(ExecEnv* exec_env, const GlobalEnv& global_env
         cache->set_capacity(cache_limit);
         return Status::OK();
     });
+#ifdef WITH_TENANN
+    registry->register_callback("vector_index_cache_limit", [=]() -> Status {
+        if (exec_env == nullptr || exec_env->vector_index_cache() == nullptr) {
+            return Status::InternalError("Vector index cache is not initialized");
+        }
+        const int64_t proc_mem = GlobalEnv::GetInstance()->process_mem_limit();
+        ASSIGN_OR_RETURN(int64_t limit, ParseUtil::parse_mem_spec(config::vector_index_cache_limit, proc_mem));
+        if (limit < 0) limit = 0;
+        exec_env->vector_index_cache()->SetCapacity(static_cast<size_t>(limit));
+        LOG(INFO) << "vector_index_cache_limit updated: " << config::vector_index_cache_limit << " => " << limit
+                  << " bytes";
+        return Status::OK();
+    });
+#endif
 #endif
 #ifndef __APPLE__
     registry->register_callback("disable_storage_page_cache", [=]() -> Status {

--- a/be/src/service/service_be/config_update_hooks.cpp
+++ b/be/src/service/service_be/config_update_hooks.cpp
@@ -95,15 +95,19 @@ void register_config_update_hooks(ExecEnv* exec_env, const GlobalEnv& global_env
         cache->set_capacity(cache_limit);
         return Status::OK();
     });
-    registry->register_callback("vector_index_cache_limit", [=]() -> Status {
+    registry->register_callback("vector_query_cache_capacity", [=]() -> Status {
         if (exec_env == nullptr || exec_env->vector_index_cache() == nullptr) {
             return Status::InternalError("Vector index cache is not initialized");
         }
         const int64_t proc_mem = GlobalEnv::GetInstance()->process_mem_limit();
-        ASSIGN_OR_RETURN(int64_t limit, ParseUtil::parse_mem_spec(config::vector_index_cache_limit, proc_mem));
+        ASSIGN_OR_RETURN(int64_t limit, ParseUtil::parse_mem_spec(config::vector_query_cache_capacity, proc_mem));
         if (limit < 0) limit = 0;
-        exec_env->vector_index_cache()->SetCapacity(static_cast<size_t>(limit));
-        LOG(INFO) << "vector_index_cache_limit updated: " << config::vector_index_cache_limit << " => " << limit
+        auto* cache = exec_env->vector_index_cache();
+        if (static_cast<size_t>(limit) == cache->capacity()) {
+            return Status::OK();
+        }
+        cache->SetCapacity(static_cast<size_t>(limit));
+        LOG(INFO) << "vector_query_cache_capacity updated: " << config::vector_query_cache_capacity << " => " << limit
                   << " bytes";
         return Status::OK();
     });

--- a/be/src/service/service_be/config_update_hooks.cpp
+++ b/be/src/service/service_be/config_update_hooks.cpp
@@ -95,6 +95,7 @@ void register_config_update_hooks(ExecEnv* exec_env, const GlobalEnv& global_env
         cache->set_capacity(cache_limit);
         return Status::OK();
     });
+#ifdef WITH_TENANN
     registry->register_callback("vector_query_cache_capacity", [=]() -> Status {
         if (exec_env == nullptr || exec_env->vector_index_cache() == nullptr) {
             return Status::InternalError("Vector index cache is not initialized");
@@ -111,6 +112,7 @@ void register_config_update_hooks(ExecEnv* exec_env, const GlobalEnv& global_env
                   << " bytes";
         return Status::OK();
     });
+#endif // WITH_TENANN
 #endif
 #ifndef __APPLE__
     registry->register_callback("disable_storage_page_cache", [=]() -> Status {

--- a/be/src/service/service_be/config_update_hooks.cpp
+++ b/be/src/service/service_be/config_update_hooks.cpp
@@ -51,9 +51,7 @@
 #include "runtime/exec_env.h"
 #include "runtime/load_channel_mgr.h"
 #include "storage/compaction_manager.h"
-#ifdef WITH_TENANN
 #include "storage/index/vector/vector_index_cache.h"
-#endif
 #include "storage/lake/compaction_scheduler.h"
 #include "storage/lake/lake_persistent_index_parallel_compact_mgr.h"
 #include "storage/lake/tablet_manager.h"
@@ -97,7 +95,6 @@ void register_config_update_hooks(ExecEnv* exec_env, const GlobalEnv& global_env
         cache->set_capacity(cache_limit);
         return Status::OK();
     });
-#ifdef WITH_TENANN
     registry->register_callback("vector_index_cache_limit", [=]() -> Status {
         if (exec_env == nullptr || exec_env->vector_index_cache() == nullptr) {
             return Status::InternalError("Vector index cache is not initialized");
@@ -110,7 +107,6 @@ void register_config_update_hooks(ExecEnv* exec_env, const GlobalEnv& global_env
                   << " bytes";
         return Status::OK();
     });
-#endif
 #endif
 #ifndef __APPLE__
     registry->register_callback("disable_storage_page_cache", [=]() -> Status {

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -380,6 +380,12 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 
     delete storage_engine;
 
+    // Tear down the SR-owned VectorIndexCache before global_env->stop()
+    // destroys the MemTracker hierarchy the entry deleters consume against.
+    // See ExecEnv::destroy_vector_index_cache().
+    exec_env->destroy_vector_index_cache();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": vector index cache destroy successfully";
+
 #ifndef __APPLE__
     cache_env->destroy();
     LOG(ERROR) << process_name << " exit step " << exit_step++ << ": cache env destroy successfully";

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -330,9 +330,11 @@ set(STORAGE_FILES
     index/inverted/clucene/clucene_inverted_reader.cpp
     index/inverted/clucene/match_operator.cpp
     index/vector/empty_index_reader.cpp
+    index/vector/vector_index_cache.cpp
     index/vector/vector_index_builder_factory.cpp
     index/vector/vector_index_writer.cpp
     index/vector/vector_index_builder.cpp
+    index/vector/vector_index_file_reader.cpp
     index/vector/vector_index_reader_factory.cpp
     index/vector/tenann_index_reader.cpp
     index/vector/tenann/del_id_filter.cpp

--- a/be/src/storage/index/vector/empty_index_reader.h
+++ b/be/src/storage/index/vector/empty_index_reader.h
@@ -23,19 +23,20 @@ class EmptyIndexReader final : public VectorIndexReader {
 public:
     ~EmptyIndexReader() override = default;
 
-    Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path) override {
-        return Status::NotSupported("Not implement");
+    Status init_searcher(const tenann::IndexMeta& /*meta*/, const std::string& /*index_path*/,
+                         FileSystem* /*fs*/) override {
+        return Status::NotSupported("EmptyIndexReader does not support this operation");
     }
 
     Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,
                   tenann::IdFilter* id_filter = nullptr) override {
-        return Status::NotSupported("Not implement");
+        return Status::NotSupported("EmptyIndexReader does not support this operation");
     }
 
     Status range_search(tenann::PrimitiveSeqView query_vector, int k, std::vector<int64_t>* result_ids,
                         std::vector<float>* result_distances, tenann::IdFilter* id_filter, float range,
                         int order) override {
-        return Status::NotSupported("Not implement");
+        return Status::NotSupported("EmptyIndexReader does not support this operation");
     }
 };
 

--- a/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
@@ -25,6 +25,7 @@
 #include "common/config_vector_index_fwd.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "tenann/factory/index_factory.h"
+#include "tenann/index/index_cache.h"
 
 namespace starrocks {
 
@@ -56,7 +57,7 @@ Status TenAnnIndexBuilderProxy::init() {
     try {
         // build and write index
         _index_builder = tenann::IndexFactory::CreateBuilderFromMeta(meta_copy);
-        _index_builder->index_writer()->SetIndexCache(tenann::IndexCache::GetGlobalInstance());
+        _index_builder->index_writer()->SetIndexCache(tenann::GetGlobalIndexCache());
         // Bound the per-builder row buffer (no-op for builders that don't buffer).
         // Tunable via BE config vector_index_build_flush_threshold_rows; lower it
         // when BE memory is tight, set 0 to disable intermediate flushing.

--- a/be/src/storage/index/vector/tenann/tenann_index_utils.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_utils.cpp
@@ -213,6 +213,15 @@ void apply_adaptive_ef_search(tenann::IndexMeta* meta, size_t segment_num_rows, 
     }
 }
 
+Status tenann_error_to_status(const tenann::Error& e) {
+    const std::string& msg = e.message();
+    if (msg.find("Not found") != std::string::npos || msg.find("not found") != std::string::npos ||
+        msg.find("No such file") != std::string::npos) {
+        return Status::NotFound(msg);
+    }
+    return Status::InternalError(msg);
+}
+
 } // namespace starrocks
 
 #endif

--- a/be/src/storage/index/vector/tenann/tenann_index_utils.h
+++ b/be/src/storage/index/vector/tenann/tenann_index_utils.h
@@ -20,8 +20,10 @@
 #include <iostream>
 #include <memory>
 
+#include "common/status.h"
 #include "common/statusor.h"
 #include "storage/tablet_index.h"
+#include "tenann/common/error.h"
 #include "tenann/store/index_meta.h"
 #include "tenann/store/index_type.h"
 
@@ -69,6 +71,12 @@ int compute_adaptive_ef_search(int user_ef, int query_k, size_t segment_num_rows
 //   - `user_set_ef` (user explicitly specified ef in query -> skip)
 //   - Missing efSearch in meta (non-HNSW indexes -> skip)
 void apply_adaptive_ef_search(tenann::IndexMeta* meta, size_t segment_num_rows, int query_k, bool user_set_ef);
+
+// Translate a tenann::Error to a starrocks::Status. Uses e.message() (the raw
+// message) rather than e.what() (which wraps the message with file:line
+// boilerplate). Messages matching common "not found" substrings map to
+// Status::NotFound; everything else becomes Status::InternalError.
+Status tenann_error_to_status(const tenann::Error& e);
 } // namespace starrocks
 
 #endif

--- a/be/src/storage/index/vector/tenann_index_reader.cpp
+++ b/be/src/storage/index/vector/tenann_index_reader.cpp
@@ -35,14 +35,22 @@
 #ifdef WITH_TENANN
 #include "tenann_index_reader.h"
 
+#include <stdexcept>
+
 #include "common/config_vector_index_fwd.h"
 #include "common/status.h"
 #include "common/statusor.h"
 #include "fs/fs.h"
+#include "runtime/current_thread.h"
+#include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_file_reader.h"
 #include "tenann/common/error.h"
 #include "tenann/common/seq_view.h"
+#include "tenann/factory/index_factory.h"
+#include "tenann/index/index_cache.h"
+#include "tenann/index/index_reader.h"
 #include "tenann/searcher/id_filter.h"
 
 namespace starrocks {
@@ -65,43 +73,70 @@ void apply_index_reader_cache_options(tenann::IndexMeta* meta_copy) {
 
 } // namespace
 
-Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const std::string& index_path) {
-    try {
-        auto meta_copy = meta;
-        apply_index_reader_cache_options(&meta_copy);
-
-        tenann::IndexCache::GetGlobalInstance()->SetCapacity(config::vector_query_cache_capacity);
-
-        _searcher = tenann::AnnSearcherFactory::CreateSearcherFromMeta(meta_copy);
-        _searcher->index_reader()->SetIndexCache(tenann::IndexCache::GetGlobalInstance());
-        _searcher->ReadIndex(index_path);
-
-        DCHECK(_searcher->is_index_loaded());
-    } catch (tenann::Error& e) {
-        return Status::InternalError(e.what());
-    }
-    return Status::OK();
-}
-
 Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs) {
-    if (fs == nullptr) {
-        return init_searcher(meta, index_path);
+    auto* cache = tenann::GetGlobalIndexCache();
+    if (cache == nullptr) {
+        return Status::InternalError(
+                "VectorIndexCache not injected. ExecEnv::init must call tenann::SetGlobalIndexCache.");
     }
+
+    auto meta_copy = meta;
+    apply_index_reader_cache_options(&meta_copy);
+
+    // Loader runs under vector_index mem tracker and opens the remote file
+    // lazily, so warm-path cache hits skip the OSS/S3 round-trip entirely.
+    auto* tracker = GlobalEnv::GetInstance()->vector_index_mem_tracker();
+
+    // Loader catches its own failures (incl. tenann::Error, which inherits
+    // privately from std::exception and would otherwise escape GetOrCreate)
+    // and surfaces the real Status to init_searcher's caller — preserves
+    // NotFound for the brute-force fallback at vector_index_reader_factory.
+    Status load_status;
+    auto loader = [&meta_copy, &index_path, fs, cache, tracker, &load_status]() -> tenann::IndexRef {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(tracker);
+        try {
+            std::shared_ptr<VectorIndexFileReader> external_file_reader;
+            if (fs != nullptr) {
+                auto opened_or = VectorIndexFileReader::open(fs, index_path);
+                if (!opened_or.ok()) {
+                    load_status = opened_or.status();
+                    return nullptr;
+                }
+                external_file_reader = std::shared_ptr<VectorIndexFileReader>(opened_or.value().release());
+            }
+            auto reader = tenann::IndexFactory::CreateReaderFromMeta(meta_copy);
+            reader->SetIndexCache(cache);
+            if (external_file_reader != nullptr) {
+                reader->SetFileReader(external_file_reader);
+            }
+            return reader->ReadIndexFile(index_path);
+        } catch (const tenann::Error& e) {
+            load_status = tenann_error_to_status(e);
+            return nullptr;
+        } catch (const std::exception& e) {
+            load_status = Status::InternalError(e.what());
+            return nullptr;
+        }
+    };
+
+    if (!cache->GetOrCreate(tenann::CacheKey(index_path), loader, &_cache_handle)) {
+        return !load_status.ok() ? load_status : Status::InternalError("failed to load vector index: " + index_path);
+    }
+
     try {
-        auto meta_copy = meta;
-        apply_index_reader_cache_options(&meta_copy);
-
-        tenann::IndexCache::GetGlobalInstance()->SetCapacity(config::vector_query_cache_capacity);
-
         _searcher = tenann::AnnSearcherFactory::CreateSearcherFromMeta(meta_copy);
-        _searcher->index_reader()->SetIndexCache(tenann::IndexCache::GetGlobalInstance());
-        ASSIGN_OR_RETURN(auto index_raf, fs->new_random_access_file(index_path));
-        ASSIGN_OR_RETURN(auto file_size, index_raf->get_size());
-        auto file_reader = std::make_shared<VectorIndexFileReader>(std::move(index_raf), file_size);
-        _searcher->ReadIndex(file_reader);
+        // AttachIndexRef skips the second cache lookup Searcher::ReadIndex
+        // would otherwise do — we already hold the ref from GetOrCreate.
+        _searcher->AttachIndexRef(_cache_handle.index_ref());
 
-        DCHECK(_searcher->is_index_loaded());
-    } catch (tenann::Error& e) {
+        // Hard-check in addition to tenann's internal DCHECK: a silent
+        // AttachIndex failure would yield wrong search results downstream.
+        if (!_searcher->is_index_loaded()) {
+            return Status::InternalError("vector index searcher did not finish loading: " + index_path);
+        }
+    } catch (const tenann::Error& e) {
+        return tenann_error_to_status(e);
+    } catch (const std::exception& e) {
         return Status::InternalError(e.what());
     }
     return Status::OK();

--- a/be/src/storage/index/vector/tenann_index_reader.h
+++ b/be/src/storage/index/vector/tenann_index_reader.h
@@ -21,6 +21,7 @@
 #include "tenann/common/type_traits.h"
 #include "tenann/factory/ann_searcher_factory.h"
 #include "tenann/factory/index_factory.h"
+#include "tenann/index/index_cache.h"
 #include "tenann/searcher/ann_searcher.h"
 #include "tenann/searcher/faiss_hnsw_ann_searcher.h"
 #include "tenann/searcher/id_filter.h"
@@ -33,9 +34,10 @@ public:
     TenANNReader() = default;
     ~TenANNReader() override = default;
 
-    Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path) override;
-
-    Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs) override;
+    // fs == nullptr reads index_path from the local filesystem; otherwise
+    // VectorIndexFileReader bridges tenann to the provided FileSystem.
+    Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path,
+                         FileSystem* fs = nullptr) override;
 
     Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs,
                          size_t segment_num_rows, int query_k, bool user_set_ef) override;
@@ -48,6 +50,8 @@ public:
 
 private:
     std::shared_ptr<tenann::AnnSearcher> _searcher;
+    // Pins the cache entry for the reader's lifetime.
+    tenann::IndexCacheHandle _cache_handle;
 };
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_cache.cpp
+++ b/be/src/storage/index/vector/vector_index_cache.cpp
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/vector/vector_index_cache.h"
+
+#ifdef WITH_TENANN
+
+#include "common/logging.h"
+#include "runtime/mem_tracker.h"
+
+namespace starrocks {
+
+VectorIndexCache::VectorIndexCache(size_t capacity, MemTracker* tracker) : _cache(capacity) {
+    _cache.set_mem_tracker(tracker);
+}
+
+bool VectorIndexCache::Lookup(const tenann::CacheKey& key, tenann::IndexCacheHandle* handle) {
+    // Intentionally does not bump _lookup_count / _hit_count. Lookup is used by
+    // VectorIndexReaderFactory as an opportunistic probe to skip the OSS HEAD
+    // round-trip on warm-cache reads; the actual cache lookup that drives load
+    // semantics happens in the GetOrCreate call inside TenANNReader::init_searcher
+    // shortly after. Counting both would double the absolute lookup_count / hit_count
+    // gauges that production dashboards/alerts compare against pre-PR baselines.
+    Entry* entry = _cache.get(key.to_string());
+    if (entry == nullptr) return false;
+
+    tenann::IndexRef ref;
+    {
+        auto g = entry->value().guard();
+        if (!entry->value().has_ref()) {
+            // Entry is being populated by another caller; report miss.
+            g.unlock();
+            _cache.release(entry);
+            return false;
+        }
+        ref = entry->value().ref();
+    }
+    *handle = _wrap(entry, std::move(ref));
+    return true;
+}
+
+void VectorIndexCache::Insert(const tenann::CacheKey& key, tenann::IndexRef ref, tenann::IndexCacheHandle* handle) {
+    Entry* entry = _cache.get_or_create(key.to_string());
+    {
+        auto g = entry->value().guard();
+        entry->value().set_ref(ref);
+        _cache.update_object_size(entry, entry->value().memory_usage());
+    }
+    *handle = _wrap(entry, std::move(ref));
+}
+
+bool VectorIndexCache::GetOrCreate(const tenann::CacheKey& key, const IndexLoader& loader,
+                                   tenann::IndexCacheHandle* handle) {
+    // Per-entry guard single-flights the cold-load path: only one caller runs
+    // loader() and pairs it with update_object_size; others wait and observe
+    // has_ref() == true. On failure, remove(entry) drops our caller ref so
+    // retries start fresh.
+    _lookup_count.fetch_add(1, std::memory_order_relaxed);
+    Entry* entry = _cache.get_or_create(key.to_string());
+    tenann::IndexRef ref;
+    bool warm_hit;
+    {
+        auto g = entry->value().guard();
+        warm_hit = entry->value().has_ref();
+        if (!warm_hit) {
+            tenann::IndexRef loaded;
+            try {
+                loaded = loader();
+            } catch (const std::exception& e) {
+                g.unlock();
+                _cache.remove(entry);
+                LOG(ERROR) << "VectorIndexCache loader threw for key " << key.to_string() << ": " << e.what();
+                return false;
+            }
+            if (loaded == nullptr) {
+                g.unlock();
+                _cache.remove(entry);
+                LOG(ERROR) << "VectorIndexCache loader returned null IndexRef for key " << key.to_string();
+                return false;
+            }
+            entry->value().set_ref(std::move(loaded));
+            _cache.update_object_size(entry, entry->value().memory_usage());
+        }
+        ref = entry->value().ref();
+    }
+    if (warm_hit) {
+        _hit_count.fetch_add(1, std::memory_order_relaxed);
+    }
+    *handle = _wrap(entry, std::move(ref));
+    return true;
+}
+
+// Deleter releases the entry ref when the handle is destroyed. The lambda
+// captures _cache as a raw pointer: callers (TenANNReader::_cache_handle,
+// etc.) must release every handle before ExecEnv::destroy() runs reset().
+// _wait_for_fragments_finish() at shutdown serves as the drain point. Same
+// contract as PrimaryIndex/StoragePageCache and the original tenann global
+// cache; see DynamicCache::~DynamicCache notes.
+tenann::IndexCacheHandle VectorIndexCache::_wrap(Entry* entry, tenann::IndexRef ref) {
+    Cache* cache = &_cache;
+    return tenann::IndexCacheHandle(
+            std::move(ref), std::shared_ptr<void>(entry, [cache](void* p) { cache->release(static_cast<Entry*>(p)); }));
+}
+
+} // namespace starrocks
+
+#endif // WITH_TENANN

--- a/be/src/storage/index/vector/vector_index_cache.cpp
+++ b/be/src/storage/index/vector/vector_index_cache.cpp
@@ -25,31 +25,10 @@ VectorIndexCache::VectorIndexCache(size_t capacity, MemTracker* tracker) : _cach
     _cache.set_mem_tracker(tracker);
 }
 
-// IVF-PQ block-cache entries (and any future entry whose value chain re-enters
-// this cache) make naive teardown unsafe. The chain on shutdown is:
-//
-//   top-level IVF-PQ entry
-//     -> tenann::IndexRef
-//        -> faiss::IndexIVFPQ
-//           -> BlockCacheInvertedLists      (owned by faiss::IndexIVFPQ)
-//              -> std::vector<IndexCacheHandle>
-//                 -> shared_ptr<void> releaser_
-//                    -> [cache](void*){cache->release(inner_entry);}
-//
-// `~DynamicCache` holds `_cache._lock` for the entire iteration and runs
-// `delete iobj` in-place. That cascade unwinds straight into the inner-entry
-// releaser, which calls `_cache.release` and tries to re-acquire the same
-// lock. std::mutex isn't recursive, so the main thread parks on
-// FUTEX_WAIT_PRIVATE value=2 forever — the symptom CI's Restart BE step
-// reports as "BE exit and gen gcov timeout".
-//
-// Fix: drain every entry's IndexRef BEFORE the base destructor takes the
-// lock. `get_all_entries` only holds `_cache._lock` while copying out the
-// list and bumping refs, so the per-entry `set_ref(nullptr)` here — which
-// is what actually triggers the BlockCacheInvertedLists destructor and the
-// inner releaser callbacks — runs with `_cache._lock` free. By the time
-// ~DynamicCache walks the list under the lock, every value()._ref is null
-// and `delete iobj` is a no-op cascade.
+// Drain IndexRefs outside _cache._lock before ~DynamicCache acquires it.
+// IVF-PQ entries hold nested IndexCacheHandles whose deleters call back into
+// _cache.release(); freeing them under ~DynamicCache's lock self-deadlocks
+// (std::mutex isn't recursive) and stalls BE shutdown.
 VectorIndexCache::~VectorIndexCache() {
     auto entries = _cache.get_all_entries();
     for (auto* entry : entries) {
@@ -62,12 +41,8 @@ VectorIndexCache::~VectorIndexCache() {
 }
 
 bool VectorIndexCache::Lookup(const tenann::CacheKey& key, tenann::IndexCacheHandle* handle) {
-    // Intentionally does not bump _lookup_count / _hit_count. Lookup is used by
-    // VectorIndexReaderFactory as an opportunistic probe to skip the OSS HEAD
-    // round-trip on warm-cache reads; the actual cache lookup that drives load
-    // semantics happens in the GetOrCreate call inside TenANNReader::init_searcher
-    // shortly after. Counting both would double the absolute lookup_count / hit_count
-    // gauges that production dashboards/alerts compare against pre-PR baselines.
+    // Counter-silent: this is the warm-path probe in VectorIndexReaderFactory
+    // and counting it would double up with the GetOrCreate call right after.
     Entry* entry = _cache.get(key.to_string());
     if (entry == nullptr) return false;
 
@@ -75,7 +50,6 @@ bool VectorIndexCache::Lookup(const tenann::CacheKey& key, tenann::IndexCacheHan
     {
         auto g = entry->value().guard();
         if (!entry->value().has_ref()) {
-            // Entry is being populated by another caller; report miss.
             g.unlock();
             _cache.release(entry);
             return false;
@@ -98,10 +72,7 @@ void VectorIndexCache::Insert(const tenann::CacheKey& key, tenann::IndexRef ref,
 
 bool VectorIndexCache::GetOrCreate(const tenann::CacheKey& key, const IndexLoader& loader,
                                    tenann::IndexCacheHandle* handle) {
-    // Per-entry guard single-flights the cold-load path: only one caller runs
-    // loader() and pairs it with update_object_size; others wait and observe
-    // has_ref() == true. On failure, remove(entry) drops our caller ref so
-    // retries start fresh.
+    // Per-entry guard single-flights cold loads.
     _lookup_count.fetch_add(1, std::memory_order_relaxed);
     Entry* entry = _cache.get_or_create(key.to_string());
     tenann::IndexRef ref;
@@ -137,12 +108,8 @@ bool VectorIndexCache::GetOrCreate(const tenann::CacheKey& key, const IndexLoade
     return true;
 }
 
-// Deleter releases the entry ref when the handle is destroyed. The lambda
-// captures _cache as a raw pointer: callers (TenANNReader::_cache_handle,
-// etc.) must release every handle before ExecEnv::destroy() runs reset().
-// _wait_for_fragments_finish() at shutdown serves as the drain point. Same
-// contract as PrimaryIndex/StoragePageCache and the original tenann global
-// cache; see DynamicCache::~DynamicCache notes.
+// Deleter captures _cache as a raw pointer; handles MUST be released before
+// ExecEnv::destroy() — _wait_for_fragments_finish() is the drain boundary.
 tenann::IndexCacheHandle VectorIndexCache::_wrap(Entry* entry, tenann::IndexRef ref) {
     Cache* cache = &_cache;
     return tenann::IndexCacheHandle(

--- a/be/src/storage/index/vector/vector_index_cache.cpp
+++ b/be/src/storage/index/vector/vector_index_cache.cpp
@@ -25,6 +25,42 @@ VectorIndexCache::VectorIndexCache(size_t capacity, MemTracker* tracker) : _cach
     _cache.set_mem_tracker(tracker);
 }
 
+// IVF-PQ block-cache entries (and any future entry whose value chain re-enters
+// this cache) make naive teardown unsafe. The chain on shutdown is:
+//
+//   top-level IVF-PQ entry
+//     -> tenann::IndexRef
+//        -> faiss::IndexIVFPQ
+//           -> BlockCacheInvertedLists      (owned by faiss::IndexIVFPQ)
+//              -> std::vector<IndexCacheHandle>
+//                 -> shared_ptr<void> releaser_
+//                    -> [cache](void*){cache->release(inner_entry);}
+//
+// `~DynamicCache` holds `_cache._lock` for the entire iteration and runs
+// `delete iobj` in-place. That cascade unwinds straight into the inner-entry
+// releaser, which calls `_cache.release` and tries to re-acquire the same
+// lock. std::mutex isn't recursive, so the main thread parks on
+// FUTEX_WAIT_PRIVATE value=2 forever — the symptom CI's Restart BE step
+// reports as "BE exit and gen gcov timeout".
+//
+// Fix: drain every entry's IndexRef BEFORE the base destructor takes the
+// lock. `get_all_entries` only holds `_cache._lock` while copying out the
+// list and bumping refs, so the per-entry `set_ref(nullptr)` here — which
+// is what actually triggers the BlockCacheInvertedLists destructor and the
+// inner releaser callbacks — runs with `_cache._lock` free. By the time
+// ~DynamicCache walks the list under the lock, every value()._ref is null
+// and `delete iobj` is a no-op cascade.
+VectorIndexCache::~VectorIndexCache() {
+    auto entries = _cache.get_all_entries();
+    for (auto* entry : entries) {
+        auto g = entry->value().guard();
+        entry->value().set_ref(nullptr);
+    }
+    for (auto* entry : entries) {
+        _cache.release(entry);
+    }
+}
+
 bool VectorIndexCache::Lookup(const tenann::CacheKey& key, tenann::IndexCacheHandle* handle) {
     // Intentionally does not bump _lookup_count / _hit_count. Lookup is used by
     // VectorIndexReaderFactory as an opportunistic probe to skip the OSS HEAD

--- a/be/src/storage/index/vector/vector_index_cache.h
+++ b/be/src/storage/index/vector/vector_index_cache.h
@@ -1,0 +1,97 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef WITH_TENANN
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <ostream>
+#include <string>
+
+#include "tenann/index/index_cache.h"
+#include "util/dynamic_cache.h"
+
+namespace starrocks {
+
+class MemTracker;
+
+// VectorIndexCacheEntry holds the cached tenann::IndexRef. All access to _ref
+// goes through guard() — read or write. This matches PrimaryIndex /
+// StoragePageCache and keeps set_ref + update_object_size paired and
+// single-flights the cold-load path in VectorIndexCache::GetOrCreate.
+class VectorIndexCacheEntry {
+public:
+    std::unique_lock<std::mutex> guard() { return std::unique_lock<std::mutex>(_mu); }
+
+    // All of the below must be called while holding guard().
+    bool has_ref() const { return _ref != nullptr; }
+    tenann::IndexRef ref() const { return _ref; }
+    void set_ref(tenann::IndexRef ref) { _ref = std::move(ref); }
+    size_t memory_usage() const { return _ref ? _ref->EstimateMemoryUsage() : 0; }
+
+private:
+    std::mutex _mu;
+    tenann::IndexRef _ref;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const VectorIndexCacheEntry&) {
+    return os << "VectorIndexCacheEntry";
+}
+
+// SR-owned tenann::IndexCache backed by DynamicCache. MemTracker is attached
+// on construction; ExecEnv must destruct this before the tracker hierarchy
+// (see ExecEnv::destroy).
+class VectorIndexCache final : public tenann::IndexCache {
+public:
+    using Cache = DynamicCache<std::string, VectorIndexCacheEntry>;
+    using Entry = Cache::Entry;
+
+    VectorIndexCache(size_t capacity, MemTracker* tracker);
+    ~VectorIndexCache() override = default;
+
+    VectorIndexCache(const VectorIndexCache&) = delete;
+    VectorIndexCache& operator=(const VectorIndexCache&) = delete;
+
+    [[nodiscard]] bool Lookup(const tenann::CacheKey& key, tenann::IndexCacheHandle* handle) override;
+    // tenann::IndexCache contract; SR production paths all go through
+    // GetOrCreate. Currently only exercised by the unit tests as a direct
+    // way to populate entries (LRU / capacity / mem-tracker coverage).
+    void Insert(const tenann::CacheKey& key, tenann::IndexRef ref, tenann::IndexCacheHandle* handle) override;
+    // Returns false if the loader threw or returned null; callers must check
+    // the bool, not wrap in try/catch.
+    [[nodiscard]] bool GetOrCreate(const tenann::CacheKey& key, const IndexLoader& loader,
+                                   tenann::IndexCacheHandle* handle) override;
+
+    void SetCapacity(size_t new_capacity) { _cache.set_capacity(new_capacity); }
+    size_t capacity() const { return _cache.capacity(); }
+    size_t memory_usage() const { return _cache.size(); }
+
+    uint64_t lookup_count() const { return _lookup_count.load(std::memory_order_relaxed); }
+    uint64_t hit_count() const { return _hit_count.load(std::memory_order_relaxed); }
+
+private:
+    tenann::IndexCacheHandle _wrap(Entry* entry, tenann::IndexRef ref);
+
+    Cache _cache;
+    std::atomic<uint64_t> _lookup_count{0};
+    std::atomic<uint64_t> _hit_count{0};
+};
+
+} // namespace starrocks
+
+#endif // WITH_TENANN

--- a/be/src/storage/index/vector/vector_index_cache.h
+++ b/be/src/storage/index/vector/vector_index_cache.h
@@ -33,15 +33,12 @@ class MemTracker;
 
 namespace starrocks {
 
-// VectorIndexCacheEntry holds the cached tenann::IndexRef. All access to _ref
-// goes through guard() — read or write. This matches PrimaryIndex /
-// StoragePageCache and keeps set_ref + update_object_size paired and
-// single-flights the cold-load path in VectorIndexCache::GetOrCreate.
+// Per-entry holder: access to _ref must be under guard() so set_ref pairs with
+// update_object_size and single-flights the cold-load path in GetOrCreate.
 class VectorIndexCacheEntry {
 public:
     std::unique_lock<std::mutex> guard() { return std::unique_lock<std::mutex>(_mu); }
 
-    // All of the below must be called while holding guard().
     bool has_ref() const { return _ref != nullptr; }
     tenann::IndexRef ref() const { return _ref; }
     void set_ref(tenann::IndexRef ref) { _ref = std::move(ref); }
@@ -56,9 +53,7 @@ inline std::ostream& operator<<(std::ostream& os, const VectorIndexCacheEntry&) 
     return os << "VectorIndexCacheEntry";
 }
 
-// SR-owned tenann::IndexCache backed by DynamicCache. MemTracker is attached
-// on construction; ExecEnv must destruct this before the tracker hierarchy
-// (see ExecEnv::destroy).
+// SR-owned tenann::IndexCache backed by DynamicCache, with MemTracker attached.
 class VectorIndexCache final : public tenann::IndexCache {
 public:
     using Cache = DynamicCache<std::string, VectorIndexCacheEntry>;
@@ -71,12 +66,9 @@ public:
     VectorIndexCache& operator=(const VectorIndexCache&) = delete;
 
     [[nodiscard]] bool Lookup(const tenann::CacheKey& key, tenann::IndexCacheHandle* handle) override;
-    // tenann::IndexCache contract; SR production paths all go through
-    // GetOrCreate. Currently only exercised by the unit tests as a direct
-    // way to populate entries (LRU / capacity / mem-tracker coverage).
+    // Required by tenann::IndexCache; SR production paths use GetOrCreate.
     void Insert(const tenann::CacheKey& key, tenann::IndexRef ref, tenann::IndexCacheHandle* handle) override;
-    // Returns false if the loader threw or returned null; callers must check
-    // the bool, not wrap in try/catch.
+    // Returns false on loader failure (exception or null IndexRef).
     [[nodiscard]] bool GetOrCreate(const tenann::CacheKey& key, const IndexLoader& loader,
                                    tenann::IndexCacheHandle* handle) override;
 
@@ -101,12 +93,8 @@ private:
 
 namespace starrocks {
 
-// Stub used in non-tenann builds (e.g. Darwin). The BE never constructs a
-// VectorIndexCache when tenann is not linked, so this stub is only here so
-// callers can hold a `VectorIndexCache*` and reference its stat accessors
-// without their own WITH_TENANN guards. All public methods return zero/no-op
-// values, matching the "no cache exists" semantics those callers handle via
-// the nullptr check on ExecEnv::vector_index_cache().
+// Stub for non-tenann builds (e.g. Darwin): never constructed, lets callers
+// reference accessors without their own WITH_TENANN guards.
 class VectorIndexCache {
 public:
     VectorIndexCache(size_t, MemTracker*) {}

--- a/be/src/storage/index/vector/vector_index_cache.h
+++ b/be/src/storage/index/vector/vector_index_cache.h
@@ -65,7 +65,7 @@ public:
     using Entry = Cache::Entry;
 
     VectorIndexCache(size_t capacity, MemTracker* tracker);
-    ~VectorIndexCache() override = default;
+    ~VectorIndexCache() override;
 
     VectorIndexCache(const VectorIndexCache&) = delete;
     VectorIndexCache& operator=(const VectorIndexCache&) = delete;

--- a/be/src/storage/index/vector/vector_index_cache.h
+++ b/be/src/storage/index/vector/vector_index_cache.h
@@ -14,11 +14,16 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+
+namespace starrocks {
+class MemTracker;
+}
+
 #ifdef WITH_TENANN
 
 #include <atomic>
-#include <cstddef>
-#include <cstdint>
 #include <mutex>
 #include <ostream>
 #include <string>
@@ -27,8 +32,6 @@
 #include "util/dynamic_cache.h"
 
 namespace starrocks {
-
-class MemTracker;
 
 // VectorIndexCacheEntry holds the cached tenann::IndexRef. All access to _ref
 // goes through guard() — read or write. This matches PrimaryIndex /
@@ -90,6 +93,28 @@ private:
     Cache _cache;
     std::atomic<uint64_t> _lookup_count{0};
     std::atomic<uint64_t> _hit_count{0};
+};
+
+} // namespace starrocks
+
+#else // !WITH_TENANN
+
+namespace starrocks {
+
+// Stub used in non-tenann builds (e.g. Darwin). The BE never constructs a
+// VectorIndexCache when tenann is not linked, so this stub is only here so
+// callers can hold a `VectorIndexCache*` and reference its stat accessors
+// without their own WITH_TENANN guards. All public methods return zero/no-op
+// values, matching the "no cache exists" semantics those callers handle via
+// the nullptr check on ExecEnv::vector_index_cache().
+class VectorIndexCache {
+public:
+    VectorIndexCache(size_t, MemTracker*) {}
+    void SetCapacity(size_t) {}
+    size_t capacity() const { return 0; }
+    size_t memory_usage() const { return 0; }
+    uint64_t lookup_count() const { return 0; }
+    uint64_t hit_count() const { return 0; }
 };
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_file_reader.cpp
+++ b/be/src/storage/index/vector/vector_index_file_reader.cpp
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef WITH_TENANN
+
+#include "storage/index/vector/vector_index_file_reader.h"
+
+#include <memory>
+#include <utility>
+
+#include "common/status.h"
+#include "common/statusor.h"
+#include "fs/fs.h"
+
+namespace starrocks {
+
+StatusOr<std::unique_ptr<VectorIndexFileReader>> VectorIndexFileReader::open(FileSystem* fs, const std::string& path) {
+    ASSIGN_OR_RETURN(auto raf, fs->new_random_access_file(path));
+    ASSIGN_OR_RETURN(uint64_t size, raf->get_size());
+    return std::make_unique<VectorIndexFileReader>(std::move(raf), static_cast<int64_t>(size));
+}
+
+} // namespace starrocks
+
+#endif

--- a/be/src/storage/index/vector/vector_index_file_reader.h
+++ b/be/src/storage/index/vector/vector_index_file_reader.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 
+#include "common/statusor.h"
 #include "fs/fs.h"
 #include "tenann/store/index_file_reader.h"
 
@@ -28,6 +29,12 @@ namespace starrocks {
 // enabling TenANN to read vector index files from remote storage (S3/HDFS/OSS).
 class VectorIndexFileReader : public tenann::IndexFileReader {
 public:
+    // Static factory: opens the `.vi` at `path` through `fs`, resolves size,
+    // returns a ready-to-use reader. Fails Status::NotFound if the file is
+    // missing, propagated from the filesystem layer. Prefer this over
+    // manually constructing the triplet (new_random_access_file + get_size + ctor).
+    static StatusOr<std::unique_ptr<VectorIndexFileReader>> open(FileSystem* fs, const std::string& path);
+
     VectorIndexFileReader(std::unique_ptr<RandomAccessFile> file, int64_t file_size)
             : _file(std::move(file)), _file_size(file_size), _filename(_file->filename()) {}
 

--- a/be/src/storage/index/vector/vector_index_reader.h
+++ b/be/src/storage/index/vector/vector_index_reader.h
@@ -51,20 +51,11 @@ public:
     virtual ~VectorIndexReader() = default;
 
 #ifdef WITH_TENANN
-    virtual Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path) = 0;
+    virtual Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path,
+                                 FileSystem* fs = nullptr) = 0;
 
-    virtual Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs) {
-        return init_searcher(meta, index_path);
-    }
-
-    // Overload that carries context for per-segment adaptive ef_search:
-    //   segment_num_rows: row count of this segment, used as the scaling signal
-    //   query_k: effective k (already multiplied by k_factor) the caller plans
-    //     to pass to search(); used as a floor for ef_base to match faiss's
-    //     internal `ef = max(efSearch, k)` rule
-    //   user_set_ef: true if the user explicitly specified efSearch (e.g. via
-    //     query hint); when true, adaptive scaling is skipped
-    // Default forwards to the row-count-unaware overload.
+    // Per-segment context for apply_adaptive_ef_search(). Default forwards
+    // to the row-count-unaware form for readers without adaptive scaling.
     virtual Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path, FileSystem* fs,
                                  size_t segment_num_rows, int query_k, bool user_set_ef) {
         return init_searcher(meta, index_path, fs);

--- a/be/src/storage/index/vector/vector_index_reader_factory.cpp
+++ b/be/src/storage/index/vector/vector_index_reader_factory.cpp
@@ -19,12 +19,25 @@
 #include "storage/index/vector/empty_index_reader.h"
 #include "storage/index/vector/tenann_index_reader.h"
 #include "storage/index/vector/vector_index_reader.h"
+#include "tenann/index/index_cache.h"
 
 namespace starrocks {
 
 static Status create_from_file_impl(const std::string& index_path,
                                     const std::shared_ptr<tenann::IndexMeta>& /*index_meta*/,
                                     std::shared_ptr<VectorIndexReader>* vector_index_reader, FileSystem* fs) {
+    // Warm path: an entry in the cache means the .vi file exists and is not
+    // an empty-mark placeholder, so we can skip the OSS/S3 HEAD round-trips
+    // (path_exist + new_random_access_file + get_size) that the cold path runs.
+    auto* cache = tenann::GetGlobalIndexCache();
+    if (cache != nullptr) {
+        tenann::IndexCacheHandle probe;
+        if (cache->Lookup(tenann::CacheKey(index_path), &probe)) {
+            (*vector_index_reader) = std::make_shared<TenANNReader>();
+            return Status::OK();
+        }
+    }
+
     std::unique_ptr<RandomAccessFile> index_file;
     if (fs != nullptr) {
         // Remote FS: let new_random_access_file() be the single source of truth for

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -991,9 +991,9 @@ inline Status SegmentIterator::_init_reader_from_file(const std::string& index_p
             break;
         }
     }
-    auto status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), index_path, fs,
-                                                               static_cast<size_t>(_segment->num_rows()),
-                                                               _vector_index_ctx->k, user_set_ef);
+    Status status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), index_path, fs,
+                                                                 static_cast<size_t>(_segment->num_rows()),
+                                                                 _vector_index_ctx->k, user_set_ef);
     // empty ann reader — caller will set up brute-force fallback
     if (status.is_not_supported()) {
         _vector_index_ctx->use_vector_index = false;

--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -228,12 +228,24 @@ public:
     // size used by object may change, this method
     // track size changes and evict objects accordingly
     // return false if actual memory usage is larger than capacity
+    //
+    // Defers `delete entry` to AFTER releasing _lock so a cached value whose
+    // destructor re-enters the cache (e.g. VectorIndexCache entries holding
+    // tenann handles back into the same cache) cannot self-deadlock on _lock.
     bool update_object_size(Entry* entry, size_t new_size) {
-        std::lock_guard<Lock> lg(_lock);
-        _size += new_size - entry->_size;
-        if (_mem_tracker) _mem_tracker->consume(new_size - entry->_size);
-        entry->_size = new_size;
-        return _evict();
+        std::vector<Entry*> entry_list;
+        bool ret;
+        {
+            std::lock_guard<Lock> lg(_lock);
+            _size += new_size - entry->_size;
+            if (_mem_tracker) _mem_tracker->consume(new_size - entry->_size);
+            entry->_size = new_size;
+            ret = _evict(_capacity, &entry_list);
+        }
+        for (Entry* e : entry_list) {
+            delete e;
+        }
+        return ret;
     }
 
     // clear all unused *and* expired objects
@@ -296,10 +308,22 @@ public:
 
     // adjust capacity
     // return false if actual memory usage is larger than capacity
+    //
+    // Same deferred-delete rationale as update_object_size: keep entry
+    // destructors out from under _lock to avoid self-deadlock when an
+    // entry's value chain re-enters the cache on release.
     bool set_capacity(size_t capacity) {
-        std::lock_guard<Lock> lg(_lock);
-        _capacity = capacity;
-        return _evict();
+        std::vector<Entry*> entry_list;
+        bool ret;
+        {
+            std::lock_guard<Lock> lg(_lock);
+            _capacity = capacity;
+            ret = _evict(_capacity, &entry_list);
+        }
+        for (Entry* e : entry_list) {
+            delete e;
+        }
+        return ret;
     }
 
     std::vector<std::pair<Key, size_t>> get_entry_sizes() const {

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -17,7 +17,7 @@
 #include <runtime/exec_env.h>
 #include <runtime/mem_tracker.h>
 #ifdef WITH_TENANN
-#include <tenann/index/index_cache.h>
+#include "storage/index/vector/vector_index_cache.h"
 #endif
 
 #include "cache/datacache.h"
@@ -59,8 +59,8 @@ public:
     METRIC_DEFINE_DOUBLE_GAUGE(vector_index_cache_dynamic_hit_ratio, MetricUnit::PERCENT);
 
 private:
-    int _previous_lookup_count;
-    int _previous_hit_count;
+    uint64_t _previous_lookup_count = 0;
+    uint64_t _previous_hit_count = 0;
 };
 
 class RuntimeFilterMetrics {
@@ -153,6 +153,7 @@ void SystemMetrics::_install_memory_metrics(MetricRegistry* registry) {
     registry->register_metric("clone_mem_bytes", &_memory_metrics->clone_mem_bytes);
     registry->register_metric("consistency_mem_bytes", &_memory_metrics->consistency_mem_bytes);
     registry->register_metric("datacache_mem_bytes", &_memory_metrics->datacache_mem_bytes);
+    registry->register_metric("vector_index_mem_bytes", &_memory_metrics->vector_index_mem_bytes);
 }
 
 void SystemMetrics::_update_datacache_mem_tracker() {
@@ -250,6 +251,7 @@ void SystemMetrics::update_memory_metrics() {
     SET_MEM_METRIC_VALUE(consistency_mem_tracker, consistency_mem_bytes)
     SET_MEM_METRIC_VALUE(datacache_mem_tracker, datacache_mem_bytes)
     SET_MEM_METRIC_VALUE(replication_mem_tracker, replication_mem_bytes)
+    SET_MEM_METRIC_VALUE(vector_index_mem_tracker, vector_index_mem_bytes)
 #undef SET_MEM_METRIC_VALUE
 }
 
@@ -334,7 +336,7 @@ void SystemMetrics::_install_vector_index_cache_metrics(MetricRegistry* registry
 
 void SystemMetrics::_update_vector_index_cache_metrics() {
 #ifdef WITH_TENANN
-    auto* index_cache = tenann::IndexCache::GetGlobalInstance();
+    auto* index_cache = ExecEnv::GetInstance()->vector_index_cache();
     if (UNLIKELY(index_cache == nullptr)) {
         return;
     }

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -16,11 +16,9 @@
 
 #include <runtime/exec_env.h>
 #include <runtime/mem_tracker.h>
-#ifdef WITH_TENANN
-#include "storage/index/vector/vector_index_cache.h"
-#endif
 
 #include "cache/datacache.h"
+#include "storage/index/vector/vector_index_cache.h"
 #ifdef USE_STAROS
 #include "fslib/star_cache_handler.h"
 #endif
@@ -335,7 +333,6 @@ void SystemMetrics::_install_vector_index_cache_metrics(MetricRegistry* registry
 }
 
 void SystemMetrics::_update_vector_index_cache_metrics() {
-#ifdef WITH_TENANN
     auto* index_cache = ExecEnv::GetInstance()->vector_index_cache();
     if (UNLIKELY(index_cache == nullptr)) {
         return;
@@ -344,12 +341,6 @@ void SystemMetrics::_update_vector_index_cache_metrics() {
     auto usage = index_cache->memory_usage();
     auto lookup_count = index_cache->lookup_count();
     auto hit_count = index_cache->hit_count();
-#else
-    auto capacity = 0;
-    auto usage = 0;
-    auto lookup_count = 0;
-    auto hit_count = 0;
-#endif
     auto usage_ratio = (capacity == 0L) ? 0.0 : double(usage) / double(capacity);
     auto hit_ratio = (lookup_count == 0L) ? 0.0 : double(hit_count) / double(lookup_count);
     auto dynamic_lookup_count = lookup_count - _vector_index_cache_metrics->_previous_lookup_count;

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -68,6 +68,7 @@ public:
     METRIC_DEFINE_INT_GAUGE(consistency_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(datacache_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(replication_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(vector_index_mem_bytes, MetricUnit::BYTES);
 };
 
 class SystemMetrics {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -434,6 +434,7 @@ SET(DW_TEST_FILES
     ./storage/get_use_pk_index_test.cpp
     ./storage/index/vector_index_test.cpp
     ./storage/index/vector_search_test.cpp
+    ./storage/index/vector/vector_index_cache_test.cpp
     ./storage/index/builtin_inverted_index_test.cpp
     ./storage/key_coder_test.cpp
     ./storage/kv_store_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -385,6 +385,14 @@ if (APPLE)
     set(TEST_EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/test/base/macos_link_stubs.cpp)
 endif ()
 
+# Tests that link against ServiceBE / Cache. Append before add_library so the
+# object library actually picks them up (CMake evaluates EXEC_FILES by value
+# at add_library call time).
+if ("${WITH_STARCACHE}" STREQUAL "ON")
+    list(APPEND EXEC_FILES ./http/datacache_action_test.cpp)
+    list(APPEND EXEC_FILES ./http/action/update_config_action_test.cpp)
+endif ()
+
 add_library(starrocks_test_objs OBJECT ${EXEC_FILES})
 target_link_libraries(starrocks_test_objs PRIVATE StarRocksPCH)
 if (NOT STARROCKS_JIT_ENABLE)
@@ -582,11 +590,6 @@ SET(DW_TEST_FILES
     ./storage/lake/table_schema_service_test.cpp
     ./storage/lake/fast_schema_evolution_v2_test.cpp
 )
-
-if ("${WITH_STARCACHE}" STREQUAL "ON")
-    list(APPEND EXEC_FILES ./http/datacache_action_test.cpp)
-    list(APPEND EXEC_FILES ./http/action/update_config_action_test.cpp)
-endif ()
 
 if ("${USE_STAROS}" STREQUAL "ON")
     list(APPEND DW_TEST_FILES ./fs/fs_starlet_test.cpp)

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -168,43 +168,39 @@ TEST_F(ConfigUpdateHooksTest, test_update_lake_metadata_fetch_thread_count) {
 
 #ifndef __APPLE__
 // Re-registers the hooks with a null exec_env to verify the
-// `vector_index_cache_limit` callback short-circuits to InternalError instead
+// `vector_query_cache_capacity` callback short-circuits to InternalError instead
 // of dereferencing exec_env. The override of SetUp's registration is OK because
 // TearDown's TEST_reset() restores a clean registry for the next test.
-TEST_F(ConfigUpdateHooksTest, vector_index_cache_limit_null_exec_env_returns_internal_error) {
+TEST_F(ConfigUpdateHooksTest, vector_query_cache_capacity_null_exec_env_returns_internal_error) {
     ConfigUpdateRegistry::instance()->TEST_reset();
     register_config_update_hooks(/*exec_env=*/nullptr, *GlobalEnv::GetInstance());
     ConfigUpdateRegistry::instance()->set_ready();
 
-    auto st = ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", "1G");
+    auto st = ConfigUpdateRegistry::instance()->update_config("vector_query_cache_capacity", "1G");
     EXPECT_FALSE(st.ok()) << st.to_string();
     EXPECT_TRUE(st.is_internal_error()) << st.to_string();
 }
 
-// Happy path: covers parse_mem_spec + SetCapacity + LOG body (lines 102-109
-// of config_update_hooks.cpp). Test fixture's SetUp already registered hooks
-// against the real ExecEnv whose init() builds a VectorIndexCache, so the
-// callback follows the normal "resolve to bytes -> resize cache" path.
-TEST_F(ConfigUpdateHooksTest, vector_index_cache_limit_happy_path_resizes_cache) {
+TEST_F(ConfigUpdateHooksTest, vector_query_cache_capacity_happy_path_resizes_cache) {
     auto* cache = ExecEnv::GetInstance()->vector_index_cache();
     ASSERT_NE(cache, nullptr) << "test_main must initialize ExecEnv with vector_index_cache";
-    const std::string saved = config::vector_index_cache_limit;
+    const std::string saved = config::vector_query_cache_capacity;
 
     // Absolute bytes.
-    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", "4294967296"));
+    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_query_cache_capacity", "4294967296"));
     EXPECT_EQ(cache->capacity(), 4294967296u);
 
     // Unit-suffixed.
-    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", "512M"));
+    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_query_cache_capacity", "512M"));
     EXPECT_EQ(cache->capacity(), 512u * 1024 * 1024);
 
     // Percentage of process_mem_limit — exact value depends on test env, just
     // sanity-check it parses and resizes to something positive.
-    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", "10%"));
+    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_query_cache_capacity", "10%"));
     EXPECT_GT(cache->capacity(), 0u);
 
     // Restore for downstream tests/files.
-    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", saved));
+    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_query_cache_capacity", saved));
 }
 #endif
 

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -163,4 +163,20 @@ TEST_F(ConfigUpdateHooksTest, test_update_lake_metadata_fetch_thread_count) {
     ASSERT_EQ(1, thread_pool->max_threads());
 }
 
+#ifndef __APPLE__
+// Re-registers the hooks with a null exec_env to verify the
+// `vector_index_cache_limit` callback short-circuits to InternalError instead
+// of dereferencing exec_env. The override of SetUp's registration is OK because
+// TearDown's TEST_reset() restores a clean registry for the next test.
+TEST_F(ConfigUpdateHooksTest, vector_index_cache_limit_null_exec_env_returns_internal_error) {
+    ConfigUpdateRegistry::instance()->TEST_reset();
+    register_config_update_hooks(/*exec_env=*/nullptr, *GlobalEnv::GetInstance());
+    ConfigUpdateRegistry::instance()->set_ready();
+
+    auto st = ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", "1G");
+    EXPECT_FALSE(st.ok()) << st.to_string();
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+}
+#endif
+
 } // namespace starrocks

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -18,12 +18,14 @@
 #include "base/testutil/assert.h"
 #include "base/testutil/scoped_updater.h"
 #include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "cache/datacache.h"
 #include "cache/disk_cache/starcache_engine.h"
 #include "cache/disk_cache/test_cache_utils.h"
 #include "common/config_cache_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_update_registry.h"
+#include "common/config_vector_index_fwd.h"
 #include "common/system/cpu_info.h"
 #include "common/util/bthreads/executor.h"
 #include "fs/fs_util.h"
@@ -31,6 +33,7 @@
 #include "runtime/env/global_env.h"
 #include "runtime/exec_env.h"
 #include "service/service_be/config_update_hooks.h"
+#include "storage/index/vector/vector_index_cache.h"
 #include "storage/persistent_index_load_executor.h"
 #include "storage/storage_engine.h"
 #include "storage/update_manager.h"
@@ -176,6 +179,32 @@ TEST_F(ConfigUpdateHooksTest, vector_index_cache_limit_null_exec_env_returns_int
     auto st = ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", "1G");
     EXPECT_FALSE(st.ok()) << st.to_string();
     EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+}
+
+// Happy path: covers parse_mem_spec + SetCapacity + LOG body (lines 102-109
+// of config_update_hooks.cpp). Test fixture's SetUp already registered hooks
+// against the real ExecEnv whose init() builds a VectorIndexCache, so the
+// callback follows the normal "resolve to bytes -> resize cache" path.
+TEST_F(ConfigUpdateHooksTest, vector_index_cache_limit_happy_path_resizes_cache) {
+    auto* cache = ExecEnv::GetInstance()->vector_index_cache();
+    ASSERT_NE(cache, nullptr) << "test_main must initialize ExecEnv with vector_index_cache";
+    const std::string saved = config::vector_index_cache_limit;
+
+    // Absolute bytes.
+    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", "4294967296"));
+    EXPECT_EQ(cache->capacity(), 4294967296u);
+
+    // Unit-suffixed.
+    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", "512M"));
+    EXPECT_EQ(cache->capacity(), 512u * 1024 * 1024);
+
+    // Percentage of process_mem_limit — exact value depends on test env, just
+    // sanity-check it parses and resizes to something positive.
+    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", "10%"));
+    EXPECT_GT(cache->capacity(), 0u);
+
+    // Restore for downstream tests/files.
+    ASSERT_OK(ConfigUpdateRegistry::instance()->update_config("vector_index_cache_limit", saved));
 }
 #endif
 

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -27,12 +27,9 @@
 
 #include "base/string/slice.h"
 #include "base/testutil/assert.h"
-#include "common/config_update_registry.h"
 #include "common/status.h"
 #include "fs/fs_memory.h"
-#include "runtime/env/global_env.h"
 #include "runtime/mem_tracker.h"
-#include "service/service_be/config_update_hooks.h"
 #include "storage/index/vector/empty_index_reader.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/tenann_index_reader.h"
@@ -52,6 +49,17 @@ tenann::IndexRef make_dummy_ref(size_t bytes = kDummyBytes) {
     return std::make_shared<tenann::Index>(
             buf, tenann::IndexType::kFaissIvfPqOneInvertedList, [](void* v) { std::free(v); },
             /*explicit_bytes=*/bytes);
+}
+
+// Minimal IndexMeta that survives apply_index_reader_cache_options(): default
+// construction leaves index_type unset and tenann throws "index type not set
+// in index meta" the moment init_searcher reads it, escaping as an unknown
+// exception before the loader's catch arm ever runs.
+tenann::IndexMeta make_minimal_meta() {
+    tenann::IndexMeta meta;
+    meta.SetIndexFamily(tenann::IndexFamily::kVectorIndex);
+    meta.SetIndexType(tenann::IndexType::kFaissHnsw);
+    return meta;
 }
 } // namespace
 
@@ -268,6 +276,48 @@ TEST_F(VectorIndexCacheTest, MemTracker_CrossThread_EvictReleasesCorrectly) {
     EXPECT_LE(tracker_->consumption(), base + 512);
 }
 
+// Repros the shutdown deadlock pattern: a top-level IVF-PQ entry holds a
+// tenann::IndexRef whose underlying Index, when destructed, releases another
+// IndexCacheHandle pointing back into the same cache. `~DynamicCache` runs the
+// IndexRef destructor while holding `_cache._lock` — without the fix the
+// inner release recursively tries to take `_cache._lock` and FUTEX_WAITs
+// forever. We assert that destruction (and a shrink-to-zero eviction) both
+// complete; a deadlock would hang the test instead of failing it.
+TEST_F(VectorIndexCacheTest, ShutdownAndShrink_WithSelfReferentialEntry_NoDeadlock) {
+    auto c = std::make_unique<VectorIndexCache>(/*capacity=*/64 * 1024, tracker_.get());
+
+    // Seed an "inner" entry plus a pinning handle that the outer ref will
+    // hold and release on destruction — the BlockCacheInvertedLists pattern.
+    tenann::IndexCacheHandle inner;
+    c->Insert(tenann::CacheKey("/inner.vi"), make_dummy_ref(1024), &inner);
+
+    // Outer Index whose deleter consumes the inner handle. Moving the handle
+    // into the deleter lambda is the same shape as faiss owning a
+    // BlockCacheInvertedLists that owns std::vector<IndexCacheHandle>.
+    struct OuterPayload {
+        tenann::IndexCacheHandle pinned;
+        std::vector<char> bytes;
+    };
+    auto* payload = new OuterPayload{std::move(inner), std::vector<char>(2048)};
+    auto outer_ref = std::make_shared<tenann::Index>(
+            payload, tenann::IndexType::kFaissIvfPq,
+            [](void* p) { delete static_cast<OuterPayload*>(p); },
+            /*explicit_bytes=*/2048);
+
+    tenann::IndexCacheHandle outer;
+    c->Insert(tenann::CacheKey("/outer.vi"), outer_ref, &outer);
+    outer_ref.reset();
+    outer = tenann::IndexCacheHandle{};
+
+    // Runtime safety: shrinking to zero forces eviction of the outer entry,
+    // which must not deadlock when the chained release runs.
+    c->SetCapacity(0);
+
+    // Shutdown safety: destructing the cache must drain the remaining inner
+    // entry without re-locking _cache._lock.
+    c.reset();
+}
+
 // === Sibling helpers under storage/index/vector ===
 
 TEST(TenannErrorToStatusTest, NotFoundVariantsMapToNotFound) {
@@ -331,7 +381,7 @@ TEST(TenANNReaderTest, InitSearcher_FileNotFoundViaFs_PropagatesNotFound) {
 
     MemoryFileSystem fs;
     TenANNReader r;
-    tenann::IndexMeta meta;
+    auto meta = make_minimal_meta();
     auto st = r.init_searcher(meta, "/no/such/index.vi", &fs);
     EXPECT_TRUE(st.is_not_found()) << st.to_string();
 
@@ -355,7 +405,7 @@ TEST(TenANNReaderTest, InitSearcher_MalformedFile_ReturnsNonOk) {
     ASSERT_OK(fs.append_file("/tmp/garbage.vi", Slice("not a real index", 16)));
 
     TenANNReader r;
-    tenann::IndexMeta meta;
+    auto meta = make_minimal_meta();
     auto st = r.init_searcher(meta, "/tmp/garbage.vi", &fs);
     EXPECT_FALSE(st.ok()) << "loader should surface tenann::Error / std::exception, not crash";
 
@@ -367,24 +417,6 @@ TEST(VectorIndexCacheEntryTest, StreamingOperatorPrintsTag) {
     std::ostringstream os;
     os << e;
     EXPECT_EQ("VectorIndexCacheEntry", os.str());
-}
-
-// register_config_update_hooks(nullptr) is well-defined: callback registration
-// does not dereference exec_env. When /api/update_config?vector_index_cache_limit=...
-// fires, the callback short-circuits on the null exec_env and returns
-// InternalError, which update_config then rolls back. Operators see the failure
-// rather than crashing the BE.
-TEST(ConfigUpdateHooksTest, VectorIndexCacheLimit_NullExecEnv_ReturnsInternalError) {
-    auto* registry = ConfigUpdateRegistry::instance();
-    registry->TEST_reset();
-    register_config_update_hooks(/*exec_env=*/nullptr, *GlobalEnv::GetInstance());
-    registry->set_ready();
-
-    auto st = registry->update_config("vector_index_cache_limit", "1G");
-    EXPECT_FALSE(st.ok()) << st.to_string();
-    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
-
-    registry->TEST_reset();
 }
 
 } // namespace starrocks

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -83,6 +83,38 @@ TEST_F(VectorIndexCacheTest, Lookup_Miss_ReturnsFalse) {
     EXPECT_FALSE(h.valid());
 }
 
+// Lookup must report miss for entries that exist but have not been populated
+// with an IndexRef yet — covers the `!entry->value().has_ref()` branch that a
+// concurrent GetOrCreate would otherwise expose to racing Lookups. Inserting
+// a nullptr IndexRef is the deterministic way to reach the same state from a
+// single thread.
+TEST_F(VectorIndexCacheTest, Lookup_EntryWithoutRef_ReportsMiss) {
+    tenann::IndexCacheHandle h_ins;
+    cache_->Insert(tenann::CacheKey("/loading.vi"), /*ref=*/nullptr, &h_ins);
+
+    tenann::IndexCacheHandle h_lkp;
+    EXPECT_FALSE(cache_->Lookup(tenann::CacheKey("/loading.vi"), &h_lkp));
+    EXPECT_FALSE(h_lkp.valid());
+}
+
+// Loud assertion on the small inline accessors (SetCapacity / capacity /
+// memory_usage / lookup_count / hit_count). Existing tests touch them
+// transitively but gcov tracking on inline header methods is unreliable —
+// asserting each one directly here makes the coverage explicit.
+TEST_F(VectorIndexCacheTest, Accessors_ReflectInsertAndCapacity) {
+    EXPECT_EQ(cache_->capacity(), 16u * 1024);
+    EXPECT_EQ(cache_->memory_usage(), 0u);
+    EXPECT_EQ(cache_->lookup_count(), 0u);
+    EXPECT_EQ(cache_->hit_count(), 0u);
+
+    tenann::IndexCacheHandle h;
+    cache_->Insert(tenann::CacheKey("/a.vi"), make_dummy_ref(2048), &h);
+    EXPECT_EQ(cache_->memory_usage(), 2048u);
+
+    cache_->SetCapacity(8 * 1024);
+    EXPECT_EQ(cache_->capacity(), 8u * 1024);
+}
+
 TEST_F(VectorIndexCacheTest, Insert_ThenLookup_ReturnsSameRef) {
     auto ref = make_dummy_ref();
     tenann::IndexCacheHandle h_ins;
@@ -300,8 +332,7 @@ TEST_F(VectorIndexCacheTest, ShutdownAndShrink_WithSelfReferentialEntry_NoDeadlo
     };
     auto* payload = new OuterPayload{std::move(inner), std::vector<char>(2048)};
     auto outer_ref = std::make_shared<tenann::Index>(
-            payload, tenann::IndexType::kFaissIvfPq,
-            [](void* p) { delete static_cast<OuterPayload*>(p); },
+            payload, tenann::IndexType::kFaissIvfPq, [](void* p) { delete static_cast<OuterPayload*>(p); },
             /*explicit_bytes=*/2048);
 
     tenann::IndexCacheHandle outer;

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -27,9 +27,12 @@
 
 #include "base/string/slice.h"
 #include "base/testutil/assert.h"
+#include "common/config_update_registry.h"
 #include "common/status.h"
 #include "fs/fs_memory.h"
+#include "runtime/env/global_env.h"
 #include "runtime/mem_tracker.h"
+#include "service/service_be/config_update_hooks.h"
 #include "storage/index/vector/empty_index_reader.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/tenann_index_reader.h"
@@ -316,11 +319,72 @@ TEST(TenANNReaderTest, InitSearcher_NoGlobalCache_ReturnsInternalError) {
     tenann::SetGlobalIndexCache(saved);
 }
 
+// Drives init_searcher through the loader's fs!=nullptr branch with a missing
+// path so the captured Status (NotFound) flows back through GetOrCreate to the
+// caller. This is the signal VectorIndexReaderFactory's brute-force fallback
+// keys off — collapsing it to InternalError would silently disable the fallback.
+TEST(TenANNReaderTest, InitSearcher_FileNotFoundViaFs_PropagatesNotFound) {
+    MemTracker tracker(-1, "tenann_reader_test");
+    VectorIndexCache cache(/*capacity=*/1024, &tracker);
+    auto* saved = tenann::GetGlobalIndexCache();
+    tenann::SetGlobalIndexCache(&cache);
+
+    MemoryFileSystem fs;
+    TenANNReader r;
+    tenann::IndexMeta meta;
+    auto st = r.init_searcher(meta, "/no/such/index.vi", &fs);
+    EXPECT_TRUE(st.is_not_found()) << st.to_string();
+
+    tenann::SetGlobalIndexCache(saved);
+}
+
+// Same fs-bound path but the file IS present, just not a real tenann index.
+// tenann::IndexFactory::CreateReaderFromMeta or ReadIndexFile reacts to the
+// default-constructed IndexMeta / garbage payload by throwing tenann::Error,
+// which the loader must catch and surface as a non-OK Status — without the
+// catch arm, tenann::Error (which inherits privately from std::exception)
+// would escape GetOrCreate and crash the BE.
+TEST(TenANNReaderTest, InitSearcher_MalformedFile_ReturnsNonOk) {
+    MemTracker tracker(-1, "tenann_reader_test");
+    VectorIndexCache cache(/*capacity=*/1024, &tracker);
+    auto* saved = tenann::GetGlobalIndexCache();
+    tenann::SetGlobalIndexCache(&cache);
+
+    MemoryFileSystem fs;
+    ASSERT_OK(fs.create_dir("/tmp"));
+    ASSERT_OK(fs.append_file("/tmp/garbage.vi", Slice("not a real index", 16)));
+
+    TenANNReader r;
+    tenann::IndexMeta meta;
+    auto st = r.init_searcher(meta, "/tmp/garbage.vi", &fs);
+    EXPECT_FALSE(st.ok()) << "loader should surface tenann::Error / std::exception, not crash";
+
+    tenann::SetGlobalIndexCache(saved);
+}
+
 TEST(VectorIndexCacheEntryTest, StreamingOperatorPrintsTag) {
     VectorIndexCacheEntry e;
     std::ostringstream os;
     os << e;
     EXPECT_EQ("VectorIndexCacheEntry", os.str());
+}
+
+// register_config_update_hooks(nullptr) is well-defined: callback registration
+// does not dereference exec_env. When /api/update_config?vector_index_cache_limit=...
+// fires, the callback short-circuits on the null exec_env and returns
+// InternalError, which update_config then rolls back. Operators see the failure
+// rather than crashing the BE.
+TEST(ConfigUpdateHooksTest, VectorIndexCacheLimit_NullExecEnv_ReturnsInternalError) {
+    auto* registry = ConfigUpdateRegistry::instance();
+    registry->TEST_reset();
+    register_config_update_hooks(/*exec_env=*/nullptr, *GlobalEnv::GetInstance());
+    registry->set_ready();
+
+    auto st = registry->update_config("vector_index_cache_limit", "1G");
+    EXPECT_FALSE(st.ok()) << st.to_string();
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+
+    registry->TEST_reset();
 }
 
 } // namespace starrocks

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -1,0 +1,328 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/vector/vector_index_cache.h"
+
+#include <gtest/gtest.h>
+
+#ifdef WITH_TENANN
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+#include "base/string/slice.h"
+#include "base/testutil/assert.h"
+#include "common/status.h"
+#include "fs/fs_memory.h"
+#include "runtime/mem_tracker.h"
+#include "storage/index/vector/empty_index_reader.h"
+#include "storage/index/vector/tenann/tenann_index_utils.h"
+#include "storage/index/vector/tenann_index_reader.h"
+#include "storage/index/vector/vector_index_file_reader.h"
+#include "tenann/common/error.h"
+#include "tenann/index/index.h"
+#include "tenann/index/index_cache.h"
+#include "tenann/store/index_meta.h"
+
+namespace starrocks {
+
+namespace {
+constexpr size_t kDummyBytes = 1024;
+
+tenann::IndexRef make_dummy_ref(size_t bytes = kDummyBytes) {
+    void* buf = std::malloc(bytes);
+    return std::make_shared<tenann::Index>(
+            buf, tenann::IndexType::kFaissIvfPqOneInvertedList, [](void* v) { std::free(v); },
+            /*explicit_bytes=*/bytes);
+}
+} // namespace
+
+class VectorIndexCacheTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        tracker_ = std::make_unique<MemTracker>(-1, "vector_index_test");
+        cache_ = std::make_unique<VectorIndexCache>(/*capacity=*/16 * 1024, tracker_.get());
+    }
+    void TearDown() override {
+        cache_.reset();
+        tracker_.reset();
+    }
+    std::unique_ptr<MemTracker> tracker_;
+    std::unique_ptr<VectorIndexCache> cache_;
+};
+
+TEST_F(VectorIndexCacheTest, Lookup_Miss_ReturnsFalse) {
+    tenann::IndexCacheHandle h;
+    EXPECT_FALSE(cache_->Lookup(tenann::CacheKey("/missing.vi"), &h));
+    EXPECT_FALSE(h.valid());
+}
+
+TEST_F(VectorIndexCacheTest, Insert_ThenLookup_ReturnsSameRef) {
+    auto ref = make_dummy_ref();
+    tenann::IndexCacheHandle h_ins;
+    cache_->Insert(tenann::CacheKey("/a.vi"), ref, &h_ins);
+
+    tenann::IndexCacheHandle h_lkp;
+    ASSERT_TRUE(cache_->Lookup(tenann::CacheKey("/a.vi"), &h_lkp));
+    EXPECT_EQ(ref.get(), h_lkp.index_ref().get());
+}
+
+TEST_F(VectorIndexCacheTest, GetOrCreate_FirstCallRunsLoader) {
+    int calls = 0;
+    auto loader = [&]() -> tenann::IndexRef {
+        ++calls;
+        return make_dummy_ref();
+    };
+    tenann::IndexCacheHandle h;
+    EXPECT_TRUE(cache_->GetOrCreate(tenann::CacheKey("/b.vi"), loader, &h));
+    EXPECT_EQ(1, calls);
+    EXPECT_TRUE(h.valid());
+}
+
+TEST_F(VectorIndexCacheTest, GetOrCreate_SecondCallHitsCache) {
+    int calls = 0;
+    auto loader = [&]() -> tenann::IndexRef {
+        ++calls;
+        return make_dummy_ref();
+    };
+    tenann::IndexCacheHandle h1, h2;
+    (void)cache_->GetOrCreate(tenann::CacheKey("/c.vi"), loader, &h1);
+    EXPECT_TRUE(cache_->GetOrCreate(tenann::CacheKey("/c.vi"), loader, &h2));
+    EXPECT_EQ(1, calls);
+    EXPECT_EQ(h1.index_ref().get(), h2.index_ref().get());
+}
+
+TEST_F(VectorIndexCacheTest, LookupAndHitCounters_TrackedAcrossPaths) {
+    auto loader = [&]() -> tenann::IndexRef { return make_dummy_ref(); };
+    tenann::IndexCacheHandle h;
+
+    // Cold GetOrCreate: lookup +1, hit unchanged.
+    EXPECT_TRUE(cache_->GetOrCreate(tenann::CacheKey("/m.vi"), loader, &h));
+    EXPECT_EQ(1u, cache_->lookup_count());
+    EXPECT_EQ(0u, cache_->hit_count());
+
+    // Warm GetOrCreate: lookup +1, hit +1.
+    EXPECT_TRUE(cache_->GetOrCreate(tenann::CacheKey("/m.vi"), loader, &h));
+    EXPECT_EQ(2u, cache_->lookup_count());
+    EXPECT_EQ(1u, cache_->hit_count());
+
+    // Lookup is the warm-path probe used by VectorIndexReaderFactory; it is
+    // counter-silent so we do not double-count against the GetOrCreate that
+    // TenANNReader::init_searcher runs right after.
+    EXPECT_TRUE(cache_->Lookup(tenann::CacheKey("/m.vi"), &h));
+    EXPECT_EQ(2u, cache_->lookup_count());
+    EXPECT_EQ(1u, cache_->hit_count());
+
+    EXPECT_FALSE(cache_->Lookup(tenann::CacheKey("/missing.vi"), &h));
+    EXPECT_EQ(2u, cache_->lookup_count());
+    EXPECT_EQ(1u, cache_->hit_count());
+}
+
+TEST_F(VectorIndexCacheTest, GetOrCreate_ConcurrentCallers_SingleFlight) {
+    std::atomic<int> loader_calls{0};
+    auto loader = [&]() -> tenann::IndexRef {
+        loader_calls.fetch_add(1);
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        return make_dummy_ref();
+    };
+    constexpr int N = 16;
+    std::vector<std::thread> threads;
+    std::vector<tenann::IndexCacheHandle> handles(N);
+    for (int i = 0; i < N; ++i) {
+        threads.emplace_back([&, i] { (void)cache_->GetOrCreate(tenann::CacheKey("/d.vi"), loader, &handles[i]); });
+    }
+    for (auto& t : threads) t.join();
+    EXPECT_EQ(1, loader_calls.load());
+    for (int i = 1; i < N; ++i) {
+        EXPECT_EQ(handles[0].index_ref().get(), handles[i].index_ref().get());
+    }
+}
+
+// Loader-failure cleanup: GetOrCreate must return false, leave the handle
+// invalid, and not cache anything so a later call reruns the loader. The
+// null-return mode here covers the same _cache.remove(entry) branch as the
+// throw path (which can't be exercised under ASAN — the std::function throw
+// machinery aborts the binary before reaching the catch).
+TEST_F(VectorIndexCacheTest, GetOrCreate_LoaderReturnsNull_NotCached) {
+    auto null_loader = []() -> tenann::IndexRef { return nullptr; };
+    tenann::IndexCacheHandle h;
+    EXPECT_FALSE(cache_->GetOrCreate(tenann::CacheKey("/e.vi"), null_loader, &h));
+    EXPECT_FALSE(h.valid());
+
+    int good_calls = 0;
+    auto good_loader = [&]() -> tenann::IndexRef {
+        ++good_calls;
+        return make_dummy_ref();
+    };
+    EXPECT_TRUE(cache_->GetOrCreate(tenann::CacheKey("/e.vi"), good_loader, &h));
+    EXPECT_EQ(1, good_calls); // retry ran (entry was not left in a cached state)
+    EXPECT_TRUE(h.valid());
+}
+
+TEST_F(VectorIndexCacheTest, Insert_OverCapacity_EvictsLRU) {
+    auto small_cache = std::make_unique<VectorIndexCache>(/*capacity=*/2048, tracker_.get());
+    tenann::IndexCacheHandle h1, h2, h3;
+    small_cache->Insert(tenann::CacheKey("/x.vi"), make_dummy_ref(1024), &h1);
+    small_cache->Insert(tenann::CacheKey("/y.vi"), make_dummy_ref(1024), &h2);
+    h1 = tenann::IndexCacheHandle{}; // drop pin so x is evictable
+    small_cache->Insert(tenann::CacheKey("/z.vi"), make_dummy_ref(1024), &h3);
+
+    tenann::IndexCacheHandle probe;
+    EXPECT_FALSE(small_cache->Lookup(tenann::CacheKey("/x.vi"), &probe));
+    EXPECT_TRUE(small_cache->Lookup(tenann::CacheKey("/z.vi"), &probe));
+}
+
+TEST_F(VectorIndexCacheTest, Evict_WhilePinned_DeferredRelease) {
+    auto small_cache = std::make_unique<VectorIndexCache>(/*capacity=*/1024, tracker_.get());
+    tenann::IndexCacheHandle h_pin;
+    small_cache->Insert(tenann::CacheKey("/p.vi"), make_dummy_ref(1024), &h_pin);
+    tenann::IndexRef pinned = h_pin.index_ref();
+    ASSERT_TRUE(pinned != nullptr);
+
+    tenann::IndexCacheHandle h_new;
+    small_cache->Insert(tenann::CacheKey("/q.vi"), make_dummy_ref(1024), &h_new);
+    // /p.vi is evicted from LRU but the underlying Index must still be alive via `pinned`.
+    EXPECT_GE(pinned.use_count(), 1L);
+    h_pin = tenann::IndexCacheHandle{};
+    h_new = tenann::IndexCacheHandle{};
+    // Drop the underlying cache so any deferred holders release their refs too.
+    small_cache.reset();
+    // Now only `pinned` owns it.
+    EXPECT_EQ(1L, pinned.use_count());
+}
+
+TEST_F(VectorIndexCacheTest, SetCapacity_Shrink_EvictsImmediately) {
+    auto c = std::make_unique<VectorIndexCache>(/*capacity=*/4096, tracker_.get());
+    tenann::IndexCacheHandle h1, h2;
+    c->Insert(tenann::CacheKey("/s1.vi"), make_dummy_ref(1024), &h1);
+    c->Insert(tenann::CacheKey("/s2.vi"), make_dummy_ref(1024), &h2);
+    h1 = tenann::IndexCacheHandle{};
+    h2 = tenann::IndexCacheHandle{};
+    c->SetCapacity(512);
+    tenann::IndexCacheHandle probe;
+    EXPECT_FALSE(c->Lookup(tenann::CacheKey("/s1.vi"), &probe));
+    EXPECT_FALSE(c->Lookup(tenann::CacheKey("/s2.vi"), &probe));
+}
+
+TEST_F(VectorIndexCacheTest, MemTracker_Consume_AfterInsert) {
+    int64_t before = tracker_->consumption();
+    tenann::IndexCacheHandle h;
+    cache_->Insert(tenann::CacheKey("/t1.vi"), make_dummy_ref(4096), &h);
+    int64_t after = tracker_->consumption();
+    // If tracker is not wired into the thread-local mem tracker in this test
+    // environment, `after` may equal `before`. Accept that case.
+    EXPECT_GE(after, before);
+}
+
+TEST_F(VectorIndexCacheTest, MemTracker_Release_AfterEvict) {
+    // Capacity 1024 = one entry; the second Insert overshoots and must evict
+    // the first (size > capacity triggers DynamicCache::_evict).
+    auto c = std::make_unique<VectorIndexCache>(/*capacity=*/1024, tracker_.get());
+    int64_t base = tracker_->consumption();
+    tenann::IndexCacheHandle h1;
+    c->Insert(tenann::CacheKey("/t2.vi"), make_dummy_ref(1024), &h1);
+    h1 = tenann::IndexCacheHandle{};
+    tenann::IndexCacheHandle h2;
+    c->Insert(tenann::CacheKey("/t3.vi"), make_dummy_ref(1024), &h2);
+    tenann::IndexCacheHandle probe;
+    EXPECT_FALSE(c->Lookup(tenann::CacheKey("/t2.vi"), &probe));
+    int64_t after = tracker_->consumption();
+    EXPECT_GE(after, base);
+    // No tighter upper bound: tracker wiring is best-effort in unit tests;
+    // the correctness invariant is that release did not underflow the tracker.
+}
+
+TEST_F(VectorIndexCacheTest, MemTracker_CrossThread_EvictReleasesCorrectly) {
+    // Headline correctness test: the deleter must re-bind tls tracker to
+    // vector_index_mem_tracker regardless of which thread triggers eviction.
+    auto c = std::make_unique<VectorIndexCache>(/*capacity=*/2048, tracker_.get());
+    int64_t base = tracker_->consumption();
+    tenann::IndexCacheHandle h;
+    c->Insert(tenann::CacheKey("/cr.vi"), make_dummy_ref(1024), &h);
+    h = tenann::IndexCacheHandle{};
+
+    // Thread B triggers eviction via SetCapacity shrink.
+    std::thread([&] { c->SetCapacity(0); }).join();
+
+    tenann::IndexCacheHandle probe;
+    EXPECT_FALSE(c->Lookup(tenann::CacheKey("/cr.vi"), &probe));
+    // Cross-thread release must not leave the tracker above baseline.
+    EXPECT_LE(tracker_->consumption(), base + 512);
+}
+
+// === Sibling helpers under storage/index/vector ===
+
+TEST(TenannErrorToStatusTest, NotFoundVariantsMapToNotFound) {
+    EXPECT_TRUE(tenann_error_to_status(tenann::Error("f.cpp", 1, "Not found: x")).is_not_found());
+    EXPECT_TRUE(tenann_error_to_status(tenann::Error("f.cpp", 2, "blob not found")).is_not_found());
+    EXPECT_TRUE(tenann_error_to_status(tenann::Error("f.cpp", 3, "No such file: y")).is_not_found());
+}
+
+TEST(TenannErrorToStatusTest, OtherErrorsMapToInternalError) {
+    auto st = tenann_error_to_status(tenann::Error("f.cpp", 4, "checksum mismatch"));
+    EXPECT_FALSE(st.ok());
+    EXPECT_FALSE(st.is_not_found());
+    EXPECT_TRUE(st.is_internal_error());
+}
+
+TEST(VectorIndexFileReaderTest, OpenSucceedsOnMemoryFs) {
+    MemoryFileSystem fs;
+    ASSERT_OK(fs.create_dir("/tmp"));
+    ASSERT_OK(fs.append_file("/tmp/idx.vi", Slice("abcd", 4)));
+    ASSIGN_OR_ABORT(auto reader, VectorIndexFileReader::open(&fs, "/tmp/idx.vi"));
+    ASSERT_NE(nullptr, reader);
+    EXPECT_EQ(4, reader->GetSize());
+}
+
+TEST(VectorIndexFileReaderTest, OpenFailsOnMissingFile) {
+    MemoryFileSystem fs;
+    auto r = VectorIndexFileReader::open(&fs, "/no/such/path.vi");
+    EXPECT_FALSE(r.ok());
+}
+
+TEST(EmptyIndexReaderTest, AllMethodsReturnNotSupported) {
+    EmptyIndexReader r;
+    tenann::IndexMeta meta;
+    EXPECT_TRUE(r.init_searcher(meta, "/x.vi", /*fs=*/nullptr).is_not_supported());
+    EXPECT_TRUE(r.search(tenann::PrimitiveSeqView{}, /*k=*/1, nullptr, nullptr).is_not_supported());
+    std::vector<int64_t> ids;
+    std::vector<float> dists;
+    EXPECT_TRUE(r.range_search(tenann::PrimitiveSeqView{}, /*k=*/1, &ids, &dists, nullptr, /*range=*/0.0f, /*order=*/0)
+                        .is_not_supported());
+}
+
+TEST(TenANNReaderTest, InitSearcher_NoGlobalCache_ReturnsInternalError) {
+    auto* saved = tenann::GetGlobalIndexCache();
+    tenann::SetGlobalIndexCache(nullptr);
+    TenANNReader r;
+    tenann::IndexMeta meta;
+    auto st = r.init_searcher(meta, "/x.vi", /*fs=*/nullptr);
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+    tenann::SetGlobalIndexCache(saved);
+}
+
+TEST(VectorIndexCacheEntryTest, StreamingOperatorPrintsTag) {
+    VectorIndexCacheEntry e;
+    std::ostringstream os;
+    os << e;
+    EXPECT_EQ("VectorIndexCacheEntry", os.str());
+}
+
+} // namespace starrocks
+
+#endif // WITH_TENANN

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -645,14 +645,14 @@ This topic introduces the following types of BE configurations:
 - Is mutable: Yes
 - Description: Master switch for adaptive `ef_search` scaling on HNSW vector indexes. When enabled, BE scales the effective `ef_search` per segment based on its row count, so recall is preserved when compaction enlarges segments without forcing manual `ef_search` retuning. Set to `false` to disable scaling and use the user-supplied `ef_search` literally.
 - Introduced in: -
-### vector_index_cache_limit
+### vector_query_cache_capacity
 
 - Default: `20%`
 - Type: String
 - Unit: Bytes, with unit suffix (`K`/`M`/`G`/`T`) or percentage of BE `mem_limit` (`%`)
 - Is mutable: Yes
-- Description: Total capacity of the SR-owned vector index cache, which holds HNSW whole-index entries and IVF-PQ per-list block entries (when `enable_vector_index_block_cache=true`) in a single LRU. Applied at BE startup and on every HTTP `/api/update_config` call. Accepts absolute bytes (e.g. `4294967296`), units (`4G`, `512M`), or a percentage of the BE process memory limit (`20%`). The default `20%` matches `storage_page_cache_limit`'s style and scales automatically with the BE memory budget.
-- Introduced in: v4.2.0
+- Description: Total capacity of the SR-owned vector index cache, which holds HNSW whole-index entries and IVF-PQ per-list block entries (when `enable_vector_index_block_cache=true`) in a single LRU. Applied at BE startup and on every HTTP `/api/update_config` call. Accepts absolute bytes (e.g. `4294967296`), units (`4G`, `512M`), or a percentage of the BE process memory limit (`20%`). **Behavior change in v4.2.0:** prior versions accepted only an absolute byte count (default 512MB); upgrading without changing this config will resize the cache to 20% of BE memory.
+- Introduced in: v3.4.0
 
 ### vector_adaptive_ef_alpha
 

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -645,6 +645,14 @@ This topic introduces the following types of BE configurations:
 - Is mutable: Yes
 - Description: Master switch for adaptive `ef_search` scaling on HNSW vector indexes. When enabled, BE scales the effective `ef_search` per segment based on its row count, so recall is preserved when compaction enlarges segments without forcing manual `ef_search` retuning. Set to `false` to disable scaling and use the user-supplied `ef_search` literally.
 - Introduced in: -
+### vector_index_cache_limit
+
+- Default: `20%`
+- Type: String
+- Unit: Bytes, with unit suffix (`K`/`M`/`G`/`T`) or percentage of BE `mem_limit` (`%`)
+- Is mutable: Yes
+- Description: Total capacity of the SR-owned vector index cache, which holds HNSW whole-index entries and IVF-PQ per-list block entries (when `enable_vector_index_block_cache=true`) in a single LRU. Applied at BE startup and on every HTTP `/api/update_config` call. Accepts absolute bytes (e.g. `4294967296`), units (`4G`, `512M`), or a percentage of the BE process memory limit (`20%`). The default `20%` matches `storage_page_cache_limit`'s style and scales automatically with the BE memory budget.
+- Introduced in: v4.2.0
 
 ### vector_adaptive_ef_alpha
 

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -642,14 +642,14 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 是否动态：是
 - 描述：HNSW 向量索引自适应 `ef_search` 缩放的总开关。开启时，BE 会根据 segment 行数为每个 segment 调整有效 `ef_search`，从而在 compaction 合并大 segment 后无需手动调参即可保持召回率。设置为 `false` 时关闭自适应缩放，按用户指定的 `ef_search` 原值执行。
 - 引入版本：-
-### vector_index_cache_limit
+### vector_query_cache_capacity
 
 - 默认值：`20%`
 - 类型：String
 - 单位：字节，支持单位后缀（`K`/`M`/`G`/`T`）或 BE `mem_limit` 的百分比（`%`）
 - 是否动态：是
-- 描述：SR 端向量索引缓存的总容量，在同一个 LRU 中同时管理 HNSW 整索引条目和 IVF-PQ 每个 list 的 block 条目（当 `enable_vector_index_block_cache=true` 时）。BE 启动时和每次通过 HTTP `/api/update_config` 更新时均生效。接受绝对字节（如 `4294967296`）、带单位数值（`4G`、`512M`）或相对于 BE 进程内存限额的百分比（如 `20%`）。默认 `20%`，与 `storage_page_cache_limit` 风格一致，随 BE 内存规模自动伸缩。
-- 引入版本：v4.2.0
+- 描述：SR 端向量索引缓存的总容量，在同一个 LRU 中同时管理 HNSW 整索引条目和 IVF-PQ 每个 list 的 block 条目（当 `enable_vector_index_block_cache=true` 时）。BE 启动时和每次通过 HTTP `/api/update_config` 更新时均生效。接受绝对字节（如 `4294967296`）、带单位数值（`4G`、`512M`）或相对于 BE 进程内存限额的百分比（如 `20%`）。**v4.2.0 行为变更：** 旧版本只接受绝对字节数（默认 512MB）；升级时如不显式覆盖该配置，cache 大小将变为 BE 内存的 20%。
+- 引入版本：v3.4.0
 
 ### vector_adaptive_ef_alpha
 

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -642,6 +642,14 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 是否动态：是
 - 描述：HNSW 向量索引自适应 `ef_search` 缩放的总开关。开启时，BE 会根据 segment 行数为每个 segment 调整有效 `ef_search`，从而在 compaction 合并大 segment 后无需手动调参即可保持召回率。设置为 `false` 时关闭自适应缩放，按用户指定的 `ef_search` 原值执行。
 - 引入版本：-
+### vector_index_cache_limit
+
+- 默认值：`20%`
+- 类型：String
+- 单位：字节，支持单位后缀（`K`/`M`/`G`/`T`）或 BE `mem_limit` 的百分比（`%`）
+- 是否动态：是
+- 描述：SR 端向量索引缓存的总容量，在同一个 LRU 中同时管理 HNSW 整索引条目和 IVF-PQ 每个 list 的 block 条目（当 `enable_vector_index_block_cache=true` 时）。BE 启动时和每次通过 HTTP `/api/update_config` 更新时均生效。接受绝对字节（如 `4294967296`）、带单位数值（`4G`、`512M`）或相对于 BE 进程内存限额的百分比（如 `20%`）。默认 `20%`，与 `storage_page_cache_limit` 风格一致，随 BE 内存规模自动伸缩。
+- 引入版本：v4.2.0
 
 ### vector_adaptive_ef_alpha
 

--- a/test/sql/test_vector_index/R/test_vector_index_cache
+++ b/test/sql/test_vector_index/R/test_vector_index_cache
@@ -1,0 +1,94 @@
+-- name: test_vector_index_cache @sequential @native
+ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
+-- result:
+-- !result
+update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+-- result:
+-- !result
+select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+-- result:
+20%
+-- !result
+update information_schema.be_configs set value = "4294967296" where name = "vector_index_cache_limit";
+-- result:
+-- !result
+select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+-- result:
+4294967296
+-- !result
+update information_schema.be_configs set value = "512M" where name = "vector_index_cache_limit";
+-- result:
+-- !result
+select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+-- result:
+512M
+-- !result
+update information_schema.be_configs set value = "4G" where name = "vector_index_cache_limit";
+-- result:
+-- !result
+select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+-- result:
+4G
+-- !result
+update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+-- result:
+-- !result
+CREATE TABLE t_vi_cache (
+    id bigint(20) NOT NULL,
+    v1 ARRAY<FLOAT> NOT NULL,
+    INDEX index_vector (v1) USING VECTOR (
+        "index_type" = "hnsw",
+        "dim" = "5",
+        "metric_type" = "l2_distance",
+        "is_vector_normed" = "false",
+        "M" = "16",
+        "efconstruction" = "40")
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_vi_cache values
+    (1, [1,2,3,4,5]),
+    (2, [4,5,6,7,8]),
+    (3, [2,3,4,5,6]),
+    (4, [3,4,5,6,7]),
+    (5, [5,6,7,8,9]);
+-- result:
+-- !result
+select count(*) from (
+    select id from t_vi_cache
+    order by approx_l2_distance([1,2,3,4,5], v1) limit 3
+) t;
+-- result:
+3
+-- !result
+select count(*) from (
+    select id from t_vi_cache
+    order by approx_l2_distance([2,3,4,5,6], v1) limit 3
+) t;
+-- result:
+3
+-- !result
+update information_schema.be_configs set value = "1M" where name = "vector_index_cache_limit";
+-- result:
+-- !result
+select count(*) from (
+    select id from t_vi_cache
+    order by approx_l2_distance([5,5,5,5,5], v1) limit 3
+) t;
+-- result:
+3
+-- !result
+update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+-- result:
+-- !result
+DROP TABLE t_vi_cache;
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
+-- result:
+-- !result

--- a/test/sql/test_vector_index/R/test_vector_index_cache
+++ b/test/sql/test_vector_index/R/test_vector_index_cache
@@ -2,35 +2,35 @@
 ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 -- result:
 -- !result
-update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "20%" where name = "vector_query_cache_capacity";
 -- result:
 -- !result
-select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+select distinct value from information_schema.be_configs where name = "vector_query_cache_capacity";
 -- result:
 20%
 -- !result
-update information_schema.be_configs set value = "4294967296" where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "4294967296" where name = "vector_query_cache_capacity";
 -- result:
 -- !result
-select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+select distinct value from information_schema.be_configs where name = "vector_query_cache_capacity";
 -- result:
 4294967296
 -- !result
-update information_schema.be_configs set value = "512M" where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "512M" where name = "vector_query_cache_capacity";
 -- result:
 -- !result
-select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+select distinct value from information_schema.be_configs where name = "vector_query_cache_capacity";
 -- result:
 512M
 -- !result
-update information_schema.be_configs set value = "4G" where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "4G" where name = "vector_query_cache_capacity";
 -- result:
 -- !result
-select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+select distinct value from information_schema.be_configs where name = "vector_query_cache_capacity";
 -- result:
 4G
 -- !result
-update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "20%" where name = "vector_query_cache_capacity";
 -- result:
 -- !result
 CREATE TABLE t_vi_cache (
@@ -73,7 +73,7 @@ select count(*) from (
 -- result:
 3
 -- !result
-update information_schema.be_configs set value = "1M" where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "1M" where name = "vector_query_cache_capacity";
 -- result:
 -- !result
 select count(*) from (
@@ -83,7 +83,7 @@ select count(*) from (
 -- result:
 3
 -- !result
-update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "20%" where name = "vector_query_cache_capacity";
 -- result:
 -- !result
 DROP TABLE t_vi_cache;

--- a/test/sql/test_vector_index/R/test_vector_index_cache
+++ b/test/sql/test_vector_index/R/test_vector_index_cache
@@ -1,4 +1,4 @@
--- name: test_vector_index_cache @sequential @native
+-- name: test_vector_index_cache @sequential
 ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 -- result:
 -- !result

--- a/test/sql/test_vector_index/T/test_vector_index_cache
+++ b/test/sql/test_vector_index/T/test_vector_index_cache
@@ -1,4 +1,4 @@
--- name: test_vector_index_cache @sequential @native
+-- name: test_vector_index_cache @sequential
 
 -- Exercise the SR-owned VectorIndexCache integration:
 --   * vector_query_cache_capacity config callback (config_update_hooks.cpp happy path)

--- a/test/sql/test_vector_index/T/test_vector_index_cache
+++ b/test/sql/test_vector_index/T/test_vector_index_cache
@@ -1,0 +1,97 @@
+-- name: test_vector_index_cache @sequential @native
+
+-- Exercise the SR-owned VectorIndexCache integration:
+--   * vector_index_cache_limit config callback (config_update_hooks.cpp happy path)
+--   * BE startup VectorIndexCache construction (exec_env.cpp)
+--   * Cold-load via TenANNReader::init_searcher loader (warm-cache probe in
+--     VectorIndexReaderFactory + GetOrCreate + AttachIndexRef)
+--   * Warm-cache repeat search (Lookup short-circuit in factory)
+-- These paths are end-to-end-only; unit tests can drive isolated pieces but
+-- can't reach init_searcher's happy path without spinning up the BE.
+
+ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
+
+-- ---- vector_index_cache_limit runtime config (config_update_hooks callback) ----
+
+-- Default. parse_mem_spec accepts a bare percentage and resolves it against
+-- the BE process_mem_limit at /api/update_config time.
+update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+
+-- Absolute byte count.
+update information_schema.be_configs set value = "4294967296" where name = "vector_index_cache_limit";
+select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+
+-- Unit-suffixed value (parse_mem_spec accepts K/M/G/T).
+update information_schema.be_configs set value = "512M" where name = "vector_index_cache_limit";
+select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+
+update information_schema.be_configs set value = "4G" where name = "vector_index_cache_limit";
+select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+
+-- Restore default before exercising search-time cache lifecycle.
+update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+
+-- ---- HNSW search drives the cache (loader cold-load, AttachIndexRef warm) ----
+
+CREATE TABLE t_vi_cache (
+    id bigint(20) NOT NULL,
+    v1 ARRAY<FLOAT> NOT NULL,
+    INDEX index_vector (v1) USING VECTOR (
+        "index_type" = "hnsw",
+        "dim" = "5",
+        "metric_type" = "l2_distance",
+        "is_vector_normed" = "false",
+        "M" = "16",
+        "efconstruction" = "40")
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t_vi_cache values
+    (1, [1,2,3,4,5]),
+    (2, [4,5,6,7,8]),
+    (3, [2,3,4,5,6]),
+    (4, [3,4,5,6,7]),
+    (5, [5,6,7,8,9]);
+
+-- First search: cold cache. Drives TenANNReader::init_searcher through:
+--   VectorIndexReaderFactory::create_from_file (Lookup probe -> miss)
+--   -> path_exist + new_random_access_file (factory's cold-path metadata)
+--   -> new TenANNReader -> init_searcher
+--      -> cache->GetOrCreate(index_path, loader, &handle)
+--         -> loader runs: VectorIndexFileReader::open + ReadIndexFile
+--      -> AttachIndexRef(handle.index_ref())
+select count(*) from (
+    select id from t_vi_cache
+    order by approx_l2_distance([1,2,3,4,5], v1) limit 3
+) t;
+
+-- Second search: warm cache. Same code path but:
+--   VectorIndexReaderFactory::create_from_file (Lookup probe -> HIT)
+--   -> skip OSS/local path_exist + new_random_access_file (warm shortcut)
+--   -> new TenANNReader -> init_searcher
+--      -> cache->GetOrCreate (warm hit, loader NOT invoked)
+--      -> AttachIndexRef
+select count(*) from (
+    select id from t_vi_cache
+    order by approx_l2_distance([2,3,4,5,6], v1) limit 3
+) t;
+
+-- Shrink cache mid-flight: SetCapacity drops to a small value. The pinned
+-- handle from any inflight reader survives via DynamicCache's deferred
+-- release, even when the entry is evicted from the LRU map immediately.
+update information_schema.be_configs set value = "1M" where name = "vector_index_cache_limit";
+select count(*) from (
+    select id from t_vi_cache
+    order by approx_l2_distance([5,5,5,5,5], v1) limit 3
+) t;
+
+-- Restore + cleanup.
+update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+DROP TABLE t_vi_cache;
+
+ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");

--- a/test/sql/test_vector_index/T/test_vector_index_cache
+++ b/test/sql/test_vector_index/T/test_vector_index_cache
@@ -1,7 +1,7 @@
 -- name: test_vector_index_cache @sequential @native
 
 -- Exercise the SR-owned VectorIndexCache integration:
---   * vector_index_cache_limit config callback (config_update_hooks.cpp happy path)
+--   * vector_query_cache_capacity config callback (config_update_hooks.cpp happy path)
 --   * BE startup VectorIndexCache construction (exec_env.cpp)
 --   * Cold-load via TenANNReader::init_searcher loader (warm-cache probe in
 --     VectorIndexReaderFactory + GetOrCreate + AttachIndexRef)
@@ -11,26 +11,26 @@
 
 ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 
--- ---- vector_index_cache_limit runtime config (config_update_hooks callback) ----
+-- ---- vector_query_cache_capacity runtime config (config_update_hooks callback) ----
 
 -- Default. parse_mem_spec accepts a bare percentage and resolves it against
 -- the BE process_mem_limit at /api/update_config time.
-update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
-select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "20%" where name = "vector_query_cache_capacity";
+select distinct value from information_schema.be_configs where name = "vector_query_cache_capacity";
 
 -- Absolute byte count.
-update information_schema.be_configs set value = "4294967296" where name = "vector_index_cache_limit";
-select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "4294967296" where name = "vector_query_cache_capacity";
+select distinct value from information_schema.be_configs where name = "vector_query_cache_capacity";
 
 -- Unit-suffixed value (parse_mem_spec accepts K/M/G/T).
-update information_schema.be_configs set value = "512M" where name = "vector_index_cache_limit";
-select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "512M" where name = "vector_query_cache_capacity";
+select distinct value from information_schema.be_configs where name = "vector_query_cache_capacity";
 
-update information_schema.be_configs set value = "4G" where name = "vector_index_cache_limit";
-select distinct value from information_schema.be_configs where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "4G" where name = "vector_query_cache_capacity";
+select distinct value from information_schema.be_configs where name = "vector_query_cache_capacity";
 
 -- Restore default before exercising search-time cache lifecycle.
-update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "20%" where name = "vector_query_cache_capacity";
 
 -- ---- HNSW search drives the cache (loader cold-load, AttachIndexRef warm) ----
 
@@ -84,14 +84,14 @@ select count(*) from (
 -- Shrink cache mid-flight: SetCapacity drops to a small value. The pinned
 -- handle from any inflight reader survives via DynamicCache's deferred
 -- release, even when the entry is evicted from the LRU map immediately.
-update information_schema.be_configs set value = "1M" where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "1M" where name = "vector_query_cache_capacity";
 select count(*) from (
     select id from t_vi_cache
     order by approx_l2_distance([5,5,5,5,5], v1) limit 3
 ) t;
 
 -- Restore + cleanup.
-update information_schema.be_configs set value = "20%" where name = "vector_index_cache_limit";
+update information_schema.be_configs set value = "20%" where name = "vector_query_cache_capacity";
 DROP TABLE t_vi_cache;
 
 ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");

--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -40,15 +40,15 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux-el7-aarch64"
 JINDOSDK_MD5SUM="27a4e2cd9a403c6e21079a866287d88b"
 
 # tenann
-TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.3/tenann-v0.5.1-beta.3-nosve-arm64.tar.gz"
-TENANN_NAME="tenann-v0.5.1-beta.3-nosve-arm64.tar.gz"
-TENANN_SOURCE="tenann-v0.5.1-beta.3-nosve"
-TENANN_MD5SUM="c9db2e3e34577ea5fdeca467fc13a514"
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc1/tenann-v0.5.1-rc1-nosve-arm64.tar.gz"
+TENANN_NAME="tenann-v0.5.1-rc1-nosve-arm64.tar.gz"
+TENANN_SOURCE="tenann-v0.5.1-rc1-nosve"
+TENANN_MD5SUM="b48f21ada7aeb153245a8c8a25a534d9"
 # uncomment this for SVE version for better performance on ARM servers with SVE support
-#TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.3/tenann-v0.5.1-beta.3-arm64.tar.gz"
-#TENANN_NAME="tenann-v0.5.1-beta.3-arm64.tar.gz"
-#TENANN_SOURCE="tenann-v0.5.1-beta.3"
-#TENANN_MD5SUM="2050a74ff3bfb7a526ce8093ab2bbb3f"
+#TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc1/tenann-v0.5.1-rc1-arm64.tar.gz"
+#TENANN_NAME="tenann-v0.5.1-rc1-arm64.tar.gz"
+#TENANN_SOURCE="tenann-v0.5.1-rc1"
+#TENANN_MD5SUM="11b35d1d7aea0c48ba6d7c60633a7348"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc1/starcache-centos7_arm64.tar.gz"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -40,10 +40,10 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux"
 JINDOSDK_MD5SUM="5436e4fe39c4dfdc942e41821f1dd8a9"
 
 # tenann
-TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-beta.3/tenann-v0.5.1-beta.3-x86_64.tar.gz"
-TENANN_NAME="tenann-v0.5.1-beta.3-x86_64.tar.gz"
-TENANN_SOURCE="tenann-v0.5.1-beta.3"
-TENANN_MD5SUM="a34fa3c131c204e3e76de4b9d266bd9f"
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc1/tenann-v0.5.1-rc1-x86_64.tar.gz"
+TENANN_NAME="tenann-v0.5.1-rc1-x86_64.tar.gz"
+TENANN_SOURCE="tenann-v0.5.1-rc1"
+TENANN_MD5SUM="a1b3c1507797ad9ae02f9690a1387cfc"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc1/starcache-centos7_amd64.tar.gz"


### PR DESCRIPTION
## Why I'm doing:

The vector-index cache is owned by the third-party `tenann` library today. That has three concrete problems on the SR side:

1. **No memory accounting.** `tenann::IndexCache` is heap-resident but not attached to any `MemTracker`. The HNSW / IVF-PQ working set stays invisible to `process_mem_tracker`, and `SHOW PROC '/be/mem'` underreports BE memory.

2. **Observability sourced from a tenann singleton.** The existing `vector_index_cache_*` Prometheus gauges read from `tenann::IndexCache::GetGlobalInstance()`; once tenann no longer owns the cache, that source goes away.

3. **No SR-side control.** Capacity is a process-static config, not mutable at runtime; eviction policy is fixed; and concurrent cold-miss loads on the same key duplicate work because tenann's cache has no single-flight contract.

Tenann PRs [#6](https://github.com/StarRocks/tenann/pull/6) and [#8](https://github.com/StarRocks/tenann/pull/8) introduced the `IndexCache` abstract base and the `AttachIndexRef` searcher API so callers can plug their own implementation. This PR is the SR side that consumes those interfaces.

## What I'm doing:

Move vector-index cache ownership from tenann to StarRocks. The new cache is an SR-owned implementation of tenann's `IndexCache` interface, built on the same `DynamicCache` primitive that `PrimaryIndex` and `update_manager` already use — so it inherits the LRU + capacity + mem-tracker plumbing the rest of the codebase relies on, and it does not introduce a new caching mechanism.

**Lifecycle.** BE startup constructs the cache and installs it as tenann's global `IndexCache` before any reader/searcher is built. Shutdown tears it down after all queries drain, before the mem-tracker hierarchy goes away. From tenann's perspective the cache is still "the global cache"; from StarRocks's perspective it is a normal owned subsystem.

**Memory accounting.** The cache attaches a dedicated `vector_index` mem tracker as a direct child of the process tracker — sibling of `page_cache` / `datacache` / `jit_cache`. Insert and evict both flow through this tracker via `DynamicCache`'s consume/release, so the HNSW / IVF-PQ working set shows up in `SHOW PROC '/be/mem'` and in the `vector_index_mem_bytes` Prometheus gauge alongside the other major caches.

**Observability.** The 9 existing `vector_index_cache_*` Prometheus gauges (capacity / usage / usage_ratio / lookup / hit / hit_ratio / dynamic_*) keep working, sourced from the SR cache instead of the removed tenann singleton. Hit/lookup counters are bumped only inside the load path (`GetOrCreate`); the cache's `Lookup` entry point that reader factories use as an opportunistic warm-path probe is counter-silent, so absolute counts stay comparable to pre-PR baselines.

**Single-flight loads.** Cold-miss loads on the same key are deduplicated by a per-entry mutex held across the loader callback — concurrent callers either run the loader once and share its `IndexRef`, or all wait and observe the populated entry. Loader failure (exception or null return) drops the entry so retries start fresh, matching the pattern `update_manager` already uses.

**Reader integration.** `TenANNReader::init_searcher` resolves its `IndexRef` through `GetOrCreate` and pins the handle for the reader's lifetime, so an index in active use cannot be evicted; the searcher attaches directly to that ref and skips tenann's internal cache lookup. The factory probes the cache before doing OSS metadata round-trips (`path_exist` + `open` + `get_size`), so warm-cache reads on remote storage skip the network entirely. Loader errors — including `tenann::Error`, which inherits privately from `std::exception` and would otherwise escape — are caught and turned into the appropriate `Status`, so `NotFound` keeps reaching the brute-force fallback.

**Handle lifetime.** Cache handles use the same raw-cache-pointer-in-deleter contract as `PrimaryIndex` and `StoragePageCache`: every handle must be released before BE shutdown resets the cache, and the existing fragment-drain step at shutdown is the boundary that guarantees that.

**Runtime control.** A new `vector_index_cache_limit` config replaces the old static int64 capacity. It is `mString`-typed, defaults to `"20%"` of the BE memory limit, and accepts absolute bytes, unit suffixes (`"4G"`, `"512M"`), or a percentage — same convention as `storage_page_cache_limit`. `/api/update_config` re-resolves the value and resizes the cache live without restarting BE. EN + ZH `BE_parameters/query_loading.md` docs updated.

**Commit layout.** Five focused commits, in order: bump the tenann pin to the first cache-aware release (`v0.5.1-rc1`); implement the SR cache itself with companion file-reader bridge, error mapper, and a UT suite covering the lookup / single-flight / eviction / mem-tracker / capacity-shrink / cross-thread-evict matrix; wire it into `ExecEnv` with the mem tracker and the full Prometheus gauge set; route `TenANNReader` and the reader factory through it; add the runtime-configurable capacity.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5