### PR TITLE
[BugFix] Transcode PK .del files on V1->V2 cross-cluster replication

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -45,6 +45,7 @@ set(STORAGE_FILES
     replication_txn_manager.cpp
     replication_utils.cpp
     segment_stream_converter.cpp
+    del_file_stream_converter.cpp
     rowset_update_state.cpp
     rowset_column_update_state.cpp
     update_compaction_state.cpp

--- a/be/src/storage/del_file_stream_converter.cpp
+++ b/be/src/storage/del_file_stream_converter.cpp
@@ -1,0 +1,143 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/del_file_stream_converter.h"
+
+#include "column/chunk.h"
+#include "column/column.h"
+#include "column/schema.h"
+#include "gutil/strings/substitute.h"
+#include "serde/column_array_serde.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/tablet_schema.h"
+#include "storage/types.h"
+#include "types/logical_type_infra.h"
+
+namespace starrocks {
+
+namespace {
+
+bool is_fixed_length_non_string_pk_type(LogicalType type) {
+    switch (type) {
+#define M(LT) case LT:
+        APPLY_FOR_ALL_PK_SUPPORT_FIXED_TYPE(M)
+#undef M
+        return true;
+    default:
+        // TYPE_VARCHAR and other types fall through; they are binary-compatible across V1/V2.
+        return false;
+    }
+}
+
+} // namespace
+
+bool is_single_fixed_length_non_string_primary_key(const Schema& pkey_schema) {
+    return pkey_schema.num_fields() == 1 && is_fixed_length_non_string_pk_type(pkey_schema.field(0)->type()->type());
+}
+
+bool is_single_fixed_length_non_string_primary_key(const TabletSchema& tablet_schema) {
+    return tablet_schema.num_key_columns() == 1 &&
+           is_fixed_length_non_string_pk_type(tablet_schema.column(0).type());
+}
+
+bool requires_v1_to_v2_del_transcode(PrimaryKeyEncodingType source_encoding, PrimaryKeyEncodingType target_encoding,
+                                     const Schema& pkey_schema) {
+    return source_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1 &&
+           target_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2 &&
+           is_single_fixed_length_non_string_primary_key(pkey_schema);
+}
+
+DelFileStreamConverter::DelFileStreamConverter(std::string_view input_file_name, uint64_t input_file_size,
+                                               std::unique_ptr<WritableFile> output_file, SchemaPtr pkey_schema,
+                                               PrimaryKeyEncodingType source_pk_encoding,
+                                               PrimaryKeyEncodingType target_pk_encoding)
+        : FileStreamConverter(input_file_name, input_file_size, std::move(output_file)),
+          _pkey_schema(std::move(pkey_schema)),
+          _source_pk_encoding(source_pk_encoding),
+          _target_pk_encoding(target_pk_encoding) {
+    DCHECK(_pkey_schema != nullptr);
+    DCHECK(_source_pk_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
+    DCHECK(_target_pk_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+}
+
+Status DelFileStreamConverter::append(const void* data, size_t size) {
+    if (size == 0) {
+        return Status::OK();
+    }
+    // Overflow-safe bound check against the declared input size.
+    const uint64_t buffered = _input_buffer.size();
+    if (buffered > _input_file_size || size > _input_file_size - buffered) {
+        LOG(WARNING) << "del file stream overflow, file: " << _input_file_name
+                     << ", declared_size: " << _input_file_size << ", already_buffered: " << buffered
+                     << ", incoming: " << size;
+        return Status::Corruption("del file append exceeds declared input_file_size");
+    }
+    _input_buffer.append(static_cast<const char*>(data), size);
+    return Status::OK();
+}
+
+Status DelFileStreamConverter::close() {
+    if (_input_buffer.size() != _input_file_size) {
+        LOG(WARNING) << "del file short read, file: " << _input_file_name << ", declared_size: " << _input_file_size
+                     << ", actual: " << _input_buffer.size();
+        return Status::Corruption("del file short read");
+    }
+
+    MutableColumnPtr src_col;
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*_pkey_schema, &src_col, _source_pk_encoding));
+
+    const uint8_t* const input_begin = reinterpret_cast<const uint8_t*>(_input_buffer.data());
+    const uint8_t* const input_end = input_begin + _input_buffer.size();
+    ASSIGN_OR_RETURN(const uint8_t* consumed_end,
+                     serde::ColumnArraySerde::deserialize(input_begin, input_end, src_col.get()));
+    if (consumed_end != input_end) {
+        LOG(WARNING) << "del file deserialize did not consume full buffer, file: " << _input_file_name
+                     << ", consumed: " << (consumed_end - input_begin) << ", total: " << _input_buffer.size();
+        return Status::Corruption("del file deserialize did not consume full buffer");
+    }
+    const size_t row_count = src_col->size();
+
+    // PrimaryKeyEncoder::encode reads typed raw_data from the source column and writes
+    // V2-encoded slices (sign-flipped big-endian for signed integers; see
+    // primary_key_encoder.h encode_integral) into the BinaryColumn destination.
+    MutableColumnPtr dst_col;
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*_pkey_schema, &dst_col, _target_pk_encoding));
+
+    Columns pk_columns;
+    pk_columns.emplace_back(std::move(src_col));
+    Chunk pk_chunk(std::move(pk_columns), _pkey_schema);
+    PrimaryKeyEncoder::encode(*_pkey_schema, pk_chunk, /*offset=*/0, /*len=*/row_count, dst_col.get(),
+                              _target_pk_encoding);
+
+    const int64_t output_capacity = serde::ColumnArraySerde::max_serialized_size(*dst_col);
+    if (output_capacity <= 0) {
+        return Status::InternalError("ColumnArraySerde::max_serialized_size returned 0 for target column");
+    }
+    std::string output_bytes;
+    output_bytes.resize(static_cast<size_t>(output_capacity));
+    auto* const output_begin = reinterpret_cast<uint8_t*>(output_bytes.data());
+    ASSIGN_OR_RETURN(uint8_t * output_end, serde::ColumnArraySerde::serialize(*dst_col, output_begin));
+    output_bytes.resize(static_cast<size_t>(output_end - output_begin));
+
+    // Skip the parent class size invariant: V1 and V2 layouts have different sizes by design.
+    RETURN_IF_ERROR(_output_file->append(Slice(output_bytes)));
+    _final_output_file_size = _output_file->size();
+
+    LOG(INFO) << "Del file V1->V2 transcode complete, file: " << _input_file_name << ", rows: " << row_count
+              << ", input_bytes: " << _input_file_size << ", output_bytes: " << _final_output_file_size;
+
+    return _output_file->close();
+}
+
+} // namespace starrocks

--- a/be/src/storage/del_file_stream_converter.cpp
+++ b/be/src/storage/del_file_stream_converter.cpp
@@ -47,8 +47,7 @@ bool is_single_fixed_length_non_string_primary_key(const Schema& pkey_schema) {
 }
 
 bool is_single_fixed_length_non_string_primary_key(const TabletSchema& tablet_schema) {
-    return tablet_schema.num_key_columns() == 1 &&
-           is_fixed_length_non_string_pk_type(tablet_schema.column(0).type());
+    return tablet_schema.num_key_columns() == 1 && is_fixed_length_non_string_pk_type(tablet_schema.column(0).type());
 }
 
 bool requires_v1_to_v2_del_transcode(PrimaryKeyEncodingType source_encoding, PrimaryKeyEncodingType target_encoding,

--- a/be/src/storage/del_file_stream_converter.h
+++ b/be/src/storage/del_file_stream_converter.h
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "column/vectorized_fwd.h"
+#include "storage/file_stream_converter.h"
+#include "storage/primary_key_encoding_types.h"
+#include "storage/types.h"
+
+namespace starrocks {
+
+class Schema;
+class TabletSchema;
+using SchemaPtr = std::shared_ptr<Schema>;
+
+// Returns true iff the primary key is a single non-string fixed-length column -- the only
+// PK shape where V1 and V2 produce different on-disk .del layouts. V1 stores it as a typed
+// column (e.g. Int32Column); V2 stores it as a BinaryColumn with order-preserving big-endian
+// slices. Composite keys and single-VARCHAR PK both materialize as BinaryColumn with
+// identical layout in V1 and V2.
+bool is_single_fixed_length_non_string_primary_key(const Schema& pkey_schema);
+bool is_single_fixed_length_non_string_primary_key(const TabletSchema& tablet_schema);
+
+// Returns true iff a .del file written with source PK encoding must be re-encoded to be
+// safely read under target PK encoding. Only V1 -> V2 on the byte-incompatible PK shape
+// above is supported for transcoding. The reverse direction (V2 -> V1) is byte-incompatible
+// too but is not transcodable here (no V2 -> typed-column decoder); callers should reject
+// it explicitly upstream.
+bool requires_v1_to_v2_del_transcode(PrimaryKeyEncodingType source_encoding, PrimaryKeyEncodingType target_encoding,
+                                     const Schema& pkey_schema);
+
+// Transcodes a primary-key .del file from source PK encoding to target PK encoding
+// during cross-cluster replication intake.
+//
+// The .del file holds the serialized PK column for deleted rows, written via
+// `serde::ColumnArraySerde::serialize`. When the source uses V1 with a single
+// non-string fixed-length PK, the on-disk shape is a typed column (e.g. Int32Column).
+// When the target uses V2, all encoders/readers expect a BinaryColumn whose slices
+// are order-preserving big-endian encodings. The two shapes are not byte-compatible,
+// so the bytes must be re-encoded once at intake. After this converter writes the
+// output file, every downstream consumer (publish-time `load_delete`, persistent-index
+// `load_dels`, future compaction or readers) sees target-encoded bytes uniformly.
+//
+// This converter is intentionally narrow: it is invoked ONLY when
+//   source = V1, target = V2, num_key_columns == 1, and the single PK column is one
+//   of the non-string fixed-length types listed in PrimaryKeyEncoder::is_supported
+//   (BOOLEAN/TINYINT/SMALLINT/INT/BIGINT/LARGEINT/DATE/DATETIME).
+// All other shapes are byte-identical between V1 and V2 (composite keys and single
+// VARCHAR PK both materialize as BinaryColumn with identical layout) and are handled
+// by the plain FileStreamConverter base.
+//
+// Buffering: a .del file is the serialized delete column from one memtable flush.
+// The full payload is buffered before decoding (the ColumnArraySerde format is not
+// streamable). This matches the existing RowsetUpdateState::load_delete pattern,
+// which also read_all()s the entire .del file before deserializing.
+class DelFileStreamConverter : public FileStreamConverter {
+public:
+    DelFileStreamConverter(std::string_view input_file_name, uint64_t input_file_size,
+                           std::unique_ptr<WritableFile> output_file, SchemaPtr pkey_schema,
+                           PrimaryKeyEncodingType source_pk_encoding, PrimaryKeyEncodingType target_pk_encoding);
+
+    Status append(const void* data, size_t size) override;
+    Status close() override;
+
+private:
+    SchemaPtr _pkey_schema;
+    PrimaryKeyEncodingType _source_pk_encoding;
+    PrimaryKeyEncodingType _target_pk_encoding;
+    std::string _input_buffer;
+};
+
+} // namespace starrocks

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -253,35 +253,9 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     std::vector<std::string> files_to_delete;
     CancelableDefer clean_files([&files_to_delete]() { lake::delete_files_async(std::move(files_to_delete)); });
 
-    // Guard: lake-to-lake replication routes .del files through copy_non_segment_file_with_retry
-    // (a raw byte copy), not through file_converters. So if source/target use different PK
-    // encodings in a way that produces non-byte-compatible .del bytes (single non-string
-    // fixed-length PK + V1->V2), the byte copy would silently corrupt the target. Reject
-    // explicitly until lake-to-lake routes .del through a transcoding converter as well.
-    //
-    // V1 source vs V2 target shows up when the source tablet is from a pre-#69939 cloud-native
-    // cluster (V1 default) and the target is post-#69939 (V2 default for new cloud-native tables).
-    if (is_primary_key(*target_tablet_meta)) {
-        // src_tablet_meta->has_schema() is guaranteed above (early Corruption otherwise).
-        TabletSchema source_schema(src_tablet_meta->schema());
-        TabletSchema target_schema(target_tablet_meta->schema());
-        ASSIGN_OR_RETURN(auto source_encoding, source_schema.primary_key_encoding_type_or_error());
-        ASSIGN_OR_RETURN(auto target_encoding, target_schema.primary_key_encoding_type_or_error());
-        // Both directions of V1<->V2 are byte-incompatible for single non-string fixed-length PK,
-        // and the lake-to-lake path raw-copies .del files. Reject either direction explicitly until
-        // .del is routed through a transcoding converter here as well.
-        if (source_encoding != target_encoding && is_single_fixed_length_non_string_primary_key(target_schema)) {
-            LOG(WARNING) << "Lake-to-lake replication with PK encoding mismatch is not supported, src_tablet: "
-                         << src_tablet_id << ", target_tablet: " << target_tablet_id
-                         << ", source_encoding: " << static_cast<int>(source_encoding)
-                         << ", target_encoding: " << static_cast<int>(target_encoding)
-                         << ", pk_logical_type: " << logical_type_to_string(target_schema.column(0).type());
-            return Status::NotSupported(
-                    "Lake-to-lake replication with V1<->V2 primary-key encoding change on a single "
-                    "non-string fixed-length PK column is not supported; .del files in this path "
-                    "are byte-copied without re-encoding and would fail to apply on the target.");
-        }
-    }
+    // src_tablet_meta->has_schema() is guaranteed by the early Corruption return above.
+    RETURN_IF_ERROR(check_pk_encoding_compat_for_lake_to_lake(src_tablet_id, target_tablet_id, *src_tablet_meta,
+                                                              *target_tablet_meta));
 
     // PK transcoding is gated above; pass nullptr/NONE so the converter never enters the .del
     // transcode branch in this code path.
@@ -489,6 +463,39 @@ bool LakeReplicationTxnManager::should_use_parallel_copy(size_t file_count, cons
         return false;
     }
     return thread_pool->num_queued_tasks() <= num_threads * kParallelCopyMaxQueuePerThread;
+}
+
+Status LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(int64_t src_tablet_id,
+                                                                            int64_t target_tablet_id,
+                                                                            const TabletMetadata& src_tablet_meta,
+                                                                            const TabletMetadata& target_tablet_meta) {
+    if (!is_primary_key(target_tablet_meta)) {
+        return Status::OK();
+    }
+    // Lake-to-lake replication routes .del files through copy_non_segment_file_with_retry (a raw
+    // byte copy), not through file_converters. So if source/target use different PK encodings in
+    // a way that produces non-byte-compatible .del bytes (single non-string fixed-length PK +
+    // V1<->V2), the byte copy would silently corrupt the target. Reject explicitly until .del
+    // is routed through a transcoding converter on this path as well.
+    //
+    // V1 source vs V2 target shows up when the source tablet is from a pre-#69939 cloud-native
+    // cluster (V1 default) and the target is post-#69939 (V2 default for new cloud-native tables).
+    TabletSchema source_schema(src_tablet_meta.schema());
+    TabletSchema target_schema(target_tablet_meta.schema());
+    ASSIGN_OR_RETURN(auto source_encoding, source_schema.primary_key_encoding_type_or_error());
+    ASSIGN_OR_RETURN(auto target_encoding, target_schema.primary_key_encoding_type_or_error());
+    if (source_encoding != target_encoding && is_single_fixed_length_non_string_primary_key(target_schema)) {
+        LOG(WARNING) << "Lake-to-lake replication with PK encoding mismatch is not supported, src_tablet: "
+                     << src_tablet_id << ", target_tablet: " << target_tablet_id
+                     << ", source_encoding: " << static_cast<int>(source_encoding)
+                     << ", target_encoding: " << static_cast<int>(target_encoding)
+                     << ", pk_logical_type: " << logical_type_to_string(target_schema.column(0).type());
+        return Status::NotSupported(
+                "Lake-to-lake replication with V1<->V2 primary-key encoding change on a single "
+                "non-string fixed-length PK column is not supported; .del files in this path "
+                "are byte-copied without re-encoding and would fail to apply on the target.");
+    }
+    return Status::OK();
 }
 
 StatusOr<size_t> LakeReplicationTxnManager::copy_non_segment_file_with_retry(

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -30,11 +30,16 @@
 #include "gen_cpp/lake_types.pb.h"
 #include "persistent_index_sstable.h"
 #include "replication_txn_manager.h"
+#include "storage/del_file_stream_converter.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/join_path.h"
+#include "storage/lake/meta_file.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/primary_key_encoding_types.h"
 #include "storage/segment_stream_converter.h"
+#include "storage/tablet_schema.h"
+#include "types/logical_type.h"
 #include "util/dynamic_cache.h"
 #include "vacuum.h"
 
@@ -248,8 +253,41 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     std::vector<std::string> files_to_delete;
     CancelableDefer clean_files([&files_to_delete]() { lake::delete_files_async(std::move(files_to_delete)); });
 
-    auto file_converters = lake::ReplicationTxnManager::build_file_converters(_tablet_manager, request, filename_map,
-                                                                              column_unique_id_map, files_to_delete);
+    // Guard: lake-to-lake replication routes .del files through copy_non_segment_file_with_retry
+    // (a raw byte copy), not through file_converters. So if source/target use different PK
+    // encodings in a way that produces non-byte-compatible .del bytes (single non-string
+    // fixed-length PK + V1->V2), the byte copy would silently corrupt the target. Reject
+    // explicitly until lake-to-lake routes .del through a transcoding converter as well.
+    //
+    // V1 source vs V2 target shows up when the source tablet is from a pre-#69939 cloud-native
+    // cluster (V1 default) and the target is post-#69939 (V2 default for new cloud-native tables).
+    if (is_primary_key(*target_tablet_meta)) {
+        // src_tablet_meta->has_schema() is guaranteed above (early Corruption otherwise).
+        TabletSchema source_schema(src_tablet_meta->schema());
+        TabletSchema target_schema(target_tablet_meta->schema());
+        ASSIGN_OR_RETURN(auto source_encoding, source_schema.primary_key_encoding_type_or_error());
+        ASSIGN_OR_RETURN(auto target_encoding, target_schema.primary_key_encoding_type_or_error());
+        // Both directions of V1<->V2 are byte-incompatible for single non-string fixed-length PK,
+        // and the lake-to-lake path raw-copies .del files. Reject either direction explicitly until
+        // .del is routed through a transcoding converter here as well.
+        if (source_encoding != target_encoding && is_single_fixed_length_non_string_primary_key(target_schema)) {
+            LOG(WARNING) << "Lake-to-lake replication with PK encoding mismatch is not supported, src_tablet: "
+                         << src_tablet_id << ", target_tablet: " << target_tablet_id
+                         << ", source_encoding: " << static_cast<int>(source_encoding)
+                         << ", target_encoding: " << static_cast<int>(target_encoding)
+                         << ", pk_logical_type: " << logical_type_to_string(target_schema.column(0).type());
+            return Status::NotSupported(
+                    "Lake-to-lake replication with V1<->V2 primary-key encoding change on a single "
+                    "non-string fixed-length PK column is not supported; .del files in this path "
+                    "are byte-copied without re-encoding and would fail to apply on the target.");
+        }
+    }
+
+    // PK transcoding is gated above; pass nullptr/NONE so the converter never enters the .del
+    // transcode branch in this code path.
+    auto file_converters = lake::ReplicationTxnManager::build_file_converters(
+            _tablet_manager, request, filename_map, column_unique_id_map, files_to_delete, /*pkey_schema=*/nullptr,
+            PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE, PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE);
 
     // Track which segments have size changes
     std::unordered_map<std::string, size_t> segment_size_changes;

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -254,7 +254,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     CancelableDefer clean_files([&files_to_delete]() { lake::delete_files_async(std::move(files_to_delete)); });
 
     // src_tablet_meta->has_schema() is guaranteed by the early Corruption return above.
-    RETURN_IF_ERROR(check_pk_encoding_compat_for_lake_to_lake(src_tablet_id, target_tablet_id, *src_tablet_meta,
+    RETURN_IF_ERROR(check_pk_encoding_compat(src_tablet_id, target_tablet_id, *src_tablet_meta,
                                                               *target_tablet_meta));
 
     // PK transcoding is gated above; pass nullptr/NONE so the converter never enters the .del
@@ -465,7 +465,7 @@ bool LakeReplicationTxnManager::should_use_parallel_copy(size_t file_count, cons
     return thread_pool->num_queued_tasks() <= num_threads * kParallelCopyMaxQueuePerThread;
 }
 
-Status LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(int64_t src_tablet_id,
+Status LakeReplicationTxnManager::check_pk_encoding_compat(int64_t src_tablet_id,
                                                                             int64_t target_tablet_id,
                                                                             const TabletMetadata& src_tablet_meta,
                                                                             const TabletMetadata& target_tablet_meta) {

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -254,8 +254,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     CancelableDefer clean_files([&files_to_delete]() { lake::delete_files_async(std::move(files_to_delete)); });
 
     // src_tablet_meta->has_schema() is guaranteed by the early Corruption return above.
-    RETURN_IF_ERROR(check_pk_encoding_compat(src_tablet_id, target_tablet_id, *src_tablet_meta,
-                                                              *target_tablet_meta));
+    RETURN_IF_ERROR(check_pk_encoding_compat(src_tablet_id, target_tablet_id, *src_tablet_meta, *target_tablet_meta));
 
     // PK transcoding is gated above; pass nullptr/NONE so the converter never enters the .del
     // transcode branch in this code path.
@@ -465,10 +464,9 @@ bool LakeReplicationTxnManager::should_use_parallel_copy(size_t file_count, cons
     return thread_pool->num_queued_tasks() <= num_threads * kParallelCopyMaxQueuePerThread;
 }
 
-Status LakeReplicationTxnManager::check_pk_encoding_compat(int64_t src_tablet_id,
-                                                                            int64_t target_tablet_id,
-                                                                            const TabletMetadata& src_tablet_meta,
-                                                                            const TabletMetadata& target_tablet_meta) {
+Status LakeReplicationTxnManager::check_pk_encoding_compat(int64_t src_tablet_id, int64_t target_tablet_id,
+                                                           const TabletMetadata& src_tablet_meta,
+                                                           const TabletMetadata& target_tablet_meta) {
     if (!is_primary_key(target_tablet_meta)) {
         return Status::OK();
     }

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -112,8 +112,8 @@ public:
     // non-string fixed-length PK column. Returns Status::OK for safe combinations and for
     // non-PK target tablets.
     static Status check_pk_encoding_compat(int64_t src_tablet_id, int64_t target_tablet_id,
-                                                            const TabletMetadata& src_tablet_meta,
-                                                            const TabletMetadata& target_tablet_meta);
+                                           const TabletMetadata& src_tablet_meta,
+                                           const TabletMetadata& target_tablet_meta);
 
     // Decide whether to use parallel copy for current tablet files.
     static bool should_use_parallel_copy(size_t file_count, const ThreadPool* thread_pool);

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -111,7 +111,7 @@ public:
     // without re-encoding). Specifically rejects either direction of V1<->V2 on a single
     // non-string fixed-length PK column. Returns Status::OK for safe combinations and for
     // non-PK target tablets.
-    static Status check_pk_encoding_compat_for_lake_to_lake(int64_t src_tablet_id, int64_t target_tablet_id,
+    static Status check_pk_encoding_compat(int64_t src_tablet_id, int64_t target_tablet_id,
                                                             const TabletMetadata& src_tablet_meta,
                                                             const TabletMetadata& target_tablet_meta);
 

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -106,6 +106,15 @@ public:
                                                              const std::string& target_file_location,
                                                              const WritableFileOptions& opts, int max_retry);
 
+    // Returns Status::NotSupported if the source/target PK encoding combination would produce
+    // byte-incompatible .del file copies in the lake-to-lake path (which raw-copies .del files
+    // without re-encoding). Specifically rejects either direction of V1<->V2 on a single
+    // non-string fixed-length PK column. Returns Status::OK for safe combinations and for
+    // non-PK target tablets.
+    static Status check_pk_encoding_compat_for_lake_to_lake(int64_t src_tablet_id, int64_t target_tablet_id,
+                                                            const TabletMetadata& src_tablet_meta,
+                                                            const TabletMetadata& target_tablet_meta);
+
     // Decide whether to use parallel copy for current tablet files.
     static bool should_use_parallel_copy(size_t file_count, const ThreadPool* thread_pool);
 

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -457,9 +457,9 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
         pkey_schema_for_del = std::make_shared<Schema>(ChunkHelper::convert_schema(target_schema, pk_idxes));
     }
 
-    auto file_converters = build_file_converters(_tablet_manager, request, filename_map, column_unique_id_map,
-                                                  files_to_delete, pkey_schema_for_del, source_pk_encoding,
-                                                  target_pk_encoding);
+    auto file_converters =
+            build_file_converters(_tablet_manager, request, filename_map, column_unique_id_map, files_to_delete,
+                                  pkey_schema_for_del, source_pk_encoding, target_pk_encoding);
 
     RETURN_IF_ERROR(ReplicationUtils::download_remote_snapshot(
             src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
@@ -706,15 +706,14 @@ FileConverterCreatorFunc ReplicationTxnManager::build_file_converters(
         const TabletManager* tablet_manager, const TReplicateSnapshotRequest& request,
         const std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map,
         std::unordered_map<uint32_t, uint32_t>& column_unique_id_map, std::vector<std::string>& files_to_delete,
-        SchemaPtr pkey_schema, PrimaryKeyEncodingType source_pk_encoding,
-        PrimaryKeyEncodingType target_pk_encoding) {
-    const bool need_del_transcode = pkey_schema != nullptr && requires_v1_to_v2_del_transcode(
-                                                                      source_pk_encoding, target_pk_encoding,
-                                                                      *pkey_schema);
-    auto file_converters = [tablet_manager, request, filename_map, &column_unique_id_map, &files_to_delete,
-                            pkey_schema, source_pk_encoding, target_pk_encoding, need_del_transcode](
-                                   const std::string& file_name,
-                                   uint64_t file_size) -> StatusOr<std::unique_ptr<FileStreamConverter>> {
+        SchemaPtr pkey_schema, PrimaryKeyEncodingType source_pk_encoding, PrimaryKeyEncodingType target_pk_encoding) {
+    const bool need_del_transcode =
+            pkey_schema != nullptr &&
+            requires_v1_to_v2_del_transcode(source_pk_encoding, target_pk_encoding, *pkey_schema);
+    auto file_converters = [tablet_manager, request, filename_map, &column_unique_id_map, &files_to_delete, pkey_schema,
+                            source_pk_encoding, target_pk_encoding,
+                            need_del_transcode](const std::string& file_name,
+                                                uint64_t file_size) -> StatusOr<std::unique_ptr<FileStreamConverter>> {
         if (request.transaction_id < get_master_info().min_active_txn_id) {
             LOG(WARNING) << "Transaction is aborted, txn_id: " << request.transaction_id
                          << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -18,10 +18,12 @@
 #include <sys/stat.h>
 
 #include <filesystem>
+#include <numeric>
 #include <set>
 
 #include "base/string/string_parser.hpp"
 #include "base/utility/defer_op.h"
+#include "column/schema.h"
 #include "common/config_http_fwd.h"
 #include "common/config_rowset_fwd.h"
 #include "common/system/backend_options.h"
@@ -39,8 +41,11 @@
 #include "platform/thrift_rpc_helper.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
+#include "storage/chunk_helper.h"
+#include "storage/del_file_stream_converter.h"
 #include "storage/delete_handler.h"
 #include "storage/delta_column_group.h"
+#include "storage/lake/filenames.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet.h"
@@ -53,6 +58,7 @@
 #include "storage/segment_stream_converter.h"
 #include "storage/snapshot_manager.h"
 #include "storage/tablet_updates.h"
+#include "types/logical_type.h"
 
 namespace starrocks::lake {
 
@@ -370,15 +376,19 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
             txn_log->mutable_op_replication()->mutable_source_schema()->CopyFrom(
                     TabletMeta::rowset_meta_pb_with_max_rowset_version(rowset_metas).tablet_schema());
             source_schema_pb = &txn_log->op_replication().source_schema();
-        } else {
-            // Get source schema from previous saved in tablet meta
+        } else if (tablet_metadata->has_source_schema()) {
+            // Get source schema from previous saved in tablet meta. Protobuf returns a default
+            // instance if the field is unset; gate on has_source_schema() so the null check
+            // below actually catches a missing schema.
             source_schema_pb = &tablet_metadata->source_schema();
         }
 
         if (source_schema_pb == nullptr) {
-            LOG(WARNING) << "Failed to get source schema, tablet meta has schema: "
-                         << snapshot_meta.tablet_meta().has_schema() << ", rowset meta has schema: "
-                         << (!rowset_metas.empty() && rowset_metas.front().has_tablet_schema());
+            LOG(WARNING) << "Failed to get source schema for PK tablet " << tablet_metadata->id()
+                         << ", snapshot has_schema=" << snapshot_meta.tablet_meta().has_schema()
+                         << ", front rowset has_tablet_schema="
+                         << (!rowset_metas.empty() && rowset_metas.front().has_tablet_schema())
+                         << ", tablet_meta has_source_schema=" << tablet_metadata->has_source_schema();
             return Status::Corruption("Failed to get source schema");
         }
     }
@@ -396,8 +406,60 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
     std::vector<std::string> files_to_delete;
     CancelableDefer clean_files([&files_to_delete]() { lake::delete_files_async(std::move(files_to_delete)); });
 
-    auto file_converters =
-            build_file_converters(_tablet_manager, request, filename_map, column_unique_id_map, files_to_delete);
+    // Determine source/target PK encoding for .del-file transcoding. NONE sentinels stay set for
+    // non-PK tables and cause build_file_converters to skip the .del transcode branch.
+    SchemaPtr pkey_schema_for_del;
+    auto target_pk_encoding = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
+    auto source_pk_encoding = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
+    if (is_primary_key(*tablet_metadata)) {
+        // target_schema is shared because ChunkHelper::convert_schema takes TabletSchemaCSPtr;
+        // source_schema is only read locally for validation, so a stack instance suffices.
+        auto target_schema = std::make_shared<TabletSchema>(tablet_metadata->schema());
+        TabletSchema source_schema(*source_schema_pb);
+        // PK encoding must be valid on both sides; PK_ENCODING_TYPE_NONE here would indicate
+        // corrupted metadata (TabletSchema falls back to V1 for pre-PR-69939 PK tables, so
+        // an invalid value should not slip through silently).
+        ASSIGN_OR_RETURN(target_pk_encoding, target_schema->primary_key_encoding_type_or_error());
+        ASSIGN_OR_RETURN(source_pk_encoding, source_schema.primary_key_encoding_type_or_error());
+
+        // Cross-cluster PK contract: column count and per-column logical type must agree.
+        // Cluster-to-cluster replication only makes sense if PK structure matches; surface
+        // any mismatch loudly instead of attempting unsafe transcoding.
+        if (source_schema.num_key_columns() != target_schema->num_key_columns()) {
+            return Status::NotSupported(strings::Substitute(
+                    "PK column count mismatch between source ($0) and target ($1) on tablet $2",
+                    source_schema.num_key_columns(), target_schema->num_key_columns(), tablet_metadata->id()));
+        }
+        for (size_t i = 0; i < target_schema->num_key_columns(); ++i) {
+            if (source_schema.column(i).type() != target_schema->column(i).type()) {
+                return Status::NotSupported(strings::Substitute(
+                        "PK column[$0] logical type mismatch between source ($1) and target ($2) on tablet $3", i,
+                        logical_type_to_string(source_schema.column(i).type()),
+                        logical_type_to_string(target_schema->column(i).type()), tablet_metadata->id()));
+            }
+        }
+
+        // Explicitly reject V2 -> V1 on the byte-incompatible PK shape. The reverse direction
+        // is not transcodable (no V2 -> typed-column decoder) and a byte copy would leave
+        // V2-shaped bytes that the V1 target reader misinterprets.
+        if (source_pk_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2 &&
+            target_pk_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1 &&
+            is_single_fixed_length_non_string_primary_key(*target_schema)) {
+            return Status::NotSupported(strings::Substitute(
+                    "V2 source -> V1 target cross-cluster replication is not supported on a single "
+                    "non-string fixed-length PK column (.del files would byte-copy and be misread on "
+                    "the target). Tablet $0, pk_logical_type $1",
+                    tablet_metadata->id(), logical_type_to_string(target_schema->column(0).type())));
+        }
+
+        std::vector<ColumnId> pk_idxes(target_schema->num_key_columns());
+        std::iota(pk_idxes.begin(), pk_idxes.end(), 0);
+        pkey_schema_for_del = std::make_shared<Schema>(ChunkHelper::convert_schema(target_schema, pk_idxes));
+    }
+
+    auto file_converters = build_file_converters(_tablet_manager, request, filename_map, column_unique_id_map,
+                                                  files_to_delete, pkey_schema_for_del, source_pk_encoding,
+                                                  target_pk_encoding);
 
     RETURN_IF_ERROR(ReplicationUtils::download_remote_snapshot(
             src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
@@ -643,8 +705,14 @@ Status ReplicationTxnManager::convert_dcg_column_unique_ids(
 FileConverterCreatorFunc ReplicationTxnManager::build_file_converters(
         const TabletManager* tablet_manager, const TReplicateSnapshotRequest& request,
         const std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map,
-        std::unordered_map<uint32_t, uint32_t>& column_unique_id_map, std::vector<std::string>& files_to_delete) {
-    auto file_converters = [tablet_manager, request, filename_map, &column_unique_id_map, &files_to_delete](
+        std::unordered_map<uint32_t, uint32_t>& column_unique_id_map, std::vector<std::string>& files_to_delete,
+        SchemaPtr pkey_schema, PrimaryKeyEncodingType source_pk_encoding,
+        PrimaryKeyEncodingType target_pk_encoding) {
+    const bool need_del_transcode = pkey_schema != nullptr && requires_v1_to_v2_del_transcode(
+                                                                      source_pk_encoding, target_pk_encoding,
+                                                                      *pkey_schema);
+    auto file_converters = [tablet_manager, request, filename_map, &column_unique_id_map, &files_to_delete,
+                            pkey_schema, source_pk_encoding, target_pk_encoding, need_del_transcode](
                                    const std::string& file_name,
                                    uint64_t file_size) -> StatusOr<std::unique_ptr<FileStreamConverter>> {
         if (request.transaction_id < get_master_info().min_active_txn_id) {
@@ -670,6 +738,10 @@ FileConverterCreatorFunc ReplicationTxnManager::build_file_converters(
 
         files_to_delete.push_back(std::move(segment_location));
 
+        if (need_del_transcode && is_del(file_name)) {
+            return std::make_unique<DelFileStreamConverter>(file_name, file_size, std::move(output_file), pkey_schema,
+                                                            source_pk_encoding, target_pk_encoding);
+        }
         if ((is_segment(file_name) || is_cols(file_name)) && !column_unique_id_map.empty()) {
             return std::make_unique<SegmentStreamConverter>(file_name, file_size, std::move(output_file),
                                                             &column_unique_id_map);

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -408,58 +408,11 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
 
     // Determine source/target PK encoding for .del-file transcoding. NONE sentinels stay set for
     // non-PK tables and cause build_file_converters to skip the .del transcode branch.
-    SchemaPtr pkey_schema_for_del;
-    auto target_pk_encoding = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
-    auto source_pk_encoding = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
-    if (is_primary_key(*tablet_metadata)) {
-        // target_schema is shared because ChunkHelper::convert_schema takes TabletSchemaCSPtr;
-        // source_schema is only read locally for validation, so a stack instance suffices.
-        auto target_schema = std::make_shared<TabletSchema>(tablet_metadata->schema());
-        TabletSchema source_schema(*source_schema_pb);
-        // PK encoding must be valid on both sides; PK_ENCODING_TYPE_NONE here would indicate
-        // corrupted metadata (TabletSchema falls back to V1 for pre-PR-69939 PK tables, so
-        // an invalid value should not slip through silently).
-        ASSIGN_OR_RETURN(target_pk_encoding, target_schema->primary_key_encoding_type_or_error());
-        ASSIGN_OR_RETURN(source_pk_encoding, source_schema.primary_key_encoding_type_or_error());
+    ASSIGN_OR_RETURN(auto del_transcode_ctx, prepare_del_transcode_context(*tablet_metadata, *source_schema_pb));
 
-        // Cross-cluster PK contract: column count and per-column logical type must agree.
-        // Cluster-to-cluster replication only makes sense if PK structure matches; surface
-        // any mismatch loudly instead of attempting unsafe transcoding.
-        if (source_schema.num_key_columns() != target_schema->num_key_columns()) {
-            return Status::NotSupported(strings::Substitute(
-                    "PK column count mismatch between source ($0) and target ($1) on tablet $2",
-                    source_schema.num_key_columns(), target_schema->num_key_columns(), tablet_metadata->id()));
-        }
-        for (size_t i = 0; i < target_schema->num_key_columns(); ++i) {
-            if (source_schema.column(i).type() != target_schema->column(i).type()) {
-                return Status::NotSupported(strings::Substitute(
-                        "PK column[$0] logical type mismatch between source ($1) and target ($2) on tablet $3", i,
-                        logical_type_to_string(source_schema.column(i).type()),
-                        logical_type_to_string(target_schema->column(i).type()), tablet_metadata->id()));
-            }
-        }
-
-        // Explicitly reject V2 -> V1 on the byte-incompatible PK shape. The reverse direction
-        // is not transcodable (no V2 -> typed-column decoder) and a byte copy would leave
-        // V2-shaped bytes that the V1 target reader misinterprets.
-        if (source_pk_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2 &&
-            target_pk_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1 &&
-            is_single_fixed_length_non_string_primary_key(*target_schema)) {
-            return Status::NotSupported(strings::Substitute(
-                    "V2 source -> V1 target cross-cluster replication is not supported on a single "
-                    "non-string fixed-length PK column (.del files would byte-copy and be misread on "
-                    "the target). Tablet $0, pk_logical_type $1",
-                    tablet_metadata->id(), logical_type_to_string(target_schema->column(0).type())));
-        }
-
-        std::vector<ColumnId> pk_idxes(target_schema->num_key_columns());
-        std::iota(pk_idxes.begin(), pk_idxes.end(), 0);
-        pkey_schema_for_del = std::make_shared<Schema>(ChunkHelper::convert_schema(target_schema, pk_idxes));
-    }
-
-    auto file_converters =
-            build_file_converters(_tablet_manager, request, filename_map, column_unique_id_map, files_to_delete,
-                                  pkey_schema_for_del, source_pk_encoding, target_pk_encoding);
+    auto file_converters = build_file_converters(
+            _tablet_manager, request, filename_map, column_unique_id_map, files_to_delete,
+            del_transcode_ctx.pkey_schema, del_transcode_ctx.source_encoding, del_transcode_ctx.target_encoding);
 
     RETURN_IF_ERROR(ReplicationUtils::download_remote_snapshot(
             src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
@@ -699,6 +652,59 @@ Status ReplicationTxnManager::convert_dcg_column_unique_ids(
         }
     }
     return Status::OK();
+}
+
+StatusOr<DelTranscodeContext> ReplicationTxnManager::prepare_del_transcode_context(
+        const TabletMetadata& tablet_metadata, const TabletSchemaPB& source_schema_pb) {
+    DelTranscodeContext ctx;
+    if (!is_primary_key(tablet_metadata)) {
+        return ctx;
+    }
+
+    // target_schema is shared because ChunkHelper::convert_schema takes TabletSchemaCSPtr;
+    // source_schema is only read locally for validation, so a stack instance suffices.
+    auto target_schema = std::make_shared<TabletSchema>(tablet_metadata.schema());
+    TabletSchema source_schema(source_schema_pb);
+    // PK encoding must be valid on both sides; PK_ENCODING_TYPE_NONE here would indicate
+    // corrupted metadata (TabletSchema falls back to V1 for pre-PR-69939 PK tables, so
+    // an invalid value should not slip through silently).
+    ASSIGN_OR_RETURN(ctx.target_encoding, target_schema->primary_key_encoding_type_or_error());
+    ASSIGN_OR_RETURN(ctx.source_encoding, source_schema.primary_key_encoding_type_or_error());
+
+    // Cross-cluster PK contract: column count and per-column logical type must agree.
+    // Cluster-to-cluster replication only makes sense if PK structure matches; surface
+    // any mismatch loudly instead of attempting unsafe transcoding.
+    if (source_schema.num_key_columns() != target_schema->num_key_columns()) {
+        return Status::NotSupported(strings::Substitute(
+                "PK column count mismatch between source ($0) and target ($1) on tablet $2",
+                source_schema.num_key_columns(), target_schema->num_key_columns(), tablet_metadata.id()));
+    }
+    for (size_t i = 0; i < target_schema->num_key_columns(); ++i) {
+        if (source_schema.column(i).type() != target_schema->column(i).type()) {
+            return Status::NotSupported(strings::Substitute(
+                    "PK column[$0] logical type mismatch between source ($1) and target ($2) on tablet $3", i,
+                    logical_type_to_string(source_schema.column(i).type()),
+                    logical_type_to_string(target_schema->column(i).type()), tablet_metadata.id()));
+        }
+    }
+
+    // Explicitly reject V2 -> V1 on the byte-incompatible PK shape. The reverse direction
+    // is not transcodable (no V2 -> typed-column decoder) and a byte copy would leave
+    // V2-shaped bytes that the V1 target reader misinterprets.
+    if (ctx.source_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2 &&
+        ctx.target_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1 &&
+        is_single_fixed_length_non_string_primary_key(*target_schema)) {
+        return Status::NotSupported(strings::Substitute(
+                "V2 source -> V1 target cross-cluster replication is not supported on a single "
+                "non-string fixed-length PK column (.del files would byte-copy and be misread on "
+                "the target). Tablet $0, pk_logical_type $1",
+                tablet_metadata.id(), logical_type_to_string(target_schema->column(0).type())));
+    }
+
+    std::vector<ColumnId> pk_idxes(target_schema->num_key_columns());
+    std::iota(pk_idxes.begin(), pk_idxes.end(), 0);
+    ctx.pkey_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(target_schema, pk_idxes));
+    return ctx;
 }
 
 // Helper function to create replication txn log with converted metadata

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -410,9 +410,9 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
     // non-PK tables and cause build_file_converters to skip the .del transcode branch.
     ASSIGN_OR_RETURN(auto del_transcode_ctx, prepare_del_transcode_context(*tablet_metadata, *source_schema_pb));
 
-    auto file_converters = build_file_converters(
-            _tablet_manager, request, filename_map, column_unique_id_map, files_to_delete,
-            del_transcode_ctx.pkey_schema, del_transcode_ctx.source_encoding, del_transcode_ctx.target_encoding);
+    auto file_converters = build_file_converters(_tablet_manager, request, filename_map, column_unique_id_map,
+                                                 files_to_delete, del_transcode_ctx.pkey_schema,
+                                                 del_transcode_ctx.source_encoding, del_transcode_ctx.target_encoding);
 
     RETURN_IF_ERROR(ReplicationUtils::download_remote_snapshot(
             src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
@@ -694,11 +694,11 @@ StatusOr<DelTranscodeContext> ReplicationTxnManager::prepare_del_transcode_conte
     if (ctx.source_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2 &&
         ctx.target_encoding == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1 &&
         is_single_fixed_length_non_string_primary_key(*target_schema)) {
-        return Status::NotSupported(strings::Substitute(
-                "V2 source -> V1 target cross-cluster replication is not supported on a single "
-                "non-string fixed-length PK column (.del files would byte-copy and be misread on "
-                "the target). Tablet $0, pk_logical_type $1",
-                tablet_metadata.id(), logical_type_to_string(target_schema->column(0).type())));
+        return Status::NotSupported(
+                strings::Substitute("V2 source -> V1 target cross-cluster replication is not supported on a single "
+                                    "non-string fixed-length PK column (.del files would byte-copy and be misread on "
+                                    "the target). Tablet $0, pk_logical_type $1",
+                                    tablet_metadata.id(), logical_type_to_string(target_schema->column(0).type())));
     }
 
     std::vector<ColumnId> pk_idxes(target_schema->num_key_columns());

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -39,6 +39,15 @@ namespace starrocks::lake {
 
 class TabletManager;
 
+// Inputs needed by ReplicationTxnManager::build_file_converters to drive .del-file
+// transcoding for cross-cluster replication intake. NONE encodings + null pkey_schema
+// signal "no transcoding" (non-PK tables or compatible PK shapes).
+struct DelTranscodeContext {
+    SchemaPtr pkey_schema;
+    PrimaryKeyEncodingType source_encoding = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
+    PrimaryKeyEncodingType target_encoding = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
+};
+
 class ReplicationTxnManager {
 public:
     explicit ReplicationTxnManager(lake::TabletManager* tablet_manager) : _tablet_manager(tablet_manager) {
@@ -52,6 +61,22 @@ public:
     Status clear_snapshots(const TxnLogPtr& txn_slog);
 
     DISALLOW_COPY_AND_MOVE(ReplicationTxnManager);
+
+    // Validates source/target PK structure for cross-cluster replication intake and computes
+    // the PK encoding pair + pkey schema needed to drive .del-file transcoding.
+    //
+    // For non-PK target tablets, returns a context with NONE encodings and null pkey_schema --
+    // the caller passes those through to build_file_converters as the "no transcoding" signal.
+    //
+    // Returns Status::NotSupported on:
+    //   - PK column count mismatch between source and target
+    //   - per-column logical type mismatch
+    //   - V2 source -> V1 target on the byte-incompatible single-non-string-fixed-length PK
+    //     shape (no V2 -> typed-column decoder exists).
+    // Returns Status::InternalError if either side reports PK_ENCODING_TYPE_NONE for a PK
+    // table (corrupted metadata: TabletSchema falls back to V1 for pre-PR-69939 schemas).
+    static StatusOr<DelTranscodeContext> prepare_del_transcode_context(const TabletMetadata& tablet_metadata,
+                                                                        const TabletSchemaPB& source_schema_pb);
 
     // pkey_schema, source_pk_encoding, target_pk_encoding describe the on-disk PK encoding of
     // .del files arriving in this snapshot. When source != target on a shape that is NOT

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "fs/encryption.h"
 #include "gen_cpp/AgentService_types.h"
@@ -24,6 +25,7 @@
 #include "storage/lake/txn_log.h"
 #include "storage/lake/types_fwd.h"
 #include "storage/olap_common.h"
+#include "storage/primary_key_encoding_types.h"
 #include "storage/rowset/rowset_meta.h"
 #include "tablet_manager.h"
 
@@ -51,10 +53,17 @@ public:
 
     DISALLOW_COPY_AND_MOVE(ReplicationTxnManager);
 
+    // pkey_schema, source_pk_encoding, target_pk_encoding describe the on-disk PK encoding of
+    // .del files arriving in this snapshot. When source != target on a shape that is NOT
+    // byte-compatible (V1 -> V2 + single non-string fixed-length PK), the converter for .del
+    // files is swapped for a DelFileStreamConverter that re-encodes the payload at intake.
+    // Pass nullptr / PK_ENCODING_TYPE_NONE for non-PK tables (no .del transcoding considered).
     static FileConverterCreatorFunc build_file_converters(
             const TabletManager* tablet_manager, const TReplicateSnapshotRequest& request,
             const std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map,
-            std::unordered_map<uint32_t, uint32_t>& column_unique_id_map, std::vector<std::string>& files_to_delete);
+            std::unordered_map<uint32_t, uint32_t>& column_unique_id_map, std::vector<std::string>& files_to_delete,
+            SchemaPtr pkey_schema, PrimaryKeyEncodingType source_pk_encoding,
+            PrimaryKeyEncodingType target_pk_encoding);
 
     // Convert DeltaColumnGroupSnapshotPB from shared-nothing non-PK table snapshot
     // into DeltaColumnGroupMetadataPB for shared-data replication.

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -76,7 +76,7 @@ public:
     // Returns Status::InternalError if either side reports PK_ENCODING_TYPE_NONE for a PK
     // table (corrupted metadata: TabletSchema falls back to V1 for pre-PR-69939 schemas).
     static StatusOr<DelTranscodeContext> prepare_del_transcode_context(const TabletMetadata& tablet_metadata,
-                                                                        const TabletSchemaPB& source_schema_pb);
+                                                                       const TabletSchemaPB& source_schema_pb);
 
     // pkey_schema, source_pk_encoding, target_pk_encoding describe the on-disk PK encoding of
     // .del files arriving in this snapshot. When source != target on a shape that is NOT

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -559,6 +559,7 @@ SET(DW_TEST_FILES
     ./storage/schema_change_test.cpp
     ./storage/segment_flush_executor_test.cpp
     ./storage/segment_stream_converter_test.cpp
+    ./storage/del_file_stream_converter_test.cpp
     ./storage/short_key_index_test.cpp
     ./storage/size_tiered_compaction_policy_test.cpp
     ./storage/snapshot_meta_test.cpp

--- a/be/test/storage/del_file_stream_converter_test.cpp
+++ b/be/test/storage/del_file_stream_converter_test.cpp
@@ -19,12 +19,14 @@
 #include <memory>
 #include <vector>
 
+#include "base/testutil/assert.h"
 #include "column/chunk.h"
 #include "column/schema.h"
 #include "fs/fs.h"
 #include "fs/fs_memory.h"
 #include "serde/column_array_serde.h"
 #include "storage/primary_key_encoder.h"
+#include "storage/tablet_schema.h"
 #include "types/datum.h"
 
 namespace starrocks {
@@ -41,6 +43,51 @@ SchemaPtr create_single_pk_schema(LogicalType type) {
     fd->set_uid(0);
     fields.emplace_back(fd);
     return std::make_shared<Schema>(std::move(fields), PRIMARY_KEYS, std::vector<ColumnId>{0});
+}
+
+// Maps LogicalType -> the protobuf-side type-name string used by TabletColumnPB.
+const char* pk_type_name(LogicalType type) {
+    switch (type) {
+    case TYPE_BOOLEAN:
+        return "BOOLEAN";
+    case TYPE_TINYINT:
+        return "TINYINT";
+    case TYPE_SMALLINT:
+        return "SMALLINT";
+    case TYPE_INT:
+        return "INT";
+    case TYPE_BIGINT:
+        return "BIGINT";
+    case TYPE_LARGEINT:
+        return "LARGEINT";
+    case TYPE_DATE:
+        return "DATE";
+    case TYPE_DATETIME:
+        return "DATETIME";
+    case TYPE_VARCHAR:
+        return "VARCHAR";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+// Build a TabletSchema with the given PK column types. Each column is keyed.
+std::shared_ptr<TabletSchema> create_tablet_schema_with_pk_columns(const std::vector<LogicalType>& pk_types) {
+    TabletSchemaPB pb;
+    pb.set_keys_type(PRIMARY_KEYS);
+    pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    for (size_t i = 0; i < pk_types.size(); ++i) {
+        auto* col = pb.add_column();
+        col->set_unique_id(static_cast<uint32_t>(i));
+        col->set_name("c" + std::to_string(i));
+        col->set_type(pk_type_name(pk_types[i]));
+        if (pk_types[i] == TYPE_VARCHAR) {
+            col->set_length(32);
+        }
+        col->set_is_key(true);
+        col->set_is_nullable(false);
+    }
+    return std::make_shared<TabletSchema>(pb);
 }
 
 // Serialize a column with ColumnArraySerde into a string buffer.
@@ -178,6 +225,135 @@ TEST_F(DelFileStreamConverterTest, CorruptInput) {
     std::string garbage = "\xff\xff\xff\xff\xde\xad\xbe\xef";
     auto status_or_out = run_converter(schema, garbage, garbage.size());
     ASSERT_FALSE(status_or_out.ok());
+}
+
+// Zero-byte append should be a fast no-op (covers the size==0 early return in append()).
+TEST_F(DelFileStreamConverterTest, AppendZeroSize) {
+    auto schema = create_single_pk_schema(TYPE_INT);
+    MemoryFileSystem fs;
+    auto wfile_or = fs.new_writable_file("/del-zero");
+    ASSERT_TRUE(wfile_or.ok());
+
+    // Declared input is a valid 1-row Int32Column payload.
+    MutableColumnPtr v1_col;
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(*schema, &v1_col, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
+    Datum d;
+    d.set<int32_t>(42);
+    v1_col->append_datum(d);
+    const std::string v1_bytes = serialize_column(*v1_col);
+
+    DelFileStreamConverter converter("zero.del", v1_bytes.size(), std::move(wfile_or.value()), schema,
+                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1,
+                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+    // A zero-byte append must not advance the buffer.
+    ASSERT_OK(converter.append(nullptr, 0));
+    ASSERT_OK(converter.append(v1_bytes.data(), v1_bytes.size()));
+    // Another zero-byte append after a full payload is also a no-op.
+    ASSERT_OK(converter.append(nullptr, 0));
+    ASSERT_OK(converter.close());
+}
+
+// Declared size larger than the actual serialized PK column leaves trailing bytes that
+// ColumnArraySerde::deserialize will not consume, exercising the "did not consume full
+// buffer" Corruption branch in close().
+TEST_F(DelFileStreamConverterTest, DeserializeLeavesTrailingBytes) {
+    auto schema = create_single_pk_schema(TYPE_INT);
+
+    MutableColumnPtr v1_col;
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(*schema, &v1_col, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
+    Datum d;
+    d.set<int32_t>(7);
+    v1_col->append_datum(d);
+    std::string v1_bytes = serialize_column(*v1_col);
+    // Append a stray byte so deserialize stops short of the buffer end.
+    v1_bytes.push_back('\0');
+
+    MemoryFileSystem fs;
+    auto wfile_or = fs.new_writable_file("/del-trailing");
+    ASSERT_TRUE(wfile_or.ok());
+    DelFileStreamConverter converter("trailing.del", v1_bytes.size(), std::move(wfile_or.value()), schema,
+                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1,
+                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+    ASSERT_OK(converter.append(v1_bytes.data(), v1_bytes.size()));
+    auto st = converter.close();
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_corruption()) << st;
+}
+
+// Round-trip golden tests for every supported single non-string fixed-length PK type.
+// These also incidentally cover the macro expansion in is_fixed_length_non_string_pk_type.
+TEST_F(DelFileStreamConverterTest, V1ToV2_SingleBoolean) {
+    check_v1_to_v2<uint8_t>(TYPE_BOOLEAN, {0, 1});
+}
+TEST_F(DelFileStreamConverterTest, V1ToV2_SingleTinyInt) {
+    check_v1_to_v2<int8_t>(TYPE_TINYINT, {-128, -1, 0, 1, 127});
+}
+TEST_F(DelFileStreamConverterTest, V1ToV2_SingleSmallInt) {
+    check_v1_to_v2<int16_t>(TYPE_SMALLINT, {std::numeric_limits<int16_t>::min(), 0, std::numeric_limits<int16_t>::max()});
+}
+TEST_F(DelFileStreamConverterTest, V1ToV2_SingleDate) {
+    // DATE storage type is int32 (Julian day count). Use representative values.
+    check_v1_to_v2<int32_t>(TYPE_DATE, {0, 700000, 999999});
+}
+TEST_F(DelFileStreamConverterTest, V1ToV2_SingleDateTime) {
+    check_v1_to_v2<int64_t>(TYPE_DATETIME, {0, 20260521000000LL, std::numeric_limits<int64_t>::max()});
+}
+
+// Predicate matrix: is_single_fixed_length_non_string_primary_key(const Schema&)
+// and requires_v1_to_v2_del_transcode(...) for every combination that matters.
+TEST_F(DelFileStreamConverterTest, Predicates_SchemaOverload) {
+    // Single fixed-length non-string types -> true.
+    for (LogicalType t : {TYPE_BOOLEAN, TYPE_TINYINT, TYPE_SMALLINT, TYPE_INT, TYPE_BIGINT, TYPE_LARGEINT, TYPE_DATE,
+                          TYPE_DATETIME}) {
+        ASSERT_TRUE(is_single_fixed_length_non_string_primary_key(*create_single_pk_schema(t)))
+                << "type=" << static_cast<int>(t);
+    }
+    // Single VARCHAR -> false (BinaryColumn on both V1/V2, byte-compatible).
+    ASSERT_FALSE(is_single_fixed_length_non_string_primary_key(*create_single_pk_schema(TYPE_VARCHAR)));
+
+    // Composite PK -> false. Build (INT, INT) schema directly.
+    Fields composite;
+    {
+        auto* a = new Field(0, "a", TYPE_INT, false);
+        a->set_is_key(true);
+        a->set_aggregate_method(STORAGE_AGGREGATE_NONE);
+        auto* b = new Field(1, "b", TYPE_INT, false);
+        b->set_is_key(true);
+        b->set_aggregate_method(STORAGE_AGGREGATE_NONE);
+        composite.emplace_back(a);
+        composite.emplace_back(b);
+    }
+    Schema composite_schema(std::move(composite), PRIMARY_KEYS, std::vector<ColumnId>{0, 1});
+    ASSERT_FALSE(is_single_fixed_length_non_string_primary_key(composite_schema));
+}
+
+TEST_F(DelFileStreamConverterTest, Predicates_TabletSchemaOverload) {
+    // Single fixed-length non-string -> true.
+    ASSERT_TRUE(is_single_fixed_length_non_string_primary_key(*create_tablet_schema_with_pk_columns({TYPE_INT})));
+    ASSERT_TRUE(is_single_fixed_length_non_string_primary_key(*create_tablet_schema_with_pk_columns({TYPE_DATETIME})));
+    // Single VARCHAR -> false.
+    ASSERT_FALSE(is_single_fixed_length_non_string_primary_key(*create_tablet_schema_with_pk_columns({TYPE_VARCHAR})));
+    // Composite -> false.
+    ASSERT_FALSE(
+            is_single_fixed_length_non_string_primary_key(*create_tablet_schema_with_pk_columns({TYPE_INT, TYPE_INT})));
+}
+
+TEST_F(DelFileStreamConverterTest, Predicates_RequiresV1ToV2DelTranscodeMatrix) {
+    auto int_schema = *create_single_pk_schema(TYPE_INT);
+    auto varchar_schema = *create_single_pk_schema(TYPE_VARCHAR);
+
+    using PKE = PrimaryKeyEncodingType;
+    // Supported direction on a byte-incompatible shape.
+    ASSERT_TRUE(requires_v1_to_v2_del_transcode(PKE::PK_ENCODING_TYPE_V1, PKE::PK_ENCODING_TYPE_V2, int_schema));
+    // V2 -> V1 on the same shape: not supported (no decoder); predicate must say false.
+    ASSERT_FALSE(requires_v1_to_v2_del_transcode(PKE::PK_ENCODING_TYPE_V2, PKE::PK_ENCODING_TYPE_V1, int_schema));
+    // Same encoding on both sides: no transcoding needed.
+    ASSERT_FALSE(requires_v1_to_v2_del_transcode(PKE::PK_ENCODING_TYPE_V1, PKE::PK_ENCODING_TYPE_V1, int_schema));
+    ASSERT_FALSE(requires_v1_to_v2_del_transcode(PKE::PK_ENCODING_TYPE_V2, PKE::PK_ENCODING_TYPE_V2, int_schema));
+    // VARCHAR PK: byte-compatible on V1/V2, no transcoding even with direction match.
+    ASSERT_FALSE(requires_v1_to_v2_del_transcode(PKE::PK_ENCODING_TYPE_V1, PKE::PK_ENCODING_TYPE_V2, varchar_schema));
+    // NONE encoding: never transcode.
+    ASSERT_FALSE(requires_v1_to_v2_del_transcode(PKE::PK_ENCODING_TYPE_NONE, PKE::PK_ENCODING_TYPE_V2, int_schema));
 }
 
 } // namespace starrocks

--- a/be/test/storage/del_file_stream_converter_test.cpp
+++ b/be/test/storage/del_file_stream_converter_test.cpp
@@ -122,8 +122,8 @@ class DelFileStreamConverterTest : public ::testing::Test {};
 
 // Golden path: single INT PK, V1 source -> V2 target.
 TEST_F(DelFileStreamConverterTest, V1ToV2_SingleInt) {
-    check_v1_to_v2<int32_t>(TYPE_INT, {42, 100, -5, 0, std::numeric_limits<int32_t>::min(),
-                                       std::numeric_limits<int32_t>::max()});
+    check_v1_to_v2<int32_t>(TYPE_INT,
+                            {42, 100, -5, 0, std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max()});
 }
 
 // Chunked append should produce the same output as a single-shot append.
@@ -133,8 +133,7 @@ TEST_F(DelFileStreamConverterTest, ChunkedAppend) {
 }
 
 TEST_F(DelFileStreamConverterTest, V1ToV2_SingleBigInt) {
-    check_v1_to_v2<int64_t>(TYPE_BIGINT,
-                             {123456789012LL, -42, 0, std::numeric_limits<int64_t>::max()});
+    check_v1_to_v2<int64_t>(TYPE_BIGINT, {123456789012LL, -42, 0, std::numeric_limits<int64_t>::max()});
 }
 
 // Declared input size shorter than what is appended -> Corruption on append (overflow guard).

--- a/be/test/storage/del_file_stream_converter_test.cpp
+++ b/be/test/storage/del_file_stream_converter_test.cpp
@@ -289,7 +289,8 @@ TEST_F(DelFileStreamConverterTest, V1ToV2_SingleTinyInt) {
     check_v1_to_v2<int8_t>(TYPE_TINYINT, {-128, -1, 0, 1, 127});
 }
 TEST_F(DelFileStreamConverterTest, V1ToV2_SingleSmallInt) {
-    check_v1_to_v2<int16_t>(TYPE_SMALLINT, {std::numeric_limits<int16_t>::min(), 0, std::numeric_limits<int16_t>::max()});
+    check_v1_to_v2<int16_t>(TYPE_SMALLINT,
+                            {std::numeric_limits<int16_t>::min(), 0, std::numeric_limits<int16_t>::max()});
 }
 TEST_F(DelFileStreamConverterTest, V1ToV2_SingleDate) {
     // DATE storage type is int32 (Julian day count). Use representative values.
@@ -303,8 +304,8 @@ TEST_F(DelFileStreamConverterTest, V1ToV2_SingleDateTime) {
 // and requires_v1_to_v2_del_transcode(...) for every combination that matters.
 TEST_F(DelFileStreamConverterTest, Predicates_SchemaOverload) {
     // Single fixed-length non-string types -> true.
-    for (LogicalType t : {TYPE_BOOLEAN, TYPE_TINYINT, TYPE_SMALLINT, TYPE_INT, TYPE_BIGINT, TYPE_LARGEINT, TYPE_DATE,
-                          TYPE_DATETIME}) {
+    for (LogicalType t :
+         {TYPE_BOOLEAN, TYPE_TINYINT, TYPE_SMALLINT, TYPE_INT, TYPE_BIGINT, TYPE_LARGEINT, TYPE_DATE, TYPE_DATETIME}) {
         ASSERT_TRUE(is_single_fixed_length_non_string_primary_key(*create_single_pk_schema(t)))
                 << "type=" << static_cast<int>(t);
     }

--- a/be/test/storage/del_file_stream_converter_test.cpp
+++ b/be/test/storage/del_file_stream_converter_test.cpp
@@ -1,0 +1,184 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/del_file_stream_converter.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "column/chunk.h"
+#include "column/schema.h"
+#include "fs/fs.h"
+#include "fs/fs_memory.h"
+#include "serde/column_array_serde.h"
+#include "storage/primary_key_encoder.h"
+#include "types/datum.h"
+
+namespace starrocks {
+
+namespace {
+
+// Build a primary-key schema with the given single PK column type. Mirrors the helper
+// used by primary_key_encoder_test.cpp.
+SchemaPtr create_single_pk_schema(LogicalType type) {
+    Fields fields;
+    auto* fd = new Field(0, "pk", type, false);
+    fd->set_is_key(true);
+    fd->set_aggregate_method(STORAGE_AGGREGATE_NONE);
+    fd->set_uid(0);
+    fields.emplace_back(fd);
+    return std::make_shared<Schema>(std::move(fields), PRIMARY_KEYS, std::vector<ColumnId>{0});
+}
+
+// Serialize a column with ColumnArraySerde into a string buffer.
+std::string serialize_column(const Column& col) {
+    int64_t max_size = serde::ColumnArraySerde::max_serialized_size(col);
+    std::string buf;
+    buf.resize(static_cast<size_t>(max_size));
+    auto* begin = reinterpret_cast<uint8_t*>(buf.data());
+    auto status_or_end = serde::ColumnArraySerde::serialize(col, begin);
+    CHECK(status_or_end.ok()) << status_or_end.status();
+    buf.resize(status_or_end.value() - begin);
+    return buf;
+}
+
+// Encode the given source-typed PK column into V2-shaped BinaryColumn using PrimaryKeyEncoder.
+// This is the reference encoder used in expectations.
+MutableColumnPtr encode_to_v2(const Schema& schema, MutableColumnPtr src_col) {
+    MutableColumnPtr dst;
+    CHECK(PrimaryKeyEncoder::create_column(schema, &dst, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2).ok());
+    Columns wrap;
+    const size_t n = src_col->size();
+    wrap.emplace_back(std::move(src_col));
+    Chunk tmp_chunk(std::move(wrap), std::make_shared<Schema>(schema));
+    PrimaryKeyEncoder::encode(schema, tmp_chunk, 0, n, dst.get(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+    return dst;
+}
+
+// Drive the converter end-to-end with the given V1 input bytes and return the output bytes.
+StatusOr<std::string> run_converter(const SchemaPtr& pkey_schema, const std::string& v1_bytes, uint64_t declared_size,
+                                    PrimaryKeyEncodingType source_enc = PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1,
+                                    PrimaryKeyEncodingType target_enc = PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2,
+                                    size_t chunk_size = 0) {
+    MemoryFileSystem fs;
+    const std::string path = "/del-test";
+    ASSIGN_OR_RETURN(auto wfile, fs.new_writable_file(path));
+    DelFileStreamConverter converter("test.del", declared_size, std::move(wfile), pkey_schema, source_enc, target_enc);
+    if (chunk_size == 0 || chunk_size >= v1_bytes.size()) {
+        RETURN_IF_ERROR(converter.append(v1_bytes.data(), v1_bytes.size()));
+    } else {
+        for (size_t off = 0; off < v1_bytes.size(); off += chunk_size) {
+            size_t n = std::min(chunk_size, v1_bytes.size() - off);
+            RETURN_IF_ERROR(converter.append(v1_bytes.data() + off, n));
+        }
+    }
+    RETURN_IF_ERROR(converter.close());
+
+    ASSIGN_OR_RETURN(auto rfile, fs.new_random_access_file(path));
+    ASSIGN_OR_RETURN(std::string output, rfile->read_all());
+    return output;
+}
+
+template <typename CppT>
+void check_v1_to_v2(LogicalType pk_type, const std::vector<CppT>& values, size_t chunk_size = 0) {
+    auto schema = create_single_pk_schema(pk_type);
+
+    // Build V1 input: typed column, serialized via ColumnArraySerde.
+    MutableColumnPtr v1_col;
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(*schema, &v1_col, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
+    for (const CppT& v : values) {
+        Datum d;
+        d.set<CppT>(v);
+        v1_col->append_datum(d);
+    }
+    const std::string v1_bytes = serialize_column(*v1_col);
+
+    // Expected V2 output bytes: encode a clone of the V1 column to V2 BinaryColumn, then serialize.
+    auto expected_v2_col = encode_to_v2(*schema, v1_col->clone());
+    const std::string expected_v2_bytes = serialize_column(*expected_v2_col);
+
+    auto status_or_out = run_converter(schema, v1_bytes, v1_bytes.size(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1,
+                                       PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2, chunk_size);
+    ASSERT_TRUE(status_or_out.ok()) << status_or_out.status();
+    ASSERT_EQ(expected_v2_bytes, status_or_out.value());
+}
+
+} // namespace
+
+class DelFileStreamConverterTest : public ::testing::Test {};
+
+// Golden path: single INT PK, V1 source -> V2 target.
+TEST_F(DelFileStreamConverterTest, V1ToV2_SingleInt) {
+    check_v1_to_v2<int32_t>(TYPE_INT, {42, 100, -5, 0, std::numeric_limits<int32_t>::min(),
+                                       std::numeric_limits<int32_t>::max()});
+}
+
+// Chunked append should produce the same output as a single-shot append.
+TEST_F(DelFileStreamConverterTest, ChunkedAppend) {
+    // Pick a chunk size smaller than the full payload to exercise the multi-append code path.
+    check_v1_to_v2<int32_t>(TYPE_INT, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, /*chunk_size=*/4);
+}
+
+TEST_F(DelFileStreamConverterTest, V1ToV2_SingleBigInt) {
+    check_v1_to_v2<int64_t>(TYPE_BIGINT,
+                             {123456789012LL, -42, 0, std::numeric_limits<int64_t>::max()});
+}
+
+// Declared input size shorter than what is appended -> Corruption on append (overflow guard).
+TEST_F(DelFileStreamConverterTest, AppendOverflow) {
+    auto schema = create_single_pk_schema(TYPE_INT);
+    MemoryFileSystem fs;
+    auto wfile_or = fs.new_writable_file("/del-overflow");
+    ASSERT_TRUE(wfile_or.ok());
+
+    const uint64_t declared = 8;
+    DelFileStreamConverter converter("t.del", declared, std::move(wfile_or.value()), schema,
+                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1,
+                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+    std::string too_much(declared + 1, 0);
+    auto st = converter.append(too_much.data(), too_much.size());
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_corruption()) << st;
+}
+
+// Closing with fewer bytes than declared -> Corruption.
+TEST_F(DelFileStreamConverterTest, ShortInput) {
+    auto schema = create_single_pk_schema(TYPE_INT);
+    MemoryFileSystem fs;
+    auto wfile_or = fs.new_writable_file("/del-short");
+    ASSERT_TRUE(wfile_or.ok());
+
+    const uint64_t declared = 16;
+    DelFileStreamConverter converter("t.del", declared, std::move(wfile_or.value()), schema,
+                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1,
+                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+    std::string partial(declared - 1, 0);
+    ASSERT_TRUE(converter.append(partial.data(), partial.size()).ok());
+    auto st = converter.close();
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_corruption()) << st;
+}
+
+// Feeding garbage bytes for the correct declared size -> ColumnArraySerde::deserialize fails.
+TEST_F(DelFileStreamConverterTest, CorruptInput) {
+    auto schema = create_single_pk_schema(TYPE_INT);
+    // 8 bytes of garbage, doesn't look like a valid serialized Int32Column.
+    std::string garbage = "\xff\xff\xff\xff\xde\xad\xbe\xef";
+    auto status_or_out = run_converter(schema, garbage, garbage.size());
+    ASSERT_FALSE(status_or_out.ok());
+}
+
+} // namespace starrocks

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -887,53 +887,53 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_prepare_del_transcode_c
     ASSERT_TRUE(ctx_or.ok()) << ctx_or.status();
 }
 
-// check_pk_encoding_compat_for_lake_to_lake: non-PK target -> OK.
+// check_pk_encoding_compat: non-PK target -> OK.
 TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_non_pk) {
     auto src = make_non_pk_tablet_metadata(1);
     auto tgt = make_non_pk_tablet_metadata(2);
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
     EXPECT_TRUE(st.ok()) << st;
 }
 
-// check_pk_encoding_compat_for_lake_to_lake: matching V2 encoding -> OK.
+// check_pk_encoding_compat: matching V2 encoding -> OK.
 TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_same_encoding) {
     auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
     auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
     EXPECT_TRUE(st.ok()) << st;
 }
 
-// check_pk_encoding_compat_for_lake_to_lake: V1 -> V2 on single fixed PK -> NotSupported.
+// check_pk_encoding_compat: V1 -> V2 on single fixed PK -> NotSupported.
 TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_v1_to_v2_rejected) {
     auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"BIGINT"});
     auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"BIGINT"});
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
     ASSERT_FALSE(st.ok());
     EXPECT_TRUE(st.is_not_supported()) << st;
 }
 
-// check_pk_encoding_compat_for_lake_to_lake: V2 -> V1 on single fixed PK -> NotSupported.
+// check_pk_encoding_compat: V2 -> V1 on single fixed PK -> NotSupported.
 TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_v2_to_v1_rejected) {
     auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
     auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"INT"});
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
     ASSERT_FALSE(st.ok());
     EXPECT_TRUE(st.is_not_supported()) << st;
 }
 
-// check_pk_encoding_compat_for_lake_to_lake: V1 -> V2 on VARCHAR PK -> OK (byte-compatible).
+// check_pk_encoding_compat: V1 -> V2 on VARCHAR PK -> OK (byte-compatible).
 TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_varchar_pk_allowed) {
     auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"VARCHAR"});
     auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"VARCHAR"});
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
     EXPECT_TRUE(st.ok()) << st;
 }
 
-// check_pk_encoding_compat_for_lake_to_lake: V1 -> V2 on composite PK -> OK (byte-compatible).
+// check_pk_encoding_compat: V1 -> V2 on composite PK -> OK (byte-compatible).
 TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_composite_pk_allowed) {
     auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"INT", "INT"});
     auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT", "INT"});
-    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat(1, 2, src, tgt);
     EXPECT_TRUE(st.ok()) << st;
 }
 

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -785,6 +785,158 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_build_file_converters_h
     EXPECT_TRUE(lake::is_del(new_del));
 }
 
+namespace {
+
+// Build a TabletMetadataPB suitable for prepare_del_transcode_context tests.
+//   keys_type=PRIMARY_KEYS, single (or composite) PK columns with the given types,
+//   set primary_key_encoding_type to the requested value.
+TabletMetadataPB make_pk_tablet_metadata(int64_t id, PrimaryKeyEncodingTypePB encoding,
+                                          const std::vector<std::string>& pk_type_names) {
+    TabletMetadataPB meta;
+    meta.set_id(id);
+    auto* schema = meta.mutable_schema();
+    schema->set_keys_type(PRIMARY_KEYS);
+    schema->set_primary_key_encoding_type(encoding);
+    for (size_t i = 0; i < pk_type_names.size(); ++i) {
+        auto* col = schema->add_column();
+        col->set_unique_id(static_cast<uint32_t>(i));
+        col->set_name("c" + std::to_string(i));
+        col->set_type(pk_type_names[i]);
+        if (pk_type_names[i] == "VARCHAR") {
+            col->set_length(32);
+        }
+        col->set_is_key(true);
+        col->set_is_nullable(false);
+    }
+    return meta;
+}
+
+// Build a duplicate-keys (non-PK) TabletMetadataPB.
+TabletMetadataPB make_non_pk_tablet_metadata(int64_t id) {
+    TabletMetadataPB meta;
+    meta.set_id(id);
+    auto* schema = meta.mutable_schema();
+    schema->set_keys_type(DUP_KEYS);
+    auto* col = schema->add_column();
+    col->set_unique_id(0);
+    col->set_name("c0");
+    col->set_type("INT");
+    col->set_is_key(true);
+    col->set_is_nullable(false);
+    return meta;
+}
+
+} // namespace
+
+// prepare_del_transcode_context: non-PK target returns empty context.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_prepare_del_transcode_context_non_pk) {
+    auto target = make_non_pk_tablet_metadata(1);
+    auto source = make_non_pk_tablet_metadata(2);
+    auto ctx_or = lake::ReplicationTxnManager::prepare_del_transcode_context(target, source.schema());
+    ASSERT_TRUE(ctx_or.ok()) << ctx_or.status();
+    EXPECT_EQ(nullptr, ctx_or.value().pkey_schema);
+    EXPECT_EQ(PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE, ctx_or.value().source_encoding);
+    EXPECT_EQ(PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE, ctx_or.value().target_encoding);
+}
+
+// prepare_del_transcode_context: V1 source + V2 target on single INT PK builds a valid context
+// with the expected encodings + pkey_schema.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_prepare_del_transcode_context_v1_to_v2_success) {
+    auto target = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
+    auto source = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"INT"});
+    auto ctx_or = lake::ReplicationTxnManager::prepare_del_transcode_context(target, source.schema());
+    ASSERT_TRUE(ctx_or.ok()) << ctx_or.status();
+    EXPECT_EQ(PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1, ctx_or.value().source_encoding);
+    EXPECT_EQ(PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2, ctx_or.value().target_encoding);
+    ASSERT_NE(nullptr, ctx_or.value().pkey_schema);
+    EXPECT_EQ(1, ctx_or.value().pkey_schema->num_fields());
+}
+
+// prepare_del_transcode_context: source has 2 PK columns, target has 1 -> NotSupported.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_prepare_del_transcode_context_pk_count_mismatch) {
+    auto target = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
+    auto source = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"INT", "INT"});
+    auto ctx_or = lake::ReplicationTxnManager::prepare_del_transcode_context(target, source.schema());
+    ASSERT_FALSE(ctx_or.ok());
+    EXPECT_TRUE(ctx_or.status().is_not_supported()) << ctx_or.status();
+}
+
+// prepare_del_transcode_context: source PK column type differs from target -> NotSupported.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_prepare_del_transcode_context_pk_type_mismatch) {
+    auto target = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
+    auto source = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"BIGINT"});
+    auto ctx_or = lake::ReplicationTxnManager::prepare_del_transcode_context(target, source.schema());
+    ASSERT_FALSE(ctx_or.ok());
+    EXPECT_TRUE(ctx_or.status().is_not_supported()) << ctx_or.status();
+}
+
+// prepare_del_transcode_context: V2 source -> V1 target on single non-string fixed PK -> NotSupported.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_prepare_del_transcode_context_v2_to_v1_rejected) {
+    auto target = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"INT"});
+    auto source = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
+    auto ctx_or = lake::ReplicationTxnManager::prepare_del_transcode_context(target, source.schema());
+    ASSERT_FALSE(ctx_or.ok());
+    EXPECT_TRUE(ctx_or.status().is_not_supported()) << ctx_or.status();
+}
+
+// prepare_del_transcode_context: V1<->V2 on VARCHAR PK (byte-compatible) is allowed.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_prepare_del_transcode_context_varchar_pk_compatible) {
+    auto target = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"VARCHAR"});
+    auto source = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"VARCHAR"});
+    auto ctx_or = lake::ReplicationTxnManager::prepare_del_transcode_context(target, source.schema());
+    ASSERT_TRUE(ctx_or.ok()) << ctx_or.status();
+}
+
+// check_pk_encoding_compat_for_lake_to_lake: non-PK target -> OK.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_non_pk) {
+    auto src = make_non_pk_tablet_metadata(1);
+    auto tgt = make_non_pk_tablet_metadata(2);
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    EXPECT_TRUE(st.ok()) << st;
+}
+
+// check_pk_encoding_compat_for_lake_to_lake: matching V2 encoding -> OK.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_same_encoding) {
+    auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
+    auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    EXPECT_TRUE(st.ok()) << st;
+}
+
+// check_pk_encoding_compat_for_lake_to_lake: V1 -> V2 on single fixed PK -> NotSupported.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_v1_to_v2_rejected) {
+    auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"BIGINT"});
+    auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"BIGINT"});
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_not_supported()) << st;
+}
+
+// check_pk_encoding_compat_for_lake_to_lake: V2 -> V1 on single fixed PK -> NotSupported.
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_v2_to_v1_rejected) {
+    auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT"});
+    auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"INT"});
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_not_supported()) << st;
+}
+
+// check_pk_encoding_compat_for_lake_to_lake: V1 -> V2 on VARCHAR PK -> OK (byte-compatible).
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_varchar_pk_allowed) {
+    auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"VARCHAR"});
+    auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"VARCHAR"});
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    EXPECT_TRUE(st.ok()) << st;
+}
+
+// check_pk_encoding_compat_for_lake_to_lake: V1 -> V2 on composite PK -> OK (byte-compatible).
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_lake_to_lake_compat_composite_pk_allowed) {
+    auto src = make_pk_tablet_metadata(1, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1, {"INT", "INT"});
+    auto tgt = make_pk_tablet_metadata(2, PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2, {"INT", "INT"});
+    auto st = lake::LakeReplicationTxnManager::check_pk_encoding_compat_for_lake_to_lake(1, 2, src, tgt);
+    EXPECT_TRUE(st.ok()) << st;
+}
+
 // Test convert_dcg_meta_for_pk: converts DeltaColumnGroupList from snapshot into DeltaColumnGroupMetadataPB
 TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_pk) {
     // Build DeltaColumnGroupList in the same format as shared-nothing PK snapshot

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -791,7 +791,7 @@ namespace {
 //   keys_type=PRIMARY_KEYS, single (or composite) PK columns with the given types,
 //   set primary_key_encoding_type to the requested value.
 TabletMetadataPB make_pk_tablet_metadata(int64_t id, PrimaryKeyEncodingTypePB encoding,
-                                          const std::vector<std::string>& pk_type_names) {
+                                         const std::vector<std::string>& pk_type_names) {
     TabletMetadataPB meta;
     meta.set_id(id);
     auto* schema = meta.mutable_schema();


### PR DESCRIPTION
## Why I'm doing:

When replicating a primary-key table with a **single non-string fixed-length PK column** (INT/BIGINT/DATE/DATETIME/...) from a V1-encoded source cluster (e.g. shared-nothing 3.5.x) to a V2-encoded target (4.1 cloud-native, default since #69939), `.del` files were byte-copied during snapshot intake. The two encodings produce incompatible on-disk shapes:
- V1 + single non-string fixed-length PK → typed column (e.g. `Int32Column`)
- V2 → `BinaryColumn` with order-preserving big-endian slices

The target reader hit `Internal error: Expected remains size 4, but get 0` in `serde::ColumnArraySerde::deserialize` during publish, and the replication txn never converged.

Composite PKs and single VARCHAR PK both materialize as `BinaryColumn` with identical layout in V1 and V2, so they were unaffected.

## What I'm doing:

Introduce `DelFileStreamConverter` (subclass of `FileStreamConverter`, alongside the existing `SegmentStreamConverter`) that re-encodes `.del` payload bytes once at replication intake. After this converter writes the output file, every downstream consumer (`load_delete`, `load_dels`, future compaction, future readers) sees uniform target-encoded bytes — no per-read awareness needed.

Wired into `ReplicationTxnManager::build_file_converters`: when `requires_v1_to_v2_del_transcode(source_enc, target_enc, pkey_schema)` returns true and the file is `.del`, the converter is used; otherwise the plain `FileStreamConverter` byte-copy is preserved.

Other fixes folded in:
- Gate the `source_schema` fallback on `tablet_metadata->has_source_schema()` (the prior nullptr check was a no-op since protobuf returns a default instance).
- Validate cross-cluster PK column count and per-column logical type match; return `NotSupported` on mismatch.
- Reject V2→V1 cross-cluster replication explicitly on the byte-incompatible PK shape (no V2→V1 transcoder).
- Lake-to-lake `NotSupported` guard for the same byte-incompatible shape (lake-to-lake raw-copies `.del` files via `copy_non_segment_file_with_retry`; routing through a transcoding converter there is a follow-up).
- Use `primary_key_encoding_type_or_error()` instead of silently treating `PK_ENCODING_TYPE_NONE` as V1.

Fixes #73577

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5