### PR TITLE
[BugFix] fix Nested materialized view refresh Npe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -231,7 +231,7 @@ public abstract class MVTimelinessArbiter {
     /**
      * Collect ref base table's update partition infos
      * @param refBaseTableAndColumns ref base table and columns of mv
-     * @return ref base table's changed partition names
+     * @return ref base table's changed partition names, or null if the partial refresh info cannot be collected safely
      */
     protected Map<Table, PCellSortedSet> collectBaseTableUpdatePartitionNames(Map<Table, List<Column>> refBaseTableAndColumns,
                                                                               MvUpdateInfo mvUpdateInfo) {
@@ -239,6 +239,11 @@ public abstract class MVTimelinessArbiter {
         for (Table baseTable : refBaseTableAndColumns.keySet()) {
             MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, baseTable,
                     true, queryRewriteParams);
+            if (mvBaseTableUpdateInfo == null) {
+                logMVPrepare(mv, "Failed to collect update info for ref base table {}, fallback to full refresh",
+                        baseTable.getName());
+                return null;
+            }
             mvUpdateInfo.getBaseTableUpdateInfos().put(baseTable, mvBaseTableUpdateInfo);
             // If base table is a mv, its to-update partitions may not be created yet, skip it
             baseChangedPartitionNames.put(baseTable, mvBaseTableUpdateInfo.getToRefreshPCells());
@@ -352,7 +357,9 @@ public abstract class MVTimelinessArbiter {
         }
         addEmptyPartitionsToRefresh(mvUpdateInfo);
         try (Timer ignored = Tracers.watchScope("CollectBaseTableUpdatePartitionNames")) {
-            collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo);
+            if (!collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo)) {
+                return MvUpdateInfo.fullRefresh(mv);
+            }
         }
         try (Timer ignored = Tracers.watchScope("CollectMVToBaseTablePartitionNames")) {
             collectMVToBaseTablePartitionNames(refBaseTablePartitionMap, diff, mvUpdateInfo);
@@ -379,10 +386,10 @@ public abstract class MVTimelinessArbiter {
      * TODO: Optimize performance in loos/force_mv mode
      * TODO: in loose mode, ignore partition that both exists in baseTable and mv
      */
-    protected void collectBaseTableUpdatePartitionNamesInLoose(MvUpdateInfo mvUpdateInfo) {
+    protected boolean collectBaseTableUpdatePartitionNamesInLoose(MvUpdateInfo mvUpdateInfo) {
         Map<Table, List<Column>> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
         // collect & update mv's to refresh partitions based on base table's partition changes
-        collectBaseTableUpdatePartitionNames(refBaseTableAndColumns, mvUpdateInfo);
+        return collectBaseTableUpdatePartitionNames(refBaseTableAndColumns, mvUpdateInfo) != null;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -70,6 +70,9 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
         try (Timer ignored = Tracers.watchScope("CollectBaseTableUpdatePartitionNames")) {
             baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTablePartitionColumns,
                     mvTimelinessInfo);
+            if (baseChangedPartitionNames == null) {
+                return MvUpdateInfo.fullRefresh(mv);
+            }
         }
 
         // collect base table's partition infos

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
@@ -69,9 +69,11 @@ public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
 
             // once mv's base table has updated, refresh the materialized view totally.
             MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, table, true, queryRewriteParams);
-            // TODO: fixme if mvBaseTableUpdateInfo is null, should return full refresh?
-            if (mvBaseTableUpdateInfo != null &&
-                    mvBaseTableUpdateInfo.getToRefreshPCells() != null &&
+            if (mvBaseTableUpdateInfo == null) {
+                logMVPrepare(mv, "Non-partitioned base table update info is unknown, need refresh totally.");
+                return MvUpdateInfo.fullRefresh(mv);
+            }
+            if (mvBaseTableUpdateInfo.getToRefreshPCells() != null &&
                     !mvBaseTableUpdateInfo.getToRefreshPCells().isEmpty()) {
                 logMVPrepare(mv, "Non-partitioned base table has updated, need refresh totally.");
                 return MvUpdateInfo.fullRefresh(mv);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -79,6 +79,9 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         try (Timer ignored = Tracers.watchScope("CollectBaseTableUpdatePartitionNames")) {
             baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTablePartitionColumns,
                     mvTimelinessInfo);
+            if (baseChangedPartitionNames == null) {
+                return MvUpdateInfo.fullRefresh(mv);
+            }
         }
 
         // collect all ref base table's partition range map


### PR DESCRIPTION
## Why I'm doing:
A partitioned MV refresh can fail with an NPE when the MV depends on nested MVs. If a nested MV returns FULL or UNKNOWN timeliness, for example because a non-ref base table changed, partition diff cannot be computed, or partition-level update info is unavailable, getMvBaseTableUpdateInfo() returns null. The parent MV then dereferences it in collectBaseTableUpdatePartitionNames()

```
Refresh mv xxx failed after 1 times, try lock failed: 0,
error-msg : java.lang.NullPointerException: Cannot invoke
"com.starrocks.catalog.MvBaseTableUpdateInfo.getToRefreshPartitionNames()"
because "mvBaseTableUpdateInfo" is null

    at com.starrocks.catalog.mv.MVTimelinessArbiter.collectBaseTableUpdatePartitionNames(MVTimelinessArbiter.java:237)
    at com.starrocks.catalog.mv.MVTimelinessRangePartitionArbiter.getMVTimelinessUpdateInfoInChecked(MVTimelinessRangePartitionArbiter.java:83)
    at com.starrocks.catalog.mv.MVTimelinessArbiter.getMVTimelinessUpdateInfo(MVTimelinessArbiter.java:153)
    at com.starrocks.catalog.MvRefreshArbiter.getMVTimelinessUpdateInfo(MvRefreshArbiter.java:93)
    at com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo(MvRefreshArbiter.java:187)
    at com.starrocks.catalog.mv.MVTimelinessArbiter.collectBaseTableUpdatePartitionNames(MVTimelinessArbiter.java:233)
    at com.starrocks.catalog.mv.MVTimelinessRangePartitionArbiter.getMVTimelinessUpdateInfoInChecked(MVTimelinessRangePartitionArbiter.java:83)
    at com.starrocks.catalog.mv.MVTimelinessArbiter.getMVTimelinessUpdateInfo(MVTimelinessArbiter.java:153)
    at com.starrocks.catalog.MvRefreshArbiter.getMVTimelinessUpdateInfo(MvRefreshArbiter.java:93)
    at com.starrocks.catalog.MvRefreshArbiter.needsToRefreshTable(MvRefreshArbiter.java:148)
    at com.starrocks.catalog.MvRefreshArbiter.needsToRefreshTable(MvRefreshArbiter.java:51)
    at com.starrocks.scheduler.mv.MVPCTRefreshPartitioner.needsRefreshBasedOnNonRefTables(MVPCTRefreshPartitioner.java:272)
    at com.starrocks.scheduler.mv.MVPCTRefreshRangePartitioner.getMVPartitionsToRefresh(MVPCTRefreshRangePartitioner.java:286)
    at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.getPartitionsToRefreshForMaterializedView(PartitionBasedMvRefreshProcessor.java:1050)
    at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.checkMvToRefreshedPartitions(PartitionBasedMvRefreshProcessor.java:298)
    at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:480)
    at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:408)
    at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:342)
    at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:195)
    at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:383)
    at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60)
    at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.base/java.lang.Thread.run(Thread.java:840)
```

## What I'm doing:
Treat null base table update info as “partial refresh info is unavailable” and fall back to full refresh instead of continuing the partial refresh path.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
