### PR TITLE
[BugFix] Recurse into nested types in IvmOpUtils state_union compat check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
@@ -33,7 +33,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.AggStateDesc;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.MapType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarbinaryType;
 import com.starrocks.type.VarcharType;
@@ -191,12 +195,38 @@ public class IvmOpUtils {
         if (intermediate.equals(mvColumn)) {
             return true;
         }
-        // MaterializedViewAnalyzer caps VARCHAR length at OlapMaxVarcharLength (65533)
-        // when persisting MV column types, so the delta side's narrower VARCHAR(N) is
-        // semantically compatible with the MV side's wider VARCHAR(65533). Same logic
+        // MaterializedViewAnalyzer caps VARCHAR length at OlapMaxVarcharLength when
+        // persisting MV column types, so the delta side's wider VARCHAR(N) is
+        // semantically compatible with the MV side's narrower VARCHAR. Same logic
         // applies to other string types sharing a primitive kind.
         if (intermediate.isStringType() && mvColumn.isStringType()
                 && intermediate.getPrimitiveType() == mvColumn.getPrimitiveType()) {
+            return true;
+        }
+        // Recurse so the rule above reaches nested strings — e.g. ARRAY_AGG's
+        // state is struct<array<varchar>> with differing VARCHAR lengths on each side.
+        if (intermediate.isArrayType() && mvColumn.isArrayType()) {
+            return typesCompatibleForStateUnion(
+                    ((ArrayType) intermediate).getItemType(),
+                    ((ArrayType) mvColumn).getItemType());
+        }
+        if (intermediate.isMapType() && mvColumn.isMapType()) {
+            MapType im = (MapType) intermediate;
+            MapType mm = (MapType) mvColumn;
+            return typesCompatibleForStateUnion(im.getKeyType(), mm.getKeyType())
+                    && typesCompatibleForStateUnion(im.getValueType(), mm.getValueType());
+        }
+        if (intermediate.isStructType() && mvColumn.isStructType()) {
+            List<StructField> iFields = ((StructType) intermediate).getFields();
+            List<StructField> mFields = ((StructType) mvColumn).getFields();
+            if (iFields.size() != mFields.size()) {
+                return false;
+            }
+            for (int i = 0; i < iFields.size(); i++) {
+                if (!typesCompatibleForStateUnion(iFields.get(i).getType(), mFields.get(i).getType())) {
+                    return false;
+                }
+            }
             return true;
         }
         return false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtilsTest.java
@@ -14,13 +14,19 @@
 
 package com.starrocks.sql.optimizer.rule.ivm.common;
 
+import com.starrocks.type.ArrayType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 /**
  * Tests for {@link IvmOpUtils#typesCompatibleForStateUnion(Type, Type)}.
@@ -81,5 +87,54 @@ public class IvmOpUtilsTest {
         ScalarType b = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 3);
         Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(a, b));
         Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(b, a));
+    }
+
+    // Nested types — ARRAY_AGG's state is struct<array<varchar>> with the delta
+    // side at VARCHAR(1073741824) and MV side at VARCHAR(OlapMaxVarcharLength).
+
+    @Test
+    public void arrayOfVarcharDifferentLengthsAreCompatible() {
+        ArrayType narrow = new ArrayType(TypeFactory.createVarcharType(50));
+        ArrayType wide = new ArrayType(TypeFactory.createVarcharType(1073741824));
+        Assertions.assertTrue(IvmOpUtils.typesCompatibleForStateUnion(narrow, wide));
+        Assertions.assertTrue(IvmOpUtils.typesCompatibleForStateUnion(wide, narrow));
+    }
+
+    @Test
+    public void arrayElementMismatchedPrimitiveNotCompatible() {
+        ArrayType varcharArr = new ArrayType(TypeFactory.createVarcharType(100));
+        ArrayType intArr = new ArrayType(IntegerType.INT);
+        Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(varcharArr, intArr));
+    }
+
+    @Test
+    public void structFieldsRecursiveCompatible() {
+        StructType intermediate = new StructType(List.<StructField>of(
+                new StructField("col1", new ArrayType(TypeFactory.createVarcharType(1073741824)))), true);
+        StructType mvColumn = new StructType(List.<StructField>of(
+                new StructField("col1", new ArrayType(TypeFactory.createVarcharType(1048576)))), true);
+        Assertions.assertTrue(IvmOpUtils.typesCompatibleForStateUnion(intermediate, mvColumn));
+        Assertions.assertTrue(IvmOpUtils.typesCompatibleForStateUnion(mvColumn, intermediate));
+    }
+
+    @Test
+    public void structDifferentFieldCountNotCompatible() {
+        StructType a = new StructType(List.<StructField>of(
+                new StructField("col1", TypeFactory.createVarcharType(100))), true);
+        StructType b = new StructType(List.<StructField>of(
+                new StructField("col1", TypeFactory.createVarcharType(100)),
+                new StructField("col2", IntegerType.INT)), true);
+        Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(a, b));
+        Assertions.assertFalse(IvmOpUtils.typesCompatibleForStateUnion(b, a));
+    }
+
+    @Test
+    public void mapOfVarcharKeysAndValuesDifferentLengths() {
+        MapType narrow = new MapType(
+                TypeFactory.createVarcharType(50), TypeFactory.createVarcharType(50));
+        MapType wide = new MapType(
+                TypeFactory.createVarcharType(1073741824), TypeFactory.createVarcharType(1073741824));
+        Assertions.assertTrue(IvmOpUtils.typesCompatibleForStateUnion(narrow, wide));
+        Assertions.assertTrue(IvmOpUtils.typesCompatibleForStateUnion(wide, narrow));
     }
 }

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_whitelist_widening
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_whitelist_widening
@@ -1,4 +1,4 @@
--- name: test_ivm_whitelist_widening @slow
+-- name: test_ivm_whitelist_widening
 -- Verifies the widened IVM aggregate-function whitelist:
 --   * MIN/MAX(VARCHAR) — enabled by #73095 (state_union accepts compatible string types)
 --   * AVG(DECIMAL)     — enabled by #73012 (preserve AggStateDesc on state_union)
@@ -95,7 +95,7 @@ AS SELECT k, dt, ARRAY_AGG(s_short ORDER BY k) AS arr_s
    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
    GROUP BY k, dt;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Failed to rewrite the query for IVM: Getting analyzing error. Detail message: IVMAnalyzer does not support array_agg with argument types [VARCHAR(1073741824), INT]..')
+E: (1064, 'Getting analyzing error. Detail message: IVMAnalyzer does not support array_agg with argument types [VARCHAR(1073741824), INT].')
 -- !result
 CREATE MATERIALIZED VIEW mv_hll PARTITION BY dt
 REFRESH DEFERRED MANUAL
@@ -104,7 +104,7 @@ AS SELECT k, dt, HLL_UNION(HLL_HASH(s_short)) AS h
    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
    GROUP BY k, dt;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Failed to rewrite the query for IVM: Getting analyzing error. Detail message: IVMAnalyzer does not support aggregate function: hll_union. Supported functions: [count, sum, avg, min, max, array_agg, bool_or, approx_count_distinct, ndv]..')
+E: (1064, 'Getting analyzing error. Detail message: IVMAnalyzer does not support aggregate function: hll_union. Supported functions: [count, sum, avg, min, max, array_agg, bool_or, approx_count_distinct, ndv].')
 -- !result
 CREATE MATERIALIZED VIEW mv_bmp PARTITION BY dt
 REFRESH DEFERRED MANUAL
@@ -113,7 +113,7 @@ AS SELECT k, dt, BITMAP_UNION(TO_BITMAP(k)) AS b
    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
    GROUP BY k, dt;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Failed to rewrite the query for IVM: Getting analyzing error. Detail message: IVMAnalyzer does not support aggregate function: bitmap_agg. Supported functions: [count, sum, avg, min, max, array_agg, bool_or, approx_count_distinct, ndv]..')
+E: (1064, 'Getting analyzing error. Detail message: IVMAnalyzer does not support aggregate function: bitmap_agg. Supported functions: [count, sum, avg, min, max, array_agg, bool_or, approx_count_distinct, ndv].')
 -- !result
 drop database db_${uuid0} force;
 -- result:

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_whitelist_widening
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_whitelist_widening
@@ -1,4 +1,4 @@
--- name: test_ivm_whitelist_widening @slow
+-- name: test_ivm_whitelist_widening
 -- Verifies the widened IVM aggregate-function whitelist:
 --   * MIN/MAX(VARCHAR) — enabled by #73095 (state_union accepts compatible string types)
 --   * AVG(DECIMAL)     — enabled by #73012 (preserve AggStateDesc on state_union)


### PR DESCRIPTION
## Why I'm doing this:

`IvmOpUtils.typesCompatibleForStateUnion` only handled flat string types. When an IVM materialized view uses `ARRAY_AGG`, its intermediate state is `AGG_STATE<struct<col1 array<varchar(N)>>>`; the delta side carries the function-signature `VARCHAR(1073741824)` while the MV side persists with `VARCHAR(OlapMaxVarcharLength)`. Because both sides nest the string under struct + array, the top-level `isStringType()` branch never matched and CREATE failed:

```
ERROR 1064 (HY000): Getting analyzing error. Detail message: Failed to generate
IVM refresh plan at CREATE time: intermediateAggScalarOp type
struct<`col1` array<varchar(1073741824)>> is incompatible with MV state
column type struct<`col1` array<varchar(1048576)>>.
```

How the regression slipped in:

1. #73095 introduced `typesCompatibleForStateUnion` for flat strings.
2. #73146 widened the IVM whitelist to include ARRAY_AGG and added `test_ivm_whitelist_widening`.
3. **One day later** #73075 made the type-compat check fire at CREATE time via `IvmTrialRewriter`.
4. The test was tagged `@slow`, and CI's SQL-Tester runs with `[attr]: !slow,!system,!celerdata,!cloud` — so the case **silently never ran** on main, and the regression sat undetected.

Verified on the StarRocks dev cluster (`8.142.108.134`): `main` HEAD + branch-4.1.1 HEAD both report the same error; `mv_array_agg` CREATE succeeds after this fix, and the full `test_ivm_whitelist_widening` passes 3/3 flaky runs.

## What I'm doing:

- `IvmOpUtils.typesCompatibleForStateUnion`: recurse into `ARRAY` / `MAP` / `STRUCT` so the existing "same primitive kind, length may differ" rule applies to nested string types.
- `IvmOpUtilsTest`: add five new cases (array of varchar; array element primitive mismatch; struct of array of varchar — the exact ARRAY_AGG shape; struct different field count; map of varchar key+value).
- `test_ivm_whitelist_widening`: drop the `@slow` tag (no reason for this case to be gated — it's small and finishes in ~20s on dev).
- `test_ivm_whitelist_widening` (R file): three negative-case error messages had an extra outer `"Failed to rewrite the query for IVM: "` wrapping from before #73075 changed how the trial-rewrite path surfaces exceptions; update them to match what the FE actually emits now.

## Fixes

Surfaced on branch-4.1.1 first; same root cause applies to `main` and `branch-4.1`. Should be backported to `branch-4.1` / `branch-4.1.1`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

(Behavior change is "ARRAY_AGG MV creation now succeeds where it previously failed at CREATE-time" — a bug being fixed rather than a user-visible new behavior.)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4