### PR TITLE
[UT] Stub ColocateChecker daemon in SplitTabletJobColocateTest

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
@@ -99,6 +99,16 @@ public class SplitTabletJobColocateTest {
                 return CompletableFuture.completedFuture(task.call());
             }
         };
+
+        // The TabletReshardJobMgr daemon ticks every 10ms and runs ColocateChecker.runOneCycle,
+        // which re-marks an unstable colocate group stable as soon as every peer is range-aligned.
+        // In these single-DB tests the split itself produces fully-aligned tablets, so the daemon
+        // would race the test thread and clear the unstable bit before the assertion runs.
+        new MockUp<ColocateChecker>() {
+            @Mock
+            public void runOneCycle() {
+            }
+        };
     }
 
     @BeforeEach


### PR DESCRIPTION
## Why I'm doing:

`SplitTabletJobColocateTest` is flaky. CI has hit:

```
multi-way Level 1 split must mark the group unstable ==> expected: <true> but was: <false>
    at SplitTabletJobColocateTest.testMultiWaySplitDetectsCanonicalLowerWithNonCanonicalUpper(SplitTabletJobColocateTest.java:248)
```

Root cause is a race between the test thread and the `TabletReshardJobMgr` daemon (tick interval `tablet_reshard_job_scheduler_interval_ms = 10ms`):

1. `SplitTabletJob.applyColocateRangeSplitResult()` splices the canonical boundary into `ColocateRangeMgr` and marks the colocate group unstable.
2. Job advances to `CLEANING`, table state goes back to `NORMAL`.
3. Before the assertion runs, the daemon ticks: `ColocateChecker.runOneCycle()` sees the unstable group, finds that the new tablets the split produced are already perfectly aligned with the new `ColocateRange` topology (single-DB test, no misaligned peer), and calls `markAllGroupsWithSameColocateGroupIdStable` — clearing the bit the test is about to assert on.
4. Assertion `isGroupUnstable(groupId) == true` fails because it is now `false`.

The same race also explains intermittent failures of `testLevelOneSplitAddsCanonicalBoundary` (2-way split, same alignment pattern) and `testCannotSplitWhileUnstable` (the `Range.all()` tablet is trivially aligned with the single `Range.all()` ColocateRange, so the daemon races to mark stable before `assertThrows` triggers); both were reproduced locally with this fix off.

In production this race is benign because real colocate groups span multiple DBs and peer tables are still unaligned at the moment one peer splits; the daemon only flips back to stable once every peer is aligned. The UT is a degenerate single-DB scenario where the splitting table is also the only peer, so a single tick is enough to undo the unstable mark.

## What I'm doing:

In `@BeforeAll`, install a `MockUp<ColocateChecker>` that no-ops `runOneCycle()` for the duration of the test class. Comment in the test file explains the race so future readers don't strip the mock.

Verified locally by running `SplitTabletJobColocateTest` 11x with the fix; all 11 runs pass 7/7. Without the fix the same workload reproduces `testMultiWaySplitDetectsCanonicalLowerWithNonCanonicalUpper` / `testLevelOneSplitAddsCanonicalBoundary` / `testCannotSplitWhileUnstable` failures.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5