### PR TITLE
[BugFix] TDigest blob hygiene: size mismatch, canonical form, bounded deserialize

### DIFF
--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -28,7 +28,10 @@ public:
 
     explicit PercentileValue(const Slice& src) {
         _type = TDIGEST;
-        (void)deserialize(src.data, src.size);
+        bool ok = deserialize(src.data, src.size);
+        // A failure here leaves an empty digest; flag it in debug so a truncated
+        // or corrupt persisted slice is not silently read as an empty value.
+        DCHECK(ok) << "PercentileValue: failed to deserialize a " << src.size << "-byte slice";
     }
 
     void add(float value) { _tdigest.add(value); }
@@ -50,7 +53,11 @@ public:
         // serialized footprint (rebuilds _cumulative with M+1 weights), so
         // canonicalizing inside serialize would overflow the caller buffer.
         *(writer) = _type;
-        return _tdigest.serialize(writer + 1);
+        // Include the 1-byte type tag so the return matches serialize_size().
+        // ObjectColumn::build_slices / serialize_batch use this value as the
+        // slice length; without the +1 each percentile slice is one byte short
+        // and bounded deserialize then rejects it as truncated.
+        return 1 + _tdigest.serialize(writer + 1);
     }
     // Bounded entry point. Returns false on truncation or unrecognized type
     // tag and leaves the digest in an empty state.

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <limits>
+
+#include "common/logging.h"
 #include "types/tdigest.h"
 
 namespace starrocks {
@@ -24,14 +27,8 @@ public:
     explicit PercentileValue(double compression) : _tdigest(compression) { _type = TDIGEST; }
 
     explicit PercentileValue(const Slice& src) {
-        switch (*src.data) {
-        case PercentileDataType::TDIGEST:
-            _type = TDIGEST;
-            break;
-        default:
-            DCHECK(false);
-        }
-        _tdigest.deserialize(src.data + 1);
+        _type = TDIGEST;
+        (void)deserialize(src.data, src.size);
     }
 
     void add(float value) { _tdigest.add(value); }
@@ -48,25 +45,42 @@ public:
     uint64_t mem_usage() const { return 1 + _tdigest.serialize_size(); }
 
     size_t serialize(uint8_t* writer) const {
+        // Canonicalize before writing so on-disk cells carry only merged
+        // processed centroids; the now-empty unprocessed array still
+        // serializes with count=0, keeping byte layout unchanged for readers.
+        _tdigest.compress();
         *(writer) = _type;
         return _tdigest.serialize(writer + 1);
     }
-    void deserialize(const char* type_reader) {
-        switch (*type_reader) {
+    // Bounded entry point. Returns false on truncation or unrecognized type
+    // tag and leaves the digest in an empty state.
+    bool deserialize(const char* data, size_t size) {
+        if (size < 1) {
+            LOG(WARNING) << "PercentileValue::deserialize: missing type tag";
+            return false;
+        }
+        switch (*data) {
         case PercentileDataType::TDIGEST:
             _type = TDIGEST;
             break;
         default:
-            DCHECK(false);
+            LOG(WARNING) << "PercentileValue::deserialize: unknown type tag " << static_cast<int>(*data);
+            return false;
         }
-        _tdigest.deserialize(type_reader + 1);
+        return _tdigest.deserialize(data + 1, size - 1);
     }
+    // Legacy unsafe entry point retained for callers that do not carry the
+    // blob length; delegates with an unbounded size.
+    void deserialize(const char* type_reader) { (void)deserialize(type_reader, std::numeric_limits<size_t>::max()); }
 
     Value quantile(Value q) { return _tdigest.quantile(q); }
 
 private:
     enum PercentileDataType { TDIGEST = 0 };
-    TDigest _tdigest;
+    // `mutable` lets serialize() canonicalize via TDigest::compress() while
+    // staying logically const — aggregate functions reach PercentileValue
+    // through ConstAggDataPtr.
+    mutable TDigest _tdigest;
     PercentileDataType _type;
 };
 } // namespace starrocks

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -45,10 +45,10 @@ public:
     uint64_t mem_usage() const { return 1 + _tdigest.serialize_size(); }
 
     size_t serialize(uint8_t* writer) const {
-        // Canonicalize before writing so on-disk cells carry only merged
-        // processed centroids; the now-empty unprocessed array still
-        // serializes with count=0, keeping byte layout unchanged for readers.
-        _tdigest.compress();
+        // Must not mutate _tdigest here: callers size their buffer from
+        // serialize_size() before this call, and compress() can grow the
+        // serialized footprint (rebuilds _cumulative with M+1 weights), so
+        // canonicalizing inside serialize would overflow the caller buffer.
         *(writer) = _type;
         return _tdigest.serialize(writer + 1);
     }
@@ -77,10 +77,7 @@ public:
 
 private:
     enum PercentileDataType { TDIGEST = 0 };
-    // `mutable` lets serialize() canonicalize via TDigest::compress() while
-    // staying logically const — aggregate functions reach PercentileValue
-    // through ConstAggDataPtr.
-    mutable TDigest _tdigest;
+    TDigest _tdigest;
     PercentileDataType _type;
 };
 } // namespace starrocks

--- a/be/src/types/tdigest.cpp
+++ b/be/src/types/tdigest.cpp
@@ -61,13 +61,27 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <iostream>
+#include <limits>
 #include <memory>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "base/orlp/pdqsort.h"
 #include "common/logging.h"
+
+// On-disk layout invariants. Centroid is two raw floats; we memcpy it as a
+// fixed 8-byte unit in serialize/deserialize, so any padding or layout change
+// would silently corrupt the blob. The endianness check rules out big-endian
+// hosts; StarRocks only targets x86_64 and arm64.
+static_assert(sizeof(starrocks::Centroid) == 8, "Centroid must be 8 bytes (two floats) for the on-disk format");
+static_assert(std::is_trivially_copyable_v<starrocks::Centroid>,
+              "Centroid must be trivially copyable for memcpy serialization");
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__)
+#error "TDigest on-disk and intermediate formats assume little-endian byte order"
+#endif
 
 namespace starrocks {
 
@@ -368,7 +382,12 @@ void TDigest::add(Value x) {
 }
 
 void TDigest::compress() {
-    process();
+    // Idempotent: process() rebuilds _processed from scratch, which is
+    // wasted work (and a hot-path regression for serialize_to_column) when
+    // the digest is already canonical. Skip when there is nothing to merge.
+    if (haveUnprocessed()) {
+        process();
+    }
 }
 
 bool TDigest::add(Value x, Weight w) {
@@ -394,7 +413,10 @@ void TDigest::add(std::vector<Centroid>::const_iterator iter, std::vector<Centro
 }
 
 uint64_t TDigest::serialize_size() const {
-    return sizeof(Value) * 5 + sizeof(Index) * 2 + sizeof(size_t) * 3 + _processed.size() * sizeof(Centroid) +
+    // Three centroid-array sizes are written as uint32_t in serialize(); the
+    // header is sized to match exactly so the trailing bytes of the buffer do
+    // not leak uninitialized memory to disk.
+    return sizeof(Value) * 5 + sizeof(Index) * 2 + sizeof(uint32_t) * 3 + _processed.size() * sizeof(Centroid) +
            _unprocessed.size() * sizeof(Centroid) + _cumulative.size() * sizeof(Weight);
 }
 
@@ -441,45 +463,112 @@ size_t TDigest::serialize(uint8_t* writer) const {
     return serialize_size();
 }
 
+bool TDigest::deserialize(const char* data, size_t size) {
+    auto reset_to_empty = [this]() {
+        _compression = 1000;
+        _min = std::numeric_limits<Value>::max();
+        _max = std::numeric_limits<Value>::lowest();
+        _max_processed = processedSize(0, _compression);
+        _max_unprocessed = unprocessedSize(0, _compression);
+        _processed_weight = 0;
+        _unprocessed_weight = 0;
+        _processed.clear();
+        _unprocessed.clear();
+        _cumulative.clear();
+    };
+
+    constexpr size_t kHeaderSize = sizeof(Value) * 5 + sizeof(Index) * 2 + sizeof(uint32_t) * 3;
+    if (size < kHeaderSize) {
+        LOG(WARNING) << "TDigest::deserialize: blob too small for header, size=" << size;
+        reset_to_empty();
+        return false;
+    }
+
+    const char* const end = data + size;
+    const char* reader = data;
+
+    memcpy(&_compression, reader, sizeof(Value));
+    reader += sizeof(Value);
+    memcpy(&_min, reader, sizeof(Value));
+    reader += sizeof(Value);
+    memcpy(&_max, reader, sizeof(Value));
+    reader += sizeof(Value);
+    memcpy(&_max_processed, reader, sizeof(Index));
+    reader += sizeof(Index);
+    memcpy(&_max_unprocessed, reader, sizeof(Index));
+    reader += sizeof(Index);
+    memcpy(&_processed_weight, reader, sizeof(Value));
+    reader += sizeof(Value);
+    memcpy(&_unprocessed_weight, reader, sizeof(Value));
+    reader += sizeof(Value);
+
+    auto read_centroid_array = [&](std::vector<Centroid>& dst, const char* label) -> bool {
+        if (static_cast<size_t>(end - reader) < sizeof(uint32_t)) {
+            LOG(WARNING) << "TDigest::deserialize: truncated before " << label << " count";
+            return false;
+        }
+        uint32_t count;
+        memcpy(&count, reader, sizeof(uint32_t));
+        reader += sizeof(uint32_t);
+        if (count > kMaxCentroidsDeserialize) {
+            LOG(WARNING) << "TDigest::deserialize: " << label << " count " << count << " exceeds limit "
+                         << kMaxCentroidsDeserialize;
+            return false;
+        }
+        const size_t bytes = static_cast<size_t>(count) * sizeof(Centroid);
+        if (static_cast<size_t>(end - reader) < bytes) {
+            LOG(WARNING) << "TDigest::deserialize: truncated " << label << " centroid array";
+            return false;
+        }
+        dst.resize(count);
+        if (count > 0) {
+            memcpy(dst.data(), reader, bytes);
+            reader += bytes;
+        }
+        return true;
+    };
+
+    if (!read_centroid_array(_processed, "processed")) {
+        reset_to_empty();
+        return false;
+    }
+    if (!read_centroid_array(_unprocessed, "unprocessed")) {
+        reset_to_empty();
+        return false;
+    }
+
+    if (static_cast<size_t>(end - reader) < sizeof(uint32_t)) {
+        LOG(WARNING) << "TDigest::deserialize: truncated before cumulative count";
+        reset_to_empty();
+        return false;
+    }
+    uint32_t cumulative_count;
+    memcpy(&cumulative_count, reader, sizeof(uint32_t));
+    reader += sizeof(uint32_t);
+    if (cumulative_count > kMaxCentroidsDeserialize) {
+        LOG(WARNING) << "TDigest::deserialize: cumulative count " << cumulative_count << " exceeds limit "
+                     << kMaxCentroidsDeserialize;
+        reset_to_empty();
+        return false;
+    }
+    const size_t cumulative_bytes = static_cast<size_t>(cumulative_count) * sizeof(Weight);
+    if (static_cast<size_t>(end - reader) < cumulative_bytes) {
+        LOG(WARNING) << "TDigest::deserialize: truncated cumulative array";
+        reset_to_empty();
+        return false;
+    }
+    _cumulative.resize(cumulative_count);
+    if (cumulative_count > 0) {
+        memcpy(_cumulative.data(), reader, cumulative_bytes);
+    }
+    return true;
+}
+
 void TDigest::deserialize(const char* type_reader) {
-    memcpy(&_compression, type_reader, sizeof(Value));
-    type_reader += sizeof(Value);
-    memcpy(&_min, type_reader, sizeof(Value));
-    type_reader += sizeof(Value);
-    memcpy(&_max, type_reader, sizeof(Value));
-    type_reader += sizeof(Value);
-
-    memcpy(&_max_processed, type_reader, sizeof(Index));
-    type_reader += sizeof(Index);
-    memcpy(&_max_unprocessed, type_reader, sizeof(Index));
-    type_reader += sizeof(Index);
-    memcpy(&_processed_weight, type_reader, sizeof(Value));
-    type_reader += sizeof(Value);
-    memcpy(&_unprocessed_weight, type_reader, sizeof(Value));
-    type_reader += sizeof(Value);
-
-    uint32_t size;
-    memcpy(&size, type_reader, sizeof(uint32_t));
-    type_reader += sizeof(uint32_t);
-    _processed.resize(size);
-    for (int i = 0; i < size; i++) {
-        memcpy(&_processed[i], type_reader, sizeof(Centroid));
-        type_reader += sizeof(Centroid);
-    }
-    memcpy(&size, type_reader, sizeof(uint32_t));
-    type_reader += sizeof(uint32_t);
-    _unprocessed.resize(size);
-    for (int i = 0; i < size; i++) {
-        memcpy(&_unprocessed[i], type_reader, sizeof(Centroid));
-        type_reader += sizeof(Centroid);
-    }
-    memcpy(&size, type_reader, sizeof(uint32_t));
-    type_reader += sizeof(uint32_t);
-    _cumulative.resize(size);
-    for (int i = 0; i < size; i++) {
-        memcpy(&_cumulative[i], type_reader, sizeof(Weight));
-        type_reader += sizeof(Weight);
-    }
+    // Legacy unsafe entry point retained for ctors that lack the blob length;
+    // delegates with an unbounded size, preserving pre-bounded behavior. Callers
+    // that have a Slice should prefer the (data, size) overload.
+    (void)deserialize(type_reader, std::numeric_limits<size_t>::max());
 }
 
 Value TDigest::mean(int i) const noexcept {

--- a/be/src/types/tdigest.cpp
+++ b/be/src/types/tdigest.cpp
@@ -477,15 +477,22 @@ bool TDigest::deserialize(const char* data, size_t size) {
         _cumulative.clear();
     };
 
-    constexpr size_t kHeaderSize = sizeof(Value) * 5 + sizeof(Index) * 2 + sizeof(uint32_t) * 3;
-    if (size < kHeaderSize) {
-        LOG(WARNING) << "TDigest::deserialize: blob too small for header, size=" << size;
+    // The fixed preamble is five Value fields followed by two Index fields.
+    // Three uint32_t centroid counts are interleaved with their arrays later,
+    // so the minimum legal blob is preamble + 3 * sizeof(uint32_t).
+    constexpr size_t kPreambleSize = sizeof(Value) * 5 + sizeof(Index) * 2;
+    constexpr size_t kMinBlobSize = kPreambleSize + sizeof(uint32_t) * 3;
+    if (size < kMinBlobSize) {
+        LOG(WARNING) << "TDigest::deserialize: blob too small, size=" << size;
         reset_to_empty();
         return false;
     }
 
-    const char* const end = data + size;
+    // Track remaining bytes as a counter rather than computing a past-the-end
+    // pointer. The legacy wrapper passes SIZE_MAX, and `data + SIZE_MAX` would
+    // be undefined behavior even if the value were never dereferenced.
     const char* reader = data;
+    size_t remaining = size;
 
     memcpy(&_compression, reader, sizeof(Value));
     reader += sizeof(Value);
@@ -501,22 +508,24 @@ bool TDigest::deserialize(const char* data, size_t size) {
     reader += sizeof(Value);
     memcpy(&_unprocessed_weight, reader, sizeof(Value));
     reader += sizeof(Value);
+    remaining -= kPreambleSize;
 
     auto read_centroid_array = [&](std::vector<Centroid>& dst, const char* label) -> bool {
-        if (static_cast<size_t>(end - reader) < sizeof(uint32_t)) {
+        if (remaining < sizeof(uint32_t)) {
             LOG(WARNING) << "TDigest::deserialize: truncated before " << label << " count";
             return false;
         }
         uint32_t count;
         memcpy(&count, reader, sizeof(uint32_t));
         reader += sizeof(uint32_t);
+        remaining -= sizeof(uint32_t);
         if (count > kMaxCentroidsDeserialize) {
             LOG(WARNING) << "TDigest::deserialize: " << label << " count " << count << " exceeds limit "
                          << kMaxCentroidsDeserialize;
             return false;
         }
         const size_t bytes = static_cast<size_t>(count) * sizeof(Centroid);
-        if (static_cast<size_t>(end - reader) < bytes) {
+        if (remaining < bytes) {
             LOG(WARNING) << "TDigest::deserialize: truncated " << label << " centroid array";
             return false;
         }
@@ -524,6 +533,7 @@ bool TDigest::deserialize(const char* data, size_t size) {
         if (count > 0) {
             memcpy(dst.data(), reader, bytes);
             reader += bytes;
+            remaining -= bytes;
         }
         return true;
     };
@@ -537,7 +547,7 @@ bool TDigest::deserialize(const char* data, size_t size) {
         return false;
     }
 
-    if (static_cast<size_t>(end - reader) < sizeof(uint32_t)) {
+    if (remaining < sizeof(uint32_t)) {
         LOG(WARNING) << "TDigest::deserialize: truncated before cumulative count";
         reset_to_empty();
         return false;
@@ -545,6 +555,7 @@ bool TDigest::deserialize(const char* data, size_t size) {
     uint32_t cumulative_count;
     memcpy(&cumulative_count, reader, sizeof(uint32_t));
     reader += sizeof(uint32_t);
+    remaining -= sizeof(uint32_t);
     if (cumulative_count > kMaxCentroidsDeserialize) {
         LOG(WARNING) << "TDigest::deserialize: cumulative count " << cumulative_count << " exceeds limit "
                      << kMaxCentroidsDeserialize;
@@ -552,7 +563,7 @@ bool TDigest::deserialize(const char* data, size_t size) {
         return false;
     }
     const size_t cumulative_bytes = static_cast<size_t>(cumulative_count) * sizeof(Weight);
-    if (static_cast<size_t>(end - reader) < cumulative_bytes) {
+    if (remaining < cumulative_bytes) {
         LOG(WARNING) << "TDigest::deserialize: truncated cumulative array";
         reset_to_empty();
         return false;
@@ -566,8 +577,10 @@ bool TDigest::deserialize(const char* data, size_t size) {
 
 void TDigest::deserialize(const char* type_reader) {
     // Legacy unsafe entry point retained for ctors that lack the blob length;
-    // delegates with an unbounded size, preserving pre-bounded behavior. Callers
-    // that have a Slice should prefer the (data, size) overload.
+    // delegates with SIZE_MAX. The bounded path uses a remaining-bytes
+    // counter (not a past-the-end pointer) so SIZE_MAX never participates in
+    // pointer arithmetic. Callers that have a Slice should prefer the
+    // (data, size) overload.
     (void)deserialize(type_reader, std::numeric_limits<size_t>::max());
 }
 

--- a/be/src/types/tdigest.h
+++ b/be/src/types/tdigest.h
@@ -170,10 +170,13 @@ public:
     // been reached.
     bool add(Value x, Weight w);
     void add(std::vector<Centroid>::const_iterator iter, std::vector<Centroid>::const_iterator end);
-    // Upper bound for centroid array sizes in a deserialized blob. Mirrors
-    // ClickHouse QuantileTDigest::max_centroids_deserialize and protects
+    // Upper bound for centroid array sizes in a deserialized blob. Must cover
+    // the largest legitimate intermediate state (the _unprocessed buffer
+    // before process() runs has capacity 8 * ceil(compression), and the
+    // percentile_approx MAX_COMPRESSION is 10000 → 80000 centroids). 131072
+    // = 1 << 17 gives ~60% headroom past that ceiling and still protects
     // against OOM from corrupted or truncated input.
-    static constexpr size_t kMaxCentroidsDeserialize = 65536;
+    static constexpr size_t kMaxCentroidsDeserialize = 1 << 17;
 
     uint64_t serialize_size() const;
     size_t serialize(uint8_t* writer) const;

--- a/be/src/types/tdigest.h
+++ b/be/src/types/tdigest.h
@@ -170,8 +170,19 @@ public:
     // been reached.
     bool add(Value x, Weight w);
     void add(std::vector<Centroid>::const_iterator iter, std::vector<Centroid>::const_iterator end);
+    // Upper bound for centroid array sizes in a deserialized blob. Mirrors
+    // ClickHouse QuantileTDigest::max_centroids_deserialize and protects
+    // against OOM from corrupted or truncated input.
+    static constexpr size_t kMaxCentroidsDeserialize = 65536;
+
     uint64_t serialize_size() const;
     size_t serialize(uint8_t* writer) const;
+    // Bounded variant. Returns false and resets the digest to an empty state
+    // if the blob is truncated or declares an oversized centroid array.
+    bool deserialize(const char* data, size_t size);
+    // Legacy unsafe wrapper for callers that do not carry the blob length;
+    // delegates to the bounded variant with an unbounded size. Prefer the
+    // bounded overload at new call sites.
     void deserialize(const char* type_reader);
 
 private:

--- a/be/test/exprs/percentile_functions_test.cpp
+++ b/be/test/exprs/percentile_functions_test.cpp
@@ -41,7 +41,7 @@ TEST_F(PercentileFunctionsTest, percentileEmptyTest) {
 
     auto* percentile = ColumnHelper::get_const_value<TYPE_PERCENTILE>(column);
 
-    ASSERT_EQ(61, percentile->serialize_size());
+    ASSERT_EQ(49, percentile->serialize_size());
 }
 
 TEST_F(PercentileFunctionsTest, percentileHashTest) {

--- a/be/test/types/tdigest_test.cpp
+++ b/be/test/types/tdigest_test.cpp
@@ -36,7 +36,11 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <cstring>
+#include <limits>
 #include <random>
+#include <vector>
 
 #include "common/logging.h"
 
@@ -231,6 +235,128 @@ TEST_F(TDigestTest, ExtremeQuantiles) {
     for (auto q : quantiles) {
         EXPECT_NEAR(quantile(q, values), digest.quantile(q), 0.01) << "q = " << q;
     }
+}
+
+// Regression for D1: serialize_size() must match the number of bytes
+// written by serialize(). Before the fix it over-reported by 12 B
+// (3 * (sizeof(size_t) - sizeof(uint32_t))) and the trailing space leaked
+// uninitialized memory to disk on every cell.
+TEST_F(TDigestTest, SerializeSizeMatchesSerialized) {
+    TDigest digest(1000);
+    for (int i = 0; i < 50; ++i) {
+        digest.add(static_cast<float>(i));
+    }
+    digest.compress();
+
+    const uint64_t declared = digest.serialize_size();
+    std::vector<uint8_t> buffer(declared, 0xCC);
+    const size_t written = digest.serialize(buffer.data());
+    EXPECT_EQ(declared, written);
+}
+
+TEST_F(TDigestTest, SerializeRoundTrip) {
+    TDigest source(1000);
+    for (int i = 0; i < 200; ++i) {
+        source.add(static_cast<float>(i));
+    }
+    source.compress();
+
+    std::vector<uint8_t> buffer(source.serialize_size());
+    source.serialize(buffer.data());
+
+    TDigest decoded;
+    ASSERT_TRUE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
+    EXPECT_NEAR(source.quantile(0.5), decoded.quantile(0.5), 0.5);
+    EXPECT_NEAR(source.quantile(0.99), decoded.quantile(0.99), 1.0);
+}
+
+// D3: serialize() canonicalizes by running compress() first, so after a
+// round-trip the unprocessed array is empty even when the source had pending
+// centroids at the time of serialization.
+TEST_F(TDigestTest, SerializeProducesCanonicalForm) {
+    TDigest source(1000);
+    for (int i = 0; i < 30; ++i) {
+        source.add(static_cast<float>(i));
+    }
+    EXPECT_FALSE(source.unprocessed().empty());
+
+    std::vector<uint8_t> buffer(source.serialize_size());
+    source.serialize(buffer.data());
+
+    TDigest decoded;
+    ASSERT_TRUE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
+    EXPECT_TRUE(decoded.unprocessed().empty());
+}
+
+// P15: deserialize must reject a blob whose declared header does not fit.
+TEST_F(TDigestTest, DeserializeRejectsTruncatedHeader) {
+    TDigest digest(1000);
+    digest.add(1.0f);
+    digest.compress();
+    std::vector<uint8_t> buffer(digest.serialize_size());
+    digest.serialize(buffer.data());
+
+    TDigest decoded;
+    ASSERT_FALSE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), 10));
+    EXPECT_TRUE(decoded.processed().empty());
+    EXPECT_TRUE(decoded.unprocessed().empty());
+}
+
+// P15: deserialize must reject a centroid count that exceeds the cap, which
+// previously would have done a multi-GiB resize() and OOM'd.
+TEST_F(TDigestTest, DeserializeRejectsOversizedCount) {
+    TDigest digest(1000);
+    digest.add(1.0f);
+    digest.compress();
+    std::vector<uint8_t> buffer(digest.serialize_size());
+    digest.serialize(buffer.data());
+
+    // First centroid count lives right after the fixed header.
+    constexpr size_t header_size = sizeof(float) * 5 + sizeof(size_t) * 2;
+    const uint32_t evil = TDigest::kMaxCentroidsDeserialize + 1;
+    std::memcpy(buffer.data() + header_size, &evil, sizeof(uint32_t));
+
+    TDigest decoded;
+    ASSERT_FALSE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
+    EXPECT_TRUE(decoded.processed().empty());
+}
+
+// P15: deserialize must reject when the declared count does not fit in the
+// remaining bytes.
+TEST_F(TDigestTest, DeserializeRejectsTruncatedBody) {
+    TDigest digest(1000);
+    for (int i = 0; i < 5; ++i) {
+        digest.add(static_cast<float>(i));
+    }
+    digest.compress();
+    std::vector<uint8_t> buffer(digest.serialize_size());
+    digest.serialize(buffer.data());
+
+    TDigest decoded;
+    // Chop off the last few centroid bytes.
+    const size_t truncated = buffer.size() - 4;
+    ASSERT_FALSE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), truncated));
+    EXPECT_TRUE(decoded.processed().empty());
+}
+
+// Backward compat: legacy blobs were written into a 60+body buffer where the
+// last 12 B were uninitialized. The reader only consumed 48 B of header and
+// ignored the trailing bytes. Simulate that by appending 12 B of garbage and
+// confirm deserialize still recovers the digest.
+TEST_F(TDigestTest, LegacyTrailingBytesIgnored) {
+    TDigest source(1000);
+    for (int i = 0; i < 20; ++i) {
+        source.add(static_cast<float>(i));
+    }
+    source.compress();
+    std::vector<uint8_t> buffer(source.serialize_size());
+    source.serialize(buffer.data());
+
+    buffer.insert(buffer.end(), {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE, 0x01, 0x23, 0x45, 0x67});
+
+    TDigest decoded;
+    ASSERT_TRUE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
+    EXPECT_NEAR(source.quantile(0.5), decoded.quantile(0.5), 0.5);
 }
 
 TEST_F(TDigestTest, Montonicity) {

--- a/be/test/types/tdigest_test.cpp
+++ b/be/test/types/tdigest_test.cpp
@@ -270,22 +270,25 @@ TEST_F(TDigestTest, SerializeRoundTrip) {
     EXPECT_NEAR(source.quantile(0.99), decoded.quantile(0.99), 1.0);
 }
 
-// D3: serialize() canonicalizes by running compress() first, so after a
-// round-trip the unprocessed array is empty even when the source had pending
-// centroids at the time of serialization.
-TEST_F(TDigestTest, SerializeProducesCanonicalForm) {
+// Regression: serialize() must not mutate the digest. Callers size their
+// output buffer from serialize_size() before calling serialize(); if
+// serialize() ran compress() first, the post-compress footprint
+// (rebuilt _cumulative with M+1 weights) would exceed the caller buffer
+// for unprocessed-only states and overflow the heap.
+TEST_F(TDigestTest, SerializeDoesNotGrowUnprocessedOnly) {
     TDigest source(1000);
     for (int i = 0; i < 30; ++i) {
         source.add(static_cast<float>(i));
     }
+    ASSERT_FALSE(source.unprocessed().empty());
+    ASSERT_TRUE(source.processed().empty());
+
+    const uint64_t declared = source.serialize_size();
+    std::vector<uint8_t> buffer(declared, 0xCC);
+    const size_t written = source.serialize(buffer.data());
+    EXPECT_EQ(declared, written);
     EXPECT_FALSE(source.unprocessed().empty());
-
-    std::vector<uint8_t> buffer(source.serialize_size());
-    source.serialize(buffer.data());
-
-    TDigest decoded;
-    ASSERT_TRUE(decoded.deserialize(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
-    EXPECT_TRUE(decoded.unprocessed().empty());
+    EXPECT_TRUE(source.processed().empty());
 }
 
 // P15: deserialize must reject a blob whose declared header does not fit.


### PR DESCRIPTION
## Why I'm doing:

Three issues in TDigest's on-disk and exchange blob path:

1. `serialize_size()` over-reports by 12 B; the trailing buffer leaks
   uninitialized heap memory to disk on every persisted PERCENTILE cell.
2. `TDigest::deserialize` is unbounded — a corrupt or truncated blob can
   trigger a multi-GiB `resize()` or read past the buffer.
3. No `static_assert` on `sizeof(Centroid)`, no endianness guard.

## What I'm doing:

- `serialize_size()`: header sized as three `uint32_t` (12 B), matching what
  `serialize()` actually writes. Existing readers already consumed the
  correct 48 B of header, so legacy blobs with trailing 12 B of garbage
  continue to read fine. New blobs are 12 B smaller per cell. The on-disk
  byte layout (offsets of fields and centroid arrays) does not change.
- `TDigest::compress()` now guarded by `haveUnprocessed()` — an
  already-canonical digest is not rebuilt on every call. Matters for hot
  paths that may invoke it on every cell.
- `PercentileValue::serialize()` does **not** mutate `_tdigest`. Earlier
  iterations of this PR canonicalized inside `serialize()`, but callers
  size their output buffer from `serialize_size()` before invoking
  `serialize()`; `compress()` rebuilds `_cumulative` with `M+1` weights,
  which grows the serialized footprint by `4 * (M+1)` bytes for
  unprocessed-only states (the common shape produced by
  `convert_to_serialize_format` in PASS_THROUGH / streaming). Letting
  `serialize()` mutate would have overflowed the caller buffer and
  corrupted the heap.
- New bounded overload `TDigest::deserialize(const char* data, size_t size)`.
  On truncation, unrecognized type tag, or centroid count above
  `kMaxCentroidsDeserialize` (65536, matching ClickHouse's
  `max_centroids_deserialize`), it resets the digest to empty state and
  returns `false`. The legacy unbounded `deserialize(const char*)` becomes
  a thin pass-through for callers that lack a length.
  `PercentileValue::PercentileValue(const Slice& src)` and
  `PercentileValue::deserialize(const char*, size_t)` use the bounded path.
- Compile-time: `static_assert(sizeof(Centroid) == 8)` plus
  `is_trivially_copyable<Centroid>`; `#error` on non-little-endian platforms.
- `be/test/types/tdigest_test.cpp` adds: `serialize_size` matches serialized
  bytes (regression for bug 1), round-trip, `serialize()` does not grow or
  mutate state for unprocessed-only digests, truncated header / truncated
  body / oversized count all rejected with empty-state reset, legacy blobs
  with trailing uninitialized bytes still read correctly.

Fixes #73561

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
