### PR TITLE
[Enhancement] Enable `avro_use_jni_reader` by default after Hive JNI behavior alignment

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2786,7 +2786,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean paimonForceJNIReader = false;
 
     @VariableMgr.VarAttr(name = AVRO_USE_JNI_READER)
-    private boolean avroUseJNIReader = true;
+    private boolean avroUseJNIReader = false;
 
     @VarAttr(name = ENABLE_QUERY_CACHE)
     private boolean enableQueryCache = false;


### PR DESCRIPTION
## Why I'm doing:
We previously kept the Avro JNI reader conservative because the JNI Hive path did not fully match the non-JNI / generic reader behavior.

That changed with [#73579](https://github.com/StarRocks/starrocks/pull/73579), which aligned the Hive-side behavior and removed one of the main blockers to using the JNI path by default. With that behavior gap addressed, we can safely switch back to the JNI reader as the default path instead of requiring users to opt in manually.

At a high level, the rollout logic becomes:

```text
before #73579:
non-JNI path != JNI path
=> keep JNI default off

after #73579:
non-JNI path ~= JNI path
=> JNI can be default on
```

## What I'm doing:
Change the default value of `avro_use_jni_reader` from `false` to `true`.

This means Avro reads will prefer the JNI reader by default, while still preserving the session variable so users can explicitly switch back if needed for debugging or compatibility verification.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
