### PR TITLE
[Doc] translation update

### DIFF
--- a/.github/workflows/ci-doc-translater.yml
+++ b/.github/workflows/ci-doc-translater.yml
@@ -173,7 +173,7 @@ jobs:
 
           if [[ -n $(git status --porcelain docs/) ]]; then
             git add docs/
-            git commit -m "docs: automated translation via Gemini"
+            git commit -m "docs: automated translation via Anthropic"
 
             # ------------------------------------------------------------------
             # CRITICAL AUTH FIX: Use PAT to push to Fork

--- a/.github/workflows/ci-doc-translater.yml
+++ b/.github/workflows/ci-doc-translater.yml
@@ -84,8 +84,8 @@ jobs:
       - name: Checkout Trusted Tools
         uses: actions/checkout@v4
         with:
-          repository: StarRocks/markdown-translator
-          ref: 'v1.0.6'
+          repository: StarRocks/doc-translator
+          ref: 'v1.0.1'
           path: trusted_tools
 
       - name: Get Changed Files
@@ -119,7 +119,7 @@ jobs:
 
       - name: Run Translations
         env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.DOCS_ANTHROPIC_API_KEY }}
           BODY: ${{ steps.get_checks.outputs.result }}
           FILES_JSON: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |          

--- a/.github/workflows/ci-doc-translation-check.yml
+++ b/.github/workflows/ci-doc-translation-check.yml
@@ -77,16 +77,12 @@ jobs:
       - name: Get PR Details
         if: steps.check_lint.outputs.result == 'true'
         id: pr_details
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = '${{ steps.pr_number.outputs.pr_number }}';
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-            core.setOutput('base_sha', pr.base.sha);
+        run: |
+          # Use HEAD^1 (first parent of the synthetic merge commit) as the base SHA.
+          # pr.base.sha from the GitHub API can be stale when the PR branch hasn't
+          # recently merged from main, causing changed-files to detect all main
+          # commits since the branch point as "PR changes".
+          echo "base_sha=$(git rev-parse HEAD^1)" >> $GITHUB_OUTPUT
 
       - name: Get Changed Files
         if: steps.check_lint.outputs.result == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ _codeql_detected_source_root
 test/.venv
 
 .lycheecache
+memory/

--- a/docs/translation/README.md
+++ b/docs/translation/README.md
@@ -1,6 +1,6 @@
 # Markdown Translator
 
-A powerful command-line tool that uses Google Gemini AI to translate markdown and MDX files from English to any specified language while preserving formatting and structure.
+A powerful command-line tool that uses Anthropic AI to translate markdown and MDX files from English to any specified language while preserving formatting and structure.
 
 Instead of including the translation code in the `StarRocks/starrocks` repo, it is separate so that it can be used for files in other repos, or outside of GitHub.
 

--- a/docs/translation/README.md
+++ b/docs/translation/README.md
@@ -4,4 +4,4 @@ A powerful command-line tool that uses Google Gemini AI to translate markdown an
 
 Instead of including the translation code in the `StarRocks/starrocks` repo, it is separate so that it can be used for files in other repos, or outside of GitHub.
 
-Follow the [README](https://github.com/StarRocks/markdown-translator/blob/main/README.md)
+Follow the [README](https://github.com/StarRocks/doc-translator/blob/main/README.md)


### PR DESCRIPTION
## Why I'm doing:

1. PRs using branches out of sync with `main` have been getting long lists of unrelated docs for translation. This is because the workflow was not comparing the files in the PR with main.
2. Translations have become inconsistent. It appears that the LLM may have changed.

## What I'm doing:

1. The Get PR Details step now runs after Checkout PR Code (which checks out refs/pull/{pr}/merge), so git rev-parse HEAD^1 gives the exact main SHA that GitHub used when computing that merge ref.
2. Use an update to the translation code and an Anthropic model. The new code includes some extra checks based on recent failures.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5