### PR TITLE
[Enhancement] Enable Avro JNI reader by default and document CHAR compatibility

### DIFF
--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -224,6 +224,16 @@ If you want to activate the roles assigned to you in a session, use the [SET ROL
 
 Used for MySQL client compatibility. No practical usage.
 
+### avro_use_jni_reader
+
+* **Scope**: Session
+* **Description**: Controls whether StarRocks uses the JNI-based Avro reader when scanning Avro data from external catalogs such as Hive. When enabled (`true`), the FE sets this session variable on Avro scan ranges and the BE chooses `HdfsAvroScanner` instead of the native Avro scanner path. This option can be used as a compatibility fallback when the native reader does not meet your needs.
+
+  Current limitation: `CHAR(n)` columns are not fully compatible between the JNI and non-JNI Avro readers. For Avro values such as `Char` read into a `CHAR(10)` column, the current native reader keeps the unpadded value instead of returning `Char` followed by six spaces, while the JNI reader may behave differently. To avoid inconsistent results, we recommend not relying on `CHAR(n)` padding semantics when switching `avro_use_jni_reader`, and using `VARCHAR` instead when possible.
+* **Default**: `true`
+* **Data Type**: boolean
+* **Introduced in**: v4.1.1
+
 ### big_query_profile_threshold
 
 * **Description**: Used to set the threshold for big queries. When the session variable `enable_profile` is set to `false` and the amount of time taken by a query exceeds the threshold specified by the variable `big_query_profile_threshold`, a profile is generated for that query.

--- a/docs/ja/sql-reference/System_variable.md
+++ b/docs/ja/sql-reference/System_variable.md
@@ -199,6 +199,16 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 MySQL クライアント互換性のために使用されます。実際の用途はありません。
 
+### avro_use_jni_reader
+
+* **スコープ**: Session
+* **説明**: Hive などの外部 Catalog にある Avro データをスキャンする際に、JNI ベースの Avro Reader を使用するかどうかを制御します。有効にすると（`true`）、FE は Avro scan range にこのセッション変数を設定し、BE はネイティブ Avro スキャン経路ではなく `HdfsAvroScanner` を優先して使用します。現在この変数は主に互換性確保のためのフォールバックとして利用されます。
+
+  現在の制限: `CHAR(n)` 列は JNI Reader と非 JNI Avro Reader の間で完全には互換ではありません。たとえば `CHAR(10)` 列に対して Avro の値 `Char` を読み込む場合、現在のネイティブ Reader は `Char` の後ろに 6 個の空白を付けず、非パディングの値をそのまま保持します。一方で JNI Reader は異なる挙動を示す可能性があります。`avro_use_jni_reader` を切り替えた際の結果不一致を避けるため、現時点では `CHAR(n)` の空白パディングの意味論に依存しないことを推奨します。可能であれば `VARCHAR` を使用してください。
+* **デフォルト**: `true`
+* **データ型**: boolean
+* **導入バージョン**: v4.1.1
+
 ### binary_encoding_format
 
 * **スコープ**: Session

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -198,6 +198,16 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * 默认值：1
 * 类型：Int
 
+### avro_use_jni_reader
+
+* **作用域**: Session
+* **描述**: 控制 StarRocks 在扫描 Hive 等外部 Catalog 中的 Avro 数据时，是否使用基于 JNI 的 Avro Reader。启用后（`true`），FE 会在 Avro scan range 上设置该会话变量，BE 会优先选择 `HdfsAvroScanner`，而不是原生 Avro 扫描路径。当前该变量主要用于兼容性兜底。
+
+  当前限制：`CHAR(n)` 列在 JNI 与非 JNI Avro Reader 之间并不完全兼容。对于写入 `CHAR(10)` 列的 Avro 值 `Char`，当前原生 Reader 会保留未补空格的值，而不会返回带 6 个尾部空格的 `Char`；JNI Reader 的行为可能不同。为了避免切换 `avro_use_jni_reader` 后结果不一致，当前不建议依赖 `CHAR(n)` 的补空格语义；如条件允许，建议优先使用 `VARCHAR`。
+* **默认值**: `true`
+* **数据类型**: boolean
+* **引入版本**: v4.1.1
+
 ### binary_encoding_format
 
 * **作用域**: Session

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -21,6 +21,8 @@ import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.hive.HiveStorageFormat;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
@@ -72,12 +74,17 @@ public class FileTableScanNode extends ScanNode {
 
     public void setupScanRangeLocations() throws Exception {
         List<RemoteFileDesc> files = fileTable.getFileDescs();
+        SessionVariable sv = SessionVariable.DEFAULT_SESSION_VARIABLE;
+        ConnectContext connectContext = ConnectContext.get();
+        if (connectContext != null) {
+            sv = connectContext.getSessionVariable();
+        }
         for (RemoteFileDesc file : files) {
-            addScanRangeLocations(file);
+            addScanRangeLocations(file, sv);
         }
     }
 
-    private void addScanRangeLocations(RemoteFileDesc file) {
+    private void addScanRangeLocations(RemoteFileDesc file, SessionVariable sv) {
         for (RemoteFileBlockDesc blockDesc : file.getBlockDescs()) {
             TScanRangeLocations scanRangeLocs = new TScanRangeLocations();
 
@@ -103,6 +110,7 @@ public class FileTableScanNode extends ScanNode {
             if (fileFormat.isTextFormat()) {
                 hdfsScanRange.setText_file_desc(file.getTextFileFormatDesc().toThrift());
             }
+            hdfsScanRange.setUse_avro_jni_reader(sv.getAvroUseJNIReader());
 
             TScanRange scanRange = new TScanRange();
             scanRange.setHdfs_scan_range(hdfsScanRange);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -110,7 +110,9 @@ public class FileTableScanNode extends ScanNode {
             if (fileFormat.isTextFormat()) {
                 hdfsScanRange.setText_file_desc(file.getTextFileFormatDesc().toThrift());
             }
-            hdfsScanRange.setUse_avro_jni_reader(sv.getAvroUseJNIReader());
+            if (fileFormat == HiveStorageFormat.AVRO) {
+                hdfsScanRange.setUse_avro_jni_reader(sv.getAvroUseJNIReader());
+            }
 
             TScanRange scanRange = new TScanRange();
             scanRange.setHdfs_scan_range(hdfsScanRange);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2786,7 +2786,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean paimonForceJNIReader = false;
 
     @VariableMgr.VarAttr(name = AVRO_USE_JNI_READER)
-    private boolean avroUseJNIReader = false;
+    private boolean avroUseJNIReader = true;
 
     @VarAttr(name = ENABLE_QUERY_CACHE)
     private boolean enableQueryCache = false;


### PR DESCRIPTION
## Why I'm doing:
We want Avro scans to use the JNI reader by default instead of requiring an explicit session override.

At the same time, this behavior was not clearly documented, and there is an important compatibility caveat for `CHAR(n)` columns between the JNI and non-JNI Avro readers. Making the default explicit in both code and docs helps reduce confusion and makes the rollout easier to understand.

## What I'm doing:
1. Change the default value of the session variable `avro_use_jni_reader` from `false` to `true`, so Avro scan planning will prefer the JNI reader by default.

2. Add `avro_use_jni_reader` to the system variable documentation in English, Chinese, and Japanese.

3. Document the current `CHAR(n)` compatibility limitation between the two Avro reader paths at a high level, so users know not to rely on padding semantics when switching reader implementations.

Reader selection after this change is effectively:

```text
Avro scan
  |
  v
avro_use_jni_reader = true   --> JNI reader (default)
avro_use_jni_reader = false  --> native reader
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5