### PR TITLE
[Enhancement] Include database name in MV refresh log prefix

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTraceUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTraceUtils.java
@@ -17,6 +17,7 @@ package com.starrocks.scheduler.mv;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
@@ -26,6 +27,7 @@ import com.starrocks.connector.PartitionUtil;
 import com.starrocks.planner.HdfsScanNode;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.PartitionNameSetMap;
 import com.starrocks.sql.plan.ExecPlan;
 import org.apache.logging.log4j.Logger;
@@ -109,7 +111,12 @@ public class MVTraceUtils {
             return "";
         } else {
             StringBuilder sb = new StringBuilder();
-            sb.append(" [").append(mv.getName()).append("] ");
+            sb.append(" [");
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+            if (db != null) {
+                sb.append(db.getFullName()).append(".");
+            }
+            sb.append(mv.getName()).append("] ");
             return sb.toString();
         }
     }


### PR DESCRIPTION
## Why

In multi-tenant setups where the same materialized view name exists in multiple schemas, the MV refresh logger prefix `[mvName]` cannot distinguish them. Original report in #59948 describes a `dim_classification_tags` MV that lives in many per-tenant schemas — log entries are indistinguishable across tenants.

Example log line today:
```
[PartitionBasedMvRefreshProcessor.getRefTableRefreshPartitions():1302] [dim_classification_tags] ref-base-table dim_classification_tags is not found in `mvRefBaseTableIntersectedPartitions` because of empty update
```
No way to tell which `dim_classification_tags` this is.

## What

`MVTraceUtils.getLogPrefix(MaterializedView)` now produces `[dbName.mvName]` instead of `[mvName]`. The prefix is computed once per logger instantiation (once per refresh-processor instance), not per log message, so the extra `getDb(dbId)` lookup is not on any hot path.

If the database lookup returns null (e.g. concurrent drop), the prefix gracefully falls back to `[mvName]`.

## Background

#60096 by @cutiechi proposed the same fix in the old `PartitionBasedMvRefreshProcessor.java`. That file was removed by the IVM refactor in #61857, so #60096 cannot be rebased without a rewrite. This PR applies the same idea to the new central log-prefix builder so it benefits all refresh processors (`MVPCTRefreshProcessor`, `MVIVMRefreshProcessor`, `MVHybridRefreshProcessor`).

cc @LiShuMing (approved #60096, requested rebase 2025-11-10), @cutiechi (original author).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5