### PR TITLE
[BugFix] Preserve column and table comments in Delta Lake catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
@@ -83,8 +83,11 @@ public class DeltaUtils {
             fullSchema.add(column);
         }
 
-        return new DeltaLakeTable(CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalog, dbName, tblName, fullSchema,
-                loadPartitionColumnNames(snapshotImpl), snapshotImpl, deltaLakeEngine, snapshot.getMetastoreTable());
+        DeltaLakeTable deltaLakeTable = new DeltaLakeTable(CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalog,
+                dbName, tblName, fullSchema, loadPartitionColumnNames(snapshotImpl), snapshotImpl, deltaLakeEngine,
+                snapshot.getMetastoreTable());
+        snapshotImpl.getMetadata().getDescription().ifPresent(deltaLakeTable::setComment);
+        return deltaLakeTable;
     }
 
     public static List<String> loadPartitionColumnNames(SnapshotImpl snapshot) {
@@ -106,7 +109,11 @@ public class DeltaUtils {
         String columnName = field.getName();
         int columnUniqueId = COLUMN_UNIQUE_ID_INIT_VALUE;
         String physicalName = "";
+        String comment = "";
 
+        if (field.getMetadata().contains("comment")) {
+            comment = (String) field.getMetadata().get("comment");
+        }
         if (columnMappingMode.equalsIgnoreCase(ColumnMapping.COLUMN_MAPPING_MODE_ID) &&
                 field.getMetadata().contains(ColumnMapping.COLUMN_MAPPING_ID_KEY)) {
             columnUniqueId = ((Long) field.getMetadata().get(ColumnMapping.COLUMN_MAPPING_ID_KEY)).intValue();
@@ -116,7 +123,7 @@ public class DeltaUtils {
             physicalName = (String) field.getMetadata().get(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY);
         }
         return new Column(columnName, type, false, null, null, true,
-                null, "", columnUniqueId, physicalName);
+                null, comment, columnUniqueId, physicalName);
     }
 
     public static RemoteFileInputFormat getRemoteFileFormat(String format) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
@@ -16,9 +16,11 @@ package com.starrocks.connector.delta;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.connector.metastore.MetastoreTable;
 import com.starrocks.sql.optimizer.validate.ValidateException;
+import com.starrocks.type.Type;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.engine.Engine;
@@ -27,6 +29,7 @@ import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.types.DateType;
+import io.delta.kernel.types.FieldMetadata;
 import io.delta.kernel.types.IntegerType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
@@ -39,6 +42,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static io.delta.kernel.internal.util.ColumnMapping.COLUMN_MAPPING_MODE_KEY;
 import static io.delta.kernel.internal.util.ColumnMapping.COLUMN_MAPPING_MODE_NAME;
@@ -70,12 +74,20 @@ public class DeltaUtilsTest {
     }
 
     @Test
-    public void testConvertDeltaSnapshotToSRTable(@Mocked SnapshotImpl snapshot) {
+    public void testConvertDeltaSnapshotToSRTable(@Mocked SnapshotImpl snapshot, @Mocked Metadata metadata) {
         new Expectations() {
             {
                 snapshot.getSchema((Engine) any);
                 result = new StructType(Lists.newArrayList(new StructField("col1", IntegerType.INTEGER, true),
                         new StructField("col2", DateType.DATE, true)));
+                minTimes = 0;
+
+                snapshot.getMetadata();
+                result = metadata;
+                minTimes = 0;
+
+                metadata.getDescription();
+                result = Optional.empty();
                 minTimes = 0;
             }
         };
@@ -101,6 +113,46 @@ public class DeltaUtilsTest {
         Assertions.assertEquals("catalog0", deltaLakeTable.getCatalogName());
         Assertions.assertEquals("db0", deltaLakeTable.getCatalogDBName());
         Assertions.assertEquals("table0", deltaLakeTable.getCatalogTableName());
+        Assertions.assertEquals("", deltaLakeTable.getComment());
+    }
+
+    @Test
+    public void testConvertDeltaSnapshotToSRTablePreservesDescription(@Mocked SnapshotImpl snapshot,
+                                                                      @Mocked Metadata metadata) {
+        new Expectations() {
+            {
+                snapshot.getSchema((Engine) any);
+                result = new StructType(Lists.newArrayList(new StructField("col1", IntegerType.INTEGER, true)));
+                minTimes = 0;
+
+                snapshot.getMetadata();
+                result = metadata;
+                minTimes = 0;
+
+                metadata.getDescription();
+                result = Optional.of("my table description");
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<ColumnMapping>() {
+            @Mock
+            public String getColumnMappingMode(Configuration configuration) {
+                return COLUMN_MAPPING_MODE_NONE;
+            }
+        };
+
+        new MockUp<DeltaUtils>() {
+            @Mock
+            public List<String> loadPartitionColumnNames(SnapshotImpl snapshot) {
+                return Lists.newArrayList();
+            }
+        };
+
+        DeltaLakeTable deltaLakeTable = DeltaUtils.convertDeltaSnapshotToSRTable("catalog0",
+                new DeltaLakeSnapshot("db0", "table0", null, snapshot,
+                        new MetastoreTable("db1", "table1", "s3://bucket/path/to/table", 123)));
+        Assertions.assertEquals("my table description", deltaLakeTable.getComment());
     }
 
     @Test
@@ -198,6 +250,64 @@ public class DeltaUtilsTest {
         Throwable exception = assertThrows(IllegalArgumentException.class, () ->
                 DeltaUtils.loadPartitionColumnNames(snapshot));
         assertThat(exception.getMessage(), containsString("Expected a non-null partition column name"));
+    }
+
+    @Test
+    public void testBuildColumnWithColumnMappingPreservesComment(@Mocked StructField field,
+                                                                 @Mocked FieldMetadata fieldMetadata,
+                                                                 @Mocked Type type) {
+        new Expectations() {
+            {
+                field.getName();
+                result = "col1";
+
+                field.getMetadata();
+                result = fieldMetadata;
+
+                fieldMetadata.contains("comment");
+                result = true;
+                fieldMetadata.get("comment");
+                result = "first column comment";
+
+                fieldMetadata.contains(ColumnMapping.COLUMN_MAPPING_ID_KEY);
+                result = false;
+                fieldMetadata.contains(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY);
+                result = false;
+            }
+        };
+
+        Column column = DeltaUtils.buildColumnWithColumnMapping(field, type, COLUMN_MAPPING_MODE_NONE);
+
+        Assertions.assertEquals("col1", column.getName());
+        Assertions.assertEquals("first column comment", column.getComment());
+    }
+
+    @Test
+    public void testBuildColumnWithColumnMappingNoCommentMetadata(@Mocked StructField field,
+                                                                  @Mocked FieldMetadata fieldMetadata,
+                                                                  @Mocked Type type) {
+        new Expectations() {
+            {
+                field.getName();
+                result = "col1";
+
+                field.getMetadata();
+                result = fieldMetadata;
+
+                fieldMetadata.contains("comment");
+                result = false;
+
+                fieldMetadata.contains(ColumnMapping.COLUMN_MAPPING_ID_KEY);
+                result = false;
+                fieldMetadata.contains(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY);
+                result = false;
+            }
+        };
+
+        Column column = DeltaUtils.buildColumnWithColumnMapping(field, type, COLUMN_MAPPING_MODE_NONE);
+
+        Assertions.assertEquals("col1", column.getName());
+        Assertions.assertEquals("", column.getComment());
     }
 
     @Test


### PR DESCRIPTION
Fixes #73682

## Why I'm doing:

When a Delta Lake table has column comments or a table description in its `_delta_log` schema metadata (set via Spark `ALTER TABLE ... ALTER COLUMN ... COMMENT '...'`, `COMMENT ON COLUMN`, or `COMMENT ON TABLE`), StarRocks dropped them during schema conversion. `SHOW CREATE TABLE`, `DESCRIBE`, and `information_schema.{columns,tables}` all returned empty comment/description for Delta Lake external catalog tables, even though Spark and Trino can see the same values.

### Reproduce

1. Create a Delta table with comments via Spark:
   ```sql
   COMMENT ON TABLE delta_db.tbl IS 'my table description';
   ALTER TABLE delta_db.tbl ALTER COLUMN id COMMENT 'user id';
   ```
2. Register in HMS and add as a StarRocks Delta Lake catalog.
3. `SHOW CREATE TABLE delta_lake_catalog.delta_db.tbl;` — both `COMMENT` clauses are missing.

### Root cause

1. `DeltaUtils.buildColumnWithColumnMapping` hardcoded the `comment` argument of the StarRocks `Column` constructor to `""`. It read `field.getMetadata()` only for column-mapping keys and never for the standard `comment` key.
2. `DeltaUtils.convertDeltaSnapshotToSRTable` never read `Metadata.getDescription()` and never propagated it to `DeltaLakeTable`.

## What I'm doing:

1. Read the standard `comment` key from `StructField.getMetadata()` and pass it through to the `Column` constructor.
2. Read `Metadata.getDescription()` (an `Optional<String>`) and propagate it to `DeltaLakeTable.setComment(...)` when present.

Added unit tests in `DeltaUtilsTest`:
- `testBuildColumnWithColumnMappingPreservesComment` — column comment metadata is propagated to `Column.getComment()`.
- `testBuildColumnWithColumnMappingNoCommentMetadata` — when no column comment metadata is set, `Column.getComment()` remains `""` (regression guard).
- `testConvertDeltaSnapshotToSRTablePreservesDescription` — table description is propagated to `DeltaLakeTable.getComment()`.
- Existing `testConvertDeltaSnapshotToSRTable` extended to assert the `Optional.empty()` description case leaves `getComment()` as `""`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
