### PR TITLE
[Enhancement] Fast-path skip stale tablet reports in ReportHandler.deleteFromMeta

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1149,6 +1149,28 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                     LOG.debug("delete tablet {} in partition {} of table {} in db {} from meta. backend[{}]",
                             tabletId, partitionId, tableId, dbId, backendId);
 
+                    // Fast path: probe via the inverted index to skip the heavy db/table/partition/index
+                    // walk when the BE's report is already stale and the disk is still online. The probe
+                    // result is only used for this filter — downstream code re-fetches the replica from
+                    // the tablet because TabletInvertedIndex.addReplica appends without dedup, while
+                    // LocalTablet.deleteRedundantReplica does not synchronously prune the inverted index,
+                    // so invertedIndex may return a replica that has been replaced on the tablet.
+                    long currentBackendReportVersion = GlobalStateMgr.getCurrentState().getNodeMgr()
+                            .getClusterInfo().getBackendReportVersion(backendId);
+                    Replica probeReplica = invertedIndex.getReplica(tabletId, backendId);
+                    if (probeReplica == null) {
+                        continue;
+                    }
+                    DiskInfo probeDiskInfo = hashToDiskInfo.get(probeReplica.getPathHash());
+                    if (probeDiskInfo != null
+                            && probeDiskInfo.getState() == DiskInfo.DiskState.ONLINE
+                            && backendReportVersion < currentBackendReportVersion) {
+                        LOG.warn("report Version from be: {} is outdated, report version in request: {}, " +
+                                        "latest report version: {}, ignore tablet: {}",
+                                backendId, backendReportVersion, currentBackendReportVersion, tabletId);
+                        continue;
+                    }
+
                     OlapTable olapTable = (OlapTable) globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, tableId);
                     if (olapTable == null) {
                         continue;
@@ -1188,20 +1210,8 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                         continue;
                     }
 
-                    long currentBackendReportVersion =
-                            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendReportVersion(backendId);
                     DiskInfo diskInfo = hashToDiskInfo.get(replica.getPathHash());
-
-                    // Only check reportVersion when the disk is online,
-                    // as there will be no tablet changes on an unavailable disk
-                    if (diskInfo != null
-                            && diskInfo.getState() == DiskInfo.DiskState.ONLINE
-                            && backendReportVersion < currentBackendReportVersion) {
-                        LOG.warn("report Version from be: {} is outdated, report version in request: {}, " +
-                                        "latest report version: {}, ignore tablet: {}",
-                                backendId, backendReportVersion, currentBackendReportVersion, tabletId);
-                        continue;
-                    } else if (diskInfo == null) {
+                    if (diskInfo == null) {
                         LOG.warn("disk of path hash {} dose not exist, delete tablet {} on backend {} from meta",
                                 replica.getPathHash(), tabletId, backendId);
                     } else if (diskInfo.getState() != DiskInfo.DiskState.ONLINE) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1149,26 +1149,32 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
                     LOG.debug("delete tablet {} in partition {} of table {} in db {} from meta. backend[{}]",
                             tabletId, partitionId, tableId, dbId, backendId);
 
-                    // Fast path: probe via the inverted index to skip the heavy db/table/partition/index
-                    // walk when the BE's report is already stale and the disk is still online. The probe
-                    // result is only used for this filter — downstream code re-fetches the replica from
-                    // the tablet because TabletInvertedIndex.addReplica appends without dedup, while
-                    // LocalTablet.deleteRedundantReplica does not synchronously prune the inverted index,
-                    // so invertedIndex may return a replica that has been replaced on the tablet.
+                    // Fast path: skip the heavy db/table/partition/index walk when the BE's report
+                    // is already stale and the disk is still online. Order matters:
+                    //   1. Check the version first — cheap, single counter read. The common
+                    //      non-stale case pays only this and exits the fast path immediately
+                    //      (no probe, no map lookup).
+                    //   2. Only when stale, probe TabletInvertedIndex for the replica. The probe
+                    //      is opportunistic: if it positively identifies an ONLINE disk for the
+                    //      backend we skip immediately; otherwise (probe missing, disk null/offline)
+                    //      we fall through to the authoritative catalog walk below — the inverted
+                    //      index is not the source of truth (e.g. RestoreJob adds replicas to the
+                    //      tablet with updateInvertedIndex=false), so a probe miss must NOT short
+                    //      circuit deletion / setBad handling.
                     long currentBackendReportVersion = GlobalStateMgr.getCurrentState().getNodeMgr()
                             .getClusterInfo().getBackendReportVersion(backendId);
-                    Replica probeReplica = invertedIndex.getReplica(tabletId, backendId);
-                    if (probeReplica == null) {
-                        continue;
-                    }
-                    DiskInfo probeDiskInfo = hashToDiskInfo.get(probeReplica.getPathHash());
-                    if (probeDiskInfo != null
-                            && probeDiskInfo.getState() == DiskInfo.DiskState.ONLINE
-                            && backendReportVersion < currentBackendReportVersion) {
-                        LOG.warn("report Version from be: {} is outdated, report version in request: {}, " +
-                                        "latest report version: {}, ignore tablet: {}",
-                                backendId, backendReportVersion, currentBackendReportVersion, tabletId);
-                        continue;
+                    if (backendReportVersion < currentBackendReportVersion) {
+                        Replica probeReplica = invertedIndex.getReplica(tabletId, backendId);
+                        if (probeReplica != null) {
+                            DiskInfo probeDiskInfo = hashToDiskInfo.get(probeReplica.getPathHash());
+                            if (probeDiskInfo != null
+                                    && probeDiskInfo.getState() == DiskInfo.DiskState.ONLINE) {
+                                LOG.warn("report Version from be: {} is outdated, report version in request: {}, "
+                                                + "latest report version: {}, ignore tablet: {}",
+                                        backendId, backendReportVersion, currentBackendReportVersion, tabletId);
+                                continue;
+                            }
+                        }
                     }
 
                     OlapTable olapTable = (OlapTable) globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(db, tableId);
@@ -1212,7 +1218,7 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
 
                     DiskInfo diskInfo = hashToDiskInfo.get(replica.getPathHash());
                     if (diskInfo == null) {
-                        LOG.warn("disk of path hash {} dose not exist, delete tablet {} on backend {} from meta",
+                        LOG.warn("disk of path hash {} does not exist, delete tablet {} on backend {} from meta",
                                 replica.getPathHash(), tabletId, backendId);
                     } else if (diskInfo.getState() != DiskInfo.DiskState.ONLINE) {
                         LOG.warn("disk of path hash {} not available, delete tablet {} on backend {} from meta",

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerEditLogTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DiskInfo;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.LocalTablet;
@@ -629,5 +630,96 @@ public class ReportHandlerEditLogTest {
 
         // 7. Verify replica is NOT setBad (because EditLog failed, WALApplier won't execute)
         Assertions.assertFalse(tabletReplica.isBad(), "Replica should not be setBad when EditLog write fails");
+    }
+
+    @Test
+    public void testDeleteFromMetaSkipsStaleReportOnOnlineDisk() throws Exception {
+        // Cover the fast-path: when the incoming report version is stale and the replica's
+        // disk is ONLINE, deleteFromMeta must short-circuit without walking the catalog or
+        // deleting the replica.
+        // The other tests in this class register backends with empty disks, so diskInfo
+        // resolves to null and the fast path is never exercised. Here we register an
+        // ONLINE disk that the replica pins to, then drive the backend's authoritative
+        // report version above the version we pass in.
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table_fast_path");
+        db.registerTableUnlocked(table);
+
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+
+        // Reset whatever (TABLET_ID, BACKEND_ID*) entries createOlapTable already pushed
+        // into the inverted index. With the pre-#73661 append-only addReplica, the helper's
+        // placeholder replica (which has no pathHash) would otherwise be the one our probe
+        // returns, hiding the ONLINE disk we install below. Mirrors the post-#73661 invariant
+        // of "at most one replica per (tabletId, backendId) in the inverted index".
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().deleteReplica(TABLET_ID, BACKEND_ID);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().deleteReplica(TABLET_ID, BACKEND_ID_2);
+
+        long onlinePathHash = 4242L;
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(2, 2, 2);
+        replica.setPathHash(onlinePathHash);
+        replica.setDeferReplicaDeleteToNextReport(false);
+        // tablet.addReplica registers the replica into the inverted index as well; no
+        // explicit invertedIndex.addReplica needed.
+        tablet.addReplica(replica);
+        // A second replica so tablet.getImmutableReplicas().size() > 1, otherwise the
+        // single-replica setBad branch in deleteFromMeta would also short-circuit and
+        // mask whether the fast-path itself fired.
+        Replica replica2 = new Replica(REPLICA_ID_2, BACKEND_ID_2, 0, Replica.ReplicaState.NORMAL);
+        replica2.updateVersionInfo(2, 2, 2);
+        tablet.addReplica(replica2);
+
+        // Replace BACKEND_ID's empty-disk backend with one that exposes an ONLINE disk
+        // matching the replica's pathHash.
+        DiskInfo onlineDisk = new DiskInfo("/data1");
+        onlineDisk.setPathHash(onlinePathHash);
+        onlineDisk.setState(DiskInfo.DiskState.ONLINE);
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(BACKEND_ID)
+                .setDisks(ImmutableMap.of("/data1", onlineDisk));
+
+        // Drive the authoritative report version higher than what we will pass in below.
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                .updateBackendReportVersion(BACKEND_ID, 100L, DB_ID);
+
+        // Sanity-check the preconditions the fast-path depends on, otherwise a failed
+        // assert below is ambiguous between "fast-path is broken" and "test setup didn't
+        // wire what the fast-path needs".
+        Assertions.assertEquals(100L,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                        .getBackendReportVersion(BACKEND_ID),
+                "test setup: authoritative report version must be advanced for the fast-path");
+        Assertions.assertSame(replica,
+                GlobalStateMgr.getCurrentState().getTabletInvertedIndex()
+                        .getReplica(TABLET_ID, BACKEND_ID),
+                "test setup: invertedIndex must hand the new replica back to the probe");
+        Assertions.assertEquals(onlinePathHash,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                        .getBackend(BACKEND_ID).getDisks().get("/data1").getPathHash(),
+                "test setup: ONLINE disk pathHash must match the replica");
+
+        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLET_ID);
+
+        long staleReportVersion = 50L;
+        ReportHandler.deleteFromMeta(tabletDeleteFromMeta, BACKEND_ID, staleReportVersion);
+
+        // Replica must still be there — fast-path skipped it without touching meta.
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID),
+                "stale report on ONLINE disk should not delete the replica");
+        Assertions.assertEquals(2, tablet.getImmutableReplicas().size(),
+                "no replicas should be removed when the fast-path skip fires");
+
+        // And no OP_BATCH_DELETE_REPLICA journal entry should have been written. If one
+        // exists, replayNextJournal would return non-null instead of throwing.
+        Assertions.assertThrows(Throwable.class,
+                () -> UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_BATCH_DELETE_REPLICA),
+                "no edit log entry should have been written when the fast-path skip fires");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When a backend's tablet report version is already outdated by the time `ReportHandler.deleteFromMeta` processes a tablet, the original code walked `db -> table -> partition -> index -> tablet -> replica` for every tablet before discarding the work at the stale-version check at the end. For a typical batch of tablets, this wastes substantial work under the db write lock.

## What I'm doing:

Hoist a per-tablet fast-path check above the catalog walk:

- Probe the replica via `TabletInvertedIndex.getReplica(tabletId, backendId)` (in-memory, no db lock required).
- If the probed disk is `ONLINE` and `backendReportVersion < currentBackendReportVersion`, log the same outdated-report warning and `continue` immediately.
- Re-evaluated per tablet so a mid-loop refresh of the backend report version takes effect on subsequent tablets.

The probe result is only used for this filter — downstream code still re-fetches the replica from the tablet. This is intentional: `TabletInvertedIndex.addReplica` appends without dedup, while `LocalTablet.deleteRedundantReplica` does not synchronously prune the inverted index, so a probe can return a replica that has been replaced on the tablet. Re-fetching from the tablet keeps the downstream state/defer/isBad checks authoritative.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4