### PR TITLE
[Enhancement] Enabling dictification for array_agg sort columns in all cases. (backport #72781)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -863,7 +863,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         return info;
     }
 
-    private boolean shouldProcessAggFunction(CallOperator agg) {
+    private boolean shouldProcessAggFunction(CallOperator agg, ColumnRefSet supportColumns, boolean isFirstStage) {
         final boolean enableArrayAgg = sessionVariable.isEnableArrayAggLowCardinalityOptimize()
                 && sessionVariable.isEnableArrayLowCardinalityOptimize()
                 && sessionVariable.isEnableStructLowCardinalityOptimize();
@@ -875,11 +875,16 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             return false;
         }
         if (isArrayAgg) {
-            // dictify array_agg only when the first child can be dictified.
+            ColumnRefSet candidateColumns = agg.getUsedColumns();
+            if (isFirstStage && agg.getArguments().get(0).isColumnRef()
+                    && !agg.getArguments().get(0).getType().isStringType()) {
+                candidateColumns.except(List.of(agg.getArguments().get(0).cast()));
+            }
             return agg.getChildren().stream().allMatch(c -> c.isColumnRef() || c.isConstantRef())
-                    && agg.getChild(0).isColumnRef() && agg.getFunction().getArgs()[0].isStringType();
+                    && supportColumns.containsAny(candidateColumns);
         }
-        return agg.getChildren().size() == 1 && agg.getChildren().get(0).isColumnRef();
+        return agg.getChildren().size() == 1 && agg.getChildren().get(0).isColumnRef()
+                && supportColumns.containsAll(agg.getUsedColumns());
     }
 
     @Override
@@ -893,9 +898,14 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         ColumnRefSet disableColumns = new ColumnRefSet();
         for (ColumnRefOperator key : aggregate.getAggregations().keySet()) {
             CallOperator agg = aggregate.getAggregations().get(key);
-            if (!shouldProcessAggFunction(agg)) {
+            final boolean isFirstStage = !agg.getArguments().isEmpty() &&
+                    (!(agg.getArguments().get(0) instanceof ColumnRefOperator ref) || ref.getId() != key.getId());
+            if (!shouldProcessAggFunction(agg, info.inputStringColumns, isFirstStage)) {
                 disableColumns.union(agg.getUsedColumns());
                 disableColumns.union(key);
+            } else if (isFirstStage && FunctionSet.ARRAY_AGG.equals(agg.getFnName()) &&
+                    agg.getArguments().get(0).isColumnRef() && !agg.getArguments().get(0).getType().isStringType()) {
+                disableColumns.union((ColumnRefOperator) agg.getArguments().get(0));
             }
         }
 
@@ -911,41 +921,33 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 continue;
             }
             CallOperator value = aggregate.getAggregations().get(key);
-            if (FunctionSet.ARRAY_AGG.equals(value.getFnName())) {
-                if (!value.getChild(0).isColumnRef() ||
-                        !info.inputStringColumns.contains(value.getChild(0).cast())) {
-                    continue;
-                }
-            } else if (!info.inputStringColumns.containsAll(value.getUsedColumns())) {
-                continue;
-            }
             // aggregate ref -> aggregate expr
             stringAggregateExpressions.computeIfAbsent(key.getId(), x -> Lists.newArrayList()).add(value);
+            AggregateFunction aggFn = (AggregateFunction) value.getFunction();
+            if (aggFn.getIntermediateTypeOrReturnType().isStructType()
+                    && !structRefToFieldUseStringRef.containsKey(key.getId())) {
+                final Map<String, ColumnRefOperator> fieldsData;
+                if (FunctionSet.ARRAY_AGG.equals(aggFn.functionName())) {
+                    fieldsData = Maps.newHashMap();
+                    StructType structType = (StructType) aggFn.getIntermediateTypeOrReturnType();
+                    Preconditions.checkState(structType.getFields().size() == value.getArguments().size());
+                    for (int i = 0; i < value.getArguments().size(); i++) {
+                        if (value.getArguments().get(i).isColumnRef() && value.getArguments().get(i).getType().isStringType()
+                                && info.inputStringColumns.contains(value.getArguments().get(i).cast())) {
+                            fieldsData.put(structType.getField(i).getName(), value.getArguments().get(i).cast());
+                        }
+                    }
+                } else if (FunctionSet.ANY_VALUE.equals(aggFn.functionName())) {
+                    fieldsData = getFieldUseStringRefMap(value.getArguments().get(0));
+                } else {
+                    throw new UnsupportedOperationException(
+                            String.format("Unsupported function: %s with Struct Type", aggFn.functionName()));
+                }
+                Preconditions.checkNotNull(fieldsData);
+                structOpToFieldUseStringRef.put(value, fieldsData);
+            }
             if (supportLowCardinality(value.getType())) {
                 info.outputStringColumns.union(key.getId());
-                AggregateFunction aggFn = (AggregateFunction) value.getFunction();
-                if (aggFn.getIntermediateTypeOrReturnType().isStructType()
-                        && !structRefToFieldUseStringRef.containsKey(key.getId())) {
-                    final Map<String, ColumnRefOperator> fieldsData;
-                    if (FunctionSet.ARRAY_AGG.equals(aggFn.functionName())) {
-                        fieldsData = Maps.newHashMap();
-                        StructType structType = (StructType) aggFn.getIntermediateTypeOrReturnType();
-                        Preconditions.checkState(structType.getFields().size() == value.getArguments().size());
-                        for (int i = 0; i < value.getArguments().size(); i++) {
-                            if (value.getArguments().get(i).isColumnRef()
-                                    && info.inputStringColumns.contains(value.getArguments().get(i).cast())) {
-                                fieldsData.put(structType.getField(i).getName(), value.getArguments().get(i).cast());
-                            }
-                        }
-                    } else if (FunctionSet.ANY_VALUE.equals(aggFn.functionName())) {
-                        fieldsData = getFieldUseStringRefMap(value.getArguments().get(0));
-                    } else {
-                        throw new UnsupportedOperationException(
-                                String.format("Unsupported function: %s with Struct Type", aggFn.functionName()));
-                    }
-                    Preconditions.checkNotNull(fieldsData);
-                    structOpToFieldUseStringRef.put(value, fieldsData);
-                }
                 setDefineExpr(key, value, 1);
             } else if (aggregate.getType().isLocal() || aggregate.getType().isDistinct()) {
                 // count/count distinct, need output dict-set in 1st stage

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
@@ -563,20 +563,58 @@ public class LowCardinalityStructTest extends PlanTestBase {
     @Test
     public void testPartialEncoding() throws Exception {
         String sql = """
-                select array_agg(VARCHAR_COL order by VARCHAR_COL2), array_agg(INTEGER_COL order by VARCHAR_COL2)
+                select array_agg(VARCHAR_COL order by VARCHAR_COL2), GROUP_CONCAT(VARCHAR_COL2)
                 from T JOIN T2 ON (KEY_COL = KEY_COL2)
                 """;
         String plan = getVerboseExplain(sql);
-        Assertions.assertTrue(plan.contains("  9:Decode\n" +
+        Assertions.assertTrue(plan.contains(" 9:Decode\n" +
                 "  |  <dict id 13> : <string id 9>\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  8:AGGREGATE (merge finalize)\n" +
-                "  |  aggregate: array_agg[([13: array_agg, struct<col1 array<int(11)>, " +
-                "col2 array<varchar(25)>>, true]); args: INT,VARCHAR; result: ARRAY<INT>; args nullable: true;" +
-                " result nullable: true], " +
-                "array_agg[([10: array_agg, struct<col1 array<int(11)>, col2 array<varchar(25)>>, true]); " +
-                "args: INT,VARCHAR; result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                "  |  aggregate: array_agg[([13: array_agg, struct<col1 array<int(11)>, col2 array<varchar(25)>>," +
+                " true]); args: INT,VARCHAR; result: ARRAY<INT>; args nullable: true; result nullable: true], " +
+                "group_concat[([10: group_concat, struct<col1 array<varchar>, col2 array<varchar>>, true], ',');" +
+                " args: VARCHAR,VARCHAR; result: VARCHAR; args nullable: true; result nullable: true]\n" +
+                "  |  cardinality: 1"), plan);
+    }
+
+    @Test
+    public void testArrayAggSortOnlyEncodingSingleStage() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='1') */ ARRAY_AGG(INTEGER_COL ORDER BY VARCHAR_COL)
+                FROM T
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("1:AGGREGATE (update finalize)\n" +
+                "  |  aggregate: array_agg[([4: INTEGER_COL, INT, true], [6: VARCHAR_COL, INT, true]); args: INT,INT;" +
+                " result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                "  |  cardinality: 1"), plan);
+    }
+
+    @Test
+    public void testArrayAggSortOnlyEncodingTwoStage() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='2') */ ARRAY_AGG(INTEGER_COL ORDER BY VARCHAR_COL)
+                FROM T
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("3:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: array_agg[([5: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>>, " +
+                "true]); args: INT,INT; result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                "  |  cardinality: 1"), plan);
+    }
+
+    @Test
+    public void testArrayAggArrayOfString() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='2') */ ARRAY_AGG(ARRAY_VARCHAR_COL)
+                FROM T
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains(" 1:AGGREGATE (update serialize)\n" +
+                "  |  aggregate: array_agg[([3: ARRAY_VARCHAR_COL, ARRAY<VARCHAR(40)>, true]); args: INVALID_TYPE; " +
+                "result: struct<col1 array<array<varchar(40)>>>; args nullable: true; result nullable: true]\n" +
                 "  |  cardinality: 1"), plan);
     }
 }


### PR DESCRIPTION
(cherry picked from commit ecf19b4f6aa066afbae20db9c1ba5633920f658f)

## Why I'm doing:
Currently low cardinality optimize framework dictifies sort column in array_agg only when output is an array<string>. These sort columns can always be dictified.

## What I'm doing:
Supporting dictification of sort columns in array agg without any limits. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

