### PR TITLE
[BugFix] Populate reader-owned DataCache reads during CACHE SELECT

### DIFF
--- a/be/src/cache/scan/cache_input_stream.h
+++ b/be/src/cache/scan/cache_input_stream.h
@@ -51,6 +51,36 @@ public:
         int64_t write_cache_fail_bytes = 0;
         int64_t read_block_buffer_bytes = 0;
         int64_t read_block_buffer_count = 0;
+
+        // Fold another stream's counters in. Used when a scan reads through more than one
+        // CacheInputStream (e.g. CACHE SELECT routes reader-owned reads through a second
+        // populate stream) and the per-stream stats must be reported as a single total.
+        Stats& operator+=(const Stats& o) {
+            read_block_cache_ns += o.read_block_cache_ns;
+            write_block_cache_ns += o.write_block_cache_ns;
+            read_block_cache_count += o.read_block_cache_count;
+            write_block_cache_count += o.write_block_cache_count;
+            write_mem_cache_bytes += o.write_mem_cache_bytes;
+            write_disk_cache_bytes += o.write_disk_cache_bytes;
+            read_block_cache_bytes += o.read_block_cache_bytes;
+            read_mem_cache_bytes += o.read_mem_cache_bytes;
+            read_disk_cache_bytes += o.read_disk_cache_bytes;
+            read_peer_cache_bytes += o.read_peer_cache_bytes;
+            read_peer_cache_count += o.read_peer_cache_count;
+            read_peer_cache_ns += o.read_peer_cache_ns;
+            write_block_cache_bytes += o.write_block_cache_bytes;
+            skip_read_cache_count += o.skip_read_cache_count;
+            skip_read_cache_bytes += o.skip_read_cache_bytes;
+            skip_read_peer_cache_count += o.skip_read_peer_cache_count;
+            skip_read_peer_cache_bytes += o.skip_read_peer_cache_bytes;
+            skip_write_cache_count += o.skip_write_cache_count;
+            skip_write_cache_bytes += o.skip_write_cache_bytes;
+            write_cache_fail_count += o.write_cache_fail_count;
+            write_cache_fail_bytes += o.write_cache_fail_bytes;
+            read_block_buffer_bytes += o.read_block_buffer_bytes;
+            read_block_buffer_count += o.read_block_buffer_count;
+            return *this;
+        }
     };
 
     explicit CacheInputStream(const std::shared_ptr<SharedBufferedInputStream>& stream, const std::string& filename,

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -350,7 +350,8 @@ void HdfsScanner::close() noexcept {
 
 StatusOr<std::unique_ptr<RandomAccessFile>> HdfsScanner::create_random_access_file(
         std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream,
-        std::shared_ptr<CacheInputStream>& cache_input_stream, const OpenFileOptions& options) {
+        std::shared_ptr<CacheInputStream>& cache_input_stream, const OpenFileOptions& options,
+        std::shared_ptr<CacheInputStream>* populate_input_stream) {
     ASSIGN_OR_RETURN(std::unique_ptr<RandomAccessFile> raw_file, options.fs->new_random_access_file(options.path))
     int64_t file_size = options.file_size;
     if (file_size < 0) {
@@ -376,6 +377,23 @@ StatusOr<std::unique_ptr<RandomAccessFile>> HdfsScanner::create_random_access_fi
         if (datacache_options.enable_cache_select) {
             cache_input_stream = std::make_shared<CacheSelectInputStream>(
                     shared_buffered_input_stream, filename, file_size, datacache_options.modification_time);
+            // CacheSelectInputStream only writes explicit IO ranges. Use CacheInputStream for
+            // reader-owned reads through _file so CACHE SELECT can populate those blocks too.
+            auto populate_stream = std::make_shared<CacheInputStream>(shared_buffered_input_stream, filename, file_size,
+                                                                      datacache_options.modification_time);
+            populate_stream->set_enable_populate_cache(datacache_options.enable_populate_datacache);
+            populate_stream->set_enable_async_populate_mode(datacache_options.enable_datacache_async_populate_mode);
+            populate_stream->set_enable_cache_io_adaptor(datacache_options.enable_datacache_io_adaptor);
+            populate_stream->set_enable_block_buffer(config::datacache_block_buffer_enable);
+            populate_stream->set_priority(datacache_options.datacache_priority);
+            populate_stream->set_ttl_seconds(datacache_options.datacache_ttl_seconds);
+            input_stream = populate_stream;
+            // CacheSelectInputStream (cache_input_stream) only accounts the explicit IO-range
+            // writes; populate_stream serves the reader-owned reads. Hand it back so its cache
+            // stats are folded into the scan's DataCache counters (see update_counter()).
+            if (populate_input_stream != nullptr) {
+                *populate_input_stream = populate_stream;
+            }
         } else {
             cache_input_stream = std::make_shared<CacheInputStream>(shared_buffered_input_stream, filename, file_size,
                                                                     datacache_options.modification_time);
@@ -419,7 +437,8 @@ Status HdfsScanner::open_random_access_file() {
                             .datacache_options = _scanner_params.datacache_options,
                             .compression_type = _compression_type};
 
-    ASSIGN_OR_RETURN(_file, create_random_access_file(_shared_buffered_input_stream, _cache_input_stream, options));
+    ASSIGN_OR_RETURN(_file, create_random_access_file(_shared_buffered_input_stream, _cache_input_stream, options,
+                                                      &_cache_select_populate_stream));
     if (_cache_input_stream) {
         _cache_input_stream->set_peer_cache_node(_scanner_params.scan_range->candidate_node);
     }
@@ -545,7 +564,12 @@ void HdfsScanner::update_counter() {
                                                                 _app_stats.page_read_counter);
 
     if (_scanner_params.datacache_options.enable_datacache && _cache_input_stream) {
-        const CacheInputStream::Stats& stats = _cache_input_stream->stats();
+        // CACHE SELECT routes reader-owned reads through a separate populate stream; fold its
+        // cache stats in so footer/init reads it warms are reflected in the DataCache counters.
+        CacheInputStream::Stats stats = _cache_input_stream->stats();
+        if (_cache_select_populate_stream) {
+            stats += _cache_select_populate_stream->stats();
+        }
         COUNTER_UPDATE(profile->datacache_read_counter, stats.read_block_cache_count);
         COUNTER_UPDATE(profile->datacache_read_bytes, stats.read_block_cache_bytes);
         COUNTER_UPDATE(profile->datacache_read_mem_bytes, stats.read_mem_cache_bytes);

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -511,7 +511,8 @@ public:
 
     static StatusOr<std::unique_ptr<RandomAccessFile>> create_random_access_file(
             std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream,
-            std::shared_ptr<CacheInputStream>& cache_input_stream, const OpenFileOptions& options);
+            std::shared_ptr<CacheInputStream>& cache_input_stream, const OpenFileOptions& options,
+            std::shared_ptr<CacheInputStream>* populate_input_stream = nullptr);
 
 protected:
     Status open_random_access_file();
@@ -537,6 +538,10 @@ protected:
     // by default it's no compression.
     CompressionTypePB _compression_type = CompressionTypePB::NO_COMPRESSION;
     std::shared_ptr<CacheInputStream> _cache_input_stream = nullptr;
+    // CACHE SELECT only: reader-owned reads are routed through this populate stream so they
+    // warm the cache too (cache_input_stream is a CacheSelectInputStream that writes only the
+    // explicit IO ranges). Held so its cache stats are folded into the scan's DataCache counters.
+    std::shared_ptr<CacheInputStream> _cache_select_populate_stream = nullptr;
     std::shared_ptr<SharedBufferedInputStream> _shared_buffered_input_stream = nullptr;
     int64_t _total_running_time = 0;
 

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
@@ -228,6 +228,62 @@ TEST_F(HdfsScannerTest, TestParquetOpen) {
     ASSERT_TRUE(status.ok());
 }
 
+#if defined(WITH_STARCACHE)
+// CACHE SELECT writes its planned IO ranges separately. Reader-owned reads through RandomAccessFile,
+// such as parquet footer reads, must populate DataCache through the regular file stream too.
+TEST_F(HdfsScannerTest, TestCacheSelectReaderReadPopulatesDataCache) {
+    auto cache_options = TestCacheUtils::create_simple_options(config::datacache_block_size, 50 * MB);
+    auto block_cache = TestCacheUtils::create_cache(cache_options);
+    DataCache::GetInstance()->set_block_cache(block_cache);
+
+    ASSIGN_OR_ABORT(auto file_size, FileSystem::Default()->get_file_size(default_parquet_file));
+    const DataCacheOptions datacache_options{
+            .enable_datacache = true, .enable_cache_select = true, .enable_populate_datacache = true};
+
+    auto read_file = [&](HdfsScanStats* fs_stats, CacheInputStream::Stats* select_stats,
+                         CacheInputStream::Stats* populate_stats) {
+        HdfsScanStats app_stats;
+        OpenFileOptions options{.fs = FileSystem::Default(),
+                                .path = default_parquet_file,
+                                .file_size = file_size,
+                                .fs_stats = fs_stats,
+                                .app_stats = &app_stats,
+                                .datacache_options = datacache_options};
+        std::shared_ptr<SharedBufferedInputStream> shared_stream;
+        std::shared_ptr<CacheInputStream> cache_stream;
+        std::shared_ptr<CacheInputStream> populate_stream;
+        ASSIGN_OR_ABORT(auto file,
+                        HdfsScanner::create_random_access_file(shared_stream, cache_stream, options, &populate_stream));
+
+        char buffer[8];
+        ASSERT_OK(file->read_at_fully(0, buffer, sizeof(buffer)));
+        // The CacheSelectInputStream handed back as cache_stream never serves reader-owned reads;
+        // those flow through the separate populate_stream, which is where their cache writes land.
+        ASSERT_TRUE(populate_stream != nullptr);
+        *select_stats = cache_stream->stats();
+        *populate_stats = populate_stream->stats();
+    };
+
+    HdfsScanStats first_fs_stats;
+    CacheInputStream::Stats first_select_stats;
+    CacheInputStream::Stats first_populate_stats;
+    read_file(&first_fs_stats, &first_select_stats, &first_populate_stats);
+    ASSERT_GT(first_fs_stats.bytes_read, 0);
+    // The footer/init reads populate the cache through populate_stream, not the CacheSelect stream.
+    // update_counter() folds these in; without the fold the write bytes would go unreported.
+    EXPECT_GT(first_populate_stats.write_block_cache_bytes, 0);
+    EXPECT_EQ(first_select_stats.write_block_cache_bytes, 0);
+
+    HdfsScanStats second_fs_stats;
+    CacheInputStream::Stats second_select_stats;
+    CacheInputStream::Stats second_populate_stats;
+    read_file(&second_fs_stats, &second_select_stats, &second_populate_stats);
+    EXPECT_EQ(second_fs_stats.bytes_read, 0);
+    // Second pass is served from cache: reads counted on populate_stream, no new backing-store IO.
+    EXPECT_GT(second_populate_stats.read_block_cache_bytes, 0);
+}
+#endif
+
 TEST_F(HdfsScannerTest, TestHdfsRunningTime) {
     auto scanner = std::make_shared<HdfsParquetScanner>();
 


### PR DESCRIPTION
## Why I'm doing:

`CACHE SELECT` populates DataCache for explicit scan IO ranges through `CacheSelectInputStream`, but format-reader reads through the scanner `RandomAccessFile` do not use a populating `CacheInputStream` in cache-select mode.

That leaves reader-owned reads such as Parquet footer reads during reader initialization outside the warmup, so a following query can still fetch those blocks from remote storage after `CACHE SELECT`.

## What I'm doing:

Wrap the scanner file stream with a regular `CacheInputStream` in cache-select mode while keeping `CacheSelectInputStream` for explicit cache-select IO range writes.

This lets reader-owned reads through `RandomAccessFile` both return bytes normally and populate DataCache during `CACHE SELECT`.

Add a regression test that reads the same file twice through `HdfsScanner::create_random_access_file` in cache-select mode and verifies that the second read no longer reaches the raw file path.

Fixes #73663

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
