### PR TITLE
[BugFix] Reject aggregate MV rewrite with HAVING predicate

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -76,7 +76,7 @@ subprojects {
         set("protobuf-java.version", "3.25.5")
         set("puppycrawl.version", "10.21.1")
         set("spark.version", "3.5.7")
-        set("staros.version", "4.0.0")
+        set("staros.version", "4.1-rc4")
         set("thrift.version", "0.23.0")
         set("tomcat.version", "8.5.70")
         set("lz4-java.version", "1.10.1")

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -153,6 +153,20 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         EquationRewriter queryExprToMvExprRewriter =
                 buildEquationRewriter(mvProjection, rewriteContext, false);
 
+        if (isRollup && mvAggOp.getPredicate() != null) {
+            if (requiresGroupingRollup(mvGroupingKeys, queryGroupingKeys, queryRangePredicate)) {
+                OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
+                        "Rollup aggregate with MV HAVING predicate is unsafe when MV grouping keys are finer " +
+                                "than query grouping keys, mv grouping keys:{}, query grouping keys:{}",
+                        mvGroupingKeys, queryGroupingKeys);
+                return null;
+            }
+            if (!canCompensateMvAggregatePredicateForRollup(rewriteContext, mvAggOp, queryAggOp,
+                    queryExprToMvExprRewriter, columnRewriter)) {
+                return null;
+            }
+        }
+
         if (isRollup) {
             return rewriteForRollup(queryAggOp, queryGroupingKeys, columnRewriter, queryExprToMvExprRewriter,
                     rewriteContext, mvOptExpr);
@@ -344,6 +358,27 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         return true;
     }
 
+    private boolean canCompensateMvAggregatePredicateForRollup(RewriteContext rewriteContext,
+                                                               LogicalAggregationOperator mvAggregationOperator,
+                                                               LogicalAggregationOperator queryAggregationOperator,
+                                                               EquationRewriter queryExprToMvExprRewriter,
+                                                               ColumnRewriter columnRewriter) {
+        AggregateFunctionRewriter aggregateFunctionRewriter =
+                new AggregateFunctionRewriter(queryExprToMvExprRewriter,
+                        rewriteContext.getQueryRefFactory(), queryAggregationOperator.getAggregations());
+        Pair<Map<ColumnRefOperator, ScalarOperator>, Boolean> result =
+                rewriteAggregatePredicateColumns(rewriteContext, queryAggregationOperator,
+                        queryExprToMvExprRewriter, columnRewriter,
+                        new ColumnRefSet(rewriteContext.getQueryColumnSet()), aggregateFunctionRewriter);
+        if (result.first == null || result.second) {
+            OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
+                    "Rewrite rollup aggregate with MV HAVING predicate failed: cannot rewrite aggregate predicate");
+            return false;
+        }
+        return canCompensateMvAggregatePredicate(rewriteContext, mvAggregationOperator,
+                queryAggregationOperator, new ReplaceColumnRefRewriter(result.first));
+    }
+
     private ScalarOperator rewriteMvAggregatePredicate(RewriteContext rewriteContext, ScalarOperator mvPredicate) {
         ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(rewriteContext.getOutputMapping());
         ScalarOperator rewritten = rewriter.rewrite(mvPredicate.clone());
@@ -450,6 +485,12 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         if (mv.getRefreshScheme().isSync() && mv.getDefaultDistributionInfo() instanceof RandomDistributionInfo) {
             return true;
         }
+        return requiresGroupingRollup(mvGroupingKeys, queryGroupingKeys, queryRangePredicate);
+    }
+
+    private boolean requiresGroupingRollup(List<ScalarOperator> mvGroupingKeys,
+                                           List<ScalarOperator> queryGroupingKeys,
+                                           ScalarOperator queryRangePredicate) {
         // after equivalence class rewrite, there may be same group keys, so here just get the distinct grouping keys
         List<ScalarOperator> distinctMvKeys = mvGroupingKeys.stream().distinct().collect(Collectors.toList());
         BitSet matchedGroupByKeySet = new BitSet(distinctMvKeys.size());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -153,18 +153,9 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         EquationRewriter queryExprToMvExprRewriter =
                 buildEquationRewriter(mvProjection, rewriteContext, false);
 
-        if (isRollup && mvAggOp.getPredicate() != null) {
-            if (requiresGroupingRollup(mvGroupingKeys, queryGroupingKeys, queryRangePredicate)) {
-                OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
-                        "Rollup aggregate with MV HAVING predicate is unsafe when MV grouping keys are finer " +
-                                "than query grouping keys, mv grouping keys:{}, query grouping keys:{}",
-                        mvGroupingKeys, queryGroupingKeys);
-                return null;
-            }
-            if (!canCompensateMvAggregatePredicateForRollup(rewriteContext, mvAggOp, queryAggOp,
-                    queryExprToMvExprRewriter, columnRewriter)) {
-                return null;
-            }
+        if (isRollup && !canRewriteRollupWithMvAggregatePredicate(rewriteContext, mvAggOp, queryAggOp,
+                mvGroupingKeys, queryGroupingKeys, queryRangePredicate, queryExprToMvExprRewriter, columnRewriter)) {
+            return null;
         }
 
         if (isRollup) {
@@ -186,6 +177,11 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
             if (result.first != null && !result.second) {
                 return result.first;
             } else if (result.second) {
+                if (!canRewriteRollupWithMvAggregatePredicate(rewriteContext, mvAggOp, queryAggOp,
+                        mvGroupingKeys, queryGroupingKeys, queryRangePredicate,
+                        queryExprToMvExprRewriter, columnRewriter)) {
+                    return null;
+                }
                 return rewriteForRollup(queryAggOp, queryGroupingKeys, columnRewriter, queryExprToMvExprRewriter,
                         rewriteContext, mvOptExpr);
             } else {
@@ -356,6 +352,28 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
             return false;
         }
         return true;
+    }
+
+    private boolean canRewriteRollupWithMvAggregatePredicate(RewriteContext rewriteContext,
+                                                             LogicalAggregationOperator mvAggregationOperator,
+                                                             LogicalAggregationOperator queryAggregationOperator,
+                                                             List<ScalarOperator> mvGroupingKeys,
+                                                             List<ScalarOperator> queryGroupingKeys,
+                                                             ScalarOperator queryRangePredicate,
+                                                             EquationRewriter queryExprToMvExprRewriter,
+                                                             ColumnRewriter columnRewriter) {
+        if (mvAggregationOperator.getPredicate() == null) {
+            return true;
+        }
+        if (requiresGroupingRollup(mvGroupingKeys, queryGroupingKeys, queryRangePredicate)) {
+            OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
+                    "Rollup aggregate with MV HAVING predicate is unsafe when MV grouping keys are finer " +
+                            "than query grouping keys, mv grouping keys:{}, query grouping keys:{}",
+                    mvGroupingKeys, queryGroupingKeys);
+            return false;
+        }
+        return canCompensateMvAggregatePredicateForRollup(rewriteContext, mvAggregationOperator,
+                queryAggregationOperator, queryExprToMvExprRewriter, columnRewriter);
     }
 
     private boolean canCompensateMvAggregatePredicateForRollup(RewriteContext rewriteContext,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregateFunctionRollupUtils;
@@ -157,7 +158,7 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
                     rewriteContext, mvOptExpr);
         } else {
             Pair<OptExpression, Boolean> result =
-                    rewriteProjection(rewriteContext, queryAggOp, queryExprToMvExprRewriter, mvOptExpr);
+                    rewriteProjection(rewriteContext, mvAggOp, queryAggOp, queryExprToMvExprRewriter, mvOptExpr);
             // even if query and mv's group-by keys are the same, it may still need rollup
             // eg:
             // example1:
@@ -191,6 +192,7 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
      * If rewritten aggregate expr contains aggregate functions, we can still try rollup rewrite again.
      */
     protected Pair<OptExpression, Boolean> rewriteProjection(RewriteContext rewriteContext,
+                                                             LogicalAggregationOperator mvAggregationOperator,
                                                              LogicalAggregationOperator queryAggregationOperator,
                                                              EquationRewriter queryExprToMvExprRewriter,
                                                              OptExpression mvOptExpr) {
@@ -231,41 +233,27 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         Projection newProjection = new Projection(newQueryProjection);
         mvOptExpr.getOp().setProjection(newProjection);
 
+        Map<ColumnRefOperator, ScalarOperator> queryColumnRefToScalarMap = null;
+        if (queryAggregationOperator.getPredicate() != null || mvAggregationOperator.getPredicate() != null) {
+            Pair<Map<ColumnRefOperator, ScalarOperator>, Boolean> result =
+                    rewriteAggregatePredicateColumns(rewriteContext, queryAggregationOperator,
+                            queryExprToMvExprRewriter, columnRewriter, originalColumnSet, aggregateFunctionRewriter);
+            if (result.first == null) {
+                return Pair.create(null, result.second);
+            }
+            queryColumnRefToScalarMap = result.first;
+        }
+        ReplaceColumnRefRewriter rewriter = queryColumnRefToScalarMap == null ? null :
+                new ReplaceColumnRefRewriter(queryColumnRefToScalarMap);
+
+        if (mvAggregationOperator.getPredicate() != null &&
+                !canCompensateMvAggregatePredicate(rewriteContext, mvAggregationOperator,
+                        queryAggregationOperator, rewriter)) {
+            return Pair.create(null, false);
+        }
+
         // rewrite aggregate having expr: add aggregate's predicate compensation after group by.
         if (queryAggregationOperator.getPredicate() != null) {
-            // NOTE: If there are having expr in agg, ensure all aggregate functions should put into new projections
-            Map<ColumnRefOperator, ScalarOperator> queryColumnRefToScalarMap = Maps.newHashMap();
-            for (Map.Entry<ColumnRefOperator, CallOperator> entry : oldAggregations.entrySet()) {
-                ScalarOperator scalarOp = entry.getValue();
-                ScalarOperator mapped = rewriteContext.getQueryColumnRefRewriter().rewrite(scalarOp.clone());
-                ScalarOperator swapped = columnRewriter.rewriteByQueryEc(mapped);
-                ScalarOperator rewritten = rewriteScalarOperator(rewriteContext, swapped,
-                        queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
-                        originalColumnSet, aggregateFunctionRewriter);
-                // for non-rollup rewrite, the rewritten result should not contain aggregate functions.
-                boolean isAggregate = isAggregate(rewritten);
-                if (rewritten == null || isAggregate) {
-                    OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
-                            "Rewrite aggregate with having expr failed: {}", scalarOp.toString());
-                    return Pair.create(null, isAggregate);
-                }
-                queryColumnRefToScalarMap.put(entry.getKey(), rewritten);
-            }
-            for (ColumnRefOperator groupKey : queryAggregationOperator.getGroupingKeys()) {
-                ScalarOperator mapped = rewriteContext.getQueryColumnRefRewriter().rewrite(groupKey.clone());
-                ScalarOperator swapped = columnRewriter.rewriteByQueryEc(mapped);
-                ScalarOperator rewritten = rewriteScalarOperator(rewriteContext, swapped,
-                        queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
-                        originalColumnSet, aggregateFunctionRewriter);
-                boolean isAggregate = isAggregate(rewritten);
-                if (rewritten == null || isAggregate) {
-                    OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
-                            "Mapping grouping key failed: {}", groupKey.toString());
-                    return Pair.create(null, isAggregate);
-                }
-                queryColumnRefToScalarMap.put(groupKey, rewritten);
-            }
-            ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(queryColumnRefToScalarMap);
             ScalarOperator aggPredicate = queryAggregationOperator.getPredicate();
             ScalarOperator rewrittenPred = rewriter.rewrite(aggPredicate);
             if (rewrittenPred == null) {
@@ -281,6 +269,147 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         }
 
         return Pair.create(mvOptExpr, false);
+    }
+
+    private Pair<Map<ColumnRefOperator, ScalarOperator>, Boolean> rewriteAggregatePredicateColumns(
+            RewriteContext rewriteContext,
+            LogicalAggregationOperator queryAggregationOperator,
+            EquationRewriter queryExprToMvExprRewriter,
+            ColumnRewriter columnRewriter,
+            ColumnRefSet originalColumnSet,
+            AggregateFunctionRewriter aggregateFunctionRewriter) {
+        // NOTE: If there are having expr in agg, ensure all aggregate functions should put into new projections
+        Map<ColumnRefOperator, ScalarOperator> queryColumnRefToScalarMap = Maps.newHashMap();
+        for (Map.Entry<ColumnRefOperator, CallOperator> entry : queryAggregationOperator.getAggregations().entrySet()) {
+            ScalarOperator scalarOp = entry.getValue();
+            ScalarOperator mapped = rewriteContext.getQueryColumnRefRewriter().rewrite(scalarOp.clone());
+            ScalarOperator swapped = columnRewriter.rewriteByQueryEc(mapped);
+            ScalarOperator rewritten = rewriteScalarOperator(rewriteContext, swapped,
+                    queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
+                    originalColumnSet, aggregateFunctionRewriter);
+            // for non-rollup rewrite, the rewritten result should not contain aggregate functions.
+            boolean isAggregate = isAggregate(rewritten);
+            if (rewritten == null || isAggregate) {
+                OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
+                        "Rewrite aggregate with having expr failed: {}", scalarOp.toString());
+                return Pair.create(null, isAggregate);
+            }
+            queryColumnRefToScalarMap.put(entry.getKey(), rewritten);
+        }
+        for (ColumnRefOperator groupKey : queryAggregationOperator.getGroupingKeys()) {
+            ScalarOperator mapped = rewriteContext.getQueryColumnRefRewriter().rewrite(groupKey.clone());
+            ScalarOperator swapped = columnRewriter.rewriteByQueryEc(mapped);
+            ScalarOperator rewritten = rewriteScalarOperator(rewriteContext, swapped,
+                    queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
+                    originalColumnSet, aggregateFunctionRewriter);
+            boolean isAggregate = isAggregate(rewritten);
+            if (rewritten == null || isAggregate) {
+                OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
+                        "Mapping grouping key failed: {}", groupKey.toString());
+                return Pair.create(null, isAggregate);
+            }
+            queryColumnRefToScalarMap.put(groupKey, rewritten);
+        }
+        return Pair.create(queryColumnRefToScalarMap, false);
+    }
+
+    private boolean canCompensateMvAggregatePredicate(RewriteContext rewriteContext,
+                                                      LogicalAggregationOperator mvAggregationOperator,
+                                                      LogicalAggregationOperator queryAggregationOperator,
+                                                      ReplaceColumnRefRewriter queryPredicateRewriter) {
+        ScalarOperator mvPredicate = mvAggregationOperator.getPredicate();
+        ScalarOperator queryPredicate = queryAggregationOperator.getPredicate();
+        if (queryPredicate == null) {
+            OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
+                    "Rewrite aggregate with MV HAVING predicate failed because query has no HAVING predicate: {}",
+                    mvPredicate);
+            return false;
+        }
+
+        ScalarOperator rewrittenQueryPredicate = queryPredicateRewriter.rewrite(queryPredicate.clone());
+        ScalarOperator rewrittenMvPredicate = rewriteMvAggregatePredicate(rewriteContext, mvPredicate);
+        if (rewrittenQueryPredicate == null || rewrittenMvPredicate == null) {
+            OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
+                    "Rewrite aggregate with MV HAVING predicate failed, query predicate: {}, mv predicate: {}",
+                    queryPredicate, mvPredicate);
+            return false;
+        }
+
+        if (!canCompensateAggregatePredicate(rewrittenQueryPredicate, rewrittenMvPredicate)) {
+            OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
+                    "Rewrite aggregate with MV HAVING predicate failed, query HAVING does not imply MV HAVING, " +
+                            "query: {}, mv: {}", rewrittenQueryPredicate, rewrittenMvPredicate);
+            return false;
+        }
+        return true;
+    }
+
+    private ScalarOperator rewriteMvAggregatePredicate(RewriteContext rewriteContext, ScalarOperator mvPredicate) {
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(rewriteContext.getOutputMapping());
+        ScalarOperator rewritten = rewriter.rewrite(mvPredicate.clone());
+        ColumnRefSet mvScanOutputColumnSet = new ColumnRefSet(rewriteContext.getOutputMapping().values());
+        if (!mvScanOutputColumnSet.containsAll(rewritten.getUsedColumns())) {
+            return null;
+        }
+        return rewritten;
+    }
+
+    private boolean canCompensateAggregatePredicate(ScalarOperator queryPredicate, ScalarOperator mvPredicate) {
+        PredicateSplit queryPredicateSplit = PredicateSplit.splitPredicate(queryPredicate);
+        PredicateSplit mvPredicateSplit = PredicateSplit.splitPredicate(mvPredicate);
+
+        ScalarOperator rangeCompensation = getAggregatePredicateCompensation(
+                queryPredicateSplit.getRangePredicates(), mvPredicateSplit.getRangePredicates(), true);
+        if (rangeCompensation == null) {
+            return false;
+        }
+
+        ScalarOperator queryResidualPredicate = Utils.compoundAnd(queryPredicateSplit.getEqualPredicates(),
+                queryPredicateSplit.getResidualPredicates());
+        ScalarOperator mvResidualPredicate = Utils.compoundAnd(mvPredicateSplit.getEqualPredicates(),
+                mvPredicateSplit.getResidualPredicates());
+        return getAggregatePredicateCompensation(queryResidualPredicate, mvResidualPredicate, false) != null;
+    }
+
+    private ScalarOperator getAggregatePredicateCompensation(ScalarOperator queryPredicate,
+                                                             ScalarOperator mvPredicate,
+                                                             boolean isRangePredicate) {
+        if (queryPredicate == null && mvPredicate == null) {
+            return ConstantOperator.TRUE;
+        } else if (queryPredicate == null) {
+            return null;
+        } else if (mvPredicate == null) {
+            return MvUtils.canonizePredicate(queryPredicate);
+        }
+
+        ScalarOperator canonizedQueryPredicate =
+                MvUtils.canonizePredicateForRewrite(queryMaterializationContext, queryPredicate);
+        ScalarOperator canonizedMvPredicate =
+                MvUtils.canonizePredicateForRewrite(queryMaterializationContext, mvPredicate);
+        ScalarOperator compensation;
+        if (isRangePredicate) {
+            RangeSimplifier simplifier = new RangeSimplifier(canonizedQueryPredicate);
+            compensation = simplifier.simplify(canonizedMvPredicate);
+        } else {
+            compensation = MvUtils.getCompensationPredicateForDisjunctive(
+                    canonizedQueryPredicate, canonizedMvPredicate);
+            if (compensation == null) {
+                compensation = getAggregateResidualPredicateCompensation(
+                        canonizedQueryPredicate, canonizedMvPredicate);
+            }
+        }
+        return compensation == null ? null : MvUtils.canonizePredicate(compensation);
+    }
+
+    private ScalarOperator getAggregateResidualPredicateCompensation(ScalarOperator queryPredicate,
+                                                                     ScalarOperator mvPredicate) {
+        List<ScalarOperator> queryConjuncts = Utils.extractConjuncts(queryPredicate);
+        List<ScalarOperator> mvConjuncts = Utils.extractConjuncts(mvPredicate);
+        if (new HashSet<>(queryConjuncts).containsAll(mvConjuncts)) {
+            queryConjuncts.removeAll(mvConjuncts);
+            return queryConjuncts.isEmpty() ? ConstantOperator.TRUE : Utils.compoundAnd(queryConjuncts);
+        }
+        return null;
     }
 
     private ScalarOperator rewriteScalarOperator(RewriteContext rewriteContext,

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -5516,7 +5516,9 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteOK(mv, "select empid, deptno,\n" +
                 " sum(salary) as total, count(salary)  as cnt\n" +
                 " from emps group by empid, deptno having sum(salary) > 10");
-        testRewriteOK(mv, "select empid,\n" +
+        // MV HAVING is evaluated per (empid, deptno). Rolling it up to empid can lose
+        // filtered dept groups without base-table compensation, so this rewrite is unsafe.
+        testRewriteFail(mv, "select empid,\n" +
                 " sum(salary) as total, count(salary)  as cnt\n" +
                 " from emps group by empid having sum(salary) > 10");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -743,6 +743,57 @@ public class MVRewriteTest extends StarRocksTestBase {
     }
 
     @Test
+    public void testMvHavingDoesNotFallbackRollupWithAggState() throws Exception {
+        String tableName = "having_state_base";
+        String mvName = "mv_having_state";
+        String duplicateTable = "CREATE TABLE " + tableName + " ( " +
+                "k1 string NOT NULL, k2 decimal(34, 0) ) " +
+                "DUPLICATE KEY(k1, k2) DISTRIBUTED BY HASH(k1) BUCKETS 3 " +
+                "PROPERTIES ('replication_num' = '1');";
+        starRocksAssert.withTable(duplicateTable);
+        try {
+            String createMV = "CREATE MATERIALIZED VIEW " + mvName + " " +
+                    "DISTRIBUTED BY HASH(k1) " +
+                    "AS SELECT k1, avg_union(avg_state(k2)) AS s " +
+                    "FROM " + tableName + " GROUP BY k1 HAVING avg(k2) > 10;";
+            String query = "SELECT k1, avg(k2) AS s FROM " + tableName +
+                    " GROUP BY k1 HAVING avg(k2) > 20;";
+
+            starRocksAssert.withMaterializedView(createMV).query(query).explainWithout(mvName);
+        } finally {
+            starRocksAssert.dropMaterializedView(mvName);
+            starRocksAssert.dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testMvHavingRandomDistributionRollupWithStrongerHaving() throws Exception {
+        String tableName = "having_random_base";
+        String mvName = "mv_having_random";
+        String duplicateTable = "CREATE TABLE " + tableName + " ( " +
+                "id bigint, region varchar(32), amount decimal(18, 2) ) " +
+                "DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 3 " +
+                "PROPERTIES ('replication_num' = '1');";
+        starRocksAssert.withTable(duplicateTable);
+        try {
+            String createMV = "CREATE MATERIALIZED VIEW " + mvName + " " +
+                    "DISTRIBUTED BY RANDOM " +
+                    "REFRESH MANUAL " +
+                    "AS SELECT region, SUM(amount) AS s, COUNT(*) AS c " +
+                    "FROM " + tableName + " GROUP BY region HAVING SUM(amount) > 100;";
+            String query = "SELECT region, SUM(amount) AS s, COUNT(*) AS c FROM " + tableName +
+                    " GROUP BY region HAVING SUM(amount) > 200;";
+
+            starRocksAssert.withMaterializedView(createMV)
+                    .query(query)
+                    .explainContains("rollup: " + mvName, "PREDICATES:", "s > 200");
+        } finally {
+            starRocksAssert.dropMaterializedView(mvName);
+            starRocksAssert.dropTable(tableName);
+        }
+    }
+
+    @Test
     public void testAggFunctionInOrder() throws Exception {
         String duplicateTable = "CREATE TABLE " + TEST_TABLE_NAME + " ( k1 int(11) NOT NULL ,  k2  int(11) NOT NULL ,"
                 + "v1  varchar(4096) NOT NULL, v2  float NOT NULL , v3  decimal(20, 7) NOT NULL ) ENGINE=OLAP "

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -641,6 +641,84 @@ public class MVRewriteTest extends StarRocksTestBase {
     }
 
     @Test
+    public void testMvHavingDoesNotRewriteQueryWithWeakerHaving() throws Exception {
+        String tableName = "mv_having_base";
+        String mvName = "mv_having_filter";
+        String duplicateTable = "CREATE TABLE " + tableName + " ( " +
+                "id bigint, region varchar(32), amount decimal(18, 2) ) " +
+                "DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 3 " +
+                "PROPERTIES ('replication_num' = '1');";
+        starRocksAssert.withTable(duplicateTable);
+        try {
+            String createMV = "CREATE MATERIALIZED VIEW " + mvName + " " +
+                    "DISTRIBUTED BY HASH(region) " +
+                    "AS SELECT region, SUM(amount) AS s, COUNT(*) AS c " +
+                    "FROM " + tableName + " GROUP BY region HAVING SUM(amount) > 100;";
+            String queryWithoutHaving = "SELECT region, SUM(amount), COUNT(*) FROM " + tableName + " GROUP BY region;";
+            String queryWithWeakerHaving = "SELECT region, SUM(amount), COUNT(*) FROM " + tableName +
+                    " GROUP BY region HAVING SUM(amount) > 0;";
+
+            starRocksAssert.withMaterializedView(createMV).query(queryWithoutHaving).explainWithout(mvName);
+            starRocksAssert.query(queryWithWeakerHaving).explainWithout(mvName);
+        } finally {
+            starRocksAssert.dropMaterializedView(mvName);
+            starRocksAssert.dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testMvHavingRewritesQueryWithStrongerHaving() throws Exception {
+        String tableName = "mv_having_filtered_base";
+        String mvName = "mv_having_filtered";
+        String duplicateTable = "CREATE TABLE " + tableName + " ( " +
+                "id bigint, region varchar(32), amount decimal(18, 2) ) " +
+                "DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 3 " +
+                "PROPERTIES ('replication_num' = '1');";
+        starRocksAssert.withTable(duplicateTable);
+        try {
+            String createMV = "CREATE MATERIALIZED VIEW " + mvName + " " +
+                    "DISTRIBUTED BY HASH(region) " +
+                    "AS SELECT region, SUM(amount) AS s, COUNT(*) AS c " +
+                    "FROM " + tableName + " GROUP BY region HAVING SUM(amount) > 100;";
+            String queryWithStrongerHaving = "SELECT region, SUM(amount) AS s, COUNT(*) AS c FROM " + tableName +
+                    " GROUP BY region HAVING SUM(amount) > 200;";
+
+            starRocksAssert.withMaterializedView(createMV)
+                    .query(queryWithStrongerHaving)
+                    .explainContains("rollup: " + mvName, "PREDICATES:", "s > 200");
+        } finally {
+            starRocksAssert.dropMaterializedView(mvName);
+            starRocksAssert.dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testQueryHavingRewritesWithMvWithoutHaving() throws Exception {
+        String tableName = "mv_having_complete_base";
+        String mvName = "mv_having_complete";
+        String duplicateTable = "CREATE TABLE " + tableName + " ( " +
+                "id bigint, region varchar(32), amount decimal(18, 2) ) " +
+                "DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 3 " +
+                "PROPERTIES ('replication_num' = '1');";
+        starRocksAssert.withTable(duplicateTable);
+        try {
+            String createMV = "CREATE MATERIALIZED VIEW " + mvName + " " +
+                    "DISTRIBUTED BY HASH(region) " +
+                    "AS SELECT region, SUM(amount) AS s, COUNT(*) AS c " +
+                    "FROM " + tableName + " GROUP BY region;";
+            String queryWithHaving = "SELECT region, SUM(amount) AS s, COUNT(*) AS c FROM " + tableName +
+                    " GROUP BY region HAVING SUM(amount) > 100;";
+
+            starRocksAssert.withMaterializedView(createMV)
+                    .query(queryWithHaving)
+                    .explainContains("rollup: " + mvName, "PREDICATES:", "s > 100");
+        } finally {
+            starRocksAssert.dropMaterializedView(mvName);
+            starRocksAssert.dropTable(tableName);
+        }
+    }
+
+    @Test
     public void testAggFunctionInOrder() throws Exception {
         String duplicateTable = "CREATE TABLE " + TEST_TABLE_NAME + " ( k1 int(11) NOT NULL ,  k2  int(11) NOT NULL ,"
                 + "v1  varchar(4096) NOT NULL, v2  float NOT NULL , v3  decimal(20, 7) NOT NULL ) ENGINE=OLAP "

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -794,6 +794,28 @@ public class MVRewriteTest extends StarRocksTestBase {
     }
 
     @Test
+    public void testMvHavingDoesNotFallbackRollupAfterProjectionFailure() throws Exception {
+        String tableName = "having_fallback_base";
+        String mvName = "mv_having_fallback";
+        String duplicateTable = "CREATE TABLE " + tableName + " ( " +
+                "id bigint, dt date ) " +
+                "DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 3 " +
+                "PROPERTIES ('replication_num' = '1');";
+        starRocksAssert.withTable(duplicateTable);
+        try {
+            String createMV = "CREATE MATERIALIZED VIEW " + mvName + " " +
+                    "DISTRIBUTED BY HASH(dt) " +
+                    "AS SELECT dt FROM " + tableName + " GROUP BY dt HAVING COUNT(*) > 1;";
+            String query = "SELECT COUNT(dt) FROM " + tableName + " WHERE dt = '2024-11-27';";
+
+            starRocksAssert.withMaterializedView(createMV).query(query).explainWithout(mvName);
+        } finally {
+            starRocksAssert.dropMaterializedView(mvName);
+            starRocksAssert.dropTable(tableName);
+        }
+    }
+
+    @Test
     public void testAggFunctionInOrder() throws Exception {
         String duplicateTable = "CREATE TABLE " + TEST_TABLE_NAME + " ( k1 int(11) NOT NULL ,  k2  int(11) NOT NULL ,"
                 + "v1  varchar(4096) NOT NULL, v2  float NOT NULL , v3  decimal(20, 7) NOT NULL ) ENGINE=OLAP "

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -693,6 +693,30 @@ public class MVRewriteTest extends StarRocksTestBase {
     }
 
     @Test
+    public void testMvHavingDoesNotRollupRewriteOverFilteredGroups() throws Exception {
+        String tableName = "having_rollup_base";
+        String mvName = "mv_having_rollup";
+        String duplicateTable = "CREATE TABLE " + tableName + " ( " +
+                "id bigint, region varchar(32), channel varchar(32), amount decimal(18, 2) ) " +
+                "DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 3 " +
+                "PROPERTIES ('replication_num' = '1');";
+        starRocksAssert.withTable(duplicateTable);
+        try {
+            String createMV = "CREATE MATERIALIZED VIEW " + mvName + " " +
+                    "DISTRIBUTED BY HASH(region) " +
+                    "AS SELECT region, channel, SUM(amount) AS s, COUNT(*) AS c " +
+                    "FROM " + tableName + " GROUP BY region, channel HAVING SUM(amount) > 1;";
+            String query = "SELECT region, SUM(amount) AS s, COUNT(*) AS c FROM " + tableName +
+                    " GROUP BY region HAVING SUM(amount) > 10;";
+
+            starRocksAssert.withMaterializedView(createMV).query(query).explainWithout(mvName);
+        } finally {
+            starRocksAssert.dropMaterializedView(mvName);
+            starRocksAssert.dropTable(tableName);
+        }
+    }
+
+    @Test
     public void testQueryHavingRewritesWithMvWithoutHaving() throws Exception {
         String tableName = "mv_having_complete_base";
         String mvName = "mv_having_complete";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
@@ -1172,7 +1172,7 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                             " PROPERTIES (\n" +
                             " 'transparent_mv_rewrite_mode' = 'true'" +
                             " ) " +
-                            " AS SELECT k1, k2, sum(v1) as agg1 from m1 group by k1, k2 having sum(v1) > 1;",
+                            " AS SELECT k1, k2, sum(v1) as agg1 from m1 group by k1, k2;",
                     () -> {
                         starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n" +
                                 "PARTITION START ('%s') END ('%s')", "1", "3"));


### PR DESCRIPTION
## Why I'm doing:

Aggregate materialized views with a HAVING clause only contain groups that satisfy the MV predicate. Reusing such an MV for queries without HAVING, or with a weaker HAVING predicate, can silently drop groups and return incomplete results.

Fixes StarRocks/StarRocksTest#11301

## What I'm doing:

- Reject aggregate MV rewrite when the MV aggregation operator has a HAVING predicate until compensation is supported.
- Add regression coverage for MV-side HAVING not rewriting queries without HAVING or with weaker HAVING.
- Add coverage that query-side HAVING still rewrites against a complete aggregate MV without MV-side HAVING.
- Keep the transparent aggregate column-pruning test focused on query-side HAVING and column pruning.
- Align the Gradle StarOS dependency version with Maven so FE Gradle builds compile against the configured API.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4