### PR TITLE
[BugFix] Surface dead-BE colocate tablets as unhealthy when balance is off

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -753,6 +753,8 @@ public class ColocateTableBalancer extends LeaderDaemon {
         boolean isGroupStable = true;
         // set the config to a local variable to avoid config params changed.
         int partitionBatchNum = Config.tablet_checker_partition_batch_num;
+        boolean disableColocateBalance = Config.tablet_sched_disable_colocate_balance;
+        SystemInfoService infoService = globalStateMgr.getNodeMgr().getClusterInfo();
         int partitionChecked = 0;
         Locker locker = new Locker();
         locker.lockDatabase(db.getId(), LockType.READ);
@@ -821,6 +823,15 @@ public class ColocateTableBalancer extends LeaderDaemon {
                             // check tablet colocate status
                             TabletHealthStatus st = TabletChecker.getColocateTabletHealthStatus(tablet, visibleVersion,
                                     replicationNum, bucketSeq);
+                            // When balance is gated off, the bucket assignment can retain dead BEs that
+                            // the inner verdict trusts. Mark the group unstable directly so the dead-BE
+                            // fact surfaces via 'show proc "/colocation_group"', without producing a
+                            // repair task that has no valid clone target.
+                            if (disableColocateBalance && st == TabletHealthStatus.HEALTHY
+                                    && !TabletChecker.hasEnoughAliveBackendsInBucketSeq(
+                                            bucketSeq, replicationNum, infoService)) {
+                                isGroupStable = false;
+                            }
                             if (st == TabletHealthStatus.COLOCATE_MISMATCH && balanceStat.isBalanced()) {
                                 balanceStat =
                                         BalanceStat.createColocationGroupBalanceStat(tabletId, tablet.getBackendIds(), bucketSeq);
@@ -1265,7 +1276,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
      * check backend available
      * backend stopped for a short period of time is still considered available
      */
-    private boolean checkBackendAvailable(Long backendId, SystemInfoService infoService) {
+    static boolean checkBackendAvailable(Long backendId, SystemInfoService infoService) {
         long currTime = System.currentTimeMillis();
         Backend be = infoService.getBackend(backendId);
         if (be == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -1214,6 +1214,26 @@ public class TabletChecker extends LeaderDaemon {
     }
 
     /**
+     * Defensive aliveness check for callers that cannot trust {@code backendsSet} contains only
+     * live BEs — used when {@code tablet_sched_disable_colocate_balance} is on, because the
+     * colocate balance step that maintains the bucket assignment is gated off and dead BEs can
+     * persist. Reuses ColocateTableBalancer's own availability predicate so the BEs we would have
+     * balanced away from (had balance been running) are exactly the BEs we now report as missing —
+     * including the {@code tablet_sched_colocate_be_down_tolerate_time_s} grace window and
+     * decommission handling.
+     */
+    static boolean hasEnoughAliveBackendsInBucketSeq(Set<Long> backendsSet, int replicationNum,
+                                                     SystemInfoService systemInfoService) {
+        int aliveInBucketSeq = 0;
+        for (Long beId : backendsSet) {
+            if (ColocateTableBalancer.checkBackendAvailable(beId, systemInfoService)) {
+                aliveInBucketSeq++;
+            }
+        }
+        return aliveInBucketSeq >= replicationNum;
+    }
+
+    /**
      * Determines whether high availability (HA) should be ensured for replica placement,
      * based on the number of replicas and the required location mapping.
      *

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletCheckerTest.java
@@ -16,6 +16,7 @@ package com.starrocks.clone;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 public class TabletCheckerTest {
@@ -131,4 +133,48 @@ public class TabletCheckerTest {
     }
 
     private static SystemInfoService systemInfoService;
+
+    private Backend aliveBackend(long id) {
+        Backend be = new Backend(id, "127.0.0.1", 9050);
+        be.setAlive(true);
+        return be;
+    }
+
+    private Backend deadBackend(long id) {
+        // Defaults: isAlive=false, status non-OK (so isAvailable=false),
+        // lastUpdateMs=0 (well past any tolerate window).
+        return new Backend(id, "127.0.0.1", 9050);
+    }
+
+    /**
+     * Defensive aliveness helper used by callers (e.g. ColocateTableBalancer.matchGroups) when
+     * tablet_sched_disable_colocate_balance is on and bucketSeq may retain dead BE references.
+     */
+    @Test
+    public void testHasEnoughAliveBackendsInBucketSeq() {
+        long be1 = 10001L;
+        long be2 = 10002L;
+        long be3 = 10003L;
+        Set<Long> backendsSet = Sets.newHashSet(be1, be2, be3);
+
+        SystemInfoService infoService = Mockito.mock(SystemInfoService.class);
+        Mockito.when(infoService.getBackend(be1)).thenReturn(aliveBackend(be1));
+        Mockito.when(infoService.getBackend(be2)).thenReturn(aliveBackend(be2));
+        Mockito.when(infoService.getBackend(be3)).thenReturn(aliveBackend(be3));
+
+        Assertions.assertTrue(
+                TabletChecker.hasEnoughAliveBackendsInBucketSeq(backendsSet, 3, infoService),
+                "all alive — bucket seq satisfies replication");
+
+        // Mark be2 dead; survivors no longer cover replicationNum=3.
+        Mockito.when(infoService.getBackend(be2)).thenReturn(deadBackend(be2));
+        Assertions.assertFalse(
+                TabletChecker.hasEnoughAliveBackendsInBucketSeq(backendsSet, 3, infoService),
+                "one dead — should fall below the replication threshold");
+
+        // With a relaxed threshold the survivors are still enough.
+        Assertions.assertTrue(
+                TabletChecker.hasEnoughAliveBackendsInBucketSeq(backendsSet, 2, infoService),
+                "two survivors cover replicationNum=2");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

When `tablet_sched_disable_colocate_balance=true`, the colocate balance step that maintains `backendsPerBucketSeq` stops running, so dead BE references persist in the bucket assignment. `ColocateTableBalancer.matchGroups` then trusts that assignment and silently treats colocate tablets whose replicas all sit on dead BEs as `HEALTHY`, leaving `show proc '/colocation_group'` reporting `IsStable=true` during partial-cluster-loss events.

## What I'm doing:

- Add `TabletChecker.hasEnoughAliveBackendsInBucketSeq`, a defensive aliveness helper that counts surviving BEs in `bucketSeq` using `ColocateTableBalancer.checkBackendAvailable` (promoted to package-private static). Reusing that predicate keeps the BEs we treat as missing in sync with the BEs colocate balance would have replaced, including the `tablet_sched_colocate_be_down_tolerate_time_s` grace window and decommission handling.
- In `ColocateTableBalancer.doMatchOneGroup`, snapshot the disable flag once per invocation. When it is on AND the inner verdict is `HEALTHY` AND the helper reports the bucket sequence no longer has enough alive BEs, mark the group unstable directly (`isGroupStable = false`) without rewriting the per-tablet verdict. The truth surfaces via `show proc '/colocation_group'` without enqueueing repair tasks that would have no valid clone target.
- The rest of `matchGroups` behavior is unchanged. Natural unhealthy verdicts (`COLOCATE_MISMATCH`, `VERSION_INCOMPLETE`, ...) still enqueue repair tasks as before — the flag was only ever meant to gate balance, not repair.
- `TabletChecker.getColocateTabletHealthStatus` and all other call sites (`TabletScheduler`, `ReportHandler`, `LocalTabletTest`) keep their original signature and behavior.
- Add a unit test for `hasEnoughAliveBackendsInBucketSeq` covering all-alive, one-dead-below-threshold, and one-dead-at-relaxed-threshold cases.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5