### PR TITLE
[BugFix] Fix Ranger policy rewrite for Hive views (backport #73265)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -584,20 +584,7 @@ public class QueryAnalyzer {
                     QueryStatement queryStatement = view.getQueryStatement();
                     ViewRelation viewRelation = new ViewRelation(tableName, view, queryStatement);
 
-                    // If tableRelation is an object that needs to be rewritten by policy,
-                    // then when it is changed to ViewRelation, both the view and the table
-                    // after the view is parsed also need to inherit this rewriting logic.
-                    if (tableRelation.isNeedRewrittenByPolicy()) {
-                        viewRelation.setNeedRewrittenByPolicy(true);
-
-                        new AstTraverser<Void, Void>() {
-                            @Override
-                            public Void visitRelation(Relation relation, Void context) {
-                                relation.setNeedRewrittenByPolicy(true);
-                                return null;
-                            }
-                        }.visit(queryStatement);
-                    }
+                    inheritPolicyRewriteFlag(tableRelation, viewRelation, queryStatement);
                     viewRelation.setAlias(tableRelation.getAlias());
 
                     r = viewRelation;
@@ -608,6 +595,7 @@ public class QueryAnalyzer {
                             connectorView.getType());
                     view.setInlineViewDefWithSqlMode(connectorView.getInlineViewDef(), 0);
                     ViewRelation viewRelation = new ViewRelation(tableName, view, queryStatement);
+                    inheritPolicyRewriteFlag(tableRelation, viewRelation, queryStatement);
                     viewRelation.setAlias(tableRelation.getAlias());
 
                     r = viewRelation;
@@ -653,6 +641,25 @@ public class QueryAnalyzer {
                 }
                 return relation;
             }
+        }
+
+        // If tableRelation is an object that needs to be rewritten by policy,
+        // then when it is changed to ViewRelation, both the view and the table
+        // after the view is parsed also need to inherit this rewriting logic.
+        private void inheritPolicyRewriteFlag(TableRelation tableRelation, ViewRelation viewRelation,
+                                              QueryStatement queryStatement) {
+            if (!tableRelation.isNeedRewrittenByPolicy()) {
+                return;
+            }
+
+            viewRelation.setNeedRewrittenByPolicy(true);
+            new AstTraverser<Void, Void>() {
+                @Override
+                public Void visitRelation(Relation relation, Void context) {
+                    relation.setNeedRewrittenByPolicy(true);
+                    return null;
+                }
+            }.visit(queryStatement);
         }
 
         // convert FileTableFunctionRelation to ValuesRelation if only list files

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
@@ -16,6 +16,9 @@ package com.starrocks.connector.hive;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveView;
 import com.starrocks.catalog.Table;
@@ -24,16 +27,30 @@ import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SqlModeHelper;
+import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.AstTraverser;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.Relation;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.ast.ViewRelation;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Optional;
 
@@ -80,6 +97,57 @@ public class HiveViewTest extends PlanTestBase {
                         "  |  join op: INNER JOIN (BROADCAST)\n" +
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 19: n_nationkey = 14: c_nationkey");
+    }
+
+    @Test
+    public void testHiveViewInheritsPolicyRewriteFlag() throws Exception {
+        TableName viewName = new TableName("hive0", "tpch", "customer_view");
+        Expr rowFilter = SqlParser.parseSqlToExpr("c_custkey = 1", SqlModeHelper.MODE_DEFAULT);
+
+        try (MockedStatic<Authorizer> authorizerMockedStatic = Mockito.mockStatic(Authorizer.class)) {
+            authorizerMockedStatic
+                    .when(() -> Authorizer.getColumnMaskingPolicy(Mockito.any(), Mockito.any(), Mockito.any()))
+                    .thenReturn(Maps.newHashMap());
+            authorizerMockedStatic
+                    .when(() -> Authorizer.getRowAccessPolicy(Mockito.any(), Mockito.eq(viewName)))
+                    .thenReturn(rowFilter);
+
+            StatementBase stmt = parseAndAnalyzeWithPolicyRewrite("select * from hive0.tpch.customer_view");
+            SelectRelation selectRelation = (SelectRelation) ((QueryStatement) stmt).getQueryRelation();
+            Assertions.assertTrue(selectRelation.getRelation() instanceof SubqueryRelation);
+
+            SubqueryRelation policyRelation = (SubqueryRelation) selectRelation.getRelation();
+            SelectRelation policySelectRelation = (SelectRelation) policyRelation.getQueryStatement().getQueryRelation();
+            Assertions.assertTrue(policySelectRelation.getRelation() instanceof ViewRelation);
+            Assertions.assertTrue(policySelectRelation.getWhereClause() instanceof BinaryPredicate);
+        }
+    }
+
+    @Test
+    public void testHiveViewBaseTableInheritsPolicyRewriteFlag() throws Exception {
+        TableName baseTableName = new TableName("hive0", "tpch", "customer");
+        Expr rowFilter = SqlParser.parseSqlToExpr("c_custkey = 1", SqlModeHelper.MODE_DEFAULT);
+
+        try (MockedStatic<Authorizer> authorizerMockedStatic = Mockito.mockStatic(Authorizer.class)) {
+            authorizerMockedStatic
+                    .when(() -> Authorizer.getColumnMaskingPolicy(Mockito.any(), Mockito.any(), Mockito.any()))
+                    .thenReturn(Maps.newHashMap());
+            authorizerMockedStatic
+                    .when(() -> Authorizer.getRowAccessPolicy(Mockito.any(), Mockito.eq(baseTableName)))
+                    .thenReturn(rowFilter);
+
+            StatementBase stmt = parseAndAnalyzeWithPolicyRewrite("select * from hive0.tpch.customer_view");
+            SelectRelation selectRelation = (SelectRelation) ((QueryStatement) stmt).getQueryRelation();
+            Assertions.assertTrue(selectRelation.getRelation() instanceof ViewRelation);
+
+            ViewRelation viewRelation = (ViewRelation) selectRelation.getRelation();
+            SelectRelation viewQueryRelation = (SelectRelation) viewRelation.getQueryStatement().getQueryRelation();
+            Assertions.assertTrue(viewQueryRelation.getRelation() instanceof SubqueryRelation);
+
+            SubqueryRelation policyRelation = (SubqueryRelation) viewQueryRelation.getRelation();
+            SelectRelation policySelectRelation = (SelectRelation) policyRelation.getQueryStatement().getQueryRelation();
+            Assertions.assertTrue(policySelectRelation.getWhereClause() instanceof BinaryPredicate);
+        }
     }
 
     @Test
@@ -186,5 +254,18 @@ public class HiveViewTest extends PlanTestBase {
                 "    t1b,t1a\n" +
                 "from\n" +
                 "    test_all_type;", viewDdl);
+    }
+
+    private StatementBase parseAndAnalyzeWithPolicyRewrite(String sql) throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitRelation(Relation relation, Void context) {
+                relation.setNeedRewrittenByPolicy(true);
+                return null;
+            }
+        }.visit(stmt);
+        Analyzer.analyze(stmt, connectContext);
+        return stmt;
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Hive views from external Hive catalogs are represented as `ConnectorView`. When such a view is queried with Ranger row filter or masking policies, the analyzer converts the original `TableRelation` into a `ViewRelation` but did not preserve the `needRewrittenByPolicy` flag. As a result, the security policy rewrite guard skipped the view and the Ranger policies configured on the Hive view were not applied.

The same missing propagation also meant relations inside the expanded Hive view definition did not inherit the rewrite marker, so policies on base tables could be skipped when accessed through the Hive view path.

## What I'm doing:

Reuse the policy rewrite flag propagation used by native StarRocks views for `ConnectorView`:

- preserve `needRewrittenByPolicy` on the created `ViewRelation` only when the outer relation was already marked for policy rewrite
- mark relations inside the expanded view query so table policies inside Hive view definitions can still be rewritten
- add Hive view unit tests covering both a policy on the Hive view itself and a policy on the base table referenced by the Hive view

Attention: New tables and columns referenced within row filter/mask expressions are not supported for rewriting again.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
