### PR TITLE
[BugFix] Avoid automatic Hive partition stats refresh (backport #73563)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -172,12 +172,12 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
                 .build(asyncReloading(CacheLoader.from(this::loadTableStatistics), executor));
 
 
+        // Partition stats refresh is driven exclusively by refreshTable() (background
+        // metadata daemon or explicit REFRESH EXTERNAL TABLE); per-key refreshAfterWrite
+        // on top of that amplifies HMS load on large partitioned tables.
         Caffeine<Object, Object> builder = Caffeine.newBuilder().maximumSize(maxSize).executor(executor);
         if (expireAfterWriteSec > 0) {
             builder.expireAfterWrite(expireAfterWriteSec, TimeUnit.SECONDS);
-        }
-        if (refreshIntervalSec > 0) {
-            builder.refreshAfterWrite(refreshIntervalSec, TimeUnit.SECONDS);
         }
         partitionStatsCache = builder.buildAsync(new PartitionStatisticsLoader(this));
     }
@@ -558,12 +558,11 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
             refreshPartitionNames = refreshPartitions(presentPartitionNames, updatedPartitionKeys,
                     this::loadPartitionsByNames, partitionCache);
             if (Config.enable_refresh_hive_partitions_statistics) {
-                partitionStatsCache.synchronous().invalidateAll(presentPartitionStatistics);
                 List<HivePartitionName> needToRefresh = presentPartitionStatistics.stream()
                         .filter(x -> x.getPartitionNames().isPresent()
                                 && updatedPartitionKeys.contains(x.getPartitionNames().get()))
                         .toList();
-                partitionStatsCache.getAll(needToRefresh);
+                needToRefresh.forEach(partitionStatsCache.synchronous()::refresh);
             }
         }
         return refreshPartitionNames;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -75,8 +76,10 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
 
     private final boolean enableListNameCache;
     protected final IHiveMetastore metastore;
+    private final Executor partitionStatsCacheExecutor;
 
     private final Map<DatabaseTableName, Long> lastAccessTimeMap;
+    private final Set<DatabaseTableName> refreshingPartitionStatsTables;
 
     // eg: HivePartitionValue -> List("year=2022/month=10", "year=2022/month=11")
     protected LoadingCache<HivePartitionValue, List<String>> partitionKeysCache;
@@ -131,8 +134,10 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
                                    boolean enableListNamesCache) {
         super(executor, expireAfterWriteSec, refreshIntervalSec, maxSize);
         this.metastore = metastore;
+        this.partitionStatsCacheExecutor = executor;
         this.enableListNameCache = enableListNamesCache;
         this.lastAccessTimeMap = Maps.newConcurrentMap();
+        this.refreshingPartitionStatsTables = ConcurrentHashMap.newKeySet();
 
         // The list names interface of hive metastore latency is very low, so we default to pull the latest every time.
         if (enableListNamesCache) {
@@ -175,7 +180,8 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         // Partition stats refresh is driven exclusively by refreshTable() (background
         // metadata daemon or explicit REFRESH EXTERNAL TABLE); per-key refreshAfterWrite
         // on top of that amplifies HMS load on large partitioned tables.
-        Caffeine<Object, Object> builder = Caffeine.newBuilder().maximumSize(maxSize).executor(executor);
+        Caffeine<Object, Object> builder = Caffeine.newBuilder().maximumSize(maxSize)
+                .executor(partitionStatsCacheExecutor);
         if (expireAfterWriteSec > 0) {
             builder.expireAfterWrite(expireAfterWriteSec, TimeUnit.SECONDS);
         }
@@ -558,11 +564,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
             refreshPartitionNames = refreshPartitions(presentPartitionNames, updatedPartitionKeys,
                     this::loadPartitionsByNames, partitionCache);
             if (Config.enable_refresh_hive_partitions_statistics) {
-                List<HivePartitionName> needToRefresh = presentPartitionStatistics.stream()
-                        .filter(x -> x.getPartitionNames().isPresent()
-                                && updatedPartitionKeys.contains(x.getPartitionNames().get()))
-                        .toList();
-                needToRefresh.forEach(partitionStatsCache.synchronous()::refresh);
+                refreshPartitionStatisticsAsync(databaseTableName, presentPartitionStatistics);
             }
         }
         return refreshPartitionNames;
@@ -590,6 +592,28 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         lastAccessTimeMap.keySet().removeIf(tableName -> !(cachedTableNames.contains(tableName)));
         LOG.info("Refresh table {}.{} in background", hiveDbName, hiveTblName);
         return refreshPartitionNames;
+    }
+
+    private void refreshPartitionStatisticsAsync(DatabaseTableName databaseTableName,
+                                                 List<HivePartitionName> presentPartitionStatistics) {
+        if (presentPartitionStatistics.isEmpty() || !refreshingPartitionStatsTables.add(databaseTableName)) {
+            return;
+        }
+
+        CompletableFuture.runAsync(() -> {
+            for (int i = 0; i < presentPartitionStatistics.size(); i += Config.max_hive_partitions_per_rpc) {
+                List<HivePartitionName> partsToFetch = presentPartitionStatistics.subList(
+                        i, Math.min(i + Config.max_hive_partitions_per_rpc, presentPartitionStatistics.size()));
+                Map<HivePartitionName, HivePartitionStats> updatedPartitionStats =
+                        loadPartitionsStatistics(partsToFetch);
+                partitionStatsCache.synchronous().putAll(updatedPartitionStats);
+            }
+        }, partitionStatsCacheExecutor).whenComplete((ignored, throwable) -> {
+            refreshingPartitionStatsTables.remove(databaseTableName);
+            if (throwable != null) {
+                LOG.warn("Failed to refresh partition statistics for {}", databaseTableName, throwable);
+            }
+        });
     }
 
     private <T> List<HivePartitionName> refreshPartitions(List<HivePartitionName> presentInCache,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -463,6 +463,10 @@ public class CachingHiveMetastoreTest {
                         cache.partitionStatsCache.asMap().get(name).join().getCommonStats().getRowNums());
             }
 
+            cache.refreshTable("db1", "table1", true);
+            Thread.sleep(100L);
+            Assertions.assertEquals(2, loadCount.get());
+
             allowRefreshComplete.countDown();
             boolean refreshCompleted = false;
             long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
@@ -483,6 +487,7 @@ public class CachingHiveMetastoreTest {
                 Thread.sleep(10L);
             }
             Assertions.assertTrue(refreshCompleted);
+            Assertions.assertEquals(2, loadCount.get());
         } finally {
             allowRefreshComplete.countDown();
             Config.enable_refresh_hive_partitions_statistics = previousRefreshPartitionStats;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -28,6 +28,7 @@ import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import mockit.Delegate;
 import mockit.Expectations;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.junit.jupiter.api.AfterEach;
@@ -39,8 +40,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.starrocks.connector.hive.RemoteFileInputFormat.ORC;
 import static org.apache.hadoop.hive.common.StatsSetupConst.TASK;
@@ -358,6 +364,129 @@ public class CachingHiveMetastoreTest {
                 HivePartitionName.of("db1", "table1", "col1=2"));
 
         Assertions.assertEquals(2, cachingHiveMetastore.getPresentPartitionsStatistics(partitionNames).size());
+    }
+
+    @Test
+    public void testPartitionStatsCacheHasNoAutoRefresh() throws Exception {
+        // Even though refreshIntervalSec=1s elapses between two gets, partitionStatsCache
+        // must not register a refreshAfterWrite policy. If it did, the second get would
+        // schedule an async reload triggering a second metastore.getPartitionStatistics
+        // call; JMockit's strict maxTimes=1 asserts this does not happen.
+        new Expectations(metastore) {
+            {
+                metastore.getPartitionStatistics(
+                        (com.starrocks.catalog.Table) any, (List<String>) any);
+                result = Map.of(
+                        "col1=1", HivePartitionStats.empty(),
+                        "col1=2", HivePartitionStats.empty());
+                maxTimes = 1;
+            }
+        };
+
+        CachingHiveMetastore cache = new CachingHiveMetastore(
+                metastore, executor, executor,
+                expireAfterWriteSec, /*refreshIntervalSec*/ 1L, 1000, false);
+
+        com.starrocks.catalog.Table table = cache.getTable("db1", "table1");
+        List<String> parts = Lists.newArrayList("col1=1", "col1=2");
+
+        cache.getPartitionStatistics(table, parts);
+        Thread.sleep(1500L);
+        cache.getPartitionStatistics(table, parts);
+        // Allow any (incorrect) async reload to run before JMockit verifies expectations.
+        Thread.sleep(500L);
+    }
+
+    @Test
+    public void testRefreshTableKeepsPartitionStatsDuringAsyncRefresh() throws Exception {
+        boolean previousRefreshPartitionStats = Config.enable_refresh_hive_partitions_statistics;
+        CountDownLatch refreshStarted = new CountDownLatch(1);
+        CountDownLatch allowRefreshComplete = new CountDownLatch(1);
+        AtomicInteger loadCount = new AtomicInteger(0);
+        HivePartitionStats cachedStats = HivePartitionStats.fromCommonStats(10, 100, 1);
+        HivePartitionStats refreshedStats = HivePartitionStats.fromCommonStats(20, 200, 2);
+        List<String> parts = Lists.newArrayList("col1=1", "col1=2");
+
+        try {
+            Config.enable_refresh_hive_partitions_statistics = true;
+            new Expectations(metastore) {
+                {
+                    metastore.getPartitionKeysByValue(anyString, "table1", (List<Optional<String>>) any);
+                    result = parts;
+                    minTimes = 0;
+
+                    metastore.getPartitionStatistics(
+                            (com.starrocks.catalog.Table) any, (List<String>) any);
+                    result = new Delegate() {
+                        Map<String, HivePartitionStats> getPartitionStatistics(
+                                com.starrocks.catalog.Table table, List<String> partitions) {
+                            int call = loadCount.incrementAndGet();
+                            if (call == 1) {
+                                return Map.of(
+                                        "col1=1", cachedStats,
+                                        "col1=2", cachedStats);
+                            }
+
+                            refreshStarted.countDown();
+                            try {
+                                if (!allowRefreshComplete.await(5, TimeUnit.SECONDS)) {
+                                    throw new IllegalStateException("timed out waiting to complete partition stats refresh");
+                                }
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                throw new RuntimeException(e);
+                            }
+                            return Map.of(
+                                    "col1=1", refreshedStats,
+                                    "col1=2", refreshedStats);
+                        }
+                    };
+                    minTimes = 0;
+                }
+            };
+
+            CachingHiveMetastore cache = new CachingHiveMetastore(
+                    metastore, executor, executor,
+                    expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+
+            com.starrocks.catalog.Table table = cache.getTable("db1", "table1");
+            cache.getPartitionStatistics(table, parts);
+
+            cache.refreshTable("db1", "table1", true);
+            Assertions.assertTrue(refreshStarted.await(5, TimeUnit.SECONDS));
+
+            for (String part : parts) {
+                HivePartitionName name = HivePartitionName.of("db1", "table1", part);
+                Assertions.assertTrue(cache.partitionStatsCache.asMap().containsKey(name));
+                Assertions.assertTrue(cache.partitionStatsCache.asMap().get(name).isDone());
+                Assertions.assertEquals(10,
+                        cache.partitionStatsCache.asMap().get(name).join().getCommonStats().getRowNums());
+            }
+
+            allowRefreshComplete.countDown();
+            boolean refreshCompleted = false;
+            long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (System.nanoTime() < deadlineNanos) {
+                refreshCompleted = true;
+                for (String part : parts) {
+                    HivePartitionName name = HivePartitionName.of("db1", "table1", part);
+                    CompletableFuture<HivePartitionStats> future = cache.partitionStatsCache.asMap().get(name);
+                    if (future == null || !future.isDone()
+                            || future.join().getCommonStats().getRowNums() != 20) {
+                        refreshCompleted = false;
+                        break;
+                    }
+                }
+                if (refreshCompleted) {
+                    break;
+                }
+                Thread.sleep(10L);
+            }
+            Assertions.assertTrue(refreshCompleted);
+        } finally {
+            allowRefreshComplete.countDown();
+            Config.enable_refresh_hive_partitions_statistics = previousRefreshPartitionStats;
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Hive partition stats refresh can overload HMS for large partitioned tables. `partitionStatsCache` was configured with per-key `refreshAfterWrite`, and `refreshTable()` also invalidated cached partition stats before scheduling async reloads. For tables with many partitions, those paths can overlap and repeatedly issue `get_partitions_statistics_req` from the FE leader while previous HMS requests are still slow or stuck.

## What I'm doing:

Remove `refreshAfterWrite` from `partitionStatsCache` so partition stats are no longer refreshed automatically per key. During `refreshTable()`, keep existing cached partition stats available and schedule a table-level async bulk refresh for cached partitions that still exist in HMS. The refresh reloads stats in `max_hive_partitions_per_rpc` batches through `loadPartitionsStatistics()` and updates the cache with `putAll()` after each batch, instead of invalidating old values or using per-partition refresh.

Add a table-level in-flight guard so overlapping refreshes for the same table are skipped while a previous partition-stats refresh is still running. Add regression tests covering no automatic partition stats refresh, preserving old stats during async refresh, and avoiding duplicate/fan-out reloads while a refresh is already in flight.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4


