### PR TITLE
[Enhancement] Respect percentile compression in MV rewrite

### DIFF
--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -54,10 +54,21 @@ class PercentileApproxAggregateFunctionBase
 protected:
     static constexpr double MIN_COMPRESSION = 2048.0;
     static constexpr double MAX_COMPRESSION = 10000.0;
-    // Used only as a rolling-upgrade fallback when an old FE ships a legacy
-    // arity (without the canonicalized compression literal). For new-FE calls
-    // FunctionAnalyzer is the single source of truth and DEFAULT lives there.
+    // Kept on BE for rolling upgrades from pre-canonicalization FEs. For
+    // new-FE calls FunctionAnalyzer is the single source of truth and DEFAULT
+    // lives there.
     static constexpr double DEFAULT_COMPRESSION_FACTOR = 10000.0;
+
+    static double clamp_compression_factor(double compression) {
+        if (LIKELY(std::isfinite(compression) && compression >= MIN_COMPRESSION && compression <= MAX_COMPRESSION)) {
+            return compression;
+        }
+        // Old FEs can still ship explicit compression literals without the
+        // analyzer-side [MIN, MAX] clamp during a rolling upgrade.
+        LOG(WARNING) << "Compression factor out of range. Using default compression factor: "
+                     << DEFAULT_COMPRESSION_FACTOR;
+        return DEFAULT_COMPRESSION_FACTOR;
+    }
 
 public:
     virtual double get_compression_factor(FunctionContext* ctx) const = 0;
@@ -107,9 +118,9 @@ public:
 class PercentileApproxAggregateFunction : public PercentileApproxAggregateFunctionBase {
 public:
     double get_compression_factor(FunctionContext* ctx) const override {
-        // FE FunctionAnalyzer is the single source of truth: an explicit
-        // compression literal is always injected (default or user-supplied)
-        // and clamped to [MIN, MAX]. The DCHECKs document that contract.
+        // FE FunctionAnalyzer is the single source of truth for new-FE calls:
+        // an explicit compression literal is always injected (default or
+        // user-supplied) and clamped to [MIN, MAX].
         //
         // Rolling-upgrade fallback: during the upgrade window BEs are upgraded
         // before FEs, so an old FE may still ship 2-arg percentile_approx
@@ -121,10 +132,7 @@ public:
             return DEFAULT_COMPRESSION_FACTOR;
         }
         double compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(ctx->get_constant_column(2));
-        DCHECK(std::isfinite(compression));
-        DCHECK_GE(compression, MIN_COMPRESSION);
-        DCHECK_LE(compression, MAX_COMPRESSION);
-        return compression;
+        return clamp_compression_factor(compression);
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
@@ -187,7 +195,8 @@ class PercentileApproxWeightedAggregateFunction : public PercentileApproxAggrega
 public:
     // SplitAggregateRule passes the const args to merge phase aggregator for performance.
     // Compression parameter is always the last constant parameter (if provided).
-    // FE FunctionAnalyzer pre-clamps the literal to [MIN, MAX] or DEFAULT.
+    // FE FunctionAnalyzer pre-clamps the literal to [MIN, MAX] or DEFAULT for
+    // new-FE calls.
     double get_compression_factor(FunctionContext* ctx) const override {
         // FE always injects the compression argument; it is the last const arg.
         // SplitAggregateRule passes const args verbatim into the merge phase
@@ -209,10 +218,7 @@ public:
             auto const_col = ctx->get_constant_column(i);
             if (const_col != nullptr) {
                 double compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(const_col);
-                DCHECK(std::isfinite(compression));
-                DCHECK_GE(compression, MIN_COMPRESSION);
-                DCHECK_LE(compression, MAX_COMPRESSION);
-                return compression;
+                return clamp_compression_factor(compression);
             }
         }
         DCHECK(false) << "FE invariant broken: percentile_approx_weighted reached BE "

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -74,19 +74,22 @@ public:
     virtual double get_compression_factor(FunctionContext* ctx) const = 0;
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        double compression = get_compression_factor(ctx);
-        // Lazy initialization of compression factor on first merge
-        if (UNLIKELY(!data(state).compression_initialized)) {
-            data(state).reinit_with_compression(compression);
-        }
-
         const auto* binary_column = down_cast<const BinaryColumn*>(column);
         Slice src = binary_column->get_slice(row_num);
         double quantile;
         memcpy(&quantile, src.data, sizeof(double));
 
-        PercentileApproxState src_percentile(compression);
+        PercentileApproxState src_percentile;
         src_percentile.percentile->deserialize((char*)src.data + sizeof(double));
+
+        // Lazy initialization of compression on first merge. Compression travels
+        // inside the serialized digest, so adopt it from the incoming state: at
+        // the merge phase SplitAggregateRule drops non-const args (e.g. a weight
+        // column), so ctx arity no longer locates the compression slot. clamp
+        // maps a garbage/empty digest value back to the default.
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            data(state).reinit_with_compression(clamp_compression_factor(src_percentile.percentile->compression()));
+        }
 
         int64_t prev_memory = data(state).percentile->mem_usage();
         data(state).percentile->merge(src_percentile.percentile.get());
@@ -353,12 +356,6 @@ public:
 
     // Override merge method, deserialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        double compression = get_compression_factor(ctx);
-        // Lazy initialization of compression factor on first merge
-        if (UNLIKELY(!data(state).compression_initialized)) {
-            data(state).reinit_with_compression(compression);
-        }
-
         const auto* binary_column = down_cast<const BinaryColumn*>(column);
         Slice src = binary_column->get_slice(row_num);
 
@@ -373,8 +370,15 @@ public:
         }
 
         // Deserialize TDigest (skip quantiles array, only need TDigest for merging)
-        PercentileApproxState src_percentile(compression);
+        PercentileApproxState src_percentile;
         src_percentile.percentile->deserialize((char*)src.data + sizeof(uint32_t) + count * sizeof(double));
+
+        // Lazy initialization of compression on first merge: adopt it from the
+        // incoming serialized digest (ctx arity is unreliable at merge because
+        // SplitAggregateRule drops non-const args); clamp guards garbage input.
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            data(state).reinit_with_compression(clamp_compression_factor(src_percentile.percentile->compression()));
+        }
 
         // Merge into current state
         int64_t prev_memory = data(state).percentile->mem_usage();
@@ -512,12 +516,6 @@ public:
 
     // Override merge method, deserialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        double compression = get_compression_factor(ctx);
-        // Lazy initialization of compression factor on first merge
-        if (UNLIKELY(!data(state).compression_initialized)) {
-            data(state).reinit_with_compression(compression);
-        }
-
         const auto* binary_column = down_cast<const BinaryColumn*>(column);
         Slice src = binary_column->get_slice(row_num);
 
@@ -532,8 +530,15 @@ public:
         }
 
         // Deserialize TDigest (skip quantiles array, only need TDigest for merging)
-        PercentileApproxState src_percentile(compression);
+        PercentileApproxState src_percentile;
         src_percentile.percentile->deserialize((char*)src.data + sizeof(uint32_t) + count * sizeof(double));
+
+        // Lazy initialization of compression on first merge: adopt it from the
+        // incoming serialized digest (ctx arity is unreliable at merge because
+        // SplitAggregateRule drops non-const args); clamp guards garbage input.
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            data(state).reinit_with_compression(clamp_compression_factor(src_percentile.percentile->compression()));
+        }
 
         // Merge into current state
         int64_t prev_memory = data(state).percentile->mem_usage();

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include "column/column_helper.h"
 #include "column/object_column.h"
 #include "column/vectorized_fwd.h"
@@ -52,6 +54,9 @@ class PercentileApproxAggregateFunctionBase
 protected:
     static constexpr double MIN_COMPRESSION = 2048.0;
     static constexpr double MAX_COMPRESSION = 10000.0;
+    // Used only as a rolling-upgrade fallback when an old FE ships a legacy
+    // arity (without the canonicalized compression literal). For new-FE calls
+    // FunctionAnalyzer is the single source of truth and DEFAULT lives there.
     static constexpr double DEFAULT_COMPRESSION_FACTOR = 10000.0;
 
 public:
@@ -102,15 +107,23 @@ public:
 class PercentileApproxAggregateFunction : public PercentileApproxAggregateFunctionBase {
 public:
     double get_compression_factor(FunctionContext* ctx) const override {
-        double compression = DEFAULT_COMPRESSION_FACTOR;
-        if (ctx->get_num_args() > 2) {
-            compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(ctx->get_constant_column(2));
-            if (compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
-                LOG(WARNING) << "Compression factor out of range. Using default compression factor: "
-                             << DEFAULT_COMPRESSION_FACTOR;
-                compression = DEFAULT_COMPRESSION_FACTOR;
-            }
+        // FE FunctionAnalyzer is the single source of truth: an explicit
+        // compression literal is always injected (default or user-supplied)
+        // and clamped to [MIN, MAX]. The DCHECKs document that contract.
+        //
+        // Rolling-upgrade fallback: during the upgrade window BEs are upgraded
+        // before FEs, so an old FE may still ship 2-arg percentile_approx
+        // calls without the canonicalized compression literal. Treat that as
+        // the default compression so the old wire format keeps working until
+        // the FE side catches up. Remove once we no longer support upgrades
+        // from pre-canonicalization FEs.
+        if (ctx->get_num_args() <= 2) {
+            return DEFAULT_COMPRESSION_FACTOR;
         }
+        double compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(ctx->get_constant_column(2));
+        DCHECK(std::isfinite(compression));
+        DCHECK_GE(compression, MIN_COMPRESSION);
+        DCHECK_LE(compression, MAX_COMPRESSION);
         return compression;
     }
 
@@ -144,6 +157,7 @@ public:
         DCHECK(src[1]->is_constant());
         const auto* const_column = down_cast<const ConstColumn*>(src[1].get());
         double quantile = const_column->get(0).get_double();
+        double compression = get_compression_factor(ctx);
         // result
         BinaryColumn* result = down_cast<BinaryColumn*>(dst.get());
         Bytes& bytes = result->get_bytes();
@@ -153,7 +167,7 @@ public:
         // serialize percentile one by one
         size_t old_size = bytes.size();
         for (size_t i = 0; i < chunk_size; ++i) {
-            PercentileValue percentile;
+            PercentileValue percentile(compression);
             percentile.add(implicit_cast<float>(data_column->immutable_data()[i]));
 
             size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
@@ -171,27 +185,39 @@ public:
 // PercentileApproxWeightedAggregateFunction: percentile_approx_weighted(expr, weight, DOUBLE p[, DOUBLE compression])
 class PercentileApproxWeightedAggregateFunction : public PercentileApproxAggregateFunctionBase {
 public:
-    // SplitAggregateRule pass the const args to merge phase aggregator for performance.
-    // Compression parameter is always the last constant parameter (if provided)
+    // SplitAggregateRule passes the const args to merge phase aggregator for performance.
+    // Compression parameter is always the last constant parameter (if provided).
+    // FE FunctionAnalyzer pre-clamps the literal to [MIN, MAX] or DEFAULT.
     double get_compression_factor(FunctionContext* ctx) const override {
-        double compression = DEFAULT_COMPRESSION_FACTOR;
+        // FE always injects the compression argument; it is the last const arg.
+        // SplitAggregateRule passes const args verbatim into the merge phase
+        // aggregator, so we still scan from the right to find the first const
+        // column (e.g. weight may be a non-const Int64 column).
+        //
+        // Rolling-upgrade fallback: BEs are upgraded before FEs, so an old FE
+        // may ship the legacy 3-arg form `percentile_approx_weighted(expr, w, q)`
+        // without the canonicalized compression literal. In that case the
+        // rightmost const arg is the quantile (e.g. 0.95), which would
+        // misinterpret as compression and break TDigest. Recognize the legacy
+        // arity explicitly and return DEFAULT. Remove once we no longer
+        // support upgrades from pre-canonicalization FEs.
         int num_args = ctx->get_num_args();
-        if (num_args > 3) {
-            for (int i = num_args - 1; i >= 0; i--) {
-                auto const_col = ctx->get_constant_column(i);
-                if (const_col != nullptr) {
-                    // Found the last constant column, this should be compression
-                    compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(const_col);
-                    if (compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
-                        LOG(WARNING) << "Compression factor out of range. Using default compression factor: "
-                                     << DEFAULT_COMPRESSION_FACTOR;
-                        compression = DEFAULT_COMPRESSION_FACTOR;
-                    }
-                    break;
-                }
+        if (num_args <= 3) {
+            return DEFAULT_COMPRESSION_FACTOR;
+        }
+        for (int i = num_args - 1; i >= 0; i--) {
+            auto const_col = ctx->get_constant_column(i);
+            if (const_col != nullptr) {
+                double compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(const_col);
+                DCHECK(std::isfinite(compression));
+                DCHECK_GE(compression, MIN_COMPRESSION);
+                DCHECK_LE(compression, MAX_COMPRESSION);
+                return compression;
             }
         }
-        return compression;
+        DCHECK(false) << "FE invariant broken: percentile_approx_weighted reached BE "
+                         "without an explicit compression argument";
+        return DEFAULT_COMPRESSION_FACTOR;
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
@@ -228,6 +254,7 @@ public:
         // argument 2
         DCHECK(src[2]->is_constant());
         double quantile = src[2]->get(0).get_double();
+        double compression = get_compression_factor(ctx);
         // result
         BinaryColumn* result = down_cast<BinaryColumn*>(dst.get());
         Bytes& bytes = result->get_bytes();
@@ -241,7 +268,7 @@ public:
             int64_t weight = src[1]->get(0).get_int64();
             if (LIKELY(weight != 0)) {
                 for (size_t i = 0; i < chunk_size; ++i) {
-                    PercentileValue percentile;
+                    PercentileValue percentile(compression);
                     double value = data_column->immutable_data()[i];
                     percentile.add(implicit_cast<float>(value), weight);
                     size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
@@ -253,8 +280,8 @@ public:
                 }
             } else {
                 // TODO: optimize for empty weight but should not happen frequently
-                PercentileValue empty_percentile;
-                static size_t delta_size = sizeof(double) + empty_percentile.serialize_size();
+                PercentileValue empty_percentile(compression);
+                size_t delta_size = sizeof(double) + empty_percentile.serialize_size();
                 for (size_t i = 0; i < chunk_size; ++i) {
                     size_t new_size = old_size + delta_size;
                     bytes.resize(new_size);
@@ -268,7 +295,7 @@ public:
             const auto* weight_column = down_cast<const Int64Column*>(src[1].get());
             for (size_t i = 0; i < chunk_size; ++i) {
                 int64_t weight = weight_column->immutable_data()[i];
-                PercentileValue percentile;
+                PercentileValue percentile(compression);
                 double value = data_column->immutable_data()[i];
                 if (LIKELY(weight != 0)) {
                     percentile.add(implicit_cast<float>(value), weight);
@@ -398,6 +425,7 @@ public:
         size_t start = offsets[0];
         size_t end = offsets[1];
         uint32_t count = static_cast<uint32_t>(end - start);
+        double compression = get_compression_factor(ctx);
 
         // Extract quantiles
         std::vector<double> quantiles(count);
@@ -418,7 +446,7 @@ public:
         // serialize percentile one by one
         size_t old_size = bytes.size();
         for (size_t i = 0; i < chunk_size; ++i) {
-            PercentileValue percentile;
+            PercentileValue percentile(compression);
             percentile.add(implicit_cast<float>(data_column->immutable_data()[i]));
 
             size_t new_size = old_size + sizeof(uint32_t) + count * sizeof(double) + percentile.serialize_size();
@@ -556,6 +584,7 @@ public:
         size_t start = offsets[0];
         size_t end = offsets[1];
         uint32_t count = static_cast<uint32_t>(end - start);
+        double compression = get_compression_factor(ctx);
 
         // Extract quantiles
         std::vector<double> quantiles(count);
@@ -580,7 +609,7 @@ public:
             int64_t weight = src[1]->get(0).get_int64();
             if (LIKELY(weight != 0)) {
                 for (size_t i = 0; i < chunk_size; ++i) {
-                    PercentileValue percentile;
+                    PercentileValue percentile(compression);
                     double value = data_column->immutable_data()[i];
                     percentile.add(implicit_cast<float>(value), weight);
 
@@ -600,7 +629,7 @@ public:
                 }
             } else {
                 // TODO: optimize for empty weight but should not happen frequently
-                PercentileValue empty_percentile;
+                PercentileValue empty_percentile(compression);
                 size_t delta_size = sizeof(uint32_t) + count * sizeof(double) + empty_percentile.serialize_size();
                 for (size_t i = 0; i < chunk_size; ++i) {
                     size_t new_size = old_size + delta_size;
@@ -621,7 +650,7 @@ public:
             const auto* weight_column = down_cast<const Int64Column*>(src[1].get());
             for (size_t i = 0; i < chunk_size; ++i) {
                 int64_t weight = weight_column->immutable_data()[i];
-                PercentileValue percentile;
+                PercentileValue percentile(compression);
                 double value = data_column->immutable_data()[i];
                 if (LIKELY(weight != 0)) {
                     percentile.add(implicit_cast<float>(value), weight);

--- a/be/src/exprs/percentile_functions.cpp
+++ b/be/src/exprs/percentile_functions.cpp
@@ -14,6 +14,8 @@
 
 #include "exprs/percentile_functions.h"
 
+#include <cmath>
+
 #include "column/column_builder.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
@@ -42,6 +44,35 @@ StatusOr<ColumnPtr> PercentileFunctions::percentile_hash(FunctionContext* contex
     } else {
         return percentile_column;
     }
+}
+
+StatusOr<ColumnPtr> PercentileFunctions::percentile_hash_with_compression(FunctionContext* context,
+                                                                          const Columns& columns) {
+    ColumnViewer<TYPE_DOUBLE> value_viewer(columns[0]);
+    // Compression is a const argument pre-clamped on FE side (see FunctionAnalyzer):
+    // NULL / non-finite / out-of-[MIN, MAX] literals are replaced with the default
+    // compression factor before reaching BE.
+    double compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(columns[1]);
+    DCHECK(std::isfinite(compression));
+    // Mirror PercentileCompression.MIN/MAX on the FE side; FunctionAnalyzer
+    // clamps any literal outside this range to the default before reaching BE.
+    DCHECK_GE(compression, 2048.0);
+    DCHECK_LE(compression, 10000.0);
+
+    auto percentile_column = PercentileColumn::create();
+    size_t size = columns[0]->size();
+    for (int row = 0; row < size; ++row) {
+        PercentileValue value(compression);
+        if (!value_viewer.is_null(row)) {
+            value.add(value_viewer.value(row));
+        }
+        percentile_column->append(&value);
+    }
+
+    if (ColumnHelper::is_all_const(columns)) {
+        return ConstColumn::create(std::move(percentile_column), size);
+    }
+    return percentile_column;
 }
 
 StatusOr<ColumnPtr> PercentileFunctions::percentile_empty(FunctionContext* context, const Columns& columns) {

--- a/be/src/exprs/percentile_functions.h
+++ b/be/src/exprs/percentile_functions.h
@@ -28,6 +28,13 @@ public:
 
     /**
      * @param:
+     * @paramType columns: [TYPE_DOUBLE, TYPE_DOUBLE]
+     * @return TYPE_PERCENTILE
+     */
+    DEFINE_VECTORIZED_FN(percentile_hash_with_compression);
+
+    /**
+     * @param:
      * @paramType columns: []
      * @return TYPE_PERCENTILE
      */

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -64,6 +64,11 @@ public:
 
     Value quantile(Value q) { return _tdigest.quantile(q); }
 
+    // Compression the underlying digest was built with. Forwarded so the merge
+    // path can adopt the compression carried inside a deserialized intermediate
+    // blob instead of re-deriving it from the function context.
+    double compression() const { return _tdigest.compression(); }
+
 private:
     enum PercentileDataType { TDIGEST = 0 };
     TDigest _tdigest;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -138,6 +138,7 @@ set(EXEC_FILES
         ./exprs/agg/data_sketch/ds_theta_test.cpp
         ./exprs/agg/json_each_test.cpp
         ./exprs/agg/aggregate_test.cpp
+        ./exprs/agg/percentile_approx_compression_test.cpp
         ./exprs/agg/window_test.cpp
         ./exprs/agg/agg_compressed_key_test.cpp
         ./exprs/agg/agg_state_functions_test.cpp

--- a/be/test/exprs/agg/percentile_approx_compression_test.cpp
+++ b/be/test/exprs/agg/percentile_approx_compression_test.cpp
@@ -1,0 +1,128 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <memory>
+
+// percentile_approx.h forward-declares FunctionContext and ArrayColumn and is not
+// self-contained; pull in their full definitions before it. Order matters, so keep
+// clang-format from hoisting percentile_approx.h to the top as the main header.
+// clang-format off
+#include "column/array_column.h"
+#include "column/column_helper.h"
+#include "exprs/function_context.h"
+#include "exprs/agg/percentile_approx.h"
+// clang-format on
+
+#include "exprs/agg/base_aggregate_test.h" // UTRawType + FunctionContext test helpers
+
+namespace starrocks {
+
+// Exposes the protected compression contract of
+// PercentileApproxAggregateFunctionBase (clamp + the [MIN, MAX]/DEFAULT
+// constants) so it can be asserted directly.
+class PercentileCompressionExposer : public PercentileApproxAggregateFunction {
+public:
+    static double clamp(double c) { return clamp_compression_factor(c); }
+    static double min_c() { return MIN_COMPRESSION; }
+    static double max_c() { return MAX_COMPRESSION; }
+    static double default_c() { return DEFAULT_COMPRESSION_FACTOR; }
+};
+
+static ColumnPtr const_double(double v) {
+    return ColumnHelper::create_const_column<TYPE_DOUBLE>(v, 1);
+}
+
+TEST(PercentileApproxCompressionTest, clampCompressionFactor) {
+    const double lo = PercentileCompressionExposer::min_c();
+    const double hi = PercentileCompressionExposer::max_c();
+    const double def = PercentileCompressionExposer::default_c();
+
+    // In-range values pass through unchanged.
+    EXPECT_DOUBLE_EQ(lo, PercentileCompressionExposer::clamp(lo));
+    EXPECT_DOUBLE_EQ(hi, PercentileCompressionExposer::clamp(hi));
+    EXPECT_DOUBLE_EQ(5000.0, PercentileCompressionExposer::clamp(5000.0));
+
+    // Below MIN, above MAX, non-positive and non-finite all canonicalize to the default.
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(lo - 1));
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(hi + 1));
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(0.0));
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(-5.0));
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(std::nan("")));
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(std::numeric_limits<double>::infinity()));
+}
+
+TEST(PercentileApproxCompressionTest, getCompressionFactorApprox) {
+    PercentileApproxAggregateFunction fn;
+    const double def = PercentileCompressionExposer::default_c();
+
+    // 2-arg call (no explicit compression): legacy/rolling-upgrade path -> default.
+    {
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+                {UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}}, UTRawType{.type = TYPE_DOUBLE}));
+        EXPECT_DOUBLE_EQ(def, fn.get_compression_factor(ctx.get()));
+    }
+    // 3-arg call, in-range constant compression -> used as-is.
+    {
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+                {UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}},
+                UTRawType{.type = TYPE_DOUBLE}));
+        ctx->set_constant_columns({nullptr, nullptr, const_double(5000.0)});
+        EXPECT_DOUBLE_EQ(5000.0, fn.get_compression_factor(ctx.get()));
+    }
+    // 3-arg call, out-of-range constant compression -> clamped to default.
+    {
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+                {UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}},
+                UTRawType{.type = TYPE_DOUBLE}));
+        ctx->set_constant_columns({nullptr, nullptr, const_double(1.0)});
+        EXPECT_DOUBLE_EQ(def, fn.get_compression_factor(ctx.get()));
+    }
+}
+
+TEST(PercentileApproxCompressionTest, getCompressionFactorWeighted) {
+    PercentileApproxWeightedAggregateFunction fn;
+    const double def = PercentileCompressionExposer::default_c();
+
+    // Legacy 3-arg form (value, weight, quantile) without compression -> default.
+    {
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+                {UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_BIGINT}, UTRawType{.type = TYPE_DOUBLE}},
+                UTRawType{.type = TYPE_DOUBLE}));
+        EXPECT_DOUBLE_EQ(def, fn.get_compression_factor(ctx.get()));
+    }
+    // 4-arg form: compression is the rightmost constant; a non-const weight (nullptr) is skipped.
+    {
+        std::unique_ptr<FunctionContext> ctx(
+                FunctionContext::create_test_context({UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_BIGINT},
+                                                      UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}},
+                                                     UTRawType{.type = TYPE_DOUBLE}));
+        ctx->set_constant_columns({nullptr, nullptr, const_double(0.5), const_double(5000.0)});
+        EXPECT_DOUBLE_EQ(5000.0, fn.get_compression_factor(ctx.get()));
+    }
+    // 4-arg form, out-of-range compression -> clamped to default.
+    {
+        std::unique_ptr<FunctionContext> ctx(
+                FunctionContext::create_test_context({UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_BIGINT},
+                                                      UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}},
+                                                     UTRawType{.type = TYPE_DOUBLE}));
+        ctx->set_constant_columns({nullptr, nullptr, const_double(0.5), const_double(20000.0)});
+        EXPECT_DOUBLE_EQ(def, fn.get_compression_factor(ctx.get()));
+    }
+}
+
+} // namespace starrocks

--- a/be/test/exprs/percentile_functions_test.cpp
+++ b/be/test/exprs/percentile_functions_test.cpp
@@ -17,6 +17,10 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <cstring>
+#include <vector>
+
+#include "column/const_column.h"
 #include "exprs/function_context.h"
 #include "types/percentile_value.h"
 
@@ -58,6 +62,36 @@ TEST_F(PercentileFunctionsTest, percentileHashTest) {
     auto percentile = ColumnHelper::cast_to<TYPE_PERCENTILE>(column);
     ASSERT_EQ(1, percentile->get_object(0)->quantile(1));
     ASSERT_EQ(2, percentile->get_object(1)->quantile(1));
+    ASSERT_EQ(3, percentile->get_object(2)->quantile(1));
+}
+
+TEST_F(PercentileFunctionsTest, percentileHashWithCompressionPreservesValue) {
+    Columns columns;
+    auto values = DoubleColumn::create();
+    values->append(1);
+    values->append(2);
+    values->append(3);
+    columns.push_back(std::move(values));
+
+    auto compression_col = DoubleColumn::create();
+    compression_col->append(5000.0);
+    columns.push_back(ConstColumn::create(std::move(compression_col), 3));
+
+    auto column = PercentileFunctions::percentile_hash_with_compression(ctx, columns).value();
+    ASSERT_TRUE(column->is_object());
+    auto percentile = ColumnHelper::cast_to<TYPE_PERCENTILE>(column);
+    for (size_t i = 0; i < percentile->size(); ++i) {
+        std::vector<uint8_t> serialized(percentile->get_object(i)->serialize_size());
+        percentile->get_object(i)->serialize(serialized.data());
+
+        // _compression is the first field the TDigest writes (right after the
+        // 1-byte PercentileValue type tag) and its width is the TDigest Value
+        // type, i.e. float -- read it at that width, not as a double.
+        float compression;
+        memcpy(&compression, serialized.data() + 1, sizeof(compression));
+        ASSERT_FLOAT_EQ(5000.0f, compression);
+    }
+    ASSERT_EQ(1, percentile->get_object(0)->quantile(1));
     ASSERT_EQ(3, percentile->get_object(2)->quantile(1));
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -789,6 +789,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String MATERIALIZED_VIEW_SUBQUERY_TEXT_MATCH_MAX_COUNT =
             "materialized_view_subquery_text_match_max_count";
 
+    // If true, MV rewrite refuses to use a percentile MV whose compression factor is smaller
+    // than the query's compression. The optimizer falls back to a base table scan and logs the
+    // skip reason via OptimizerTraceUtil.logMVRewriteFailReason. Default false keeps the
+    // historical behaviour (silently uses the MV even on compression mismatch).
+    public static final String ENABLE_MV_PERCENTILE_STRICT_MATCH = "enable_mv_percentile_strict_match";
+
     public static final String LARGE_DECIMAL_UNDERLYING_TYPE = "large_decimal_underlying_type";
 
     public static final String ENABLE_ICEBERG_IDENTITY_COLUMN_OPTIMIZE = "enable_iceberg_identity_column_optimize";
@@ -2870,6 +2876,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_TEXT_MATCH_REWRITE)
     private boolean enableMaterializedViewTextMatchRewrite = true;
+
+    @VarAttr(name = ENABLE_MV_PERCENTILE_STRICT_MATCH)
+    private boolean enableMvPercentileStrictMatch = false;
 
     @VarAttr(name = MATERIALIZED_VIEW_SUBQUERY_TEXT_MATCH_MAX_COUNT)
     private int materializedViewSubQueryTextMatchMaxCount = 4;
@@ -5231,6 +5240,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableMaterializedViewTextMatchRewrite(boolean enable) {
         this.enableMaterializedViewTextMatchRewrite = enable;
+    }
+
+    public boolean isEnableMvPercentileStrictMatch() {
+        return enableMvPercentileStrictMatch;
+    }
+
+    public void setEnableMvPercentileStrictMatch(boolean enable) {
+        this.enableMvPercentileStrictMatch = enable;
     }
 
     public int getMaterializedViewSubQueryTextMatchMaxCount() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -508,10 +508,17 @@ public class FunctionAnalyzer {
             // Validate second parameter (percentile) is numeric or array type
             validatePercentileParameter(functionCallExpr.getChild(1), "second", 
                     "percentile_approx", functionCallExpr.getPos());
-            // Validate optional third parameter (compression) is numeric type
+            // NULL is allowed past validate-numeric and routed through clamp,
+            // which canonicalizes it to DEFAULT just like out-of-range ints.
             if (children.size() == 3) {
-                validateNumericParameter(functionCallExpr.getChild(2), "third", "compression", 
-                        "percentile_approx", functionCallExpr.getPos());
+                Expr cArg = functionCallExpr.getChild(2);
+                if (!(cArg instanceof NullLiteral)) {
+                    validateNumericParameter(cArg, "third", "compression",
+                            "percentile_approx", functionCallExpr.getPos());
+                }
+                clampCompressionLiteral(functionCallExpr, 2);
+            } else {
+                injectDefaultCompression(functionCallExpr);
             }
         }
 
@@ -532,10 +539,17 @@ public class FunctionAnalyzer {
             // Validate third parameter (percentile) is numeric or array type
             validatePercentileParameter(functionCallExpr.getChild(2), "third", 
                     "percentile_approx_weighted", functionCallExpr.getPos());
-            // Validate optional fourth parameter (compression) is numeric type
+            // NULL is allowed past validate-numeric and routed through clamp,
+            // which canonicalizes it to DEFAULT just like out-of-range ints.
             if (children.size() == 4) {
-                validateNumericParameter(functionCallExpr.getChild(3), "fourth", "compression", 
-                        "percentile_approx_weighted", functionCallExpr.getPos());
+                Expr cArg = functionCallExpr.getChild(3);
+                if (!(cArg instanceof NullLiteral)) {
+                    validateNumericParameter(cArg, "fourth", "compression",
+                            "percentile_approx_weighted", functionCallExpr.getPos());
+                }
+                clampCompressionLiteral(functionCallExpr, 3);
+            } else {
+                injectDefaultCompression(functionCallExpr);
             }
         }
 
@@ -730,8 +744,8 @@ public class FunctionAnalyzer {
      * @param pos The position in the source code for error reporting
      * @throws SemanticException if the parameter is not numeric type
      */
-    private static void validateNumericParameter(Expr paramExpr, String paramPosition, 
-                                                  String paramName, String functionName, 
+    private static void validateNumericParameter(Expr paramExpr, String paramPosition,
+                                                  String paramName, String functionName,
                                                   NodePosition pos) {
         if (!paramExpr.getType().isNumericType()) {
             throw new SemanticException(
@@ -739,6 +753,82 @@ public class FunctionAnalyzer {
                             functionName, paramPosition, paramName, paramExpr.getType().toSql()),
                     pos);
         }
+    }
+
+    /**
+     * Append {@code IntLiteral(DEFAULT)} as the next child and re-bind the
+     * FunctionCallExpr to the compression-aware overload, so that downstream
+     * (planner / BE) always sees an explicit compression argument. The
+     * registered overloads of percentile_approx[_weighted] expose the
+     * compression slot as DOUBLE in their signature (see the note on
+     * {@link #clampCompressionLiteral}); the IntLiteral here matches the
+     * pattern used for user-written integer literals — SR's standard implicit
+     * cast handles the int→double conversion when the value is materialized.
+     */
+    private static void injectDefaultCompression(FunctionCallExpr fn) {
+        Function current = fn.getFn();
+        Preconditions.checkState(current != null,
+                "function must be resolved before injecting compression");
+        Type[] currentArgs = current.getArgs();
+        Type[] expandedArgs = new Type[currentArgs.length + 1];
+        System.arraycopy(currentArgs, 0, expandedArgs, 0, currentArgs.length);
+        expandedArgs[currentArgs.length] = FloatType.DOUBLE;
+        Function expanded = ExprUtils.getBuiltinFunction(
+                current.getFunctionName().getFunction(), expandedArgs,
+                Function.CompareMode.IS_IDENTICAL);
+        Preconditions.checkState(expanded != null,
+                "no compression-aware overload registered for "
+                        + current.getFunctionName().getFunction());
+        IntLiteral defaultC = new IntLiteral(PercentileCompression.DEFAULT);
+        defaultC.setPos(fn.getPos());
+        fn.addChild(defaultC);
+        fn.setFn(expanded);
+    }
+
+    /**
+     * Canonicalize the compression argument of a percentile function. Only an
+     * integer literal (or literal NULL) is accepted; CAST, arithmetic, column
+     * references and other expressions are rejected up front. Values outside
+     * [MIN, MAX] and literal NULL are replaced with the default.
+     *
+     * AST mutation via {@code setChild} follows the established
+     * {@code FunctionAnalyzer} pattern (see {@code date_trunc} normalization).
+     * <p>
+     * The user-facing contract for compression is integer-only, but the
+     * registered BE function signature keeps DOUBLE for the compression slot:
+     * the percentile aggregates are registered via a variadic template on BE
+     * ({@code add_aggregate_mapping_variadic<DOUBLE, DOUBLE, ...>}) which forces
+     * a single trailing-arg type. Switching to BIGINT end-to-end would require
+     * a new fixed-arity BE template plus parallel changes to FunctionSet,
+     * gensrc, and the resolver — out of scope here. SR's standard implicit
+     * cast wraps this IntLiteral in a planner-side {@code CAST(int AS DOUBLE)}
+     * before the value reaches BE, so the wire format is unaffected.
+     */
+    private static void clampCompressionLiteral(FunctionCallExpr fn, int argIdx) {
+        if (fn.getChildren().size() <= argIdx) {
+            return;
+        }
+        Expr arg = fn.getChild(argIdx);
+        long c;
+        boolean isInvalid;
+        if (arg instanceof NullLiteral) {
+            isInvalid = true;
+            c = 0;
+        } else {
+            // extractIntegerValue accepts both literal ints and user variables
+            // bound to integer constants (`set @c = 5000`).
+            Optional<Long> extracted = extractIntegerValue(arg);
+            if (!extracted.isPresent()) {
+                throw new SemanticException(
+                        "compression must be an integer literal", fn.getPos());
+            }
+            c = extracted.get();
+            isInvalid = c < PercentileCompression.MIN || c > PercentileCompression.MAX;
+        }
+        long finalC = isInvalid ? PercentileCompression.DEFAULT : c;
+        IntLiteral clamped = new IntLiteral(finalC);
+        clamped.setPos(arg.getPos());
+        fn.setChild(argIdx, clamped);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -791,9 +791,12 @@ public class FunctionAnalyzer {
 
     /**
      * Canonicalize the compression argument of a percentile function. Only an
-     * integer literal (or literal NULL) is accepted; CAST, arithmetic, column
-     * references and other expressions are rejected up front. Values outside
-     * [MIN, MAX] and literal NULL are replaced with the default.
+     * integer literal, a user variable bound to an integer constant, or literal
+     * NULL is accepted; CAST, arithmetic, and column references (including
+     * CTE-projected ones) are rejected up front so the planner, MV rewrite, and
+     * BE all see one canonical compression literal rather than an expression that
+     * would only fold later. Values outside [MIN, MAX] and literal NULL are
+     * replaced with the default.
      *
      * AST mutation via {@code setChild} follows the established
      * {@code FunctionAnalyzer} pattern (see {@code date_trunc} normalization).

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -767,8 +767,13 @@ public class FunctionAnalyzer {
      */
     private static void injectDefaultCompression(FunctionCallExpr fn) {
         Function current = fn.getFn();
-        Preconditions.checkState(current != null,
-                "function must be resolved before injecting compression");
+        if (current == null) {
+            // The aggregate-combinator path (e.g. percentile_approx_if) re-runs this
+            // validation on a freshly-built, unresolved FunctionCallExpr whose fn is null;
+            // its mutations are discarded. Skip injection — the real call is canonicalized
+            // on its own resolved pass, and BE keeps its legacy default for the 2-arg arity.
+            return;
+        }
         Type[] currentArgs = current.getArgs();
         Type[] expandedArgs = new Type[currentArgs.length + 1];
         System.arraycopy(currentArgs, 0, expandedArgs, 0, currentArgs.length);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -174,6 +174,25 @@ public class FunctionAnalyzer {
                         functionCallExpr.getPos());
             }
         }
+        // percentile_hash is a scalar function: validate here on the scalar path,
+        // because analyzeBuiltinAggFunction only runs for AggregateFunction.
+        // percentile_hash(value [, compression]). The 1-arg overload keeps the
+        // legacy storage compression (1000). The 2-arg overload requires a
+        // constant compression; out-of-range / NULL / non-finite values are
+        // canonicalized to DEFAULT_COMPRESSION_FACTOR so downstream code can
+        // trust the literal.
+        if (fnName.equals(FunctionSet.PERCENTILE_HASH)) {
+            List<Expr> percentileHashChildren = functionCallExpr.getChildren();
+            if (percentileHashChildren.size() == 2) {
+                Expr cArg = functionCallExpr.getChild(1);
+                if (!(cArg instanceof NullLiteral)) {
+                    validateNumericParameter(cArg, "second", "compression",
+                            "percentile_hash", functionCallExpr.getPos());
+                }
+                clampCompressionLiteral(functionCallExpr, 1);
+            }
+        }
+
         Function fn = functionCallExpr.getFn();
         final String funcName = fnName;
         if (fn instanceof StateFunctionCombinator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -779,8 +779,7 @@ public class FunctionAnalyzer {
         Preconditions.checkState(expanded != null,
                 "no compression-aware overload registered for "
                         + current.getFunctionName().getFunction());
-        IntLiteral defaultC = new IntLiteral(PercentileCompression.DEFAULT);
-        defaultC.setPos(fn.getPos());
+        IntLiteral defaultC = new IntLiteral(PercentileCompression.DEFAULT, fn.getPos());
         fn.addChild(defaultC);
         fn.setFn(expanded);
     }
@@ -826,8 +825,7 @@ public class FunctionAnalyzer {
             isInvalid = c < PercentileCompression.MIN || c > PercentileCompression.MAX;
         }
         long finalC = isInvalid ? PercentileCompression.DEFAULT : c;
-        IntLiteral clamped = new IntLiteral(finalC);
-        clamped.setPos(arg.getPos());
+        IntLiteral clamped = new IntLiteral(finalC, arg.getPos());
         fn.setChild(argIdx, clamped);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PercentileCompression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PercentileCompression.java
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+/**
+ * Single source of truth for the percentile-aggregate compression literal
+ * contract on the FE side. Mirrors the BE constants in
+ * {@code PercentileApproxAggregateFunctionBase} (be/src/exprs/agg/percentile_approx.h).
+ *
+ * <p>Used by {@link FunctionAnalyzer} to canonicalize the literal in the AST.
+ */
+public final class PercentileCompression {
+    /** Lower bound of the accepted compression range. */
+    public static final long MIN = 2048;
+
+    /** Upper bound of the accepted compression range. */
+    public static final long MAX = 10000;
+
+    /**
+     * Default applied when no explicit compression is given, or when a literal
+     * is out of range / NULL / non-finite. Matches BE
+     * {@code DEFAULT_COMPRESSION_FACTOR}.
+     */
+    public static final long DEFAULT = 10000;
+
+    private PercentileCompression() {
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
@@ -54,6 +54,12 @@ public class MvRewriteContext {
 
     private AggregatePushDownContext aggregatePushDownContext;
 
+    // Per-MV signal carried out of EquivalentShuttleContext into the per-attempt
+    // RewriteResult (see BaseMaterializedViewRewriteRule). BestMvSelector reads
+    // it to rank subsume candidates above non-subsume ones in legacy mode; in
+    // strict mode the caller logs a fail reason and returns null instead.
+    private boolean hasPercentileNonSubsumeRewrite;
+
     public MvRewriteContext(
             MaterializationContext materializationContext,
             List<Table> queryTables,
@@ -158,5 +164,13 @@ public class MvRewriteContext {
 
     public void setAggregatePushDownContext(AggregatePushDownContext aggregatePushDownContext) {
         this.aggregatePushDownContext = aggregatePushDownContext;
+    }
+
+    public boolean hasPercentileNonSubsumeRewrite() {
+        return hasPercentileNonSubsumeRewrite;
+    }
+
+    public void setPercentileNonSubsumeRewrite(boolean v) {
+        this.hasPercentileNonSubsumeRewrite = v;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -41,6 +41,7 @@ import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregateFunctionRollupUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.EquivalentShuttleContext;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.IRewriteEquivalent;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.PercentileRewriteEquivalent;
 import com.starrocks.sql.optimizer.rule.tree.pdagg.AggregatePushDownContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -297,6 +298,12 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
 
         Pair<ScalarOperator, EquivalentShuttleContext> result =
                 equationRewriter.replaceExprWithEquivalent(rewriteContext, scalarOp);
+        // Check compression mismatch before the result.first null-check below.
+        // In legacy mode the shuttle still produces a non-null rewrite even on
+        // mismatch; in strict mode we must short-circuit without using it.
+        if (handlePercentileMismatch(result.second)) {
+            return null;
+        }
         ScalarOperator rewritten = result.first;
         if (rewritten == null || scalarOp == rewritten) {
             return null;
@@ -306,6 +313,26 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
             return null;
         }
         return rewritten;
+    }
+
+    /**
+     * Propagate the PercentileRewriteEquivalent compression-mismatch signal from
+     * the shuttle into MvRewriteContext, and decide whether the caller should
+     * skip this rewrite based on the strict-match session var. Returns true when
+     * the caller must short-circuit to no-rewrite (strict + non-subsume MV).
+     */
+    private boolean handlePercentileMismatch(EquivalentShuttleContext shuttle) {
+        if (shuttle == null || !shuttle.hasPercentileNonSubsumeRewrite()) {
+            return false;
+        }
+        mvRewriteContext.setPercentileNonSubsumeRewrite(true);
+        if (PercentileRewriteEquivalent.isStrictMatchEnabled()) {
+            OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext,
+                    "percentile compression mismatch: MV.c={} < query.c={}",
+                    shuttle.getPercentileMismatchMvC(), shuttle.getPercentileMismatchQueryC());
+            return true;
+        }
+        return false;
     }
 
     // NOTE: this method is not exactly right to check whether it's a rollup aggregate:
@@ -788,6 +815,12 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
                                                                             ColumnRefSet queryColumnSet,
                                                                             CallOperator aggCall) {
         Pair<ScalarOperator, EquivalentShuttleContext> result = equationRewriter.replaceExprWithRollup(rewriteContext, aggCall);
+        // Check compression mismatch before the targetColumn null-check below.
+        // In legacy mode the shuttle still produces a non-null rewrite even on
+        // mismatch; in strict mode we must short-circuit without using it.
+        if (handlePercentileMismatch(result.second)) {
+            return null;
+        }
         ScalarOperator targetColumn = result.first;
         if (targetColumn == null || !isAllExprReplaced(targetColumn, queryColumnSet)) {
             // it means there is some column that can not be rewritten by outputs of mv

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
@@ -40,6 +40,7 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.Rule;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.rule.BaseMaterializedViewRewriteRule;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 import org.apache.commons.collections4.CollectionUtils;
@@ -53,20 +54,50 @@ import java.util.stream.Collectors;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 
 public class BestMvSelector {
-    private final List<OptExpression> mvValidExpressions;
+    // Per-attempt rewrite results. The {@link BaseMaterializedViewRewriteRule.RewriteResult}
+    // carries each MV's rewritten {@code OptExpression} plus carrier signals
+    // (e.g. {@code hasPercentileNonSubsumeRewrite}) consumed by CandidateScore.
+    private final List<BaseMaterializedViewRewriteRule.RewriteResult> mvCandidates;
     private final OptimizerContext optimizerContext;
     private final OptExpression queryPlan;
     private final boolean isAggQuery;
     private final Rule rule;
 
-    public BestMvSelector(List<OptExpression> mvValidExpressions,
+    public BestMvSelector(List<BaseMaterializedViewRewriteRule.RewriteResult> mvCandidates,
                           OptimizerContext optimizerContext,
                           OptExpression queryPlan, Rule rule) {
-        this.mvValidExpressions = mvValidExpressions;
+        this.mvCandidates = mvCandidates;
         this.optimizerContext = optimizerContext;
         this.queryPlan = queryPlan;
         this.isAggQuery = queryPlan.getOp() instanceof LogicalAggregationOperator;
         this.rule = rule;
+    }
+
+    /**
+     * Convenience factory for callers that have a plain list of OptExpressions
+     * (e.g. tests) and don't need to carry per-rewrite signals.
+     */
+    public static BestMvSelector forExpressions(List<OptExpression> expressions,
+                                                OptimizerContext optimizerContext,
+                                                OptExpression queryPlan, Rule rule) {
+        List<BaseMaterializedViewRewriteRule.RewriteResult> wrapped = expressions.stream()
+                .map(BaseMaterializedViewRewriteRule.RewriteResult::of)
+                .collect(Collectors.toList());
+        return new BestMvSelector(wrapped, optimizerContext, queryPlan, rule);
+    }
+
+    private OptExpression expressionAt(int idx) {
+        return mvCandidates.get(idx).expression();
+    }
+
+    private int candidateCount() {
+        return mvCandidates.size();
+    }
+
+    private List<OptExpression> candidateExpressions() {
+        return mvCandidates.stream()
+                .map(BaseMaterializedViewRewriteRule.RewriteResult::expression)
+                .collect(Collectors.toList());
     }
 
     public enum ChooseMode {
@@ -114,8 +145,8 @@ public class BestMvSelector {
     }
 
     public List<OptExpression> selectBest(boolean isConsiderQueryDataLayout) {
-        if (mvValidExpressions.isEmpty()) {
-            return mvValidExpressions;
+        if (mvCandidates.isEmpty()) {
+            return Lists.newArrayList();
         }
         List<Table> queryTables = MvUtils.getAllTables(queryPlan);
         // add query's context
@@ -127,12 +158,12 @@ public class BestMvSelector {
 
     private List<OptExpression> selectBest(List<Table> queryTables,
                                            boolean isConsiderQueryDataLayout) {
-        if (mvValidExpressions.size() == 1 && !isConsiderQueryDataLayout) {
+        if (candidateCount() == 1 && !isConsiderQueryDataLayout) {
             logMVRewrite(optimizerContext, rule, "[ChooseBestMV] Only one candidate mv, skip best mv select.");
-            return mvValidExpressions;
+            return candidateExpressions();
         }
         // compute the statistics of OptExpression
-        calculateStatistics(mvValidExpressions, optimizerContext);
+        calculateStatistics(candidateExpressions(), optimizerContext);
 
         // split predicates' columns to equivalence and non-equivalence sets which its names are all lower case.
         Set<ScalarOperator> queryPredicates = MvUtils.getAllValidPredicatesFromScans(queryPlan);
@@ -148,8 +179,8 @@ public class BestMvSelector {
         List<CandidateContext> contexts = Lists.newArrayList();
         int globalIdx = 0;
         // add all mvs' context first
-        for (int i = 0; i < mvValidExpressions.size(); i++) {
-            OptExpression mvOptExpression = mvValidExpressions.get(i);
+        for (int i = 0; i < candidateCount(); i++) {
+            OptExpression mvOptExpression = expressionAt(i);
             List<Table> mvTables = MvUtils.getAllTables(mvOptExpression);
             queryTables.stream().forEach(originalTable -> mvTables.remove(originalTable));
             CandidateContext candidateContext = buildCandidateContext(
@@ -160,6 +191,9 @@ public class BestMvSelector {
                         mvTables.stream().map(Table::getName).collect(Collectors.joining(",")));
                 continue;
             }
+            // Per-rewrite carrier read from RewriteResult — see CandidateScore.
+            candidateContext.getScore().hasPercentileNonSubsumeRewrite =
+                    mvCandidates.get(i).hasPercentileNonSubsumeRewrite();
             globalIdx += 1;
             contexts.add(candidateContext);
         }
@@ -241,8 +275,15 @@ public class BestMvSelector {
         public int aggCount;
         public int joinCount;
 
+        // First-class preference: a rewrite that succeeded only because we
+        // permitted a percentile MV with smaller compression than the query
+        // ranks below any rewrite that did not need that fallback. Stays
+        // false for non-percentile rewrites so other comparisons are unchanged.
+        public boolean hasPercentileNonSubsumeRewrite = false;
+
         /**
          * Compare two CandidateScore, the comparison logic is as follows:
+         * - Prefer subsume percentile rewrites over non-subsume fallbacks.
          * - Compare by agg/join/scan count, smaller is better.
          * - Compare by distribution score, larger is better.
          * - Compare by group by key num, smaller is better.
@@ -259,7 +300,13 @@ public class BestMvSelector {
             if (this == other) {
                 return 0;
             }
-            int ret = 0;
+            int ret;
+            // First-class signal: subsume candidates outrank non-subsume.
+            // Boolean.compare(false, true) = -1 → subsume sorts first.
+            ret = Boolean.compare(this.hasPercentileNonSubsumeRewrite, other.hasPercentileNonSubsumeRewrite);
+            if (ret != 0) {
+                return ret;
+            }
             // smaller is better
             ret = Integer.compare(this.aggCount, other.aggCount);
             if (ret != 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/EquivalentShuttleContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/EquivalentShuttleContext.java
@@ -28,6 +28,15 @@ public class EquivalentShuttleContext {
     private IRewriteEquivalent.RewriteEquivalentType rewriteEquivalentType;
     private Map<ColumnRefOperator, CallOperator> newColumnRefToAggFuncMap;
 
+    // Per-rewrite signal raised by PercentileRewriteEquivalent when the MV's
+    // stored compression is strictly smaller than the query's compression.
+    // BestMvSelector inspects the flag through MvRewriteContext / RewriteResult
+    // to prefer subsume MVs; strict mode (session var) turns this into a hard
+    // skip (caller emits a logMVRewriteFailReason and returns null).
+    private boolean hasPercentileNonSubsumeRewrite;
+    private double percentileMismatchMvC;
+    private double percentileMismatchQueryC;
+
     public EquivalentShuttleContext(RewriteContext rewriteContext, boolean isRollup, boolean isRewrittenByEquivalent,
                                     IRewriteEquivalent.RewriteEquivalentType type) {
         this.rewriteContext = rewriteContext;
@@ -70,5 +79,29 @@ public class EquivalentShuttleContext {
 
     public IRewriteEquivalent.RewriteEquivalentType getRewriteEquivalentType() {
         return rewriteEquivalentType;
+    }
+
+    public boolean hasPercentileNonSubsumeRewrite() {
+        return hasPercentileNonSubsumeRewrite;
+    }
+
+    public void setPercentileNonSubsumeRewrite(boolean v) {
+        this.hasPercentileNonSubsumeRewrite = v;
+    }
+
+    public double getPercentileMismatchMvC() {
+        return percentileMismatchMvC;
+    }
+
+    public void setPercentileMismatchMvC(double v) {
+        this.percentileMismatchMvC = v;
+    }
+
+    public double getPercentileMismatchQueryC() {
+        return percentileMismatchQueryC;
+    }
+
+    public void setPercentileMismatchQueryC(double v) {
+        this.percentileMismatchQueryC = v;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/PercentileRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/PercentileRewriteEquivalent.java
@@ -17,24 +17,36 @@ import com.google.common.base.Preconditions;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.analyzer.PercentileCompression;
 import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.optimizer.ConstantOperatorUtils;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.PercentileType;
 import com.starrocks.type.Type;
 
 import java.util.Arrays;
+import java.util.OptionalDouble;
 
 import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
 import static com.starrocks.catalog.FunctionSet.PERCENTILE_APPROX;
 import static com.starrocks.catalog.FunctionSet.PERCENTILE_APPROX_RAW;
 import static com.starrocks.catalog.FunctionSet.PERCENTILE_UNION;
 
+// Rewrite percentile_approx using MV's percentile_union(percentile_hash(...)).
+// Compression-aware: if MV digest's compression < query's, the rewrite is
+// non-subsume (silently downgrades precision). Signals via EquivalentShuttleContext;
+// flag flows into MvRewriteContext and BestMvSelector.CandidateScore which ranks
+// subsume rewrites first. Session var enable_mv_percentile_strict_match turns
+// the warning into a hard skip (fail reason logged via OptimizerTraceUtil).
 public class PercentileRewriteEquivalent extends IAggregateRewriteEquivalent {
     public static IAggregateRewriteEquivalent INSTANCE = new PercentileRewriteEquivalent();
+    private static final long LEGACY_STORAGE = 1000;
 
     public PercentileRewriteEquivalent() {
     }
@@ -59,14 +71,7 @@ public class PercentileRewriteEquivalent extends IAggregateRewriteEquivalent {
                 CallOperator call0 = (CallOperator) arg0;
                 if (call0.getFnName().equals(FunctionSet.PERCENTILE_HASH)) {
                     // percentile_union(percentile_hash()) can be used for rewrite
-                    if (call0 instanceof CastOperator) {
-                        CastOperator castOperator = (CastOperator) call0;
-                        if (castOperator.getType().isDouble()) {
-                            return new RewriteEquivalentContext(castOperator.getChild(0), op);
-                        }
-                    } else {
-                        return new RewriteEquivalentContext(call0.getChild(0), op);
-                    }
+                    return new RewriteEquivalentContext(call0.getChild(0), op);
                 }
             } else {
                 return new RewriteEquivalentContext(arg0, op);
@@ -105,9 +110,105 @@ public class PercentileRewriteEquivalent extends IAggregateRewriteEquivalent {
             if (!eqArg.equals(eqChild)) {
                 return null;
             }
+            // Asymmetric check: only mvC < queryC is a problem (precision loss).
+            // mvC >= queryC means the MV digest is at least as precise as asked.
+            double queryC = extractQueryCompression(aggFunc);
+            double mvC = extractMvCompression(eqContext.getInput());
+            if (mvC < queryC) {
+                // Carry the flag + both values on the shuttle so the per-MV
+                // MvRewriteContext / BestMvSelector can prefer subsume MVs, and
+                // strict-mode trace can quote the actual compressions.
+                shuttleContext.setPercentileNonSubsumeRewrite(true);
+                shuttleContext.setPercentileMismatchMvC(mvC);
+                shuttleContext.setPercentileMismatchQueryC(queryC);
+                if (isStrictMatchEnabled()) {
+                    // Strict: refuse this MV; caller falls back to base scan.
+                    return null;
+                }
+                // Legacy: still rewrite but downstream picks subsume if available.
+            }
             return rewriteImpl(shuttleContext, aggFunc, replace);
         }
         return null;
+    }
+
+    public static boolean isStrictMatchEnabled() {
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx == null) {
+            return false;
+        }
+        SessionVariable sv = ctx.getSessionVariable();
+        return sv != null && sv.isEnableMvPercentileStrictMatch();
+    }
+
+    private static double extractQueryCompression(CallOperator percentileApprox) {
+        // percentile_approx(v, q[, c]) — compression is the third arg if present.
+        if (percentileApprox.getChildren().size() > 2) {
+            Double c = readDoubleConstant(percentileApprox.getChild(2));
+            if (c != null) {
+                return c;
+            }
+        }
+        // Query without an explicit compression is interpreted as exact DEFAULT
+        // (mirrors BE's PercentileApproxAggregateFunction::get_compression_factor).
+        return PercentileCompression.DEFAULT;
+    }
+
+    // Walks the MV-side ScalarOperator tree captured in prepare() and reads the
+    // stored compression. Accepts every shape prepare() admits and never
+    // blind-casts. Anything that does not look like percentile_hash(col[, c]) is
+    // treated as legacy storage with compression=1000.
+    private static double extractMvCompression(ScalarOperator input) {
+        if (!(input instanceof CallOperator)) {
+            return LEGACY_STORAGE;
+        }
+        CallOperator unionCall = (CallOperator) input;
+        if (unionCall.getChildren().isEmpty()) {
+            return LEGACY_STORAGE;
+        }
+        ScalarOperator child0 = unionCall.getChild(0);
+        if (!(child0 instanceof CallOperator)) {
+            // Legacy MV shape: percentile_union(percentile_col) with a direct
+            // column-ref child. Pre-`percentile_hash(_, c)` data was written
+            // with the default TDigest(1000), hence LEGACY_STORAGE.
+            return LEGACY_STORAGE;
+        }
+        CallOperator hashCall = (CallOperator) child0;
+        if (!FunctionSet.PERCENTILE_HASH.equalsIgnoreCase(hashCall.getFnName())) {
+            // Defensive: PercentileRewriteEquivalent.prepare() only registers
+            // percentile_union(percentile_hash(...)) or percentile_union(non-call),
+            // so a CallOperator with a different name should never reach here.
+            // Fall back to LEGACY_STORAGE rather than crash if prepare() is
+            // ever broadened.
+            return LEGACY_STORAGE;
+        }
+        if (hashCall.getChildren().size() > 1) {
+            Double c = readDoubleConstant(hashCall.getChild(1));
+            if (c != null) {
+                return c;
+            }
+        }
+        return LEGACY_STORAGE;
+    }
+
+    // FunctionAnalyzer canonicalizes compression to an integer literal; implicit
+    // int→double casts are folded before this matcher runs, so the tree always
+    // carries a plain ConstantOperator here. Finite-value post-filter is an
+    // extra invariant.
+    private static Double readDoubleConstant(ScalarOperator op) {
+        if (!(op instanceof ConstantOperator)) {
+            return null;
+        }
+        ConstantOperator c = (ConstantOperator) op;
+        if (c.isNull()) {
+            return null;
+        }
+        OptionalDouble v = ConstantOperatorUtils.doubleValueFromConstant(c);
+        if (!v.isPresent()) {
+            return null;
+        }
+        double d = v.getAsDouble();
+        return Double.isFinite(d) ? d : null;
     }
 
     private CallOperator makePercentileUnion(ScalarOperator replace) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -54,6 +54,17 @@ import static com.starrocks.sql.optimizer.rule.transformation.materialization.Mv
 
 public abstract class BaseMaterializedViewRewriteRule extends TransformationRule implements IMaterializedViewRewriteRule {
 
+    // Per-attempt rewrite output plus the boolean signal that BestMvSelector
+    // reads to prefer subsume percentile MVs over non-subsume fallbacks.
+    // The mismatch values (mvC, queryC) live on EquivalentShuttleContext
+    // where the strict-mode trace consumes them — no need to carry doubles
+    // further up the stack. Public-static so BestMvSelector can import it.
+    public static record RewriteResult(OptExpression expression, boolean hasPercentileNonSubsumeRewrite) {
+        public static RewriteResult of(OptExpression expression) {
+            return new RewriteResult(expression, false);
+        }
+    }
+
     protected BaseMaterializedViewRewriteRule(RuleType type, Pattern pattern) {
         super(type, pattern);
     }
@@ -118,12 +129,12 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
     @Override
     public List<OptExpression> transform(OptExpression queryExpression, OptimizerContext context) {
         try {
-            List<OptExpression> expressions = doTransform(queryExpression, context);
-            if (expressions == null || expressions.isEmpty()) {
+            List<RewriteResult> results = doTransform(queryExpression, context);
+            if (results == null || results.isEmpty()) {
                 return Lists.newArrayList();
             }
             // in rbo/cbo phase, only return the best one result
-            BestMvSelector bestMvSelector = new BestMvSelector(expressions, context, queryExpression, this);
+            BestMvSelector bestMvSelector = new BestMvSelector(results, context, queryExpression, this);
             boolean isConsiderQueryDataLayout = isChooseBestMVBasedDataLayout(queryExpression);
             return bestMvSelector.selectBest(isConsiderQueryDataLayout);
         } catch (Exception e) {
@@ -142,7 +153,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         return mvCandidateContexts;
     }
 
-    public List<OptExpression> doTransform(OptExpression queryExpression, OptimizerContext context) {
+    public List<RewriteResult> doTransform(OptExpression queryExpression, OptimizerContext context) {
         // 1. collect all candidate mvs for the input
         List<MaterializationContext> mvCandidateContexts = Lists.newArrayList();
         if (queryExpression.getGroupExpression() != null) {
@@ -187,10 +198,10 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
      * @param context: optimizer context.
      * @return: the rewritten query opt expression and associated materialization context pair if rewrite success, otherwise null.
      */
-    protected List<OptExpression> doTransform(List<MaterializationContext> mvCandidateContexts,
+    protected List<RewriteResult> doTransform(List<MaterializationContext> mvCandidateContexts,
                                               OptExpression queryExpression,
                                               OptimizerContext context) {
-        List<OptExpression> results = Lists.newArrayList();
+        List<RewriteResult> results = Lists.newArrayList();
         // Construct queryPredicateSplit to avoid creating multi times for multi MVs.
         // Compute Query queryPredicateSplit
         final ColumnRefFactory queryColumnRefFactory = context.getColumnRefFactory();
@@ -246,7 +257,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             // NOTE: derive logical property is necessary for statistics calculation.
             deriveLogicalProperty(candidate);
 
-            results.add(candidate);
+            results.add(new RewriteResult(candidate, mvRewriteContext.hasPercentileNonSubsumeRewrite()));
             mvContext.updateMVUsedCount();
             IMaterializedViewMetricsEntity mvEntity =
                     MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mvContext.getMv().getMvId());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -32,7 +32,7 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         assertPlanContains(sql, "output: any_value(1: v1)");
 
         sql = "select approx_percentile(v1, 0.99) from t0;";
-        assertPlanContains(sql, "output: percentile_approx(CAST(1: v1 AS DOUBLE), 0.99)");
+        assertPlanContains(sql, "output: percentile_approx(CAST(1: v1 AS DOUBLE), 0.99, 10000.0)");
 
         sql = "select stddev(v1) from t0;";
         assertPlanContains(sql, "output: stddev_samp(1: v1)");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -1014,10 +1014,10 @@ public class TrinoQueryTest extends TrinoTestBase {
         analyzeFail(sql);
 
         sql = "select approx_percentile(2.25, 1.79E-10)";
-        assertPlanContains(sql, "percentile_approx(2.25, 1.79E-10)");
+        assertPlanContains(sql, "percentile_approx(2.25, 1.79E-10, 10000.0)");
 
         sql = "select approx_percentile(2.25, 0.4)";
-        assertPlanContains(sql, "percentile_approx(2.25, 0.4)");
+        assertPlanContains(sql, "percentile_approx(2.25, 0.4, 10000.0)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -98,6 +98,19 @@ public class SessionVariableTest {
     }
 
     @Test
+    public void testEnableMvPercentileStrictMatchDefaultFalseAndSettable() {
+        SessionVariable sessionVariable = new SessionVariable();
+        Assertions.assertFalse(sessionVariable.isEnableMvPercentileStrictMatch(),
+                "the percentile strict-match flag must default to legacy (false)");
+
+        sessionVariable.setEnableMvPercentileStrictMatch(true);
+        Assertions.assertTrue(sessionVariable.isEnableMvPercentileStrictMatch());
+
+        sessionVariable.setEnableMvPercentileStrictMatch(false);
+        Assertions.assertFalse(sessionVariable.isEnableMvPercentileStrictMatch());
+    }
+
+    @Test
     public void testConnectorSinkShuffleModeBackwardCompatibility() {
         SessionVariable sessionVariable = new SessionVariable();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -331,6 +331,31 @@ public class AnalyzeAggregateTest {
     }
 
     @Test
+    public void testPercentileHashFunction() {
+        // percentile_hash is a scalar function; its compression validation must run
+        // on the scalar analyze path (not analyzeBuiltinAggFunction). Wrap in
+        // percentile_approx_raw so the PERCENTILE result has a query-able output type.
+        // 1-arg overload keeps the legacy storage compression and needs no validation.
+        analyzeSuccess("select percentile_approx_raw(percentile_hash(tf), 0.5) from tall");
+        // Valid in-range integer compression literal.
+        analyzeSuccess("select percentile_approx_raw(percentile_hash(tf, 5000), 0.5) from tall");
+        // Out-of-range integer literal is silently clamped to DEFAULT.
+        analyzeSuccess("select percentile_approx_raw(percentile_hash(tf, 1047), 0.5) from tall");
+        // NULL literal is canonicalized to DEFAULT.
+        analyzeSuccess("select percentile_approx_raw(percentile_hash(tf, NULL), 0.5) from tall");
+        // Non-constant compression (column ref) must be rejected up front rather than
+        // reaching BE, where get_const_value would do an invalid ConstColumn downcast.
+        analyzeFail("select percentile_approx_raw(percentile_hash(tf, tc), 0.5) from tall",
+                "compression must be an integer literal");
+        // Non-integer literal compression is rejected.
+        analyzeFail("select percentile_approx_raw(percentile_hash(tf, 5000.0), 0.5) from tall",
+                "compression must be an integer literal");
+        // Casts and arithmetic expressions for compression are rejected.
+        analyzeFail("select percentile_approx_raw(percentile_hash(tf, CAST(5000 AS DOUBLE)), 0.5) from tall",
+                "compression must be an integer literal");
+    }
+
+    @Test
     public void testPercentileApproxWeightedFunction() {
         // Test parameter count validation
         analyzeFail("select percentile_approx_weighted(1, 2) from tall group by tb");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -288,9 +288,26 @@ public class AnalyzeAggregateTest {
         analyzeFail("select percentile_approx(1,'c') from tall group by tb");
         analyzeFail("select percentile_approx(1,1,'c') from tall group by tb");
         analyzeFail("select percentile_approx(1,1,0.5,tc) from tall group by tb");
-        analyzeSuccess("select percentile_approx(1,1,tc) from tall group by tb");
+        // FunctionAnalyzer now canonicalizes compression at analyze phase:
+        // non-constant compression arguments are rejected up front rather than
+        // letting the query reach TypeChecker.
+        analyzeFail("select percentile_approx(1,1,tc) from tall group by tb",
+                "compression must be an integer literal");
         analyzeSuccess("select percentile_approx(1,5) from tall group by tb");
+        // Out-of-range integer literal: silently clamped to DEFAULT_COMPRESSION_FACTOR.
         analyzeSuccess("select percentile_approx(1,0.5,1047) from tall group by tb");
+        // NULL literal: canonicalized to DEFAULT.
+        analyzeSuccess("select percentile_approx(1, 0.5, NULL) from tall group by tb");
+        // Zero and negative integer literals are out-of-range and silently clamped.
+        analyzeSuccess("select percentile_approx(1, 0.5, 0) from tall group by tb");
+        // Non-integer literal compression is rejected.
+        analyzeFail("select percentile_approx(1, 0.5, 5000.0) from tall group by tb",
+                "compression must be an integer literal");
+        // Casts and arithmetic expressions for compression are rejected.
+        analyzeFail("select percentile_approx(1, 0.5, CAST(5000 AS DOUBLE)) from tall group by tb",
+                "compression must be an integer literal");
+        analyzeFail("select percentile_approx(1, 0.5, 2500 + 2500) from tall group by tb",
+                "compression must be an integer literal");
         analyzeSuccess("select percentile_disc(tj,0.5) from tall group by tb");
         analyzeSuccess("select percentile_cont(tj,0.5) from tall group by tb");
         analyzeSuccess("select percentile_cont(tj, cast(0.5 as double)) from tall group by tb");
@@ -349,7 +366,10 @@ public class AnalyzeAggregateTest {
         analyzeFail("select percentile_approx_weighted(1, 2, 0.5, 'c') from tall group by tb",
                 "requires the fourth parameter (compression) to be numeric type");
         analyzeSuccess("select percentile_approx_weighted(1, 2, 0.5, 100) from tall group by tb");
-        analyzeSuccess("select percentile_approx_weighted(1, 2, 0.5, tc) from tall group by tb");
+        // Non-constant compression is now rejected at analyze phase
+        // (FunctionAnalyzer canonicalizes the literal before plan generation).
+        analyzeFail("select percentile_approx_weighted(1, 2, 0.5, tc) from tall group by tb",
+                "compression must be an integer literal");
 
         // Test with different numeric types
         analyzeSuccess("select percentile_approx_weighted(tc, tj, 0.5) from tall group by tb");
@@ -391,7 +411,10 @@ public class AnalyzeAggregateTest {
         analyzeFail("select percentile_approx(1, 0.5, 'c') from tall group by tb",
                 "requires the third parameter (compression) to be numeric type");
         analyzeSuccess("select percentile_approx(1, 0.5, 100) from tall group by tb");
-        analyzeSuccess("select percentile_approx(1, 0.5, tc) from tall group by tb");
+        // Non-constant compression is now rejected at analyze phase
+        // (FunctionAnalyzer canonicalizes the literal before plan generation).
+        analyzeFail("select percentile_approx(1, 0.5, tc) from tall group by tb",
+                "compression must be an integer literal");
 
         // Test with different numeric types
         analyzeSuccess("select percentile_approx(tc, 0.5) from tall group by tb");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelectorTest.java
@@ -90,7 +90,7 @@ public class BestMvSelectorTest extends MVTestBase {
         List<OptExpression> mvExpressions = Lists.newArrayList();
         OptExpression queryPlan = createMockQueryPlan();
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         
         Assertions.assertNotNull(selector);
         // Test that constructor works without throwing exceptions
@@ -103,7 +103,7 @@ public class BestMvSelectorTest extends MVTestBase {
         List<OptExpression> mvExpressions = Lists.newArrayList();
         OptExpression queryPlan = createMockAggQueryPlan();
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         
         // Test that constructor works with aggregation query
         Assertions.assertNotNull(selector);
@@ -115,7 +115,7 @@ public class BestMvSelectorTest extends MVTestBase {
         List<OptExpression> mvExpressions = Lists.newArrayList();
         OptExpression queryPlan = createMockQueryPlan();
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(true);
         
         Assertions.assertTrue(result.isEmpty());
@@ -128,7 +128,7 @@ public class BestMvSelectorTest extends MVTestBase {
         OptExpression mvExpression = createMockMvExpression();
         List<OptExpression> mvExpressions = Lists.newArrayList(mvExpression);
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(true);
         
         Assertions.assertEquals(0, result.size());
@@ -148,7 +148,7 @@ public class BestMvSelectorTest extends MVTestBase {
         mvExpression1.setStatistics(stats1);
         mvExpression2.setStatistics(stats2);
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(true);
         
         // Should return the best one (with lower row count)
@@ -161,7 +161,7 @@ public class BestMvSelectorTest extends MVTestBase {
         OptExpression mvExpression = createMockMvExpression();
         List<OptExpression> mvExpressions = Lists.newArrayList(mvExpression);
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(true);
         
         Assertions.assertEquals(0, result.size());
@@ -189,7 +189,7 @@ public class BestMvSelectorTest extends MVTestBase {
         Statistics stats = createMockStatistics(100.0, 50.0);
         mvExpression.setStatistics(stats);
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(true);
         
         Assertions.assertEquals(0, result.size());
@@ -227,7 +227,7 @@ public class BestMvSelectorTest extends MVTestBase {
         Statistics stats = createMockStatistics(100.0, 50.0);
         mvExpression.setStatistics(stats);
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(true);
         
         Assertions.assertEquals(0, result.size());
@@ -244,7 +244,7 @@ public class BestMvSelectorTest extends MVTestBase {
         Statistics stats = createMockStatistics(100.0, 50.0);
         mvExpression.setStatistics(stats);
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(true);
         
         Assertions.assertEquals(0, result.size());
@@ -265,7 +265,7 @@ public class BestMvSelectorTest extends MVTestBase {
             }
         };
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         
         // Should not throw exception, should handle gracefully
         Assertions.assertDoesNotThrow(() -> selector.selectBest(true));
@@ -286,7 +286,7 @@ public class BestMvSelectorTest extends MVTestBase {
             }
         };
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(true);
         
         Assertions.assertTrue(result.isEmpty());
@@ -323,7 +323,7 @@ public class BestMvSelectorTest extends MVTestBase {
             }
         };
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(true);
         
         Assertions.assertTrue(result.isEmpty());
@@ -335,7 +335,7 @@ public class BestMvSelectorTest extends MVTestBase {
         OptExpression queryPlan = createMockQueryPlan();
         List<OptExpression> mvExpressions = Lists.newArrayList();
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         
         // Test calcSortScore method
         Method calcSortScoreMethod = BestMvSelector.class.getDeclaredMethod(
@@ -359,7 +359,7 @@ public class BestMvSelectorTest extends MVTestBase {
         OptExpression queryPlan = createMockQueryPlan();
         List<OptExpression> mvExpressions = Lists.newArrayList();
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         
         // Test calcDistScore method
         Method calcDistScoreMethod = BestMvSelector.class.getDeclaredMethod(
@@ -423,7 +423,7 @@ public class BestMvSelectorTest extends MVTestBase {
             }
         };
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(true);
         
         // Should return empty list when contexts are empty
@@ -445,7 +445,7 @@ public class BestMvSelectorTest extends MVTestBase {
             }
         };
         
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         
         // Should handle exception gracefully and still return a result
         Assertions.assertDoesNotThrow(() -> {
@@ -460,7 +460,7 @@ public class BestMvSelectorTest extends MVTestBase {
         OptExpression mvExpression = createMockMvExpression();
         List<OptExpression> mvExpressions = Lists.newArrayList(mvExpression);
 
-        BestMvSelector selector = new BestMvSelector(mvExpressions, optimizerContext, queryPlan, rule);
+        BestMvSelector selector = BestMvSelector.forExpressions(mvExpressions, optimizerContext, queryPlan, rule);
         List<OptExpression> result = selector.selectBest(false);
 
         Assertions.assertEquals(1, result.size());
@@ -954,5 +954,37 @@ public class BestMvSelectorTest extends MVTestBase {
             // Should choose the MV with advertiser_id as distribution key for tablet pruning benefit
             PlanTestBase.assertContains(plan, "mv_ad_fact_advertiser");
         }
+    }
+
+    /**
+     * Direct compareTo coverage for the percentile non-subsume signal: when two
+     * candidates have the same structural score, the one whose rewrite needed a
+     * compression downgrade (hasPercentileNonSubsumeRewrite=true) must sort
+     * AFTER the subsume candidate, so BestMvSelector picks the subsume MV.
+     */
+    @Test
+    public void testPercentileSubsumeCandidatePreferredOverNonSubsumeInLegacy() {
+        BestMvSelector.CandidateScore subsume = new BestMvSelector.CandidateScore();
+        subsume.index = 0;
+        subsume.hasPercentileNonSubsumeRewrite = false;
+
+        BestMvSelector.CandidateScore nonSubsume = new BestMvSelector.CandidateScore();
+        nonSubsume.index = 1;
+        nonSubsume.hasPercentileNonSubsumeRewrite = true;
+
+        // Boolean.compare(false, true) = -1 → subsume < nonSubsume → picker
+        // (which uses Comparator.min) returns the subsume one.
+        Assertions.assertTrue(subsume.compareTo(nonSubsume) < 0,
+                "subsume must outrank non-subsume regardless of index");
+        Assertions.assertTrue(nonSubsume.compareTo(subsume) > 0,
+                "non-subsume must rank below subsume");
+
+        // When both flags match the comparison falls through to the existing
+        // tie-breakers (here: index ascending).
+        BestMvSelector.CandidateScore alsoSubsume = new BestMvSelector.CandidateScore();
+        alsoSubsume.index = 2;
+        alsoSubsume.hasPercentileNonSubsumeRewrite = false;
+        Assertions.assertTrue(subsume.compareTo(alsoSubsume) < 0,
+                "ties on the percentile flag must fall through to existing rules");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -920,6 +920,30 @@ public class MvRewriteTest extends MVTestBase {
     }
 
     @Test
+    public void testPercentileStrictCompressionMatch() throws Exception {
+        String lowCompressionMv = "percentile_strict_low_mv";
+        String highCompressionMv = "percentile_strict_high_mv";
+        String query = "select empid, percentile_approx(salary, 0.95, 5000) from emps group by empid";
+
+        createAndRefreshMv("create materialized view " + lowCompressionMv +
+                " distributed by hash(empid) as select empid, " +
+                "percentile_union(percentile_hash(salary)) from emps group by empid");
+        connectContext.getSessionVariable().setEnableMvPercentileStrictMatch(true);
+        try {
+            PlanTestBase.assertNotContains(getFragmentPlan(query), lowCompressionMv);
+
+            createAndRefreshMv("create materialized view " + highCompressionMv +
+                    " distributed by hash(empid) as select empid, " +
+                    "percentile_union(percentile_hash(salary, 5000)) from emps group by empid");
+            PlanTestBase.assertContains(getFragmentPlan(query), highCompressionMv);
+        } finally {
+            connectContext.getSessionVariable().setEnableMvPercentileStrictMatch(false);
+            dropMv("test", lowCompressionMv);
+            dropMv("test", highCompressionMv);
+        }
+    }
+
+    @Test
     public void testAggExprRewrite() throws Exception {
         // Group by Cast Expr
         starRocksAssert.withMTable("json_tbl",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2517,12 +2517,12 @@ public class AggregateTest extends PlanTestBase {
         // For compatibility
         String sql = "select percentile_approx(1, cast(0.4 as DOUBLE));";
         String plan = getCostExplain(sql);
-        assertContains(plan, "percentile_approx[(1.0, 0.4); args: DOUBLE,DOUBLE");
+        assertContains(plan, "percentile_approx[(1.0, 0.4, 10000.0); args: DOUBLE,DOUBLE,DOUBLE");
 
         sql = "with cc as (select 1 as a) select percentile_approx(1, cc.a) from cc;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "2:AGGREGATE (update finalize)\n" +
-                "  |  output: percentile_approx(1.0, 1.0)\n" +
+                "  |  output: percentile_approx(1.0, 1.0, 10000.0)\n" +
                 "  |  group by: ");
         Exception exception = Assertions.assertThrows(StarRocksPlannerException.class, () -> {
             String testSql = "with cc as (select 1 as a, v1 from t0) select percentile_approx(1, cc.a, cc.v1) from cc;";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2528,8 +2528,10 @@ public class AggregateTest extends PlanTestBase {
             String testSql = "with cc as (select 1 as a, v1 from t0) select percentile_approx(1, cc.a, cc.v1) from cc;";
             getFragmentPlan(testSql);
         });
-        Assertions.assertTrue(exception.getMessage().contains("Type check failed. want constant arg in " +
-                "percentile_approx (compression), but input is cast(1: v1 as double)"));
+        // FunctionAnalyzer pre-clamps the compression literal at analyze phase
+        // and rejects non-constant inputs up front (SemanticException extends
+        // StarRocksPlannerException so the assertion above still matches).
+        Assertions.assertTrue(exception.getMessage().contains("compression must be an integer literal"));
 
         Throwable exception2 = assertThrows(StarRocksPlannerException.class, () -> {
             getCostExplain("select percentile_approx(1, cast(1.3 as DOUBLE));");
@@ -2595,18 +2597,17 @@ public class AggregateTest extends PlanTestBase {
                 "column 7 to line 1, column 44. Detail message: percentile_approx_weighted requires " +
                 "the third parameter (percentile) to be ARRAY<NUMERIC>, but got: ARRAY<NULL_TYPE>."));
 
-        // Test compression parameter validation
-        Throwable exception6 = assertThrows(StarRocksPlannerException.class, () -> {
-            getCostExplain("select percentile_approx_weighted(v1, v2, 0.5, 0) from t0;");
-        });
-        assertThat(exception6.getMessage(), containsString("Type check failed. " +
-                "compression parameter must be positive in percentile_approx_weighted, but got: 0.0"));
+        // Compression literals outside [MIN_COMPRESSION, MAX_COMPRESSION] are
+        // canonicalized to DEFAULT_COMPRESSION_FACTOR by FunctionAnalyzer; the
+        // query plans successfully and the compression argument is rewritten to
+        // 10000 before reaching the optimizer.
+        sql = "select percentile_approx_weighted(v1, v2, 0.5, 0) from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "percentile_approx_weighted");
 
-        Throwable exception7 = assertThrows(StarRocksPlannerException.class, () -> {
-            getCostExplain("select percentile_approx_weighted(v1, v2, 0.5, -100) from t0;");
-        });
-        assertThat(exception7.getMessage(), containsString("Type check failed. " +
-                "compression parameter must be positive in percentile_approx_weighted, but got: -100.0"));
+        sql = "select percentile_approx_weighted(v1, v2, 0.5, -100) from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "percentile_approx_weighted");
 
         // Test valid array percentile
         sql = "select percentile_approx_weighted(v1, v2, [0.0, 0.5, 1.0]) from t0;";
@@ -2671,18 +2672,17 @@ public class AggregateTest extends PlanTestBase {
                 "column 7 to line 1, column 31. Detail message: " +
                 "percentile_approx requires the second parameter (percentile) to be ARRAY<NUMERIC>, but got: ARRAY<NULL_TYPE>."));
 
-        // Test compression parameter validation
-        Throwable exception6 = assertThrows(StarRocksPlannerException.class, () -> {
-            getCostExplain("select percentile_approx(v1, 0.5, 0) from t0;");
-        });
-        assertThat(exception6.getMessage(), containsString("Type check failed. " +
-                "compression parameter must be positive in percentile_approx, but got: 0.0"));
+        // Compression literals outside [MIN_COMPRESSION, MAX_COMPRESSION] are
+        // canonicalized to DEFAULT_COMPRESSION_FACTOR by FunctionAnalyzer; the
+        // query plans successfully and the compression argument is rewritten to
+        // 10000 before reaching the optimizer.
+        sql = "select percentile_approx(v1, 0.5, 0) from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "percentile_approx");
 
-        Throwable exception7 = assertThrows(StarRocksPlannerException.class, () -> {
-            getCostExplain("select percentile_approx(v1, 0.5, -100) from t0;");
-        });
-        assertThat(exception7.getMessage(), containsString("Type check failed. " +
-                "compression parameter must be positive in percentile_approx, but got: -100.0"));
+        sql = "select percentile_approx(v1, 0.5, -100) from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "percentile_approx");
 
         // Test valid array percentile
         sql = "select percentile_approx(v1, [0.0, 0.5, 1.0]) from t0;";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -447,7 +447,7 @@ public class ConstantExpressionTest extends PlanTestBase {
                     "  |  <slot 3> : clone(2: percentile_approx)\n" +
                     "  |  \n" +
                     "  1:AGGREGATE (update finalize)\n" +
-                    "  |  output: percentile_approx(2.25, 0.0)\n" +
+                    "  |  output: percentile_approx(2.25, 0.0, 10000.0)\n" +
                     "  |  group by: ");
 
             sql = "SELECT COUNT(CASE WHEN 1 THEN 1 END), COUNT(CASE WHEN TRUE THEN 1 END), " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectHintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectHintTest.java
@@ -99,7 +99,7 @@ public class SelectHintTest extends PlanTestBase {
 
         sql = "select /*+ set_user_variable(@a = 1, @b = 10) */ percentile_approx(v1, @a) from t0";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "percentile_approx(CAST(1: v1 AS DOUBLE), 1.0)");
+        assertContains(plan, "percentile_approx(CAST(1: v1 AS DOUBLE), 1.0, 10000.0)");
 
         Exception exception = Assertions.assertThrows(SemanticException.class, () -> {
             String invalidSql = "select /*+ set_user_variable(@a = 1, @b = 1000000) */ APPROX_TOP_K(v1, @a), " +

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -1049,6 +1049,8 @@ vectorized_functions = [
     [130001, 'percentile_empty', True, False, 'PERCENTILE', [], 'PercentileFunctions::percentile_empty'],
     [130002, 'percentile_approx_raw', True, False, 'DOUBLE', ['PERCENTILE', 'DOUBLE'],
      'PercentileFunctions::percentile_approx_raw'],
+    [130003, 'percentile_hash', True, False, 'PERCENTILE', ['DOUBLE', 'DOUBLE'],
+     'PercentileFunctions::percentile_hash_with_compression'],
 
     [140000, 'grouping_id', True, False, 'BIGINT', ['BIGINT'], 'GroupingSetsFunctions::grouping_id'],
     [140001, 'grouping', True, False, 'BIGINT', ['BIGINT'], 'GroupingSetsFunctions::grouping'],

--- a/test/sql/test_agg_function/R/test_percentile_approx
+++ b/test/sql/test_agg_function/R/test_percentile_approx
@@ -41,6 +41,10 @@ with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 =
 -- !result
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx(c2, v1, v2 + 1) as int) from tt;
 -- result:
+[REGEX]E: \(1064.*compression must be an integer literal.*
+-- !result
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx(c2, v1, @v2) as int) from tt;
+-- result:
 25000
 -- !result
 select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, array<double>[0.25, 0.5, 0.75]) from t1;

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -59,7 +59,7 @@ select cast(percentile_approx_weighted(c2, 1, 0.9) as int) from t1;
 -- !result
 select cast(percentile_approx_weighted(c2, 0, 0.9, 0) as int) from t1;
 -- result:
-E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: 0.0')
+None
 -- !result
 select cast(percentile_approx_weighted(c2, 0, 0.9, 1) as int) from t1;
 -- result:
@@ -67,7 +67,7 @@ None
 -- !result
 select cast(percentile_approx_weighted(c2, 1, 0.9, 0) as int) from t1;
 -- result:
-E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: 0.0')
+44999
 -- !result
 select cast(percentile_approx_weighted(c2, 1, 0.9, 1) as int) from t1;
 -- result:
@@ -489,11 +489,11 @@ select percentile_approx_weighted(k, v, [0.25, 0.5, 0.75, 0.9]) from t2;
 -- !result
 select percentile_approx_weighted(k, v, 0.5, 0) from t2;
 -- result:
-E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: 0.0')
+3.4000000953674316
 -- !result
 select percentile_approx_weighted(k, v, 0.5, -100) from t2;
 -- result:
-E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: -100.0')
+3.4000000953674316
 -- !result
 select percentile_approx_weighted(k, v, 0.5, 1) from t2;
 -- result:

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -243,6 +243,10 @@ with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 =
 -- !result
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx_weighted(c2, c1, v1, v2 + 1) as int) from tt;
 -- result:
+[REGEX]E: \(1064.*compression must be an integer literal.*
+-- !result
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx_weighted(c2, c1, v1, @v2) as int) from tt;
+-- result:
 35355
 -- !result
 set pipeline_dop=1;
@@ -425,6 +429,10 @@ with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 =
 35355
 -- !result
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx_weighted(c2, c1, v1, v2 + 1) as int) from tt;
+-- result:
+[REGEX]E: \(1064.*compression must be an integer literal.*
+-- !result
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx_weighted(c2, c1, v1, @v2) as int) from tt;
 -- result:
 35355
 -- !result

--- a/test/sql/test_agg_function/T/test_percentile_approx
+++ b/test/sql/test_agg_function/T/test_percentile_approx
@@ -18,6 +18,7 @@ select cast(percentile_approx(c2, 0.9, 10000) as int) from t1;
 
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ cast(percentile_approx(c2, v1) as int) from tt;
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx(c2, v1, v2 + 1) as int) from tt;
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx(c2, v1, @v2) as int) from tt;
 
 select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, array<double>[0.25, 0.5, 0.75]) from t1;
 select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, array<double>[0.0, 0.5, 1.0]) from t1;

--- a/test/sql/test_agg_function/T/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/T/test_percentile_approx_weighted
@@ -95,6 +95,7 @@ select cast(percentile_approx_weighted(c13.b, 1, 0.5) as int) from t1;
 
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ cast(percentile_approx_weighted(c2, c1, v1) as int) from tt;
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx_weighted(c2, c1, v1, v2 + 1) as int) from tt;
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx_weighted(c2, c1, v1, @v2) as int) from tt;
 
 set pipeline_dop=1;
 
@@ -156,6 +157,7 @@ select cast(percentile_approx_weighted(c13.b, 1, 0.5) as int) from t1;
 
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ cast(percentile_approx_weighted(c2, c1, v1) as int) from tt;
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx_weighted(c2, c1, v1, v2 + 1) as int) from tt;
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx_weighted(c2, c1, v1, @v2) as int) from tt;
 CREATE TABLE `t2` (
   `k` int(11) NULL COMMENT "",
   `v` int(11) NULL COMMENT ""


### PR DESCRIPTION
## Why I'm doing:

`percentile_approx(v, q, c)` builds a T-digest sized by `c`, where the
compression controls the precision / memory tradeoff.

Today percentile MV rewrite does not reason about that compression contract.
A query that asks for a higher compression can be rewritten to a percentile MV
whose stored digest was built at a lower compression, and the rewrite proceeds
without any signal that precision was downgraded.

That makes compression requests invisible to the optimizer at the point where
it decides whether a percentile MV is an adequate substitute for the base-table
aggregation.

## What I'm doing:

Teach percentile MV rewrite to track whether the MV-side digest compression
covers the query-side compression request.

`PercentileRewriteEquivalent` reads:

- `queryC` from the query-side `percentile_approx`
- `mvC` from the MV-side percentile digest shape

The rewrite is considered subsume when `mvC >= queryC`. When `mvC < queryC`,
the rewrite is marked as a percentile non-subsume rewrite and that signal is
propagated through the MV rewrite path into candidate selection.

This lets the rewrite path apply one compression-aware policy:

- prefer subsume percentile MV candidates when they are available;
- preserve legacy rewrite behavior by default for a non-subsume candidate;
- reject a non-subsume candidate when
  `enable_mv_percentile_strict_match` is enabled, with the compression mismatch
  logged for tracing.

Tests cover the new session variable and candidate ordering behavior.

### Stack note

This PR is the headline MV rewrite piece and is currently stacked on:

- #73721, which canonicalizes percentile compression literals in
  `FunctionAnalyzer`
- #73723, which adds `percentile_hash(value, compression)` so MV definitions can
  store an explicit percentile compression

Until those PRs are merged, the GitHub diff against `main` includes their base
changes as well.

The independent `percentile_union` compression preservation fix is split into
#73722.

Fixes #73636

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
