### PR TITLE
[Enhancement] Use array-table for low-cardinality global-dict group-by keys

### DIFF
--- a/be/src/bench/CMakeLists.txt
+++ b/be/src/bench/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ADD_BE_BENCH(${SRC_DIR}/bench/chunks_sorter_bench)
+ADD_BE_BENCH(${SRC_DIR}/bench/agg_low_card_dict_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/runtime_filter_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/csv_reader_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/shuffle_chunk_bench)

--- a/be/src/bench/agg_low_card_dict_bench.cpp
+++ b/be/src/bench/agg_low_card_dict_bench.cpp
@@ -112,7 +112,10 @@ static std::vector<int> build_zipf_codes(int distinct_count) {
         int lo = 0, hi = distinct_count - 1;
         while (lo < hi) {
             int mid = (lo + hi) >> 1;
-            if (cum[mid] < r) lo = mid + 1; else hi = mid;
+            if (cum[mid] < r)
+                lo = mid + 1;
+            else
+                hi = mid;
         }
         codes[i] = lo;
     }

--- a/be/src/bench/agg_low_card_dict_bench.cpp
+++ b/be/src/bench/agg_low_card_dict_bench.cpp
@@ -22,15 +22,22 @@
 // parallel: low_cardinality_key8.
 //
 // Driver: production callsite build_hash_map with a production-shaped
-// HashTableKeyAllocator (sizeof(int64_t) state matching COUNT(*)).  Density
-// caps at 255 because dict codes only span [0, 255] under
-// Config.low_cardinality_threshold = 255; higher densities are blocked at
-// FE.  Construction is cheap (256-cell array = ~2 KiB) so Section C is a
-// regression guard, not a primary signal.
+// HashTableKeyAllocator (sizeof(int64_t) state matching COUNT(*)).
+//
+// Density and code-range semantics:
+//   * Config.low_cardinality_threshold caps dictionary size at <=255
+//     entries; the FE guard rejects marking a slot when threshold > 255.
+//     With threshold=255 a dictionary holds up to 255 entries giving
+//     codes in [0, 254].  density=255 in the bench produces exactly that
+//     worst-case shape (255 distinct codes 0..254 filling the array).
+//   * density=256 cannot occur in production with the current guard and
+//     is not benched.  If the guard is relaxed in the future, codes 0..255
+//     remain a single read of the array (cell 256 is the sentinel slot
+//     reserved by SmallFixedSizeHashMap, see fixed_hash_map.h).
 
-#include <base/testutil/assert.h>
 #include <benchmark/benchmark.h>
 
+#include <cmath>
 #include <memory>
 #include <random>
 #include <vector>
@@ -71,6 +78,7 @@ enum class Distribution : int {
     Random = 0,
     Sorted = 1,
     Clustered64 = 2,
+    Zipf = 3, // skewed: ~90% of mass on top decile (s=1.5)
 };
 
 // Production-shaped allocator -- same shape as the SMALLINT bench so the
@@ -84,9 +92,36 @@ struct BenchAllocateState {
     }
 };
 
+// Build a 4096-entry Zipf code table over [0, distinct_count) so the
+// chunk-gen loop just samples a slot in this pre-built table.
+static std::vector<int> build_zipf_codes(int distinct_count) {
+    constexpr int table_size = 4096;
+    constexpr double s = 1.5;
+    if (distinct_count <= 0) return {};
+    std::vector<double> cum(distinct_count);
+    double total = 0.0;
+    for (int k = 0; k < distinct_count; ++k) {
+        total += 1.0 / std::pow(k + 1, s);
+        cum[k] = total;
+    }
+    std::vector<int> codes(table_size);
+    std::mt19937 rng(0xBEEFCAFE);
+    std::uniform_real_distribution<double> uni(0.0, total);
+    for (int i = 0; i < table_size; ++i) {
+        double r = uni(rng);
+        int lo = 0, hi = distinct_count - 1;
+        while (lo < hi) {
+            int mid = (lo + hi) >> 1;
+            if (cum[mid] < r) lo = mid + 1; else hi = mid;
+        }
+        codes[i] = lo;
+    }
+    return codes;
+}
+
 // Generate (num_rows / kBenchChunkSize) Int32 chunks of kBenchChunkSize rows
 // each, each chunk a fresh Int32Column owning its own buffer.  Values are
-// FE-generated dict codes in [0, distinct_count - 1] (distinct_count <= 256).
+// FE-generated dict codes in [0, distinct_count - 1] (distinct_count <= 255).
 class Int32CodeChunkStream {
 public:
     Int32CodeChunkStream(int64_t num_rows, int distinct_count, Distribution dist) {
@@ -94,6 +129,13 @@ public:
         std::uniform_int_distribution<int> uni(0, distinct_count > 0 ? distinct_count - 1 : 0);
         const int64_t num_chunks = (num_rows + kBenchChunkSize - 1) / kBenchChunkSize;
         _chunks.reserve(num_chunks);
+
+        std::vector<int> zipf_codes;
+        if (dist == Distribution::Zipf) {
+            zipf_codes = build_zipf_codes(distinct_count);
+        }
+        std::uniform_int_distribution<int> zipf_pick(0, zipf_codes.empty() ? 0 : zipf_codes.size() - 1);
+
         for (int64_t c = 0; c < num_chunks; ++c) {
             auto col = Int32Column::create();
             auto& data = col->get_data();
@@ -118,6 +160,12 @@ public:
                 for (int i = 0; i < kBenchChunkSize; ++i) {
                     if (i > 0 && i % 64 == 0) current = uni(rng);
                     data[i] = current;
+                }
+                break;
+            }
+            case Distribution::Zipf: {
+                for (int i = 0; i < kBenchChunkSize; ++i) {
+                    data[i] = zipf_codes[zipf_pick(rng)];
                 }
                 break;
             }
@@ -199,11 +247,16 @@ public:
     std::unique_ptr<AggStatistics> _agg_stat;
 };
 
+template <typename Wrapper>
+inline size_t hash_table_bytes(Wrapper* w) {
+    return w->hash_map.dump_bound();
+}
+
 // ============================================================================
-// Section A — main steady-state win (hash insert only)
+// Section A -- main steady-state win (hash insert only)
 // ============================================================================
 template <typename Wrapper>
-static void BM_LowCardColdBuild(benchmark::State& state) {
+static void BM_LowCardBuildOnly(benchmark::State& state) {
     const int64_t num_rows = state.range(0);
     const int distinct = static_cast<int>(state.range(1));
     const Distribution dist = static_cast<Distribution>(state.range(2));
@@ -213,6 +266,10 @@ static void BM_LowCardColdBuild(benchmark::State& state) {
     Int32CodeChunkStream stream(num_rows, distinct, dist);
 
     int64_t total_rows = 0;
+    size_t final_groups = 0;
+    size_t final_ht_bytes = 0;
+    size_t final_pool_bytes = 0;
+    int64_t cum_checksum = 0;
     for (auto _ : state) {
         state.PauseTiming();
         auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
@@ -229,23 +286,36 @@ static void BM_LowCardColdBuild(benchmark::State& state) {
             wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
             total_rows += kBenchChunkSize;
         }
+        benchmark::DoNotOptimize(agg_states.data());
+        benchmark::ClobberMemory();
 
         state.PauseTiming();
+        final_groups = wrapper->hash_map.size();
+        final_ht_bytes = hash_table_bytes(wrapper.get());
+        final_pool_bytes = suite._mem_pool->total_allocated_bytes();
+        int64_t cs = 0;
+        for (int i = 0; i < kBenchChunkSize; ++i) cs += reinterpret_cast<intptr_t>(agg_states[i]);
+        cum_checksum += cs;
         wrapper.reset();
         suite._mem_pool->clear();
     }
+    benchmark::DoNotOptimize(cum_checksum);
     state.SetItemsProcessed(total_rows);
     state.counters["distinct"] = distinct;
+    state.counters["dist"] = static_cast<int>(dist);
     state.counters["rows_per_iter"] = num_rows;
+    state.counters["final_groups"] = final_groups;
+    state.counters["hash_table_bytes"] = final_ht_bytes;
+    state.counters["pool_bytes"] = final_pool_bytes;
 
     suite.TearDown();
 }
 
 // ============================================================================
-// Section A (continued) — hash insert + COUNT(*) update
+// Section A (continued) -- hash insert + COUNT(*) update
 // ============================================================================
 template <typename Wrapper>
-static void BM_LowCardColdBuildAndCount(benchmark::State& state) {
+static void BM_LowCardBuildAndCount(benchmark::State& state) {
     const int64_t num_rows = state.range(0);
     const int distinct = static_cast<int>(state.range(1));
     const Distribution dist = static_cast<Distribution>(state.range(2));
@@ -255,6 +325,10 @@ static void BM_LowCardColdBuildAndCount(benchmark::State& state) {
     Int32CodeChunkStream stream(num_rows, distinct, dist);
 
     int64_t total_rows = 0;
+    size_t final_groups = 0;
+    size_t final_ht_bytes = 0;
+    size_t final_pool_bytes = 0;
+    int64_t cum_checksum = 0;
     for (auto _ : state) {
         state.PauseTiming();
         auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
@@ -274,20 +348,33 @@ static void BM_LowCardColdBuildAndCount(benchmark::State& state) {
             }
             total_rows += kBenchChunkSize;
         }
+        benchmark::DoNotOptimize(agg_states.data());
+        benchmark::ClobberMemory();
 
         state.PauseTiming();
+        final_groups = wrapper->hash_map.size();
+        final_ht_bytes = hash_table_bytes(wrapper.get());
+        final_pool_bytes = suite._mem_pool->total_allocated_bytes();
+        int64_t cs = 0;
+        for (int i = 0; i < kBenchChunkSize; ++i) cs += *reinterpret_cast<int64_t*>(agg_states[i]);
+        cum_checksum += cs;
         wrapper.reset();
         suite._mem_pool->clear();
     }
+    benchmark::DoNotOptimize(cum_checksum);
     state.SetItemsProcessed(total_rows);
     state.counters["distinct"] = distinct;
+    state.counters["dist"] = static_cast<int>(dist);
     state.counters["rows_per_iter"] = num_rows;
+    state.counters["final_groups"] = final_groups;
+    state.counters["hash_table_bytes"] = final_ht_bytes;
+    state.counters["pool_bytes"] = final_pool_bytes;
 
     suite.TearDown();
 }
 
 // ============================================================================
-// Section C — construction-only cost
+// Section C -- construction-only cost
 // LowCardUInt8Map is a 257-cell array (~2 KiB heap); phmap starts at zero
 // capacity.  This section just verifies the array path does not regress
 // construction cost in the small-table regime.
@@ -307,10 +394,10 @@ static void BM_LowCardConstruct(benchmark::State& state) {
 }
 
 // ============================================================================
-// Section D — nullable coverage
+// Section D -- nullable coverage
 // ============================================================================
 template <typename Wrapper>
-static void BM_LowCardNullableColdBuild(benchmark::State& state) {
+static void BM_LowCardNullableBuildOnly(benchmark::State& state) {
     const int64_t num_rows = state.range(0);
     const int distinct = static_cast<int>(state.range(1));
     const double null_fraction = state.range(2) * 0.01;
@@ -320,6 +407,7 @@ static void BM_LowCardNullableColdBuild(benchmark::State& state) {
     NullableInt32CodeChunkStream stream(num_rows, distinct, null_fraction);
 
     int64_t total_rows = 0;
+    int64_t cum_checksum = 0;
     for (auto _ : state) {
         state.PauseTiming();
         auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
@@ -336,11 +424,17 @@ static void BM_LowCardNullableColdBuild(benchmark::State& state) {
             wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
             total_rows += kBenchChunkSize;
         }
+        benchmark::DoNotOptimize(agg_states.data());
+        benchmark::ClobberMemory();
 
         state.PauseTiming();
+        int64_t cs = 0;
+        for (int i = 0; i < kBenchChunkSize; ++i) cs += reinterpret_cast<intptr_t>(agg_states[i]);
+        cum_checksum += cs;
         wrapper.reset();
         suite._mem_pool->clear();
     }
+    benchmark::DoNotOptimize(cum_checksum);
     state.SetItemsProcessed(total_rows);
     state.counters["distinct"] = distinct;
     state.counters["null_pct"] = state.range(2);
@@ -352,20 +446,20 @@ static void BM_LowCardNullableColdBuild(benchmark::State& state) {
 // Args registration
 // ============================================================================
 
-// Section A: density caps at 255 because Config.low_cardinality_threshold
-// = 255 by default; dict codes above 255 are blocked at FE in this PR (see
-// PlanFragmentBuilder.visitPhysicalHashAggregate guard).
-//   1   -> pathological single value
+// Section A: density caps at 255.  Codes are 0..(distinct-1); at
+// distinct=255 codes 0..254 fill the array short by one sentinel slot
+// (cell 255 reserved by SmallFixedSizeHashMap).
+//   1   -> pathological single value (boundary, not headline)
 //   4   -> typical enum bucket
 //   24  -> hour-of-day
 //   100 -> typical low-card column (status, segment)
 //   200 -> deeper realistic GROUP BY low-card range
-//   255 -> threshold ceiling, array fills its full 256-cell table
+//   255 -> threshold ceiling, worst-case fill of the array
 static void RegisterArgs_SectionA(benchmark::internal::Benchmark* b) {
     b->ArgNames({"rows", "distinct", "dist"});
     constexpr int64_t kRows = 100'000'000;
     for (int distinct : {1, 4, 24, 100, 200, 255}) {
-        for (int d = 0; d <= 2; ++d) {
+        for (int d = 0; d <= 3; ++d) {
             b->Args({kRows, distinct, d});
         }
     }
@@ -396,20 +490,20 @@ static void RegisterArgs_SectionD(benchmark::internal::Benchmark* b) {
     b->Iterations(3);
 }
 
-BENCHMARK_TEMPLATE(BM_LowCardColdBuild, PhmapInt32Wrapper)->Apply(RegisterArgs_SectionA);
-BENCHMARK_TEMPLATE(BM_LowCardColdBuild, LowCardWrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_LowCardBuildOnly, PhmapInt32Wrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_LowCardBuildOnly, LowCardWrapper)->Apply(RegisterArgs_SectionA);
 
-BENCHMARK_TEMPLATE(BM_LowCardColdBuildAndCount, PhmapInt32Wrapper)->Apply(RegisterArgs_SectionA);
-BENCHMARK_TEMPLATE(BM_LowCardColdBuildAndCount, LowCardWrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_LowCardBuildAndCount, PhmapInt32Wrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_LowCardBuildAndCount, LowCardWrapper)->Apply(RegisterArgs_SectionA);
 
-BENCHMARK_TEMPLATE(BM_LowCardColdBuild, PhmapInt32Wrapper)->Apply(RegisterArgs_SectionB);
-BENCHMARK_TEMPLATE(BM_LowCardColdBuild, LowCardWrapper)->Apply(RegisterArgs_SectionB);
+BENCHMARK_TEMPLATE(BM_LowCardBuildOnly, PhmapInt32Wrapper)->Apply(RegisterArgs_SectionB);
+BENCHMARK_TEMPLATE(BM_LowCardBuildOnly, LowCardWrapper)->Apply(RegisterArgs_SectionB);
 
 BENCHMARK_TEMPLATE(BM_LowCardConstruct, PhmapInt32Wrapper)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE(BM_LowCardConstruct, LowCardWrapper)->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(BM_LowCardNullableColdBuild, PhmapInt32NullableWrapper)->Apply(RegisterArgs_SectionD);
-BENCHMARK_TEMPLATE(BM_LowCardNullableColdBuild, LowCardNullableWrapper)->Apply(RegisterArgs_SectionD);
+BENCHMARK_TEMPLATE(BM_LowCardNullableBuildOnly, PhmapInt32NullableWrapper)->Apply(RegisterArgs_SectionD);
+BENCHMARK_TEMPLATE(BM_LowCardNullableBuildOnly, LowCardNullableWrapper)->Apply(RegisterArgs_SectionD);
 
 } // namespace starrocks
 

--- a/be/src/bench/agg_low_card_dict_bench.cpp
+++ b/be/src/bench/agg_low_card_dict_bench.cpp
@@ -1,0 +1,416 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Midi-bench for the low-cardinality global-dict GROUP BY routing.  When FE
+// marks a single bare-SlotRef GROUP BY as dict-encoded (TAggregationNode
+// .low_card_dict_group_by_slots), BE routes through AggHashMapWithLowCard
+// DictKey<SmallFixedSizeHashMap<uint8_t, AggDataPtr>> instead of
+// AggHashMapWithOneNumberKey<TYPE_INT, phmap::flat_hash_map<int32_t, ...>>.
+// Both wrappers accept Int32Column input; the dict wrapper narrows to
+// uint8_t internally and indexes a 256-cell array directly.  ClickHouse
+// parallel: low_cardinality_key8.
+//
+// Driver: production callsite build_hash_map with a production-shaped
+// HashTableKeyAllocator (sizeof(int64_t) state matching COUNT(*)).  Density
+// caps at 255 because dict codes only span [0, 255] under
+// Config.low_cardinality_threshold = 255; higher densities are blocked at
+// FE.  Construction is cheap (256-cell array = ~2 KiB) so Section C is a
+// regression guard, not a primary signal.
+
+#include <base/testutil/assert.h>
+#include <benchmark/benchmark.h>
+
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "base/phmap/phmap.h"
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config_exec_fwd.h"
+#include "common/runtime_profile.h"
+#include "exec/aggregate/agg_hash_map.h"
+#include "exec/aggregate/agg_profile.h"
+#include "exec/aggregator.h"
+#include "runtime/mem_pool.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+inline constexpr int kBenchChunkSize = 4096;
+
+// Baseline: generic Int32 number-key wrapper over phmap.
+template <PhmapSeed seed>
+using PhmapInt32 = phmap::flat_hash_map<int32_t, AggDataPtr, StdHashWithSeed<int32_t, seed>>;
+
+using PhmapInt32Wrapper = AggHashMapWithOneNumberKey<TYPE_INT, PhmapInt32<PhmapSeed1>>;
+using PhmapInt32NullableWrapper = AggHashMapWithOneNullableNumberKey<TYPE_INT, PhmapInt32<PhmapSeed1>>;
+
+// Treatment: AggHashMapWithLowCardDictKey accepts Int32Column input and
+// narrows to uint8_t internally; the hash map is a 256-cell direct array
+// indexed by static_cast<uint8_t>(code).
+using LowCardUInt8Map = SmallFixedSizeHashMap<uint8_t, AggDataPtr, PhmapSeed1>;
+using LowCardWrapper = AggHashMapWithOneLowCardDictKey<LowCardUInt8Map>;
+using LowCardNullableWrapper = AggHashMapWithOneNullableLowCardDictKey<LowCardUInt8Map>;
+
+enum class Distribution : int {
+    Random = 0,
+    Sorted = 1,
+    Clustered64 = 2,
+};
+
+// Production-shaped allocator -- same shape as the SMALLINT bench so the
+// two PR's bench results are comparable when read side by side.
+struct BenchAllocateState {
+    HashTableKeyAllocator* allocator;
+    AggDataPtr operator()(std::nullptr_t) { return allocator->allocate_null_key_data(); }
+    template <typename KeyType>
+    AggDataPtr operator()(KeyType /*key*/) {
+        return allocator->allocate();
+    }
+};
+
+// Generate (num_rows / kBenchChunkSize) Int32 chunks of kBenchChunkSize rows
+// each, each chunk a fresh Int32Column owning its own buffer.  Values are
+// FE-generated dict codes in [0, distinct_count - 1] (distinct_count <= 256).
+class Int32CodeChunkStream {
+public:
+    Int32CodeChunkStream(int64_t num_rows, int distinct_count, Distribution dist) {
+        std::mt19937 rng(0xC0FFEE);
+        std::uniform_int_distribution<int> uni(0, distinct_count > 0 ? distinct_count - 1 : 0);
+        const int64_t num_chunks = (num_rows + kBenchChunkSize - 1) / kBenchChunkSize;
+        _chunks.reserve(num_chunks);
+        for (int64_t c = 0; c < num_chunks; ++c) {
+            auto col = Int32Column::create();
+            auto& data = col->get_data();
+            data.resize(kBenchChunkSize);
+            switch (dist) {
+            case Distribution::Random:
+                for (int i = 0; i < kBenchChunkSize; ++i) {
+                    data[i] = uni(rng);
+                }
+                break;
+            case Distribution::Sorted: {
+                std::vector<int> vals(kBenchChunkSize);
+                for (int i = 0; i < kBenchChunkSize; ++i) vals[i] = uni(rng);
+                std::sort(vals.begin(), vals.end());
+                for (int i = 0; i < kBenchChunkSize; ++i) {
+                    data[i] = vals[i];
+                }
+                break;
+            }
+            case Distribution::Clustered64: {
+                int current = uni(rng);
+                for (int i = 0; i < kBenchChunkSize; ++i) {
+                    if (i > 0 && i % 64 == 0) current = uni(rng);
+                    data[i] = current;
+                }
+                break;
+            }
+            }
+            _chunks.emplace_back(std::move(col));
+        }
+    }
+
+    const std::vector<ColumnPtr>& chunks() const { return _chunks; }
+
+private:
+    std::vector<ColumnPtr> _chunks;
+};
+
+// Same generator wrapped in NullableColumn.
+class NullableInt32CodeChunkStream {
+public:
+    NullableInt32CodeChunkStream(int64_t num_rows, int distinct_count, double null_fraction) {
+        std::mt19937 rng(0xC0FFEE);
+        std::uniform_int_distribution<int> uni(0, distinct_count > 0 ? distinct_count - 1 : 0);
+        std::uniform_real_distribution<double> coin(0.0, 1.0);
+        const int64_t num_chunks = (num_rows + kBenchChunkSize - 1) / kBenchChunkSize;
+        _chunks.reserve(num_chunks);
+        for (int64_t c = 0; c < num_chunks; ++c) {
+            auto data_col = Int32Column::create();
+            auto null_col = NullColumn::create();
+            auto& data = data_col->get_data();
+            auto& nulls = null_col->get_data();
+            data.resize(kBenchChunkSize);
+            nulls.resize(kBenchChunkSize);
+            bool any_null = false;
+            for (int i = 0; i < kBenchChunkSize; ++i) {
+                if (null_fraction > 0 && coin(rng) < null_fraction) {
+                    nulls[i] = 1;
+                    data[i] = 0;
+                    any_null = true;
+                } else {
+                    nulls[i] = 0;
+                    data[i] = uni(rng);
+                }
+            }
+            auto nullable = NullableColumn::create(std::move(data_col), std::move(null_col));
+            nullable->set_has_null(any_null);
+            _chunks.emplace_back(std::move(nullable));
+        }
+    }
+
+    const std::vector<ColumnPtr>& chunks() const { return _chunks; }
+
+private:
+    std::vector<ColumnPtr> _chunks;
+};
+
+class BenchSuite {
+public:
+    void SetUp() {
+        config::vector_chunk_size = kBenchChunkSize;
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        query_options.batch_size = kBenchChunkSize;
+        TQueryGlobals query_globals;
+        _runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
+        _runtime_state->init_instance_mem_tracker();
+        _mem_pool = std::make_unique<MemPool>();
+        _runtime_profile = std::make_unique<RuntimeProfile>("agg_low_card_dict_bench");
+        _agg_stat = std::make_unique<AggStatistics>(_runtime_profile.get());
+    }
+
+    void TearDown() {
+        _agg_stat.reset();
+        _runtime_profile.reset();
+        _mem_pool.reset();
+        _runtime_state.reset();
+    }
+
+    std::shared_ptr<RuntimeState> _runtime_state;
+    std::unique_ptr<MemPool> _mem_pool;
+    std::unique_ptr<RuntimeProfile> _runtime_profile;
+    std::unique_ptr<AggStatistics> _agg_stat;
+};
+
+// ============================================================================
+// Section A — main steady-state win (hash insert only)
+// ============================================================================
+template <typename Wrapper>
+static void BM_LowCardColdBuild(benchmark::State& state) {
+    const int64_t num_rows = state.range(0);
+    const int distinct = static_cast<int>(state.range(1));
+    const Distribution dist = static_cast<Distribution>(state.range(2));
+
+    BenchSuite suite;
+    suite.SetUp();
+    Int32CodeChunkStream stream(num_rows, distinct, dist);
+
+    int64_t total_rows = 0;
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
+        HashTableKeyAllocator allocator;
+        allocator.aggregate_key_size = sizeof(int64_t);
+        allocator.pool = suite._mem_pool.get();
+        BenchAllocateState alloc{&allocator};
+        Buffer<AggDataPtr> agg_states(kBenchChunkSize);
+        state.ResumeTiming();
+
+        for (const auto& chunk_col : stream.chunks()) {
+            Columns key_columns;
+            key_columns.emplace_back(chunk_col);
+            wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
+            total_rows += kBenchChunkSize;
+        }
+
+        state.PauseTiming();
+        wrapper.reset();
+        suite._mem_pool->clear();
+    }
+    state.SetItemsProcessed(total_rows);
+    state.counters["distinct"] = distinct;
+    state.counters["rows_per_iter"] = num_rows;
+
+    suite.TearDown();
+}
+
+// ============================================================================
+// Section A (continued) — hash insert + COUNT(*) update
+// ============================================================================
+template <typename Wrapper>
+static void BM_LowCardColdBuildAndCount(benchmark::State& state) {
+    const int64_t num_rows = state.range(0);
+    const int distinct = static_cast<int>(state.range(1));
+    const Distribution dist = static_cast<Distribution>(state.range(2));
+
+    BenchSuite suite;
+    suite.SetUp();
+    Int32CodeChunkStream stream(num_rows, distinct, dist);
+
+    int64_t total_rows = 0;
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
+        HashTableKeyAllocator allocator;
+        allocator.aggregate_key_size = sizeof(int64_t);
+        allocator.pool = suite._mem_pool.get();
+        BenchAllocateState alloc{&allocator};
+        Buffer<AggDataPtr> agg_states(kBenchChunkSize);
+        state.ResumeTiming();
+
+        for (const auto& chunk_col : stream.chunks()) {
+            Columns key_columns;
+            key_columns.emplace_back(chunk_col);
+            wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
+            for (int i = 0; i < kBenchChunkSize; ++i) {
+                ++(*reinterpret_cast<int64_t*>(agg_states[i]));
+            }
+            total_rows += kBenchChunkSize;
+        }
+
+        state.PauseTiming();
+        wrapper.reset();
+        suite._mem_pool->clear();
+    }
+    state.SetItemsProcessed(total_rows);
+    state.counters["distinct"] = distinct;
+    state.counters["rows_per_iter"] = num_rows;
+
+    suite.TearDown();
+}
+
+// ============================================================================
+// Section C — construction-only cost
+// LowCardUInt8Map is a 257-cell array (~2 KiB heap); phmap starts at zero
+// capacity.  This section just verifies the array path does not regress
+// construction cost in the small-table regime.
+// ============================================================================
+template <typename Wrapper>
+static void BM_LowCardConstruct(benchmark::State& state) {
+    BenchSuite suite;
+    suite.SetUp();
+    for (auto _ : state) {
+        auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
+        benchmark::DoNotOptimize(wrapper.get());
+        state.PauseTiming();
+        wrapper.reset();
+        state.ResumeTiming();
+    }
+    suite.TearDown();
+}
+
+// ============================================================================
+// Section D — nullable coverage
+// ============================================================================
+template <typename Wrapper>
+static void BM_LowCardNullableColdBuild(benchmark::State& state) {
+    const int64_t num_rows = state.range(0);
+    const int distinct = static_cast<int>(state.range(1));
+    const double null_fraction = state.range(2) * 0.01;
+
+    BenchSuite suite;
+    suite.SetUp();
+    NullableInt32CodeChunkStream stream(num_rows, distinct, null_fraction);
+
+    int64_t total_rows = 0;
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto wrapper = std::make_unique<Wrapper>(kBenchChunkSize, suite._agg_stat.get());
+        HashTableKeyAllocator allocator;
+        allocator.aggregate_key_size = sizeof(int64_t);
+        allocator.pool = suite._mem_pool.get();
+        BenchAllocateState alloc{&allocator};
+        Buffer<AggDataPtr> agg_states(kBenchChunkSize);
+        state.ResumeTiming();
+
+        for (const auto& chunk_col : stream.chunks()) {
+            Columns key_columns;
+            key_columns.emplace_back(chunk_col);
+            wrapper->build_hash_map(kBenchChunkSize, key_columns, suite._mem_pool.get(), alloc, &agg_states);
+            total_rows += kBenchChunkSize;
+        }
+
+        state.PauseTiming();
+        wrapper.reset();
+        suite._mem_pool->clear();
+    }
+    state.SetItemsProcessed(total_rows);
+    state.counters["distinct"] = distinct;
+    state.counters["null_pct"] = state.range(2);
+
+    suite.TearDown();
+}
+
+// ============================================================================
+// Args registration
+// ============================================================================
+
+// Section A: density caps at 255 because Config.low_cardinality_threshold
+// = 255 by default; dict codes above 255 are blocked at FE in this PR (see
+// PlanFragmentBuilder.visitPhysicalHashAggregate guard).
+//   1   -> pathological single value
+//   4   -> typical enum bucket
+//   24  -> hour-of-day
+//   100 -> typical low-card column (status, segment)
+//   200 -> deeper realistic GROUP BY low-card range
+//   255 -> threshold ceiling, array fills its full 256-cell table
+static void RegisterArgs_SectionA(benchmark::internal::Benchmark* b) {
+    b->ArgNames({"rows", "distinct", "dist"});
+    constexpr int64_t kRows = 100'000'000;
+    for (int distinct : {1, 4, 24, 100, 200, 255}) {
+        for (int d = 0; d <= 2; ++d) {
+            b->Args({kRows, distinct, d});
+        }
+    }
+    b->Unit(benchmark::kMillisecond);
+    b->Iterations(3);
+}
+
+// Section B: construction-vs-amortization break-even at density=24, sorted.
+// Array's upfront cost is ~2 KiB so we expect break-even at very small
+// row counts; this section confirms it.
+static void RegisterArgs_SectionB(benchmark::internal::Benchmark* b) {
+    b->ArgNames({"rows", "distinct", "dist"});
+    for (int64_t rows : {4'096LL, 100'000LL, 1'000'000LL, 10'000'000LL, 100'000'000LL}) {
+        b->Args({rows, 24, /*Sorted*/ 1});
+    }
+    b->Unit(benchmark::kMillisecond);
+    b->Iterations(3);
+}
+
+// Section D: nullable at density=24, sorted, three null fractions.
+static void RegisterArgs_SectionD(benchmark::internal::Benchmark* b) {
+    b->ArgNames({"rows", "distinct", "null_pct"});
+    constexpr int64_t kRows = 50'000'000;
+    for (int null_pct : {0, 10, 50}) {
+        b->Args({kRows, 24, null_pct});
+    }
+    b->Unit(benchmark::kMillisecond);
+    b->Iterations(3);
+}
+
+BENCHMARK_TEMPLATE(BM_LowCardColdBuild, PhmapInt32Wrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_LowCardColdBuild, LowCardWrapper)->Apply(RegisterArgs_SectionA);
+
+BENCHMARK_TEMPLATE(BM_LowCardColdBuildAndCount, PhmapInt32Wrapper)->Apply(RegisterArgs_SectionA);
+BENCHMARK_TEMPLATE(BM_LowCardColdBuildAndCount, LowCardWrapper)->Apply(RegisterArgs_SectionA);
+
+BENCHMARK_TEMPLATE(BM_LowCardColdBuild, PhmapInt32Wrapper)->Apply(RegisterArgs_SectionB);
+BENCHMARK_TEMPLATE(BM_LowCardColdBuild, LowCardWrapper)->Apply(RegisterArgs_SectionB);
+
+BENCHMARK_TEMPLATE(BM_LowCardConstruct, PhmapInt32Wrapper)->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_LowCardConstruct, LowCardWrapper)->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_LowCardNullableColdBuild, PhmapInt32NullableWrapper)->Apply(RegisterArgs_SectionD);
+BENCHMARK_TEMPLATE(BM_LowCardNullableColdBuild, LowCardNullableWrapper)->Apply(RegisterArgs_SectionD);
+
+} // namespace starrocks
+
+BENCHMARK_MAIN();

--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -61,6 +61,10 @@ template <PhmapSeed seed>
 using Int8AggHashMap = SmallFixedSizeHashMap<int8_t, AggDataPtr, seed>;
 template <PhmapSeed seed>
 using Int16AggHashMap = phmap::flat_hash_map<int16_t, AggDataPtr, StdHashWithSeed<int16_t, seed>>;
+// Dedicated unsigned key for low-cardinality global-dict aggregation: codes
+// 128..255 must not be sign-extended on reinterpret_cast<KeyType*>(state).
+template <PhmapSeed seed>
+using LowCardDictUInt8AggHashMap = SmallFixedSizeHashMap<uint8_t, AggDataPtr, seed>;
 template <PhmapSeed seed>
 using Int32AggHashMap = phmap::flat_hash_map<int32_t, AggDataPtr, StdHashWithSeed<int32_t, seed>>;
 template <PhmapSeed seed>
@@ -446,6 +450,165 @@ template <LogicalType logical_type, typename HashMap>
 using AggHashMapWithOneNumberKey = AggHashMapWithOneNumberKeyWithNullable<logical_type, HashMap, false>;
 template <LogicalType logical_type, typename HashMap>
 using AggHashMapWithOneNullableNumberKey = AggHashMapWithOneNumberKeyWithNullable<logical_type, HashMap, true>;
+
+// ==============================================================
+// handle one number hash key whose values are global-dict codes
+//
+// Models ClickHouse's AggregationMethodSingleLowCardinalityColumn over
+// AggregationMethodOneNumber<UInt8, ...>. The FE rewrites a GROUP BY on a
+// low-cardinality string column into a GROUP BY on Int32 dict codes; this
+// wrapper reads that Int32Column, narrows each code to a uint8_t index into
+// SmallFixedSizeHashMap<uint8_t, AggDataPtr, seed> (a 256-cell array), and
+// writes the code back out as int32 on iteration. uint8_t is mandatory:
+// int8_t would round-trip codes 128..255 through reinterpret_cast as -128..-1.
+template <typename HashMap, bool is_nullable = false>
+struct AggHashMapWithLowCardDictKey
+        : public AggHashMapWithKey<HashMap, AggHashMapWithLowCardDictKey<HashMap, is_nullable>> {
+    using Self = AggHashMapWithLowCardDictKey<HashMap, is_nullable>;
+    using Base = AggHashMapWithKey<HashMap, Self>;
+    using KeyType = typename HashMap::key_type;
+    using Iterator = typename HashMap::iterator;
+    using ColumnType = Int32Column;
+    using ResultVector = typename ColumnType::Container;
+    using FieldType = int32_t;
+
+    static_assert(std::is_unsigned_v<KeyType>,
+                  "dict codes must use unsigned key to survive reinterpret_cast round-trip");
+
+    template <class... Args>
+    AggHashMapWithLowCardDictKey(Args&&... args) : Base(std::forward<Args>(args)...) {}
+
+    AggDataPtr get_null_key_data() { return null_key_data; }
+    void set_null_key_data(AggDataPtr data) { null_key_data = data; }
+
+    template <AllocFunc<Self> Func, typename HTBuildOp>
+    void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
+                            Buffer<AggDataPtr>* agg_states, ExtraAggParam* extra) {
+        auto key_column = key_columns[0].get();
+        if constexpr (is_nullable) {
+            return this->template compute_agg_states_nullable<Func, HTBuildOp>(
+                    chunk_size, key_column, pool, std::forward<Func>(allocate_func), agg_states, extra);
+        } else {
+            return this->template compute_agg_states_non_nullable<Func, HTBuildOp>(
+                    chunk_size, key_column, pool, std::forward<Func>(allocate_func), agg_states, extra);
+        }
+    }
+
+    template <AllocFunc<Self> Func, typename HTBuildOp>
+    ALWAYS_NOINLINE void compute_agg_states_non_nullable(size_t chunk_size, const Column* key_column, MemPool* pool,
+                                                         Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
+                                                         ExtraAggParam* extra) {
+        DCHECK(!key_column->is_nullable());
+        const auto* column = down_cast<const ColumnType*>(key_column);
+        const auto container = column->immutable_data();
+        size_t hash_table_size = this->hash_map.size();
+        auto* __restrict not_founds = extra->not_founds;
+        for (size_t i = 0; i < chunk_size; i++) {
+            const KeyType key = static_cast<KeyType>(container[i]);
+            if constexpr (HTBuildOp::process_limit) {
+                if (hash_table_size < extra->limits) {
+                    _emplace_key(key, (*agg_states)[i], allocate_func, [&]() { hash_table_size++; });
+                } else {
+                    _find_key((*agg_states)[i], (*not_founds)[i], key);
+                }
+            } else if constexpr (HTBuildOp::allocate) {
+                _emplace_key(key, (*agg_states)[i], allocate_func,
+                             FillNotFounds<HTBuildOp::fill_not_found>(not_founds, i));
+            } else if constexpr (HTBuildOp::fill_not_found) {
+                _find_key((*agg_states)[i], (*not_founds)[i], key);
+            }
+        }
+    }
+
+    template <AllocFunc<Self> Func, typename HTBuildOp>
+    ALWAYS_NOINLINE void compute_agg_states_nullable(size_t chunk_size, const Column* key_column, MemPool* pool,
+                                                     Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
+                                                     ExtraAggParam* extra) {
+        if (key_column->only_null()) {
+            if (null_key_data == nullptr) {
+                null_key_data = allocate_func(nullptr);
+            }
+            for (size_t i = 0; i < chunk_size; i++) {
+                (*agg_states)[i] = null_key_data;
+            }
+            return;
+        }
+        DCHECK(key_column->is_nullable());
+        const auto* nullable_column = down_cast<const NullableColumn*>(key_column);
+        const auto* data_column = down_cast<const ColumnType*>(nullable_column->data_column().get());
+        if (!nullable_column->has_null()) {
+            return compute_agg_states_non_nullable<Func, HTBuildOp>(
+                    chunk_size, data_column, pool, std::forward<Func>(allocate_func), agg_states, extra);
+        }
+        const auto container = data_column->immutable_data();
+        const auto& null_data = nullable_column->null_column_data();
+        size_t hash_table_size = this->hash_map.size();
+        auto* __restrict not_founds = extra->not_founds;
+        for (size_t i = 0; i < chunk_size; i++) {
+            if (null_data[i]) {
+                if (UNLIKELY(null_key_data == nullptr)) {
+                    null_key_data = allocate_func(nullptr);
+                }
+                (*agg_states)[i] = null_key_data;
+            } else {
+                const KeyType key = static_cast<KeyType>(container[i]);
+                if constexpr (HTBuildOp::process_limit) {
+                    if (hash_table_size < extra->limits) {
+                        _emplace_key(key, (*agg_states)[i], allocate_func, [&]() { hash_table_size++; });
+                    } else {
+                        _find_key((*agg_states)[i], (*not_founds)[i], key);
+                    }
+                } else if constexpr (HTBuildOp::allocate) {
+                    _emplace_key(key, (*agg_states)[i], allocate_func,
+                                 FillNotFounds<HTBuildOp::fill_not_found>(not_founds, i));
+                } else if constexpr (HTBuildOp::fill_not_found) {
+                    _find_key((*agg_states)[i], (*not_founds)[i], key);
+                }
+            }
+        }
+    }
+
+    template <AllocFunc<Self> Func, typename EmplaceCallBack>
+    ALWAYS_INLINE void _emplace_key(KeyType key, AggDataPtr& target_state, Func&& allocate_func,
+                                    EmplaceCallBack&& callback) {
+        auto iter = this->hash_map.lazy_emplace(key, [&](const auto& ctor) {
+            callback();
+            AggDataPtr pv = allocate_func(key);
+            ctor(key, pv);
+        });
+        target_state = iter->second;
+    }
+
+    ALWAYS_INLINE void _find_key(AggDataPtr& target_state, uint8_t& not_found, KeyType key) {
+        if (auto iter = this->hash_map.find(key); iter != this->hash_map.end()) {
+            target_state = iter->second;
+        } else {
+            not_found = 1;
+        }
+    }
+
+    void insert_keys_to_columns(const ResultVector& keys, MutableColumns& key_columns, size_t chunk_size) {
+        if constexpr (is_nullable) {
+            auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
+            auto* column = down_cast<ColumnType*>(nullable_column->data_column_raw_ptr());
+            column->get_data().insert(column->get_data().end(), keys.begin(), keys.begin() + chunk_size);
+            nullable_column->null_column_data().resize(chunk_size);
+        } else {
+            DCHECK(!null_key_data);
+            auto* column = down_cast<ColumnType*>(key_columns[0].get());
+            column->get_data().insert(column->get_data().end(), keys.begin(), keys.begin() + chunk_size);
+        }
+    }
+
+    static constexpr bool has_single_null_key = is_nullable;
+    AggDataPtr null_key_data = nullptr;
+    ResultVector results;
+};
+
+template <typename HashMap>
+using AggHashMapWithOneLowCardDictKey = AggHashMapWithLowCardDictKey<HashMap, false>;
+template <typename HashMap>
+using AggHashMapWithOneNullableLowCardDictKey = AggHashMapWithLowCardDictKey<HashMap, true>;
 
 template <typename HashMap, bool is_nullable>
 struct AggHashMapWithOneStringKeyWithNullable

--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -100,6 +100,16 @@
     M(phase2_slice_cx8)              \
     M(phase2_slice_cx16)
 
+#define APPLY_FOR_AGG_MAP_VARIANT_EXTRA(M) \
+    M(phase1_low_card_dict_uint8)          \
+    M(phase1_null_low_card_dict_uint8)     \
+    M(phase2_low_card_dict_uint8)          \
+    M(phase2_null_low_card_dict_uint8)
+
+#define APPLY_FOR_AGG_MAP_VARIANT_ALL(M) \
+    APPLY_FOR_AGG_VARIANT_ALL(M)         \
+    APPLY_FOR_AGG_MAP_VARIANT_EXTRA(M)
+
 namespace starrocks {
 namespace detail {
 template <AggHashMapVariant::Type>
@@ -187,6 +197,11 @@ DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_cx1, CompressedFixedSize1A
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_cx4, CompressedFixedSize4AggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_cx8, CompressedFixedSize8AggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_cx16, CompressedFixedSize16AggHashMap<PhmapSeed2>);
+
+DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_low_card_dict_uint8, LowCardDictAggHashMapWithKey<PhmapSeed1>);
+DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_null_low_card_dict_uint8, NullLowCardDictAggHashMapWithKey<PhmapSeed1>);
+DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_low_card_dict_uint8, LowCardDictAggHashMapWithKey<PhmapSeed2>);
+DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_null_low_card_dict_uint8, NullLowCardDictAggHashMapWithKey<PhmapSeed2>);
 
 template <AggHashSetVariant::Type>
 struct AggHashSetVariantTypeTraits;
@@ -287,7 +302,7 @@ void AggHashMapVariant::init(RuntimeState* state, Type type, AggStatistics* agg_
         hash_map_with_key = std::make_unique<detail::AggHashMapVariantTypeTraits<Type::NAME>::HashMapWithKeyType>( \
                 state->chunk_size(), _agg_stat);                                                                   \
         break;
-        APPLY_FOR_AGG_VARIANT_ALL(M)
+        APPLY_FOR_AGG_MAP_VARIANT_ALL(M)
 #undef M
     }
 }

--- a/be/src/exec/aggregate/agg_hash_variant.h
+++ b/be/src/exec/aggregate/agg_hash_variant.h
@@ -109,6 +109,12 @@ using SerializedKeyFixedSize8AggHashMap = AggHashMapWithSerializedKeyFixedSize<F
 template <PhmapSeed seed>
 using SerializedKeyFixedSize16AggHashMap = AggHashMapWithSerializedKeyFixedSize<FixedSize16SliceAggHashMap<seed>>;
 
+// low-cardinality global-dict GROUP BY key (Int32Column of codes in [0, 256))
+template <PhmapSeed seed>
+using LowCardDictAggHashMapWithKey = AggHashMapWithOneLowCardDictKey<LowCardDictUInt8AggHashMap<seed>>;
+template <PhmapSeed seed>
+using NullLowCardDictAggHashMapWithKey = AggHashMapWithOneNullableLowCardDictKey<LowCardDictUInt8AggHashMap<seed>>;
+
 // fixed compress key
 template <PhmapSeed seed>
 using CompressedFixedSize1AggHashMap = AggHashMapWithCompressedKeyFixedSize<Int8AggHashMap<seed>>;
@@ -304,6 +310,8 @@ using AggHashMapWithKeyPtr = std::variant<
         std::unique_ptr<CompressedFixedSize4AggHashMap<PhmapSeed1>>,
         std::unique_ptr<CompressedFixedSize8AggHashMap<PhmapSeed1>>,
         std::unique_ptr<CompressedFixedSize16AggHashMap<PhmapSeed1>>,
+        std::unique_ptr<LowCardDictAggHashMapWithKey<PhmapSeed1>>,
+        std::unique_ptr<NullLowCardDictAggHashMapWithKey<PhmapSeed1>>,
         std::unique_ptr<UInt8AggHashMapWithOneNumberKey<PhmapSeed2>>,
         std::unique_ptr<Int8AggHashMapWithOneNumberKey<PhmapSeed2>>,
         std::unique_ptr<Int16AggHashMapWithOneNumberKey<PhmapSeed2>>,
@@ -340,7 +348,9 @@ using AggHashMapWithKeyPtr = std::variant<
         std::unique_ptr<CompressedFixedSize1AggHashMap<PhmapSeed2>>,
         std::unique_ptr<CompressedFixedSize4AggHashMap<PhmapSeed2>>,
         std::unique_ptr<CompressedFixedSize8AggHashMap<PhmapSeed2>>,
-        std::unique_ptr<CompressedFixedSize16AggHashMap<PhmapSeed2>>>;
+        std::unique_ptr<CompressedFixedSize16AggHashMap<PhmapSeed2>>,
+        std::unique_ptr<LowCardDictAggHashMapWithKey<PhmapSeed2>>,
+        std::unique_ptr<NullLowCardDictAggHashMapWithKey<PhmapSeed2>>>;
 
 using AggHashSetWithKeyPtr = std::variant<
         std::unique_ptr<UInt8AggHashSetOfOneNumberKey<PhmapSeed1>>,
@@ -462,6 +472,9 @@ struct AggHashMapVariant {
         phase1_slice_cx8,
         phase1_slice_cx16,
 
+        phase1_low_card_dict_uint8,
+        phase1_null_low_card_dict_uint8,
+
         phase2_uint8,
         phase2_int8,
         phase2_int16,
@@ -502,6 +515,9 @@ struct AggHashMapVariant {
         phase2_slice_cx4,
         phase2_slice_cx8,
         phase2_slice_cx16,
+
+        phase2_low_card_dict_uint8,
+        phase2_null_low_card_dict_uint8,
     };
 
     detail::AggHashMapWithKeyPtr hash_map_with_key;

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -34,12 +34,14 @@
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/agg/aggregate_state_allocator.h"
 #include "exprs/agg/combinator/agg_state_utils.h"
+#include "exprs/column_ref.h"
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
 #include "exprs/literal.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
+#include "runtime/global_dict/config.h"
 #include "runtime/runtime_state.h"
 #include "types/logical_type.h"
 #ifndef __APPLE__
@@ -193,6 +195,10 @@ AggregatorParamsPtr convert_to_aggregator_params(const TPlanNode& tnode) {
                 tnode.agg_node.__isset.enable_pipeline_share_limit ? tnode.agg_node.enable_pipeline_share_limit : false;
         params->grouping_min_max =
                 tnode.agg_node.__isset.group_by_min_max ? tnode.agg_node.group_by_min_max : std::vector<TExpr>{};
+        if (tnode.agg_node.__isset.low_card_dict_group_by_slots) {
+            params->low_card_dict_group_by_slots.assign(tnode.agg_node.low_card_dict_group_by_slots.begin(),
+                                                        tnode.agg_node.low_card_dict_group_by_slots.end());
+        }
 
         break;
     }
@@ -471,6 +477,16 @@ Status Aggregator::prepare(RuntimeState* state, RuntimeProfile* runtime_profile)
     _group_by_columns.resize(group_by_size);
     _group_by_types = _params->group_by_types;
     _has_nullable_key = _params->has_nullable_key;
+
+    // Surface global-dict GROUP BY routing in the Aggregator profile so a
+    // profile diff makes it obvious which queries qualified for the
+    // array-table path even when FE-side marker analysis missed (the BE
+    // routing decision in _get_hash_table_type() is the authoritative one,
+    // but this info string is the visible signal).
+    if (_runtime_profile != nullptr && !_params->low_card_dict_group_by_slots.empty()) {
+        _runtime_profile->add_info_string("LowCardDictGroupBySlots",
+                                          std::to_string(_params->low_card_dict_group_by_slots.size()));
+    }
 
     _tmp_agg_states.resize(_state->chunk_size());
 
@@ -1494,8 +1510,31 @@ typename HashVariantType::Type Aggregator::_get_hash_table_type() {
     // using one key hash table
     if (_group_by_types.size() == 1) {
         bool nullable = _group_by_types[0].is_nullable;
-        LogicalType type = _group_by_types[0].result_type.type;
-        return HashVariantResolver<HashVariantType>::instance().get_unary_type(_aggr_phase, type, nullable);
+        LogicalType ltype = _group_by_types[0].result_type.type;
+
+        // Single low-cardinality global-dict GROUP BY: route to a direct
+        // array-table (SmallFixedSizeHashMap<uint8_t,...>). FE marks the slot
+        // explicitly; we verify the lone group-by expression is a bare
+        // SlotRef matching that slot.
+        if constexpr (std::is_same_v<HashVariantType, AggHashMapVariant>) {
+            const bool session_gate = _state == nullptr || _state->enable_agg_low_card_dict_array_table();
+            if (session_gate && ltype == LowCardDictType && !_params->low_card_dict_group_by_slots.empty() &&
+                _group_by_expr_ctxs.size() == 1 && _group_by_expr_ctxs[0]->root()->is_slotref()) {
+                auto* ref = down_cast<ColumnRef*>(_group_by_expr_ctxs[0]->root());
+                SlotId sid = ref->slot_id();
+                if (std::find(_params->low_card_dict_group_by_slots.begin(),
+                              _params->low_card_dict_group_by_slots.end(),
+                              sid) != _params->low_card_dict_group_by_slots.end()) {
+                    return _aggr_phase == AggrPhase1
+                                   ? (nullable ? HashVariantType::Type::phase1_null_low_card_dict_uint8
+                                               : HashVariantType::Type::phase1_low_card_dict_uint8)
+                                   : (nullable ? HashVariantType::Type::phase2_null_low_card_dict_uint8
+                                               : HashVariantType::Type::phase2_low_card_dict_uint8);
+                }
+            }
+        }
+
+        return HashVariantResolver<HashVariantType>::instance().get_unary_type(_aggr_phase, ltype, nullable);
     }
     return type;
 }
@@ -1601,11 +1640,27 @@ template <typename HashVariantType>
 void Aggregator::_init_agg_hash_variant(HashVariantType& hash_variant) {
     auto type = _get_hash_table_type<HashVariantType>();
 
+    // The low-card global-dict array-table is a more specific choice than
+    // bit-compressed key: ApplyMinMaxStatisticRule fills 0..dictSize ranges
+    // for the same group-by, which makes _try_to_apply_compressed_key_opt
+    // overwrite the dict-uint8 routing back to slice_cx1/cx4 and trade a
+    // direct 256-cell lookup for a phmap-on-compressed-key path. Skip the
+    // compression rewrite when we already picked the low-card map.
+    bool is_low_card_dict_path = false;
+    if constexpr (std::is_same_v<HashVariantType, AggHashMapVariant>) {
+        using T = typename HashVariantType::Type;
+        is_low_card_dict_path =
+                (type == T::phase1_low_card_dict_uint8 || type == T::phase2_low_card_dict_uint8 ||
+                 type == T::phase1_null_low_card_dict_uint8 || type == T::phase2_null_low_card_dict_uint8);
+    }
+
     CompressKeyContext compress_key_ctx;
     bool apply_compress_key_opt = false;
     typename HashVariantType::Type prev_type = type;
-    type = _try_to_apply_compressed_key_opt<HashVariantType>(type, &compress_key_ctx);
-    apply_compress_key_opt = prev_type != type;
+    if (!is_low_card_dict_path) {
+        type = _try_to_apply_compressed_key_opt<HashVariantType>(type, &compress_key_ctx);
+        apply_compress_key_opt = prev_type != type;
+    }
     if (apply_compress_key_opt) {
         // build with compressed key
         VLOG_ROW << "apply compressed key";

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -225,6 +225,10 @@ struct AggregatorParams {
     std::vector<TExpr> intermediate_aggr_exprs;
     std::vector<TExpr> grouping_min_max;
 
+    // SlotIds whose corresponding group-by key is a global-dict code (TYPE_INT
+    // bounded by DICT_DECODE_MAX_SIZE). Routes to a direct array-table.
+    std::vector<int32_t> low_card_dict_group_by_slots;
+
     // Incremental MV
     // Whether it's testing, use MemStateTable in testing, instead use IMTStateTable.
     bool is_testing;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -515,7 +515,6 @@ public:
                _query_options.enable_agg_low_card_dict_array_table;
     }
 
-
     const std::vector<TTabletCommitInfo>& tablet_commit_infos() const { return _tablet_commit_infos; }
 
     std::vector<TTabletCommitInfo>& tablet_commit_infos() { return _tablet_commit_infos; }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -509,6 +509,13 @@ public:
                _query_options.enable_hash_join_serialize_fixed_size_string;
     }
 
+    // Aggregation: single-key low-cardinality global-dict array-table routing.
+    bool enable_agg_low_card_dict_array_table() const {
+        return !_query_options.__isset.enable_agg_low_card_dict_array_table ||
+               _query_options.enable_agg_low_card_dict_array_table;
+    }
+
+
     const std::vector<TTabletCommitInfo>& tablet_commit_infos() const { return _tablet_commit_infos; }
 
     std::vector<TTabletCommitInfo>& tablet_commit_infos() { return _tablet_commit_infos; }

--- a/be/test/exec/agg_hash_map_test.cpp
+++ b/be/test/exec/agg_hash_map_test.cpp
@@ -226,7 +226,6 @@ TEST(LowCardDictAggHashMapTest, RoundTripHighCodes) {
     ASSERT_EQ(read_key(agg_states[3]), 255);
 }
 
-
 class AggHashMapKeyNotFoundsTest : public ::testing::Test {
 public:
     template <typename HashMapWithKey>

--- a/be/test/exec/agg_hash_map_test.cpp
+++ b/be/test/exec/agg_hash_map_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <any>
+#include <cstring>
 
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
@@ -177,6 +178,54 @@ TEST(HashMapTest, TwoLevelConvert) {
         ASSERT_TRUE(two_level_set.contains(key));
     }
 }
+
+// Codes above 127 must survive the int32->uint8->int32 round-trip exposed by
+// reinterpret_cast on the state block. int8_t would yield negative results.
+TEST(LowCardDictAggHashMapTest, RoundTripHighCodes) {
+    RuntimeProfile profile("LowCardDictAggHashMapTest");
+    AggStatistics statis(&profile);
+
+    using HashMapWithKey = LowCardDictAggHashMapWithKey<PhmapSeed1>;
+    HashMapWithKey hash_map_with_key(1024, &statis);
+
+    MemPool pool;
+    const int32_t chunk_size = 4;
+    Buffer<AggDataPtr> agg_states(chunk_size);
+
+    auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+    col->append_datum(Datum(int32_t{0}));
+    col->append_datum(Datum(int32_t{1}));
+    col->append_datum(Datum(int32_t{200}));
+    col->append_datum(Datum(int32_t{255}));
+
+    Columns key_columns;
+    key_columns.emplace_back(std::move(col));
+
+    // mirrors AllocateState in aggregator.cpp: leading bytes of the state block
+    // hold the key. This is the read path the iteration loop relies on.
+    auto allocate_func = [&pool](const auto& key) {
+        AggDataPtr p = pool.allocate(16);
+        std::memset(p, 0, 16);
+        if constexpr (!std::is_same_v<std::decay_t<decltype(key)>, std::nullptr_t>) {
+            using K = std::decay_t<decltype(key)>;
+            *reinterpret_cast<K*>(p) = key;
+        }
+        return p;
+    };
+    hash_map_with_key.build_hash_map(chunk_size, key_columns, &pool, allocate_func, &agg_states);
+
+    ASSERT_EQ(hash_map_with_key.hash_map.size(), 4);
+    // simulate the readback path that aggregator.cpp uses on iteration
+    auto read_key = [](AggDataPtr state) -> int32_t {
+        using KeyType = typename HashMapWithKey::HashMapType::key_type;
+        return static_cast<int32_t>(*reinterpret_cast<KeyType*>(state));
+    };
+    ASSERT_EQ(read_key(agg_states[0]), 0);
+    ASSERT_EQ(read_key(agg_states[1]), 1);
+    ASSERT_EQ(read_key(agg_states[2]), 200);
+    ASSERT_EQ(read_key(agg_states[3]), 255);
+}
+
 
 class AggHashMapKeyNotFoundsTest : public ::testing::Test {
 public:

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2466,6 +2466,15 @@ public class Config extends ConfigBase {
     @ConfField
     public static int dict_collect_thread_pool_for_lake_size = 4;
 
+    // WARNING: BE's low-card-dict array-table aggregation path narrows dict
+    // codes to uint8_t (256-cell direct array, mirroring ClickHouse's
+    // low_cardinality_key8).  Raising this above 255 would let codes 256+
+    // silently collapse onto the same bucket and return wrong GROUP BY
+    // results.  PlanFragmentBuilder gates the FE-side slot marking on
+    // `low_cardinality_threshold <= 255` so the BE never sees a slot that
+    // it cannot represent, but if you change the upper bound here you must
+    // also revisit `AggHashMapWithLowCardDictKey` and the FE guard in
+    // PlanFragmentBuilder.visitPhysicalHashAggregate.
     @ConfField
     public static int low_cardinality_threshold = 255;
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -119,6 +119,10 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
     private SortInfo topNSortInfo;
     private long topNLimit = -1;
 
+    // SlotIds of group-by keys that are physically encoded as global-dict codes.
+    // Routes the BE aggregator to a direct array-table for the single-key case.
+    private List<Integer> lowCardDictGroupBySlots = Lists.newArrayList();
+
     /**
      * Create an agg node that is not an intermediate node.
      * isIntermediate is true if it is a slave node in a 2-part agg plan.
@@ -188,6 +192,10 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
 
     public void setGroupByMinMaxStats(List<Pair<ConstantOperator, ConstantOperator>> groupByMinMaxStats) {
         this.groupByMinMaxStats = groupByMinMaxStats;
+    }
+
+    public void setLowCardDictGroupBySlots(List<Integer> slots) {
+        this.lowCardDictGroupBySlots = slots;
     }
 
     @Override
@@ -332,6 +340,10 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
             List<TRuntimeFilterDescription> tRuntimeFilterDescriptions =
                     RuntimeFilterDescription.toThriftRuntimeFilterDescriptions(buildRuntimeFilters);
             msg.agg_node.setBuild_runtime_filters(tRuntimeFilterDescriptions);
+        }
+
+        if (lowCardDictGroupBySlots != null && !lowCardDictGroupBySlots.isEmpty()) {
+            msg.agg_node.setLow_card_dict_group_by_slots(lowCardDictGroupBySlots);
         }
 
         msg.agg_node.setHas_outer_join_child(hasNullableGenerateChild);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -596,6 +596,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_JOIN_RUNTIME_FILTER_PUSH_DOWN = "enable_join_runtime_filter_push_down";
     public static final String ENABLE_JOIN_RUNTIME_BITSET_FILTER = "enable_join_runtime_bitset_filter";
 
+    public static final String ENABLE_AGG_LOW_CARD_DICT_ARRAY_TABLE = "enable_agg_low_card_dict_array_table";
+
+
     public static final String ENABLE_HASH_JOIN_RANGE_DIRECT_MAPPING_OPT = "enable_hash_join_range_direct_mapping_opt";
     public static final String ENABLE_HASH_JOIN_LINEAR_CHAINED_OPT = "enable_hash_join_linear_chained_opt";
     public static final String ENABLE_HASH_JOIN_SERIALIZE_FIXED_SIZE_STRING = "enable_hash_join_serialize_fixed_size_string";
@@ -1994,6 +1997,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableJoinRuntimeFilterPushDown = true;
     @VariableMgr.VarAttr(name = ENABLE_JOIN_RUNTIME_BITSET_FILTER, flag = VariableMgr.INVISIBLE)
     private boolean enableJoinRuntimeBitsetFilter = true;
+
+    @VarAttr(name = ENABLE_AGG_LOW_CARD_DICT_ARRAY_TABLE)
+    private boolean enableAggLowCardDictArrayTable = true;
+
+    public boolean isEnableAggLowCardDictArrayTable() {
+        return enableAggLowCardDictArrayTable;
+    }
+
 
     @VarAttr(name = ENABLE_HASH_JOIN_RANGE_DIRECT_MAPPING_OPT)
     private boolean enableHashJoinRangeDirectMappingOpt = true;
@@ -6482,6 +6493,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_hash_join_range_direct_mapping_opt(enableHashJoinRangeDirectMappingOpt);
         tResult.setEnable_hash_join_linear_chained_opt(enableHashJoinLinearChainedOpt);
         tResult.setEnable_hash_join_serialize_fixed_size_string(enableHashJoinSerializeFixedSizeString);
+        tResult.setEnable_agg_low_card_dict_array_table(enableAggLowCardDictArrayTable);
 
         // http_request function SSL verification (admin-enforced setting from Config)
         tResult.setHttp_request_ssl_verification_required(Config.http_request_ssl_verification_required);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2675,6 +2675,31 @@ public class PlanFragmentBuilder {
             aggregationNode.computeStatistics(optExpr.getStatistics());
             aggregationNode.setGroupByMinMaxStats(node.getGroupByMinMaxStatistic());
 
+            // Flag group-by slots that are physically dict-encoded codes (TYPE_INT
+            // in [0, DICT_DECODE_MAX_SIZE)). BE uses this to route a single-key
+            // aggregation into a direct array-table indexed by uint8_t code, so
+            // dictionaries that can hold codes >= 256 would silently narrow and
+            // collapse distinct values; require the FE-side threshold to stay
+            // within that range.
+            // Session-gated so it can be bisected against a regression.
+            if (ConnectContext.get().getSessionVariable().isEnableAggLowCardDictArrayTable()
+                    && Config.low_cardinality_threshold <= 255
+                    && groupBys != null && !groupBys.isEmpty()
+                    && inputFragment.getQueryGlobalDicts() != null
+                    && !inputFragment.getQueryGlobalDicts().isEmpty()) {
+                Set<Integer> dictColumnIds = inputFragment.getQueryGlobalDicts().stream()
+                        .map(p -> p.first).collect(Collectors.toSet());
+                List<Integer> lowCardDictSlots = Lists.newArrayList();
+                for (ColumnRefOperator gb : groupBys) {
+                    if (gb.getType().isInt() && dictColumnIds.contains(gb.getId())) {
+                        lowCardDictSlots.add(gb.getId());
+                    }
+                }
+                if (!lowCardDictSlots.isEmpty()) {
+                    aggregationNode.setLowCardDictGroupBySlots(lowCardDictSlots);
+                }
+            }
+
             if (node.isOnePhaseAgg() || node.isMergedLocalAgg() || node.getType().isDistinctGlobal() ||
                     node.getType().isGlobal()) {
                 // For ScanNode->LocalShuffle->AggNode, we needn't assign scan ranges per driver sequence.

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -359,6 +359,7 @@ struct TQueryOptions {
   162: optional bool enable_hash_join_range_direct_mapping_opt;
   163: optional bool enable_hash_join_linear_chained_opt;
   164: optional bool enable_hash_join_serialize_fixed_size_string;
+  165: optional bool enable_agg_low_card_dict_array_table;
 
   170: optional bool enable_parquet_reader_bloom_filter;
   171: optional bool enable_parquet_reader_page_index;

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -953,6 +953,12 @@ struct TAggregationNode {
 
   31: optional list<Exprs.TExpr> group_by_min_max
 
+  // SlotIds of group-by keys that are physically encoded as global-dict codes
+  // (TYPE_INT in range [0, DICT_DECODE_MAX_SIZE)). BE uses this to route a
+  // single-key aggregation into a direct array-table (SmallFixedSizeHashMap)
+  // instead of a hash map.
+  32: optional list<i32> low_card_dict_group_by_slots
+
 }
 
 struct TRepeatNode {


### PR DESCRIPTION
Fixes #73589.

## Why I'm doing:

After the FE's low-cardinality rewrite, a `GROUP BY` on a global-dict-
encoded string column becomes a `GROUP BY` on an `Int32Column` of dict
codes bounded by `DICT_DECODE_MAX_SIZE` (256).  Today such queries go
through `Int32AggHashMapWithOneNumberKey` (`phmap::flat_hash_map<int32_t>`)
and pay the full hash + probe + key-compare cost even though the key
space is at most 256 values and would fit in a direct-indexed array.
ClickHouse ships the same shape as `low_cardinality_key8`.

## What I'm doing:

Route these queries through a direct 256-cell
`SmallFixedSizeHashMap<uint8_t>` instead.  Two new variant types
(`phase{1,2}_low_card_dict_uint8` plus nullable counterparts) plus a
wrapper `AggHashMapWithLowCardDictKey` that reads `Int32Column`,
narrows each code to `uint8_t` once, and writes back as `int32` on
iteration.

### How the route is picked

The FE marks dict-encoded group-by slots in a new `TAggregationNode`
field `low_card_dict_group_by_slots` (`PlanFragmentBuilder`).  BE routes
into the new variant only when the lone group-by expression is a bare
`SlotRef` matching one of those slots, so a plain `TYPE_INT` `GROUP BY`
on an unrelated integer column is unaffected.

### Why `uint8_t` (not `int8_t`)

`int8_t` would round-trip codes 128..255 through
`reinterpret_cast<KeyType*>(state)` as -128..-1 and sign-extend negative
on iteration.  `static_assert(std::is_unsigned_v<KeyType>)` on the
wrapper locks this.  A UT (`agg_hash_map_test.cpp:LowCardDictAggHashMapTest.RoundTripHighCodes`)
exercises key=255 to lock the invariant.

### Bounds safety

Routing assumes codes fit in `uint8_t`, so the FE additionally requires
`Config.low_cardinality_threshold <= 255` before marking any slot
(`PlanFragmentBuilder.java:2686`).  Without that guard a future config
change that raised the threshold would let dictionaries grow into
codes 256+ that silently narrow to `uint8_t` and collapse distinct
dictionary values into the same bucket.  A comment on
`Config.low_cardinality_threshold` calls out the BE coupling so a
future change to the upper bound is forced to revisit this path.

### Compressed-key skip

`ApplyMinMaxStatisticRule` fills a 0..dictSize range for the same
dict-encoded group-by, so without intervention
`_try_to_apply_compressed_key_opt` observes a tiny bit width and
rewrites the variant from `low_card_dict_uint8` back to `slice_cx1/cx4` —
trading a direct 256-cell lookup for a hash map on a bit-compressed
key.  `_init_agg_hash_variant` detects the dict-uint8 routing and
skips the compressed-key rewrite so the intended path actually runs.

### Session gate

Session-gated by `enable_agg_low_card_dict_array_table` (default true).
Following the same convention as other `enable_agg_*` opts in the BE
(`enable_global_runtime_filter*`, `enable_join_runtime_*`, etc.) so a
regression can be bisected per query without a BE redeploy.

### Profile signal

When the slot list is non-empty, Aggregator emits
`LowCardDictGroupBySlots = <count>` as an info string so a profile diff
makes the routing decision visible.

### Bench

`be/src/bench/agg_low_card_dict_bench.cpp` instantiates the phmap
baseline (`AggHashMapWithOneNumberKey<TYPE_INT, phmap::flat_hash_map<int32_t, AggDataPtr>>`)
and the array treatment (`AggHashMapWithOneLowCardDictKey<SmallFixedSizeHashMap<uint8_t, AggDataPtr>>`)
side-by-side and drives both through the production callsite
`build_hash_map` with a production-shaped `HashTableKeyAllocator`
(`sizeof(int64_t)` state matching `COUNT(*)`).

Sections:
- **A**: density {1, 4, 24, 100, 200, 255} × distribution
  {random, sorted, clustered-run-length-64, Zipf s=1.5} at 100M rows.
  Density caps at 255 because `Config.low_cardinality_threshold = 255`
  is the FE guard ceiling.  Hash-only (`BM_LowCardBuildOnly`) and
  hash + COUNT(*) update (`BM_LowCardBuildAndCount`).
- **B**: construction-vs-amortization break-even at density=24, sorted,
  rows {4K, 100K, 1M, 10M, 100M}.  Array path's ~2 KiB upfront cost is
  trivial so break-even sits at very small row counts.
- **C**: construct-only regression guard (`BM_LowCardConstruct`).
- **D**: nullable coverage at null fractions {0%, 10%, 50%} exercising
  both the no-nulls fall-through and the per-row null-bit-aware loop.

#### Results (100M rows, median, x86_64 r6a.xlarge, ASLR on)

Hash-only:

| distinct | dist | phmap | array | speedup |
|----------|------|-------|-------|---------|
| 1 | random | 411 ms | 148 ms | **2.8×** |
| 24 | random | 539 | 147 | **3.7×** |
| 100 | random | 533 | 147 | **3.6×** |
| 200 | random | 541 | 147 | **3.7×** |
| 255 | random | 538 | 147 | **3.7×** |
| 24 | Zipf | 533 | 149 | **3.6×** |

Array path time is **constant ~148ms** across all densities (direct
array index, no hashing).  phmap scales with distinct count.

Build+count (hash insert + per-row counter increment):
**1.2–3.6×** depending on density.

#### Memory trade-off

Array always 2 KiB regardless of distinct; phmap up to 8.7 KiB at
distinct=255.  Array path is also memory-cheaper.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

