### PR TITLE
[Enhancement] Surface global-dict scan application in profile

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -483,6 +483,13 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(_extend_schema_by_access_paths());
     ASSIGN_OR_RETURN(_tablet_schema, extend_schema_by_virtual_columns(_tablet_schema, *_slots));
     RETURN_IF_ERROR(init_global_dicts(&_params));
+    // init_global_dicts intersects the FE-level dict map with this scan's
+    // materialized tablet schema, so the resulting size counts columns that
+    // will actually flow through the encoded path on this scan instance.
+    if (_params.global_dictmaps != nullptr && !_params.global_dictmaps->empty() && _runtime_profile != nullptr) {
+        _runtime_profile->add_info_string("GlobalDictOptApplied", "true");
+        _runtime_profile->add_info_string("GlobalDictAppliedSlots", std::to_string(_params.global_dictmaps->size()));
+    }
     RETURN_IF_ERROR(init_unused_output_columns(thrift_lake_scan_node.unused_output_column_name));
     RETURN_IF_ERROR(init_reader_params(_scanner_ranges));
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -124,6 +124,18 @@ struct HdfsScanStats {
     // late materialize round-by-round
     int64_t group_min_round_cost = 0;
 
+    // Parquet global-dict opt application — populated by parquet::GroupReader as
+    // it wraps column readers with dict-aware adapters.  These counters answer
+    // "did the FE global-dict optimization actually reach Parquet column readers
+    // on this scan instance, and through which wrapper path?" for Hive/Iceberg
+    // workloads where the connector-level dict map can otherwise lie about
+    // schema-evolved files.
+    int64_t global_dict_total_row_groups = 0;       // selected row groups this scanner read
+    int64_t global_dict_applied_row_groups = 0;     // row groups with >=1 dict-wrapped slot
+    int64_t global_dict_applied_slots = 0;          // sum of wrapped slots across row groups
+    int64_t global_dict_dict_code_reader_slots = 0; // wrapped via LowCardColumnReader
+    int64_t global_dict_encode_reader_slots = 0;    // wrapped via LowRowsColumnReader
+
     // orc stripe information
     std::vector<int64_t> orc_stripe_sizes{};
     int64_t orc_total_tiny_stripe_size = 0;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -228,6 +228,28 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
         _runtime_state->fragment_ctx()->pred_tree_params().enable_show_in_profile) {
         root->add_info_string("ParquetPredicateTreeFilter", _scanner_ctx.predicate_tree.root().debug_string());
     }
+
+    // Global-dict opt visibility for Hive/Iceberg/Hudi/Paimon Parquet workloads.
+    // Authoritative signal is the counter pair; the info-string is a quick grep
+    // hook published if any row group wrapped a dict-aware reader at all.
+    RuntimeProfile::Counter* gd_total_row_groups =
+            ADD_CHILD_COUNTER(root, "GlobalDictTotalRowGroups", TUnit::UNIT, kParquetProfileSectionPrefix);
+    RuntimeProfile::Counter* gd_applied_row_groups =
+            ADD_CHILD_COUNTER(root, "GlobalDictAppliedRowGroups", TUnit::UNIT, kParquetProfileSectionPrefix);
+    RuntimeProfile::Counter* gd_applied_slots =
+            ADD_CHILD_COUNTER(root, "GlobalDictAppliedSlots", TUnit::UNIT, kParquetProfileSectionPrefix);
+    RuntimeProfile::Counter* gd_dict_code_reader_slots =
+            ADD_CHILD_COUNTER(root, "GlobalDictDictCodeReaderSlots", TUnit::UNIT, kParquetProfileSectionPrefix);
+    RuntimeProfile::Counter* gd_encode_reader_slots =
+            ADD_CHILD_COUNTER(root, "GlobalDictEncodeReaderSlots", TUnit::UNIT, kParquetProfileSectionPrefix);
+    COUNTER_UPDATE(gd_total_row_groups, _app_stats.global_dict_total_row_groups);
+    COUNTER_UPDATE(gd_applied_row_groups, _app_stats.global_dict_applied_row_groups);
+    COUNTER_UPDATE(gd_applied_slots, _app_stats.global_dict_applied_slots);
+    COUNTER_UPDATE(gd_dict_code_reader_slots, _app_stats.global_dict_dict_code_reader_slots);
+    COUNTER_UPDATE(gd_encode_reader_slots, _app_stats.global_dict_encode_reader_slots);
+    if (_app_stats.global_dict_applied_row_groups > 0) {
+        root->add_info_string_if_not_exists("GlobalDictOptApplied", "true");
+    }
 }
 
 Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -577,6 +577,13 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(_extend_schema_by_access_paths());
     ASSIGN_OR_RETURN(_tablet_schema, extend_schema_by_virtual_columns(_tablet_schema, *_slots));
     RETURN_IF_ERROR(_init_global_dicts(&_params));
+    // _init_global_dicts intersects the FE-level dict map with this scan's
+    // materialized tablet schema, so the resulting size counts columns that
+    // will actually flow through the encoded path on this scan instance.
+    if (_params.global_dictmaps != nullptr && !_params.global_dictmaps->empty()) {
+        _runtime_profile->add_info_string("GlobalDictOptApplied", "true");
+        _runtime_profile->add_info_string("GlobalDictAppliedSlots", std::to_string(_params.global_dictmaps->size()));
+    }
     RETURN_IF_ERROR(_init_glm(&_params));
     RETURN_IF_ERROR(_init_unused_output_columns(thrift_olap_scan_node.unused_output_column_name));
     RETURN_IF_ERROR(_init_reader_params(_scan_ctx->key_ranges()));

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -65,6 +65,16 @@ Status TabletScanner::init(RuntimeState* runtime_state, const TabletScannerParam
     RETURN_IF_ERROR(_init_unused_output_columns(*params.unused_output_columns));
     RETURN_IF_ERROR(_init_return_columns());
     RETURN_IF_ERROR(_init_global_dicts());
+    // _init_global_dicts intersects the FE-level dict map with this scan's
+    // materialized tablet schema, so the resulting size counts columns that
+    // will actually flow through the encoded path on this scan instance.
+    // Mirrors the marker emitted from the pipeline scan paths.
+    if (_params.global_dictmaps != nullptr && !_params.global_dictmaps->empty() &&
+        _parent->runtime_profile() != nullptr) {
+        _parent->runtime_profile()->add_info_string("GlobalDictOptApplied", "true");
+        _parent->runtime_profile()->add_info_string("GlobalDictAppliedSlots",
+                                                    std::to_string(_params.global_dictmaps->size()));
+    }
     RETURN_IF_ERROR(_init_reader_params(params.key_ranges));
     Schema child_schema = ChunkHelper::convert_schema(_tablet_schema, _reader_columns);
     _reader = std::make_shared<TabletReader>(_tablet, Version(0, _version), std::move(child_schema));

--- a/be/src/formats/parquet/column_reader_factory.cpp
+++ b/be/src/formats/parquet/column_reader_factory.cpp
@@ -527,7 +527,8 @@ StatusOr<ColumnReaderPtr> ColumnReaderFactory::create_variant_column_reader(cons
 }
 
 StatusOr<ColumnReaderPtr> ColumnReaderFactory::create(ColumnReaderPtr raw_reader, const GlobalDictMap* dict,
-                                                      SlotId slot_id, int64_t num_rows) {
+                                                      SlotId slot_id, int64_t num_rows,
+                                                      GlobalDictReaderKind* out_kind) {
     FAIL_POINT_TRIGGER_EXECUTE(parquet_reader_returns_global_dict_not_match_status, {
         return Status::GlobalDictNotMatch(
                 fmt::format("SlotId: {}, Not dict encoded and not low rows on global dict column. ", slot_id));
@@ -537,7 +538,7 @@ StatusOr<ColumnReaderPtr> ColumnReaderFactory::create(ColumnReaderPtr raw_reader
         ASSIGN_OR_RETURN(ColumnReaderPtr child_reader,
                          ColumnReaderFactory::create(
                                  std::move((down_cast<ListColumnReader*>(raw_reader.get()))->get_element_reader()),
-                                 dict, slot_id, num_rows));
+                                 dict, slot_id, num_rows, out_kind));
         return std::make_unique<ListColumnReader>(raw_reader->get_column_parquet_field(), std::move(child_reader));
     } else {
         RawColumnReader* scalar_reader = dynamic_cast<RawColumnReader*>(raw_reader.get());
@@ -545,8 +546,10 @@ StatusOr<ColumnReaderPtr> ColumnReaderFactory::create(ColumnReaderPtr raw_reader
             return Status::InternalError("Error on reader transform for low cardinality reader");
         }
         if (scalar_reader->column_all_pages_dict_encoded()) {
+            if (out_kind != nullptr) *out_kind = GlobalDictReaderKind::kDictCode;
             return std::make_unique<LowCardColumnReader>(*scalar_reader, dict, slot_id);
         } else if (num_rows <= dict->size()) {
+            if (out_kind != nullptr) *out_kind = GlobalDictReaderKind::kLowRowsEncode;
             return std::make_unique<LowRowsColumnReader>(*scalar_reader, dict, slot_id);
         } else {
             return Status::GlobalDictNotMatch(

--- a/be/src/formats/parquet/column_reader_factory.h
+++ b/be/src/formats/parquet/column_reader_factory.h
@@ -37,6 +37,17 @@ struct VariantShreddedReadHints {
     void clear();
 };
 
+// Which dict-aware wrapper a global-dict-encoded slot ended up with. Reported back
+// by the dict-wrapping create() overload so the GroupReader can attribute the
+// applied slot to the right counter (Parquet has no force-encode fallback like
+// OLAP; the two truthful paths are LowCardColumnReader for all-page-dict columns
+// and LowRowsColumnReader when row count fits the FE dictionary).
+enum class GlobalDictReaderKind {
+    kNone,          // no wrapper selected (factory returned GlobalDictNotMatch)
+    kDictCode,      // LowCardColumnReader: reader consumes Parquet dict codes directly
+    kLowRowsEncode, // LowRowsColumnReader: reader reads strings then encodes per row
+};
+
 class ColumnReaderFactory {
 public:
     // create a column reader
@@ -48,8 +59,13 @@ public:
                                             const TypeDescriptor& col_type,
                                             const TIcebergSchemaField* lake_schema_field);
 
+    // Wrap an already-built scalar reader with a dict-aware reader for the given
+    // FE global dictionary.  If out_kind is non-null, it is set to identify which
+    // wrapper was picked so the caller can publish profile counters for the
+    // dict-code vs. low-rows-encode path.  Out_kind is left at kNone on failure
+    // (the function returns a GlobalDictNotMatch status in that case).
     static StatusOr<ColumnReaderPtr> create(ColumnReaderPtr raw_reader, const GlobalDictMap* dict, const SlotId slot_id,
-                                            int64_t num_rows);
+                                            int64_t num_rows, GlobalDictReaderKind* out_kind = nullptr);
 
     static StatusOr<ColumnReaderPtr> create_variant_column_reader(const ColumnReaderOptions& opts,
                                                                   const ParquetField* variant_field,

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -962,6 +962,7 @@ VariantShreddedReadHints GroupReader::_get_variant_shredded_hints(std::string_vi
 
 Status GroupReader::_create_column_readers() {
     SCOPED_RAW_TIMER(&_param.stats->column_reader_init_ns);
+    _global_dict_applied_in_group = false;
     // ColumnReaderOptions is used by all column readers in one row group
     ColumnReaderOptions& opts = _column_reader_opts;
     opts.file_meta_data = _param.file_metadata;
@@ -1132,6 +1133,13 @@ Status GroupReader::_create_column_readers() {
                                                                               projection.target_type));
     }
 
+    if (_param.stats != nullptr) {
+        _param.stats->global_dict_total_row_groups++;
+        if (_global_dict_applied_in_group) {
+            _param.stats->global_dict_applied_row_groups++;
+        }
+    }
+
     return Status::OK();
 }
 
@@ -1153,10 +1161,20 @@ StatusOr<ColumnReaderPtr> GroupReader::_create_column_reader(const GroupReaderPa
                                                          column.t_lake_schema_field));
         }
         if (_param.global_dictmaps->contains(column.slot_id())) {
+            GlobalDictReaderKind kind = GlobalDictReaderKind::kNone;
             ASSIGN_OR_RETURN(
                     column_reader,
                     ColumnReaderFactory::create(std::move(column_reader), _param.global_dictmaps->at(column.slot_id()),
-                                                column.slot_id(), _row_group_metadata->num_rows));
+                                                column.slot_id(), _row_group_metadata->num_rows, &kind));
+            if (_param.stats != nullptr && kind != GlobalDictReaderKind::kNone) {
+                _param.stats->global_dict_applied_slots++;
+                if (kind == GlobalDictReaderKind::kDictCode) {
+                    _param.stats->global_dict_dict_code_reader_slots++;
+                } else if (kind == GlobalDictReaderKind::kLowRowsEncode) {
+                    _param.stats->global_dict_encode_reader_slots++;
+                }
+                _global_dict_applied_in_group = true;
+            }
         }
         if (column_reader == nullptr) {
             // this shouldn't happen but guard

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -338,6 +338,11 @@ private:
 
     int64_t _end_offset = 0;
 
+    // set to true by _create_column_reader when the FE global-dict map produced a
+    // dict-aware wrapper for at least one slot in this row group; consumed by
+    // _create_column_readers to bump the per-row-group applied counter.
+    bool _global_dict_applied_in_group = false;
+
     // columns(index) use as dict filter column
     std::vector<int> _dict_column_indices;
     std::unordered_map<int, std::vector<std::vector<std::string>>> _dict_column_sub_field_paths;


### PR DESCRIPTION
Fixes #73587.

## Why I'm doing:

When FE's low-cardinality rewrite turns a string column into a global-dict
code, the scan should deliver Int32 codes directly without re-materializing
the underlying string.  Today there's no profile signal that surfaces whether
the dict-encoded path actually ran for a given scan instance — a missing
or broken dict-application silently falls back to string materialization
and the only visible symptom is degraded performance.

## What I'm doing:

Adds runtime profile signals so a profile diff exposes whether the FE
global dictionary low-cardinality optimization actually reached the scan.
Covers native OLAP, shared-data lake, and Hive/Iceberg/Hudi/Paimon
Parquet workloads.

Native OLAP and Lake scans publish two info-strings after
`_init_global_dicts` has intersected the FE-level query dictionary with the
materialized tablet schema, so the size reflects columns that will actually
flow through the encoded path on this scan instance:

    GlobalDictOptApplied   = true
    GlobalDictAppliedSlots = <n>

Touch points:
- `be/src/exec/pipeline/scan/olap_chunk_source.cpp` — pipeline OLAP
- `be/src/exec/tablet_scanner.cpp` — legacy non-pipeline OLAP
- `be/src/connector/lake_connector.cpp` — shared-data lake

**What the OLAP marker covers — and what it does not:**

Native OLAP stores string columns via a per-segment local dictionary
(codes 0..N local to each segment).  When the FE global-dict opt is
applied, the scan emits Int32 codes from the **global** dictionary
instead of strings.  Inside `SegmentIterator` there are two paths to
produce that encoded output:

1. **Fast path** — local dict ⊆ global dict: a cheap mapping
   `local_code → global_code` per row.  This is the win the optimization
   was designed for.
2. **Force-encode path** — `ColumnDecoder::need_force_encode_to_global_id()`
   returns true when the local dictionary contains entries that are not
   in the global dictionary (e.g. global dict was built from a sampled
   subset and a segment has values the sample missed).  The scan then
   decodes the string from the local code and re-encodes it into a
   global code — still cheaper than returning raw strings, but
   noticeably more work than the fast-path mapping.

The marker only states *"this scan's output schema is FE-global-dict-
encoded for at least one materialized column,"* which is the bit
downstream operators care about (they branch on encoded vs. raw).
It does NOT say *"the fast-path mapping was hit on every row."*  If
someone sees `GlobalDictOptApplied = true` and the query is still slow,
the force-encode path is a candidate root cause but this marker alone
cannot confirm it — a separate per-row counter would be needed for
that, out of scope here.

For Hive/Iceberg/Hudi/Paimon the marker is published at GroupReader level
from inside the parquet column reader factory, so it reports per-column
whether the file's data delivers dict codes directly (count surfaces in
the `Parquet/GlobalDict*` counters on the scan profile).

ORC's local dict-filter machinery is unrelated to the FE global-dict
output encoding signalled here and is left untouched.

Observability only; no behavior change for any query.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

