### PR TITLE
[Enhancement] Use array-table for SMALLINT group-by keys

### DIFF
--- a/be/src/base/container/fixed_hash_map.h
+++ b/be/src/base/container/fixed_hash_map.h
@@ -38,7 +38,14 @@ public:
     static constexpr int hash_table_size = 1 << sizeof(KeyType) * 8;
 
     using key_type = KeyType;
+    using mapped_type = ValueType;
     using search_key_type = typename std::make_unsigned<KeyType>::type;
+
+    // Real heap footprint of the dense pointer array. Used by aggregator
+    // memory accounting so spill/streaming budgets do not under-count the
+    // 64K-cell SMALLINT path (~512 KiB) as if it stored only `KeyType` per
+    // slot.
+    static constexpr size_t bucket_byte_size() { return sizeof(ValueType) * (hash_table_size + 1); }
 
     SmallFixedSizeHashMap() {
         memset(_hash_table, 0, sizeof(ValueType) * hash_table_size);
@@ -121,7 +128,10 @@ public:
 
     size_t capacity() { return hash_table_size; }
 
-    size_t dump_bound() { return hash_table_size; }
+    // Byte footprint of the dense pointer table. Matches the byte-based
+    // semantics used by phmap so spill/serialization callers measure real
+    // memory rather than a slot count.
+    size_t dump_bound() { return bucket_byte_size(); }
 
     void clear() {
         memset(_hash_table, 0, sizeof(ValueType) * hash_table_size);
@@ -141,6 +151,8 @@ public:
 
     using key_type = KeyType;
     using search_key_type = typename std::make_unsigned<KeyType>::type;
+
+    static constexpr size_t bucket_byte_size() { return sizeof(uint8_t) * (hash_table_size + 1); }
 
     class iterator {
     public:
@@ -190,7 +202,10 @@ public:
 
     bool contains(KeyType key) { return _hash_table[static_cast<search_key_type>(key)]; }
 
-    size_t dump_bound() { return hash_table_size; }
+    // Byte footprint of the dense byte table. Matches the byte-based
+    // semantics used by phmap so spill/serialization callers measure real
+    // memory rather than a slot count.
+    size_t dump_bound() { return bucket_byte_size(); }
 
     size_t size() { return _size; }
 

--- a/be/src/base/container/fixed_hash_map.h
+++ b/be/src/base/container/fixed_hash_map.h
@@ -238,4 +238,22 @@ constexpr bool is_no_prefetch_set = no_prefetch_set<T>::value;
 template <class T>
 constexpr bool is_no_prefetch_map = no_prefetch_map<T>::value;
 
+template <typename T>
+struct is_fixed_hash_map : std::false_type {};
+
+template <typename KeyType, typename ValueType, PhmapSeed seed>
+struct is_fixed_hash_map<SmallFixedSizeHashMap<KeyType, ValueType, seed>> : std::true_type {};
+
+template <typename T>
+struct is_fixed_hash_set : std::false_type {};
+
+template <typename KeyType, PhmapSeed seed>
+struct is_fixed_hash_set<SmallFixedSizeHashSet<KeyType, seed>> : std::true_type {};
+
+template <class T>
+constexpr bool is_fixed_hash_map_v = is_fixed_hash_map<T>::value;
+
+template <class T>
+constexpr bool is_fixed_hash_set_v = is_fixed_hash_set<T>::value;
+
 } // namespace starrocks

--- a/be/src/bench/CMakeLists.txt
+++ b/be/src/bench/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ADD_BE_BENCH(${SRC_DIR}/bench/chunks_sorter_bench)
+ADD_BE_BENCH(${SRC_DIR}/bench/agg_hash_map_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/runtime_filter_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/csv_reader_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/shuffle_chunk_bench)

--- a/be/src/bench/agg_hash_map_bench.cpp
+++ b/be/src/bench/agg_hash_map_bench.cpp
@@ -94,7 +94,10 @@ enum class Distribution : int {
 struct BenchAllocateState {
     HashTableKeyAllocator* allocator;
     AggDataPtr operator()(std::nullptr_t) { return allocator->allocate_null_key_data(); }
-    AggDataPtr operator()(int16_t /*key*/) { return allocator->allocate(); }
+    template <typename K>
+    AggDataPtr operator()(K /*key*/) {
+        return allocator->allocate();
+    }
 };
 
 // Build (num_rows / kBenchChunkSize) Int16 chunks of kBenchChunkSize rows
@@ -547,6 +550,93 @@ static void BM_Int16NullableBuildOnly(benchmark::State& state) {
 }
 
 // ============================================================================
+// Section E -- cx1 (compressed-key int8) vs direct array (int16) for
+// SMALLINT GROUP BY when the FE-supplied value range fits in 8 bits.
+//
+// Today our slice_cx1 guard on TINYINT/BOOL/SMALLINT (aggregator.cpp) means
+// we always pick the 65 536-cell int16 direct array, even when the range
+// stats say only 8 bits are used.  stdpain raised on #73558 that for int16
+// with an 8-bit range, slice_cx1 may actually win: footprint drops from
+// 524 KiB to 2 KiB (L1-resident) at the cost of a bitcompress_serialize
+// step per row.  This section answers that head-on.
+//
+// SliceCx1Wrapper is the production wrapper used when slice_cx1 routing
+// fires: AggHashMapWithCompressedKeyFixedSize over Int8AggHashMap
+// (SmallFixedSizeHashMap<int8_t>).  The wrapper requires bases/offsets/
+// used_bits set up before build_hash_map, normally done by Aggregator's
+// _build_hash_variant; we mirror that setup explicitly.
+// ============================================================================
+using SliceCx1Wrapper = AggHashMapWithCompressedKeyFixedSize<Int8AggHashMap<PhmapSeed1>>;
+
+template <typename Wrapper>
+static void BM_Int16Cx1BuildOnly(benchmark::State& state) {
+    const int64_t num_rows = state.range(0);
+    const int distinct = static_cast<int>(state.range(1));
+    const Distribution dist = static_cast<Distribution>(state.range(2));
+
+    BenchSuite suite;
+    suite.SetUp();
+    Int16ChunkStream stream(num_rows, distinct, dist);
+
+    // Same range Int16ChunkStream uses: keys live in
+    // [-distinct/2, distinct/2).  delta = distinct - 1, used_bits is the
+    // number of bits Aggregator would have computed via get_used_bits.
+    const int16_t range_start = static_cast<int16_t>(-distinct / 2);
+    const int16_t range_end = static_cast<int16_t>(range_start + distinct - 1);
+    const uint16_t delta = static_cast<uint16_t>(static_cast<uint16_t>(range_end) - static_cast<uint16_t>(range_start));
+    const int used_bits = delta == 0 ? 0 : (32 - __builtin_clz(static_cast<uint32_t>(delta)));
+
+    int64_t total_rows = 0;
+    size_t final_groups = 0;
+    size_t final_ht_bytes = 0;
+    int64_t cum_checksum = 0;
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
+        // Mirror Aggregator::_build_hash_variant's CompressKeyContext setup
+        // for a single int16 column: base = min value, offset = 0,
+        // used_bits = ceil_log2(range + 1).
+        wrapper->bases = std::vector<std::any>{range_start};
+        wrapper->offsets = std::vector<int>{0};
+        wrapper->used_bits = std::vector<int>{used_bits};
+        HashTableKeyAllocator allocator;
+        allocator.aggregate_key_size = sizeof(int64_t);
+        allocator.pool = suite._mem_pool.get();
+        BenchAllocateState alloc{&allocator};
+        Buffer<AggDataPtr> agg_states(kBenchChunkSize);
+        state.ResumeTiming();
+
+        for (const auto& chunk_col : stream.chunks()) {
+            Columns key_columns;
+            key_columns.emplace_back(chunk_col);
+            wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
+            total_rows += kBenchChunkSize;
+        }
+        benchmark::DoNotOptimize(agg_states.data());
+        benchmark::ClobberMemory();
+
+        state.PauseTiming();
+        final_groups = wrapper->hash_map.size();
+        final_ht_bytes = wrapper->hash_map.dump_bound();
+        int64_t cs = 0;
+        for (int i = 0; i < kBenchChunkSize; ++i) cs += reinterpret_cast<intptr_t>(agg_states[i]);
+        cum_checksum += cs;
+        wrapper.reset();
+        suite._mem_pool->clear();
+    }
+    benchmark::DoNotOptimize(cum_checksum);
+    state.SetItemsProcessed(total_rows);
+    state.counters["distinct"] = distinct;
+    state.counters["dist"] = static_cast<int>(dist);
+    state.counters["rows_per_iter"] = num_rows;
+    state.counters["final_groups"] = final_groups;
+    state.counters["hash_table_bytes"] = final_ht_bytes;
+    state.counters["used_bits"] = used_bits;
+
+    suite.TearDown();
+}
+
+// ============================================================================
 // Args registration
 // ============================================================================
 
@@ -598,6 +688,22 @@ static void RegisterArgs_SectionD(benchmark::internal::Benchmark* b) {
     b->Iterations(3);
 }
 
+// Section E: cx1 vs direct for SMALLINT with 8-bit value range.  All
+// distincts <= 256 so slice_cx1 is a legal routing (8 used_bits).
+// Random and Sorted cover the prefetch-vs-no-prefetch axis; cx1 has
+// prefetch-on under flat_hash_map but no_prefetch under
+// SmallFixedSizeHashMap<int8>, so Sorted is the cleanest read.
+static void RegisterArgs_SectionE(benchmark::internal::Benchmark* b) {
+    b->ArgNames({"rows", "distinct", "dist"});
+    constexpr int64_t kRows = 100'000'000;
+    for (int distinct : {16, 64, 128, 200, 256}) {
+        b->Args({kRows, distinct, /*Sorted*/ 1});
+        b->Args({kRows, distinct, /*Random*/ 0});
+    }
+    b->Unit(benchmark::kMillisecond);
+    b->Iterations(3);
+}
+
 BENCHMARK_TEMPLATE(BM_Int16BuildOnly, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionA);
 BENCHMARK_TEMPLATE(BM_Int16BuildOnly, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionA);
 
@@ -615,6 +721,9 @@ BENCHMARK_TEMPLATE(BM_Int16Construct, ArrayInt16Wrapper)->Unit(benchmark::kMicro
 
 BENCHMARK_TEMPLATE(BM_Int16NullableBuildOnly, PhmapInt16NullableWrapper)->Apply(RegisterArgs_SectionD);
 BENCHMARK_TEMPLATE(BM_Int16NullableBuildOnly, ArrayInt16NullableWrapper)->Apply(RegisterArgs_SectionD);
+
+BENCHMARK_TEMPLATE(BM_Int16BuildOnly, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionE);
+BENCHMARK_TEMPLATE(BM_Int16Cx1BuildOnly, SliceCx1Wrapper)->Apply(RegisterArgs_SectionE);
 
 } // namespace starrocks
 

--- a/be/src/bench/agg_hash_map_bench.cpp
+++ b/be/src/bench/agg_hash_map_bench.cpp
@@ -1,0 +1,448 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Midi-bench comparing phmap::flat_hash_map<int16_t, AggDataPtr> vs
+// SmallFixedSizeHashMap<int16_t, AggDataPtr> (a direct 65 537-cell array
+// indexed by static_cast<uint16_t>(key)) as the backing of the SMALLINT
+// GROUP BY wrapper AggHashMapWithOneNumberKey<TYPE_SMALLINT, ...>.
+//
+// Driver: production callsite build_hash_map with a production-shaped
+// HashTableKeyAllocator (sizeof(int64_t) state matching COUNT(*)).  No FE,
+// no scan I/O, no pipeline operator overhead.  Working-set sized so the
+// Int16 column (~200 MiB at 100M rows) does not fit in L3.
+//
+// Sections:
+//   A) Density x distribution sweep at 100M rows; both hash-only and
+//      hash + simulated COUNT(*) update.
+//   B) Construction-vs-amortization break-even: row count sweep at
+//      density=24 sorted, exposes the cell count beyond which the
+//      array's 524 KiB upfront alloc stops dominating.
+//   C) Construction-only cost regression guard.
+//   D) Nullable wrapper at null fractions {0%, 10%, 50%}.
+
+#include <base/testutil/assert.h>
+#include <benchmark/benchmark.h>
+
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "base/phmap/phmap.h"
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config_exec_fwd.h"
+#include "common/runtime_profile.h"
+#include "exec/aggregate/agg_hash_map.h"
+#include "exec/aggregate/agg_profile.h"
+#include "exec/aggregator.h"
+#include "runtime/mem_pool.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+inline constexpr int kBenchChunkSize = 4096;
+
+// PhmapInt16 mirrors the original phmap<int16_t, AggDataPtr> using-declaration
+// verbatim so we measure the actual baseline, not a default-constructed phmap
+// with different hash/seed parameters.
+template <PhmapSeed seed>
+using PhmapInt16 = phmap::flat_hash_map<int16_t, AggDataPtr, StdHashWithSeed<int16_t, seed>>;
+
+using PhmapInt16Wrapper = AggHashMapWithOneNumberKey<TYPE_SMALLINT, PhmapInt16<PhmapSeed1>>;
+using ArrayInt16Wrapper =
+        AggHashMapWithOneNumberKey<TYPE_SMALLINT, SmallFixedSizeHashMap<int16_t, AggDataPtr, PhmapSeed1>>;
+
+using PhmapInt16NullableWrapper = AggHashMapWithOneNullableNumberKey<TYPE_SMALLINT, PhmapInt16<PhmapSeed1>>;
+using ArrayInt16NullableWrapper =
+        AggHashMapWithOneNullableNumberKey<TYPE_SMALLINT, SmallFixedSizeHashMap<int16_t, AggDataPtr, PhmapSeed1>>;
+
+enum class Distribution : int {
+    Random = 0,
+    Sorted = 1,
+    Clustered64 = 2, // run-length 64: each value repeats 64 times before the next
+};
+
+// Production-shaped allocator.  Aggregator uses HashTableKeyAllocator with
+// aggregate_key_size set to the COUNT aggregate state size (sizeof(int64_t));
+// matching this layout keeps allocation cost realistic across the two
+// hash-map backings.
+struct BenchAllocateState {
+    HashTableKeyAllocator* allocator;
+    AggDataPtr operator()(std::nullptr_t) { return allocator->allocate_null_key_data(); }
+    AggDataPtr operator()(int16_t /*key*/) { return allocator->allocate(); }
+};
+
+// Build (num_rows / kBenchChunkSize) Int16 chunks of kBenchChunkSize rows
+// each.  Each chunk is a fresh Int16Column owning its own buffer, so the
+// hot loop walks across distinct cache lines and the prefetcher behavior
+// matches a streaming-scan scenario rather than an L1-resident replay.
+class Int16ChunkStream {
+public:
+    Int16ChunkStream(int64_t num_rows, int distinct_count, Distribution dist) {
+        std::mt19937 rng(0xC0FFEE);
+        std::uniform_int_distribution<int> uni(0, distinct_count > 0 ? distinct_count - 1 : 0);
+        const int64_t num_chunks = (num_rows + kBenchChunkSize - 1) / kBenchChunkSize;
+        _chunks.reserve(num_chunks);
+        const int range_start = -distinct_count / 2; // straddle signed range to exercise unsigned cast
+        for (int64_t c = 0; c < num_chunks; ++c) {
+            auto col = Int16Column::create();
+            auto& data = col->get_data();
+            data.resize(kBenchChunkSize);
+            switch (dist) {
+            case Distribution::Random:
+                for (int i = 0; i < kBenchChunkSize; ++i) {
+                    data[i] = static_cast<int16_t>(range_start + uni(rng));
+                }
+                break;
+            case Distribution::Sorted: {
+                std::vector<int> vals(kBenchChunkSize);
+                for (int i = 0; i < kBenchChunkSize; ++i) vals[i] = uni(rng);
+                std::sort(vals.begin(), vals.end());
+                for (int i = 0; i < kBenchChunkSize; ++i) {
+                    data[i] = static_cast<int16_t>(range_start + vals[i]);
+                }
+                break;
+            }
+            case Distribution::Clustered64: {
+                int current = uni(rng);
+                for (int i = 0; i < kBenchChunkSize; ++i) {
+                    if (i > 0 && i % 64 == 0) current = uni(rng);
+                    data[i] = static_cast<int16_t>(range_start + current);
+                }
+                break;
+            }
+            }
+            // MutPtr -> ImmutPtr requires rvalue (ImmutPtr(const MutPtr&) is deleted).
+            _chunks.emplace_back(std::move(col));
+        }
+    }
+
+    const std::vector<ColumnPtr>& chunks() const { return _chunks; }
+
+private:
+    std::vector<ColumnPtr> _chunks;
+};
+
+// Same as Int16ChunkStream but each chunk is wrapped in a NullableColumn.
+// null_fraction = 0 produces nullable-column-with-has_null=false (the
+// AggHashMapWithOneNullableNumberKey fast path that delegates to the
+// non-nullable code), 0.1 / 0.5 produce realistic mixed-null inputs that
+// route through compute_agg_through_null_data.
+class NullableInt16ChunkStream {
+public:
+    NullableInt16ChunkStream(int64_t num_rows, int distinct_count, double null_fraction) {
+        std::mt19937 rng(0xC0FFEE);
+        std::uniform_int_distribution<int> uni(0, distinct_count > 0 ? distinct_count - 1 : 0);
+        std::uniform_real_distribution<double> coin(0.0, 1.0);
+        const int64_t num_chunks = (num_rows + kBenchChunkSize - 1) / kBenchChunkSize;
+        _chunks.reserve(num_chunks);
+        const int range_start = -distinct_count / 2;
+        for (int64_t c = 0; c < num_chunks; ++c) {
+            auto data_col = Int16Column::create();
+            auto null_col = NullColumn::create();
+            auto& data = data_col->get_data();
+            auto& nulls = null_col->get_data();
+            data.resize(kBenchChunkSize);
+            nulls.resize(kBenchChunkSize);
+            bool any_null = false;
+            for (int i = 0; i < kBenchChunkSize; ++i) {
+                if (null_fraction > 0 && coin(rng) < null_fraction) {
+                    nulls[i] = 1;
+                    data[i] = 0;
+                    any_null = true;
+                } else {
+                    nulls[i] = 0;
+                    data[i] = static_cast<int16_t>(range_start + uni(rng));
+                }
+            }
+            auto nullable = NullableColumn::create(std::move(data_col), std::move(null_col));
+            nullable->set_has_null(any_null);
+            _chunks.emplace_back(std::move(nullable));
+        }
+    }
+
+    const std::vector<ColumnPtr>& chunks() const { return _chunks; }
+
+private:
+    std::vector<ColumnPtr> _chunks;
+};
+
+class BenchSuite {
+public:
+    void SetUp() {
+        config::vector_chunk_size = kBenchChunkSize;
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        query_options.batch_size = kBenchChunkSize;
+        TQueryGlobals query_globals;
+        _runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
+        _runtime_state->init_instance_mem_tracker();
+        _mem_pool = std::make_unique<MemPool>();
+        _runtime_profile = std::make_unique<RuntimeProfile>("agg_hash_map_bench");
+        _agg_stat = std::make_unique<AggStatistics>(_runtime_profile.get());
+    }
+
+    void TearDown() {
+        _agg_stat.reset();
+        _runtime_profile.reset();
+        _mem_pool.reset();
+        _runtime_state.reset();
+    }
+
+    std::shared_ptr<RuntimeState> _runtime_state;
+    std::unique_ptr<MemPool> _mem_pool;
+    std::unique_ptr<RuntimeProfile> _runtime_profile;
+    std::unique_ptr<AggStatistics> _agg_stat;
+};
+
+// ============================================================================
+// Section A — main steady-state win (hash insert only)
+// ============================================================================
+template <typename Wrapper>
+static void BM_Int16ColdBuild(benchmark::State& state) {
+    const int64_t num_rows = state.range(0);
+    const int distinct = static_cast<int>(state.range(1));
+    const Distribution dist = static_cast<Distribution>(state.range(2));
+
+    BenchSuite suite;
+    suite.SetUp();
+    Int16ChunkStream stream(num_rows, distinct, dist);
+
+    int64_t total_rows = 0;
+    for (auto _ : state) {
+        state.PauseTiming();
+        // Heap-allocated to match production (Aggregator uses std::make_unique
+        // for variant pointers).  Stack alloc would hide the 524 KiB upfront
+        // cost the array path actually pays in production.
+        auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
+        HashTableKeyAllocator allocator;
+        allocator.aggregate_key_size = sizeof(int64_t);
+        allocator.pool = suite._mem_pool.get();
+        BenchAllocateState alloc{&allocator};
+        Buffer<AggDataPtr> agg_states(kBenchChunkSize);
+        state.ResumeTiming();
+
+        for (const auto& chunk_col : stream.chunks()) {
+            Columns key_columns;
+            key_columns.emplace_back(chunk_col);
+            wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
+            total_rows += kBenchChunkSize;
+        }
+
+        // End the iteration paused so wrapper / pool destruction does not
+        // bleed into the next iter's measurement window.
+        state.PauseTiming();
+        wrapper.reset();
+        suite._mem_pool->clear();
+    }
+    state.SetItemsProcessed(total_rows);
+    state.counters["distinct"] = distinct;
+    state.counters["rows_per_iter"] = num_rows;
+
+    suite.TearDown();
+}
+
+// ============================================================================
+// Section A (continued) — hash insert + COUNT(*) update
+// Same shape as BM_Int16ColdBuild but with a simulated COUNT(*) increment
+// per resolved AggDataPtr.  Exposes the total per-row cost (hash-insert
+// cost + agg-state-update cost) so the reader can see how the kernel-level
+// delta translates to total agg-phase delta.
+// ============================================================================
+template <typename Wrapper>
+static void BM_Int16ColdBuildAndCount(benchmark::State& state) {
+    const int64_t num_rows = state.range(0);
+    const int distinct = static_cast<int>(state.range(1));
+    const Distribution dist = static_cast<Distribution>(state.range(2));
+
+    BenchSuite suite;
+    suite.SetUp();
+    Int16ChunkStream stream(num_rows, distinct, dist);
+
+    int64_t total_rows = 0;
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
+        HashTableKeyAllocator allocator;
+        allocator.aggregate_key_size = sizeof(int64_t);
+        allocator.pool = suite._mem_pool.get();
+        BenchAllocateState alloc{&allocator};
+        Buffer<AggDataPtr> agg_states(kBenchChunkSize);
+        state.ResumeTiming();
+
+        for (const auto& chunk_col : stream.chunks()) {
+            Columns key_columns;
+            key_columns.emplace_back(chunk_col);
+            wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
+            // Simulated CountAggregateFunction::update per row: state is
+            // sizeof(int64_t) counter, increment unconditionally.
+            for (int i = 0; i < kBenchChunkSize; ++i) {
+                ++(*reinterpret_cast<int64_t*>(agg_states[i]));
+            }
+            total_rows += kBenchChunkSize;
+        }
+
+        state.PauseTiming();
+        wrapper.reset();
+        suite._mem_pool->clear();
+    }
+    state.SetItemsProcessed(total_rows);
+    state.counters["distinct"] = distinct;
+    state.counters["rows_per_iter"] = num_rows;
+
+    suite.TearDown();
+}
+
+// ============================================================================
+// Section C — construction-only cost
+// SmallFixedSizeHashMap<int16_t> ctor zero-fills the 524 KiB pointer table
+// while phmap starts at near-zero capacity; this exposes the upfront cost
+// independent of any workload.
+// ============================================================================
+template <typename Wrapper>
+static void BM_Int16Construct(benchmark::State& state) {
+    BenchSuite suite;
+    suite.SetUp();
+    for (auto _ : state) {
+        // make_unique allocates on heap matching production -- this exposes
+        // the malloc + 524 KiB memset cost the array wrapper pays at every
+        // Aggregator instantiation.
+        auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
+        benchmark::DoNotOptimize(wrapper.get());
+        state.PauseTiming();
+        wrapper.reset();
+        state.ResumeTiming();
+    }
+    suite.TearDown();
+}
+
+// ============================================================================
+// Section D — nullable coverage
+// Three null fractions exercise the three branches of compute_agg_states_nullable:
+//   null_fraction == 0  -> NullableColumn with has_null=false; fast-path
+//                          falls through to compute_agg_states_non_nullable.
+//   null_fraction == 0.1 / 0.5 -> NullableColumn with has_null=true;
+//                          routes through compute_agg_through_null_data
+//                          (the per-row null-bit-aware loop).
+// ============================================================================
+template <typename Wrapper>
+static void BM_Int16NullableColdBuild(benchmark::State& state) {
+    const int64_t num_rows = state.range(0);
+    const int distinct = static_cast<int>(state.range(1));
+    // null_fraction encoded as state.range(2) * 0.01 (so 0, 10, 50 -> 0%, 10%, 50%)
+    const double null_fraction = state.range(2) * 0.01;
+
+    BenchSuite suite;
+    suite.SetUp();
+    NullableInt16ChunkStream stream(num_rows, distinct, null_fraction);
+
+    int64_t total_rows = 0;
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
+        HashTableKeyAllocator allocator;
+        allocator.aggregate_key_size = sizeof(int64_t);
+        allocator.pool = suite._mem_pool.get();
+        BenchAllocateState alloc{&allocator};
+        Buffer<AggDataPtr> agg_states(kBenchChunkSize);
+        state.ResumeTiming();
+
+        for (const auto& chunk_col : stream.chunks()) {
+            Columns key_columns;
+            key_columns.emplace_back(chunk_col);
+            wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
+            total_rows += kBenchChunkSize;
+        }
+
+        state.PauseTiming();
+        wrapper.reset();
+        suite._mem_pool->clear();
+    }
+    state.SetItemsProcessed(total_rows);
+    state.counters["distinct"] = distinct;
+    state.counters["null_pct"] = state.range(2);
+
+    suite.TearDown();
+}
+
+// ============================================================================
+// Args registration
+// ============================================================================
+
+// Section A: density x distribution sweep at 100M rows.
+// Densities chosen for realistic SMALLINT GROUP BY shapes:
+//   1     -> pathological "OneUniqueValue" (single bucket / single slot)
+//   4     -> year bucket
+//   24    -> hour-of-day
+//   366   -> day-of-year
+//   1000  -> region-code-ish
+//   10000 -> ClickHouse fixed_hash_table baseline density
+//   65536 -> array's worst-case memory locality (every slot used)
+static void RegisterArgs_SectionA(benchmark::internal::Benchmark* b) {
+    b->ArgNames({"rows", "distinct", "dist"});
+    constexpr int64_t kRows = 100'000'000;
+    for (int distinct : {1, 4, 24, 366, 1000, 10000, 65536}) {
+        for (int d = 0; d <= 2; ++d) {
+            b->Args({kRows, distinct, d});
+        }
+    }
+    b->Unit(benchmark::kMillisecond);
+    b->Iterations(3);
+}
+
+// Section B: construction-vs-amortization break-even sweep at density=24, sorted.
+// Shows where the 524 KiB upfront alloc stops dominating.
+static void RegisterArgs_SectionB(benchmark::internal::Benchmark* b) {
+    b->ArgNames({"rows", "distinct", "dist"});
+    for (int64_t rows : {4'096LL, 100'000LL, 1'000'000LL, 10'000'000LL, 100'000'000LL}) {
+        b->Args({rows, 24, /*Sorted*/ 1});
+    }
+    b->Unit(benchmark::kMillisecond);
+    b->Iterations(3);
+}
+
+// Section D: nullable, density=24 hour-of-day shape, sorted, three null
+// fractions {0%, 10%, 50%}, smaller row count because nullable codepath is
+// inherently slower and we just want to verify no regression vs baseline.
+static void RegisterArgs_SectionD(benchmark::internal::Benchmark* b) {
+    b->ArgNames({"rows", "distinct", "null_pct"});
+    constexpr int64_t kRows = 50'000'000;
+    for (int null_pct : {0, 10, 50}) {
+        b->Args({kRows, 24, null_pct});
+    }
+    b->Unit(benchmark::kMillisecond);
+    b->Iterations(3);
+}
+
+BENCHMARK_TEMPLATE(BM_Int16ColdBuild, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_Int16ColdBuild, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionA);
+
+BENCHMARK_TEMPLATE(BM_Int16ColdBuildAndCount, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_Int16ColdBuildAndCount, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionA);
+
+BENCHMARK_TEMPLATE(BM_Int16ColdBuild, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionB);
+BENCHMARK_TEMPLATE(BM_Int16ColdBuild, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionB);
+
+BENCHMARK_TEMPLATE(BM_Int16Construct, PhmapInt16Wrapper)->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_Int16Construct, ArrayInt16Wrapper)->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_Int16NullableColdBuild, PhmapInt16NullableWrapper)->Apply(RegisterArgs_SectionD);
+BENCHMARK_TEMPLATE(BM_Int16NullableColdBuild, ArrayInt16NullableWrapper)->Apply(RegisterArgs_SectionD);
+
+} // namespace starrocks
+
+BENCHMARK_MAIN();

--- a/be/src/bench/agg_hash_map_bench.cpp
+++ b/be/src/bench/agg_hash_map_bench.cpp
@@ -22,18 +22,28 @@
 // no scan I/O, no pipeline operator overhead.  Working-set sized so the
 // Int16 column (~200 MiB at 100M rows) does not fit in L3.
 //
-// Sections:
-//   A) Density x distribution sweep at 100M rows; both hash-only and
-//      hash + simulated COUNT(*) update.
-//   B) Construction-vs-amortization break-even: row count sweep at
-//      density=24 sorted, exposes the cell count beyond which the
-//      array's 524 KiB upfront alloc stops dominating.
-//   C) Construction-only cost regression guard.
+// What is timed in each section:
+//   A) build_hash_map only.  Wrapper construction is paused; the array
+//      path's 524 KiB upfront zero-fill is NOT in the timed number here.
+//      This isolates steady-state hash-insert cost.
+//   B) Both BuildOnly and BuildWithCtor companions on a rows sweep.
+//      BuildWithCtor includes wrapper construction inside the timed
+//      region, so the per-iteration timing carries the 524 KiB upfront
+//      cost paid at every Aggregator instantiation.  Comparing the two
+//      sections shows the row count beyond which construction stops
+//      dominating -- the construction-vs-amortization break-even.
+//   C) Construction-only cost (regression guard, microsecond unit).
 //   D) Nullable wrapper at null fractions {0%, 10%, 50%}.
+//
+// density=1 is included as a boundary case (single distinct value after
+// partition pruning); it is the array path's best case but NOT the
+// headline density we expect upstream readers to focus on.  Mid-density
+// (24 hour-of-day, 366 day-of-year, 1000 region-code) is where production
+// SMALLINT GROUP BY queries cluster.
 
-#include <base/testutil/assert.h>
 #include <benchmark/benchmark.h>
 
+#include <cmath>
 #include <memory>
 #include <random>
 #include <vector>
@@ -74,6 +84,7 @@ enum class Distribution : int {
     Random = 0,
     Sorted = 1,
     Clustered64 = 2, // run-length 64: each value repeats 64 times before the next
+    Zipf = 3,        // skewed: ~90% of rows hit ~10% of values (s=1.5)
 };
 
 // Production-shaped allocator.  Aggregator uses HashTableKeyAllocator with
@@ -98,6 +109,14 @@ public:
         const int64_t num_chunks = (num_rows + kBenchChunkSize - 1) / kBenchChunkSize;
         _chunks.reserve(num_chunks);
         const int range_start = -distinct_count / 2; // straddle signed range to exercise unsigned cast
+
+        // Pre-build a Zipf code table once if needed.
+        std::vector<int> zipf_codes;
+        if (dist == Distribution::Zipf) {
+            zipf_codes = build_zipf_codes(distinct_count);
+        }
+        std::uniform_int_distribution<int> zipf_pick(0, zipf_codes.empty() ? 0 : zipf_codes.size() - 1);
+
         for (int64_t c = 0; c < num_chunks; ++c) {
             auto col = Int16Column::create();
             auto& data = col->get_data();
@@ -125,8 +144,13 @@ public:
                 }
                 break;
             }
+            case Distribution::Zipf: {
+                for (int i = 0; i < kBenchChunkSize; ++i) {
+                    data[i] = static_cast<int16_t>(range_start + zipf_codes[zipf_pick(rng)]);
+                }
+                break;
             }
-            // MutPtr -> ImmutPtr requires rvalue (ImmutPtr(const MutPtr&) is deleted).
+            }
             _chunks.emplace_back(std::move(col));
         }
     }
@@ -134,6 +158,36 @@ public:
     const std::vector<ColumnPtr>& chunks() const { return _chunks; }
 
 private:
+    // Build a 4096-entry sample table over [0, distinct_count) with
+    // Zipf(s=1.5) frequencies; sample uniformly from this table to emit
+    // skewed codes.  Top ~10% of distinct values get ~80-90% of mass for
+    // typical OLAP dimension columns (status, country, segment).
+    static std::vector<int> build_zipf_codes(int distinct_count) {
+        constexpr int table_size = 4096;
+        constexpr double s = 1.5;
+        if (distinct_count <= 0) return {};
+        // Cumulative weights w_k = 1 / k^s.
+        std::vector<double> cum(distinct_count);
+        double total = 0.0;
+        for (int k = 0; k < distinct_count; ++k) {
+            total += 1.0 / std::pow(k + 1, s);
+            cum[k] = total;
+        }
+        std::vector<int> codes(table_size);
+        std::mt19937 rng(0xBEEFCAFE);
+        std::uniform_real_distribution<double> uni(0.0, total);
+        for (int i = 0; i < table_size; ++i) {
+            double r = uni(rng);
+            int lo = 0, hi = distinct_count - 1;
+            while (lo < hi) {
+                int mid = (lo + hi) >> 1;
+                if (cum[mid] < r) lo = mid + 1; else hi = mid;
+            }
+            codes[i] = lo;
+        }
+        return codes;
+    }
+
     std::vector<ColumnPtr> _chunks;
 };
 
@@ -209,11 +263,20 @@ public:
     std::unique_ptr<AggStatistics> _agg_stat;
 };
 
+// Memory snapshot helper: hash-table byte footprint via dump_bound()
+// (uniform across phmap and SmallFixedSizeHashMap) plus mem-pool
+// allocated bytes.  Reported as benchmark counters so reviewers can see
+// the time/memory trade-off without re-running with a profiler.
+template <typename Wrapper>
+inline size_t hash_table_bytes(Wrapper* w) {
+    return w->hash_map.dump_bound();
+}
+
 // ============================================================================
-// Section A — main steady-state win (hash insert only)
+// Section A -- steady-state hash-insert win (build_hash_map only)
 // ============================================================================
 template <typename Wrapper>
-static void BM_Int16ColdBuild(benchmark::State& state) {
+static void BM_Int16BuildOnly(benchmark::State& state) {
     const int64_t num_rows = state.range(0);
     const int distinct = static_cast<int>(state.range(1));
     const Distribution dist = static_cast<Distribution>(state.range(2));
@@ -223,6 +286,10 @@ static void BM_Int16ColdBuild(benchmark::State& state) {
     Int16ChunkStream stream(num_rows, distinct, dist);
 
     int64_t total_rows = 0;
+    size_t final_groups = 0;
+    size_t final_ht_bytes = 0;
+    size_t final_pool_bytes = 0;
+    int64_t cum_checksum = 0;
     for (auto _ : state) {
         state.PauseTiming();
         // Heap-allocated to match production (Aggregator uses std::make_unique
@@ -242,29 +309,44 @@ static void BM_Int16ColdBuild(benchmark::State& state) {
             wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
             total_rows += kBenchChunkSize;
         }
+        benchmark::DoNotOptimize(agg_states.data());
+        benchmark::ClobberMemory();
 
         // End the iteration paused so wrapper / pool destruction does not
         // bleed into the next iter's measurement window.
         state.PauseTiming();
+        final_groups = wrapper->hash_map.size();
+        final_ht_bytes = hash_table_bytes(wrapper.get());
+        final_pool_bytes = suite._mem_pool->total_allocated_bytes();
+        // Observe the last-chunk AggDataPtr targets so build_hash_map
+        // results survive DCE.
+        int64_t cs = 0;
+        for (int i = 0; i < kBenchChunkSize; ++i) cs += reinterpret_cast<intptr_t>(agg_states[i]);
+        cum_checksum += cs;
         wrapper.reset();
         suite._mem_pool->clear();
     }
+    benchmark::DoNotOptimize(cum_checksum);
     state.SetItemsProcessed(total_rows);
     state.counters["distinct"] = distinct;
+    state.counters["dist"] = static_cast<int>(dist);
     state.counters["rows_per_iter"] = num_rows;
+    state.counters["final_groups"] = final_groups;
+    state.counters["hash_table_bytes"] = final_ht_bytes;
+    state.counters["pool_bytes"] = final_pool_bytes;
 
     suite.TearDown();
 }
 
 // ============================================================================
-// Section A (continued) — hash insert + COUNT(*) update
-// Same shape as BM_Int16ColdBuild but with a simulated COUNT(*) increment
+// Section A (continued) -- build_hash_map + COUNT(*) update
+// Same shape as BM_Int16BuildOnly but with a simulated COUNT(*) increment
 // per resolved AggDataPtr.  Exposes the total per-row cost (hash-insert
 // cost + agg-state-update cost) so the reader can see how the kernel-level
 // delta translates to total agg-phase delta.
 // ============================================================================
 template <typename Wrapper>
-static void BM_Int16ColdBuildAndCount(benchmark::State& state) {
+static void BM_Int16BuildAndCount(benchmark::State& state) {
     const int64_t num_rows = state.range(0);
     const int distinct = static_cast<int>(state.range(1));
     const Distribution dist = static_cast<Distribution>(state.range(2));
@@ -274,6 +356,10 @@ static void BM_Int16ColdBuildAndCount(benchmark::State& state) {
     Int16ChunkStream stream(num_rows, distinct, dist);
 
     int64_t total_rows = 0;
+    size_t final_groups = 0;
+    size_t final_ht_bytes = 0;
+    size_t final_pool_bytes = 0;
+    int64_t cum_checksum = 0;
     for (auto _ : state) {
         state.PauseTiming();
         auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
@@ -295,20 +381,91 @@ static void BM_Int16ColdBuildAndCount(benchmark::State& state) {
             }
             total_rows += kBenchChunkSize;
         }
+        benchmark::DoNotOptimize(agg_states.data());
+        benchmark::ClobberMemory();
 
         state.PauseTiming();
+        final_groups = wrapper->hash_map.size();
+        final_ht_bytes = hash_table_bytes(wrapper.get());
+        final_pool_bytes = suite._mem_pool->total_allocated_bytes();
+        int64_t cs = 0;
+        for (int i = 0; i < kBenchChunkSize; ++i) cs += *reinterpret_cast<int64_t*>(agg_states[i]);
+        cum_checksum += cs;
         wrapper.reset();
         suite._mem_pool->clear();
     }
+    benchmark::DoNotOptimize(cum_checksum);
     state.SetItemsProcessed(total_rows);
     state.counters["distinct"] = distinct;
+    state.counters["dist"] = static_cast<int>(dist);
     state.counters["rows_per_iter"] = num_rows;
+    state.counters["final_groups"] = final_groups;
+    state.counters["hash_table_bytes"] = final_ht_bytes;
+    state.counters["pool_bytes"] = final_pool_bytes;
 
     suite.TearDown();
 }
 
 // ============================================================================
-// Section C — construction-only cost
+// Section B -- amortization sweep, ctor-included companion
+// Same as BM_Int16BuildOnly but wrapper construction (and the 524 KiB
+// zero-fill for the array path) happens INSIDE the timed region.  This
+// is the row count at which the upfront cost stops dominating.
+// ============================================================================
+template <typename Wrapper>
+static void BM_Int16BuildWithCtor(benchmark::State& state) {
+    const int64_t num_rows = state.range(0);
+    const int distinct = static_cast<int>(state.range(1));
+    const Distribution dist = static_cast<Distribution>(state.range(2));
+
+    BenchSuite suite;
+    suite.SetUp();
+    Int16ChunkStream stream(num_rows, distinct, dist);
+
+    int64_t total_rows = 0;
+    size_t final_ht_bytes = 0;
+    int64_t cum_checksum = 0;
+    for (auto _ : state) {
+        // No PauseTiming before construction -- the ctor's 524 KiB
+        // zero-fill (array path) or default-capacity table (phmap) is
+        // included in the per-iter timing.
+        auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
+        HashTableKeyAllocator allocator;
+        allocator.aggregate_key_size = sizeof(int64_t);
+        allocator.pool = suite._mem_pool.get();
+        BenchAllocateState alloc{&allocator};
+        Buffer<AggDataPtr> agg_states(kBenchChunkSize);
+
+        for (const auto& chunk_col : stream.chunks()) {
+            Columns key_columns;
+            key_columns.emplace_back(chunk_col);
+            wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
+            total_rows += kBenchChunkSize;
+        }
+        benchmark::DoNotOptimize(agg_states.data());
+        benchmark::ClobberMemory();
+
+        state.PauseTiming();
+        final_ht_bytes = hash_table_bytes(wrapper.get());
+        int64_t cs = 0;
+        for (int i = 0; i < kBenchChunkSize; ++i) cs += reinterpret_cast<intptr_t>(agg_states[i]);
+        cum_checksum += cs;
+        wrapper.reset();
+        suite._mem_pool->clear();
+        state.ResumeTiming();
+    }
+    benchmark::DoNotOptimize(cum_checksum);
+    state.SetItemsProcessed(total_rows);
+    state.counters["distinct"] = distinct;
+    state.counters["dist"] = static_cast<int>(dist);
+    state.counters["rows_per_iter"] = num_rows;
+    state.counters["hash_table_bytes"] = final_ht_bytes;
+
+    suite.TearDown();
+}
+
+// ============================================================================
+// Section C -- construction-only cost
 // SmallFixedSizeHashMap<int16_t> ctor zero-fills the 524 KiB pointer table
 // while phmap starts at near-zero capacity; this exposes the upfront cost
 // independent of any workload.
@@ -331,7 +488,7 @@ static void BM_Int16Construct(benchmark::State& state) {
 }
 
 // ============================================================================
-// Section D — nullable coverage
+// Section D -- nullable coverage
 // Three null fractions exercise the three branches of compute_agg_states_nullable:
 //   null_fraction == 0  -> NullableColumn with has_null=false; fast-path
 //                          falls through to compute_agg_states_non_nullable.
@@ -340,7 +497,7 @@ static void BM_Int16Construct(benchmark::State& state) {
 //                          (the per-row null-bit-aware loop).
 // ============================================================================
 template <typename Wrapper>
-static void BM_Int16NullableColdBuild(benchmark::State& state) {
+static void BM_Int16NullableBuildOnly(benchmark::State& state) {
     const int64_t num_rows = state.range(0);
     const int distinct = static_cast<int>(state.range(1));
     // null_fraction encoded as state.range(2) * 0.01 (so 0, 10, 50 -> 0%, 10%, 50%)
@@ -351,6 +508,7 @@ static void BM_Int16NullableColdBuild(benchmark::State& state) {
     NullableInt16ChunkStream stream(num_rows, distinct, null_fraction);
 
     int64_t total_rows = 0;
+    int64_t cum_checksum = 0;
     for (auto _ : state) {
         state.PauseTiming();
         auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
@@ -367,11 +525,17 @@ static void BM_Int16NullableColdBuild(benchmark::State& state) {
             wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
             total_rows += kBenchChunkSize;
         }
+        benchmark::DoNotOptimize(agg_states.data());
+        benchmark::ClobberMemory();
 
         state.PauseTiming();
+        int64_t cs = 0;
+        for (int i = 0; i < kBenchChunkSize; ++i) cs += reinterpret_cast<intptr_t>(agg_states[i]);
+        cum_checksum += cs;
         wrapper.reset();
         suite._mem_pool->clear();
     }
+    benchmark::DoNotOptimize(cum_checksum);
     state.SetItemsProcessed(total_rows);
     state.counters["distinct"] = distinct;
     state.counters["null_pct"] = state.range(2);
@@ -385,9 +549,10 @@ static void BM_Int16NullableColdBuild(benchmark::State& state) {
 
 // Section A: density x distribution sweep at 100M rows.
 // Densities chosen for realistic SMALLINT GROUP BY shapes:
-//   1     -> pathological "OneUniqueValue" (single bucket / single slot)
+//   1     -> boundary "single distinct after pruning"; array's pathological
+//            best case.  Not the headline density.
 //   4     -> year bucket
-//   24    -> hour-of-day
+//   24    -> hour-of-day (headline mid density)
 //   366   -> day-of-year
 //   1000  -> region-code-ish
 //   10000 -> ClickHouse fixed_hash_table baseline density
@@ -396,7 +561,7 @@ static void RegisterArgs_SectionA(benchmark::internal::Benchmark* b) {
     b->ArgNames({"rows", "distinct", "dist"});
     constexpr int64_t kRows = 100'000'000;
     for (int distinct : {1, 4, 24, 366, 1000, 10000, 65536}) {
-        for (int d = 0; d <= 2; ++d) {
+        for (int d = 0; d <= 3; ++d) {
             b->Args({kRows, distinct, d});
         }
     }
@@ -404,8 +569,10 @@ static void RegisterArgs_SectionA(benchmark::internal::Benchmark* b) {
     b->Iterations(3);
 }
 
-// Section B: construction-vs-amortization break-even sweep at density=24, sorted.
-// Shows where the 524 KiB upfront alloc stops dominating.
+// Section B: amortization sweep at density=24, sorted.  Shows where the
+// 524 KiB upfront alloc stops dominating.  Same args used by both
+// BM_Int16BuildOnly (ctor paused) and BM_Int16BuildWithCtor (ctor timed)
+// so reviewers can read the two side by side.
 static void RegisterArgs_SectionB(benchmark::internal::Benchmark* b) {
     b->ArgNames({"rows", "distinct", "dist"});
     for (int64_t rows : {4'096LL, 100'000LL, 1'000'000LL, 10'000'000LL, 100'000'000LL}) {
@@ -428,20 +595,23 @@ static void RegisterArgs_SectionD(benchmark::internal::Benchmark* b) {
     b->Iterations(3);
 }
 
-BENCHMARK_TEMPLATE(BM_Int16ColdBuild, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionA);
-BENCHMARK_TEMPLATE(BM_Int16ColdBuild, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_Int16BuildOnly, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_Int16BuildOnly, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionA);
 
-BENCHMARK_TEMPLATE(BM_Int16ColdBuildAndCount, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionA);
-BENCHMARK_TEMPLATE(BM_Int16ColdBuildAndCount, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_Int16BuildAndCount, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_Int16BuildAndCount, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionA);
 
-BENCHMARK_TEMPLATE(BM_Int16ColdBuild, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionB);
-BENCHMARK_TEMPLATE(BM_Int16ColdBuild, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionB);
+BENCHMARK_TEMPLATE(BM_Int16BuildOnly, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionB);
+BENCHMARK_TEMPLATE(BM_Int16BuildOnly, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionB);
+
+BENCHMARK_TEMPLATE(BM_Int16BuildWithCtor, PhmapInt16Wrapper)->Apply(RegisterArgs_SectionB);
+BENCHMARK_TEMPLATE(BM_Int16BuildWithCtor, ArrayInt16Wrapper)->Apply(RegisterArgs_SectionB);
 
 BENCHMARK_TEMPLATE(BM_Int16Construct, PhmapInt16Wrapper)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE(BM_Int16Construct, ArrayInt16Wrapper)->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(BM_Int16NullableColdBuild, PhmapInt16NullableWrapper)->Apply(RegisterArgs_SectionD);
-BENCHMARK_TEMPLATE(BM_Int16NullableColdBuild, ArrayInt16NullableWrapper)->Apply(RegisterArgs_SectionD);
+BENCHMARK_TEMPLATE(BM_Int16NullableBuildOnly, PhmapInt16NullableWrapper)->Apply(RegisterArgs_SectionD);
+BENCHMARK_TEMPLATE(BM_Int16NullableBuildOnly, ArrayInt16NullableWrapper)->Apply(RegisterArgs_SectionD);
 
 } // namespace starrocks
 

--- a/be/src/bench/agg_hash_map_bench.cpp
+++ b/be/src/bench/agg_hash_map_bench.cpp
@@ -181,7 +181,10 @@ private:
             int lo = 0, hi = distinct_count - 1;
             while (lo < hi) {
                 int mid = (lo + hi) >> 1;
-                if (cum[mid] < r) lo = mid + 1; else hi = mid;
+                if (cum[mid] < r)
+                    lo = mid + 1;
+                else
+                    hi = mid;
             }
             codes[i] = lo;
         }

--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -60,7 +60,7 @@ concept AllocFunc = HasKeyType<HashMapWithKey>&& requires(T t, const typename Ha
 template <PhmapSeed seed>
 using Int8AggHashMap = SmallFixedSizeHashMap<int8_t, AggDataPtr, seed>;
 template <PhmapSeed seed>
-using Int16AggHashMap = phmap::flat_hash_map<int16_t, AggDataPtr, StdHashWithSeed<int16_t, seed>>;
+using Int16AggHashMap = SmallFixedSizeHashMap<int16_t, AggDataPtr, seed>;
 template <PhmapSeed seed>
 using Int32AggHashMap = phmap::flat_hash_map<int32_t, AggDataPtr, StdHashWithSeed<int32_t, seed>>;
 template <PhmapSeed seed>

--- a/be/src/exec/aggregate/agg_hash_set.h
+++ b/be/src/exec/aggregate/agg_hash_set.h
@@ -56,7 +56,7 @@ static constexpr size_t AGG_HASH_MAP_DEFAULT_PREFETCH_DIST = 16;
 template <PhmapSeed seed>
 using Int8AggHashSet = SmallFixedSizeHashSet<int8_t, seed>;
 template <PhmapSeed seed>
-using Int16AggHashSet = phmap::flat_hash_set<int16_t, StdHashWithSeed<int16_t, seed>>;
+using Int16AggHashSet = SmallFixedSizeHashSet<int16_t, seed>;
 template <PhmapSeed seed>
 using Int32AggHashSet = phmap::flat_hash_set<int32_t, StdHashWithSeed<int32_t, seed>>;
 template <PhmapSeed seed>

--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -350,7 +350,7 @@ bool AggHashMapVariant::need_expand(size_t increasement) const {
     return visit([increasement](const auto& hash_map_with_key) {
         using HashMap = std::remove_reference_t<decltype(hash_map_with_key->hash_map)>;
         const size_t size = hash_map_with_key->hash_map.size() + increasement;
-        if constexpr (requires { HashMap::bucket_byte_size(); }) {
+        if constexpr (is_fixed_hash_map_v<HashMap>) {
             return size > HashMap::hash_table_size;
         }
         const size_t capacity = hash_map_with_key->hash_map.capacity();
@@ -369,7 +369,7 @@ size_t AggHashMapVariant::allocated_memory_usage(const MemPool* pool) const {
     return visit([pool](const auto& hash_map_with_key) {
         using HashMap = std::remove_reference_t<decltype(hash_map_with_key->hash_map)>;
         size_t hash_map_bytes;
-        if constexpr (requires { HashMap::bucket_byte_size(); }) {
+        if constexpr (is_fixed_hash_map_v<HashMap>) {
             // SmallFixedSizeHashMap pre-allocates a dense pointer array; the
             // SMALLINT path is ~512 KiB and must be reported as such, not as
             // sizeof(KeyType) * capacity.
@@ -455,7 +455,7 @@ bool AggHashSetVariant::need_expand(size_t increasement) const {
     return visit([increasement](const auto& hash_set_with_key) {
         using HashSet = std::remove_reference_t<decltype(hash_set_with_key->hash_set)>;
         const size_t size = hash_set_with_key->hash_set.size() + increasement;
-        if constexpr (requires { HashSet::bucket_byte_size(); }) {
+        if constexpr (is_fixed_hash_set_v<HashSet>) {
             return size > HashSet::hash_table_size;
         }
         const size_t capacity = hash_set_with_key->hash_set.capacity();
@@ -474,7 +474,7 @@ size_t AggHashSetVariant::allocated_memory_usage(const MemPool* pool) const {
     return visit([&](auto& hash_set_with_key) {
         using HashSet = std::remove_reference_t<decltype(hash_set_with_key->hash_set)>;
         size_t hash_set_bytes;
-        if constexpr (requires { HashSet::bucket_byte_size(); }) {
+        if constexpr (is_fixed_hash_set_v<HashSet>) {
             hash_set_bytes = HashSet::bucket_byte_size();
         } else {
             hash_set_bytes = sizeof(typename HashSet::key_type) * hash_set_with_key->hash_set.capacity();

--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -342,11 +342,20 @@ size_t AggHashMapVariant::size() const {
 }
 
 bool AggHashMapVariant::need_expand(size_t increasement) const {
-    size_t capacity = this->capacity();
-    // TODO: think about two-level hashmap
-    size_t size = this->size() + increasement;
-    // see detail implement in reset_growth_left
-    return size >= capacity - capacity / 8;
+    // Direct-array hash maps (SmallFixedSizeHashMap for TINYINT/BOOL/SMALLINT
+    // and the low-card-dict uint8 variant) have a hard-coded full keyspace
+    // and never rehash, so streaming/spill paths should only fall back when
+    // the array is actually full -- not at the 87.5% growth-heuristic
+    // threshold used by phmap.
+    return visit([increasement](const auto& hash_map_with_key) {
+        using HashMap = std::remove_reference_t<decltype(hash_map_with_key->hash_map)>;
+        const size_t size = hash_map_with_key->hash_map.size() + increasement;
+        if constexpr (requires { HashMap::bucket_byte_size(); }) {
+            return size > HashMap::hash_table_size;
+        }
+        const size_t capacity = hash_map_with_key->hash_map.capacity();
+        return size >= capacity - capacity / 8;
+    });
 }
 
 size_t AggHashMapVariant::reserved_memory_usage(const MemPool* pool) const {
@@ -441,10 +450,17 @@ size_t AggHashSetVariant::size() const {
 }
 
 bool AggHashSetVariant::need_expand(size_t increasement) const {
-    size_t capacity = this->capacity();
-    size_t size = this->size() + increasement;
-    // see detail implement in reset_growth_left
-    return size >= capacity - capacity / 8;
+    // Direct-array hash sets (SmallFixedSizeHashSet for TINYINT/BOOL/SMALLINT)
+    // never rehash; only fall back when the array is actually full.
+    return visit([increasement](const auto& hash_set_with_key) {
+        using HashSet = std::remove_reference_t<decltype(hash_set_with_key->hash_set)>;
+        const size_t size = hash_set_with_key->hash_set.size() + increasement;
+        if constexpr (requires { HashSet::bucket_byte_size(); }) {
+            return size > HashSet::hash_table_size;
+        }
+        const size_t capacity = hash_set_with_key->hash_set.capacity();
+        return size >= capacity - capacity / 8;
+    });
 }
 
 size_t AggHashSetVariant::reserved_memory_usage(const MemPool* pool) const {

--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -358,9 +358,18 @@ size_t AggHashMapVariant::reserved_memory_usage(const MemPool* pool) const {
 
 size_t AggHashMapVariant::allocated_memory_usage(const MemPool* pool) const {
     return visit([pool](const auto& hash_map_with_key) {
-        return sizeof(typename decltype(hash_map_with_key->hash_map)::key_type) *
-                       hash_map_with_key->hash_map.capacity() +
-               pool->total_allocated_bytes();
+        using HashMap = std::remove_reference_t<decltype(hash_map_with_key->hash_map)>;
+        size_t hash_map_bytes;
+        if constexpr (requires { HashMap::bucket_byte_size(); }) {
+            // SmallFixedSizeHashMap pre-allocates a dense pointer array; the
+            // SMALLINT path is ~512 KiB and must be reported as such, not as
+            // sizeof(KeyType) * capacity.
+            hash_map_bytes = HashMap::bucket_byte_size();
+        } else {
+            hash_map_bytes = sizeof(typename HashMap::key_type) * hash_map_with_key->hash_map.capacity();
+        }
+        const size_t pool_bytes = (pool != nullptr) ? pool->total_allocated_bytes() : 0;
+        return hash_map_bytes + pool_bytes;
     });
 }
 
@@ -447,9 +456,15 @@ size_t AggHashSetVariant::reserved_memory_usage(const MemPool* pool) const {
 
 size_t AggHashSetVariant::allocated_memory_usage(const MemPool* pool) const {
     return visit([&](auto& hash_set_with_key) {
-        return sizeof(typename decltype(hash_set_with_key->hash_set)::key_type) *
-                       hash_set_with_key->hash_set.capacity() +
-               pool->total_allocated_bytes();
+        using HashSet = std::remove_reference_t<decltype(hash_set_with_key->hash_set)>;
+        size_t hash_set_bytes;
+        if constexpr (requires { HashSet::bucket_byte_size(); }) {
+            hash_set_bytes = HashSet::bucket_byte_size();
+        } else {
+            hash_set_bytes = sizeof(typename HashSet::key_type) * hash_set_with_key->hash_set.capacity();
+        }
+        const size_t pool_bytes = (pool != nullptr) ? pool->total_allocated_bytes() : 0;
+        return hash_set_bytes + pool_bytes;
     });
 }
 

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -1538,6 +1538,22 @@ typename HashVariantType::Type Aggregator::_try_to_apply_compressed_key_opt(type
     if (_group_by_types.empty()) {
         return type;
     }
+    // Don't shadow direct-array variants with the slice_cx1 rewrite.
+    // TINYINT / BOOL / SMALLINT route to SmallFixedSizeHashMap-backed
+    // direct arrays; the slice_cx1 path sits on the same direct array
+    // under int8 but adds a per-row bitcompress_serialize step, so any
+    // query that supplies range stats via `group_by_min_max` would
+    // otherwise silently regress to the slower slice path.
+    if (_group_by_types.size() == 1) {
+        switch (_group_by_types[0].result_type.type) {
+        case TYPE_TINYINT:
+        case TYPE_BOOLEAN:
+        case TYPE_SMALLINT:
+            return type;
+        default:
+            break;
+        }
+    }
     for (size_t i = 0; i < _ranges.size(); ++i) {
         if (!_ranges[i].has_value()) {
             return type;


### PR DESCRIPTION
Fixes #73588.

## Why I'm doing:

`GROUP BY` on a `SMALLINT` column today pays the full phmap cost — hash,
probe chain, key compare — even though the key space is only 2¹⁶ values
and would fit in a direct-indexed array.  TINYINT/BOOL already use a
fixed-size array hash map; SMALLINT was left on phmap.  ClickHouse ships
the same direct-array shape as `AggregatedDataWithUInt16Key` (`key16`).

## What I'm doing:

Switch `Int16AggHashMap` / `Int16AggHashSet` from
`phmap::flat_hash_{map,set}<int16_t>` to `SmallFixedSizeHash{Map,Set}<int16_t>`,
giving a direct-indexed 65 536-cell array.  No hashing, no conflict
chain, no key comparison — just `array[static_cast<uint16_t>(key)]`.

The wrapper (`AggHashMapWithOneNumberKey`) and the nullable wrapper
already specialize on `is_no_prefetch_map`, so prefetch and the
consecutive-keys cache are correctly disabled for the new path.
`convert_to_two_level` only fires for slice/string variants, so the
Int16 path is unaffected.

**No session-var gate:** the optimization is unconditionally faster
(no hash, no probe, no key compare) and ClickHouse ships the equivalent
without a switch.

### Memory accounting fix (rolled in)

`SmallFixedSizeHashMap<int16_t, AggDataPtr>` owns a dense ~512 KiB
pointer array per hash map.  The prior accounting paths under-reported
this:
- `allocated_memory_usage` computed `sizeof(KeyType) * capacity()` (~128 KiB).
- `reserved_memory_usage` went through `SmallFixedSizeHash{Map,Set}::dump_bound()`,
  which returned the slot **count** (65 536) instead of bytes.

Both now report `sizeof(ValueType) * (hash_table_size + 1)`:
- `allocated_memory_usage` consults a new `bucket_byte_size()` constant
  via a `requires` expression.
- `dump_bound()` returns the same byte count, matching phmap's
  byte-based dump_bound semantics.

This keeps spill / streaming-memory budgets and serialization paths
honest at the true footprint of this **and the pre-existing TINYINT/BOOL
array path** (which had the same accounting bug).

### Compressed-key opt gate (rolled in)

`_try_to_apply_compressed_key_opt` rewrites the agg hash variant to
the slice_cx1/4/8/16 path when FE supplies range stats via the
`group_by_min_max` channel and `could_apply_bitcompress_opt`
succeeds.  For TINYINT / BOOL / SMALLINT this **overrides** the
direct-array route with `slice_cx1`, which sits on the same
`SmallFixedSizeHashMap<int8_t>` under the hood but layers a per-row
`bitcompress_serialize` step on top.

The observable consequence: SMALLINT `GROUP BY` would run **slower**
when FE has range stats than when it doesn't.  More information at
FE → slower BE.  Pre-existing for TINYINT / BOOL on `main`; newly
exposed for SMALLINT by the direct-array switch in this PR.

Fix: gate the rewrite on the source type.  When the single group-by
column is `TYPE_TINYINT`, `TYPE_BOOLEAN`, or `TYPE_SMALLINT`, return
the input variant unchanged.  Multi-column GROUP BY and INT / BIGINT /
DECIMAL paths are unaffected — `slice_cx1` remains the best
available path for those today.

### Bench

`be/src/bench/agg_hash_map_bench.cpp` instantiates the phmap baseline
and the array treatment of `AggHashMapWithOneNumberKey<TYPE_SMALLINT,
...>` side-by-side and drives them through the production callsite
`build_hash_map` with a production-shaped `HashTableKeyAllocator`
(`sizeof(int64_t)` aggregate state matching `COUNT(*)`).

Sections:
- **A**: density {1, 4, 24, 366, 1000, 10000, 65536} × distribution
  {random, sorted, clustered-run-length-64, Zipf s=1.5} at 100M rows.
  Forces L3 eviction of the column buffer so hash-table cost dominates.
  Reports both hash-only (`BM_Int16BuildOnly`) and hash+COUNT-update
  (`BM_Int16BuildAndCount`).
- **B**: amortization sweep at density=24 sorted, rows {4K, 100K, 1M,
  10M, 100M}.  `BM_Int16BuildOnly` (ctor paused) + `BM_Int16BuildWithCtor`
  (ctor inside timing) side-by-side shows the row count beyond which the
  array's 524 KiB upfront alloc stops dominating.
- **C**: construct-only cost (`BM_Int16Construct`) — makes the 524 KiB
  memset explicit.
- **D**: nullable coverage at null fractions {0%, 10%, 50%}.

#### Results (100M rows, median, x86_64 r6a.xlarge, ASLR on)

Hash-only:

| distinct | dist | phmap | array | speedup |
|----------|------|-------|-------|---------|
| 1 | random | 424 ms | 130 ms | **3.3×** |
| 24 | random | 539 | 130 | **4.1×** |
| 1000 | sorted | 825 | 132 | **6.3×** |
| 10000 | random | 980 | 148 | **6.6×** |
| 65536 | random | 1121 | 209 | **5.4×** |
| 24 | Zipf | 527 | 130 | **4.1×** |

Build+count (hash insert + per-row counter increment):
**1.6–3.9×** depending on density.

#### Memory trade-off

Array path is always ~524 KiB; phmap scales with distinct.  Crossover
at `distinct ≈ 10k`: at 65 536 distinct phmap holds **2.23 MiB** vs.
**524 KiB** for the array — i.e. the array path is also memory-cheaper
on the densest workloads it has to handle.

#### Amortization break-even (Section B, density=24 sorted)

| rows | phmap ctor-included | array ctor-included | array wins from |
|------|---------------------|----------------------|------------------|
| 4 096 | 0.010 ms | 0.015 ms | — |
| 100 000 | 0.214 | 0.075 | ✅ ~2.85× |
| 1M+ | scales linearly | scales linearly | ✅ ~3.16× |

The 524 KiB ctor is a one-time hit; the array path beats phmap from
~50–100 K rows onward.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4




