### PR TITLE
[Doc] Disables AWS_EC2_METADATA on Iceberg quickstart

### DIFF
--- a/docs/en/quick_start/iceberg.md
+++ b/docs/en/quick_start/iceberg.md
@@ -79,6 +79,7 @@ services:
       iceberg_net:
     environment:
       - HOST_TYPE=FQDN
+      - AWS_EC2_METADATA_DISABLED=true
 
   rest:
     image: apache/iceberg-rest-fixture

--- a/docs/ja/quick_start/iceberg.md
+++ b/docs/ja/quick_start/iceberg.md
@@ -73,6 +73,7 @@ services:
       iceberg_net:
     environment:
       - HOST_TYPE=FQDN
+      - AWS_EC2_METADATA_DISABLED=true
 
   rest:
     image: apache/iceberg-rest-fixture

--- a/docs/zh/quick_start/iceberg.md
+++ b/docs/zh/quick_start/iceberg.md
@@ -76,6 +76,7 @@ services:
       iceberg_net:
     environment:
       - HOST_TYPE=FQDN
+      - AWS_EC2_METADATA_DISABLED=true
 
   rest:
     image: apache/iceberg-rest-fixture


### PR DESCRIPTION
Addresses https://github.com/StarRocks/starrocks/issues/63220 which prevents the data insertion

## Why I'm doing:
I was stuck inserting data from the quickstart guide on Apache Iceberg Lakehouse. The `insert into table` command was stuck for several minutes, not inserting the data.

It turns out I found the #63320 issue containing a tip to include the `AWS_EC2_METADATA_DISABLED=true` env var on the `starrocks-be` container. I applied it and it corrected the insertion.

## What I'm doing:
Adding the `AWS_EC2_METADATA_DISABLED=true` env var on the docker-compose.yml on the content of the quickstart guide.

Fixes #63220 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [X] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.1
  - [ ] 4.0
  - [ ] 3.5