### PR TITLE
[BugFix] Reject lossy literal casts when pushing down predicates to Iceberg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.sql.ast.expression.BoolLiteral;
@@ -38,9 +39,9 @@ import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
-import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarbinaryType;
 import com.starrocks.type.VarcharType;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
@@ -51,6 +52,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.math.RoundingMode;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -410,30 +412,122 @@ public class ScalarOperatorToIcebergExpr {
                     res = operator.castTo(BooleanType.BOOLEAN);
                     break;
                 case DATE:
+                    // Reject literal with non-zero time-of-day when the iceberg column is DATE.
+                    // After visitCastOperator peels the column-side cast, two literal shapes
+                    // can reach here: DATETIME literal (analyzer promoted DATE vs DATETIME to
+                    // a common DATETIME type) or STRING literal (user wrote an explicit
+                    // CAST(date_col AS STRING) that the analyzer kept intact).
+                    // For both, ConstantOperator.castTo(DATE) silently truncates the
+                    // time-of-day, so a predicate like
+                    //     WHERE date_col >= TIMESTAMP '2024-01-01 12:00:00'
+                    // would be pushed down as `date_col >= DATE '2024-01-01'` and return
+                    // wrong rows. A pure-date / 00:00:00 literal is lossless and falls
+                    // through to castTo(DATE).
+                    if (operator.getType().isDatetime()) {
+                        LocalDateTime dt = operator.getDatetime();
+                        if (dt.getHour() != 0 || dt.getMinute() != 0
+                                || dt.getSecond() != 0 || dt.getNano() != 0) {
+                            return null;
+                        }
+                    } else if (operator.getType().getPrimitiveType().isStringType()) {
+                        // Mirror ConstantOperator.castTo(DATE/DATETIME)'s parsing: strip the same
+                        // 4 ASCII whitespace chars and call DateUtils.parseStrictDateTime, so the
+                        // guard sees exactly the same LocalDateTime that castTo would see.
+                        try {
+                            String dateStr = StringUtils.strip(operator.getVarchar(), "\r\n\t ");
+                            LocalDateTime dt = DateUtils.parseStrictDateTime(dateStr);
+                            if (dt.getHour() != 0 || dt.getMinute() != 0
+                                    || dt.getSecond() != 0 || dt.getNano() != 0) {
+                                return null;
+                            }
+                        } catch (Exception ignored) {
+                            // Unparseable string (e.g. '2024/01/01'): we cannot prove the
+                            // time-of-day is zero, so conservatively refuse pushdown.
+                            return null;
+                        }
+                    }
                     res = operator.castTo(DateType.DATE);
                     break;
                 case TIMESTAMP:
+                    // Reject DATE literal when the iceberg column is DATETIME.
+                    // The DATE -> DATETIME literal cast itself is lossless (fills 00:00:00),
+                    // but it is unsafe AFTER visitCastOperator unconditionally peels the outer
+                    // cast on the column side. Concretely, consider:
+                    //     WHERE CAST(datetime_col AS DATE) = DATE '2024-01-01'
+                    // The original semantics is "truncate the column to day, then compare", so a
+                    // row with datetime_col = '2024-01-01 12:00:00' MUST match. After peeling the
+                    // column side becomes plain `datetime_col` (DATETIME) and the literal is the
+                    // DATE '2024-01-01'; lifting the literal to DATETIME 00:00:00 would push down
+                    //     datetime_col = TIMESTAMP '2024-01-01 00:00:00'
+                    // which evaluates to FALSE on that row -> we silently drop matching rows.
+                    // From the literal-side view, this dangerous case and the legitimate
+                    //     WHERE datetime_col = DATE '2024-01-01'
+                    // share the exact same (literal=DATE, columnType=TIMESTAMP) input, so we
+                    // cannot tell them apart and must conservatively refuse pushdown for both.
+                    // Non-DATE literals (e.g. STRING) fall through to castTo(DATETIME) as usual.
+                    if (operator.getType().isDate()) {
+                        return null;
+                    }
                     res = operator.castTo(DateType.DATETIME);
                     break;
                 case STRING:
                 case UUID:
-                    // num and string has different comparator
-                    if (operator.getType().isNumericType()) {
+                    // Reject non-character literal when the iceberg column is STRING/UUID.
+                    // After visitCastOperator peels the outer cast on the column side, the
+                    // remaining comparison is `string_col <op> castTo(VARCHAR, literal)`, which
+                    // compares by lexicographic order while the original predicate compared by
+                    // the literal's native order. The two orders disagree for every non-string
+                    // literal type, so pushdown may return a wrong row set:
+                    //
+                    // 1) NUMERIC: WHERE CAST(string_col AS INT) > 10
+                    //    Pushed down as `string_col > '10'`. A row with string_col = '9' is
+                    //    wrongly returned because '9' > '10' under string ordering, even though
+                    //    9 < 10 numerically.
+                    //
+                    // 2) DATE: WHERE CAST(string_col AS DATE) = DATE '2024-01-01'
+                    //    Pushed down as `string_col = '2024-01-01'`. A row with
+                    //    string_col = '2024-1-1' is silently dropped, even though it parses to
+                    //    the same DATE value as the literal.
+                    //
+                    // 3) DATETIME: WHERE CAST(string_col AS DATETIME) = TIMESTAMP '2024-01-01 00:00:00'
+                    //    Pushed down as `string_col = '2024-01-01 00:00:00'`. A row with
+                    //    string_col = '2024-01-01' is silently dropped, even though it parses to
+                    //    the same DATETIME value (time-of-day defaults to 00:00:00).
+                    //
+                    // 4) BOOLEAN: WHERE CAST(string_col AS BOOLEAN) = FALSE
+                    //    Note: `= TRUE` is normally folded away by the optimizer
+                    //    (SimplifyCastRule etc.) into a bare `CAST(string_col AS BOOLEAN)`,
+                    //    so in practice only `= FALSE` reaches this branch. We still guard
+                    //    by type (not by value) for defence in depth, in case future
+                    //    rule changes let a `= TRUE` slip through.
+                    //    ConstantOperator.castTo(VARCHAR) on a BOOLEAN literal is hard-coded
+                    //    to "1" / "0" (see ConstantOperator.castTo: `getBoolean() ? "1" : "0"`),
+                    //    so without this guard the predicate would be pushed down as
+                    //    `string_col = '0'`. But the BE-side CAST(string AS BOOLEAN)
+                    //    (StringParser::string_to_bool_internal) recognizes a wider set of
+                    //    inputs: "1"/"0" plus case-insensitive "true"/"false" (with optional
+                    //    trailing whitespace). Rows like 'false' / 'FALSE' evaluate to FALSE
+                    //    at the engine but do NOT equal the string literal "0", and would be
+                    //    silently dropped once Iceberg file/row-group min-max pruning kicks in.
+                    // Only true string-class literals fall through to castTo(VARCHAR).
+                    PrimitiveType lt = operator.getType().getPrimitiveType();
+                    if (lt.isNumericType()
+                            || lt == PrimitiveType.DATE
+                            || lt == PrimitiveType.DATETIME
+                            || lt == PrimitiveType.BOOLEAN) {
                         return null;
-                    } else {
-                        res = operator.castTo(VarcharType.VARCHAR);
                     }
+                    res = operator.castTo(VarcharType.VARCHAR);
                     break;
                 case BINARY:
                     res = operator.castTo(VarbinaryType.VARBINARY);
                     break;
-                // num usually don't need cast, and num and string has different comparator
-                // cast is dangerous.
-                case DECIMAL:
-                    res = operator.castTo(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 9, 0));
-                    break;
+                    // num usually don't need cast, and num and string has different comparator
+                    // cast is dangerous.
                 case INTEGER:
                 case LONG:
+                    // usually not used as partition column, don't do much work
+                case DECIMAL:
                 case FLOAT:
                 case DOUBLE:
                 case STRUCT:

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
@@ -363,9 +363,7 @@ public class IcebergExprVisitorTest {
         CastOperator cast = new CastOperator(DateType.DATE, K6);
         convertedExpr = converter.convert(Lists.newArrayList(
                 new BinaryPredicateOperator(BinaryType.EQ, cast, value)), context);
-        expectedExpr = Expressions.equal("k6", "2022-11-11");
-        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
-                "Generated equal expression should be correct");
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
 
         // cast date column to string
         value = ConstantOperator.createVarchar("2022-11-11");
@@ -560,5 +558,187 @@ public class IcebergExprVisitorTest {
                         new BinaryPredicateOperator(BinaryType.EQ, syntheticVariantColumn, ConstantOperator.createInt(10))),
                 context);
         Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
+    }
+
+    /**
+     * Verifies the literal-side rejections in {@code ExtractLiteralValue.tryCastToResultType}
+     * together with the column-side cast peeling in {@code visitCastOperator}, covering the
+     * cases where peeling the column-side cast would otherwise silently push down a wrong
+     * predicate (truncated date, lex-vs-numeric ordering, integer wrap, float precision loss,
+     * etc.). Same-typed regression cases that do not go through the cast path are also covered.
+     */
+    @Test
+    public void testCastPeelRejectsLossyLiterals() {
+        ScalarOperatorToIcebergExpr.IcebergContext context =
+                new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
+        ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+
+        Expression convertedExpr;
+        Expression expectedExpr;
+
+        // DATE column = midnight DATETIME literal -> lossless cast, push down.
+        ConstantOperator dtMidnight =
+                ConstantOperator.createDatetime(LocalDateTime.of(2024, 1, 1, 0, 0, 0));
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K3, dtMidnight)), context);
+        expectedExpr = Expressions.equal("k3", LocalDate.of(2024, 1, 1).toEpochDay());
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "midnight DATETIME literal should be pushed down to DATE column");
+
+        // DATE column >= DATETIME literal with non-zero time-of-day -> silent truncation, reject.
+        ConstantOperator dtNoon =
+                ConstantOperator.createDatetime(LocalDateTime.of(2024, 1, 1, 12, 0, 0));
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GE, K3, dtNoon)), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "DATETIME literal with non-zero time-of-day must be rejected on DATE column");
+
+        // CAST(date_col AS STRING) = '2024-01-01 12:00:00' -> reject (non-zero time-of-day).
+        CastOperator dateColAsString = new CastOperator(VarcharType.VARCHAR, K3);
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, dateColAsString,
+                        ConstantOperator.createVarchar("2024-01-01 12:00:00"))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "STRING literal with non-zero time-of-day must be rejected on DATE column");
+
+        // CAST(date_col AS STRING) = '2024-01-01 00:00:00' -> push down (midnight).
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, dateColAsString,
+                        ConstantOperator.createVarchar("2024-01-01 00:00:00"))), context);
+        expectedExpr = Expressions.equal("k3", LocalDate.of(2024, 1, 1).toEpochDay());
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "midnight STRING literal should be pushed down to DATE column");
+
+        // CAST(date_col AS STRING) = '2024/01/01' -> conservatively reject unparseable literal.
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, dateColAsString,
+                        ConstantOperator.createVarchar("2024/01/01"))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "unparseable STRING literal must be conservatively rejected on DATE column");
+
+        // DATETIME column = bare DATE literal -> reject (ambiguous with CAST(dt AS DATE)= pattern).
+        ConstantOperator dateLit =
+                ConstantOperator.createDate(LocalDate.of(2024, 1, 1).atStartOfDay());
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K4, dateLit)), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "bare DATE literal on DATETIME column must be conservatively rejected");
+
+        // CAST(datetime_col AS DATE) = DATE literal -> reject after column-side peel.
+        CastOperator datetimeColAsDate = new CastOperator(DateType.DATE, K4);
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, datetimeColAsDate, dateLit)), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "CAST(datetime_col AS DATE) = DATE literal must be rejected after column-side peel");
+
+        // DATETIME column = same-typed DATETIME literal -> no cast involved, push down.
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K4, dtMidnight)), context);
+        long expectedMicros = TimeUnit.MICROSECONDS.convert(
+                LocalDateTime.of(2024, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC), TimeUnit.SECONDS);
+        expectedExpr = Expressions.equal("k4", expectedMicros);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "same-typed DATETIME literal on DATETIME column should be pushed down (no cast involved)");
+
+        // CAST(string_col AS DATETIME) > DATETIME literal -> reject (lex order != date order).
+        CastOperator stringColAsDatetime = new CastOperator(DateType.DATETIME, K6);
+        ConstantOperator dtMay = ConstantOperator.createDatetime(LocalDateTime.of(2026, 5, 15, 0, 0, 0));
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GT, stringColAsDatetime, dtMay)), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "DATETIME literal on STRING column must be rejected (lex order != date order)");
+
+        // CAST(string_col AS INT) > 10 -> reject (lex order != numeric order).
+        CastOperator stringColAsInt = new CastOperator(IntegerType.INT, K6);
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GT, stringColAsInt,
+                        ConstantOperator.createInt(10))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "numeric literal on STRING column must be rejected (lex order != numeric order)");
+
+        // CAST(string_col AS DATE) = DATE literal -> reject.
+        CastOperator stringColAsDate = new CastOperator(DateType.DATE, K6);
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, stringColAsDate, dateLit)), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "DATE literal on STRING column must be rejected");
+
+        // CAST(string_col AS BOOLEAN) = false -> reject ('1'/'0' vs 'true'/'false' mismatch).
+        CastOperator stringColAsBool = new CastOperator(BooleanType.BOOLEAN, K6);
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, stringColAsBool,
+                        ConstantOperator.createBoolean(false))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "BOOLEAN literal on STRING column must be rejected ('1'/'0' vs 'true'/'false' mismatch)");
+
+        // STRING column = same-typed STRING literal -> push down.
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K6,
+                        ConstantOperator.createVarchar("2024-01-01"))), context);
+        expectedExpr = Expressions.equal("k6", "2024-01-01");
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "same-typed STRING literal on STRING column should be pushed down");
+
+        // INT column = BIGINT literal out of INT range -> reject (silent wrap risk).
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K1,
+                        ConstantOperator.createBigint(999999999999L))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "BIGINT literal out of INT range must be rejected on INT column");
+
+        // INT column = BIGINT literal within INT range -> still rejected (one-shot null policy).
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K1,
+                        ConstantOperator.createBigint(100L))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "BIGINT literal in INT range is currently rejected (acceptable conservatism)");
+
+        // FLOAT column = DOUBLE literal -> reject (precision loss risk).
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K8,
+                        ConstantOperator.createDouble(1.0))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "DOUBLE literal on FLOAT column must be rejected");
+
+        // BIGINT column = INT literal -> reject (numeric one-shot null policy).
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K7,
+                        ConstantOperator.createInt(1))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "INT literal on BIGINT column must be rejected");
+
+        // DOUBLE column = FLOAT literal -> reject (numeric one-shot null policy).
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K9,
+                        ConstantOperator.createFloat(1.0))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "FLOAT literal on DOUBLE column must be rejected");
+
+        // Same-typed regression cases (no cast path involved).
+
+        // DATE column > same-typed DATE literal -> push down.
+        ConstantOperator dateMay =
+                ConstantOperator.createDate(LocalDate.of(2026, 5, 15).atStartOfDay());
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GT, K3, dateMay)), context);
+        expectedExpr = Expressions.greaterThan("k3", LocalDate.of(2026, 5, 15).toEpochDay());
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "same-typed DATE literal on DATE column should be pushed down");
+
+        // INT column = same-typed INT literal -> push down.
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K1,
+                        ConstantOperator.createInt(100))), context);
+        expectedExpr = Expressions.equal("k1", 100);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "same-typed INT literal on INT column should be pushed down");
+
+        // BOOLEAN column = same-typed BOOLEAN literal -> push down.
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K5,
+                        ConstantOperator.createBoolean(true))), context);
+        expectedExpr = Expressions.equal("k5", true);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "same-typed BOOLEAN literal on BOOLEAN column should be pushed down");
     }
 }


### PR DESCRIPTION

## Why I'm doing:
`ScalarOperatorToIcebergExpr.visitCastOperator` peels the column-side cast unconditionally and then lifts the literal to the column's underlying type. Whenever that lift is lossy or the two sides compare under different orders, predicate pushdown silently returns wrong rows once Iceberg min-max / partition pruning kicks in.

Today only `numeric literal -> string column` is guarded. Every other shape below is wrong:

| # | Original predicate | Pushed-down form | Why it's wrong |
|---|---|---|---|
| 1 | `date_col >= TIMESTAMP '2024-01-01 12:00:00'` | `date_col >= DATE '2024-01-01'` | time-of-day silently truncated, extra rows returned |
| 2 | `CAST(datetime_col AS DATE) = DATE '2024-01-01'` | `datetime_col = TIMESTAMP '2024-01-01 00:00:00'` | rows with non-midnight times silently dropped |
| 3 | `CAST(string_col AS INT) > 10` | `string_col > '10'` | `'9' > '10'` lexicographically, wrong rows returned |
| 4 | `CAST(string_col AS DATE) = DATE '2024-01-01'` / `CAST(string_col AS DATETIME) = TIMESTAMP '2024-01-01 00:00:00'` | string equality on the literal | `'2024-1-1'` vs `'2024-01-01'` (or `'2024-01-01'` vs `'2024-01-01 00:00:00'`) silently dropped |
| 5 | `CAST(string_col AS BOOLEAN) = FALSE` | `string_col = '0'` | `ConstantOperator.castTo(VARCHAR)` hard-codes `"1"/"0"`, but BE-side `CAST(string AS BOOLEAN)` also accepts `"true"/"false"`, so `'false'` / `'FALSE'` rows silently dropped |


## What I'm doing:
In ExtractLiteralValue.tryCastToResultType, refuse to materialize the literal whenever the lift would change semantics. Column-side peeling is unchanged; rejected predicates return null and fall back to engine-side evaluation via the existing alwaysTrue() + AND partial-pushdown path.
Rejection rules added:

- DATE column: DATETIME literal with non-zero time-of-day, or STRING literal whose DateUtils.parseStrictDateTime result has non-zero time-of-day / fails to parse.

- DATETIME column: bare DATE literal (indistinguishable from the dangerous CAST(dt AS DATE) = DATE shape after column-side peel).

- STRING / UUID column: generalize the previous numeric-only check to also reject DATE / DATETIME / BOOLEAN literals — every non-string-class type whose native order disagrees with lexicographic order.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
