### PR TITLE
[Tool] In start_fe.sh, set the fe-core version to 4.1.1

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -214,14 +214,14 @@ mkdir -p ${meta_dir:-"$STARROCKS_HOME/meta"}
 for f in $STARROCKS_HOME/lib/*.jar; do
   CLASSPATH=$f:${CLASSPATH};
 done
-# Explicitly put fe-core-main.jar at the front of classpath to ensure StarRocks' 
-# customized classes (e.g., HiveMetaStoreClient) are loaded before the original 
+# Explicitly put fe-core-4.1.1.jar at the front of classpath to ensure StarRocks'
+# customized classes (e.g., HiveMetaStoreClient) are loaded before the original
 # ones from third-party JARs (e.g., hive-apache-3.1.2-22.jar).
-# This prevents ClassLoader conflicts where the original HiveMetaStoreClient 
+# This prevents ClassLoader conflicts where the original HiveMetaStoreClient
 # (which uses old thrift paths like org.apache.thrift.transport.TFramedTransport)
 # might be loaded instead of StarRocks' version (which uses the correct new paths
 # like org.apache.thrift.transport.layered.TFramedTransport).
-export CLASSPATH=${STARROCKS_HOME}/lib/fe-core-main.jar:${STARROCKS_HOME}/lib/starrocks-hadoop-ext.jar:${CLASSPATH}:${STARROCKS_HOME}/lib:${STARROCKS_HOME}/conf
+export CLASSPATH=${STARROCKS_HOME}/lib/fe-core-4.1.1.jar:${STARROCKS_HOME}/lib/starrocks-hadoop-ext.jar:${CLASSPATH}:${STARROCKS_HOME}/lib:${STARROCKS_HOME}/conf
 
 pidfile=$PID_DIR/fe.pid
 


### PR DESCRIPTION
## Summary
Update fe-core version in start_fe.sh from `fe-core-main.jar` to `fe-core-4.1.1.jar` to match the 4.1.1 release version.

Reference: #71189

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
