### PR TITLE
[BugFix] Defer JDBC REMARKS fetch out of getTable() hot path (backport #73488)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -57,6 +57,11 @@ public class JDBCTable extends Table {
     // Used for Oracle datetime predicate pushdown to determine TO_DATE/TO_TIMESTAMP wrapping.
     private transient Map<String, Integer> originalJdbcColumnTypes;
 
+    // Transient marker used by information_schema.tables to avoid fetching JDBC
+    // REMARKS more than once for the same cached table instance. Reset when the
+    // cache entry is evicted or refreshTable creates a new JDBCTable.
+    private transient boolean commentFetched;
+
     public JDBCTable() {
         super(TableType.JDBC);
     }
@@ -114,6 +119,14 @@ public class JDBCTable extends Table {
 
     public void setOriginalJdbcColumnTypes(Map<String, Integer> originalJdbcColumnTypes) {
         this.originalJdbcColumnTypes = originalJdbcColumnTypes;
+    }
+
+    public boolean isCommentFetched() {
+        return commentFetched;
+    }
+
+    public void setCommentFetched(boolean commentFetched) {
+        this.commentFetched = commentFetched;
     }
 
     public Map<String, String> getConnectInfo() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -150,6 +150,16 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public String getTableComment(ConnectContext context, String dbName, String tblName) {
+        ConnectorMetadata metadata = metadataOfTable(tblName);
+        if (metadata == null) {
+            metadata = metadataOfDb(dbName);
+        }
+
+        return metadata.getTableComment(context, dbName, tblName);
+    }
+
+    @Override
     public TableVersionRange getTableVersionRange(String dbName, Table table,
                                                   Optional<ConnectorTableVersion> startVersion,
                                                   Optional<ConnectorTableVersion> endVersion) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -126,6 +127,16 @@ public interface ConnectorMetadata {
      */
     default Table getTable(ConnectContext context, String dbName, String tblName) {
         return null;
+    }
+
+    /**
+     * Lazily fetch the table comment when a caller really needs it.
+     * The default implementation reuses the comment already carried by
+     * getTable(); JDBC overrides this to issue a dedicated REMARKS query.
+     */
+    default String getTableComment(ConnectContext context, String dbName, String tblName) {
+        Table table = getTable(context, dbName, tblName);
+        return table == null ? "" : Strings.nullToEmpty(table.getComment());
     }
 
     default TableVersionRange getTableVersionRange(String dbName, Table table,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -260,7 +260,6 @@ public class JDBCMetadata implements ConnectorMetadata {
                         Table table = schemaResolver.getTable(tableId, tblName, fullSchema,
                                 partitionColumns, dbName, catalogName, properties);
                         if (table != null) {
-                            table.setComment(schemaResolver.getTableComment(connection, dbName, tblName));
                             if (table instanceof JDBCTable && !originalJdbcTypes.isEmpty()) {
                                 ((JDBCTable) table).setOriginalJdbcColumnTypes(originalJdbcTypes);
                             }
@@ -271,6 +270,16 @@ public class JDBCMetadata implements ConnectorMetadata {
                         return null;
                     }
                 });
+    }
+
+    @Override
+    public String getTableComment(ConnectContext context, String dbName, String tblName) {
+        try (Connection connection = getConnection()) {
+            return schemaResolver.getTableComment(connection, dbName, tblName);
+        } catch (SQLException e) {
+            LOG.warn("get table comment for JDBC catalog fail!", e);
+            return "";
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -52,6 +52,7 @@ import com.starrocks.authentication.AuthenticationHandler;
 import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.PrivilegeType;
+import com.starrocks.catalog.BasicTable;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -521,13 +522,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (db != null) {
             for (String tableName : metadataMgr.listTableNames(context, catalogName, params.db)) {
                 LOG.debug("get table: {}, wait to check", tableName);
-                Table tbl = null;
+                BasicTable tbl = null;
                 if (!PatternMatcher.matchPattern(params.getPattern(), tableName, matcher, caseSensitive)) {
                     continue;
                 }
 
                 try {
-                    tbl = metadataMgr.getTable(context, catalogName, params.db, tableName);
+                    tbl = metadataMgr.getBasicTable(context, catalogName, params.db, tableName);
                 } catch (Exception e) {
                     LOG.warn(e.getMessage(), e);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -28,6 +28,7 @@ import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
@@ -557,6 +558,14 @@ public class InformationSchemaDataSource {
                 }
                 if (table == null) {
                     continue;
+                }
+                if (table instanceof JDBCTable jt
+                        && Config.enable_external_catalog_information_schema_tables_access_full_metadata
+                        && !jt.isCommentFetched()) {
+                    metadataMgr.getOptionalMetadata(catalogName).ifPresent(m -> {
+                        jt.setComment(m.getTableComment(context, dbName, tableName));
+                        jt.setCommentFetched(true);
+                    });
                 }
 
                 try {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -359,15 +359,26 @@ public class JDBCMetadataTest {
     }
 
     @Test
-    public void testGetTableSetsCommentFromMetadata() throws SQLException {
-        // Prepare a TABLES result set with REMARKS for tbl1
+    public void testGetTableDoesNotFetchComment() throws SQLException {
+        // getTable() must not populate the comment, keeping its hot path single
+        // round-trip (getColumns only). Comment fetch is deferred to
+        // getTableComment(). No getTables() mock is set for "tbl1" here so any
+        // unintended REMARKS round-trip in the lambda would also surface via the
+        // returned table's empty comment.
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
+        Assertions.assertNotNull(table);
+        Assertions.assertEquals("", table.getComment());
+    }
+
+    @Test
+    public void testGetTableCommentReadsRemarks() throws SQLException {
         MockResultSet tablesWithRemarks = new MockResultSet("tables_with_remarks");
         tablesWithRemarks.addColumn("TABLE_NAME", Arrays.asList("tbl1"));
         tablesWithRemarks.addColumn("REMARKS", Arrays.asList("jdbc table comment"));
 
         new Expectations() {
             {
-                // getColumns is already mocked in setUp; here we only need to mock getTables for a single table
                 connection.getMetaData().getTables("test", null, "tbl1", new String[] {"TABLE", "VIEW"});
                 result = tablesWithRemarks;
                 minTimes = 0;
@@ -375,9 +386,8 @@ public class JDBCMetadataTest {
         };
 
         JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
-        Assertions.assertNotNull(table);
-        Assertions.assertEquals("jdbc table comment", table.getComment());
+        String comment = jdbcMetadata.getTableComment(new ConnectContext(), "test", "tbl1");
+        Assertions.assertEquals("jdbc table comment", comment);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

#70197 added a `schemaResolver.getTableComment()` round-trip inside `JDBCMetadata.getTable()`'s cache-loader lambda. Every cache miss now costs 2 round-trips (`getColumns` + `getTables`-for-REMARKS) instead of 1. When the loader runs under `PlannerMetaLocker` (mixed internal + external queries, with pre-parse disabled or bypassed) the extra IO extends the intensive READ lock hold on the query's internal tables and blocks their concurrent DDL.

## What I'm doing:

Move comment fetch off the hot path:

- `ConnectorMetadata` adds a `default getTableComment(ctx, db, tbl)` that falls back to the comment already carried by `getTable()` — HMS / Iceberg / Hudi pay nothing because their `getTable` populates comment inline.
- `JDBCMetadata` overrides `getTableComment` to issue the dedicated REMARKS query; the `getTable` lambda no longer pre-populates comment.
- `information_schema.tables` (the only caller that needs comment for external catalogs) explicitly invokes the SPI and writes back to the cached `Table` so subsequent calls within the JDBC meta cache TTL skip the extra round-trip.

Also drop the unused `fetchExternalMetadata=true` argument in `FrontendServiceImpl.getTableNames`: the caller only uses `tbl != null` + `getType()` for auth filtering; full metadata fetch was never read.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
