### PR TITLE
[UT] Stabilize test_list_partition in test_automatic_partition

### DIFF
--- a/test/sql/test_automatic_bucket/R/test_automatic_partition
+++ b/test/sql/test_automatic_bucket/R/test_automatic_partition
@@ -203,6 +203,7 @@ select count(*) from information_schema.be_tablets t1, information_schema.tables
 insert into t values('2021-01-01', 1);
 -- result:
 -- !result
+function: wait_db_transaction_finish("ddd", 60)
 select count(*) from information_schema.be_tablets t1, information_schema.tables_config t2 where TABLE_NAME='t' and t1.TABLE_ID=t2.TABLE_ID and TABLE_SCHEMA='ddd';
 -- result:
 15
@@ -210,6 +211,7 @@ select count(*) from information_schema.be_tablets t1, information_schema.tables
 insert into t values('2021-01-03', 1);
 -- result:
 -- !result
+function: wait_db_transaction_finish("ddd", 60)
 select count(*) from information_schema.be_tablets t1, information_schema.tables_config t2 where TABLE_NAME='t' and t1.TABLE_ID=t2.TABLE_ID and TABLE_SCHEMA='ddd';
 -- result:
 18
@@ -217,6 +219,7 @@ select count(*) from information_schema.be_tablets t1, information_schema.tables
 insert into t values('2021-01-05', 1);
 -- result:
 -- !result
+function: wait_db_transaction_finish("ddd", 60)
 select count(*) from information_schema.be_tablets t1, information_schema.tables_config t2 where TABLE_NAME='t' and t1.TABLE_ID=t2.TABLE_ID and TABLE_SCHEMA='ddd';
 -- result:
 21
@@ -224,6 +227,7 @@ select count(*) from information_schema.be_tablets t1, information_schema.tables
 insert into t values('2021-01-01', 1);
 -- result:
 -- !result
+function: wait_db_transaction_finish("ddd", 60)
 select count(*) from information_schema.be_tablets t1, information_schema.tables_config t2 where TABLE_NAME='t' and t1.TABLE_ID=t2.TABLE_ID and TABLE_SCHEMA='ddd';
 -- result:
 24

--- a/test/sql/test_automatic_bucket/T/test_automatic_partition
+++ b/test/sql/test_automatic_bucket/T/test_automatic_partition
@@ -64,12 +64,16 @@ PROPERTIES (
 
 select count(*) from information_schema.be_tablets t1, information_schema.tables_config t2 where TABLE_NAME='t' and t1.TABLE_ID=t2.TABLE_ID and TABLE_SCHEMA='ddd';
 insert into t values('2021-01-01', 1);
+function: wait_db_transaction_finish("ddd", 60)
 select count(*) from information_schema.be_tablets t1, information_schema.tables_config t2 where TABLE_NAME='t' and t1.TABLE_ID=t2.TABLE_ID and TABLE_SCHEMA='ddd';
 insert into t values('2021-01-03', 1);
+function: wait_db_transaction_finish("ddd", 60)
 select count(*) from information_schema.be_tablets t1, information_schema.tables_config t2 where TABLE_NAME='t' and t1.TABLE_ID=t2.TABLE_ID and TABLE_SCHEMA='ddd';
 insert into t values('2021-01-05', 1);
+function: wait_db_transaction_finish("ddd", 60)
 select count(*) from information_schema.be_tablets t1, information_schema.tables_config t2 where TABLE_NAME='t' and t1.TABLE_ID=t2.TABLE_ID and TABLE_SCHEMA='ddd';
 insert into t values('2021-01-01', 1);
+function: wait_db_transaction_finish("ddd", 60)
 select count(*) from information_schema.be_tablets t1, information_schema.tables_config t2 where TABLE_NAME='t' and t1.TABLE_ID=t2.TABLE_ID and TABLE_SCHEMA='ddd';
 select * from t;
 


### PR DESCRIPTION
## Why I'm doing:

Wait for db transactions to finish after each insert so the count of information_schema.be_tablets is consistent before the next query. Without the wait, async tablet visibility from BE reports can lag the publish version, occasionally producing 18 instead of 21.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
