### PR TITLE
[BugFix] Add write timeout to MysqlChannel result send path

### DIFF
--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -839,6 +839,15 @@ This topic introduces the following types of FE configurations:
 - Description: The length of the backlog queue held by the MySQL server in the FE node.
 - Introduced in: -
 
+### `mysql_send_packet_timeout_ms`
+
+- Default: 60000
+- Type: Long
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: Per-packet write timeout for the MySQL protocol channel. Bounds how long the FE worker can wait for a slow client's TCP recv buffer to drain when sending result rows. Without this bound the worker can block in `Selector.select()` indefinitely and the query becomes unkillable via `KILL QUERY`. Set to `0` to disable (legacy unbounded wait).
+- Introduced in: v4.1
+
 ### `mysql_server_version`
 
 - Default: 8.0.33

--- a/docs/ja/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/FE_parameters/log_server_meta.md
@@ -830,6 +830,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：FE ノードの MySQL サーバーが保持するバックログキューの長さ。
 - 導入時期：-
 
+### `mysql_send_packet_timeout_ms`
+
+- デフォルト：60000
+- タイプ：Long
+- 単位：Milliseconds
+- 変更可能：Yes
+- 説明：MySQL プロトコルチャネルにおけるパケット単位の書き込みタイムアウト。結果行を送信する際、低速クライアントの TCP 受信バッファが空くまで FE ワーカーが待つ時間を制限します。これを設けないと、ワーカーが `Selector.select()` で無期限にブロックし、クエリが `KILL QUERY` で終了できなくなります。`0` に設定するとタイムアウトを無効化します（従来の無期限待機の動作）。
+- 導入時期：v4.1
+
 ### `mysql_server_version`
 
 - デフォルト：8.0.33

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -838,6 +838,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: FE 节点中 MySQL 服务器持有的 backlog 队列的长度。
 - 引入版本: -
 
+### `mysql_send_packet_timeout_ms`
+
+- 默认值: 60000
+- 类型: Long
+- 单位: Milliseconds
+- 是否可变: Yes
+- 描述: MySQL 协议通道单次写包的超时时间。限制 FE worker 在发送结果行时等待慢客户端 TCP 接收缓冲区排空的时长。不限制的话 worker 可能在 `Selector.select()` 上无限阻塞，且查询无法被 `KILL QUERY` 终止。设置为 `0` 禁用（旧版无限等待行为）。
+- 引入版本: v4.1
+
 ### `mysql_server_version`
 
 - 默认值: 8.0.33

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1099,6 +1099,15 @@ public class Config extends ConfigBase {
     public static int max_mysql_service_task_threads_num = 4096;
 
     /**
+     * Per-packet write timeout for MysqlChannel result delivery. Bounds how long the FE
+     * worker can wait for a slow client's TCP recv buffer to drain; without this the
+     * worker can sit in {@code Selector.select()} indefinitely and the query becomes
+     * unkillable by {@code KILL QUERY}. Set to 0 for the legacy unbounded wait.
+     */
+    @ConfField(mutable = true)
+    public static long mysql_send_packet_timeout_ms = 60_000L;
+
+    /**
      * modifies the version string returned by following situations:
      * select version();
      * handshake packet version.

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.mysql;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.util.NetUtils;
 import com.starrocks.mysql.nio.MySQLReadListener;
 import com.starrocks.mysql.ssl.SSLChannel;
@@ -48,6 +49,7 @@ import org.xnio.channels.Channels;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class used to read/write MySQL logical packet.
@@ -244,12 +246,24 @@ public class MysqlChannel {
 
     public void realNetSend(ByteBuffer buffer) throws IOException {
         long bufLen = buffer.remaining();
-        long writeLen = Channels.writeBlocking(conn.getSinkChannel(), buffer);
+        // timeoutMs <= 0 keeps legacy unbounded wait for both phases. With a timeout, both
+        // writeBlocking and flushBlocking are bounded; either phase converts a slow-client
+        // hang into IOException so the connection cleanup path runs.
+        long timeoutMs = Config.mysql_send_packet_timeout_ms;
+        long writeLen = timeoutMs > 0
+                ? Channels.writeBlocking(conn.getSinkChannel(), buffer, timeoutMs, TimeUnit.MILLISECONDS)
+                : Channels.writeBlocking(conn.getSinkChannel(), buffer);
         if (bufLen != writeLen) {
             throw new IOException("Write mysql packet failed.[write=" + writeLen
-                    + ", needToWrite=" + bufLen + "]");
+                    + ", needToWrite=" + bufLen + ", timeoutMs=" + timeoutMs + "]");
         }
-        Channels.flushBlocking(conn.getSinkChannel());
+        if (timeoutMs > 0) {
+            if (!Channels.flushBlocking(conn.getSinkChannel(), timeoutMs, TimeUnit.MILLISECONDS)) {
+                throw new IOException("Flush mysql packet timed out.[timeoutMs=" + timeoutMs + "]");
+            }
+        } else {
+            Channels.flushBlocking(conn.getSinkChannel());
+        }
         isSend = true;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChannelTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlChannelTest.java
@@ -1,0 +1,183 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.mysql;
+
+import com.starrocks.common.Config;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xnio.StreamConnection;
+import org.xnio.channels.Channels;
+import org.xnio.conduits.ConduitStreamSinkChannel;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+public class MysqlChannelTest {
+
+    @Mocked
+    private StreamConnection conn;
+
+    @Mocked
+    private ConduitStreamSinkChannel sinkChannel;
+
+    // @Mocked on Channels makes JMockit intercept the static writeBlocking / flushBlocking
+    // calls; without it the real XNIO code would block on the mocked sink channel.
+    @Mocked
+    private Channels channels;
+
+    private long originalTimeout;
+
+    @BeforeEach
+    public void setUp() {
+        originalTimeout = Config.mysql_send_packet_timeout_ms;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Config.mysql_send_packet_timeout_ms = originalTimeout;
+    }
+
+    private MysqlChannel newChannelWithConn() {
+        // Constructor reads getPeerAddress() for diagnostics; return a real InetSocketAddress.
+        InetSocketAddress peer = new InetSocketAddress("127.0.0.1", 12345);
+        new Expectations() {
+            {
+                conn.getPeerAddress();
+                result = peer;
+                minTimes = 0;
+            }
+        };
+        return new MysqlChannel(conn);
+    }
+
+    @Test
+    public void testRealNetSendUsesTimedWriteAndFlushWhenTimeoutConfigured() throws Exception {
+        Config.mysql_send_packet_timeout_ms = 30_000L;
+        MysqlChannel channel = newChannelWithConn();
+        ByteBuffer buffer = ByteBuffer.allocate(16);
+        buffer.position(buffer.limit());
+        buffer.flip();
+
+        new Expectations() {
+            {
+                conn.getSinkChannel();
+                result = sinkChannel;
+                minTimes = 1;
+
+                Channels.writeBlocking(sinkChannel, buffer, 30_000L, TimeUnit.MILLISECONDS);
+                result = 16;
+                times = 1;
+
+                Channels.flushBlocking(sinkChannel, 30_000L, TimeUnit.MILLISECONDS);
+                result = true;
+                times = 1;
+            }
+        };
+
+        channel.realNetSend(buffer);
+    }
+
+    @Test
+    public void testRealNetSendUsesUntimedWriteAndFlushWhenTimeoutDisabled() throws Exception {
+        Config.mysql_send_packet_timeout_ms = 0L;
+        MysqlChannel channel = newChannelWithConn();
+        ByteBuffer buffer = ByteBuffer.allocate(16);
+        buffer.position(buffer.limit());
+        buffer.flip();
+
+        new Expectations() {
+            {
+                conn.getSinkChannel();
+                result = sinkChannel;
+                minTimes = 1;
+
+                Channels.writeBlocking(sinkChannel, buffer);
+                result = 16;
+                times = 1;
+
+                Channels.flushBlocking(sinkChannel);
+                times = 1;
+            }
+        };
+
+        channel.realNetSend(buffer);
+    }
+
+    @Test
+    public void testRealNetSendThrowsOnPartialWriteAfterTimeout() throws Exception {
+        Config.mysql_send_packet_timeout_ms = 5_000L;
+        MysqlChannel channel = newChannelWithConn();
+        ByteBuffer buffer = ByteBuffer.allocate(100);
+        buffer.position(buffer.limit());
+        buffer.flip();
+
+        new Expectations() {
+            {
+                conn.getSinkChannel();
+                result = sinkChannel;
+                minTimes = 1;
+
+                Channels.writeBlocking(sinkChannel, buffer, 5_000L, TimeUnit.MILLISECONDS);
+                result = 40; // simulate timeout after partial write
+                times = 1;
+            }
+        };
+
+        IOException ex = Assertions.assertThrows(IOException.class, () -> channel.realNetSend(buffer));
+        Assertions.assertTrue(ex.getMessage().contains("write=40"),
+                "Exception message should report bytes actually written; got: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("needToWrite=100"),
+                "Exception message should report bytes requested; got: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("timeoutMs=5000"),
+                "Exception message should include the configured timeout; got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testRealNetSendThrowsOnFlushTimeout() throws Exception {
+        Config.mysql_send_packet_timeout_ms = 5_000L;
+        MysqlChannel channel = newChannelWithConn();
+        ByteBuffer buffer = ByteBuffer.allocate(16);
+        buffer.position(buffer.limit());
+        buffer.flip();
+
+        new Expectations() {
+            {
+                conn.getSinkChannel();
+                result = sinkChannel;
+                minTimes = 1;
+
+                Channels.writeBlocking(sinkChannel, buffer, 5_000L, TimeUnit.MILLISECONDS);
+                result = 16;
+                times = 1;
+
+                Channels.flushBlocking(sinkChannel, 5_000L, TimeUnit.MILLISECONDS);
+                result = false; // flush timed out
+                times = 1;
+            }
+        };
+
+        IOException ex = Assertions.assertThrows(IOException.class, () -> channel.realNetSend(buffer));
+        Assertions.assertTrue(ex.getMessage().contains("Flush"),
+                "Exception message should indicate flush failure; got: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("timeoutMs=5000"),
+                "Exception message should include the configured timeout; got: " + ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When a MySQL client stops draining its TCP receive buffer (slow consumer or backpressure), the FE worker that's sending result rows blocks **indefinitely** in `Selector.select()` on `OP_WRITE` inside `MysqlChannel.realNetSend`. The query becomes unkillable via `KILL QUERY` because `Coordinator.cancel()` only cancels work on the BE side and does not interrupt the FE-side socket wait. The connection can only be released via `KILL CONNECTION`, which closes the channel and wakes the selector.

We hit this in production on a follower FE running shared-data. A `WITH ... window function` query stayed in `SHOW PROC '/current_queries'` for ~30 minutes; `KILL QUERY` and the internal `Connect-Scheduler-Check-Timer` both ran every second but had no effect. The stack trace captured during the hang:

```
"starrocks-mysql-nio-pool-15167" #1321580 daemon prio=5 ... runnable
   java.lang.Thread.State: RUNNABLE
    at sun.nio.ch.EPoll.wait(Native Method)
    at sun.nio.ch.EPollSelectorImpl.doSelect(EPollSelectorImpl.java:118)
    at sun.nio.ch.SelectorImpl.lockAndDoSelect(SelectorImpl.java:129)
    at sun.nio.ch.SelectorImpl.select(SelectorImpl.java:146)
    at org.xnio.nio.SelectorUtils.await(SelectorUtils.java:51)
    at org.xnio.nio.NioSocketConduit.awaitWritable(NioSocketConduit.java:233)
    at org.xnio.channels.Channels.writeBlocking(Channels.java:149)
    at com.starrocks.mysql.MysqlChannel.realNetSend(MysqlChannel.java:239)
    at com.starrocks.mysql.MysqlChannel.send(MysqlChannel.java:232)
    at com.starrocks.mysql.MysqlChannel.flush(MysqlChannel.java:256)
    at com.starrocks.mysql.MysqlChannel.writeBuffer(MysqlChannel.java:294)
    at com.starrocks.mysql.MysqlChannel.sendOnePacket(MysqlChannel.java:318)
    at com.starrocks.qe.StmtExecutor.responseRowBatch(StmtExecutor.java:1621)
    at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:1598)
    at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:812)
    at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:372)
    ...
```

The thread is parked on epoll waiting for `OP_WRITE` while sending result rows; the client is just not consuming.

## What I'm doing:

Switch `MysqlChannel.realNetSend` to the timed variant of `Channels.writeBlocking`, gated by a new mutable FE config `mysql_send_packet_timeout_ms` (default 60_000 ms, aligned in spirit with MySQL's `net_write_timeout`). When the timeout fires, the underlying `writeBlocking` returns a partial byte count, the existing `bufLen != writeLen` check throws `IOException`, the call stack unwinds, and the connection is cleaned up through the normal error path — `KILL QUERY` and timeout-based kill both work again. Setting the config to `0` preserves the legacy unbounded-wait behavior for compatibility.

The error message now includes `timeoutMs=...` so the failure mode is easy to identify in logs.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes
- [x] Parameter changes: a new FE config `mysql_send_packet_timeout_ms` is introduced. Default is 60_000 ms; set to 0 for legacy behavior.
- [ ] Policy changes
- [ ] Feature removed
- [ ] Miscellaneous

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
  - `MysqlChannelTest` covers: timed variant when timeout > 0, untimed variant when timeout = 0, IOException on partial write after timeout.
- [x] This pr needs user documentation
  - [x] I have added documentation for my new feature or new function (EN / ZH / JA `FE_parameters/log_server_meta.md`)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5