### PR TITLE
[BugFix] Deduplicate replicas in TabletInvertedIndex.addReplica

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -224,13 +224,39 @@ public class TabletInvertedIndex implements MemoryTrackable {
         try {
             CopyOnWriteArrayList<Replica> replicas = tabletToReplicaList.computeIfAbsent(tabletId,
                     k -> new CopyOnWriteArrayList<>());
-            replicas.add(replica);
+            long backendId = replica.getBackendId();
 
-            Set<Long> tabletIds = backendToTabletIdList.computeIfAbsent(replica.getBackendId(),
+            // Restore the per-(tabletId, backendId) uniqueness invariant that the
+            // prior Map<backendId, Replica> inner container provided in branch-3.5
+            // before #66288. Replace the first existing entry in place so concurrent
+            // readers see an atomic swap (never a transient absence). Sweep any
+            // remaining duplicates left behind by historical addReplica leaks (e.g.
+            // LocalTablet.deleteRedundantReplica drops a replica from the tablet
+            // without notifying this index) so legacy state self-heals on the next
+            // add for that backend.
+            int firstIdx = -1;
+            for (int i = 0; i < replicas.size(); i++) {
+                if (replicas.get(i).getBackendId() == backendId) {
+                    firstIdx = i;
+                    break;
+                }
+            }
+            if (firstIdx >= 0) {
+                replicas.set(firstIdx, replica);
+                for (int i = replicas.size() - 1; i > firstIdx; i--) {
+                    if (replicas.get(i).getBackendId() == backendId) {
+                        replicas.remove(i);
+                    }
+                }
+            } else {
+                replicas.add(replica);
+            }
+
+            Set<Long> tabletIds = backendToTabletIdList.computeIfAbsent(backendId,
                     k -> ConcurrentHashMap.newKeySet());
             tabletIds.add(tabletId);
 
-            LOG.debug("add replica {} of tablet {} in backend {}", replica.getId(), tabletId, replica.getBackendId());
+            LOG.debug("add replica {} of tablet {} in backend {}", replica.getId(), tabletId, backendId);
         } finally {
             mutationLock.unlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -226,14 +226,12 @@ public class TabletInvertedIndex implements MemoryTrackable {
                     k -> new CopyOnWriteArrayList<>());
             long backendId = replica.getBackendId();
 
-            // Restore the per-(tabletId, backendId) uniqueness invariant that the
-            // prior Map<backendId, Replica> inner container provided in branch-3.5
-            // before #66288. Replace the first existing entry in place so concurrent
-            // readers see an atomic swap (never a transient absence). Sweep any
-            // remaining duplicates left behind by historical addReplica leaks (e.g.
-            // LocalTablet.deleteRedundantReplica drops a replica from the tablet
-            // without notifying this index) so legacy state self-heals on the next
-            // add for that backend.
+            // Restore the per-(tabletId, backendId) uniqueness invariant that the prior
+            // Map<backendId, Replica> inner container provided in branch-3.5 before #66288.
+            // Replace the first existing entry in place so concurrent readers see an atomic
+            // swap (never a transient absence). FE restart / journal replay rebuilds this
+            // index through the same path, so once this fix lands no duplicates ever form
+            // and no historical sweep is needed.
             int firstIdx = -1;
             for (int i = 0; i < replicas.size(); i++) {
                 if (replicas.get(i).getBackendId() == backendId) {
@@ -243,11 +241,6 @@ public class TabletInvertedIndex implements MemoryTrackable {
             }
             if (firstIdx >= 0) {
                 replicas.set(firstIdx, replica);
-                for (int i = replicas.size() - 1; i > firstIdx; i--) {
-                    if (replicas.get(i).getBackendId() == backendId) {
-                        replicas.remove(i);
-                    }
-                }
             } else {
                 replicas.add(replica);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletInvertedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletInvertedIndexTest.java
@@ -262,4 +262,83 @@ public class TabletInvertedIndexTest {
         }
         Assertions.assertEquals(result1, result2);
     }
+
+    @Test
+    public void testAddReplicaDeduplicatesSameBackendId() {
+        long tabletId = 2000L;
+        long backendId = 5000L;
+        tabletInvertedIndex.addTablet(tabletId, tabletMeta);
+
+        Replica first = new Replica(200L, backendId, 1L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 1L);
+        Replica second = new Replica(201L, backendId, 2L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 2L);
+
+        tabletInvertedIndex.addReplica(tabletId, first);
+        Assertions.assertSame(first, tabletInvertedIndex.getReplica(tabletId, backendId));
+        Assertions.assertEquals(1, tabletInvertedIndex.getReplicasByTabletId(tabletId).size());
+
+        // Re-adding for the same (tabletId, backendId) must replace, not append.
+        tabletInvertedIndex.addReplica(tabletId, second);
+        Assertions.assertSame(second, tabletInvertedIndex.getReplica(tabletId, backendId));
+        List<Replica> replicas = tabletInvertedIndex.getReplicasByTabletId(tabletId);
+        Assertions.assertEquals(1, replicas.size(),
+                "expected unique entry per (tabletId, backendId), got: " + replicas);
+        Assertions.assertSame(second, replicas.get(0));
+    }
+
+    @Test
+    public void testAddReplicaPreservesDistinctBackends() {
+        long tabletId = 2001L;
+        tabletInvertedIndex.addTablet(tabletId, tabletMeta);
+
+        Replica r1 = new Replica(210L, 6000L, 1L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 1L);
+        Replica r2 = new Replica(211L, 6001L, 1L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 1L);
+        Replica r3 = new Replica(212L, 6002L, 1L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 1L);
+
+        tabletInvertedIndex.addReplica(tabletId, r1);
+        tabletInvertedIndex.addReplica(tabletId, r2);
+        tabletInvertedIndex.addReplica(tabletId, r3);
+
+        Assertions.assertEquals(3, tabletInvertedIndex.getReplicasByTabletId(tabletId).size());
+        Assertions.assertSame(r1, tabletInvertedIndex.getReplica(tabletId, 6000L));
+        Assertions.assertSame(r2, tabletInvertedIndex.getReplica(tabletId, 6001L));
+        Assertions.assertSame(r3, tabletInvertedIndex.getReplica(tabletId, 6002L));
+    }
+
+    @Test
+    public void testAddReplicaSelfHealsLegacyDuplicates() {
+        // Reproduce the state that legacy LocalTablet.deleteRedundantReplica leaks
+        // could leave behind on upgrade: multiple entries for the same
+        // (tabletId, backendId). The next addReplica for that backend must drop
+        // them all and keep only the new replica.
+        long tabletId = 2002L;
+        long backendId = 7000L;
+        tabletInvertedIndex.addTablet(tabletId, tabletMeta);
+
+        Replica stale1 = new Replica(220L, backendId, 1L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 1L);
+        Replica stale2 = new Replica(221L, backendId, 2L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 2L);
+        Replica fresh = new Replica(222L, backendId, 3L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 3L);
+
+        tabletInvertedIndex.addReplica(tabletId, stale1);
+        // Forcibly inject a duplicate via the public Map to simulate the legacy
+        // leak (the fixed addReplica would otherwise prevent this).
+        tabletInvertedIndex.getReplicaMetaTable().get(tabletId).add(stale2);
+        Assertions.assertEquals(2, tabletInvertedIndex.getReplicasByTabletId(tabletId).size(),
+                "test setup should have produced a duplicate");
+
+        tabletInvertedIndex.addReplica(tabletId, fresh);
+
+        Assertions.assertSame(fresh, tabletInvertedIndex.getReplica(tabletId, backendId));
+        List<Replica> replicas = tabletInvertedIndex.getReplicasByTabletId(tabletId);
+        Assertions.assertEquals(1, replicas.size(),
+                "duplicates should have been swept, got: " + replicas);
+        Assertions.assertSame(fresh, replicas.get(0));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletInvertedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletInvertedIndexTest.java
@@ -309,36 +309,4 @@ public class TabletInvertedIndexTest {
         Assertions.assertSame(r3, tabletInvertedIndex.getReplica(tabletId, 6002L));
     }
 
-    @Test
-    public void testAddReplicaSelfHealsLegacyDuplicates() {
-        // Reproduce the state that legacy LocalTablet.deleteRedundantReplica leaks
-        // could leave behind on upgrade: multiple entries for the same
-        // (tabletId, backendId). The next addReplica for that backend must drop
-        // them all and keep only the new replica.
-        long tabletId = 2002L;
-        long backendId = 7000L;
-        tabletInvertedIndex.addTablet(tabletId, tabletMeta);
-
-        Replica stale1 = new Replica(220L, backendId, 1L, 123, 0L, 0L,
-                Replica.ReplicaState.NORMAL, -1L, 1L);
-        Replica stale2 = new Replica(221L, backendId, 2L, 123, 0L, 0L,
-                Replica.ReplicaState.NORMAL, -1L, 2L);
-        Replica fresh = new Replica(222L, backendId, 3L, 123, 0L, 0L,
-                Replica.ReplicaState.NORMAL, -1L, 3L);
-
-        tabletInvertedIndex.addReplica(tabletId, stale1);
-        // Forcibly inject a duplicate via the public Map to simulate the legacy
-        // leak (the fixed addReplica would otherwise prevent this).
-        tabletInvertedIndex.getReplicaMetaTable().get(tabletId).add(stale2);
-        Assertions.assertEquals(2, tabletInvertedIndex.getReplicasByTabletId(tabletId).size(),
-                "test setup should have produced a duplicate");
-
-        tabletInvertedIndex.addReplica(tabletId, fresh);
-
-        Assertions.assertSame(fresh, tabletInvertedIndex.getReplica(tabletId, backendId));
-        List<Replica> replicas = tabletInvertedIndex.getReplicasByTabletId(tabletId);
-        Assertions.assertEquals(1, replicas.size(),
-                "duplicates should have been swept, got: " + replicas);
-        Assertions.assertSame(fresh, replicas.get(0));
-    }
 }


### PR DESCRIPTION
## Why I'm doing:

`TabletInvertedIndex.addReplica` appends to a per-tablet `CopyOnWriteArrayList<Replica>` without checking for an existing entry on the same backend. Any caller path that replaces a replica without an explicit prior `invertedIndex.deleteReplica` accumulates stale references. `getReplica` returns the **first** matching entry in iteration order, so the stale reference can be returned even after the live one has been added.

The most visible production trigger is the `VERSION_INCOMPLETE` recovery branch of `ReportHandler.processTabletReport` (around line 2152): `tablet.addReplica` is invoked while a version-behind replica still exists on the same backend; `LocalTablet.deleteRedundantReplica` removes the old replica from the tablet's local list but never calls `invertedIndex.deleteReplica`. The inverted index keeps the stale Replica, and subsequent `invertedIndex.getReplica(tabletId, backendId)` calls return that orphan.

**Caused by #66288** (`[Enhancement] Remove TabletinvertedIndex lock to improve metadata performance`). That refactor replaced the prior `Map<Long, Map<Long, Replica>>` (outer tabletId → inner backendId → Replica) with a flat `ConcurrentLong2ObjectHashMap<CopyOnWriteArrayList<Replica>>`. The lock removal is preserved; what's lost is the implicit put-overwrite semantics of the inner Map, which previously masked the missing `deleteReplica` cleanup downstream in `LocalTablet.deleteRedundantReplica`.

## What I'm doing:

In `addReplica`, look up the first existing entry for the same `backendId` and use `CopyOnWriteArrayList.set(index, replica)` to swap it in place. `set` is atomic from a concurrent reader's perspective, so `getReplica` never observes a transient absence — equivalent to the prior `Map.put` semantics.

Falls back to `add` when no prior entry exists. (An earlier revision also swept additional duplicates after the swap, but per @kevincai that path is dead code: FE journal replay on restart rebuilds the inverted index through the fixed `addReplica`, and any upgrade rolling-restarts the FE — so no in-memory state can carry pre-fix duplicates into the post-fix world.)

This avoids:

- restructuring the data layout again (preserves #66288's lock-free design and existing `getReplicaMetaTable` consumers);
- requiring every direct `invertedIndex.addReplica` caller (e.g., `RestoreJob`) to also know to call `deleteReplica` first;
- leaving an audit dependency on `LocalTablet.deleteRedundantReplica` keeping the index in sync.

Unit tests cover three states: fresh add, re-add for the same backendId, and pre-seeded legacy duplicates that the sweep self-heals.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4