### PR TITLE
[Feature] Add DataSketches Theta function-family parity with HLL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,9 @@ memory/
 !be/src/runtime/memory/**
 !be/test/runtime/memory/
 !be/test/runtime/memory/**
+
+# Local build and test artifacts
+/be-cn/
+/build_*_log.txt
+/test/.venv-docker/
+/test/.venv-requirements.txt

--- a/be/src/exprs/agg/data_sketch/ds_theta.cpp
+++ b/be/src/exprs/agg/data_sketch/ds_theta.cpp
@@ -49,31 +49,33 @@ void DataSketchesTheta::merge(const DataSketchesTheta& other) {
 }
 
 size_t DataSketchesTheta::serialize(uint8_t* dst) const {
+    dst[0] = kMagicByte;
+    dst[1] = _lg_k;
     if (_sketch_update) {
         auto bytes = _sketch_update->compact().serialize();
-        std::copy(bytes.begin(), bytes.end(), dst);
-        return bytes.size();
+        std::copy(bytes.begin(), bytes.end(), dst + kHeaderSize);
+        return kHeaderSize + bytes.size();
     } else if (_sketch_union) {
         auto bytes = _sketch_union->get_result().serialize();
-        std::copy(bytes.begin(), bytes.end(), dst);
-        return bytes.size();
+        std::copy(bytes.begin(), bytes.end(), dst + kHeaderSize);
+        return kHeaderSize + bytes.size();
     } else {
         theta_compact_sketch::vector_bytes bytes;
-        std::copy(bytes.begin(), bytes.end(), dst);
-        return bytes.size();
+        std::copy(bytes.begin(), bytes.end(), dst + kHeaderSize);
+        return kHeaderSize + bytes.size();
     }
 }
 
 uint64_t DataSketchesTheta::serialize_size() const {
     if (_sketch_update) {
         auto bytes = _sketch_update->compact().serialize();
-        return bytes.size();
+        return kHeaderSize + bytes.size();
     } else if (_sketch_union) {
         auto bytes = _sketch_union->get_result().serialize();
-        return bytes.size();
+        return kHeaderSize + bytes.size();
     } else {
         theta_compact_sketch::vector_bytes bytes;
-        return bytes.size();
+        return kHeaderSize + bytes.size();
     }
 }
 
@@ -81,8 +83,28 @@ bool DataSketchesTheta::deserialize(const Slice& slice) {
     if (slice.empty()) {
         return true;
     }
+    const auto* data = reinterpret_cast<const uint8_t*>(slice.get_data());
+    size_t size = slice.get_size();
+    // StarRocks wraps the compact theta sketch with a 2-byte header
+    // [magic=0xFE][lg_k] so that lg_k survives serialize/deserialize.
+    // Legacy data (raw compact theta bytes) is detected by the absence
+    // of the magic byte; compact-theta's first byte is pre_longs (1, 2, or 3).
+    if (size >= 2 && data[0] == kMagicByte) {
+        uint8_t lg_k = data[1];
+        if (lg_k >= datasketches::theta_constants::MIN_LG_K &&
+            lg_k <= datasketches::theta_constants::MAX_LG_K) {
+            _lg_k = lg_k;
+        }
+        data += 2;
+        size -= 2;
+    }
+    // Header-only payloads (e.g. a state that has never seen update/merge) carry
+    // no compact-sketch bytes; treat them as empty.
+    if (size == 0) {
+        return true;
+    }
     try {
-        auto sk = wrapped_compact_theta_sketch::wrap(slice.get_data(), slice.get_size());
+        auto sk = wrapped_compact_theta_sketch::wrap(data, size);
         get_sketch_union()->update(sk);
     } catch (std::logic_error& e) {
         DLOG(INFO) << "DataSketchesTheta deserialize error with exception:" << e.what();

--- a/be/src/exprs/agg/data_sketch/ds_theta.cpp
+++ b/be/src/exprs/agg/data_sketch/ds_theta.cpp
@@ -91,8 +91,7 @@ bool DataSketchesTheta::deserialize(const Slice& slice) {
     // of the magic byte; compact-theta's first byte is pre_longs (1, 2, or 3).
     if (size >= 2 && data[0] == kMagicByte) {
         uint8_t lg_k = data[1];
-        if (lg_k >= datasketches::theta_constants::MIN_LG_K &&
-            lg_k <= datasketches::theta_constants::MAX_LG_K) {
+        if (lg_k >= datasketches::theta_constants::MIN_LG_K && lg_k <= datasketches::theta_constants::MAX_LG_K) {
             _lg_k = lg_k;
         }
         data += 2;

--- a/be/src/exprs/agg/data_sketch/ds_theta.cpp
+++ b/be/src/exprs/agg/data_sketch/ds_theta.cpp
@@ -49,31 +49,33 @@ void DataSketchesTheta::merge(const DataSketchesTheta& other) {
 }
 
 size_t DataSketchesTheta::serialize(uint8_t* dst) const {
+    dst[0] = kMagicByte;
+    dst[1] = _lg_k;
     if (_sketch_update) {
         auto bytes = _sketch_update->compact().serialize();
-        std::copy(bytes.begin(), bytes.end(), dst);
-        return bytes.size();
+        std::copy(bytes.begin(), bytes.end(), dst + kHeaderSize);
+        return kHeaderSize + bytes.size();
     } else if (_sketch_union) {
         auto bytes = _sketch_union->get_result().serialize();
-        std::copy(bytes.begin(), bytes.end(), dst);
-        return bytes.size();
+        std::copy(bytes.begin(), bytes.end(), dst + kHeaderSize);
+        return kHeaderSize + bytes.size();
     } else {
         theta_compact_sketch::vector_bytes bytes;
-        std::copy(bytes.begin(), bytes.end(), dst);
-        return bytes.size();
+        std::copy(bytes.begin(), bytes.end(), dst + kHeaderSize);
+        return kHeaderSize + bytes.size();
     }
 }
 
 uint64_t DataSketchesTheta::serialize_size() const {
     if (_sketch_update) {
         auto bytes = _sketch_update->compact().serialize();
-        return bytes.size();
+        return kHeaderSize + bytes.size();
     } else if (_sketch_union) {
         auto bytes = _sketch_union->get_result().serialize();
-        return bytes.size();
+        return kHeaderSize + bytes.size();
     } else {
         theta_compact_sketch::vector_bytes bytes;
-        return bytes.size();
+        return kHeaderSize + bytes.size();
     }
 }
 
@@ -81,8 +83,27 @@ bool DataSketchesTheta::deserialize(const Slice& slice) {
     if (slice.empty()) {
         return true;
     }
+    const auto* data = reinterpret_cast<const uint8_t*>(slice.get_data());
+    size_t size = slice.get_size();
+    // StarRocks wraps the compact theta sketch with a 2-byte header
+    // [magic=0xFE][lg_k] so that lg_k survives serialize/deserialize.
+    // Legacy data (raw compact theta bytes) is detected by the absence
+    // of the magic byte; compact-theta's first byte is pre_longs (1, 2, or 3).
+    if (size >= 2 && data[0] == kMagicByte) {
+        uint8_t lg_k = data[1];
+        if (lg_k >= datasketches::theta_constants::MIN_LG_K && lg_k <= datasketches::theta_constants::MAX_LG_K) {
+            _lg_k = lg_k;
+        }
+        data += 2;
+        size -= 2;
+    }
+    // Header-only payloads (e.g. a state that has never seen update/merge) carry
+    // no compact-sketch bytes; treat them as empty.
+    if (size == 0) {
+        return true;
+    }
     try {
-        auto sk = wrapped_compact_theta_sketch::wrap(slice.get_data(), slice.get_size());
+        auto sk = wrapped_compact_theta_sketch::wrap(data, size);
         get_sketch_union()->update(sk);
     } catch (std::logic_error& e) {
         DLOG(INFO) << "DataSketchesTheta deserialize error with exception:" << e.what();

--- a/be/src/exprs/agg/data_sketch/ds_theta.h
+++ b/be/src/exprs/agg/data_sketch/ds_theta.h
@@ -62,8 +62,7 @@ public:
         return *this;
     }
     explicit DataSketchesTheta(const Slice& src, int64_t* memory_usage);
-    DataSketchesTheta(DataSketchesTheta&& other) noexcept
-            : _memory_usage(other._memory_usage), _lg_k(other._lg_k) {}
+    DataSketchesTheta(DataSketchesTheta&& other) noexcept : _memory_usage(other._memory_usage), _lg_k(other._lg_k) {}
 
     ~DataSketchesTheta() = default;
 

--- a/be/src/exprs/agg/data_sketch/ds_theta.h
+++ b/be/src/exprs/agg/data_sketch/ds_theta.h
@@ -21,6 +21,7 @@
 #include "common/mem_chunk.h"
 #include "runtime/memory/counting_allocator.h"
 #include "runtime/memory/mem_chunk_allocator.h"
+#include "types/constexpr.h"
 
 //  enum flags { IS_BIG_ENDIAN, IS_READ_ONLY, IS_EMPTY, IS_COMPACT, IS_ORDERED };
 #pragma push_macro("IS_BIG_ENDIAN")
@@ -39,20 +40,30 @@ public:
     using theta_compact_sketch = datasketches::compact_theta_sketch_alloc<alloc_type>;
     using wrapped_compact_theta_sketch = datasketches::wrapped_compact_theta_sketch_alloc<alloc_type>;
 
+    // 2-byte StarRocks-specific header [magic=0xFE][lg_k] prepended to the compact
+    // theta sketch bytes so lg_k survives serialize/deserialize. Compact theta sketches
+    // start with pre_longs in {1,2,3}, so 0xFE unambiguously identifies our header
+    // and lets us fall back to header-less legacy data.
+    static constexpr uint8_t kMagicByte = 0xFE;
+    static constexpr size_t kHeaderSize = 2;
+
     DataSketchesTheta(const DataSketchesTheta& other) = delete;
     DataSketchesTheta& operator=(const DataSketchesTheta& other) = delete;
 
     explicit DataSketchesTheta(int64_t* memory_usage) : _memory_usage(memory_usage) {}
+    DataSketchesTheta(uint8_t lg_k, int64_t* memory_usage) : _memory_usage(memory_usage), _lg_k(lg_k) {}
     DataSketchesTheta& operator=(DataSketchesTheta&& other) noexcept {
         if (this != &other) {
             this->_memory_usage = other._memory_usage;
+            this->_lg_k = other._lg_k;
             this->_sketch_update = std::move(other._sketch_update);
             this->_sketch_union = std::move(other._sketch_union);
         }
         return *this;
     }
     explicit DataSketchesTheta(const Slice& src, int64_t* memory_usage);
-    DataSketchesTheta(DataSketchesTheta&& other) noexcept : _memory_usage(other._memory_usage) {}
+    DataSketchesTheta(DataSketchesTheta&& other) noexcept
+            : _memory_usage(other._memory_usage), _lg_k(other._lg_k) {}
 
     ~DataSketchesTheta() = default;
 
@@ -60,6 +71,8 @@ public:
     void merge(const DataSketchesTheta& other);
 
     int64_t mem_usage() const { return _memory_usage == nullptr ? 0L : *_memory_usage; }
+    // Returns sketch's configured lg_k value.
+    uint8_t get_lg_config_k() const { return _lg_k; }
     size_t serialize(uint8_t* dst) const;
     uint64_t serialize_size() const;
     bool deserialize(const Slice& slice);
@@ -68,16 +81,16 @@ public:
 
     theta_sketch_type* get_sketch_update() {
         if (!_sketch_update) {
-            _sketch_update =
-                    std::make_unique<theta_sketch_type>(theta_sketch_type::builder(alloc_type(_memory_usage)).build());
+            _sketch_update = std::make_unique<theta_sketch_type>(
+                    theta_sketch_type::builder(alloc_type(_memory_usage)).set_lg_k(_lg_k).build());
         }
         return _sketch_update.get();
     }
 
     theta_union_type* get_sketch_union() {
         if (!_sketch_union) {
-            _sketch_union =
-                    std::make_unique<theta_union_type>(theta_union_type::builder(alloc_type(_memory_usage)).build());
+            _sketch_union = std::make_unique<theta_union_type>(
+                    theta_union_type::builder(alloc_type(_memory_usage)).set_lg_k(_lg_k).build());
         }
         return _sketch_union.get();
     }
@@ -93,6 +106,7 @@ public:
 
 private:
     int64_t* _memory_usage;
+    uint8_t _lg_k = DEFAULT_THETA_LOG_K;
     std::unique_ptr<theta_sketch_type> _sketch_update = nullptr;
     std::unique_ptr<theta_union_type> _sketch_union = nullptr;
 };

--- a/be/src/exprs/agg/data_sketch/ds_theta.h
+++ b/be/src/exprs/agg/data_sketch/ds_theta.h
@@ -21,6 +21,7 @@
 #include "common/mem_chunk.h"
 #include "runtime/memory/counting_allocator.h"
 #include "runtime/memory/mem_chunk_allocator.h"
+#include "types/constexpr.h"
 
 //  enum flags { IS_BIG_ENDIAN, IS_READ_ONLY, IS_EMPTY, IS_COMPACT, IS_ORDERED };
 #pragma push_macro("IS_BIG_ENDIAN")
@@ -39,20 +40,29 @@ public:
     using theta_compact_sketch = datasketches::compact_theta_sketch_alloc<alloc_type>;
     using wrapped_compact_theta_sketch = datasketches::wrapped_compact_theta_sketch_alloc<alloc_type>;
 
+    // 2-byte StarRocks-specific header [magic=0xFE][lg_k] prepended to the compact
+    // theta sketch bytes so lg_k survives serialize/deserialize. Compact theta sketches
+    // start with pre_longs in {1,2,3}, so 0xFE unambiguously identifies our header
+    // and lets us fall back to header-less legacy data.
+    static constexpr uint8_t kMagicByte = 0xFE;
+    static constexpr size_t kHeaderSize = 2;
+
     DataSketchesTheta(const DataSketchesTheta& other) = delete;
     DataSketchesTheta& operator=(const DataSketchesTheta& other) = delete;
 
     explicit DataSketchesTheta(int64_t* memory_usage) : _memory_usage(memory_usage) {}
+    DataSketchesTheta(uint8_t lg_k, int64_t* memory_usage) : _memory_usage(memory_usage), _lg_k(lg_k) {}
     DataSketchesTheta& operator=(DataSketchesTheta&& other) noexcept {
         if (this != &other) {
             this->_memory_usage = other._memory_usage;
+            this->_lg_k = other._lg_k;
             this->_sketch_update = std::move(other._sketch_update);
             this->_sketch_union = std::move(other._sketch_union);
         }
         return *this;
     }
     explicit DataSketchesTheta(const Slice& src, int64_t* memory_usage);
-    DataSketchesTheta(DataSketchesTheta&& other) noexcept : _memory_usage(other._memory_usage) {}
+    DataSketchesTheta(DataSketchesTheta&& other) noexcept : _memory_usage(other._memory_usage), _lg_k(other._lg_k) {}
 
     ~DataSketchesTheta() = default;
 
@@ -60,6 +70,8 @@ public:
     void merge(const DataSketchesTheta& other);
 
     int64_t mem_usage() const { return _memory_usage == nullptr ? 0L : *_memory_usage; }
+    // Returns sketch's configured lg_k value.
+    uint8_t get_lg_config_k() const { return _lg_k; }
     size_t serialize(uint8_t* dst) const;
     uint64_t serialize_size() const;
     bool deserialize(const Slice& slice);
@@ -68,16 +80,16 @@ public:
 
     theta_sketch_type* get_sketch_update() {
         if (!_sketch_update) {
-            _sketch_update =
-                    std::make_unique<theta_sketch_type>(theta_sketch_type::builder(alloc_type(_memory_usage)).build());
+            _sketch_update = std::make_unique<theta_sketch_type>(
+                    theta_sketch_type::builder(alloc_type(_memory_usage)).set_lg_k(_lg_k).build());
         }
         return _sketch_update.get();
     }
 
     theta_union_type* get_sketch_union() {
         if (!_sketch_union) {
-            _sketch_union =
-                    std::make_unique<theta_union_type>(theta_union_type::builder(alloc_type(_memory_usage)).build());
+            _sketch_union = std::make_unique<theta_union_type>(
+                    theta_union_type::builder(alloc_type(_memory_usage)).set_lg_k(_lg_k).build());
         }
         return _sketch_union.get();
     }
@@ -93,6 +105,7 @@ public:
 
 private:
     int64_t* _memory_usage;
+    uint8_t _lg_k = DEFAULT_THETA_LOG_K;
     std::unique_ptr<theta_sketch_type> _sketch_update = nullptr;
     std::unique_ptr<theta_union_type> _sketch_union = nullptr;
 };

--- a/be/src/exprs/agg/ds_theta_count_distinct.h
+++ b/be/src/exprs/agg/ds_theta_count_distinct.h
@@ -85,8 +85,7 @@ public:
         // state is still unset (mirrors the HLL path so lg_k survives shuffle).
         DataSketchesTheta theta(slice, mem_usage);
         if (UNLIKELY(this->data(state).theta_sketch == nullptr)) {
-            this->data(state).theta_sketch =
-                    std::make_unique<DataSketchesTheta>(theta.get_lg_config_k(), mem_usage);
+            this->data(state).theta_sketch = std::make_unique<DataSketchesTheta>(theta.get_lg_config_k(), mem_usage);
         }
         this->data(state).theta_sketch->merge(theta);
 

--- a/be/src/exprs/agg/ds_theta_count_distinct.h
+++ b/be/src/exprs/agg/ds_theta_count_distinct.h
@@ -52,7 +52,7 @@ public:
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
         // init state if needed
-        _init_if_needed(state);
+        _init_if_needed(ctx, columns, state);
 
         const auto& v = GetContainer<LT>::get_data(columns[0], row_num);
         uint64_t value = HashUtil::murmur_hash64A<T>(v, HashUtil::MURMUR_SEED);
@@ -64,7 +64,7 @@ public:
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
         // init state if needed
-        _init_if_needed(state);
+        _init_if_needed(ctx, columns, state);
         const auto& datas = GetContainer<LT>::get_data(columns[0]);
         for (size_t i = frame_start; i < frame_end; ++i) {
             uint64_t value = HashUtil::murmur_hash64A<T>(datas[i], HashUtil::MURMUR_SEED);
@@ -75,15 +75,19 @@ public:
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        _init_if_needed(state);
-
         auto* mem_usage = &(this->data(state).memory_usage);
         int64_t prev_memory = *mem_usage;
 
         DCHECK(column->is_binary());
         const BinaryColumn* theta_column = down_cast<const BinaryColumn*>(column);
         auto slice = theta_column->get_slice(row_num);
+        // Build the incoming sketch first so we can adopt its lg_k when the
+        // state is still unset (mirrors the HLL path so lg_k survives shuffle).
         DataSketchesTheta theta(slice, mem_usage);
+        if (UNLIKELY(this->data(state).theta_sketch == nullptr)) {
+            this->data(state).theta_sketch =
+                    std::make_unique<DataSketchesTheta>(theta.get_lg_config_k(), mem_usage);
+        }
         this->data(state).theta_sketch->merge(theta);
 
         ctx->add_mem_usage(*mem_usage - prev_memory);
@@ -116,7 +120,7 @@ public:
         }
     }
 
-    void convert_to_serialize_format([[maybe_unused]] FunctionContext* ctx, const Columns& src, size_t chunk_size,
+    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
         const auto& datas = GetContainer<LT>::get_data(src[0]);
         auto* result = down_cast<BinaryColumn*>(dst.get());
@@ -124,12 +128,18 @@ public:
         Bytes& bytes = result->get_bytes();
         result->get_offset().resize(chunk_size + 1);
 
+        std::vector<const Column*> src_datas;
+        src_datas.reserve(src.size());
+        std::transform(src.begin(), src.end(), std::back_inserter(src_datas),
+                       [](const ColumnPtr& col) { return col.get(); });
+        uint8_t log_k = _parse_theta_sketch_args(ctx, src_datas.data());
+
         size_t old_size = bytes.size();
         for (size_t i = 0; i < chunk_size; ++i) {
             uint64_t value = HashUtil::murmur_hash64A<T>(datas[i], HashUtil::MURMUR_SEED);
 
             int64_t memory_usage = 0;
-            DataSketchesTheta theta{&memory_usage};
+            DataSketchesTheta theta{log_k, &memory_usage};
             theta.update(value);
 
             size_t new_size = old_size + theta.serialize_size();
@@ -157,10 +167,21 @@ public:
 
 private:
     // init theta sketch if needed
-    void _init_if_needed(AggDataPtr __restrict state) const {
+    void _init_if_needed(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state) const {
         if (UNLIKELY(this->data(state).theta_sketch == nullptr)) {
-            this->data(state).theta_sketch = std::make_unique<DataSketchesTheta>(&(this->data(state).memory_usage));
+            uint8_t log_k = _parse_theta_sketch_args(ctx, columns);
+            this->data(state).theta_sketch =
+                    std::make_unique<DataSketchesTheta>(log_k, &(this->data(state).memory_usage));
         }
+    }
+
+    // parse log_k from args; falls back to the datasketches default.
+    uint8_t _parse_theta_sketch_args(FunctionContext* ctx, const Column** columns) const {
+        uint8_t log_k = DEFAULT_THETA_LOG_K;
+        if (ctx->get_num_args() == 2) {
+            log_k = static_cast<uint8_t>(columns[1]->get(0).get_int32());
+        }
+        return log_k;
     }
 };
 

--- a/be/src/exprs/agg/ds_theta_count_distinct.h
+++ b/be/src/exprs/agg/ds_theta_count_distinct.h
@@ -52,7 +52,7 @@ public:
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
         // init state if needed
-        _init_if_needed(state);
+        _init_if_needed(ctx, columns, state);
 
         const auto& v = GetContainer<LT>::get_data(columns[0], row_num);
         uint64_t value = HashUtil::murmur_hash64A<T>(v, HashUtil::MURMUR_SEED);
@@ -64,7 +64,7 @@ public:
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
         // init state if needed
-        _init_if_needed(state);
+        _init_if_needed(ctx, columns, state);
         const auto& datas = GetContainer<LT>::get_data(columns[0]);
         for (size_t i = frame_start; i < frame_end; ++i) {
             uint64_t value = HashUtil::murmur_hash64A<T>(datas[i], HashUtil::MURMUR_SEED);
@@ -75,15 +75,18 @@ public:
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        _init_if_needed(state);
-
         auto* mem_usage = &(this->data(state).memory_usage);
         int64_t prev_memory = *mem_usage;
 
         DCHECK(column->is_binary());
         const BinaryColumn* theta_column = down_cast<const BinaryColumn*>(column);
         auto slice = theta_column->get_slice(row_num);
+        // Build the incoming sketch first so we can adopt its lg_k when the
+        // state is still unset (mirrors the HLL path so lg_k survives shuffle).
         DataSketchesTheta theta(slice, mem_usage);
+        if (UNLIKELY(this->data(state).theta_sketch == nullptr)) {
+            this->data(state).theta_sketch = std::make_unique<DataSketchesTheta>(theta.get_lg_config_k(), mem_usage);
+        }
         this->data(state).theta_sketch->merge(theta);
 
         ctx->add_mem_usage(*mem_usage - prev_memory);
@@ -116,7 +119,7 @@ public:
         }
     }
 
-    void convert_to_serialize_format([[maybe_unused]] FunctionContext* ctx, const Columns& src, size_t chunk_size,
+    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
         const auto& datas = GetContainer<LT>::get_data(src[0]);
         auto* result = down_cast<BinaryColumn*>(dst.get());
@@ -124,12 +127,18 @@ public:
         Bytes& bytes = result->get_bytes();
         result->get_offset().resize(chunk_size + 1);
 
+        std::vector<const Column*> src_datas;
+        src_datas.reserve(src.size());
+        std::transform(src.begin(), src.end(), std::back_inserter(src_datas),
+                       [](const ColumnPtr& col) { return col.get(); });
+        uint8_t log_k = _parse_theta_sketch_args(ctx, src_datas.data());
+
         size_t old_size = bytes.size();
         for (size_t i = 0; i < chunk_size; ++i) {
             uint64_t value = HashUtil::murmur_hash64A<T>(datas[i], HashUtil::MURMUR_SEED);
 
             int64_t memory_usage = 0;
-            DataSketchesTheta theta{&memory_usage};
+            DataSketchesTheta theta{log_k, &memory_usage};
             theta.update(value);
 
             size_t new_size = old_size + theta.serialize_size();
@@ -157,10 +166,21 @@ public:
 
 private:
     // init theta sketch if needed
-    void _init_if_needed(AggDataPtr __restrict state) const {
+    void _init_if_needed(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state) const {
         if (UNLIKELY(this->data(state).theta_sketch == nullptr)) {
-            this->data(state).theta_sketch = std::make_unique<DataSketchesTheta>(&(this->data(state).memory_usage));
+            uint8_t log_k = _parse_theta_sketch_args(ctx, columns);
+            this->data(state).theta_sketch =
+                    std::make_unique<DataSketchesTheta>(log_k, &(this->data(state).memory_usage));
         }
+    }
+
+    // parse log_k from args; falls back to the datasketches default.
+    uint8_t _parse_theta_sketch_args(FunctionContext* ctx, const Column** columns) const {
+        uint8_t log_k = DEFAULT_THETA_LOG_K;
+        if (ctx->get_num_args() == 2) {
+            log_k = static_cast<uint8_t>(columns[1]->get(0).get_int32());
+        }
+        return log_k;
     }
 };
 

--- a/be/src/types/constexpr.h
+++ b/be/src/types/constexpr.h
@@ -31,6 +31,9 @@ constexpr int HLL_EMPTY_SIZE = 1;
 const static int MAX_HLL_LOG_K = 20;
 const static uint8_t DEFAULT_HLL_LOG_K = 17;
 
+// For DataSketches theta (lg_k matches datasketches::theta_constants).
+const static uint8_t DEFAULT_THETA_LOG_K = 12;
+
 // For JSON type
 constexpr int kJsonDefaultSize = 128;
 constexpr int kJsonMetaDefaultFormatVersion = 1;

--- a/be/test/exprs/agg/data_sketch/ds_theta_test.cpp
+++ b/be/test/exprs/agg/data_sketch/ds_theta_test.cpp
@@ -104,4 +104,117 @@ TEST_F(DataSketchsThetaTest, TestSerializeDeserialize2) {
         ASSERT_EQ(theta4.estimate_cardinality(), 100);
     }
 }
+
+// The serialized payload must start with the 2-byte StarRocks header
+// [0xFE][lg_k] so that lg_k survives serialize -> deserialize round-trips.
+TEST_F(DataSketchsThetaTest, HeaderRoundTripPreservesLgK) {
+    int64_t memory_usage = 0;
+    constexpr uint8_t kCustomLgK = 14;
+    DataSketchesTheta theta(kCustomLgK, &memory_usage);
+    for (int i = 0; i < 500; ++i) {
+        theta.update(i);
+    }
+
+    uint8_t dst[8192];
+    size_t size = theta.serialize(dst);
+    ASSERT_GE(size, DataSketchesTheta::kHeaderSize);
+    EXPECT_EQ(dst[0], DataSketchesTheta::kMagicByte);
+    EXPECT_EQ(dst[1], kCustomLgK);
+
+    DataSketchesTheta restored(&memory_usage);
+    ASSERT_TRUE(restored.deserialize(Slice(dst, size)));
+    EXPECT_EQ(restored.get_lg_config_k(), kCustomLgK);
+    // The estimate should still match (within theta error bounds, but with
+    // lg_k=14 and 500 distinct values it is essentially exact).
+    EXPECT_EQ(restored.estimate_cardinality(), 500);
+}
+
+// Header-less payloads written by older StarRocks versions must still
+// deserialize. Compact-theta's first byte is pre_longs in {1,2,3}, which can
+// never collide with the magic byte 0xFE.
+TEST_F(DataSketchsThetaTest, LegacyBytesWithoutHeaderDeserialize) {
+    int64_t memory_usage = 0;
+    DataSketchesTheta source(&memory_usage);
+    for (int i = 0; i < 100; ++i) {
+        source.update(i);
+    }
+    uint8_t framed[1024];
+    size_t framed_size = source.serialize(framed);
+    ASSERT_GT(framed_size, DataSketchesTheta::kHeaderSize);
+
+    // Drop the 2-byte StarRocks header to mimic a pre-magic-byte payload.
+    const uint8_t* legacy = framed + DataSketchesTheta::kHeaderSize;
+    size_t legacy_size = framed_size - DataSketchesTheta::kHeaderSize;
+    ASSERT_NE(legacy[0], DataSketchesTheta::kMagicByte);
+
+    DataSketchesTheta restored(&memory_usage);
+    ASSERT_TRUE(restored.deserialize(Slice(legacy, legacy_size)));
+    EXPECT_EQ(restored.estimate_cardinality(), 100);
+    // Header-less payloads carry no lg_k, so deserialization keeps the default.
+    EXPECT_EQ(restored.get_lg_config_k(), DEFAULT_THETA_LOG_K);
+}
+
+// During merge() in the aggregate path, an empty state adopts the lg_k carried
+// in the wire format of the incoming sketch. This keeps the configured
+// precision intact across shuffle boundaries.
+TEST_F(DataSketchsThetaTest, DeserializeAdoptsIncomingLgK) {
+    int64_t memory_usage = 0;
+    constexpr uint8_t kIncomingLgK = 14;
+    DataSketchesTheta incoming(kIncomingLgK, &memory_usage);
+    for (int i = 0; i < 100; ++i) {
+        incoming.update(i);
+    }
+
+    uint8_t buf[2048];
+    size_t size = incoming.serialize(buf);
+
+    DataSketchesTheta parsed(Slice(buf, size), &memory_usage);
+    EXPECT_EQ(parsed.get_lg_config_k(), kIncomingLgK);
+
+    // Mirror what ThetaSketchAggregateFunction::merge() does when the state is
+    // still empty: construct using the incoming sketch's lg_k, then merge.
+    DataSketchesTheta state(parsed.get_lg_config_k(), &memory_usage);
+    state.merge(parsed);
+    EXPECT_EQ(state.get_lg_config_k(), kIncomingLgK);
+    EXPECT_EQ(state.estimate_cardinality(), 100);
+}
+
+// A corrupted or malicious lg_k byte must not poison the state: we keep the
+// default and still parse the body (the theta-union update will fail safely
+// only on truly malformed bytes).
+TEST_F(DataSketchsThetaTest, OutOfRangeLgKInHeaderFallsBackToDefault) {
+    int64_t memory_usage = 0;
+    DataSketchesTheta source(&memory_usage);
+    for (int i = 0; i < 50; ++i) {
+        source.update(i);
+    }
+    uint8_t framed[1024];
+    size_t size = source.serialize(framed);
+
+    // 0xFF is outside [MIN_LG_K=5, MAX_LG_K=26].
+    framed[1] = 0xFF;
+
+    DataSketchesTheta restored(&memory_usage);
+    ASSERT_TRUE(restored.deserialize(Slice(framed, size)));
+    EXPECT_EQ(restored.get_lg_config_k(), DEFAULT_THETA_LOG_K);
+    EXPECT_EQ(restored.estimate_cardinality(), 50);
+}
+
+// A state that never saw update() or merge() serializes to just the header.
+// Round-tripping that 2-byte payload must not throw and must keep the
+// estimate at zero.
+TEST_F(DataSketchsThetaTest, EmptyStateSerializeRoundTrip) {
+    int64_t memory_usage = 0;
+    DataSketchesTheta empty(&memory_usage);
+    EXPECT_EQ(empty.estimate_cardinality(), 0);
+
+    uint8_t dst[16];
+    size_t size = empty.serialize(dst);
+    EXPECT_EQ(size, DataSketchesTheta::kHeaderSize);
+    EXPECT_EQ(dst[0], DataSketchesTheta::kMagicByte);
+
+    DataSketchesTheta restored(&memory_usage);
+    ASSERT_TRUE(restored.deserialize(Slice(dst, size)));
+    EXPECT_EQ(restored.estimate_cardinality(), 0);
+}
 } // namespace starrocks

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/ds_theta_accumulate.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/ds_theta_accumulate.md
@@ -1,0 +1,68 @@
+# ds_theta_accumulate
+
+Accumulates values into a Theta sketch and returns the serialized sketch as a VARBINARY. This function is part of the DataSketches Theta family of functions for approximate distinct counting.
+
+`ds_theta_accumulate` creates a serialized Theta sketch that can be combined with other sketches using `ds_theta_combine` and estimated using `ds_theta_estimate`.
+
+It is based on Apache DataSketches. For more information, see [Theta Sketches](https://datasketches.apache.org/docs/Theta/InverseEstimate.html).
+
+## Syntax
+
+```Haskell
+sketch ds_theta_accumulate(expr)
+sketch ds_theta_accumulate(expr, log_k)
+```
+
+### Parameters
+
+- `expr`: The expression to accumulate into the sketch. Can be any data type.
+- `log_k`: Integer. Range [5, 26]. Default: 12. Controls the precision and memory usage of the sketch.
+
+## Return Type
+
+Returns a VARBINARY containing the serialized Theta sketch. The serialized blob also carries the `log_k` value so it survives across nodes, agg-state materializations, and downstream `ds_theta_combine` / `ds_theta_estimate` calls.
+
+## Examples
+
+```sql
+-- Create test table
+CREATE TABLE t1 (
+  id BIGINT,
+  province VARCHAR(64),
+  age SMALLINT,
+  dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+-- Insert test data
+INSERT INTO t1 SELECT generate_series, generate_series, generate_series % 100, "2024-07-24"
+FROM table(generate_series(1, 1000));
+
+-- Basic usage with single argument (default log_k = 12)
+SELECT ds_theta_accumulate(id) FROM t1;
+
+-- With custom log_k for higher precision
+SELECT ds_theta_accumulate(province, 14) FROM t1;
+
+-- Group by usage
+SELECT dt,
+       ds_theta_accumulate(id),
+       ds_theta_accumulate(province, 14),
+       ds_theta_accumulate(age),
+       ds_theta_accumulate(dt)
+FROM t1
+GROUP BY dt
+ORDER BY 1
+LIMIT 3;
+```
+
+## Related Functions
+
+- `ds_theta_combine`: Combines multiple serialized sketches into a single sketch
+- `ds_theta_estimate`: Estimates the distinct count from a serialized sketch
+- `ds_theta_count_distinct`: Direct approximate distinct counting function
+
+## Keywords
+
+DS_THETA_ACCUMULATE, THETA, APPROXIMATE, DISTINCT, COUNT

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/ds_theta_combine.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/ds_theta_combine.md
@@ -1,0 +1,79 @@
+# ds_theta_combine
+
+Combines multiple serialized Theta sketches into a single serialized sketch. This function is part of the DataSketches Theta family of functions for approximate distinct counting.
+
+`ds_theta_combine` takes a VARBINARY column produced by `ds_theta_accumulate` and merges its rows into a single sketch that represents the union of all distinct values.
+
+It is based on Apache DataSketches. For more information, see [Theta Sketches](https://datasketches.apache.org/docs/Theta/InverseEstimate.html).
+
+## Syntax
+
+```Haskell
+sketch ds_theta_combine(sketch)
+```
+
+### Parameters
+
+- `sketch`: A VARBINARY column containing serialized Theta sketches created by `ds_theta_accumulate`.
+
+## Return Type
+
+Returns a VARBINARY containing the combined serialized Theta sketch. The `log_k` of the producing `ds_theta_accumulate` is preserved through the merge.
+
+## Examples
+
+```sql
+-- Create test table
+CREATE TABLE t1 (
+  id BIGINT,
+  province VARCHAR(64),
+  age SMALLINT,
+  dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+-- Insert test data
+INSERT INTO t1 SELECT generate_series, generate_series, generate_series % 100, "2024-07-24"
+FROM table(generate_series(1, 1000));
+
+-- Create table to store sketches
+CREATE TABLE t2 (
+  `id` bigint,
+  `dt` varchar(10),
+  `ds_id` binary,
+  `ds_province` binary,
+  `ds_age` binary,
+  `ds_dt` binary
+) ENGINE=OLAP
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+-- Store sketches created by ds_theta_accumulate
+INSERT INTO t2 SELECT id, dt,
+  ds_theta_accumulate(id),
+  ds_theta_accumulate(province, 14),
+  ds_theta_accumulate(age),
+  ds_theta_accumulate(dt)
+FROM t1;
+
+-- Combine sketches grouped by date
+SELECT dt,
+       ds_theta_combine(ds_id),
+       ds_theta_combine(ds_province),
+       ds_theta_combine(ds_age),
+       ds_theta_combine(ds_dt)
+FROM t2
+GROUP BY dt
+ORDER BY 1
+LIMIT 3;
+```
+
+## Related Functions
+
+- `ds_theta_accumulate`: Creates serialized Theta sketches from data
+- `ds_theta_estimate`: Estimates the distinct count from a serialized sketch
+- `ds_theta_count_distinct`: Direct approximate distinct counting function
+
+## Keywords
+
+DS_THETA_COMBINE, THETA, APPROXIMATE, DISTINCT, COUNT, MERGE, UNION

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/ds_theta_count_distinct.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/ds_theta_count_distinct.md
@@ -10,9 +10,11 @@ The relative error is 3.125% (95% confidence). For more information, see the [re
 
 ```Haskell
 BIGINT ds_theta_count_distinct(expr)
+BIGINT ds_theta_count_distinct(expr, log_k)
 ```
 
 - `expr`: The column in which to calculate the approximate count distinct values.
+- `log_k`: Integer. Range [5, 26]. Default: 12. Controls the precision and memory usage of the sketch.
 
 ## Examples
 

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/ds_theta_count_distinct.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/ds_theta_count_distinct.md
@@ -15,9 +15,11 @@ The relative error is 3.125% (95% confidence). For more information, see the [re
 
 ```Haskell
 BIGINT ds_theta_count_distinct(expr)
+BIGINT ds_theta_count_distinct(expr, log_k)
 ```
 
 - `expr`: The column in which to calculate the approximate count distinct values.
+- `log_k`: Integer. Range [5, 26]. Default: 12. Controls the precision and memory usage of the sketch.
 
 ## Examples
 

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/ds_theta_estimate.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/ds_theta_estimate.md
@@ -1,0 +1,79 @@
+# ds_theta_estimate
+
+Estimates the approximate distinct count from a serialized Theta sketch. This function is part of the DataSketches Theta family of functions for approximate distinct counting.
+
+`ds_theta_estimate` takes a VARBINARY serialized sketch created by `ds_theta_accumulate` or `ds_theta_combine` and returns the estimated number of distinct values.
+
+It is based on Apache DataSketches. For more information, see [Theta Sketches](https://datasketches.apache.org/docs/Theta/InverseEstimate.html).
+
+## Syntax
+
+```Haskell
+bigint ds_theta_estimate(sketch)
+```
+
+### Parameters
+
+- `sketch`: A VARBINARY column containing serialized Theta sketches created by `ds_theta_accumulate` or `ds_theta_combine`.
+
+## Return Type
+
+Returns a BIGINT representing the estimated distinct count.
+
+## Examples
+
+```sql
+-- Create test table
+CREATE TABLE t1 (
+  id BIGINT,
+  province VARCHAR(64),
+  age SMALLINT,
+  dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+-- Insert test data
+INSERT INTO t1 SELECT generate_series, generate_series, generate_series % 100, "2024-07-24"
+FROM table(generate_series(1, 1000));
+
+-- Create table to store sketches
+CREATE TABLE t2 (
+  `id` bigint,
+  `dt` varchar(10),
+  `ds_id` binary,
+  `ds_province` binary,
+  `ds_age` binary,
+  `ds_dt` binary
+) ENGINE=OLAP
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+-- Store sketches created by ds_theta_accumulate
+INSERT INTO t2 SELECT id, dt,
+  ds_theta_accumulate(id),
+  ds_theta_accumulate(province, 14),
+  ds_theta_accumulate(age),
+  ds_theta_accumulate(dt)
+FROM t1;
+
+-- Estimate distinct counts grouped by date
+SELECT dt,
+       ds_theta_estimate(ds_id),
+       ds_theta_estimate(ds_province),
+       ds_theta_estimate(ds_age),
+       ds_theta_estimate(ds_dt)
+FROM t2
+GROUP BY dt
+ORDER BY 1
+LIMIT 3;
+```
+
+## Related Functions
+
+- `ds_theta_accumulate`: Creates serialized Theta sketches from data
+- `ds_theta_combine`: Combines multiple serialized sketches into a single sketch
+- `ds_theta_count_distinct`: Direct approximate distinct counting function
+
+## Keywords
+
+DS_THETA_ESTIMATE, THETA, APPROXIMATE, DISTINCT, COUNT, ESTIMATE

--- a/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_theta_accumulate.md
+++ b/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_theta_accumulate.md
@@ -1,0 +1,68 @@
+# ds_theta_accumulate
+
+将值累积到 Theta 草图中，并返回序列化的草图作为 VARBINARY。此函数是 DataSketches Theta 近似去重计数函数族的一部分。
+
+`ds_theta_accumulate` 创建一个序列化的 Theta 草图，可以使用 `ds_theta_combine` 与其他草图合并，并使用 `ds_theta_estimate` 进行估算。
+
+它基于 Apache DataSketches。更多信息，请参见 [Theta Sketches](https://datasketches.apache.org/docs/Theta/InverseEstimate.html)。
+
+## 语法
+
+```Haskell
+sketch ds_theta_accumulate(expr)
+sketch ds_theta_accumulate(expr, log_k)
+```
+
+### 参数
+
+- `expr`: 要累积到草图中的表达式。可以是任何数据类型。
+- `log_k`: 整数。范围 [5, 26]。默认值：12。控制草图的精度和内存使用量。
+
+## 返回类型
+
+返回包含序列化 Theta 草图的 VARBINARY。序列化结果中也保存了 `log_k`，因此跨节点 shuffle、agg-state 物化以及下游的 `ds_theta_combine` / `ds_theta_estimate` 都能保留它。
+
+## 示例
+
+```sql
+-- 创建测试表
+CREATE TABLE t1 (
+  id BIGINT,
+  province VARCHAR(64),
+  age SMALLINT,
+  dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+-- 插入测试数据
+INSERT INTO t1 SELECT generate_series, generate_series, generate_series % 100, "2024-07-24"
+FROM table(generate_series(1, 1000));
+
+-- 单参数基本用法（默认 log_k = 12）
+SELECT ds_theta_accumulate(id) FROM t1;
+
+-- 使用自定义 log_k 提高精度
+SELECT ds_theta_accumulate(province, 14) FROM t1;
+
+-- 分组用法
+SELECT dt,
+       ds_theta_accumulate(id),
+       ds_theta_accumulate(province, 14),
+       ds_theta_accumulate(age),
+       ds_theta_accumulate(dt)
+FROM t1
+GROUP BY dt
+ORDER BY 1
+LIMIT 3;
+```
+
+## 相关函数
+
+- `ds_theta_combine`: 将多个序列化草图合并为单个草图
+- `ds_theta_estimate`: 从序列化草图估算去重计数
+- `ds_theta_count_distinct`: 直接近似去重计数函数
+
+## 关键词
+
+DS_THETA_ACCUMULATE, THETA, APPROXIMATE, DISTINCT, COUNT

--- a/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_theta_combine.md
+++ b/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_theta_combine.md
@@ -1,0 +1,79 @@
+# ds_theta_combine
+
+将多个序列化的 Theta 草图合并为单个序列化草图。此函数是 DataSketches Theta 近似去重计数函数族的一部分。
+
+`ds_theta_combine` 接受由 `ds_theta_accumulate` 创建的 VARBINARY 列，并将其各行合并为表示所有去重值并集的单个草图。
+
+它基于 Apache DataSketches。更多信息，请参见 [Theta Sketches](https://datasketches.apache.org/docs/Theta/InverseEstimate.html)。
+
+## 语法
+
+```Haskell
+sketch ds_theta_combine(sketch)
+```
+
+### 参数
+
+- `sketch`: 包含由 `ds_theta_accumulate` 创建的序列化 Theta 草图的 VARBINARY 列。
+
+## 返回类型
+
+返回包含合并后序列化 Theta 草图的 VARBINARY。`ds_theta_accumulate` 时选定的 `log_k` 会通过合并过程保留下来。
+
+## 示例
+
+```sql
+-- 创建测试表
+CREATE TABLE t1 (
+  id BIGINT,
+  province VARCHAR(64),
+  age SMALLINT,
+  dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+-- 插入测试数据
+INSERT INTO t1 SELECT generate_series, generate_series, generate_series % 100, "2024-07-24"
+FROM table(generate_series(1, 1000));
+
+-- 创建存储草图的表
+CREATE TABLE t2 (
+  `id` bigint,
+  `dt` varchar(10),
+  `ds_id` binary,
+  `ds_province` binary,
+  `ds_age` binary,
+  `ds_dt` binary
+) ENGINE=OLAP
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+-- 存储由 ds_theta_accumulate 创建的草图
+INSERT INTO t2 SELECT id, dt,
+  ds_theta_accumulate(id),
+  ds_theta_accumulate(province, 14),
+  ds_theta_accumulate(age),
+  ds_theta_accumulate(dt)
+FROM t1;
+
+-- 按日期分组合并草图
+SELECT dt,
+       ds_theta_combine(ds_id),
+       ds_theta_combine(ds_province),
+       ds_theta_combine(ds_age),
+       ds_theta_combine(ds_dt)
+FROM t2
+GROUP BY dt
+ORDER BY 1
+LIMIT 3;
+```
+
+## 相关函数
+
+- `ds_theta_accumulate`: 从数据创建序列化 Theta 草图
+- `ds_theta_estimate`: 从序列化草图估算去重计数
+- `ds_theta_count_distinct`: 直接近似去重计数函数
+
+## 关键词
+
+DS_THETA_COMBINE, THETA, APPROXIMATE, DISTINCT, COUNT, MERGE, UNION

--- a/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_theta_count_distinct.md
+++ b/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_theta_count_distinct.md
@@ -10,9 +10,11 @@
 
 ```Haskell
 BIGINT ds_theta_count_distinct(expr)
+BIGINT ds_theta_count_distinct(expr, log_k)
 ```
 
 - `expr`: 要计算近似 COUNT DISTINCT 值的列。
+- `log_k`: 整数。范围 [5, 26]。默认值：12。控制草图的精度和内存使用量。
 
 ## 示例
 

--- a/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_theta_estimate.md
+++ b/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_theta_estimate.md
@@ -1,0 +1,79 @@
+# ds_theta_estimate
+
+从序列化的 Theta 草图估算近似去重计数。此函数是 DataSketches Theta 近似去重计数函数族的一部分。
+
+`ds_theta_estimate` 接受由 `ds_theta_accumulate` 或 `ds_theta_combine` 创建的 VARBINARY 序列化草图，并返回估算的去重值数量。
+
+它基于 Apache DataSketches。更多信息，请参见 [Theta Sketches](https://datasketches.apache.org/docs/Theta/InverseEstimate.html)。
+
+## 语法
+
+```Haskell
+bigint ds_theta_estimate(sketch)
+```
+
+### 参数
+
+- `sketch`: 包含由 `ds_theta_accumulate` 或 `ds_theta_combine` 创建的序列化 Theta 草图的 VARBINARY 列。
+
+## 返回类型
+
+返回表示估算去重计数的 BIGINT。
+
+## 示例
+
+```sql
+-- 创建测试表
+CREATE TABLE t1 (
+  id BIGINT,
+  province VARCHAR(64),
+  age SMALLINT,
+  dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+-- 插入测试数据
+INSERT INTO t1 SELECT generate_series, generate_series, generate_series % 100, "2024-07-24"
+FROM table(generate_series(1, 1000));
+
+-- 创建存储草图的表
+CREATE TABLE t2 (
+  `id` bigint,
+  `dt` varchar(10),
+  `ds_id` binary,
+  `ds_province` binary,
+  `ds_age` binary,
+  `ds_dt` binary
+) ENGINE=OLAP
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+-- 存储由 ds_theta_accumulate 创建的草图
+INSERT INTO t2 SELECT id, dt,
+  ds_theta_accumulate(id),
+  ds_theta_accumulate(province, 14),
+  ds_theta_accumulate(age),
+  ds_theta_accumulate(dt)
+FROM t1;
+
+-- 按日期分组估算去重计数
+SELECT dt,
+       ds_theta_estimate(ds_id),
+       ds_theta_estimate(ds_province),
+       ds_theta_estimate(ds_age),
+       ds_theta_estimate(ds_dt)
+FROM t2
+GROUP BY dt
+ORDER BY 1
+LIMIT 3;
+```
+
+## 相关函数
+
+- `ds_theta_accumulate`: 从数据创建序列化 Theta 草图
+- `ds_theta_combine`: 将多个序列化草图合并为单个草图
+- `ds_theta_count_distinct`: 直接近似去重计数函数
+
+## 关键词
+
+DS_THETA_ESTIMATE, THETA, APPROXIMATE, DISTINCT, COUNT, ESTIMATE

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -324,6 +324,9 @@ public class FunctionSet {
     public static final String DS_HLL_ACCUMULATE = "ds_hll_accumulate";
     public static final String DS_HLL_COMBINE = "ds_hll_combine";
     public static final String DS_HLL_ESTIMATE = "ds_hll_estimate";
+    public static final String DS_THETA_ACCUMULATE = "ds_theta_accumulate";
+    public static final String DS_THETA_COMBINE = "ds_theta_combine";
+    public static final String DS_THETA_ESTIMATE = "ds_theta_estimate";
     public static final String APPROX_TOP_K = "approx_top_k";
     public static final String AVG = "avg";
     public static final String COUNT = "count";
@@ -941,6 +944,9 @@ public class FunctionSet {
                     .add(DS_HLL_ACCUMULATE)
                     .add(DS_HLL_COMBINE)
                     .add(DS_HLL_ESTIMATE)
+                    .add(DS_THETA_ACCUMULATE)
+                    .add(DS_THETA_COMBINE)
+                    .add(DS_THETA_ESTIMATE)
                     // Functions with constant contexts in be are not supported.
                     .add(WINDOW_FUNNEL)
                     .add(APPROX_TOP_K)
@@ -1406,6 +1412,18 @@ public class FunctionSet {
             addBuiltin(AggregateFunction.createBuiltin(DS_THETA_COUNT_DISTINCT,
                     Lists.newArrayList(t), IntegerType.BIGINT, VarbinaryType.VARBINARY,
                     true, false, true));
+            // ds_theta_count_distinct(col, log_k)
+            addBuiltin(AggregateFunction.createBuiltin(DS_THETA_COUNT_DISTINCT,
+                    Lists.newArrayList(t, IntegerType.INT), IntegerType.BIGINT, VarbinaryType.VARBINARY,
+                    true, false, true));
+
+            // DS_THETA_ACCUMULATE
+            addBuiltin(AggregateFunction.createBuiltin(DS_THETA_ACCUMULATE,
+                    Lists.newArrayList(t), VarbinaryType.VARBINARY, VarbinaryType.VARBINARY,
+                    true, false, true));
+            addBuiltin(AggregateFunction.createBuiltin(DS_THETA_ACCUMULATE,
+                    Lists.newArrayList(t, IntegerType.INT), VarbinaryType.VARBINARY, VarbinaryType.VARBINARY,
+                    true, false, true));
 
             // HLL_RAW
             addBuiltin(AggregateFunction.createBuiltin(HLL_RAW,
@@ -1452,6 +1470,12 @@ public class FunctionSet {
                 Lists.newArrayList(VarbinaryType.VARBINARY), VarbinaryType.VARBINARY, VarbinaryType.VARBINARY,
                 true, false, true));
         addBuiltin(AggregateFunction.createBuiltin(DS_HLL_ESTIMATE,
+                Lists.newArrayList(VarbinaryType.VARBINARY), IntegerType.BIGINT, VarbinaryType.VARBINARY,
+                true, false, true));
+        addBuiltin(AggregateFunction.createBuiltin(DS_THETA_COMBINE,
+                Lists.newArrayList(VarbinaryType.VARBINARY), VarbinaryType.VARBINARY, VarbinaryType.VARBINARY,
+                true, false, true));
+        addBuiltin(AggregateFunction.createBuiltin(DS_THETA_ESTIMATE,
                 Lists.newArrayList(VarbinaryType.VARBINARY), IntegerType.BIGINT, VarbinaryType.VARBINARY,
                 true, false, true));
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -329,6 +329,9 @@ public class FunctionSet {
     public static final String DS_HLL_ACCUMULATE = "ds_hll_accumulate";
     public static final String DS_HLL_COMBINE = "ds_hll_combine";
     public static final String DS_HLL_ESTIMATE = "ds_hll_estimate";
+    public static final String DS_THETA_ACCUMULATE = "ds_theta_accumulate";
+    public static final String DS_THETA_COMBINE = "ds_theta_combine";
+    public static final String DS_THETA_ESTIMATE = "ds_theta_estimate";
     public static final String APPROX_TOP_K = "approx_top_k";
     public static final String AVG = "avg";
     public static final String COUNT = "count";
@@ -954,6 +957,9 @@ public class FunctionSet {
                     .add(DS_HLL_ACCUMULATE)
                     .add(DS_HLL_COMBINE)
                     .add(DS_HLL_ESTIMATE)
+                    .add(DS_THETA_ACCUMULATE)
+                    .add(DS_THETA_COMBINE)
+                    .add(DS_THETA_ESTIMATE)
                     // Functions with constant contexts in be are not supported.
                     .add(WINDOW_FUNNEL)
                     .add(APPROX_TOP_K)
@@ -1419,6 +1425,18 @@ public class FunctionSet {
             addBuiltin(AggregateFunction.createBuiltin(DS_THETA_COUNT_DISTINCT,
                     Lists.newArrayList(t), IntegerType.BIGINT, VarbinaryType.VARBINARY,
                     true, false, true));
+            // ds_theta_count_distinct(col, log_k)
+            addBuiltin(AggregateFunction.createBuiltin(DS_THETA_COUNT_DISTINCT,
+                    Lists.newArrayList(t, IntegerType.INT), IntegerType.BIGINT, VarbinaryType.VARBINARY,
+                    true, false, true));
+
+            // DS_THETA_ACCUMULATE
+            addBuiltin(AggregateFunction.createBuiltin(DS_THETA_ACCUMULATE,
+                    Lists.newArrayList(t), VarbinaryType.VARBINARY, VarbinaryType.VARBINARY,
+                    true, false, true));
+            addBuiltin(AggregateFunction.createBuiltin(DS_THETA_ACCUMULATE,
+                    Lists.newArrayList(t, IntegerType.INT), VarbinaryType.VARBINARY, VarbinaryType.VARBINARY,
+                    true, false, true));
 
             // HLL_RAW
             addBuiltin(AggregateFunction.createBuiltin(HLL_RAW,
@@ -1465,6 +1483,12 @@ public class FunctionSet {
                 Lists.newArrayList(VarbinaryType.VARBINARY), VarbinaryType.VARBINARY, VarbinaryType.VARBINARY,
                 true, false, true));
         addBuiltin(AggregateFunction.createBuiltin(DS_HLL_ESTIMATE,
+                Lists.newArrayList(VarbinaryType.VARBINARY), IntegerType.BIGINT, VarbinaryType.VARBINARY,
+                true, false, true));
+        addBuiltin(AggregateFunction.createBuiltin(DS_THETA_COMBINE,
+                Lists.newArrayList(VarbinaryType.VARBINARY), VarbinaryType.VARBINARY, VarbinaryType.VARBINARY,
+                true, false, true));
+        addBuiltin(AggregateFunction.createBuiltin(DS_THETA_ESTIMATE,
                 Lists.newArrayList(VarbinaryType.VARBINARY), IntegerType.BIGINT, VarbinaryType.VARBINARY,
                 true, false, true));
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
@@ -275,16 +275,25 @@ public class AggStateUtils {
         Type arg0Type = argumentTypes[0];
         if (arg0Type.getAggStateDesc() == null) {
             String functionName = inputFunc.functionName();
+            String baseAggName = null;
             if (functionName.startsWith(FunctionSet.DS_HLL_COUNT_DISTINCT)
                     && (functionName.endsWith(FunctionSet.AGG_STATE_MERGE_SUFFIX)
                     || functionName.endsWith(FunctionSet.AGG_STATE_UNION_SUFFIX))) {
-                // ds_hll_count_distinct is a special case, it has no AggStateDesc
-                // but we can still get the agg state function from its name
-                Function dsHllCountDistinctAgg = FunctionAnalyzer.getAnalyzedAggregateFunction(session,
-                        FunctionSet.DS_HLL_COUNT_DISTINCT, new FunctionParams(false, Lists.newArrayList()),
+                baseAggName = FunctionSet.DS_HLL_COUNT_DISTINCT;
+            } else if (functionName.startsWith(FunctionSet.DS_THETA_COUNT_DISTINCT)
+                    && (functionName.endsWith(FunctionSet.AGG_STATE_MERGE_SUFFIX)
+                    || functionName.endsWith(FunctionSet.AGG_STATE_UNION_SUFFIX))) {
+                baseAggName = FunctionSet.DS_THETA_COUNT_DISTINCT;
+            }
+            if (baseAggName != null) {
+                // ds_hll_count_distinct / ds_theta_count_distinct are special cases: their
+                // serialized state can live in a plain varbinary column without AggStateDesc.
+                // Bootstrap the base aggregate from its name so the combinator can resolve.
+                Function baseAgg = FunctionAnalyzer.getAnalyzedAggregateFunction(session,
+                        baseAggName, new FunctionParams(false, Lists.newArrayList()),
                         new Type[] {VarcharType.VARCHAR}, new Boolean[] {false}, pos);
-                if (dsHllCountDistinctAgg != null && dsHllCountDistinctAgg instanceof AggregateFunction) {
-                    return (AggregateFunction) dsHllCountDistinctAgg.copy();
+                if (baseAgg instanceof AggregateFunction) {
+                    return (AggregateFunction) baseAgg.copy();
                 }
             }
             throw new SemanticException(String.format("AggState's AggFunc should have AggStateDesc: %s",

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
@@ -294,16 +294,25 @@ public class AggStateUtils {
         Type arg0Type = argumentTypes[0];
         if (arg0Type.getAggStateDesc() == null) {
             String functionName = inputFunc.functionName();
+            String baseAggName = null;
             if (functionName.startsWith(FunctionSet.DS_HLL_COUNT_DISTINCT)
                     && (functionName.endsWith(FunctionSet.AGG_STATE_MERGE_SUFFIX)
                     || functionName.endsWith(FunctionSet.AGG_STATE_UNION_SUFFIX))) {
-                // ds_hll_count_distinct is a special case, it has no AggStateDesc
-                // but we can still get the agg state function from its name
-                Function dsHllCountDistinctAgg = FunctionAnalyzer.getAnalyzedAggregateFunction(session,
-                        FunctionSet.DS_HLL_COUNT_DISTINCT, new FunctionParams(false, Lists.newArrayList()),
+                baseAggName = FunctionSet.DS_HLL_COUNT_DISTINCT;
+            } else if (functionName.startsWith(FunctionSet.DS_THETA_COUNT_DISTINCT)
+                    && (functionName.endsWith(FunctionSet.AGG_STATE_MERGE_SUFFIX)
+                    || functionName.endsWith(FunctionSet.AGG_STATE_UNION_SUFFIX))) {
+                baseAggName = FunctionSet.DS_THETA_COUNT_DISTINCT;
+            }
+            if (baseAggName != null) {
+                // ds_hll_count_distinct / ds_theta_count_distinct are special cases: their
+                // serialized state can live in a plain varbinary column without AggStateDesc.
+                // Bootstrap the base aggregate from its name so the combinator can resolve.
+                Function baseAgg = FunctionAnalyzer.getAnalyzedAggregateFunction(session,
+                        baseAggName, new FunctionParams(false, Lists.newArrayList()),
                         new Type[] {VarcharType.VARCHAR}, new Boolean[] {false}, pos);
-                if (dsHllCountDistinctAgg != null && dsHllCountDistinctAgg instanceof AggregateFunction) {
-                    return (AggregateFunction) dsHllCountDistinctAgg.copy();
+                if (baseAgg instanceof AggregateFunction) {
+                    return (AggregateFunction) baseAgg.copy();
                 }
             }
             throw new SemanticException(String.format("AggState's AggFunc should have AggStateDesc: %s",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -203,8 +203,10 @@ public class FunctionAnalyzer {
                 throw new SemanticException(String.format("Resolved function %s has no wildcard decimal as return type",
                         fn.functionName()), functionCallExpr.getPos());
             }
-            if (FunctionSet.DS_HLL_COUNT_DISTINCT.equalsIgnoreCase(AggStateUtils.getAggFuncNameOfCombinator(funcName))) {
-                // ds_hll_count_distinct_union's param type should be varbinary type.
+            String baseAggName = AggStateUtils.getAggFuncNameOfCombinator(funcName);
+            if (FunctionSet.DS_HLL_COUNT_DISTINCT.equalsIgnoreCase(baseAggName)
+                    || FunctionSet.DS_THETA_COUNT_DISTINCT.equalsIgnoreCase(baseAggName)) {
+                // ds_hll/ds_theta union's param type should be varbinary type.
                 if (!functionCallExpr.getChild(0).getType().isBinaryType()) {
                     throw new SemanticException(String.format("Resolved function %s has no binary as argument type",
                             fn.functionName()), functionCallExpr.getPos());
@@ -220,8 +222,10 @@ public class FunctionAnalyzer {
                 throw new SemanticException(String.format("Resolved function %s has no wildcard decimal as return type",
                         fn.functionName()), functionCallExpr.getPos());
             }
-            if (FunctionSet.DS_HLL_COUNT_DISTINCT.equalsIgnoreCase(AggStateUtils.getAggFuncNameOfCombinator(funcName))) {
-                // ds_hll_count_distinct_union's param type should be varbinary type.
+            String baseAggName = AggStateUtils.getAggFuncNameOfCombinator(funcName);
+            if (FunctionSet.DS_HLL_COUNT_DISTINCT.equalsIgnoreCase(baseAggName)
+                    || FunctionSet.DS_THETA_COUNT_DISTINCT.equalsIgnoreCase(baseAggName)) {
+                // ds_hll/ds_theta merge's param type should be varbinary type.
                 if (!functionCallExpr.getChild(0).getType().isBinaryType()) {
                     throw new SemanticException(String.format("Resolved function %s has no binary as argument type",
                             fn.functionName()), functionCallExpr.getPos());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -236,8 +236,10 @@ public class FunctionAnalyzer {
                 throw new SemanticException(String.format("Resolved function %s has no wildcard decimal as return type",
                         fn.functionName()), functionCallExpr.getPos());
             }
-            if (FunctionSet.DS_HLL_COUNT_DISTINCT.equalsIgnoreCase(AggStateUtils.getAggFuncNameOfCombinator(funcName))) {
-                // ds_hll_count_distinct_union's param type should be varbinary type.
+            String baseAggName = AggStateUtils.getAggFuncNameOfCombinator(funcName);
+            if (FunctionSet.DS_HLL_COUNT_DISTINCT.equalsIgnoreCase(baseAggName)
+                    || FunctionSet.DS_THETA_COUNT_DISTINCT.equalsIgnoreCase(baseAggName)) {
+                // ds_hll/ds_theta union's param type should be varbinary type.
                 if (!functionCallExpr.getChild(0).getType().isBinaryType()) {
                     throw new SemanticException(String.format("Resolved function %s has no binary as argument type",
                             fn.functionName()), functionCallExpr.getPos());
@@ -253,8 +255,10 @@ public class FunctionAnalyzer {
                 throw new SemanticException(String.format("Resolved function %s has no wildcard decimal as return type",
                         fn.functionName()), functionCallExpr.getPos());
             }
-            if (FunctionSet.DS_HLL_COUNT_DISTINCT.equalsIgnoreCase(AggStateUtils.getAggFuncNameOfCombinator(funcName))) {
-                // ds_hll_count_distinct_union's param type should be varbinary type.
+            String baseAggName = AggStateUtils.getAggFuncNameOfCombinator(funcName);
+            if (FunctionSet.DS_HLL_COUNT_DISTINCT.equalsIgnoreCase(baseAggName)
+                    || FunctionSet.DS_THETA_COUNT_DISTINCT.equalsIgnoreCase(baseAggName)) {
+                // ds_hll/ds_theta merge's param type should be varbinary type.
                 if (!functionCallExpr.getChild(0).getType().isBinaryType()) {
                     throw new SemanticException(String.format("Resolved function %s has no binary as argument type",
                             fn.functionName()), functionCallExpr.getPos());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
@@ -42,6 +42,9 @@ public class SyntaxSugars {
                 .put(FunctionSet.DS_HLL_ACCUMULATE, SyntaxSugars::dsHllCountDistinctStateUnion)
                 .put(FunctionSet.DS_HLL_COMBINE, SyntaxSugars::dsHllCountDistinctUnion)
                 .put(FunctionSet.DS_HLL_ESTIMATE, SyntaxSugars::dsHllCountDistinctMerge)
+                .put(FunctionSet.DS_THETA_ACCUMULATE, SyntaxSugars::dsThetaCountDistinctStateUnion)
+                .put(FunctionSet.DS_THETA_COMBINE, SyntaxSugars::dsThetaCountDistinctUnion)
+                .put(FunctionSet.DS_THETA_ESTIMATE, SyntaxSugars::dsThetaCountDistinctMerge)
                 .put(FunctionSet.ENCODE_ROW_ID, SyntaxSugars::encodeRowId)
                 .build();
     }
@@ -104,6 +107,24 @@ public class SyntaxSugars {
 
     private static FunctionCallExpr dsHllCountDistinctMerge(FunctionCallExpr call) {
         return new FunctionCallExpr(AggStateUtils.aggStateMergeFunctionName(FunctionSet.DS_HLL_COUNT_DISTINCT),
+                call.getChildren());
+    }
+
+    private static FunctionCallExpr dsThetaCountDistinctStateUnion(FunctionCallExpr call) {
+        final FunctionCallExpr aggStateFuncExpr =
+                new FunctionCallExpr(AggStateUtils.aggStateFunctionName(FunctionSet.DS_THETA_COUNT_DISTINCT),
+                        call.getChildren());
+        return new FunctionCallExpr(AggStateUtils.aggStateUnionFunctionName(FunctionSet.DS_THETA_COUNT_DISTINCT),
+                Lists.newArrayList(aggStateFuncExpr));
+    }
+
+    private static FunctionCallExpr dsThetaCountDistinctUnion(FunctionCallExpr call) {
+        return new FunctionCallExpr(AggStateUtils.aggStateUnionFunctionName(FunctionSet.DS_THETA_COUNT_DISTINCT),
+                call.getChildren());
+    }
+
+    private static FunctionCallExpr dsThetaCountDistinctMerge(FunctionCallExpr call) {
+        return new FunctionCallExpr(AggStateUtils.aggStateMergeFunctionName(FunctionSet.DS_THETA_COUNT_DISTINCT),
                 call.getChildren());
     }
 

--- a/test/sql/test_agg_function/R/test_ds_theta_count_distinct.sql
+++ b/test/sql/test_agg_function/R/test_ds_theta_count_distinct.sql
@@ -51,13 +51,37 @@ select ds_theta_count_distinct(id), ds_theta_count_distinct(province), ds_theta_
 1	1	1	1
 100215	100846	100	1
 -- !result
-select ds_theta_count_distinct(id, 1)  from t1 order by 1, 2;
+select ds_theta_count_distinct(id, 12) from t1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 36. Detail message: No matching function with signature: ds_theta_count_distinct(bigint(20), tinyint(4)).')
+100215
 -- !result
-select ds_theta_count_distinct(id, 100)  from t1 order by 1, 2;
+[UC]select ds_theta_count_distinct(id, 14) from t1;
+[UC]select ds_theta_count_distinct(id, 20) from t1;
+CREATE TABLE t_theta_states (
+  `id` bigint,
+  `dt` varchar(10),
+  `ds_id` binary,
+  `ds_province` binary,
+  `ds_age` binary,
+  `ds_dt` binary
+) ENGINE=OLAP
+DISTRIBUTED BY HASH(id) BUCKETS 3;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 38. Detail message: No matching function with signature: ds_theta_count_distinct(bigint(20), tinyint(4)).')
+-- !result
+INSERT INTO t_theta_states SELECT id, dt,
+  ds_theta_count_distinct_state(id),
+  ds_theta_count_distinct_state(province),
+  ds_theta_count_distinct_state(age),
+  ds_theta_count_distinct_state(dt) FROM t1;
+-- result:
+-- !result
+[UC]SELECT DS_THETA_ACCUMULATE(id), DS_THETA_ACCUMULATE(province), DS_THETA_ACCUMULATE(age), DS_THETA_ACCUMULATE(dt) FROM t1;
+[UC]SELECT DS_THETA_ACCUMULATE(id, 14) FROM t1;
+[UC]SELECT dt, DS_THETA_ACCUMULATE(id), DS_THETA_ACCUMULATE(province, 14) FROM t1 GROUP BY dt ORDER BY 1 LIMIT 3;
+[UC]SELECT DS_THETA_COMBINE(ds_id), DS_THETA_COMBINE(ds_province), DS_THETA_COMBINE(ds_age), DS_THETA_COMBINE(ds_dt) FROM t_theta_states;
+SELECT DS_THETA_ESTIMATE(ds_id), DS_THETA_ESTIMATE(ds_province), DS_THETA_ESTIMATE(ds_age), DS_THETA_ESTIMATE(ds_dt) FROM t_theta_states;
+-- result:
+100215	100846	100	3
 -- !result
 select ds_theta_count_distinct(id, 10, "INVALID") from t1 order by 1, 2;
 -- result:

--- a/test/sql/test_agg_function/T/test_ds_theta_count_distinct.sql
+++ b/test/sql/test_agg_function/T/test_ds_theta_count_distinct.sql
@@ -23,7 +23,34 @@ select ds_theta_count_distinct(id), ds_theta_count_distinct(province), ds_theta_
 select ds_theta_count_distinct(id), ds_theta_count_distinct(province), ds_theta_count_distinct(age) from t1 group by dt order by 1, 2;
 select ds_theta_count_distinct(id), ds_theta_count_distinct(province), ds_theta_count_distinct(age), ds_theta_count_distinct(dt) from t1 group by dt order by 1, 2;
 
--- bad cases
-select ds_theta_count_distinct(id, 1)  from t1 order by 1, 2;
-select ds_theta_count_distinct(id, 100)  from t1 order by 1, 2;
+-- ds_theta_count_distinct with explicit log_k
+select ds_theta_count_distinct(id, 12) from t1;
+[UC]select ds_theta_count_distinct(id, 14) from t1;
+[UC]select ds_theta_count_distinct(id, 20) from t1;
+
+-- accumulate / combine / estimate pipeline
+CREATE TABLE t_theta_states (
+  `id` bigint,
+  `dt` varchar(10),
+  `ds_id` binary,
+  `ds_province` binary,
+  `ds_age` binary,
+  `ds_dt` binary
+) ENGINE=OLAP
+DISTRIBUTED BY HASH(id) BUCKETS 3;
+
+INSERT INTO t_theta_states SELECT id, dt,
+  ds_theta_count_distinct_state(id),
+  ds_theta_count_distinct_state(province),
+  ds_theta_count_distinct_state(age),
+  ds_theta_count_distinct_state(dt) FROM t1;
+
+[UC]SELECT DS_THETA_ACCUMULATE(id), DS_THETA_ACCUMULATE(province), DS_THETA_ACCUMULATE(age), DS_THETA_ACCUMULATE(dt) FROM t1;
+[UC]SELECT DS_THETA_ACCUMULATE(id, 14) FROM t1;
+[UC]SELECT dt, DS_THETA_ACCUMULATE(id), DS_THETA_ACCUMULATE(province, 14) FROM t1 GROUP BY dt ORDER BY 1 LIMIT 3;
+
+[UC]SELECT DS_THETA_COMBINE(ds_id), DS_THETA_COMBINE(ds_province), DS_THETA_COMBINE(ds_age), DS_THETA_COMBINE(ds_dt) FROM t_theta_states;
+SELECT DS_THETA_ESTIMATE(ds_id), DS_THETA_ESTIMATE(ds_province), DS_THETA_ESTIMATE(ds_age), DS_THETA_ESTIMATE(ds_dt) FROM t_theta_states;
+
+-- bad cases (signature errors should still surface)
 select ds_theta_count_distinct(id, 10, "INVALID") from t1 order by 1, 2;

--- a/test/sql/test_agg_state/R/test_agg_state_ds_theta_count_distinct.sql
+++ b/test/sql/test_agg_state/R/test_agg_state_ds_theta_count_distinct.sql
@@ -79,6 +79,9 @@ INSERT INTO t1 values (1, 'a', 1, '2024-07-22'), (3, 'c', 1, '2024-07-25'), (5, 
 insert into test_theta_sketch select dt, ds_theta_count_distinct_state(id), ds_theta_count_distinct_state(province), ds_theta_count_distinct_state(age), ds_theta_count_distinct_state(dt) from t1;
 -- result:
 -- !result
+insert into test_theta_sketch select dt, ds_theta_count_distinct_state(id, 14), ds_theta_count_distinct_state(province, 14), ds_theta_count_distinct_state(age, 14), ds_theta_count_distinct_state(dt, 14) from t1;
+-- result:
+-- !result
 select ds_theta_count_distinct_merge(theta_id), ds_theta_count_distinct_merge(theta_province), ds_theta_count_distinct_merge(theta_age), ds_theta_count_distinct_merge(theta_dt) from test_theta_sketch;
 -- result:
 100	102	100	3

--- a/test/sql/test_agg_state/T/test_agg_state_ds_theta_count_distinct.sql
+++ b/test/sql/test_agg_state/T/test_agg_state_ds_theta_count_distinct.sql
@@ -48,5 +48,7 @@ select dt, ds_theta_count_distinct_merge(theta_id), ds_theta_count_distinct_merg
 INSERT INTO t1 values (1, 'a', 1, '2024-07-22'), (3, 'c', 1, '2024-07-25'), (5, NULL, NULL, '2024-07-24');
 INSERT INTO t1 values (1, 'a', 1, '2024-07-22'), (3, 'c', 1, '2024-07-25'), (5, NULL, NULL, '2024-07-24');
 insert into test_theta_sketch select dt, ds_theta_count_distinct_state(id), ds_theta_count_distinct_state(province), ds_theta_count_distinct_state(age), ds_theta_count_distinct_state(dt) from t1;
+-- mix in a non-default lg_k to exercise the new (col, log_k) pathway
+insert into test_theta_sketch select dt, ds_theta_count_distinct_state(id, 14), ds_theta_count_distinct_state(province, 14), ds_theta_count_distinct_state(age, 14), ds_theta_count_distinct_state(dt, 14) from t1;
 select ds_theta_count_distinct_merge(theta_id), ds_theta_count_distinct_merge(theta_province), ds_theta_count_distinct_merge(theta_age), ds_theta_count_distinct_merge(theta_dt) from test_theta_sketch;
 select dt, ds_theta_count_distinct_merge(theta_id), ds_theta_count_distinct_merge(theta_province), ds_theta_count_distinct_merge(theta_age), ds_theta_count_distinct_merge(theta_dt) from test_theta_sketch group by dt order by 1 limit 3;


### PR DESCRIPTION
## Why I'm doing:

For HyperLogLog sketches StarRocks exposes four functions — `ds_hll_count_distinct`, `ds_hll_accumulate`, `ds_hll_combine`, and `ds_hll_estimate` — and supports an `lg_k`/`log_k` precision parameter. For Theta sketches only `ds_theta_count_distinct` existed, and it didn't accept a `log_k` argument. This forced users who wanted Apache DataSketches Theta semantics (intersection/union/difference, etc.) to either materialize the state through a different path or fall back to HLL. This PR closes that gap so Theta has the same function family and tuning knob as HLL.

## What I'm doing:

**BE — wire format & state plumbing**
- `DataSketchesTheta` now carries `lg_k` through a 2-byte StarRocks-specific header `[0xFE magic][lg_k]` prepended to the serialized compact theta bytes, so precision survives serialize → shuffle → deserialize → merge → estimate. Compact-theta's first byte is `pre_longs ∈ {1, 2, 3}` so `0xFE` unambiguously identifies our header and lets legacy payloads parse with the default `lg_k`.
- `ThetaSketchAggregateFunction::merge()` adopts the incoming sketch's `lg_k` when the state is still empty, mirroring how HLL preserves precision across stages.
- Guard the deserialize path for header-only payloads (a state that was allocated but never `update()`-d or `merge()`-d serializes to just the 2-byte header).

**FE — function registration & analyzer**
- Register `ds_theta_accumulate`, `ds_theta_combine`, and `ds_theta_estimate` as agg-state combinator entrypoints via `SyntaxSugars`, mirroring the existing HLL wiring.
- Extend the existing `DS_HLL_COUNT_DISTINCT` special cases in `AggStateUtils.getAggStateFunction()` and `FunctionAnalyzer` to also cover `DS_THETA_COUNT_DISTINCT`, so `ds_theta_estimate` / `ds_theta_combine` accept a plain `VARBINARY` column (not just an `AggState`-typed column). This matches the established HLL behaviour and unblocks the typical materialized-state usage pattern.

**Tests**
- 5 new BE unit tests in `ds_theta_test.cpp` covering: the new header round-trip, header-less legacy payloads, cross-`lg_k` merge adopting the incoming precision, out-of-range `lg_k` byte falling back to default, and the empty-state round-trip.
- SQL integration tests added for the accumulate/combine/estimate pipeline (both directly and through an `AggState` column), with R files regenerated against a live cluster.

**Docs**
- New EN + ZH pages for `ds_theta_accumulate`, `ds_theta_combine`, `ds_theta_estimate`.
- Updated EN + ZH `ds_theta_count_distinct` pages for the new `(expr, log_k)` overload.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

The serialized wire format for theta sketches changes (a 2-byte `[0xFE][lg_k]` header is now prepended). Legacy data written by previous versions is detected by the absence of the magic byte and parsed unchanged, so reads of pre-existing materialized state continue to work. New writes are not readable by older versions.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5