### PR TITLE
[Enhancement] Bump minimum required CMake version

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 set(STARROCKS_PRECONFIG_MODE "AUTO" CACHE STRING "Preconfigure bootstrap mode: AUTO, ON, or OFF")
 set_property(CACHE STARROCKS_PRECONFIG_MODE PROPERTY STRINGS AUTO ON OFF)

--- a/be/cmake_modules/PreBuildModule.cmake
+++ b/be/cmake_modules/PreBuildModule.cmake
@@ -36,7 +36,6 @@ if ("${USE_STAROS}" STREQUAL "ON")
     set(PROTOBUF_FOUND TRUE)
     # starrocks project has its imported libprotobuf.a and libre2.a
     # add following ALIAS so grpc can find the correct dependent libraries
-    add_library(re2::re2 ALIAS re2)
     add_library(glog::glog ALIAS glog)
     add_library(gflags::gflags_static ALIAS gflags)
     add_library(hdfs::hdfs ALIAS hdfs)

--- a/be/src/formats/orc/apache-orc/CMakeLists.txt
+++ b/be/src/formats/orc/apache-orc/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 3.10.12)
+cmake_minimum_required (VERSION 3.20)
 if (POLICY CMP0048)
     cmake_policy(SET CMP0048 NEW)
 endif ()


### PR DESCRIPTION
## Why I'm doing:

To upgrade to C++23 in https://github.com/StarRocks/starrocks/pull/73504, we need to first bump the minimum required CMake version. 

## What I'm doing:

Bump minimum required CMake version and remove unnecessary `add_library` alias that caused issues due to changes in CMake policy documented [here](https://cmake.org/cmake/help/latest/policy/CMP0107.html). More details see the commit message.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
