### PR TITLE
[Enhancement] Align Hive JNI reader CHAR handling with non-JNI Avro reader behavior

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -886,7 +886,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
         use_kudu_jni_reader = scan_range.use_kudu_jni_reader;
     }
 
-    bool use_avro_jni_reader = false;
+    bool use_avro_jni_reader = true;
     if (scan_range.__isset.use_avro_jni_reader) {
         use_avro_jni_reader = scan_range.use_avro_jni_reader;
     }

--- a/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveColumnValue.java
+++ b/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveColumnValue.java
@@ -16,6 +16,7 @@ package com.starrocks.hive.reader;
 
 import com.starrocks.jni.connector.ColumnType;
 import com.starrocks.jni.connector.ColumnValue;
+import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
@@ -94,6 +95,9 @@ public class HiveColumnValue implements ColumnValue {
     @Override
     public String getString(ColumnType.TypeValue type) {
         Object o = inspectObject();
+        if (o instanceof HiveChar) {
+            return ((HiveChar) o).getStrippedValue();
+        }
         return o.toString();
     }
 

--- a/test/sql/test_external_file/R/test_hive_jni_format
+++ b/test/sql/test_external_file/R/test_hive_jni_format
@@ -1,9 +1,5 @@
 -- name: testHiveAvroFormat
 [UC]shell: avro_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/avro_format/"
--- result:
-0
-oss://starrocks-env-s3-unit-test/test_hive_format/f81c141277504324a587846c0c566663/avro_format/
--- !result
 shell: ossutil64 mkdir ${avro_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -50,11 +46,11 @@ PROPERTIES
 -- !result
 select * from test_hive_avro_format where col_string = 'world';
 -- result:
-7	13	74	13000000000	6.15	4.376	57.30	world	Char      	Varchar	1	2022-01-01 10:00:00	2022-01-01	["A","B","C"]	{"key1":1,"key2":2}	{"name":"John","age":30}
+7	13	74	13000000000	6.15	4.376	57.30	world	Char	Varchar	1	2022-01-01 10:00:00	2022-01-01	["A","B","C"]	{"key1":1,"key2":2}	{"name":"John","age":30}
 -- !result
 select * from test_hive_avro_format where abs(col_float - 1.23) < 0.01 ;
 -- result:
-1	2	3	10000000000	1.23	3.14	100.50	you	are       	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k1":3,"k2":5}	{"name":"chandler","age":54}
+1	2	3	10000000000	1.23	3.14	100.50	you	are	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k1":3,"k2":5}	{"name":"chandler","age":54}
 -- !result
 select col_tinyint,col_decimal,col_array from test_hive_avro_format order by 1;
 -- result:
@@ -87,10 +83,6 @@ shell: ossutil64 rm -rf ${avro_prefix[1]}  >/dev/null || echo "exit 0" >/dev/nul
 -- !result
 -- name: testHiveRcbinayFormat
 [UC]shell: rcbinary_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/rcbinary_format/"
--- result:
-0
-oss://starrocks-env-s3-unit-test/test_hive_format/744f2c100abf4fa0af69da7b4824ad02/rcbinary_format/
--- !result
 shell: ossutil64 mkdir ${rcbinary_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -137,11 +129,11 @@ PROPERTIES
 -- !result
 select * from test_hive_rcbinary_format where col_string = 'world';
 -- result:
-7	13	74	13000000000	6.15	4.376	57.30	world	Char      	Varchar	1	2022-01-01 10:00:00	2022-01-01	["A","B","C"]	{"key2":2,"key1":1}	{"name":"John","age":30}
+7	13	74	13000000000	6.15	4.376	57.30	world	Char	Varchar	1	2022-01-01 10:00:00	2022-01-01	["A","B","C"]	{"key2":2,"key1":1}	{"name":"John","age":30}
 -- !result
 select * from test_hive_rcbinary_format where abs(col_float - 1.23) < 0.01 ;
 -- result:
-1	2	3	10000000000	1.23	3.14	100.50	you	are       	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k2":5,"k1":3}	{"name":"chandler","age":54}
+1	2	3	10000000000	1.23	3.14	100.50	you	are	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k2":5,"k1":3}	{"name":"chandler","age":54}
 -- !result
 select col_tinyint,col_decimal,col_array from test_hive_rcbinary_format order by 1;
 -- result:
@@ -174,10 +166,6 @@ shell: ossutil64 rm -rf ${rcbinary_prefix[1]}  >/dev/null || echo "exit 0" >/dev
 -- !result
 -- name: testHiveRctextFormat
 [UC]shell: rctext_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/rctext_format/"
--- result:
-0
-oss://starrocks-env-s3-unit-test/test_hive_format/aead1b6eaffd4516999a69b52092962a/rctext_format/
--- !result
 shell: ossutil64 mkdir ${rctext_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -224,16 +212,16 @@ PROPERTIES
 -- !result
 select * from test_hive_rctext_format where col_string = 'world';
 -- result:
-7	13	74	13000000000	6.15	4.376	57.30	world	Char      	Varchar	1	2022-01-01 10:00:00	2022-01-01	["A","B","C"]	{"key2":2,"key1":1}	{"name":"John","age":30}
+7	13	74	13000000000	6.15	4.376	57.30	world	Char	Varchar	1	2022-01-01 10:00:00	2022-01-01	["A","B","C"]	{"key2":2,"key1":1}	{"name":"John","age":30}
 -- !result
 select * from test_hive_rctext_format where abs(col_float - 1.23) < 0.01 ;
 -- result:
-1	2	3	10000000000	1.23	3.14	100.50	you	are       	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k2":5,"k1":3}	{"name":"chandler","age":54}
+1	2	3	10000000000	1.23	3.14	100.50	you	are	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k2":5,"k1":3}	{"name":"chandler","age":54}
 -- !result
 select col_tinyint,col_decimal,col_array from test_hive_rctext_format;
 -- result:
-1	100.50	["D","E","F"]
 7	57.30	["A","B","C"]
+1	100.50	["D","E","F"]
 -- !result
 set enable_rewrite_simple_agg_to_hdfs_scan = true;
 -- result:
@@ -256,10 +244,6 @@ shell: ossutil64 rm -rf ${rctext_prefix[1]}  >/dev/null || echo "exit 0" >/dev/n
 -- !result
 -- name: testHiveSequenceFormat
 [UC]shell: sequence_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/sequence_format/"
--- result:
-0
-oss://starrocks-env-s3-unit-test/test_hive_format/c42ab996c96f4035a7e2b04d1edb39ea/sequence_format/
--- !result
 shell: ossutil64 mkdir ${sequence_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -306,11 +290,11 @@ PROPERTIES
 -- !result
 select * from test_hive_sequence_format where col_string = 'world';
 -- result:
-7	13	74	13000000000	6.15	4.376	57.30	world	Char      	Varchar	1	2022-01-01 10:00:00	2022-01-01	["A","B","C"]	{"key2":2,"key1":1}	{"name":"John","age":30}
+7	13	74	13000000000	6.15	4.376	57.30	world	Char	Varchar	1	2022-01-01 10:00:00	2022-01-01	["A","B","C"]	{"key2":2,"key1":1}	{"name":"John","age":30}
 -- !result
 select * from test_hive_sequence_format where abs(col_float - 1.23) < 0.01 ;
 -- result:
-1	2	3	10000000000	1.23	3.14	100.50	you	are       	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k2":5,"k1":3}	{"name":"chandler","age":54}
+1	2	3	10000000000	1.23	3.14	100.50	you	are	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k2":5,"k1":3}	{"name":"chandler","age":54}
 -- !result
 select col_tinyint,col_decimal,col_array from test_hive_sequence_format;
 -- result:
@@ -338,10 +322,6 @@ shell: ossutil64 rm -rf ${sequence_prefix[1]}  >/dev/null || echo "exit 0" >/dev
 -- !result
 -- name: testHiveStructCharAndVarchar
 [UC]shell: struct_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/strcut/"
--- result:
-0
-oss://starrocks-env-s3-unit-test/test_hive_format/e15c6685c54140d497cb5453dd4e4765/strcut/
--- !result
 shell: ossutil64 mkdir ${struct_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -368,7 +348,7 @@ PROPERTIES
 -- !result
 select col_int,col_struct from hive_hdfs_sequencefile_struct_mix_deflate order by 1 limit 1;
 -- result:
--2144975700	{"c_int":1102434235,"c_float":-9972.251,"c_double":18.68127,"c_char":"(115)699-5565x12614           ","c_varchar":"Mozilla/5.0 (compatible; MSIE 5.0; Windows 95; Trident/4.1)","c_date":"2000-01-29","c_timestamp":"2000-11-10 11:01:59","c_boolean":1}
+-2144975700	{"c_int":1102434235,"c_float":-9972.251,"c_double":18.68127,"c_char":"(115)699-5565x12614","c_varchar":"Mozilla/5.0 (compatible; MSIE 5.0; Windows 95; Trident/4.1)","c_date":"2000-01-29","c_timestamp":"2000-11-10 11:01:59","c_boolean":1}
 -- !result
 shell: ossutil64 rm -rf ${struct_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:

--- a/test/sql/test_external_file/T/test_hive_jni_format
+++ b/test/sql/test_external_file/T/test_hive_jni_format
@@ -38,7 +38,6 @@ PROPERTIES
     "format" = "avro"
 );
 
-
 select * from test_hive_avro_format where col_string = 'world';
 select * from test_hive_avro_format where abs(col_float - 1.23) < 0.01 ;
 select col_tinyint,col_decimal,col_array from test_hive_avro_format order by 1;


### PR DESCRIPTION
## Why I'm doing:
While validating Avro/Hive reads, we found that `CHAR(n)` values were not handled consistently between the two reader paths we use today:

```text
non-JNI / generic reader  -> returns logical value without trailing padding
JNI / Hive reader         -> returns Hive padded CHAR value
```

For example, when reading a value like `Char` into `CHAR(10)`, the JNI reader could surface the padded representation, while the generic reader kept the unpadded logical value. This difference makes query results depend on which reader implementation is chosen, which is confusing for users and risky when `avro_use_jni_reader` is enabled by default.

## What I'm doing:
I updated the Hive JNI reader path to normalize Hive `CHAR` values before sending them to StarRocks.

At a high level, the change is:

```text
Hive primitive value
      |
      v
   HiveChar ? ---- yes ---> getStrippedValue()
      |
      no
      v
   existing conversion path
```

This keeps the fix narrowly scoped to the JNI Hive reader path and brings its `CHAR(n)` behavior closer to the existing non-JNI / generic reader behavior, without changing the rest of the Hive deserialization flow.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
