### PR TITLE
[BugFix] percentile_approx: input validation, NULL on empty state, stack safety, merge fast-path

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -49,8 +49,22 @@
 
 namespace starrocks {
 
+// percentile_approx* return SQL NULL on empty / all-rejected state (zero total
+// weight) via PercentileApproxAggEmptyPred. The predicate lives in the
+// nullable wrapper, so the resolver must select the nullable mapping even when
+// all arguments are non-nullable; otherwise the raw aggregate path would
+// finalize the empty digest to NaN.
 static const std::unordered_set<std::string> ALWAYS_NULLABLE_RESULT_AGG_FUNCS = {
-        "variance_samp", "var_samp", "stddev_samp", "covar_samp", "corr", "max_by_v2", "min_by_v2"};
+        "variance_samp",
+        "var_samp",
+        "stddev_samp",
+        "covar_samp",
+        "corr",
+        "max_by_v2",
+        "min_by_v2",
+        "percentile_approx",
+        "percentile_approx_weighted",
+};
 
 static const std::string FUNCTION_COUNT = "count";
 

--- a/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
@@ -48,29 +48,37 @@ struct LowCardPercentileDispatcher {
 };
 
 void AggregateFuncResolver::register_others() {
+    // null_pred returns SQL NULL for a state with zero total weight instead
+    // of NaN. See PercentileApproxAggEmptyPred for the sources of empty state.
     add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_DOUBLE, PercentileApproxState>(
-            "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction());
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_DOUBLE, PercentileApproxState>(
-            "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction());
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
 
     // percentile_approx(expr, ARRAY<DOUBLE>) -> ARRAY<DOUBLE>
     add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_ARRAY, PercentileApproxState>(
-            "percentile_approx", false, AggregateFactory::MakePercentileApproxArrayAggregateFunction());
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxArrayAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_ARRAY, PercentileApproxState>(
-            "percentile_approx", false, AggregateFactory::MakePercentileApproxArrayAggregateFunction());
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxArrayAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
 
     add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_DOUBLE, PercentileApproxState>(
-            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction());
+            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_DOUBLE, PercentileApproxState>(
-            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction());
+            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
 
     // percentile_approx_weighted(expr, weight, ARRAY<DOUBLE>) -> ARRAY<DOUBLE>
     add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_ARRAY, PercentileApproxState>(
-            "percentile_approx_weighted", false,
-            AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction());
+            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_ARRAY, PercentileApproxState>(
-            "percentile_approx_weighted", false,
-            AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction());
+            "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction(),
+            PercentileApproxAggEmptyPred{});
 
     add_aggregate_mapping<TYPE_PERCENTILE, TYPE_PERCENTILE, PercentileValue>(
             "percentile_union", false, AggregateFactory::MakePercentileUnionAggregateFunction());

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -14,10 +14,12 @@
 
 #pragma once
 
+#include "column/array_column.h"
 #include "column/column_helper.h"
 #include "column/object_column.h"
 #include "column/vectorized_fwd.h"
 #include "exprs/agg/aggregate.h"
+#include "exprs/function_context.h"
 #include "gutil/casts.h"
 #include "types/percentile_value.h"
 #include "types/tdigest.h"

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -47,6 +47,14 @@ public:
             targetQuantiles; // Stores target quantile(s), single value for scalar mode, multiple for array mode
 };
 
+// Null predicate for percentile_approx*. A state that received zero total
+// weight (no input rows, all inputs filtered out, all weights <= 0, all
+// values non-finite) must finalize to SQL NULL instead of NaN. Passed to
+// NullableAggregateFunctionVariadic via add_aggregate_mapping_variadic.
+struct PercentileApproxAggEmptyPred {
+    bool operator()(const PercentileApproxState& state) const { return state.percentile->is_empty(); }
+};
+
 class PercentileApproxAggregateFunctionBase
         : public AggregateFunctionBatchHelper<PercentileApproxState, PercentileApproxAggregateFunctionBase> {
 protected:
@@ -73,7 +81,19 @@ public:
         src_percentile.percentile->deserialize((char*)src.data + sizeof(double));
 
         int64_t prev_memory = data(state).percentile->mem_usage();
-        data(state).percentile->merge(src_percentile.percentile.get());
+        // Fast-path: when convert_to_serialize_format ships a single value
+        // per row (PASS_THROUGH / FORCE_STREAMING), every incoming digest is
+        // a singleton. TDigest::merge() would route it through a priority
+        // queue and a batched mergeProcessed/mergeUnprocessed cycle, which
+        // is overkill for one centroid. add() pushes directly into the
+        // target's _unprocessed buffer.
+        float singleton_mean;
+        float singleton_weight;
+        if (src_percentile.percentile->try_extract_singleton(&singleton_mean, &singleton_weight)) {
+            data(state).percentile->add(singleton_mean, singleton_weight);
+        } else {
+            data(state).percentile->merge(src_percentile.percentile.get());
+        }
         if (data(state).targetQuantiles.empty()) {
             data(state).targetQuantiles.push_back(quantile);
         }
@@ -82,12 +102,15 @@ public:
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         size_t size = data(state).percentile->serialize_size();
-        uint8_t result[size + sizeof(double)];
+        size_t total = size + sizeof(double);
+        // Avoid a stack VLA: a high-compression digest can serialize to tens
+        // of KB of centroids, large enough to risk stack overflow.
+        std::vector<uint8_t> result(total);
         double quantile = data(state).targetQuantiles.empty() ? 0.0 : data(state).targetQuantiles[0];
-        memcpy(result, &quantile, sizeof(double));
-        data(state).percentile->serialize(result + sizeof(double));
+        memcpy(result.data(), &quantile, sizeof(double));
+        data(state).percentile->serialize(result.data() + sizeof(double));
         auto* column = down_cast<BinaryColumn*>(to);
-        column->append(Slice(result, size + sizeof(double)));
+        column->append(Slice(result.data(), total));
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
@@ -105,7 +128,11 @@ public:
         double compression = DEFAULT_COMPRESSION_FACTOR;
         if (ctx->get_num_args() > 2) {
             compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(ctx->get_constant_column(2));
-            if (compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
+            // !std::isfinite catches NaN/+Inf/-Inf which the < / > comparisons
+            // below silently pass through (NaN < X and NaN > X are both false),
+            // letting std::ceil(NaN) reach processedSize()/unprocessedSize() with
+            // an undefined cast to size_t.
+            if (!std::isfinite(compression) || compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
                 LOG(WARNING) << "Compression factor out of range. Using default compression factor: "
                              << DEFAULT_COMPRESSION_FACTOR;
                 compression = DEFAULT_COMPRESSION_FACTOR;
@@ -182,7 +209,9 @@ public:
                 if (const_col != nullptr) {
                     // Found the last constant column, this should be compression
                     compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(const_col);
-                    if (compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
+                    // See PercentileApproxAggregateFunction::get_compression_factor for why
+                    // !std::isfinite is required in addition to the range check.
+                    if (!std::isfinite(compression) || compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
                         LOG(WARNING) << "Compression factor out of range. Using default compression factor: "
                                      << DEFAULT_COMPRESSION_FACTOR;
                         compression = DEFAULT_COMPRESSION_FACTOR;
@@ -214,8 +243,10 @@ public:
 
         double column_value = data_column->immutable_data()[row_num];
         int64_t prev_memory = data(state).percentile->mem_usage();
-        // add value with weight
-        if (LIKELY(weight != 0)) {
+        // add value with weight. Reject w <= 0: a negative weight pushes
+        // _processed_weight negative and yields NaN from weightedAverageSorted().
+        // TDigest::add() also rejects non-positive weights as a second guard.
+        if (LIKELY(weight > 0)) {
             data(state).percentile->add(implicit_cast<float>(column_value), weight);
         }
         ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
@@ -235,11 +266,12 @@ public:
         result->get_offset().resize(chunk_size + 1);
 
         // argument 1, weight column can be int64 or const column
-        // serialize percentile one by one
+        // serialize percentile one by one. weight <= 0 must not be added: a
+        // negative weight corrupts the digest's running weight totals.
         size_t old_size = bytes.size();
         if (src[1]->is_constant()) {
             int64_t weight = src[1]->get(0).get_int64();
-            if (LIKELY(weight != 0)) {
+            if (LIKELY(weight > 0)) {
                 for (size_t i = 0; i < chunk_size; ++i) {
                     PercentileValue percentile;
                     double value = data_column->immutable_data()[i];
@@ -270,7 +302,7 @@ public:
                 int64_t weight = weight_column->immutable_data()[i];
                 PercentileValue percentile;
                 double value = data_column->immutable_data()[i];
-                if (LIKELY(weight != 0)) {
+                if (LIKELY(weight > 0)) {
                     percentile.add(implicit_cast<float>(value), weight);
                 }
                 size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
@@ -343,9 +375,16 @@ public:
         PercentileApproxState src_percentile(compression);
         src_percentile.percentile->deserialize((char*)src.data + sizeof(uint32_t) + count * sizeof(double));
 
-        // Merge into current state
+        // Merge into current state. See base class merge() for the singleton
+        // fast-path rationale.
         int64_t prev_memory = data(state).percentile->mem_usage();
-        data(state).percentile->merge(src_percentile.percentile.get());
+        float singleton_mean;
+        float singleton_weight;
+        if (src_percentile.percentile->try_extract_singleton(&singleton_mean, &singleton_weight)) {
+            data(state).percentile->add(singleton_mean, singleton_weight);
+        } else {
+            data(state).percentile->merge(src_percentile.percentile.get());
+        }
         ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
     }
 
@@ -355,19 +394,20 @@ public:
         uint32_t count = static_cast<uint32_t>(data(state).targetQuantiles.size());
         size_t total_size = sizeof(uint32_t) + count * sizeof(double) + tdigest_size;
 
-        uint8_t result[total_size];
+        // Avoid stack VLA (see PercentileApproxAggregateFunctionBase::serialize_to_column).
+        std::vector<uint8_t> result(total_size);
 
         // Write quantile count
-        memcpy(result, &count, sizeof(uint32_t));
+        memcpy(result.data(), &count, sizeof(uint32_t));
 
         // Write all quantiles
-        memcpy(result + sizeof(uint32_t), data(state).targetQuantiles.data(), count * sizeof(double));
+        memcpy(result.data() + sizeof(uint32_t), data(state).targetQuantiles.data(), count * sizeof(double));
 
         // Write TDigest data
-        data(state).percentile->serialize(result + sizeof(uint32_t) + count * sizeof(double));
+        data(state).percentile->serialize(result.data() + sizeof(uint32_t) + count * sizeof(double));
 
         auto* column = down_cast<BinaryColumn*>(to);
-        column->append(Slice(result, total_size));
+        column->append(Slice(result.data(), total_size));
     }
 
     // Override finalize_to_column method, returns ARRAY<DOUBLE>
@@ -469,8 +509,10 @@ public:
 
         double column_value = data_column->immutable_data()[row_num];
         int64_t prev_memory = data(state).percentile->mem_usage();
-        // add value with weight
-        if (LIKELY(weight != 0)) {
+        // add value with weight. Reject w <= 0: a negative weight pushes
+        // _processed_weight negative and yields NaN from weightedAverageSorted().
+        // TDigest::add() also rejects non-positive weights as a second guard.
+        if (LIKELY(weight > 0)) {
             data(state).percentile->add(implicit_cast<float>(column_value), weight);
         }
         ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
@@ -501,9 +543,16 @@ public:
         PercentileApproxState src_percentile(compression);
         src_percentile.percentile->deserialize((char*)src.data + sizeof(uint32_t) + count * sizeof(double));
 
-        // Merge into current state
+        // Merge into current state. See base class merge() for the singleton
+        // fast-path rationale.
         int64_t prev_memory = data(state).percentile->mem_usage();
-        data(state).percentile->merge(src_percentile.percentile.get());
+        float singleton_mean;
+        float singleton_weight;
+        if (src_percentile.percentile->try_extract_singleton(&singleton_mean, &singleton_weight)) {
+            data(state).percentile->add(singleton_mean, singleton_weight);
+        } else {
+            data(state).percentile->merge(src_percentile.percentile.get());
+        }
         ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
     }
 
@@ -513,19 +562,20 @@ public:
         uint32_t count = static_cast<uint32_t>(data(state).targetQuantiles.size());
         size_t total_size = sizeof(uint32_t) + count * sizeof(double) + tdigest_size;
 
-        uint8_t result[total_size];
+        // Avoid stack VLA (see PercentileApproxAggregateFunctionBase::serialize_to_column).
+        std::vector<uint8_t> result(total_size);
 
         // Write quantile count
-        memcpy(result, &count, sizeof(uint32_t));
+        memcpy(result.data(), &count, sizeof(uint32_t));
 
         // Write all quantiles
-        memcpy(result + sizeof(uint32_t), data(state).targetQuantiles.data(), count * sizeof(double));
+        memcpy(result.data() + sizeof(uint32_t), data(state).targetQuantiles.data(), count * sizeof(double));
 
         // Write TDigest data
-        data(state).percentile->serialize(result + sizeof(uint32_t) + count * sizeof(double));
+        data(state).percentile->serialize(result.data() + sizeof(uint32_t) + count * sizeof(double));
 
         auto* column = down_cast<BinaryColumn*>(to);
-        column->append(Slice(result, total_size));
+        column->append(Slice(result.data(), total_size));
     }
 
     // Override finalize_to_column method, returns ARRAY<DOUBLE>
@@ -573,12 +623,13 @@ public:
         bytes.reserve(chunk_size * estimated_size_per_row);
         result->get_offset().resize(chunk_size + 1);
 
-        // argument 1, weight column can be int64 or const column
+        // argument 1, weight column can be int64 or const column. weight <= 0
+        // must not be added (see PercentileApproxWeightedAggregateFunction).
         // serialize percentile one by one
         size_t old_size = bytes.size();
         if (src[1]->is_constant()) {
             int64_t weight = src[1]->get(0).get_int64();
-            if (LIKELY(weight != 0)) {
+            if (LIKELY(weight > 0)) {
                 for (size_t i = 0; i < chunk_size; ++i) {
                     PercentileValue percentile;
                     double value = data_column->immutable_data()[i];
@@ -623,7 +674,7 @@ public:
                 int64_t weight = weight_column->immutable_data()[i];
                 PercentileValue percentile;
                 double value = data_column->immutable_data()[i];
-                if (LIKELY(weight != 0)) {
+                if (LIKELY(weight > 0)) {
                     percentile.add(implicit_cast<float>(value), weight);
                 }
 

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -85,7 +85,11 @@ public:
     // percentile_approx null predicate to return SQL NULL instead of a
     // silent NaN when the digest is empty (e.g. weighted variant with all
     // w <= 0, or input values rejected as non-finite by TDigest::add).
-    bool is_empty() const { return _tdigest.totalWeight() == 0; }
+    // Test the centroid vectors directly rather than TDigest::totalWeight(),
+    // which narrows the accumulated float weight to long (UB once a weighted
+    // sum exceeds the long range). A digest holds a centroid iff some w > 0
+    // was added, so emptiness == both vectors empty.
+    bool is_empty() const { return _tdigest.processed().empty() && _tdigest.unprocessed().empty(); }
 
 private:
     enum PercentileDataType { TDIGEST = 0 };

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -38,7 +38,24 @@ public:
 
     void add(float value, int64_t weight) { _tdigest.add(value, static_cast<float>(weight)); }
 
+    void add(float value, float weight) { _tdigest.add(value, weight); }
+
     void merge(const PercentileValue* other) { _tdigest.merge(&other->_tdigest); }
+
+    // Fast-path probe for the very common shape produced by
+    // PercentileApproxAggregateFunction::convert_to_serialize_format in
+    // PASS_THROUGH / streaming: one unprocessed centroid, no processed.
+    // Caller can then add(mean, weight) directly to the target and skip
+    // the priority-queue merge path in TDigest::add(iter, end).
+    bool try_extract_singleton(float* mean, float* weight) const {
+        if (!_tdigest.processed().empty() || _tdigest.unprocessed().size() != 1) {
+            return false;
+        }
+        const Centroid& c = _tdigest.unprocessed().front();
+        *mean = c.mean();
+        *weight = c.weight();
+        return true;
+    }
 
     uint64_t serialize_size() const {
         //_type 1 bytes
@@ -63,6 +80,12 @@ public:
     }
 
     Value quantile(Value q) { return _tdigest.quantile(q); }
+
+    // True iff the digest received zero total weight. Used by the
+    // percentile_approx null predicate to return SQL NULL instead of a
+    // silent NaN when the digest is empty (e.g. weighted variant with all
+    // w <= 0, or input values rejected as non-finite by TDigest::add).
+    bool is_empty() const { return _tdigest.totalWeight() == 0; }
 
 private:
     enum PercentileDataType { TDIGEST = 0 };

--- a/be/src/types/tdigest.cpp
+++ b/be/src/types/tdigest.cpp
@@ -372,7 +372,12 @@ void TDigest::compress() {
 }
 
 bool TDigest::add(Value x, Weight w) {
-    if (std::isnan(x)) {
+    // Reject non-finite values (NaN, +Inf, -Inf) and non-positive weights:
+    // - NaN propagates through Centroid::add() to silently NaN mean.
+    // - Mixing +Inf and -Inf via Centroid::add() also yields NaN mean.
+    // - w <= 0 corrupts _unprocessed_weight (negative or zero total) and breaks
+    //   weightedAverageSorted() / quantile() with NaN.
+    if (!std::isfinite(x) || !(w > 0)) {
         return false;
     }
     _unprocessed.emplace_back(x, w);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -138,6 +138,7 @@ set(EXEC_FILES
         ./exprs/agg/data_sketch/ds_theta_test.cpp
         ./exprs/agg/json_each_test.cpp
         ./exprs/agg/aggregate_test.cpp
+        ./exprs/agg/percentile_approx_test.cpp
         ./exprs/agg/window_test.cpp
         ./exprs/agg/agg_compressed_key_test.cpp
         ./exprs/agg/agg_state_functions_test.cpp

--- a/be/test/exprs/agg/percentile_approx_test.cpp
+++ b/be/test/exprs/agg/percentile_approx_test.cpp
@@ -1,0 +1,243 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/agg/percentile_approx.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <memory>
+
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "exprs/agg/aggregate_factory.h"
+#include "exprs/agg/aggregate_state_allocator.h"
+#include "exprs/function_context.h"
+#include "testutil/function_utils.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+class PercentileApproxAggTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _utils = std::make_unique<FunctionUtils>();
+        _ctx = _utils->get_fn_ctx();
+        _allocator = std::make_unique<CountingAllocatorWithHook>();
+        tls_agg_state_allocator = _allocator.get();
+    }
+    void TearDown() override {
+        tls_agg_state_allocator = nullptr;
+        _allocator.reset();
+        _utils.reset();
+    }
+
+protected:
+    std::unique_ptr<FunctionUtils> _utils;
+    FunctionContext* _ctx{};
+    std::unique_ptr<CountingAllocatorWithHook> _allocator;
+};
+
+namespace {
+
+// Build a FunctionContext that carries the const columns the aggregate
+// expects via ctx->get_constant_column(i). Used for the quantile and
+// (optionally) compression parameters.
+std::unique_ptr<FunctionContext> make_ctx(std::vector<TypeDescriptor> arg_types, TypeDescriptor return_type,
+                                          Columns const_columns) {
+    std::unique_ptr<FunctionContext> ctx(
+            FunctionContext::create_test_context(std::move(arg_types), std::move(return_type)));
+    ctx->set_constant_columns(std::move(const_columns));
+    return ctx;
+}
+
+struct ManagedState {
+    ManagedState(FunctionContext* ctx, const AggregateFunction* func) : _ctx(ctx), _func(func) {
+        _state = _mem_pool.allocate_aligned(func->size(), func->alignof_size());
+        _func->create(_ctx, _state);
+    }
+    ~ManagedState() { _func->destroy(_ctx, _state); }
+    AggDataPtr state() { return _state; }
+
+    FunctionContext* _ctx;
+    const AggregateFunction* _func;
+    MemPool _mem_pool;
+    AggDataPtr _state;
+};
+
+} // namespace
+
+// percentile_approx_weighted with a row whose weight is negative.
+// The bug: only weight == 0 was filtered, so the negative-weight row
+// entered the digest and produced an incorrect median.
+TEST_F(PercentileApproxAggTest, weighted_negative_weight_is_skipped) {
+    const AggregateFunction* func =
+            get_aggregate_function("percentile_approx_weighted", TYPE_DOUBLE, TYPE_DOUBLE, /*is_nullable=*/false);
+    ASSERT_NE(func, nullptr);
+
+    std::vector<TypeDescriptor> arg_types{TypeDescriptor::from_logical_type(TYPE_DOUBLE),
+                                          TypeDescriptor::from_logical_type(TYPE_BIGINT),
+                                          TypeDescriptor::from_logical_type(TYPE_DOUBLE)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_DOUBLE);
+    auto quantile_const = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.5, 1);
+    Columns const_columns{ColumnHelper::create_const_column<TYPE_DOUBLE>(0, 1),
+                          ColumnHelper::create_const_column<TYPE_BIGINT>(0, 1), quantile_const};
+    auto ctx = make_ctx(arg_types, return_type, const_columns);
+
+    auto values = DoubleColumn::create();
+    auto weights = Int64Column::create();
+    for (auto v : {10.0, 20.0, 30.0}) {
+        values->append(v);
+        weights->append(1);
+    }
+    values->append(100.0);
+    weights->append(-10);
+
+    std::vector<const Column*> raw{values.get(), weights.get(), quantile_const.get()};
+
+    ManagedState state(ctx.get(), func);
+    for (size_t i = 0; i < values->size(); ++i) {
+        func->update(ctx.get(), raw.data(), state.state(), i);
+    }
+
+    auto result = DoubleColumn::create();
+    func->finalize_to_column(ctx.get(), state.state(), result.get());
+
+    ASSERT_EQ(1U, result->size());
+    EXPECT_DOUBLE_EQ(20.0, result->get_data()[0]);
+}
+
+// percentile_approx with non-finite values in the input.
+// Bug: TDigest::add() rejected NaN but accepted +Inf / -Inf, which
+// distorted the digest and the quantile.
+TEST_F(PercentileApproxAggTest, scalar_inf_values_are_skipped) {
+    const AggregateFunction* func =
+            get_aggregate_function("percentile_approx", TYPE_DOUBLE, TYPE_DOUBLE, /*is_nullable=*/false);
+    ASSERT_NE(func, nullptr);
+
+    std::vector<TypeDescriptor> arg_types{TypeDescriptor::from_logical_type(TYPE_DOUBLE),
+                                          TypeDescriptor::from_logical_type(TYPE_DOUBLE)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_DOUBLE);
+    auto quantile_const = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.5, 1);
+    Columns const_columns{ColumnHelper::create_const_column<TYPE_DOUBLE>(0, 1), quantile_const};
+    auto ctx = make_ctx(arg_types, return_type, const_columns);
+
+    auto values = DoubleColumn::create();
+    for (auto v : {10.0, 20.0, 30.0}) {
+        values->append(v);
+    }
+    values->append(std::numeric_limits<double>::infinity());
+    values->append(-std::numeric_limits<double>::infinity());
+    values->append(std::numeric_limits<double>::quiet_NaN());
+
+    std::vector<const Column*> raw{values.get(), quantile_const.get()};
+
+    ManagedState state(ctx.get(), func);
+    for (size_t i = 0; i < values->size(); ++i) {
+        func->update(ctx.get(), raw.data(), state.state(), i);
+    }
+
+    auto result = DoubleColumn::create();
+    func->finalize_to_column(ctx.get(), state.state(), result.get());
+
+    ASSERT_EQ(1U, result->size());
+    const double median = result->get_data()[0];
+    EXPECT_TRUE(std::isfinite(median));
+    // T-Digest is approximate; the median of {10, 20, 30} should be near 20.
+    EXPECT_GE(median, 10.0);
+    EXPECT_LE(median, 30.0);
+}
+
+// Zero-total-weight state must finalize to SQL NULL via the nullable
+// wrapper, not NaN. Reproduces only on the is_nullable=true mapping,
+// which is what ALWAYS_NULLABLE_RESULT_AGG_FUNCS forces at runtime.
+TEST_F(PercentileApproxAggTest, weighted_empty_state_finalizes_to_null) {
+    const AggregateFunction* func =
+            get_aggregate_function("percentile_approx_weighted", TYPE_DOUBLE, TYPE_DOUBLE, /*is_nullable=*/true);
+    ASSERT_NE(func, nullptr);
+
+    std::vector<TypeDescriptor> arg_types{TypeDescriptor::from_logical_type(TYPE_DOUBLE),
+                                          TypeDescriptor::from_logical_type(TYPE_BIGINT),
+                                          TypeDescriptor::from_logical_type(TYPE_DOUBLE)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_DOUBLE);
+    auto weight_const = ColumnHelper::create_const_column<TYPE_BIGINT>(0, 1);
+    auto quantile_const = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.5, 1);
+    Columns const_columns{ColumnHelper::create_const_column<TYPE_DOUBLE>(0, 1), weight_const, quantile_const};
+    auto ctx = make_ctx(arg_types, return_type, const_columns);
+
+    auto values = NullableColumn::create(DoubleColumn::create(), NullColumn::create());
+    auto* values_data = down_cast<DoubleColumn*>(values->data_column().get());
+    for (auto v : {10.0, 20.0, 30.0}) {
+        values_data->append(v);
+        values->null_column_data().push_back(0);
+    }
+
+    auto weights = NullableColumn::create(weight_const->clone_shared(), NullColumn::create(values->size(), 0));
+
+    std::vector<const Column*> raw{values.get(), weights.get(), quantile_const.get()};
+
+    ManagedState state(ctx.get(), func);
+    for (size_t i = 0; i < values->size(); ++i) {
+        func->update(ctx.get(), raw.data(), state.state(), i);
+    }
+
+    auto result = NullableColumn::create(DoubleColumn::create(), NullColumn::create());
+    func->finalize_to_column(ctx.get(), state.state(), result.get());
+
+    ASSERT_EQ(1U, result->size());
+    EXPECT_TRUE(result->is_null(0));
+}
+
+// Non-finite compression must not propagate to TDigest sizing math.
+// FE blocks the SQL path, so we drive it directly via FunctionContext to
+// exercise the BE-side guard.
+TEST_F(PercentileApproxAggTest, non_finite_compression_falls_back_to_default) {
+    const AggregateFunction* func =
+            get_aggregate_function("percentile_approx", TYPE_DOUBLE, TYPE_DOUBLE, /*is_nullable=*/false);
+    ASSERT_NE(func, nullptr);
+
+    std::vector<TypeDescriptor> arg_types{TypeDescriptor::from_logical_type(TYPE_DOUBLE),
+                                          TypeDescriptor::from_logical_type(TYPE_DOUBLE),
+                                          TypeDescriptor::from_logical_type(TYPE_DOUBLE)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_DOUBLE);
+    auto quantile_const = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.5, 1);
+    auto bad_compression = ColumnHelper::create_const_column<TYPE_DOUBLE>(std::numeric_limits<double>::quiet_NaN(), 1);
+    Columns const_columns{ColumnHelper::create_const_column<TYPE_DOUBLE>(0, 1), quantile_const, bad_compression};
+    auto ctx = make_ctx(arg_types, return_type, const_columns);
+
+    auto values = DoubleColumn::create();
+    for (auto v : {10.0, 20.0, 30.0}) {
+        values->append(v);
+    }
+    std::vector<const Column*> raw{values.get(), quantile_const.get(), bad_compression.get()};
+
+    ManagedState state(ctx.get(), func);
+    for (size_t i = 0; i < values->size(); ++i) {
+        func->update(ctx.get(), raw.data(), state.state(), i);
+    }
+
+    auto result = DoubleColumn::create();
+    func->finalize_to_column(ctx.get(), state.state(), result.get());
+
+    ASSERT_EQ(1U, result->size());
+    const double median = result->get_data()[0];
+    EXPECT_TRUE(std::isfinite(median));
+    EXPECT_GE(median, 10.0);
+    EXPECT_LE(median, 30.0);
+}
+
+} // namespace starrocks

--- a/be/test/exprs/agg/percentile_approx_test.cpp
+++ b/be/test/exprs/agg/percentile_approx_test.cpp
@@ -27,6 +27,8 @@
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/agg/aggregate_state_allocator.h"
 #include "exprs/function_context.h"
+#include "runtime/mem_pool.h"
+#include "runtime/memory/counting_allocator.h"
 #include "testutil/function_utils.h"
 #include "types/logical_type.h"
 
@@ -180,13 +182,13 @@ TEST_F(PercentileApproxAggTest, weighted_empty_state_finalizes_to_null) {
     auto ctx = make_ctx(arg_types, return_type, const_columns);
 
     auto values = NullableColumn::create(DoubleColumn::create(), NullColumn::create());
-    auto* values_data = down_cast<DoubleColumn*>(values->data_column().get());
+    auto* values_data = down_cast<DoubleColumn*>(values->data_column()->as_mutable_raw_ptr());
     for (auto v : {10.0, 20.0, 30.0}) {
         values_data->append(v);
         values->null_column_data().push_back(0);
     }
 
-    auto weights = NullableColumn::create(weight_const->clone_shared(), NullColumn::create(values->size(), 0));
+    auto weights = NullableColumn::create(weight_const->clone(), NullColumn::create(values->size(), 0));
 
     std::vector<const Column*> raw{values.get(), weights.get(), quantile_const.get()};
 

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -538,8 +538,8 @@ select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighte
 -- !result
 select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighted(value, 0, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile_weighted group by id_int;
 -- result:
-[nan,nan]
-[nan,nan]
+None
+None
 -- !result
 select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighted(value, value, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile_weighted group by id_int;
 -- result:
@@ -586,7 +586,7 @@ select /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming') */ percen
 -- !result
 select /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming') */ percentile_approx_weighted(v2, 0, array<double>[0.1, 0.5, 0.9], 5000) from t0_convert_to_serialize_format join t1_convert_to_serialize_format group by 'a';
 -- result:
-[nan,nan,nan]
+None
 -- !result
 select /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming') */ percentile_approx_weighted(v2, v1, array<double>[0.1, 0.5, 0.9], 5000) from t0_convert_to_serialize_format join t1_convert_to_serialize_format group by 'a';
 -- result:


### PR DESCRIPTION
## Why I'm doing:

`percentile_approx` / `percentile_approx_weighted` accept inputs that should be rejected and silently produce wrong results or NaN. See #73523 for SQL repro (verified on 3.3 and 4.1).

Five bugs covered by this PR:

1. Negative weight in `percentile_approx_weighted` corrupts the running weight totals — returns 10 instead of 20 on the repro.
2. `+Inf` / `-Inf` values are not filtered alongside NaN; infinite centroids enter the digest and distort all quantiles.
3. Zero-total-weight state finalizes to NaN instead of SQL NULL (inconsistent with `percentile_approx(NULL, q)`).
4. `serialize_to_column` allocates the output blob via a runtime-sized stack VLA; high-compression digests serialize to tens of KB and can overflow the thread stack.
5. `merge()` routes every singleton incoming blob (produced per-row by `convert_to_serialize_format` in PASS_THROUGH / FORCE_STREAMING) through `TDigest::merge()`'s priority-queue path — per-row overhead on high-cardinality `GROUP BY` queries.

## What I'm doing:

- `TDigest::add()`: reject `+Inf` / `-Inf` and `w <= 0` (in addition to NaN).
- `get_compression_factor()`: reject non-finite `compression` as defense in depth. The SQL path is already blocked by the FE TypeChecker's `ConstantOperator` / numeric-constant check, but session variables, future planner changes, or UDF rewrites could deliver a non-finite value to BE.
- `percentile_approx_weighted` `update()` and `convert_to_serialize_format()`: filter `weight > 0` instead of `weight != 0`.
- Add `PercentileApproxAggEmptyPred` (zero total weight) and pass it to `add_aggregate_mapping_variadic` for all four `percentile_approx` variants. Add `percentile_approx` / `percentile_approx_weighted` to `ALWAYS_NULLABLE_RESULT_AGG_FUNCS` so the resolver picks the nullable mapping (which carries the predicate) even when all arguments are non-nullable.
- Replace all three stack VLA sites in `serialize_to_column` with `std::vector<uint8_t>` and an explicit `Slice` append.
- `merge()`: when the incoming digest is a singleton (one unprocessed centroid, no processed), call `state.add(mean, weight)` directly and skip `TDigest::merge()`'s priority queue. Helper `PercentileValue::try_extract_singleton()` performs the probe.
- New `be/test/exprs/agg/percentile_approx_test.cpp` covers negative weight, ±Inf values, empty-state NULL, and non-finite compression.

Fixes #73523

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
