### PR TITLE
[BugFix] Move routine-load broker RPC out of the per-job writeLock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -77,6 +77,7 @@ import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -422,68 +423,222 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         updateNewPartitionProgress();
     }
 
-    // if customKafkaPartition is not null, then return false immediately
-    // else if kafka partitions of topic has been changed, return true.
-    // else return false
-    // update current kafka partition at the same time
-    // current kafka partitions = customKafkaPartitions == 0 ? all of partition of kafka topic : customKafkaPartitions
+    // Refresh `currentKafkaPartitions` against the broker. The slow step is a FE -> BE brpc
+    // (KafkaUtil.getAllKafkaPartitions), so we must not hold the per-job writeLock across it -
+    // otherwise readers (admin RPCs, SHOW ROUTINE LOAD, processTimeoutTasks) stall for the
+    // full RPC plus retries. Three phases:
+    //   1. Snapshot brokerList/topic/state/configVersion under readLock.
+    //   2. Run convertCustomProperties (self-synchronized) and the brpc with no per-job lock.
+    //   3. Apply under writeLock, discarding the result if configVersion changed mid-flight.
     @Override
-    protected boolean unprotectNeedReschedule() throws StarRocksException {
-        // only running and need_schedule job need to be changed current kafka partitions
+    protected void refreshPartitionsIfNeeded() throws StarRocksException {
+        FetchSnapshot snapshot;
+        readLock();
+        try {
+            snapshot = takeFetchSnapshot();
+        } finally {
+            readUnlock();
+        }
+        if (snapshot == null) {
+            return;
+        }
+        switch (snapshot.kind) {
+            case PAUSED_AUTO_SCHEDULE:
+                applyPausedAutoSchedule();
+                return;
+            case CUSTOM_ONLY:
+                applyCustomPartitions(snapshot);
+                return;
+            case FETCH:
+                break;
+            default:
+                return;
+        }
+
+        List<Integer> newPartitions = null;
+        Exception fetchError = null;
+        try {
+            newPartitions = KafkaUtil.getAllKafkaPartitions(snapshot.brokerList, snapshot.topic,
+                    snapshotConvertedCustomProperties(), snapshot.computeResource);
+        } catch (Exception e) {
+            fetchError = e;
+        }
+
+        applyFetchResult(snapshot, newPartitions, fetchError);
+    }
+
+    // Phase 1 helper. Must be called with at least readLock held so the read of state,
+    // customKafkaPartitions, brokerList, topic, dataSourceConfigVersion is consistent.
+    // Returns null when the job is in a final state (STOPPED/CANCELLED) or any state that
+    // does not require partition refresh; callers must short-circuit the rest of the cycle
+    // in that case.
+    private FetchSnapshot takeFetchSnapshot() {
         if (this.state == JobState.RUNNING || this.state == JobState.NEED_SCHEDULE) {
-            if (customKafkaPartitions != null && customKafkaPartitions.size() != 0) {
+            if (customKafkaPartitions != null && !customKafkaPartitions.isEmpty()) {
+                // User pinned the partition list at CREATE time; no broker RPC needed.
+                return FetchSnapshot.customOnly(dataSourceConfigVersion);
+            }
+            return FetchSnapshot.fetch(brokerList, topic, computeResource, dataSourceConfigVersion);
+        }
+        if (this.state == JobState.PAUSED) {
+            // PAUSED jobs do not need partition info, but may be eligible for auto-resume.
+            return FetchSnapshot.pausedAutoSchedule();
+        }
+        return null;
+    }
+
+    // Phase 3 (fast path). For jobs created with PROPERTIES("kafka_partitions"=...) there is no
+    // broker RPC; we just copy the user-pinned list into currentKafkaPartitions. We still take
+    // writeLock and re-check configVersion + state because phase 1 ran under readLock and an
+    // ALTER ROUTINE LOAD could have landed in between - in that case we drop the assignment and
+    // let the next scheduler tick re-snapshot with the new config.
+    private void applyCustomPartitions(FetchSnapshot snapshot) {
+        writeLock();
+        try {
+            if (dataSourceConfigVersion != snapshot.configVersion) {
+                return;
+            }
+            if (this.state != JobState.RUNNING && this.state != JobState.NEED_SCHEDULE) {
+                return;
+            }
+            if (customKafkaPartitions != null && !customKafkaPartitions.isEmpty()) {
                 currentKafkaPartitions = customKafkaPartitions;
-                return false;
-            } else {
-                List<Integer> newCurrentKafkaPartition;
-                try {
-                    newCurrentKafkaPartition = getAllKafkaPartitions();
-                } catch (Exception e) {
-                    String msg = "Job failed to fetch all current partition with error [" + e.getMessage() + "]";
-                    LOG.warn(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
-                            .add("error_msg", msg)
-                            .build(), e);
-                    if (this.state == JobState.NEED_SCHEDULE) {
-                        unprotectUpdateState(JobState.PAUSED,
-                                new ErrorReason(InternalErrorCode.PARTITIONS_ERR, msg));
-                    }
-                    return false;
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    // Phase 3 (PAUSED auto-resume). If a PAUSED job's pauseReason is recoverable (currently:
+    // REPLICA_FEW_ERR within ScheduleRule's retry/window budget), promote it back to
+    // NEED_SCHEDULE so the next RoutineLoadScheduler tick re-divides it into tasks. Pure FE
+    // state-machine work; no external calls, so the writeLock window is tiny.
+    private void applyPausedAutoSchedule() throws StarRocksException {
+        writeLock();
+        try {
+            if (this.state != JobState.PAUSED) {
+                return;
+            }
+            if (!ScheduleRule.isNeedAutoSchedule(this)) {
+                return;
+            }
+            LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                    .add("name", name)
+                    .add("current_state", this.state)
+                    .add("msg", "Job need to be rescheduled")
+                    .build());
+            unprotectUpdateProgress();
+            unprotectUpdateState(JobState.NEED_SCHEDULE, null);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    private void applyFetchResult(FetchSnapshot snapshot, List<Integer> newPartitions, Exception fetchError)
+            throws StarRocksException {
+        writeLock();
+        try {
+            if (dataSourceConfigVersion != snapshot.configVersion) {
+                // ALTER ROUTINE LOAD landed during the brpc; drop the stale fetch and let the
+                // next scheduler tick refetch with the new config.
+                return;
+            }
+            if (this.state != JobState.RUNNING && this.state != JobState.NEED_SCHEDULE) {
+                return;
+            }
+            if (fetchError != null) {
+                String msg = "Job failed to fetch all current partition with error [" + fetchError.getMessage() + "]";
+                LOG.warn(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                        .add("error_msg", msg)
+                        .build(), fetchError);
+                // Only PAUSE jobs that were waiting to be (re)scheduled; jobs already RUNNING
+                // keep their current tasks so a transient broker hiccup does not nuke an
+                // otherwise-healthy pipeline. The next scheduler tick will retry.
+                if (this.state == JobState.NEED_SCHEDULE) {
+                    unprotectUpdateState(JobState.PAUSED,
+                            new ErrorReason(InternalErrorCode.PARTITIONS_ERR, msg));
                 }
-                if (currentKafkaPartitions.containsAll(newCurrentKafkaPartition)) {
-                    if (currentKafkaPartitions.size() > newCurrentKafkaPartition.size()) {
-                        currentKafkaPartitions = newCurrentKafkaPartition;
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
-                                    .add("current_kafka_partitions", Joiner.on(",").join(currentKafkaPartitions))
-                                    .add("msg", "current kafka partitions has been change")
-                                    .build());
-                        }
-                        return true;
-                    } else {
-                        return false;
-                    }
-                } else {
-                    currentKafkaPartitions = newCurrentKafkaPartition;
+                return;
+            }
+            // Diff currentKafkaPartitions vs newPartitions. Three cases:
+            //   1) current is a strict superset of new  -> partitions were removed
+            //      -> swap to the smaller list and reschedule
+            //   2) current equals new (same set, same size) -> no change
+            //   3) current is missing at least one of new -> partitions were added (or set was
+            //      replaced) -> swap to the new list and reschedule
+            boolean changed;
+            if (currentKafkaPartitions.containsAll(newPartitions)) {
+                if (currentKafkaPartitions.size() > newPartitions.size()) {
+                    currentKafkaPartitions = newPartitions;
                     if (LOG.isDebugEnabled()) {
                         LOG.debug(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
                                 .add("current_kafka_partitions", Joiner.on(",").join(currentKafkaPartitions))
                                 .add("msg", "current kafka partitions has been change")
                                 .build());
                     }
-                    return true;
+                    changed = true;
+                } else {
+                    changed = false;
                 }
+            } else {
+                currentKafkaPartitions = newPartitions;
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                            .add("current_kafka_partitions", Joiner.on(",").join(currentKafkaPartitions))
+                            .add("msg", "current kafka partitions has been change")
+                            .build());
+                }
+                changed = true;
             }
-        } else if (this.state == JobState.PAUSED) {
-            boolean autoSchedule = ScheduleRule.isNeedAutoSchedule(this);
-            if (autoSchedule) {
-                LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, name)
-                        .add("current_state", this.state)
-                        .add("msg", "should be rescheduled")
+            if (changed) {
+                LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                        .add("msg", "Job need to be rescheduled")
                         .build());
+                unprotectUpdateProgress();
+                unprotectUpdateState(JobState.NEED_SCHEDULE, null);
             }
-            return autoSchedule;
-        } else {
-            return false;
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    // Discriminator for the apply phase of refreshPartitionsIfNeeded.
+    //   FETCH                - state RUNNING/NEED_SCHEDULE, no custom partitions; needs broker RPC
+    //   CUSTOM_ONLY          - state RUNNING/NEED_SCHEDULE, user-pinned partitions; no RPC needed
+    //   PAUSED_AUTO_SCHEDULE - state PAUSED; evaluate ScheduleRule for auto-resume
+    private enum FetchSnapshotKind { FETCH, CUSTOM_ONLY, PAUSED_AUTO_SCHEDULE }
+
+    // Immutable snapshot of the inputs captured in phase 1 (readLock) and consumed unchanged
+    // through phase 2 (unlocked broker RPC) and phase 3 (writeLock apply). Carrying the values
+    // on a snapshot rather than re-reading the mutable fields keeps the RPC inputs stable, and
+    // pairing them with configVersion lets phase 3 detect a concurrent ALTER and discard the
+    // stale fetch result.
+    private static final class FetchSnapshot {
+        final FetchSnapshotKind kind;
+        final String brokerList;
+        final String topic;
+        final ComputeResource computeResource;
+        final long configVersion;
+
+        private FetchSnapshot(FetchSnapshotKind kind, String brokerList, String topic,
+                              ComputeResource computeResource, long configVersion) {
+            this.kind = kind;
+            this.brokerList = brokerList;
+            this.topic = topic;
+            this.computeResource = computeResource;
+            this.configVersion = configVersion;
+        }
+
+        static FetchSnapshot fetch(String brokerList, String topic, ComputeResource cr, long ver) {
+            return new FetchSnapshot(FetchSnapshotKind.FETCH, brokerList, topic, cr, ver);
+        }
+
+        static FetchSnapshot customOnly(long ver) {
+            return new FetchSnapshot(FetchSnapshotKind.CUSTOM_ONLY, null, null, null, ver);
+        }
+
+        static FetchSnapshot pausedAutoSchedule() {
+            return new FetchSnapshot(FetchSnapshotKind.PAUSED_AUTO_SCHEDULE, null, null, null, 0L);
         }
     }
 
@@ -507,9 +662,21 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     }
 
     private List<Integer> getAllKafkaPartitions() throws StarRocksException {
-        convertCustomProperties(false);
         return KafkaUtil.getAllKafkaPartitions(brokerList, topic,
-                ImmutableMap.copyOf(convertedCustomProperties), computeResource);
+                snapshotConvertedCustomProperties(), computeResource);
+    }
+
+    // Snapshot `convertedCustomProperties` for use in an unlocked RPC call. Holds the intrinsic
+    // monitor across convertCustomProperties(false) + ImmutableMap.copyOf so a concurrent ALTER
+    // ROUTINE LOAD running modifyDataSourceProperties (which calls customProperties.putAll +
+    // convertCustomProperties(true) under the same monitor) cannot rebuild the backing HashMap
+    // mid-iteration. All RPC paths that need the converted-properties map must go through this
+    // helper - direct ImmutableMap.copyOf(convertedCustomProperties) is racy outside the monitor.
+    private ImmutableMap<String, String> snapshotConvertedCustomProperties() throws DdlException {
+        synchronized (this) {
+            convertCustomProperties(false);
+            return ImmutableMap.copyOf(convertedCustomProperties);
+        }
     }
 
     public static KafkaRoutineLoadJob fromCreateStmt(CreateRoutineLoadStmt stmt) throws StarRocksException {
@@ -840,8 +1007,13 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         }
 
         if (!customKafkaProperties.isEmpty()) {
-            this.customProperties.putAll(customKafkaProperties);
-            convertCustomProperties(true);
+            // Hold the intrinsic monitor across putAll + convertCustomProperties(true): the
+            // scheduler's lock-free refresh path reads customProperties via the synchronized
+            // convertCustomProperties(false); putAll outside the monitor would race that read.
+            synchronized (this) {
+                this.customProperties.putAll(customKafkaProperties);
+                convertCustomProperties(true);
+            }
         }
 
         if (dataSourceProperties.getConfluentSchemaRegistryUrl() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
@@ -55,6 +55,7 @@ import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -327,56 +328,211 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
         ((PulsarProgress) progress).unprotectUpdate(currentPulsarPartitions, defaultInitialPosition);
     }
 
-    // if customPulsarPartition is not null, then return false immediately
-    // else if pulsar partitions of topic has been changed, return true.
-    // else return false
-    // update current pulsar partition at the same time
-    // current pulsar partitions = customPulsarPartitions == 0 ? all of partition of pulsar topic : customPulsarPartitions
+    // Refresh `currentPulsarPartitions` against the broker. The slow step is a FE -> BE brpc
+    // (PulsarUtil.getAllPulsarPartitions), so we must not hold the per-job writeLock across it -
+    // otherwise readers (admin RPCs, SHOW ROUTINE LOAD, processTimeoutTasks) stall for the
+    // full RPC plus retries. Three phases: snapshot under readLock, fetch with no lock, apply
+    // under writeLock with a configVersion guard to discard a mid-flight ALTER.
     @Override
-    protected boolean unprotectNeedReschedule() throws StarRocksException {
-        // only running and need_schedule job need to be changed current pulsar partitions
+    protected void refreshPartitionsIfNeeded() throws StarRocksException {
+        FetchSnapshot snapshot;
+        readLock();
+        try {
+            snapshot = takeFetchSnapshot();
+        } finally {
+            readUnlock();
+        }
+        if (snapshot == null) {
+            return;
+        }
+        switch (snapshot.kind) {
+            case PAUSED_AUTO_SCHEDULE:
+                applyPausedAutoSchedule();
+                return;
+            case CUSTOM_ONLY:
+                applyCustomPartitions(snapshot);
+                return;
+            case FETCH:
+                break;
+            default:
+                return;
+        }
+
+        List<String> newPartitions = null;
+        Exception fetchError = null;
+        try {
+            newPartitions = PulsarUtil.getAllPulsarPartitions(snapshot.serviceUrl, snapshot.topic,
+                    snapshot.subscription, snapshotConvertedCustomProperties(), snapshot.computeResource);
+        } catch (Exception e) {
+            fetchError = e;
+        }
+
+        applyFetchResult(snapshot, newPartitions, fetchError);
+    }
+
+    // Phase 1 helper. Must be called with at least readLock held so the read of state,
+    // customPulsarPartitions, serviceUrl, topic, subscription, dataSourceConfigVersion is
+    // consistent. Returns null when the job is in a final state (STOPPED/CANCELLED) or any
+    // state that does not require partition refresh; callers must short-circuit the rest of
+    // the cycle in that case.
+    private FetchSnapshot takeFetchSnapshot() {
         if (this.state == JobState.RUNNING || this.state == JobState.NEED_SCHEDULE) {
-            if (customPulsarPartitions != null && customPulsarPartitions.size() != 0) {
+            if (customPulsarPartitions != null && !customPulsarPartitions.isEmpty()) {
+                // User pinned the partition list at CREATE time; no broker RPC needed.
+                return FetchSnapshot.customOnly(dataSourceConfigVersion);
+            }
+            return FetchSnapshot.fetch(serviceUrl, topic, subscription, computeResource, dataSourceConfigVersion);
+        }
+        if (this.state == JobState.PAUSED) {
+            // PAUSED jobs do not need partition info, but may be eligible for auto-resume.
+            return FetchSnapshot.pausedAutoSchedule();
+        }
+        return null;
+    }
+
+    // Phase 3 (fast path). For jobs created with PROPERTIES("pulsar_partitions"=...) there is no
+    // broker RPC; we just copy the user-pinned list into currentPulsarPartitions. We still take
+    // writeLock and re-check configVersion + state because phase 1 ran under readLock and an
+    // ALTER ROUTINE LOAD could have landed in between - in that case we drop the assignment and
+    // let the next scheduler tick re-snapshot with the new config.
+    private void applyCustomPartitions(FetchSnapshot snapshot) {
+        writeLock();
+        try {
+            if (dataSourceConfigVersion != snapshot.configVersion) {
+                return;
+            }
+            if (this.state != JobState.RUNNING && this.state != JobState.NEED_SCHEDULE) {
+                return;
+            }
+            if (customPulsarPartitions != null && !customPulsarPartitions.isEmpty()) {
                 currentPulsarPartitions = customPulsarPartitions;
-                return false;
-            } else {
-                List<String> newCurrentPulsarPartition;
-                try {
-                    newCurrentPulsarPartition = getAllPulsarPartitions();
-                } catch (Exception e) {
-                    String msg = "Job failed to fetch all current partition with error [" + e.getMessage() + "]";
-                    LOG.warn(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
-                            .add("error_msg", msg)
-                            .build(), e);
-                    if (this.state == JobState.NEED_SCHEDULE) {
-                        unprotectUpdateState(JobState.PAUSED,
-                                new ErrorReason(InternalErrorCode.PARTITIONS_ERR, msg));
-                    }
-                    return false;
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    // Phase 3 (PAUSED auto-resume). If a PAUSED job's pauseReason is recoverable (currently:
+    // REPLICA_FEW_ERR within ScheduleRule's retry/window budget), promote it back to
+    // NEED_SCHEDULE so the next RoutineLoadScheduler tick re-divides it into tasks. Pure FE
+    // state-machine work; no external calls, so the writeLock window is tiny.
+    private void applyPausedAutoSchedule() throws StarRocksException {
+        writeLock();
+        try {
+            if (this.state != JobState.PAUSED) {
+                return;
+            }
+            if (!ScheduleRule.isNeedAutoSchedule(this)) {
+                return;
+            }
+            LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                    .add("name", name)
+                    .add("current_state", this.state)
+                    .add("msg", "Job need to be rescheduled")
+                    .build());
+            unprotectUpdateProgress();
+            unprotectUpdateState(JobState.NEED_SCHEDULE, null);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    private void applyFetchResult(FetchSnapshot snapshot, List<String> newPartitions, Exception fetchError)
+            throws StarRocksException {
+        writeLock();
+        try {
+            if (dataSourceConfigVersion != snapshot.configVersion) {
+                // ALTER ROUTINE LOAD landed during the brpc; drop the stale fetch and let the
+                // next scheduler tick refetch with the new config.
+                return;
+            }
+            if (this.state != JobState.RUNNING && this.state != JobState.NEED_SCHEDULE) {
+                return;
+            }
+            if (fetchError != null) {
+                String msg = "Job failed to fetch all current partition with error [" + fetchError.getMessage() + "]";
+                LOG.warn(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                        .add("error_msg", msg)
+                        .build(), fetchError);
+                // Only PAUSE jobs that were waiting to be (re)scheduled; jobs already RUNNING
+                // keep their current tasks so a transient broker hiccup does not nuke an
+                // otherwise-healthy pipeline. The next scheduler tick will retry.
+                if (this.state == JobState.NEED_SCHEDULE) {
+                    unprotectUpdateState(JobState.PAUSED,
+                            new ErrorReason(InternalErrorCode.PARTITIONS_ERR, msg));
                 }
-                if (currentPulsarPartitions.containsAll(newCurrentPulsarPartition)) {
-                    if (currentPulsarPartitions.size() > newCurrentPulsarPartition.size()) {
-                        unprotectUpdateCurrentPartitions(newCurrentPulsarPartition);
-                        return true;
-                    } else {
-                        return false;
-                    }
+                return;
+            }
+            // Diff currentPulsarPartitions vs newPartitions. Three cases:
+            //   1) current is a strict superset of new  -> partitions were removed
+            //      -> swap to the smaller list and reschedule
+            //   2) current equals new (same set, same size) -> no change
+            //   3) current is missing at least one of new -> partitions were added (or set was
+            //      replaced) -> swap to the new list and reschedule
+            boolean changed;
+            if (currentPulsarPartitions.containsAll(newPartitions)) {
+                if (currentPulsarPartitions.size() > newPartitions.size()) {
+                    unprotectUpdateCurrentPartitions(newPartitions);
+                    changed = true;
                 } else {
-                    unprotectUpdateCurrentPartitions(newCurrentPulsarPartition);
-                    return true;
+                    changed = false;
                 }
+            } else {
+                unprotectUpdateCurrentPartitions(newPartitions);
+                changed = true;
             }
-        } else if (this.state == JobState.PAUSED) {
-            boolean autoSchedule = ScheduleRule.isNeedAutoSchedule(this);
-            if (autoSchedule) {
-                LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, name)
-                        .add("current_state", this.state)
-                        .add("msg", "should be rescheduled")
+            if (changed) {
+                LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                        .add("msg", "Job need to be rescheduled")
                         .build());
+                unprotectUpdateProgress();
+                unprotectUpdateState(JobState.NEED_SCHEDULE, null);
             }
-            return autoSchedule;
-        } else {
-            return false;
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    // Discriminator for the apply phase of refreshPartitionsIfNeeded.
+    //   FETCH                - state RUNNING/NEED_SCHEDULE, no custom partitions; needs broker RPC
+    //   CUSTOM_ONLY          - state RUNNING/NEED_SCHEDULE, user-pinned partitions; no RPC needed
+    //   PAUSED_AUTO_SCHEDULE - state PAUSED; evaluate ScheduleRule for auto-resume
+    private enum FetchSnapshotKind { FETCH, CUSTOM_ONLY, PAUSED_AUTO_SCHEDULE }
+
+    // Immutable snapshot of the inputs captured in phase 1 (readLock) and consumed unchanged
+    // through phase 2 (unlocked broker RPC) and phase 3 (writeLock apply). Carrying the values
+    // on a snapshot rather than re-reading the mutable fields keeps the RPC inputs stable, and
+    // pairing them with configVersion lets phase 3 detect a concurrent ALTER and discard the
+    // stale fetch result.
+    private static final class FetchSnapshot {
+        final FetchSnapshotKind kind;
+        final String serviceUrl;
+        final String topic;
+        final String subscription;
+        final ComputeResource computeResource;
+        final long configVersion;
+
+        private FetchSnapshot(FetchSnapshotKind kind, String serviceUrl, String topic, String subscription,
+                              ComputeResource computeResource, long configVersion) {
+            this.kind = kind;
+            this.serviceUrl = serviceUrl;
+            this.topic = topic;
+            this.subscription = subscription;
+            this.computeResource = computeResource;
+            this.configVersion = configVersion;
+        }
+
+        static FetchSnapshot fetch(String serviceUrl, String topic, String subscription,
+                                   ComputeResource cr, long ver) {
+            return new FetchSnapshot(FetchSnapshotKind.FETCH, serviceUrl, topic, subscription, cr, ver);
+        }
+
+        static FetchSnapshot customOnly(long ver) {
+            return new FetchSnapshot(FetchSnapshotKind.CUSTOM_ONLY, null, null, null, null, ver);
+        }
+
+        static FetchSnapshot pausedAutoSchedule() {
+            return new FetchSnapshot(FetchSnapshotKind.PAUSED_AUTO_SCHEDULE, null, null, null, null, 0L);
         }
     }
 
@@ -409,10 +565,22 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
     }
 
     public List<String> getAllPulsarPartitions() throws StarRocksException {
-        // Get custom properties like tokens
-        convertCustomProperties(false);
+        // Get custom properties like tokens.
         return PulsarUtil.getAllPulsarPartitions(serviceUrl, topic,
-                subscription, ImmutableMap.copyOf(convertedCustomProperties), computeResource);
+                subscription, snapshotConvertedCustomProperties(), computeResource);
+    }
+
+    // Snapshot `convertedCustomProperties` for use in an unlocked RPC call. Holds the intrinsic
+    // monitor across convertCustomProperties(false) + ImmutableMap.copyOf so a concurrent ALTER
+    // ROUTINE LOAD running modifyDataSourceProperties (which calls customProperties.putAll +
+    // convertCustomProperties(true) under the same monitor) cannot rebuild the backing HashMap
+    // mid-iteration. All RPC paths that need the converted-properties map must go through this
+    // helper - direct ImmutableMap.copyOf(convertedCustomProperties) is racy outside the monitor.
+    private ImmutableMap<String, String> snapshotConvertedCustomProperties() throws DdlException {
+        synchronized (this) {
+            convertCustomProperties(false);
+            return ImmutableMap.copyOf(convertedCustomProperties);
+        }
     }
 
     public static PulsarRoutineLoadJob fromCreateStmt(CreateRoutineLoadStmt stmt) throws StarRocksException {
@@ -579,8 +747,13 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
         }
 
         if (!customPulsarProperties.isEmpty()) {
-            this.customProperties.putAll(customPulsarProperties);
-            convertCustomProperties(true);
+            // Hold the intrinsic monitor across putAll + convertCustomProperties(true): the
+            // scheduler's lock-free refresh path reads customProperties via the synchronized
+            // convertCustomProperties(false); putAll outside the monitor would race that read.
+            synchronized (this) {
+                this.customProperties.putAll(customPulsarProperties);
+                convertCustomProperties(true);
+            }
 
             if (customPulsarProperties.containsKey(CreateRoutineLoadStmt.PULSAR_DEFAULT_INITIAL_POSITION)) {
                 // defaultInitialPosition should be updated by convertCustomProperties()

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -315,6 +315,19 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     protected ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
 
     protected QueryableReentrantReadWriteLock lock = new QueryableReentrantReadWriteLock(true);
+
+    // Monotonically increased whenever `applyModifyJob` is called with a non-null
+    // RoutineLoadDataSourceProperties (i.e. any ALTER ROUTINE LOAD that carries a data-source
+    // clause), regardless of whether `modifyDataSourceProperties` actually mutated a field or
+    // threw. The conservative bump is intentional: a spurious bump only costs one extra
+    // scheduler refetch, while missing a bump could send stale-config fetch results into apply.
+    // Used by refreshPartitionsIfNeeded() to detect mid-flight ALTER and discard a stale fetch.
+    // Reads happen under read or write lock; writes happen under writeLock. Not persisted in the
+    // checkpoint image - reinitialized to 0 on image load, then re-incremented for each
+    // ALTER ROUTINE LOAD edit log entry replayed afterwards (so the post-restart value depends
+    // on replay). The absolute value carries no meaning across restarts; only monotonic
+    // comparison between a snapshot and its corresponding apply matters.
+    protected long dataSourceConfigVersion = 0;
     // TODO(ml): error sample
 
     // save the latest 3 error log urls
@@ -1551,6 +1564,21 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         }
 
         // check if partition has been changed
+        refreshPartitionsIfNeeded();
+    }
+
+    /**
+     * Refresh the per-job view of external partitions and trigger a reschedule if it changed.
+     *
+     * The default implementation runs the legacy `unprotectNeedReschedule` decision under the
+     * per-job writeLock. Subclasses whose decision requires a slow external call (e.g. a BE
+     * brpc to fetch broker metadata) should override this method and split the work into a
+     * snapshot phase under readLock, a fetch phase under no per-job lock, and an apply phase
+     * under writeLock that checks `dataSourceConfigVersion` to discard a stale result.
+     *
+     * Called by the single-threaded routine-load scheduler on each scheduler tick.
+     */
+    protected void refreshPartitionsIfNeeded() throws StarRocksException {
         writeLock();
         try {
             if (unprotectNeedReschedule()) {
@@ -1879,6 +1907,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
             } catch (DdlException e) {
                 LOG.error("modify data source properties failed", e);
             }
+            // Invalidate any in-flight partition-fetch snapshot.
+            ++dataSourceConfigVersion;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -45,6 +45,7 @@ import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.KafkaUtil;
+import com.starrocks.common.util.PulsarUtil;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.load.RoutineLoadDesc;
 import com.starrocks.metric.TableMetricsEntity;
@@ -468,6 +469,348 @@ public class RoutineLoadJobTest {
         routineLoadJob.update();
 
         Assertions.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+    }
+
+    @Test
+    public void testUpdateKafkaPartitionsContainsAllShrink(@Injectable KafkaProgress kafkaProgress) throws StarRocksException {
+        long dbId = 12L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        new MockUp<KafkaUtil>() {
+            @Mock
+            public List<Integer> getAllKafkaPartitions(String brokerList, String topic,
+                                                       ImmutableMap<String, String> properties,
+                                                       ComputeResource computeResource) throws StarRocksException {
+                return Lists.newArrayList(1, 2);
+            }
+        };
+
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(111L, "test", dbId, 22L, "brokerList", "topic");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
+        Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
+        Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", Lists.newArrayList(1, 2, 3));
+        routineLoadJob.update();
+
+        // shrink: currentKafkaPartitions = [1,2,3] containsAll [1,2] && size > 2 -> reschedule with [1,2]
+        Assertions.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+        Assertions.assertEquals(Lists.newArrayList(1, 2),
+                Deencapsulation.getField(routineLoadJob, "currentKafkaPartitions"));
+    }
+
+    @Test
+    public void testUpdateKafkaFetchErrorPauses(@Injectable KafkaProgress kafkaProgress) throws StarRocksException {
+        long dbId = 13L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        new MockUp<KafkaUtil>() {
+            @Mock
+            public List<Integer> getAllKafkaPartitions(String brokerList, String topic,
+                                                       ImmutableMap<String, String> properties,
+                                                       ComputeResource computeResource) throws StarRocksException {
+                throw new StarRocksException("kafka broker unreachable");
+            }
+        };
+
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(112L, "test", dbId, 22L, "brokerList", "topic");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.NEED_SCHEDULE);
+        Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
+        routineLoadJob.update();
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
+        ErrorReason reason = routineLoadJob.pauseReason;
+        Assertions.assertEquals(InternalErrorCode.PARTITIONS_ERR, reason.getCode());
+        Assertions.assertTrue(reason.getMsg().contains("kafka broker unreachable"), reason.getMsg());
+    }
+
+    @Test
+    public void testUpdateKafkaPausedAutoSchedule(@Injectable KafkaProgress kafkaProgress) throws StarRocksException {
+        long dbId = 14L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        new MockUp<ScheduleRule>() {
+            @Mock
+            public boolean isNeedAutoSchedule(RoutineLoadJob job) {
+                return true;
+            }
+        };
+
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(113L, "test", dbId, 22L, "brokerList", "topic");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.PAUSED);
+        Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
+        routineLoadJob.update();
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+    }
+
+    @Test
+    public void testUpdateKafkaPausedNoAutoSchedule(@Injectable KafkaProgress kafkaProgress) throws StarRocksException {
+        long dbId = 15L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        new MockUp<ScheduleRule>() {
+            @Mock
+            public boolean isNeedAutoSchedule(RoutineLoadJob job) {
+                return false;
+            }
+        };
+
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(114L, "test", dbId, 22L, "brokerList", "topic");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.PAUSED);
+        Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
+        routineLoadJob.update();
+
+        // PAUSED with isNeedAutoSchedule=false -> state stays PAUSED
+        Assertions.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
+    }
+
+    @Test
+    public void testUpdateKafkaCustomPartitions(@Injectable KafkaProgress kafkaProgress) throws StarRocksException {
+        long dbId = 16L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(115L, "test", dbId, 22L, "brokerList", "topic");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
+        Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
+        Deencapsulation.setField(routineLoadJob, "customKafkaPartitions", Lists.newArrayList(5, 6, 7));
+        routineLoadJob.update();
+
+        // customKafkaPartitions short-circuits the fetch; currentKafkaPartitions becomes customKafkaPartitions,
+        // state stays RUNNING (no reschedule triggered).
+        Assertions.assertEquals(RoutineLoadJob.JobState.RUNNING, routineLoadJob.getState());
+        Assertions.assertEquals(Lists.newArrayList(5, 6, 7),
+                Deencapsulation.getField(routineLoadJob, "currentKafkaPartitions"));
+    }
+
+    @Test
+    public void testUpdateKafkaStoppedSnapshotIsNull(@Injectable KafkaProgress kafkaProgress) throws StarRocksException {
+        long dbId = 17L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(116L, "test", dbId, 22L, "brokerList", "topic");
+        // STOPPED is a final state - takeFetchSnapshot returns null, refreshPartitionsIfNeeded returns early.
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.STOPPED);
+        Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
+        routineLoadJob.update();
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.STOPPED, routineLoadJob.getState());
+    }
+
+    @Test
+    public void testUpdatePulsarPartitionsChanged(@Injectable PulsarProgress pulsarProgress) throws StarRocksException {
+        long dbId = 18L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        new MockUp<PulsarUtil>() {
+            @Mock
+            public List<String> getAllPulsarPartitions(String serviceUrl, String topic, String subscription,
+                                                      ImmutableMap<String, String> properties,
+                                                      ComputeResource computeResource) throws StarRocksException {
+                return Lists.newArrayList("p1", "p2", "p3");
+            }
+        };
+
+        RoutineLoadJob routineLoadJob = new PulsarRoutineLoadJob(211L, "test", dbId, 22L,
+                "http://pulsar-service", "topic1", "sub1");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
+        Deencapsulation.setField(routineLoadJob, "progress", pulsarProgress);
+        routineLoadJob.update();
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+        Assertions.assertEquals(Lists.newArrayList("p1", "p2", "p3"),
+                Deencapsulation.getField(routineLoadJob, "currentPulsarPartitions"));
+    }
+
+    @Test
+    public void testUpdatePulsarFetchErrorPauses(@Injectable PulsarProgress pulsarProgress) throws StarRocksException {
+        long dbId = 19L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        new MockUp<PulsarUtil>() {
+            @Mock
+            public List<String> getAllPulsarPartitions(String serviceUrl, String topic, String subscription,
+                                                      ImmutableMap<String, String> properties,
+                                                      ComputeResource computeResource) throws StarRocksException {
+                throw new StarRocksException("pulsar service unreachable");
+            }
+        };
+
+        RoutineLoadJob routineLoadJob = new PulsarRoutineLoadJob(212L, "test", dbId, 22L,
+                "http://pulsar-service", "topic1", "sub1");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.NEED_SCHEDULE);
+        Deencapsulation.setField(routineLoadJob, "progress", pulsarProgress);
+        routineLoadJob.update();
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
+        ErrorReason reason = routineLoadJob.pauseReason;
+        Assertions.assertEquals(InternalErrorCode.PARTITIONS_ERR, reason.getCode());
+        Assertions.assertTrue(reason.getMsg().contains("pulsar service unreachable"), reason.getMsg());
+    }
+
+    @Test
+    public void testUpdatePulsarPausedAutoSchedule(@Injectable PulsarProgress pulsarProgress) throws StarRocksException {
+        long dbId = 20L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        new MockUp<ScheduleRule>() {
+            @Mock
+            public boolean isNeedAutoSchedule(RoutineLoadJob job) {
+                return true;
+            }
+        };
+
+        RoutineLoadJob routineLoadJob = new PulsarRoutineLoadJob(213L, "test", dbId, 22L,
+                "http://pulsar-service", "topic1", "sub1");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.PAUSED);
+        Deencapsulation.setField(routineLoadJob, "progress", pulsarProgress);
+        routineLoadJob.update();
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+    }
+
+    @Test
+    public void testUpdatePulsarCustomPartitions(@Injectable PulsarProgress pulsarProgress) throws StarRocksException {
+        long dbId = 21L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        RoutineLoadJob routineLoadJob = new PulsarRoutineLoadJob(214L, "test", dbId, 22L,
+                "http://pulsar-service", "topic1", "sub1");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
+        Deencapsulation.setField(routineLoadJob, "progress", pulsarProgress);
+        Deencapsulation.setField(routineLoadJob, "customPulsarPartitions", Lists.newArrayList("p5", "p6"));
+        routineLoadJob.update();
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.RUNNING, routineLoadJob.getState());
+        Assertions.assertEquals(Lists.newArrayList("p5", "p6"),
+                Deencapsulation.getField(routineLoadJob, "currentPulsarPartitions"));
+    }
+
+    @Test
+    public void testUpdateKafkaStaleFetchDiscarded(@Injectable KafkaProgress kafkaProgress) throws StarRocksException {
+        long dbId = 30L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        // Hold a reference the mock can mutate to simulate a concurrent ALTER that bumps
+        // dataSourceConfigVersion while the fetch is in flight.
+        final RoutineLoadJob[] jobRef = new RoutineLoadJob[1];
+        new MockUp<KafkaUtil>() {
+            @Mock
+            public List<Integer> getAllKafkaPartitions(String brokerList, String topic,
+                                                       ImmutableMap<String, String> properties,
+                                                       ComputeResource computeResource) throws StarRocksException {
+                long v = (Long) Deencapsulation.getField(jobRef[0], "dataSourceConfigVersion");
+                Deencapsulation.setField(jobRef[0], "dataSourceConfigVersion", v + 1);
+                return Lists.newArrayList(1, 2, 3);
+            }
+        };
+
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(117L, "test", dbId, 22L, "brokerList", "topic");
+        jobRef[0] = routineLoadJob;
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
+        Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
+        routineLoadJob.update();
+
+        // Snapshot captured version 0; mock bumped to 1 mid-fetch; applyFetchResult sees
+        // version mismatch and discards. Job stays RUNNING with empty currentKafkaPartitions.
+        Assertions.assertEquals(RoutineLoadJob.JobState.RUNNING, routineLoadJob.getState());
+        List<Integer> current = Deencapsulation.getField(routineLoadJob, "currentKafkaPartitions");
+        Assertions.assertTrue(current.isEmpty(), "currentKafkaPartitions should not be updated when configVersion changes");
+    }
+
+    @Test
+    public void testUpdatePulsarStaleFetchDiscarded(@Injectable PulsarProgress pulsarProgress)
+            throws StarRocksException {
+        long dbId = 31L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        final RoutineLoadJob[] jobRef = new RoutineLoadJob[1];
+        new MockUp<PulsarUtil>() {
+            @Mock
+            public List<String> getAllPulsarPartitions(String serviceUrl, String topic, String subscription,
+                                                      ImmutableMap<String, String> properties,
+                                                      ComputeResource computeResource) throws StarRocksException {
+                long v = (Long) Deencapsulation.getField(jobRef[0], "dataSourceConfigVersion");
+                Deencapsulation.setField(jobRef[0], "dataSourceConfigVersion", v + 1);
+                return Lists.newArrayList("p1", "p2", "p3");
+            }
+        };
+
+        RoutineLoadJob routineLoadJob = new PulsarRoutineLoadJob(216L, "test", dbId, 22L,
+                "http://pulsar-service", "topic1", "sub1");
+        jobRef[0] = routineLoadJob;
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
+        Deencapsulation.setField(routineLoadJob, "progress", pulsarProgress);
+        routineLoadJob.update();
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.RUNNING, routineLoadJob.getState());
+        List<String> current = Deencapsulation.getField(routineLoadJob, "currentPulsarPartitions");
+        Assertions.assertTrue(current.isEmpty(),
+                "currentPulsarPartitions should not be updated when configVersion changes");
+    }
+
+    @Test
+    public void testUpdatePulsarPartitionsContainsAllShrink(@Injectable PulsarProgress pulsarProgress)
+            throws StarRocksException {
+        long dbId = 22L;
+        Database database = new Database(dbId, "testDb");
+        OlapTable table = new OlapTable(22L, "test", null, null, null, null);
+        database.registerTableUnlocked(table);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayCreateDb(database);
+
+        new MockUp<PulsarUtil>() {
+            @Mock
+            public List<String> getAllPulsarPartitions(String serviceUrl, String topic, String subscription,
+                                                      ImmutableMap<String, String> properties,
+                                                      ComputeResource computeResource) throws StarRocksException {
+                return Lists.newArrayList("p1", "p2");
+            }
+        };
+
+        RoutineLoadJob routineLoadJob = new PulsarRoutineLoadJob(215L, "test", dbId, 22L,
+                "http://pulsar-service", "topic1", "sub1");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
+        Deencapsulation.setField(routineLoadJob, "progress", pulsarProgress);
+        Deencapsulation.setField(routineLoadJob, "currentPulsarPartitions", Lists.newArrayList("p1", "p2", "p3"));
+        routineLoadJob.update();
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+        Assertions.assertEquals(Lists.newArrayList("p1", "p2"),
+                Deencapsulation.getField(routineLoadJob, "currentPulsarPartitions"));
     }
 
     @Test


### PR DESCRIPTION
The routine-load scheduler held RoutineLoadJob.lock in exclusive mode while making a BE brpc to fetch broker partition metadata (KafkaUtil.getAllKafkaPartitions / PulsarUtil.getAllPulsarPartitions). A slow brpc blocked all readers - admin RPCs, SHOW ROUTINE LOAD, processTimeoutTasks - on the fair RW lock. Production saw 42 slow-lock events in one day with waitTime up to 33.6 s, all with the "Routine load scheduler" thread as exclusive holder.

Split the partition-check segment of update() into three phases:
  1. Snapshot brokerList/topic/state and a new dataSourceConfigVersion under readLock.
  2. Run convertCustomProperties (self-synchronized) and the brpc with no per-job lock held.
  3. Apply under writeLock, discarding the result if configVersion changed mid-flight (concurrent ALTER ROUTINE LOAD) or the state left RUNNING/NEED_SCHEDULE.

A new overridable refreshPartitionsIfNeeded() hook on RoutineLoadJob keeps backward compatibility; its default impl runs the legacy writeLock + unprotectNeedReschedule pattern, so subclasses that do not make external calls are unaffected. KafkaRoutineLoadJob and PulsarRoutineLoadJob override the hook with the three-phase impl.

## Why I'm doing:

```
  ---
  Thread A (holder) — Routine load scheduler (FrontendDaemon, single instance)

  "Routine load scheduler" #78
     java.base@17.0.15/java.lang.Object.wait(Native Method)
     - waiting on a brpc callback object held by the FE -> BE RPC client
     app//com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy.doWaitCallback(ProtobufRpcProxy.java:627)
     app//com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy.access$0(ProtobufRpcProxy.java:611)
     app//com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy$2.get(ProtobufRpcProxy.java:576)
     app//com.starrocks.common.util.KafkaUtil$ProxyAPI.sendProxyRequest(KafkaUtil.java:253)
     app//com.starrocks.common.util.KafkaUtil$ProxyAPI.getAllKafkaPartitions(KafkaUtil.java:131)
     app//com.starrocks.common.util.KafkaUtil.getAllKafkaPartitions(KafkaUtil.java:78)
     app//com.starrocks.load.routineload.KafkaRoutineLoadJob.getAllKafkaPartitions(KafkaRoutineLoadJob.java:510)
     app//com.starrocks.load.routineload.KafkaRoutineLoadJob.unprotectNeedReschedule(KafkaRoutineLoadJob.java:439)
     - holds RoutineLoadJob.lock (exclusive) on RoutineLoadJob id=817465022 [Z_CLS_CS_INFO_RT]
     app//com.starrocks.load.routineload.RoutineLoadJob.update(RoutineLoadJob.java:1529)
     app//com.starrocks.load.routineload.RoutineLoadMgr.updateRoutineLoadJob(RoutineLoadMgr.java:695)
     app//com.starrocks.load.routineload.RoutineLoadScheduler.process(RoutineLoadScheduler.java:79)
     app//com.starrocks.load.routineload.RoutineLoadScheduler.runAfterCatalogReady(RoutineLoadScheduler.java:71)
     app//com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72)
     app//com.starrocks.common.util.Daemon.run(Daemon.java:98)

  ---
  Thread B (waiter) — PUBLISH_VERSION|58 (PublishVersionDaemon worker, single thread)

  "PUBLISH_VERSION" #58
     java.base@17.0.15/jdk.internal.misc.Unsafe.park(Native Method)
     - parking to wait for write lock acquisition on RoutineLoadJob.lock
       (job id=817465022; current holder is "Routine load scheduler")
     java.base@17.0.15/java.util.concurrent.locks.LockSupport.park(LockSupport.java:341)
     java.base@17.0.15/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:540)
     java.base@17.0.15/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1166)
     java.base@17.0.15/java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(ReentrantReadWriteLock.java:961)
     app//com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock.lockDetectingSlowLock(QueryableReentrantReadWriteLock.java:84)
     app//com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock.exclusiveLockDetectingSlowLock(QueryableReentrantReadWriteLock.java:81)
     app//com.starrocks.load.routineload.RoutineLoadJob.writeLock(RoutineLoadJob.java:505)
     app//com.starrocks.load.routineload.RoutineLoadJob.afterVisible(RoutineLoadJob.java:1105)
     app//com.starrocks.transaction.TransactionState.afterStateTransform(TransactionState.java:837)
     app//com.starrocks.transaction.DatabaseTransactionMgr.finishTransaction(DatabaseTransactionMgr.java:1393)
     - holds table-WRITE lock on tableId=817393606 (via lockTablesWithIntensiveDbLock)
     - holds TransactionState.writeLock on txnId=3855487786
     app//com.starrocks.transaction.GlobalTransactionMgr.finishTransaction(GlobalTransactionMgr.java:633)
     app//com.starrocks.transaction.PublishVersionDaemon.tryFinishTransaction(PublishVersionDaemon.java:407)
     app//com.starrocks.transaction.PublishVersionDaemon.publishVersionForOlapTable(PublishVersionDaemon.java:335)
     app//com.starrocks.common.util.LeaderDaemon.runOneCycle(LeaderDaemon.java:194)
     app//com.starrocks.common.util.LeaderDaemon.loop(LeaderDaemon.java:151)
     java.base@17.0.15/java.lang.Thread.run(Thread.java:840)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
