### PR TITLE
[Feature] Support min/max statistics skipping for Paimon tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMinMaxUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMinMaxUtil.java
@@ -1,0 +1,308 @@
+\// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.paimon;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.thrift.TExprMinMaxValue;
+import com.starrocks.thrift.TExprNodeType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.paimon.data.BinaryArray;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.RowType;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Utility class to convert Paimon DataFileMeta value statistics into thrift TExprMinMaxValue
+ * structures for per-file min/max skipping in the native C++ reader (Parquet/ORC).
+ *
+ */
+public final class PaimonMinMaxUtil {
+    private static final Logger LOG = LogManager.getLogger(PaimonMinMaxUtil.class);
+
+    private static final Set<DataTypeRoot> SUPPORTED_TYPES = Set.of(
+            DataTypeRoot.BOOLEAN,
+            DataTypeRoot.TINYINT,
+            DataTypeRoot.SMALLINT,
+            DataTypeRoot.INTEGER,
+            DataTypeRoot.BIGINT,
+            DataTypeRoot.FLOAT,
+            DataTypeRoot.DOUBLE,
+            DataTypeRoot.DATE,
+            DataTypeRoot.TIME_WITHOUT_TIME_ZONE,
+            DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
+            DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+    );
+
+    private PaimonMinMaxUtil() {
+    }
+
+    /**
+     * Extracts min/max values from Paimon and converts them to a map of slot ID
+     * suitable for populating THdfsScanRange.min_max_values
+     */
+    public static Map<Integer, TExprMinMaxValue> toThriftMinMaxValueBySlots(
+            RowType rowType,
+            DataFileMeta dataFileMeta,
+            List<SlotDescriptor> slots) {
+
+        SimpleStats valueStats = dataFileMeta.valueStats();
+        if (valueStats == null || valueStats == SimpleStats.EMPTY_STATS) {
+            return Map.of();
+        }
+
+        long rowCount = dataFileMeta.rowCount();
+        List<String> valueStatsCols = dataFileMeta.valueStatsCols();
+
+        return toThriftMinMaxValueBySlots(rowType, valueStats, valueStatsCols, rowCount, slots);
+    }
+
+    /**
+     * Core conversion logic
+     */
+    @VisibleForTesting
+    public static Map<Integer, TExprMinMaxValue> toThriftMinMaxValueBySlots(
+            RowType rowType,
+            SimpleStats valueStats,
+            List<String> valueStatsCols,
+            long rowCount,
+            List<SlotDescriptor> slots) {
+
+        if (valueStats == null || valueStats == SimpleStats.EMPTY_STATS) {
+            return Map.of();
+        }
+
+        BinaryRow minValues = valueStats.minValues();
+        BinaryRow maxValues = valueStats.maxValues();
+        BinaryArray nullCounts = valueStats.nullCounts();
+
+        if (minValues == null || maxValues == null) {
+            return Map.of();
+        }
+
+        // Build column name to position mapping in the Paimon row type
+        List<DataField> fields = rowType.getFields();
+        Map<String, Integer> columnNameToPosition = new HashMap<>(fields.size());
+        Map<String, DataType> columnNameToType = new HashMap<>(fields.size());
+        for (int i = 0; i < fields.size(); i++) {
+            DataField field = fields.get(i);
+            columnNameToPosition.put(field.name(), i);
+            columnNameToType.put(field.name(), field.type());
+        }
+
+        // If valueStatsCols is non-null and non-empty, only those columns have valid stats.
+        // Otherwise, all value columns have stats and the BinaryRow indices correspond to
+        // column positions in the row type.
+        Set<String> statsColumnSet = null;
+        Map<String, Integer> statsColumnToIndex = null;
+        boolean useSubsetMapping = valueStatsCols != null && !valueStatsCols.isEmpty();
+
+        if (useSubsetMapping) {
+            statsColumnSet = new HashSet<>(valueStatsCols);
+            // When valueStatsCols is a subset, the BinaryRow indices correspond to the
+            // position within the valueStatsCols list, NOT the position in the full row type.
+            statsColumnToIndex = new HashMap<>(valueStatsCols.size());
+            for (int i = 0; i < valueStatsCols.size(); i++) {
+                statsColumnToIndex.put(valueStatsCols.get(i), i);
+            }
+        }
+
+        Map<Integer, TExprMinMaxValue> result = new HashMap<>();
+
+        for (SlotDescriptor slot : slots) {
+            if (!slot.getType().isScalarType()) {
+                continue;
+            }
+
+            String columnName = slot.getColumn().getName();
+
+            // Skip columns not in the stats subset
+            if (useSubsetMapping && !statsColumnSet.contains(columnName)) {
+                continue;
+            }
+
+            // Find the Paimon data type for this column
+            DataType paimonType = columnNameToType.get(columnName);
+            if (paimonType == null) {
+                continue;
+            }
+
+            // Skip unsupported types
+            if (!SUPPORTED_TYPES.contains(paimonType.getTypeRoot())) {
+                continue;
+            }
+
+            // Determine the index into the BinaryRow for min/max values
+            int statsIndex;
+            if (useSubsetMapping) {
+                Integer idx = statsColumnToIndex.get(columnName);
+                if (idx == null) {
+                    continue;
+                }
+                statsIndex = idx;
+            } else {
+                Integer pos = columnNameToPosition.get(columnName);
+                if (pos == null) {
+                    continue;
+                }
+                statsIndex = pos;
+            }
+
+            // Bounds check
+            if (statsIndex >= minValues.getFieldCount() || statsIndex >= maxValues.getFieldCount()) {
+                continue;
+            }
+
+            // Extract null count for this column
+            long nullCount = 0;
+            if (nullCounts != null && statsIndex < nullCounts.size()) {
+                if (!nullCounts.isNullAt(statsIndex)) {
+                    nullCount = nullCounts.getLong(statsIndex);
+                }
+            }
+
+            TExprMinMaxValue texpr = new TExprMinMaxValue();
+            texpr.setHas_null(nullCount > 0);
+            texpr.setAll_null(rowCount > 0 && nullCount >= rowCount);
+
+            if (rowCount > 0 && nullCount >= rowCount) {
+                // All values are null
+                texpr.setType(TExprNodeType.NULL_LITERAL);
+                result.put(slot.getId().asInt(), texpr);
+                continue;
+            }
+
+            boolean minNull = minValues.isNullAt(statsIndex);
+            boolean maxNull = maxValues.isNullAt(statsIndex);
+            if (minNull || maxNull) {
+                // Cannot use min/max if either bound is null (but not all-null)
+                continue;
+            }
+
+            boolean success = fillMinMaxFromPaimonType(texpr, slot, paimonType, minValues, maxValues, statsIndex);
+            if (success) {
+                result.put(slot.getId().asInt(), texpr);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Reads min/max values from BinaryRow based on the Paimon data type and populates
+     * the TExprMinMaxValue. Returns true if successful.
+     */
+    private static boolean fillMinMaxFromPaimonType(
+            TExprMinMaxValue texpr,
+            SlotDescriptor slot,
+            DataType paimonType,
+            BinaryRow minValues,
+            BinaryRow maxValues,
+            int index) {
+
+        switch (paimonType.getTypeRoot()) {
+            case BOOLEAN:
+                texpr.setType(TExprNodeType.BOOL_LITERAL);
+                texpr.setMin_int_value(minValues.getBoolean(index) ? 1 : 0);
+                texpr.setMax_int_value(maxValues.getBoolean(index) ? 1 : 0);
+                return true;
+
+            case TINYINT:
+                texpr.setType(TExprNodeType.INT_LITERAL);
+                texpr.setMin_int_value(minValues.getByte(index));
+                texpr.setMax_int_value(maxValues.getByte(index));
+                return true;
+
+            case SMALLINT:
+                texpr.setType(TExprNodeType.INT_LITERAL);
+                texpr.setMin_int_value(minValues.getShort(index));
+                texpr.setMax_int_value(maxValues.getShort(index));
+                return true;
+
+            case INTEGER:
+            case DATE:
+                // Paimon stores DATE as days since epoch (int), same as Iceberg
+                texpr.setType(TExprNodeType.INT_LITERAL);
+                texpr.setMin_int_value(minValues.getInt(index));
+                texpr.setMax_int_value(maxValues.getInt(index));
+                return true;
+
+            case BIGINT:
+            case TIME_WITHOUT_TIME_ZONE:
+                texpr.setType(TExprNodeType.INT_LITERAL);
+                texpr.setMin_int_value(minValues.getLong(index));
+                texpr.setMax_int_value(maxValues.getLong(index));
+                return true;
+
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                // Paimon stores timestamps using the Timestamp class.
+                // For min/max filtering, we need the microsecond value.
+                // Paimon's BinaryRow stores TIMESTAMP as a composite (nanoOfMillisecond + millisecond),
+                // accessed via getTimestamp(index, precision). We use the millis-to-micros conversion.
+                try {
+                    org.apache.paimon.data.Timestamp minTs = minValues.getTimestamp(index, 6);
+                    org.apache.paimon.data.Timestamp maxTs = maxValues.getTimestamp(index, 6);
+                    if (minTs == null || maxTs == null) {
+                        return false;
+                    }
+                    texpr.setType(TExprNodeType.INT_LITERAL);
+                    texpr.setMin_int_value(timestampToMicros(minTs));
+                    texpr.setMax_int_value(timestampToMicros(maxTs));
+                    return true;
+                } catch (Exception e) {
+                    LOG.debug("Failed to read timestamp min/max for column {}: {}",
+                            slot.getColumn().getName(), e.getMessage());
+                    return false;
+                }
+
+            case FLOAT:
+                texpr.setType(TExprNodeType.FLOAT_LITERAL);
+                texpr.setMin_float_value(minValues.getFloat(index));
+                texpr.setMax_float_value(maxValues.getFloat(index));
+                return true;
+
+            case DOUBLE:
+                texpr.setType(TExprNodeType.FLOAT_LITERAL);
+                texpr.setMin_float_value(minValues.getDouble(index));
+                texpr.setMax_float_value(maxValues.getDouble(index));
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Converts a Paimon Timestamp to microseconds since epoch.
+     */
+    private static long timestampToMicros(org.apache.paimon.data.Timestamp ts) {
+        long millis = ts.getMillisecond();
+        int nanoOfMillisecond = ts.getNanoOfMillisecond();
+        // Convert millis to micros, then add the sub-millisecond microseconds
+        return millis * 1000L + nanoOfMillisecond / 1000;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.paimon.PaimonMinMaxUtil;
 import com.starrocks.connector.paimon.PaimonRemoteFileDesc;
 import com.starrocks.connector.paimon.PaimonSplitsInfo;
 import com.starrocks.credential.CloudConfiguration;
@@ -34,6 +35,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TExprMinMaxValue;
 import com.starrocks.thrift.THdfsFileFormat;
 import com.starrocks.thrift.THdfsScanNode;
 import com.starrocks.thrift.THdfsScanRange;
@@ -53,10 +55,12 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DeletionFile;
 import org.apache.paimon.table.source.RawFile;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InstantiationUtil;
 
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -149,6 +153,7 @@ public class PaimonScanNode extends ScanNode {
             return;
         }
 
+        RowType rowType = paimonTable.getNativeTable().rowType();
         boolean forceJNIReader = ConnectContext.get().getSessionVariable().getPaimonForceJNIReader();
         Map<BinaryRow, Long> selectedPartitions = Maps.newHashMap();
         for (Split split : splits) {
@@ -160,12 +165,17 @@ public class PaimonScanNode extends ScanNode {
                     boolean validFormat = rawFiles.stream().allMatch(p -> fromType(p.format()) != THdfsFileFormat.UNKNOWN);
                     if (validFormat) {
                         Optional<List<DeletionFile>> deletionFiles = dataSplit.deletionFiles();
+                        List<DataFileMeta> dataFiles = dataSplit.dataFiles();
                         for (int i = 0; i < rawFiles.size(); i++) {
-                            if (deletionFiles.isPresent()) {
-                                splitRawFileScanRangeLocations(rawFiles.get(i), deletionFiles.get().get(i));
-                            } else {
-                                splitRawFileScanRangeLocations(rawFiles.get(i), null);
+                            // Extract per-file min/max stats from DataFileMeta
+                            Map<Integer, TExprMinMaxValue> minMaxValues = Collections.emptyMap();
+                            if (i < dataFiles.size()) {
+                                minMaxValues = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                                        rowType, dataFiles.get(i), tupleDescriptor.getSlots());
                             }
+                            DeletionFile deletionFile = (deletionFiles.isPresent()) ?
+                                    deletionFiles.get().get(i) : null;
+                            splitRawFileScanRangeLocations(rawFiles.get(i), deletionFile, minMaxValues);
                         }
                     } else {
                         long totalFileLength = getTotalFileLength(dataSplit);
@@ -243,15 +253,20 @@ public class PaimonScanNode extends ScanNode {
     }
 
     public void splitRawFileScanRangeLocations(RawFile rawFile, @Nullable DeletionFile deletionFile) {
+        splitRawFileScanRangeLocations(rawFile, deletionFile, Collections.emptyMap());
+    }
+
+    public void splitRawFileScanRangeLocations(RawFile rawFile, @Nullable DeletionFile deletionFile,
+                                               Map<Integer, TExprMinMaxValue> minMaxValues) {
         SessionVariable sv = SessionVariable.DEFAULT_SESSION_VARIABLE;
         long splitSize = sv.getConnectorMaxSplitSize();
         long totalSize = rawFile.length();
         long offset = rawFile.offset();
         boolean needSplit = totalSize > splitSize;
         if (needSplit) {
-            splitScanRangeLocations(rawFile, offset, totalSize, splitSize, deletionFile);
+            splitScanRangeLocations(rawFile, offset, totalSize, splitSize, deletionFile, minMaxValues);
         } else {
-            addRawFileScanRangeLocations(rawFile, deletionFile);
+            addRawFileScanRangeLocations(rawFile, deletionFile, minMaxValues);
         }
     }
 
@@ -260,26 +275,39 @@ public class PaimonScanNode extends ScanNode {
                                         long length,
                                         long splitSize,
                                         @Nullable DeletionFile deletionFile) {
+        splitScanRangeLocations(rawFile, offset, length, splitSize, deletionFile, Collections.emptyMap());
+    }
+
+    public void splitScanRangeLocations(RawFile rawFile,
+                                        long offset,
+                                        long length,
+                                        long splitSize,
+                                        @Nullable DeletionFile deletionFile,
+                                        Map<Integer, TExprMinMaxValue> minMaxValues) {
         long remainingBytes = length;
         do {
             if (remainingBytes < 2 * splitSize) {
-                addRawFileScanRangeLocations(rawFile, offset + length - remainingBytes, remainingBytes, deletionFile);
+                addRawFileScanRangeLocations(rawFile, offset + length - remainingBytes,
+                        remainingBytes, deletionFile, minMaxValues);
                 remainingBytes = 0;
             } else {
-                addRawFileScanRangeLocations(rawFile, offset + length - remainingBytes, splitSize, deletionFile);
+                addRawFileScanRangeLocations(rawFile, offset + length - remainingBytes,
+                        splitSize, deletionFile, minMaxValues);
                 remainingBytes -= splitSize;
             }
         } while (remainingBytes > 0);
     }
 
-    private void addRawFileScanRangeLocations(RawFile rawFile, @Nullable DeletionFile deletionFile) {
-        addRawFileScanRangeLocations(rawFile, rawFile.offset(), rawFile.length(), deletionFile);
+    private void addRawFileScanRangeLocations(RawFile rawFile, @Nullable DeletionFile deletionFile,
+                                              Map<Integer, TExprMinMaxValue> minMaxValues) {
+        addRawFileScanRangeLocations(rawFile, rawFile.offset(), rawFile.length(), deletionFile, minMaxValues);
     }
 
     private void addRawFileScanRangeLocations(RawFile rawFile,
                                               long offset,
                                               long length,
-                                              @Nullable DeletionFile deletionFile) {
+                                              @Nullable DeletionFile deletionFile,
+                                              Map<Integer, TExprMinMaxValue> minMaxValues) {
         TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
 
         THdfsScanRange hdfsScanRange = new THdfsScanRange();
@@ -296,6 +324,11 @@ public class PaimonScanNode extends ScanNode {
             paimonDeletionFile.setOffset(deletionFile.offset());
             paimonDeletionFile.setLength(deletionFile.length());
             hdfsScanRange.setPaimon_deletion_file(paimonDeletionFile);
+        }
+
+        // Populate per-file min/max stats for native reader file skipping
+        if (minMaxValues != null && !minMaxValues.isEmpty()) {
+            hdfsScanRange.setMin_max_values(minMaxValues);
         }
 
         TScanRange scanRange = new TScanRange();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MinMaxOptOnScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MinMaxOptOnScanRule.java
@@ -17,6 +17,8 @@ package com.starrocks.sql.optimizer.rule.transformation;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.PaimonTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.Operator;
@@ -39,11 +41,12 @@ import java.util.Set;
 
 public class MinMaxOptOnScanRule extends TransformationRule {
     private static final Set<OperatorType> SUPPORTED = Set.of(
-            OperatorType.LOGICAL_ICEBERG_SCAN
+            OperatorType.LOGICAL_ICEBERG_SCAN,
+            OperatorType.LOGICAL_PAIMON_SCAN
     );
 
     public MinMaxOptOnScanRule() {
-        // agg -> project -> iceberg scan
+        // agg -> project -> scan (iceberg/paimon)
         super(RuleType.TF_REWRITE_MIN_MAX_COUNT_AGG,
                 Pattern.create(OperatorType.LOGICAL_AGGR).
                         addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT).
@@ -86,8 +89,17 @@ public class MinMaxOptOnScanRule extends TransformationRule {
             }
             // must be un-partitioned table, or partition columns are identity columns.
             // otherwise partition values will be materialized from files but the same in a single file.
-            IcebergTable table = (IcebergTable) scanOperator.getTable();
-            if (!(table.isUnPartitioned() || table.isAllPartitionColumnsAlwaysIdentity())) {
+            Table table = scanOperator.getTable();
+            if (table instanceof IcebergTable) {
+                IcebergTable icebergTable = (IcebergTable) table;
+                if (!(icebergTable.isUnPartitioned() || icebergTable.isAllPartitionColumnsAlwaysIdentity())) {
+                    return false;
+                }
+            } else if (table instanceof PaimonTable) {
+                // Paimon partition columns are always identity transforms, so only
+                // need to check un-partitioned for the group-by-partition-only case.
+                // (If we got here, all group-by keys are partition columns.)
+            } else {
                 return false;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFileScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalPaimonScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.MultiOpPattern;
@@ -58,7 +59,8 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
 
     private static final Set<OperatorType> SUPPORTED = Set.of(OperatorType.LOGICAL_HIVE_SCAN,
             OperatorType.LOGICAL_ICEBERG_SCAN,
-            OperatorType.LOGICAL_FILE_SCAN
+            OperatorType.LOGICAL_FILE_SCAN,
+            OperatorType.LOGICAL_PAIMON_SCAN
     );
 
     public static final RewriteSimpleAggToHDFSScanRule SCAN_NO_PROJECT =
@@ -154,6 +156,9 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
                     scanOperator.getTvrVersionRange());
         } else if (scanOperator instanceof LogicalFileScanOperator) {
             newMetaScan = new LogicalFileScanOperator(scanOperator.getTable(),
+                    newScanColumnRefs, newScanColumnMeta, scanOperator.getLimit(), scanOperator.getPredicate());
+        } else if (scanOperator instanceof LogicalPaimonScanOperator) {
+            newMetaScan = new LogicalPaimonScanOperator(scanOperator.getTable(),
                     newScanColumnRefs, newScanColumnMeta, scanOperator.getLimit(), scanOperator.getPredicate());
         } else {
             LOG.warn("Unexpected scan operator: " + scanOperator);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMinMaxUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMinMaxUtilTest.java
@@ -1,0 +1,532 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.paimon;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.SlotId;
+import com.starrocks.thrift.TExprMinMaxValue;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.DateType;
+import com.starrocks.type.FloatType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.TypeFactory;
+import org.apache.paimon.data.BinaryArray;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class PaimonMinMaxUtilTest {
+
+    private SlotDescriptor createSlotDescriptor(int slotId, String name, com.starrocks.type.Type type) {
+        SlotDescriptor sd = new SlotDescriptor(new SlotId(slotId), name, type, true);
+        sd.setColumn(new Column(name, type));
+        return sd;
+    }
+
+    private BinaryArray createNullCountArray(Long... values) {
+        return BinaryArray.fromLongArray(values);
+    }
+
+    @Test
+    public void testIntegerMinMax() {
+        // Schema: id INT, value INT
+        RowType rowType = RowType.of(
+                new DataField(0, "id", DataTypes.INT()),
+                new DataField(1, "value", DataTypes.INT()));
+
+        BinaryRow minRow = new BinaryRow(2);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.writeInt(0, 10);
+        minWriter.writeInt(1, 100);
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(2);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.writeInt(0, 50);
+        maxWriter.writeInt(1, 500);
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L, 5L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "id", IntegerType.INT),
+                createSlotDescriptor(2, "value", IntegerType.INT)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertEquals(2, result.size());
+
+        // Check id column
+        TExprMinMaxValue idValue = result.get(1);
+        Assertions.assertNotNull(idValue);
+        Assertions.assertEquals(TExprNodeType.INT_LITERAL, idValue.getType());
+        Assertions.assertEquals(10, idValue.getMin_int_value());
+        Assertions.assertEquals(50, idValue.getMax_int_value());
+        Assertions.assertFalse(idValue.isHas_null());
+        Assertions.assertFalse(idValue.isAll_null());
+
+        // Check value column
+        TExprMinMaxValue valueValue = result.get(2);
+        Assertions.assertNotNull(valueValue);
+        Assertions.assertEquals(TExprNodeType.INT_LITERAL, valueValue.getType());
+        Assertions.assertEquals(100, valueValue.getMin_int_value());
+        Assertions.assertEquals(500, valueValue.getMax_int_value());
+        Assertions.assertTrue(valueValue.isHas_null());
+        Assertions.assertFalse(valueValue.isAll_null());
+    }
+
+    @Test
+    public void testLongMinMax() {
+        RowType rowType = RowType.of(
+                new DataField(0, "big_id", DataTypes.BIGINT()));
+
+        BinaryRow minRow = new BinaryRow(1);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.writeLong(0, Long.MIN_VALUE);
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(1);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.writeLong(0, Long.MAX_VALUE);
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "big_id", IntegerType.BIGINT)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertEquals(1, result.size());
+        TExprMinMaxValue value = result.get(1);
+        Assertions.assertEquals(TExprNodeType.INT_LITERAL, value.getType());
+        Assertions.assertEquals(Long.MIN_VALUE, value.getMin_int_value());
+        Assertions.assertEquals(Long.MAX_VALUE, value.getMax_int_value());
+    }
+
+    @Test
+    public void testDoubleMinMax() {
+        RowType rowType = RowType.of(
+                new DataField(0, "price", DataTypes.DOUBLE()));
+
+        BinaryRow minRow = new BinaryRow(1);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.writeDouble(0, 1.5);
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(1);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.writeDouble(0, 99.9);
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "price", FloatType.DOUBLE)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertEquals(1, result.size());
+        TExprMinMaxValue value = result.get(1);
+        Assertions.assertEquals(TExprNodeType.FLOAT_LITERAL, value.getType());
+        Assertions.assertEquals(1.5, value.getMin_float_value(), 0.001);
+        Assertions.assertEquals(99.9, value.getMax_float_value(), 0.001);
+    }
+
+    @Test
+    public void testFloatMinMax() {
+        RowType rowType = RowType.of(
+                new DataField(0, "score", DataTypes.FLOAT()));
+
+        BinaryRow minRow = new BinaryRow(1);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.writeFloat(0, 0.5f);
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(1);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.writeFloat(0, 10.0f);
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "score", FloatType.FLOAT)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertEquals(1, result.size());
+        TExprMinMaxValue value = result.get(1);
+        Assertions.assertEquals(TExprNodeType.FLOAT_LITERAL, value.getType());
+        Assertions.assertEquals(0.5f, (float) value.getMin_float_value(), 0.001);
+        Assertions.assertEquals(10.0f, (float) value.getMax_float_value(), 0.001);
+    }
+
+    @Test
+    public void testBooleanMinMax() {
+        RowType rowType = RowType.of(
+                new DataField(0, "flag", DataTypes.BOOLEAN()));
+
+        BinaryRow minRow = new BinaryRow(1);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.writeBoolean(0, false);
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(1);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.writeBoolean(0, true);
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "flag", BooleanType.BOOLEAN)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertEquals(1, result.size());
+        TExprMinMaxValue value = result.get(1);
+        Assertions.assertEquals(TExprNodeType.BOOL_LITERAL, value.getType());
+        Assertions.assertEquals(0, value.getMin_int_value());
+        Assertions.assertEquals(1, value.getMax_int_value());
+    }
+
+    @Test
+    public void testAllNullColumn() {
+        RowType rowType = RowType.of(
+                new DataField(0, "id", DataTypes.INT()));
+
+        BinaryRow minRow = new BinaryRow(1);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.setNullAt(0);
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(1);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.setNullAt(0);
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(100L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "id", IntegerType.INT)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertEquals(1, result.size());
+        TExprMinMaxValue value = result.get(1);
+        Assertions.assertEquals(TExprNodeType.NULL_LITERAL, value.getType());
+        Assertions.assertTrue(value.isAll_null());
+        Assertions.assertTrue(value.isHas_null());
+    }
+
+    @Test
+    public void testEmptyStats() {
+        RowType rowType = RowType.of(
+                new DataField(0, "id", DataTypes.INT()));
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "id", IntegerType.INT)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, SimpleStats.EMPTY_STATS, null, 100L, slots);
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testNullStats() {
+        RowType rowType = RowType.of(
+                new DataField(0, "id", DataTypes.INT()));
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "id", IntegerType.INT)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, null, null, 100L, slots);
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testValueStatsColsSubset() {
+        // Schema: id INT, name STRING, value INT
+        // Stats only available for "id" and "value"
+        RowType rowType = RowType.of(
+                new DataField(0, "id", DataTypes.INT()),
+                new DataField(1, "name", DataTypes.STRING()),
+                new DataField(2, "value", DataTypes.INT()));
+
+        // Build min/max with 2 fields (matching valueStatsCols size)
+        BinaryRow minRow = new BinaryRow(2);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.writeInt(0, 1);    // id min
+        minWriter.writeInt(1, 10);   // value min
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(2);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.writeInt(0, 100);  // id max
+        maxWriter.writeInt(1, 200);  // value max
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L, 0L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<String> valueStatsCols = Arrays.asList("id", "value");
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "id", IntegerType.INT),
+                createSlotDescriptor(2, "name", TypeFactory.createDefaultCatalogString()),
+                createSlotDescriptor(3, "value", IntegerType.INT)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, valueStatsCols, 100L, slots);
+
+        // "name" column is STRING (unsupported) and also not in valueStatsCols
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertNull(result.get(2)); // name not present
+
+        TExprMinMaxValue idValue = result.get(1);
+        Assertions.assertNotNull(idValue);
+        Assertions.assertEquals(1, idValue.getMin_int_value());
+        Assertions.assertEquals(100, idValue.getMax_int_value());
+
+        TExprMinMaxValue valValue = result.get(3);
+        Assertions.assertNotNull(valValue);
+        Assertions.assertEquals(10, valValue.getMin_int_value());
+        Assertions.assertEquals(200, valValue.getMax_int_value());
+    }
+
+    @Test
+    public void testUnsupportedTypeSkipped() {
+        // STRING and DECIMAL types should be skipped
+        RowType rowType = RowType.of(
+                new DataField(0, "name", DataTypes.STRING()),
+                new DataField(1, "amount", DataTypes.DECIMAL(10, 2)));
+
+        BinaryRow minRow = new BinaryRow(2);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.setNullAt(0);
+        minWriter.setNullAt(1);
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(2);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.setNullAt(0);
+        maxWriter.setNullAt(1);
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L, 0L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "name", TypeFactory.createDefaultCatalogString()),
+                createSlotDescriptor(2, "amount", TypeFactory.createDecimalV3NarrowestType(10, 2))
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testDateMinMax() {
+        RowType rowType = RowType.of(
+                new DataField(0, "dt", DataTypes.DATE()));
+
+        BinaryRow minRow = new BinaryRow(1);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.writeInt(0, 18628); // 2021-01-01 days since epoch
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(1);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.writeInt(0, 18993); // 2022-01-01 days since epoch
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "dt", DateType.DATE)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertEquals(1, result.size());
+        TExprMinMaxValue value = result.get(1);
+        Assertions.assertEquals(TExprNodeType.INT_LITERAL, value.getType());
+        Assertions.assertEquals(18628, value.getMin_int_value());
+        Assertions.assertEquals(18993, value.getMax_int_value());
+    }
+
+    @Test
+    public void testMixedTypes() {
+        // Schema with multiple types
+        RowType rowType = RowType.of(
+                new DataField(0, "id", DataTypes.INT()),
+                new DataField(1, "score", DataTypes.DOUBLE()),
+                new DataField(2, "active", DataTypes.BOOLEAN()));
+
+        BinaryRow minRow = new BinaryRow(3);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.writeInt(0, 1);
+        minWriter.writeDouble(1, 0.5);
+        minWriter.writeBoolean(2, false);
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(3);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.writeInt(0, 100);
+        maxWriter.writeDouble(1, 99.9);
+        maxWriter.writeBoolean(2, true);
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L, 2L, 0L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "id", IntegerType.INT),
+                createSlotDescriptor(2, "score", FloatType.DOUBLE),
+                createSlotDescriptor(3, "active", BooleanType.BOOLEAN)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertEquals(3, result.size());
+
+        // INT
+        TExprMinMaxValue idVal = result.get(1);
+        Assertions.assertEquals(TExprNodeType.INT_LITERAL, idVal.getType());
+        Assertions.assertEquals(1, idVal.getMin_int_value());
+        Assertions.assertEquals(100, idVal.getMax_int_value());
+
+        // DOUBLE
+        TExprMinMaxValue scoreVal = result.get(2);
+        Assertions.assertEquals(TExprNodeType.FLOAT_LITERAL, scoreVal.getType());
+        Assertions.assertTrue(scoreVal.isHas_null());
+
+        // BOOLEAN
+        TExprMinMaxValue activeVal = result.get(3);
+        Assertions.assertEquals(TExprNodeType.BOOL_LITERAL, activeVal.getType());
+    }
+
+    @Test
+    public void testColumnNotInSchema() {
+        RowType rowType = RowType.of(
+                new DataField(0, "id", DataTypes.INT()));
+
+        BinaryRow minRow = new BinaryRow(1);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.writeInt(0, 1);
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(1);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.writeInt(0, 100);
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        // Request a column that doesn't exist in the schema
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "nonexistent", IntegerType.INT)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testSmallintAndTinyint() {
+        RowType rowType = RowType.of(
+                new DataField(0, "small_val", DataTypes.SMALLINT()),
+                new DataField(1, "tiny_val", DataTypes.TINYINT()));
+
+        BinaryRow minRow = new BinaryRow(2);
+        BinaryRowWriter minWriter = new BinaryRowWriter(minRow);
+        minWriter.writeShort(0, (short) -100);
+        minWriter.writeByte(1, (byte) 0);
+        minWriter.complete();
+
+        BinaryRow maxRow = new BinaryRow(2);
+        BinaryRowWriter maxWriter = new BinaryRowWriter(maxRow);
+        maxWriter.writeShort(0, (short) 100);
+        maxWriter.writeByte(1, (byte) 127);
+        maxWriter.complete();
+
+        BinaryArray nullCounts = createNullCountArray(0L, 0L);
+        SimpleStats stats = new SimpleStats(minRow, maxRow, nullCounts);
+
+        List<SlotDescriptor> slots = Arrays.asList(
+                createSlotDescriptor(1, "small_val", IntegerType.SMALLINT),
+                createSlotDescriptor(2, "tiny_val", IntegerType.TINYINT)
+        );
+
+        Map<Integer, TExprMinMaxValue> result = PaimonMinMaxUtil.toThriftMinMaxValueBySlots(
+                rowType, stats, null, 100L, slots);
+
+        Assertions.assertEquals(2, result.size());
+
+        TExprMinMaxValue smallVal = result.get(1);
+        Assertions.assertEquals(TExprNodeType.INT_LITERAL, smallVal.getType());
+        Assertions.assertEquals(-100, smallVal.getMin_int_value());
+        Assertions.assertEquals(100, smallVal.getMax_int_value());
+
+        TExprMinMaxValue tinyVal = result.get(2);
+        Assertions.assertEquals(TExprNodeType.INT_LITERAL, tinyVal.getType());
+        Assertions.assertEquals(0, tinyVal.getMin_int_value());
+        Assertions.assertEquals(127, tinyVal.getMax_int_value());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
@@ -179,4 +179,83 @@ public class PaimonScanNodeTest {
         TScanRangeLocations tScanRangeLocations = scanNode.getScanRangeLocations(10).get(0);
         Assertions.assertEquals(THdfsFileFormat.UNKNOWN, tScanRangeLocations.getScan_range().getHdfs_scan_range().getFile_format());
     }
+
+    @Test
+    public void testSplitRawFileScanRangeWithMinMaxValues(@Mocked PaimonTable table, @Mocked RawFile rawFile) {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        new Expectations() {
+            {
+                rawFile.format();
+                result = "parquet";
+                rawFile.path();
+                result = "/data/file1.parquet";
+                rawFile.offset();
+                result = 0L;
+                rawFile.length();
+                result = 1000L;
+            }
+        };
+
+        PaimonScanNode scanNode = new PaimonScanNode(new PlanNodeId(0), desc, "XXX");
+
+        // Build min/max values map
+        com.starrocks.thrift.TExprMinMaxValue minMaxValue = new com.starrocks.thrift.TExprMinMaxValue();
+        minMaxValue.setType(com.starrocks.thrift.TExprNodeType.INT_LITERAL);
+        minMaxValue.setMin_int_value(10);
+        minMaxValue.setMax_int_value(100);
+        minMaxValue.setHas_null(false);
+        minMaxValue.setAll_null(false);
+
+        java.util.Map<Integer, com.starrocks.thrift.TExprMinMaxValue> minMaxValues = new HashMap<>();
+        minMaxValues.put(1, minMaxValue);
+
+        // Call with min/max values
+        scanNode.splitRawFileScanRangeLocations(rawFile, null, minMaxValues);
+
+        List<TScanRangeLocations> locations = scanNode.getScanRangeLocations(10);
+        Assertions.assertEquals(1, locations.size());
+
+        // Verify min/max values are set on the scan range
+        var hdfsScanRange = locations.get(0).getScan_range().getHdfs_scan_range();
+        Assertions.assertTrue(hdfsScanRange.isSetMin_max_values());
+        Assertions.assertEquals(1, hdfsScanRange.getMin_max_values().size());
+
+        com.starrocks.thrift.TExprMinMaxValue result = hdfsScanRange.getMin_max_values().get(1);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(com.starrocks.thrift.TExprNodeType.INT_LITERAL, result.getType());
+        Assertions.assertEquals(10, result.getMin_int_value());
+        Assertions.assertEquals(100, result.getMax_int_value());
+        Assertions.assertFalse(result.isHas_null());
+    }
+
+    @Test
+    public void testSplitRawFileScanRangeWithoutMinMaxValues(@Mocked PaimonTable table, @Mocked RawFile rawFile) {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        new Expectations() {
+            {
+                rawFile.format();
+                result = "orc";
+                rawFile.path();
+                result = "/data/file1.orc";
+                rawFile.offset();
+                result = 0L;
+                rawFile.length();
+                result = 500L;
+            }
+        };
+
+        PaimonScanNode scanNode = new PaimonScanNode(new PlanNodeId(0), desc, "XXX");
+
+        // Call without min/max values (legacy path)
+        scanNode.splitRawFileScanRangeLocations(rawFile, null);
+
+        List<TScanRangeLocations> locations = scanNode.getScanRangeLocations(10);
+        Assertions.assertEquals(1, locations.size());
+
+        // Verify min/max values are NOT set on the scan range
+        var hdfsScanRange = locations.get(0).getScan_range().getHdfs_scan_range();
+        Assertions.assertFalse(hdfsScanRange.isSetMin_max_values());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Paimon's DataFileMeta.valueStats() provides per-column min/max values that can be used for skipping before reading.
The PaimonPredicateConverter already pushes predicates to Paimon's manifest-level filtering during split planning, but the native C++ reader path (Parquet/ORC) does not receive min/max stats for per-file skipping.
The BE scanner already supports min_max_conjuncts and can_use_min_max_opt via THdfsScanRange.min_max_values.
Iceberg already implements this via IcebergUtil.toThriftMinMaxValueBySlots() PR-60385
Paimon tables are missing this optimization, resulting in unnecessary file reads when the native reader is used.

## What I'm doing:
* parse lower/upper bound at fe side to object
          - For the native reader path, extracts min/max stats from each DataFileMeta.valueStats() and populate THdfsScanRange.min_max_values
* pass this object down to BE side
* if it's some sql pattern like select max(a), and if we find we have lower_bound value of a, we just output that

test result on tpcds data set
**before**:
mysql> select max(ss_sold_date_sk) from store_sales;
+----------------------+
| max(ss_sold_date_sk) |
+----------------------+
|              2452642 |
+----------------------+
1 row in set (0.44 sec)

**after:**
mysql> select max(ss_sold_date_sk) from store_sales;
+----------------------+
| max(ss_sold_date_sk) |
+----------------------+
|              2452642 |
+----------------------+
1 row in set (0.06 sec)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
