### PR TITLE
[BugFix] Convert explicit-txn COMMIT timeout from seconds to milliseconds

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -312,7 +312,7 @@ public class TransactionStmtExecutor {
                     commitInfos,
                     failInfos,
                     txnCommitAttachment,
-                    timeout);
+                    timeout * 1000L);
 
             // Re-fetch transactionState after commit because the COW pattern in DatabaseTransactionMgr
             // replaces the in-memory state with a deep copy, making the original reference stale.

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -23,6 +23,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
+import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.load.loadv2.JobState;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.load.loadv2.LoadMgr;
@@ -556,6 +557,60 @@ public class ExplicitTxnTest {
         Assertions.assertEquals(0, context.getTxnId());
         Assertions.assertNull(globalTransactionMgr.getExplicitTxnState(transactionId));
         Assertions.assertEquals("database 0 is not found", context.getState().getErrorMessage());
+    }
+
+    @Test
+    public void testCommitTimeoutPassedInMilliseconds() {
+        // Regression: commitStmt() reads query_timeout (seconds) and previously passed it
+        // directly to GlobalTransactionMgr.retryCommitOnRateLimitExceeded(..., long timeoutMs),
+        // causing a 300s query_timeout to become a 300ms lock wait.
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+
+        int queryTimeoutS = 300;
+        context.getSessionVariable().setQueryTimeoutS(queryTimeoutS);
+
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Assertions.assertNotNull(db1);
+
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        long transactionId = globalTransactionMgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState transactionState = new TransactionState(transactionId, "timeout-unit-test", null,
+                TransactionState.LoadJobSourceType.INSERT_STREAMING,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, FrontendOptions.getLocalHostAddress()),
+                context.getExecTimeout() * 1000L);
+        transactionState.setDbId(db1.getId());
+
+        ExplicitTxnState explicitTxnState = new ExplicitTxnState();
+        explicitTxnState.setTransactionState(transactionState);
+
+        ExplicitTxnState.ExplicitTxnStateItem item = new ExplicitTxnState.ExplicitTxnStateItem();
+        item.setTabletCommitInfos(List.of());
+        item.setTabletFailInfos(List.of());
+        explicitTxnState.addTransactionItem(item);
+
+        globalTransactionMgr.addTransactionState(transactionId, explicitTxnState);
+        context.setTxnId(transactionId);
+
+        long[] capturedTimeoutMs = {-1L};
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public VisibleStateWaiter retryCommitOnRateLimitExceeded(
+                    Database db, long txnId, List<TabletCommitInfo> commitInfos, List<TabletFailInfo> failInfos,
+                    TxnCommitAttachment attachment, long timeoutMs) throws LockTimeoutException {
+                capturedTimeoutMs[0] = timeoutMs;
+                // Short-circuit the rest of commitStmt; the exception is caught and reported as error.
+                throw new LockTimeoutException(
+                        "get database write lock timeout, database=" + db.getFullName() + ", timeout=" + timeoutMs + "ms");
+            }
+        };
+
+        TransactionStmtExecutor.commitStmt(context, new CommitStmt(NodePosition.ZERO));
+
+        Assertions.assertEquals((long) queryTimeoutS * 1000L, capturedTimeoutMs[0],
+                "query_timeout (" + queryTimeoutS + "s) must be passed to retryCommitOnRateLimitExceeded "
+                        + "as milliseconds, got " + capturedTimeoutMs[0]);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`TransactionStmtExecutor.commitStmt()` reads `query_timeout` in **seconds** (default 300) and passes it directly to `GlobalTransactionMgr.retryCommitOnRateLimitExceeded(..., long timeoutMs)`, which expects **milliseconds** and forwards the value to `Locker.tryLockTablesWithIntensiveDbLock(..., timeoutMs, TimeUnit.MILLISECONDS)`.

Effect: a `COMMIT` inside an explicit transaction (`START TRANSACTION ... ; INSERT ... ; COMMIT;`) only waits up to ~300 ms (not 300 s) for the database write lock. Any concurrent writer briefly holding the lock causes:

```
LockTimeoutException: get database write lock timeout, database=<db>, timeout=300ms
```

Raising `query_timeout` does not help — the unit mismatch caps the wait at `query_timeout` ms regardless. Only the explicit-transaction COMMIT path is affected; the implicit single-`INSERT` path multiplies seconds by 1000 correctly via `jobDeadLineMs` and is fine.

## What I'm doing:

- Multiply the timeout by `1000L` at the call site so the value handed to `retryCommitOnRateLimitExceeded(..., long timeoutMs)` is in milliseconds.
- Add `ExplicitTxnTest.testCommitTimeoutPassedInMilliseconds`, which mocks `retryCommitOnRateLimitExceeded` to capture the `timeoutMs` argument and asserts it equals `query_timeout * 1000`. Verified to fail before the fix (`expected: <300000> but was: <300>`) and pass after.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5