### PR TITLE
[Tool] Set starrocks-fe version and spark_dpp_version to 4.1.1

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>4.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1275,7 +1275,7 @@ public class Config extends ConfigBase {
      * Default spark dpp version
      */
     @ConfField
-    public static String spark_dpp_version = "main";
+    public static String spark_dpp_version = "4.1.1";
     /**
      * Default spark load timeout
      */

--- a/fe/fe-grammar/pom.xml
+++ b/fe/fe-grammar/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>4.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-parser/pom.xml
+++ b/fe/fe-parser/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>4.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-server/pom.xml
+++ b/fe/fe-server/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>4.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-spi/pom.xml
+++ b/fe/fe-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>4.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-testing/pom.xml
+++ b/fe/fe-testing/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>4.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-type/pom.xml
+++ b/fe/fe-type/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>4.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-utils/pom.xml
+++ b/fe/fe-utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>starrocks-fe</artifactId>
         <groupId>com.starrocks</groupId>
-        <version>main</version>
+        <version>4.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/plugin/hive-udf/pom.xml
+++ b/fe/plugin/hive-udf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>starrocks-fe</artifactId>
         <groupId>com.starrocks</groupId>
-        <version>main</version>
+        <version>4.1.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fe/plugin/spark-dpp/pom.xml
+++ b/fe/plugin/spark-dpp/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>4.1.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
     <groupId>com.starrocks</groupId>
     <artifactId>starrocks-fe</artifactId>
-    <version>main</version>
+    <version>4.1.1</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
## Summary
- Set `starrocks-fe` artifact version from `main` to `4.1.1` across all 11 FE pom.xml files
- Set `spark_dpp_version` from `main` to `4.1.1` in `Config.java`

## References
- #71078

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
