### PR TITLE
[BugFix] Restore TimeUtils session-tz, zone-aware formatting, and year-0000 parsing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -74,14 +74,12 @@ public class TimeUtils {
     public static final ImmutableMap<String, String> TIME_ZONE_ALIAS_MAP = ImmutableMap.of(
             "CST", DEFAULT_TIME_ZONE, "PRC", DEFAULT_TIME_ZONE);
 
-    //Used to convert a string to a date. Compatible: 2013-2-29
-    private static final DateTimeFormatter STRING_TO_DATE_FORMAT = DateTimeFormatter.ofPattern("y-M-d").withZone(TIME_ZONE);
-    //Used to convert a string to a datetime. Compatible: 2013-2-28 2:3:4
+    // Proleptic year ("u") is required so that year 0000 can be parsed.
+    // Single-letter components allow non-padded inputs, e.g. "2013-2-2".
+    private static final DateTimeFormatter STRING_TO_DATE_FORMAT = DateTimeFormatter.ofPattern("u-M-d").withZone(TIME_ZONE);
     private static final DateTimeFormatter STRING_TO_DATETIME_FORMAT =
-            DateTimeFormatter.ofPattern("y-M-d H:m:s").withZone(TIME_ZONE);
+            DateTimeFormatter.ofPattern("u-M-d H:m:s").withZone(TIME_ZONE);
 
-    //Used to convert a date to a string.
-    private static final DateTimeFormatter DATE_TO_STRING_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(TIME_ZONE);
     //Used to convert a datetime to a string.
     private static final DateTimeFormatter DATETIME_TO_STRING_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(TIME_ZONE);
@@ -122,8 +120,17 @@ public class TimeUtils {
         return System.nanoTime() - startTime;
     }
 
+    /**
+     * Returns the current wall-clock time formatted as "yyyy-MM-dd HH:mm:ss" in the
+     * cluster-wide storage zone (fixed +08:00), NOT the JVM default zone and NOT the
+     * caller's session timezone. Matches the pre-#66360 contract relied on by metadata
+     * and scheduler timestamps that must stay stable across FE hosts.
+     *
+     * <p>Note: the input must be an {@link Instant} - {@link DateTimeFormatter#withZone}
+     * is a no-op when formatting a {@link LocalDateTime}, which was the #66360 regression.
+     */
     public static String getCurrentFormatTime() {
-        return DATETIME_TO_STRING_FORMAT.format(LocalDateTime.now());
+        return DATETIME_TO_STRING_FORMAT.format(Instant.now());
     }
 
     public static TimeZone getTimeZone() {
@@ -167,11 +174,28 @@ public class TimeUtils {
         return dateFormat.format(Instant.ofEpochMilli(timeStamp));
     }
 
+    /**
+     * Formats an epoch-millisecond timestamp as "yyyy-MM-dd HH:mm:ss" in the caller's
+     * SESSION timezone (resolved via {@link #getTimeZone()}). Returns
+     * {@link FeConstants#NULL_STRING} for non-positive timestamps.
+     *
+     * <p>This is the user-facing default used by SHOW / proc / load / metadata code
+     * paths; the output is intentionally session-zone dependent so that two clients
+     * connected with different {@code time_zone} session variables see their own
+     * local wall-clock. Switching this to a fixed zone is what regressed in #66360;
+     * keep it session-zoned. Callers that need a fixed zone should build their own
+     * formatter and use {@link #longToTimeString(long, DateTimeFormatter)} instead.
+     */
     public static String longToTimeString(long timeStamp) {
+        // Fast-path sentinel timestamps (unset / negative) before touching the session
+        // timezone - those code paths are hot in SHOW / load metadata and resolving the
+        // session zone can fail when the thread has no ConnectContext.
         if (timeStamp <= 0L) {
             return FeConstants.NULL_STRING;
         }
-        return longToTimeString(timeStamp, DATETIME_TO_STRING_FORMAT);
+        // Reuse the pre-parsed pattern (DATETIME_TO_STRING_FORMAT) and only rebind the
+        // zone per call - .withZone(...) returns a thin wrapper without re-parsing.
+        return longToTimeString(timeStamp, DATETIME_TO_STRING_FORMAT.withZone(getTimeZone().toZoneId()));
     }
 
     /**
@@ -341,14 +365,20 @@ public class TimeUtils {
         }
     }
 
+    /**
+     * Returns the effective session timezone string:
+     *   1. the per-request value from the current {@link ConnectContext}, or
+     *   2. the cluster-wide default from GlobalStateMgr's VariableMgr, or
+     *   3. {@link #DEFAULT_TIME_ZONE} ("Asia/Shanghai") as a last-resort fallback.
+     */
     public static String getSessionTimeZone() {
-        String timezone;
+        String timezone = null;
         if (ConnectContext.get() != null) {
             timezone = ConnectContext.get().getSessionVariable().getTimeZone();
         } else {
             timezone = GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultSessionVariable().getTimeZone();
         }
-        return timezone;
+        return timezone != null ? timezone : DEFAULT_TIME_ZONE;
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/TimeUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/TimeUtilsTest.java
@@ -22,13 +22,16 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.ast.expression.DateLiteral;
 import com.starrocks.type.DateType;
-import mockit.Expectations;
-import mockit.Mocked;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.TimeZone;
@@ -39,34 +42,15 @@ import static com.starrocks.common.util.TimeUtils.DATETIME_WITH_TIME_ZONE_PATTER
 
 public class TimeUtilsTest {
 
-    @Mocked
-    TimeUtils timeUtils;
-
-    @BeforeEach
-    public void setUp() {
-        TimeZone tz = TimeZone.getTimeZone(ZoneId.of("Asia/Shanghai"));
-        new Expectations(timeUtils) {
-            {
-                TimeUtils.getTimeZone();
-                minTimes = 0;
-                result = tz;
-            }
-        };
-    }
-
     @Test
     public void testNormal() {
         Assertions.assertNotNull(TimeUtils.getCurrentFormatTime());
         Assertions.assertTrue(TimeUtils.getEstimatedTime(0L) > 0);
 
-        Assertions.assertEquals(-62167248343000L,
-                TimeUtils.MIN_DATE.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
-        Assertions.assertEquals(253402185600000L,
-                TimeUtils.MAX_DATE.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
-        Assertions.assertEquals(-62167248343000L,
-                TimeUtils.MIN_DATETIME.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
-        Assertions.assertEquals(253402271999000L,
-                TimeUtils.MAX_DATETIME.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+        Assertions.assertEquals(LocalDate.of(0, 1, 1), TimeUtils.MIN_DATE);
+        Assertions.assertEquals(LocalDate.of(9999, 12, 31), TimeUtils.MAX_DATE);
+        Assertions.assertEquals(LocalDateTime.of(0, 1, 1, 0, 0, 0), TimeUtils.MIN_DATETIME);
+        Assertions.assertEquals(LocalDateTime.of(9999, 12, 31, 23, 59, 59), TimeUtils.MAX_DATETIME);
     }
 
     @Test
@@ -79,6 +63,7 @@ public class TimeUtilsTest {
         validDateList.add("9999-12-31");
         validDateList.add("1900-01-01");
         validDateList.add("2013-2-28");
+        validDateList.add("0000-01-01");
         for (String validDate : validDateList) {
             try {
                 TimeUtils.parseDate(validDate);
@@ -119,6 +104,7 @@ public class TimeUtilsTest {
         validDateTimeList.add("2013-2-28 23:59:59");
         validDateTimeList.add("2013-2-28 2:3:4");
         validDateTimeList.add("2014-05-07 19:8:50");
+        validDateTimeList.add("0000-01-01 00:00:00");
         for (String validDateTime : validDateTimeList) {
             try {
                 TimeUtils.parseDateTime(validDateTime);
@@ -150,6 +136,13 @@ public class TimeUtilsTest {
 
     @Test
     public void testDateTrans() throws AnalysisException {
+        new MockUp<TimeUtils>() {
+            @Mock
+            public TimeZone getTimeZone() {
+                return TimeZone.getTimeZone(ZoneId.of("Asia/Shanghai"));
+            }
+        };
+
         Assertions.assertEquals(FeConstants.NULL_STRING, TimeUtils.longToTimeString(-2));
 
         long timestamp = 1426125600000L;
@@ -289,5 +282,67 @@ public class TimeUtilsTest {
         String value3 = " 2024-09-10";
         Matcher matcher3 = DATETIME_WITH_TIME_ZONE_PATTERN.matcher(value3);
         Assertions.assertFalse(matcher3.matches());
+    }
+
+    // Regressions introduced by the java.time refactor in PR #66360.
+    // These tests fail on the unfixed code and pass after the fix.
+
+    @Test
+    public void testLongToTimeStringHonorsSessionTimeZone() {
+        new MockUp<TimeUtils>() {
+            @Mock
+            public TimeZone getTimeZone() {
+                return TimeZone.getTimeZone(ZoneOffset.UTC);
+            }
+        };
+        // 1426125600000L = 2015-03-12 10:00:00 +08:00 = 2015-03-12 02:00:00 UTC
+        long timestamp = 1426125600000L;
+        Assertions.assertEquals("2015-03-12 02:00:00", TimeUtils.longToTimeString(timestamp));
+    }
+
+    @Test
+    public void testGetCurrentFormatTimeUsesFixedShanghaiTimeZone() {
+        // Pin Instant.now() so the assertion is deterministic; do not rely on wall-clock
+        // tolerance windows. Setting the JVM default to UTC simultaneously guards
+        // against a regression to LocalDateTime.now() (which would silently follow the
+        // JVM default zone instead of the fixed storage zone).
+        Instant fixed = Instant.parse("2024-06-15T07:30:45Z");
+        new MockUp<Instant>() {
+            @Mock
+            public Instant now() {
+                return fixed;
+            }
+        };
+        TimeZone original = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+            // 2024-06-15 07:30:45 UTC = 2024-06-15 15:30:45 +08:00.
+            Assertions.assertEquals("2024-06-15 15:30:45", TimeUtils.getCurrentFormatTime());
+        } finally {
+            TimeZone.setDefault(original);
+        }
+    }
+
+    @Test
+    public void testParseSupportsYearZero() {
+        Assertions.assertEquals(LocalDate.of(0, 1, 1),
+                Assertions.assertDoesNotThrow(() -> TimeUtils.parseDate("0000-01-01")));
+        Assertions.assertEquals(LocalDateTime.of(0, 1, 1, 0, 0, 0),
+                Assertions.assertDoesNotThrow(() -> TimeUtils.parseDateTime("0000-01-01 00:00:00")));
+        Assertions.assertNotEquals(-1L, TimeUtils.timeStringToLong("0000-01-01 00:00:00"));
+    }
+
+    @Test
+    public void testMinMaxConstantsAreTimezoneIndependent() {
+        TimeZone original = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+            Assertions.assertEquals(LocalDate.of(0, 1, 1), TimeUtils.MIN_DATE);
+            Assertions.assertEquals(LocalDate.of(9999, 12, 31), TimeUtils.MAX_DATE);
+            Assertions.assertEquals(LocalDateTime.of(0, 1, 1, 0, 0, 0), TimeUtils.MIN_DATETIME);
+            Assertions.assertEquals(LocalDateTime.of(9999, 12, 31, 23, 59, 59), TimeUtils.MAX_DATETIME);
+        } finally {
+            TimeZone.setDefault(original);
+        }
     }
 }


### PR DESCRIPTION
Address regressions from PR #66360

- longToTimeString(long): rebuild a session-zoned formatter on each call via getTimeZone() instead of using the fixed +08:00 formatter. SHOW / proc / load / metadata paths now respect the session time_zone again.
- getCurrentFormatTime(): format Instant.now() instead of LocalDateTime .now() so that DateTimeFormatter.withZone(TIME_ZONE) actually applies. Output is once more pinned to +08:00 on hosts with a non-Shanghai JVM default zone.
- STRING_TO_DATE_FORMAT / STRING_TO_DATETIME_FORMAT: switch from year-of -era ("y") to proleptic year ("u") so that "0000-01-01" and "0000-01-01 00:00:00" parse instead of throwing AnalysisException / returning -1.
- Remove the unused DATE_TO_STRING_FORMAT private constant.
- Correct the misleading "Compatible: 2013-2-29" comment (2013 is not a leap year and the parser rejects it).
- Re-add the "0000-01-01" / "0000-01-01 00:00:00" valid-input cases that #66360 deleted to mask the year-of-era regression.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
