### PR TITLE
[BugFix] Route rand()/srand() callsites through ThreadLocalRandom32()

### DIFF
--- a/be/src/base/random/random.cc
+++ b/be/src/base/random/random.cc
@@ -72,4 +72,16 @@ std::string Random::RandomBinaryString(int len) {
     return ret;
 }
 
+int32_t ThreadLocalRandomUniform(int32_t range) {
+    STORAGE_DECL Random32* tls_instance;
+    STORAGE_DECL std::aligned_storage<sizeof(Random32)>::type tls_instance_bytes;
+
+    auto* rv = tls_instance;
+    if (UNLIKELY(rv == nullptr)) {
+        rv = new (&tls_instance_bytes) Random32(std::random_device{}());
+        tls_instance = rv;
+    }
+    return static_cast<int32_t>(rv->Uniform(static_cast<uint32_t>(range)));
+}
+
 } // namespace starrocks

--- a/be/src/base/random/random.h
+++ b/be/src/base/random/random.h
@@ -189,4 +189,13 @@ void RandomShuffle(RandomIt first, RandomIt last) {
     RandomShuffle(first, last, std::random_device{}());
 }
 
+// Returns a value uniformly distributed in [0, range), using a thread-local
+// std::mt19937 seeded once per thread from std::random_device. Use this in
+// place of POSIX rand(), which shares a single non-thread-safe global state.
+// Returning the value directly (rather than a pointer to the generator)
+// prevents callers from accidentally sharing the per-thread state across
+// threads.
+// REQUIRES: range > 0
+int32_t ThreadLocalRandomUniform(int32_t range);
+
 } // namespace starrocks

--- a/be/src/exec/data_sinks/data_stream_sender.cpp
+++ b/be/src/exec/data_sinks/data_stream_sender.cpp
@@ -462,7 +462,6 @@ Status DataStreamSender::prepare(RuntimeState* state) {
     // Randomize the order we open/transmit to channels to avoid thundering herd problems.
     _channel_indices.resize(_channels.size());
     std::iota(_channel_indices.begin(), _channel_indices.end(), 0);
-    srand(reinterpret_cast<uint64_t>(this));
     std::shuffle(_channel_indices.begin(), _channel_indices.end(), std::mt19937(std::random_device()()));
 
     _bytes_sent_counter = ADD_COUNTER(profile(), "BytesSent", TUnit::BYTES);

--- a/be/src/fs/azure/fs_azblob.cpp
+++ b/be/src/fs/azure/fs_azblob.cpp
@@ -20,6 +20,7 @@
 #include <azure/storage/blobs.hpp>
 
 #include "base/concurrency/stopwatch.hpp"
+#include "base/random/random.h"
 #include "fs/azure/azblob_uri.h"
 #include "fs/azure/utils.h"
 #include "fs/credential/cloud_configuration_factory.h"
@@ -274,7 +275,7 @@ Status AzBlobOutputStream::complete_multipart_upload() {
 
 class AzBlobClientFactory {
 public:
-    AzBlobClientFactory() { srand(time(nullptr)); }
+    AzBlobClientFactory() = default;
     ~AzBlobClientFactory() = default;
 
     BlobContainerClientPtr new_blob_container_client(const AzureCloudCredential& azure_cloud_credential,
@@ -320,8 +321,8 @@ BlobContainerClientPtr AzBlobClientFactory::new_blob_container_client(
             }
         }
 
-        auto& client =
-                _client_cache.size() < kMaxItems ? _client_cache.emplace_back() : _client_cache[rand() % kMaxItems];
+        auto& client = _client_cache.size() < kMaxItems ? _client_cache.emplace_back()
+                                                        : _client_cache[ThreadLocalRandomUniform(kMaxItems)];
         client.azure_cloud_credential = azure_cloud_credential;
         client.blob_container_client = container_client;
     }

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -529,7 +529,6 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(TStorageMedium
     }
 
     // randomize the preferential paths to balance number of tablets each disk has
-    std::srand(std::random_device()());
     std::shuffle(stores.begin(), stores.begin() + last_candidate_idx, std::mt19937(std::random_device()()));
     return stores;
 }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -23,6 +23,7 @@
 
 #include "base/debug/trace.h"
 #include "base/failpoint/fail_point.h"
+#include "base/random/random.h"
 #include "base/utility/defer_op.h"
 #include "base/utility/pretty_printer.h"
 #include "base/utility/scoped_cleanup.h"
@@ -3073,7 +3074,7 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
         }
     }
     // give 10s time gitter, so same table's compaction don't start at same time
-    _last_compaction_time_ms = UnixMillis() + rand() % 10000;
+    _last_compaction_time_ms = UnixMillis() + ThreadLocalRandomUniform(10000);
     if (info->inputs.empty()) {
         VLOG(2) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
         _compaction_running = false;
@@ -3253,7 +3254,7 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
                 _tablet.tablet_id(), version_count, _pending_commits.size());
     } else {
         // give 10s time gitter, so same table's compaction don't start at same time
-        _last_compaction_time_ms = UnixMillis() + rand() % 10000;
+        _last_compaction_time_ms = UnixMillis() + ThreadLocalRandomUniform(10000);
     }
 
     int64_t del_rows = total_rows - stat.num_rows;
@@ -5829,7 +5830,7 @@ Status TabletUpdates::compaction_random(MemTracker* mem_tracker) {
                 LOG(WARNING) << msg;
             } else if (itr->second->compaction_score > 0) {
                 // 30% chance to pick this rowset
-                if (rand() % 100 < 30) {
+                if (ThreadLocalRandomUniform(100) < 30) {
                     info->inputs.push_back(rowsetid);
                     if (info->inputs.size() >= config::max_update_compaction_num_singleton_deltas) {
                         break;
@@ -5840,7 +5841,7 @@ Status TabletUpdates::compaction_random(MemTracker* mem_tracker) {
     }
 
     // give 10s time gitter, so same table's compaction don't start at same time
-    _last_compaction_time_ms = UnixMillis() + rand() % 10000;
+    _last_compaction_time_ms = UnixMillis() + ThreadLocalRandomUniform(10000);
     if (info->inputs.empty()) {
         VLOG(2) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
         _compaction_running = false;

--- a/be/src/types/value_generator.h
+++ b/be/src/types/value_generator.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "base/random/random.h"
 #include "types/date_value.h"
 #include "types/timestamp_value.h"
 
@@ -45,14 +46,14 @@ struct AlwaysOneGenerator {
 
 template <class T, int range>
 struct RandomGenerator {
-    static T next_value() { return rand() % range; }
+    static T next_value() { return ThreadLocalRandomUniform(range); }
 };
 
 template <class T, int range>
 struct RandomConstGenerator {
     static T next_value() {
         if (!_is_initialize) {
-            const_value = rand() % range;
+            const_value = ThreadLocalRandomUniform(range);
             _is_initialize = true;
         }
         return const_value;

--- a/be/src/udf/python/env.cpp
+++ b/be/src/udf/python/env.cpp
@@ -31,6 +31,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "base/random/random.h"
 #include "base/string/slice.h"
 #include "base/utility/defer_op.h"
 #include "butil/fd_guard.h"
@@ -203,7 +204,7 @@ StatusOr<std::shared_ptr<PyWorker>> PyWorkerManager::_acquire_worker(int32_t dri
         std::lock_guard guard(_mutex);
         auto& workers = _processes[driver_id];
         if (workers.size() > max_worker_per_driver) {
-            worker = workers[rand() % max_worker_per_driver];
+            worker = workers[ThreadLocalRandomUniform(static_cast<int32_t>(max_worker_per_driver))];
         }
     }
     if (worker && worker->is_dead()) {


### PR DESCRIPTION
## Why I'm doing:

POSIX rand()/srand() share a single non-thread-safe global state; concurrent callers race on it, leading to skewed or duplicated draws. Replace first-party callsites with a thread-local std::mt19937 exposed by base/random.

base/random already provides Random32 (a std::mt19937 wrapper) and the per-thread instance pattern used by Random::GetTLSInstance. Add a sibling ThreadLocalRandom32() that returns a Random32* seeded once per thread from std::random_device, so callers no longer need to inline "thread_local std::mt19937 rng{std::random_device{}()};" themselves.

Convert callsites:
- fs/azure/fs_azblob.cpp: drop srand() in factory ctor; use ThreadLocalRandom32()->Uniform(kMaxItems) for cache slot selection
- udf/python/env.cpp: ThreadLocalRandom32()->Uniform(...) for worker pool
- storage/tablet_updates.cpp: ThreadLocalRandom32()->Uniform(...) for the compaction time jitter (3 sites) and rowset pick (1 site)
- exec/data_sinks/data_stream_sender.cpp: drop redundant srand() that preceded a std::shuffle already seeded by std::random_device
- storage/storage_engine.cpp: drop redundant std::srand() before std::shuffle that already uses std::random_device
- types/value_generator.h: route RandomGenerator/RandomConstGenerator through ThreadLocalRandom32()


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
