### PR TITLE
[BugFix] Surface AccessDenied reason for sys.fe_memory_usage / sys.fe_locks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
@@ -19,10 +19,12 @@ import com.google.common.base.Joiner;
 import com.google.gson.JsonObject;
 import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.ErrorCode;
 import com.starrocks.common.util.concurrent.lock.LockHolder;
 import com.starrocks.common.util.concurrent.lock.LockInfo;
 import com.starrocks.common.util.concurrent.lock.LockManager;
@@ -75,7 +77,8 @@ public class SysFeLocks {
                 Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
             }
         } catch (AccessDeniedException e) {
-            throw new TException(e.getMessage(), e);
+            throw new TException(ErrorCode.ERR_ACCESS_DENIED_FOR_EXTERNAL_ACCESS_CONTROLLER.formatErrorMsg(
+                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), ""), e);
         }
 
         TFeLocksRes response = new TFeLocksRes();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
@@ -21,10 +21,10 @@ import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PrivilegeType;
+import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
-import com.starrocks.common.ErrorCode;
 import com.starrocks.common.util.concurrent.lock.LockHolder;
 import com.starrocks.common.util.concurrent.lock.LockInfo;
 import com.starrocks.common.util.concurrent.lock.LockManager;
@@ -77,8 +77,9 @@ public class SysFeLocks {
                 Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
             }
         } catch (AccessDeniedException e) {
-            throw new TException(ErrorCode.ERR_ACCESS_DENIED_FOR_EXTERNAL_ACCESS_CONTROLLER.formatErrorMsg(
-                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), ""), e);
+            AccessDeniedException.reportAccessDenied(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
         }
 
         TFeLocksRes response = new TFeLocksRes();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
@@ -18,10 +18,10 @@ import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PrivilegeType;
+import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
-import com.starrocks.common.ErrorCode;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.Authorizer;
@@ -58,8 +58,9 @@ public class SysFeMemoryUsage {
         try {
             Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
         } catch (AccessDeniedException e) {
-            throw new TException(ErrorCode.ERR_ACCESS_DENIED_FOR_EXTERNAL_ACCESS_CONTROLLER.formatErrorMsg(
-                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), ""), e);
+            AccessDeniedException.reportAccessDenied(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
         }
 
         TFeMemoryRes response = new TFeMemoryRes();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
@@ -16,10 +16,12 @@ package com.starrocks.catalog.system.sys;
 
 import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.ErrorCode;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.Authorizer;
@@ -56,7 +58,8 @@ public class SysFeMemoryUsage {
         try {
             Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
         } catch (AccessDeniedException e) {
-            throw new TException(e.getMessage(), e);
+            throw new TException(ErrorCode.ERR_ACCESS_DENIED_FOR_EXTERNAL_ACCESS_CONTROLLER.formatErrorMsg(
+                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), ""), e);
         }
 
         TFeMemoryRes response = new TFeMemoryRes();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeLocksTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeLocksTest.java
@@ -60,11 +60,11 @@ public class SysFeLocksTest {
             }
         };
 
-        TException ex = assertThrows(TException.class, () -> SysFeLocks.listLocks(req, true));
+        Exception ex = assertThrows(Exception.class, () -> SysFeLocks.listLocks(req, true));
         assertNotNull(ex.getMessage(), "AccessDenied message should not be null");
-        assertTrue(ex.getMessage().contains("Access denied"), "Should match canonical format: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains("OPERATE"), "Should mention OPERATE: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains("SYSTEM"), "Should mention SYSTEM: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(
+                        "Access denied; you need (at least one of) the OPERATE privilege(s) on SYSTEM for this operation."),
+                "Should match canonical format: " + ex.getMessage());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeLocksTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeLocksTest.java
@@ -14,12 +14,20 @@
 
 package com.starrocks.catalog.system.sys;
 
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.authorization.PrivilegeType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.thrift.TAuthInfo;
 import com.starrocks.thrift.TFeLocksReq;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SysFeLocksTest {
@@ -34,6 +42,29 @@ public class SysFeLocksTest {
 
         var res = SysFeLocks.listLocks(req, false);
         assertTrue(StringUtils.isNotEmpty(res.toString()));
+    }
+
+    @Test
+    public void testListLocksAccessDeniedSurfacesMessage() {
+        TFeLocksReq req = new TFeLocksReq();
+        TAuthInfo auth = new TAuthInfo();
+        auth.setUser("nopriv");
+        auth.setUser_ip("127.0.0.1");
+        req.setAuth_info(auth);
+
+        new MockUp<Authorizer>() {
+            @Mock
+            public void checkSystemAction(ConnectContext context, PrivilegeType privilegeType)
+                    throws AccessDeniedException {
+                throw new AccessDeniedException();
+            }
+        };
+
+        TException ex = assertThrows(TException.class, () -> SysFeLocks.listLocks(req, true));
+        assertNotNull(ex.getMessage(), "AccessDenied message should not be null");
+        assertTrue(ex.getMessage().contains("Access denied"), "Should match canonical format: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("OPERATE"), "Should mention OPERATE: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("SYSTEM"), "Should mention SYSTEM: " + ex.getMessage());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeMemoryUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeMemoryUsageTest.java
@@ -25,12 +25,16 @@ import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.thrift.TAuthInfo;
 import com.starrocks.thrift.TFeMemoryReq;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SysFeMemoryUsageTest {
@@ -57,6 +61,29 @@ public class SysFeMemoryUsageTest {
 
         var res = SysFeMemoryUsage.listFeMemoryUsage(req);
         assertTrue(StringUtils.isNotEmpty(res.toString()));
+    }
+
+    @Test
+    public void testListFeMemoryUsageAccessDeniedSurfacesMessage() {
+        TFeMemoryReq req = new TFeMemoryReq();
+        TAuthInfo auth = new TAuthInfo();
+        auth.setUser("nopriv");
+        auth.setUser_ip("127.0.0.1");
+        req.setAuth_info(auth);
+
+        new MockUp<Authorizer>() {
+            @Mock
+            public void checkSystemAction(ConnectContext context, PrivilegeType privilegeType)
+                    throws AccessDeniedException {
+                throw new AccessDeniedException();
+            }
+        };
+
+        TException ex = assertThrows(TException.class, () -> SysFeMemoryUsage.listFeMemoryUsage(req));
+        assertNotNull(ex.getMessage(), "AccessDenied message should not be null");
+        assertTrue(ex.getMessage().contains("Access denied"), "Should match canonical format: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("OPERATE"), "Should mention OPERATE: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("SYSTEM"), "Should mention SYSTEM: " + ex.getMessage());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeMemoryUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeMemoryUsageTest.java
@@ -79,11 +79,11 @@ public class SysFeMemoryUsageTest {
             }
         };
 
-        TException ex = assertThrows(TException.class, () -> SysFeMemoryUsage.listFeMemoryUsage(req));
+        Exception ex = assertThrows(Exception.class, () -> SysFeMemoryUsage.listFeMemoryUsage(req));
         assertNotNull(ex.getMessage(), "AccessDenied message should not be null");
-        assertTrue(ex.getMessage().contains("Access denied"), "Should match canonical format: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains("OPERATE"), "Should mention OPERATE: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains("SYSTEM"), "Should mention SYSTEM: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(
+                        "Access denied; you need (at least one of) the OPERATE privilege(s) on SYSTEM for this operation."),
+                "Should match canonical format: " + ex.getMessage());
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:

Fixes #73547.

Querying `sys.fe_memory_usage` / `sys.fe_locks` as a user without `OPERATE ON SYSTEM` produces a misleading "node lookup" style error:

```
FE RPC failure, address=TNetworkAddress(hostname=<fe-host>, port=9020),
  reason=Internal error processing listFeMemoryUsage: BE:10026, host: unknown
```

The actual cause is an `AccessDeniedException`, but its message is dropped on the way out. Three layers conspire:

1. `NativeAccessController.java:321` throws `new AccessDeniedException()` with no message.
2. `SysFeMemoryUsage.java:58-60` and `SysFeLocks.java:86-88` catch it and rethrow as `new TException(e.getMessage(), e)` — `e.getMessage()` is null.
3. Apache Thrift wraps the empty-message TException, the BE thrift_rpc_helper adds the `FE RPC failure ... reason=` prefix, the CN pipeline driver appends `: BE:{be_id}`, and `DefaultCoordinator.dealStatusToTryRetry` finally wraps with `RpcException("unknown", status.getErrorMsg())` — the literal `"unknown"` is what produces `, host: unknown`.

The user-facing error ends up as `<decorative-be-tag>:<decorative-host-tag>` with the real reason gone.

## What I'm doing:

In both `SysFeMemoryUsage.listFeMemoryUsage` and `SysFeLocks.listLocks`, replace `e.getMessage()` (null) with a properly formatted message produced via `ErrorCode.ERR_ACCESS_DENIED_FOR_EXTERNAL_ACCESS_CONTROLLER.formatErrorMsg(...)`, so the phrasing matches every other privilege check in the codebase:

```
Access denied; you need (at least one of) the OPERATE privilege(s) on SYSTEM for this operation.
```

Two production files changed, ~3 lines each. No semantics change — same exception type, same control flow, only a clearer message. Existing tests still pass; two new tests cover the access-denied path with `MockUp<Authorizer>` (the same mock pattern used in `TaskRunsSystemTableTest`).

The broader anti-pattern (`new AccessDeniedException()` everywhere in `NativeAccessController`) is intentionally left for a follow-up — this PR keeps the diff minimal and reviewable.

Fixes #73547

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: error message phrasing only (no API/SQL/config surface change)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
