### PR TITLE
[BugFix] Skip per-replica scan on single-medium BEs in BackendLoadStatistic

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
@@ -57,9 +57,11 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
@@ -290,8 +292,10 @@ public class BackendLoadStatistic {
         memUsed = be.getMemUsedBytes();
 
         ImmutableMap<String, DiskInfo> disks = be.getDisks();
+        Set<TStorageMedium> mediaOnBackend = EnumSet.noneOf(TStorageMedium.class);
         for (DiskInfo diskInfo : disks.values()) {
             TStorageMedium medium = diskInfo.getStorageMedium();
+            mediaOnBackend.add(medium);
             if (diskInfo.getState() == DiskState.ONLINE) {
                 // we only collect online disk's capacity
                 totalCapacityMap
@@ -306,15 +310,44 @@ public class BackendLoadStatistic {
             pathStatistics.add(pathStatistic);
         }
 
-        totalReplicaNumMap = invertedIndex.getReplicaNumByBeIdAndStorageMedium(beId);
-        // This is very tricky. because the number of replica on specified medium we get
-        // from getReplicaNumByBeIdAndStorageMedium() is defined by table properties,
-        // but in fact there may not has SSD disk on this backend. So if we found that no SSD disk on this
-        // backend, set the replica number to 0, otherwise, the average replica number on specified medium
-        // will be incorrect.
-        for (TStorageMedium medium : TStorageMedium.values()) {
-            if (!hasMedium(medium)) {
+        totalReplicaNumMap = Maps.newHashMap();
+        if (mediaOnBackend.isEmpty()) {
+            // BE has not reported any disks yet (newly added / dead / pre-heartbeat). Skip the
+            // per-tablet scan -- with no pathStatistics, the hasMedium() post-pass would zero
+            // every count anyway. Match that outcome directly.
+            for (TStorageMedium medium : TStorageMedium.values()) {
                 totalReplicaNumMap.put(medium, 0L);
+            }
+        } else if (mediaOnBackend.size() == 1) {
+            // Homogeneous-disk BE: every replica on the BE physically resides on its only
+            // medium, so we can read the count directly from the backend->tablet index in O(1)
+            // instead of scanning every TabletMeta. This avoids holding the inverted-index walk
+            // each ClusterLoadStatistic refresh (~20s) on busy clusters with ~350k replicas/BE.
+            //
+            // Storage-cooldown consideration: when a partition's DataProperty flips from SSD to
+            // HDD, ReportHandler propagates the new intended medium into TabletMeta even on
+            // single-medium BEs that cannot migrate (ReportHandler skips the migrate task when
+            // backendStorageTypeCnt <= 1). The per-tablet scan would then attribute those
+            // replicas to the medium the BE physically lacks, and the post-pass below would
+            // zero them out -- making the replicas vanish from the load-balance averages.
+            // Counting by physical placement here is both cheaper and more accurate.
+            TStorageMedium onlyMedium = mediaOnBackend.iterator().next();
+            long totalOnBe = invertedIndex.getTabletNumByBackendId(beId);
+            for (TStorageMedium medium : TStorageMedium.values()) {
+                totalReplicaNumMap.put(medium, medium == onlyMedium ? totalOnBe : 0L);
+            }
+        } else {
+            // Mixed-medium BE (BE has both HDD and SSD disks): per-tablet scan so the count
+            // reflects each replica's TabletMeta.storageMedium, which is what drives migration
+            // scheduling on BEs that actually have both media available.
+            totalReplicaNumMap = invertedIndex.getReplicaNumByBeIdAndStorageMedium(beId);
+            // Defensive post-pass: zero a medium if the BE has no disks of that type. With
+            // mediaOnBackend.size() == 2 both media are present, so this is currently a no-op;
+            // kept for parity with the historical behavior if disk reporting becomes partial.
+            for (TStorageMedium medium : TStorageMedium.values()) {
+                if (!hasMedium(medium)) {
+                    totalReplicaNumMap.put(medium, 0L);
+                }
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
@@ -162,6 +162,135 @@ public class ClusterLoadStatisticsTest {
     }
 
     @Test
+    public void testInit_singleMediumShortcutCountsAllReplicasUnderPhysicalMedium() throws LoadBalanceException {
+        // Build a BE with HDD-only disks but a mix of HDD- and SSD-declared TabletMeta. The
+        // SSD-declared entries simulate the post-cooldown / mis-placed-tablet windows where
+        // TabletMeta.storageMedium diverges from physical placement on a single-medium BE that
+        // ReportHandler cannot migrate. The shortcut in BackendLoadStatistic.init must count
+        // every replica on the BE under HDD (its physical medium), not drop the SSD-declared
+        // ones via the hasMedium() post-pass.
+        Backend hddOnlyBe = new Backend(11001, "192.168.0.11", 9051);
+        Map<String, DiskInfo> hddDisks = Maps.newHashMap();
+        DiskInfo hddDisk = new DiskInfo("/path1");
+        hddDisk.setTotalCapacityB(1_000_000);
+        hddDisk.setAvailableCapacityB(900_000);
+        hddDisk.setDataUsedCapacityB(100_000);
+        hddDisk.setStorageMedium(TStorageMedium.HDD);
+        hddDisks.put(hddDisk.getRootPath(), hddDisk);
+        hddOnlyBe.setDisks(ImmutableMap.copyOf(hddDisks));
+        hddOnlyBe.setAlive(true);
+
+        SystemInfoService localInfo = new SystemInfoService();
+        localInfo.addBackend(hddOnlyBe);
+
+        TabletInvertedIndex localIndex = new TabletInvertedIndex();
+        long tabletId = 80000;
+        // 3 HDD-declared and 2 SSD-declared replicas, all physically on the HDD-only BE.
+        for (int i = 0; i < 3; i++, tabletId++) {
+            localIndex.addTablet(tabletId, new TabletMeta(1, 2, 3, 4, TStorageMedium.HDD));
+            localIndex.addReplica(tabletId, new Replica(tabletId + 100, hddOnlyBe.getId(), 0, ReplicaState.NORMAL));
+        }
+        for (int i = 0; i < 2; i++, tabletId++) {
+            localIndex.addTablet(tabletId, new TabletMeta(1, 2, 3, 5, TStorageMedium.SSD));
+            localIndex.addReplica(tabletId, new Replica(tabletId + 100, hddOnlyBe.getId(), 0, ReplicaState.NORMAL));
+        }
+
+        BackendLoadStatistic stat = new BackendLoadStatistic(
+                hddOnlyBe.getId(), SystemInfoService.DEFAULT_CLUSTER, localInfo, localIndex);
+        stat.init();
+
+        Assertions.assertEquals(5L, stat.getReplicaNum(TStorageMedium.HDD),
+                "single-medium HDD BE must count every replica under HDD, including SSD-declared ones");
+        Assertions.assertEquals(0L, stat.getReplicaNum(TStorageMedium.SSD),
+                "single-medium HDD BE must report zero SSD replicas");
+    }
+
+    @Test
+    public void testInit_singleMediumSsdShortcut() throws LoadBalanceException {
+        // Symmetric to the HDD-only case: SSD-only BE counts every replica under SSD even when
+        // some TabletMeta entries still carry the legacy HDD declaration.
+        Backend ssdOnlyBe = new Backend(11002, "192.168.0.12", 9051);
+        Map<String, DiskInfo> ssdDisks = Maps.newHashMap();
+        DiskInfo ssdDisk = new DiskInfo("/path1");
+        ssdDisk.setTotalCapacityB(1_000_000);
+        ssdDisk.setAvailableCapacityB(900_000);
+        ssdDisk.setDataUsedCapacityB(100_000);
+        ssdDisk.setStorageMedium(TStorageMedium.SSD);
+        ssdDisks.put(ssdDisk.getRootPath(), ssdDisk);
+        ssdOnlyBe.setDisks(ImmutableMap.copyOf(ssdDisks));
+        ssdOnlyBe.setAlive(true);
+
+        SystemInfoService localInfo = new SystemInfoService();
+        localInfo.addBackend(ssdOnlyBe);
+
+        TabletInvertedIndex localIndex = new TabletInvertedIndex();
+        long tabletId = 81000;
+        for (int i = 0; i < 4; i++, tabletId++) {
+            localIndex.addTablet(tabletId, new TabletMeta(1, 2, 3, 4, TStorageMedium.SSD));
+            localIndex.addReplica(tabletId, new Replica(tabletId + 100, ssdOnlyBe.getId(), 0, ReplicaState.NORMAL));
+        }
+        for (int i = 0; i < 3; i++, tabletId++) {
+            localIndex.addTablet(tabletId, new TabletMeta(1, 2, 3, 5, TStorageMedium.HDD));
+            localIndex.addReplica(tabletId, new Replica(tabletId + 100, ssdOnlyBe.getId(), 0, ReplicaState.NORMAL));
+        }
+
+        BackendLoadStatistic stat = new BackendLoadStatistic(
+                ssdOnlyBe.getId(), SystemInfoService.DEFAULT_CLUSTER, localInfo, localIndex);
+        stat.init();
+
+        Assertions.assertEquals(7L, stat.getReplicaNum(TStorageMedium.SSD),
+                "single-medium SSD BE must count every replica under SSD, including HDD-declared ones");
+        Assertions.assertEquals(0L, stat.getReplicaNum(TStorageMedium.HDD),
+                "single-medium SSD BE must report zero HDD replicas");
+    }
+
+    @Test
+    public void testInit_mixedMediumStillScansAndHonorsTabletMeta() throws LoadBalanceException {
+        // BE with both HDD and SSD disks: the per-tablet scan must run and counts must match
+        // TabletMeta.storageMedium so the migration scheduler in ReportHandler sees the right
+        // intended counts.
+        Backend mixedBe = new Backend(11003, "192.168.0.13", 9051);
+        Map<String, DiskInfo> mixedDisks = Maps.newHashMap();
+        DiskInfo hdd = new DiskInfo("/hdd");
+        hdd.setTotalCapacityB(2_000_000);
+        hdd.setAvailableCapacityB(1_500_000);
+        hdd.setDataUsedCapacityB(500_000);
+        hdd.setStorageMedium(TStorageMedium.HDD);
+        mixedDisks.put(hdd.getRootPath(), hdd);
+        DiskInfo ssd = new DiskInfo("/ssd");
+        ssd.setTotalCapacityB(1_000_000);
+        ssd.setAvailableCapacityB(700_000);
+        ssd.setDataUsedCapacityB(300_000);
+        ssd.setStorageMedium(TStorageMedium.SSD);
+        mixedDisks.put(ssd.getRootPath(), ssd);
+        mixedBe.setDisks(ImmutableMap.copyOf(mixedDisks));
+        mixedBe.setAlive(true);
+
+        SystemInfoService localInfo = new SystemInfoService();
+        localInfo.addBackend(mixedBe);
+
+        TabletInvertedIndex localIndex = new TabletInvertedIndex();
+        long tabletId = 82000;
+        for (int i = 0; i < 6; i++, tabletId++) {
+            localIndex.addTablet(tabletId, new TabletMeta(1, 2, 3, 4, TStorageMedium.HDD));
+            localIndex.addReplica(tabletId, new Replica(tabletId + 100, mixedBe.getId(), 0, ReplicaState.NORMAL));
+        }
+        for (int i = 0; i < 4; i++, tabletId++) {
+            localIndex.addTablet(tabletId, new TabletMeta(1, 2, 3, 5, TStorageMedium.SSD));
+            localIndex.addReplica(tabletId, new Replica(tabletId + 100, mixedBe.getId(), 0, ReplicaState.NORMAL));
+        }
+
+        BackendLoadStatistic stat = new BackendLoadStatistic(
+                mixedBe.getId(), SystemInfoService.DEFAULT_CLUSTER, localInfo, localIndex);
+        stat.init();
+
+        Assertions.assertEquals(6L, stat.getReplicaNum(TStorageMedium.HDD),
+                "mixed-medium BE must keep the per-tablet scan counts");
+        Assertions.assertEquals(4L, stat.getReplicaNum(TStorageMedium.SSD),
+                "mixed-medium BE must keep the per-tablet scan counts");
+    }
+
+    @Test
     public void testToString() {
         ClusterLoadStatistic clusterLoad = new ClusterLoadStatistic(systemInfoService, invertedIndex);
         clusterLoad.init();


### PR DESCRIPTION
ClusterLoadStatistic refreshes every ~20s and calls BackendLoadStatistic.init for every BE. On homogeneous-disk fleets (~350k replicas/BE), the per-tablet scan in TabletInvertedIndex.getReplicaNumByBeIdAndStorageMedium dominates each refresh. When the BE physically hosts a single storage medium, every replica on the BE resides on that medium by definition, so we can read the count from TabletInvertedIndex.getTabletNumByBackendId in O(1).

This also fixes a counting hole during storage cooldown: when a partition's DataProperty flips from SSD to HDD, ReportHandler propagates the new intended medium into TabletMeta even on single-medium BEs that ReportHandler cannot migrate (backendStorageTypeCnt <= 1). The previous scan attributed those replicas to the medium the BE physically lacked, and the hasMedium() post-pass zeroed them out, removing them from the cluster load-balance averages. Counting by physical placement keeps them accounted for.

Mixed-medium BEs keep the scan path so per-medium counts continue to reflect TabletMeta.storageMedium, which drives migration scheduling.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
