### PR TITLE
[BugFix] Push down table_name predicate for tables_config (backport #73210)

### DIFF
--- a/be/src/exec/schema_scanner/schema_tables_config_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tables_config_scanner.cpp
@@ -62,6 +62,9 @@ Status SchemaTablesConfigScanner::start(RuntimeState* state) {
     }
     TGetTablesConfigRequest tables_config_req;
     tables_config_req.__set_auth_info(auth_info);
+    if (nullptr != _param->table) {
+        tables_config_req.__set_table_name(*(_param->table));
+    }
 
     // init schema scanner state
     RETURN_IF_ERROR(SchemaScanner::init_schema_scanner_state(state));

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -241,6 +241,19 @@ public class InformationSchemaDataSource {
 
         AuthDbRequestResult result = getAuthDbRequestResult(request.getAuth_info());
 
+        // WHERE table_schema='...' predicate is already pushed down via auth_info.pattern
+        // (set by the BE schema scanner from _param->db) and applied in getAuthDbRequestResult,
+        // so result.authorizedDbs is pre-filtered. Only the table_name predicate needs handling here.
+        PatternMatcher tableMatcher = null;
+        if (request.isSetTable_name()) {
+            try {
+                tableMatcher = PatternMatcher.createMysqlPattern(request.getTable_name(),
+                        CaseSensibility.TABLE.getCaseSensibility());
+            } catch (SemanticException e) {
+                throw new TException("Pattern is in bad format: " + request.getTable_name());
+            }
+        }
+
         for (String dbName : result.authorizedDbs) {
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (db != null) {
@@ -249,6 +262,10 @@ public class InformationSchemaDataSource {
                 try {
                     List<Table> allTables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
                     for (Table table : allTables) {
+                        if (tableMatcher != null && !tableMatcher.match(table.getName())) {
+                            continue;
+                        }
+
                         try {
                             ConnectContext context = result.buildConnectContext();
                             Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);

--- a/fe/fe-core/src/test/java/com/starrocks/service/LakeInformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/LakeInformationSchemaDataSourceTest.java
@@ -15,7 +15,9 @@
 package com.starrocks.service;
 
 import com.google.gson.Gson;
+import com.starrocks.common.PatternMatcher;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.thrift.TAuthInfo;
 import com.starrocks.thrift.TGetTablesConfigRequest;
@@ -23,13 +25,19 @@ import com.starrocks.thrift.TGetTablesConfigResponse;
 import com.starrocks.thrift.TTableConfigInfo;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.thrift.TException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class LakeInformationSchemaDataSourceTest {
 
@@ -100,5 +108,116 @@ public class LakeInformationSchemaDataSourceTest {
         Assertions.assertEquals("1", propsMap.get("replication_num"));
         Assertions.assertEquals("HDD", propsMap.get("storage_medium"));
         Assertions.assertEquals("builtin_storage_volume", propsMap.get("storage_volume"));
+    }
+
+    @Test
+    public void testGetTablesConfigWithExactTableNameFilter() throws Exception {
+        starRocksAssert.withEnableMV().withDatabase("db_exact_filter").useDatabase("db_exact_filter");
+        starRocksAssert.withTable("CREATE TABLE db_exact_filter.target_table " +
+                "(`k1` int, `v1` int) PRIMARY KEY(`k1`) " +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1 " +
+                "PROPERTIES ('replication_num' = '1');");
+        starRocksAssert.withTable("CREATE TABLE db_exact_filter.other_table " +
+                "(`k1` int, `v1` int) PRIMARY KEY(`k1`) " +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1 " +
+                "PROPERTIES ('replication_num' = '1');");
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TGetTablesConfigRequest req = new TGetTablesConfigRequest();
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setPattern("db_exact_filter");
+        authInfo.setUser("root");
+        authInfo.setUser_ip("%");
+        req.setAuth_info(authInfo);
+        req.setTable_name("target_table");
+
+        TGetTablesConfigResponse response = impl.getTablesConfig(req);
+
+        Assertions.assertEquals(1, response.getTables_config_infos().size());
+        Assertions.assertEquals("target_table", response.getTables_config_infos().get(0).getTable_name());
+    }
+
+    @Test
+    public void testGetTablesConfigWithLikePatternFilter() throws Exception {
+        starRocksAssert.withEnableMV().withDatabase("db_like_filter").useDatabase("db_like_filter");
+        starRocksAssert.withTable("CREATE TABLE db_like_filter.order_table_a " +
+                "(`k1` int, `v1` int) PRIMARY KEY(`k1`) " +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1 " +
+                "PROPERTIES ('replication_num' = '1');");
+        starRocksAssert.withTable("CREATE TABLE db_like_filter.order_table_b " +
+                "(`k1` int, `v1` int) PRIMARY KEY(`k1`) " +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1 " +
+                "PROPERTIES ('replication_num' = '1');");
+        starRocksAssert.withTable("CREATE TABLE db_like_filter.user_table " +
+                "(`k1` int, `v1` int) PRIMARY KEY(`k1`) " +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1 " +
+                "PROPERTIES ('replication_num' = '1');");
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TGetTablesConfigRequest req = new TGetTablesConfigRequest();
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setPattern("db_like_filter");
+        authInfo.setUser("root");
+        authInfo.setUser_ip("%");
+        req.setAuth_info(authInfo);
+        req.setTable_name("order%");
+
+        TGetTablesConfigResponse response = impl.getTablesConfig(req);
+
+        List<String> names = response.getTables_config_infos().stream()
+                .map(TTableConfigInfo::getTable_name)
+                .collect(Collectors.toList());
+        Assertions.assertEquals(2, names.size());
+        Assertions.assertTrue(names.contains("order_table_a"));
+        Assertions.assertTrue(names.contains("order_table_b"));
+        Assertions.assertFalse(names.contains("user_table"));
+    }
+
+    @Test
+    public void testGetTablesConfigWithNonExistentTableNameReturnsEmpty() throws Exception {
+        starRocksAssert.withEnableMV().withDatabase("db_empty_filter").useDatabase("db_empty_filter");
+        starRocksAssert.withTable("CREATE TABLE db_empty_filter.some_table " +
+                "(`k1` int, `v1` int) PRIMARY KEY(`k1`) " +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1 " +
+                "PROPERTIES ('replication_num' = '1');");
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TGetTablesConfigRequest req = new TGetTablesConfigRequest();
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setPattern("db_empty_filter");
+        authInfo.setUser("root");
+        authInfo.setUser_ip("%");
+        req.setAuth_info(authInfo);
+        req.setTable_name("does_not_exist");
+
+        TGetTablesConfigResponse response = impl.getTablesConfig(req);
+
+        Assertions.assertTrue(response.getTables_config_infos().isEmpty());
+    }
+
+    @Test
+    public void testGetTablesConfigWithInvalidTableNamePattern() {
+        String invalidPattern = "invalid_table_pattern";
+        new MockUp<PatternMatcher>() {
+            @Mock
+            public PatternMatcher createMysqlPattern(Invocation invocation, String mysqlPattern, boolean caseSensitive) {
+                if (invalidPattern.equals(mysqlPattern)) {
+                    throw new SemanticException("bad table name pattern");
+                }
+                return invocation.proceed(mysqlPattern, caseSensitive);
+            }
+        };
+
+        TGetTablesConfigRequest req = new TGetTablesConfigRequest();
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setPattern("db_empty_filter");
+        authInfo.setUser("root");
+        authInfo.setUser_ip("%");
+        req.setAuth_info(authInfo);
+        req.setTable_name(invalidPattern);
+
+        TException exception = Assertions.assertThrows(TException.class,
+                () -> InformationSchemaDataSource.generateTablesConfigResponse(req));
+        Assertions.assertEquals("Pattern is in bad format: " + invalidPattern, exception.getMessage());
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1514,6 +1514,7 @@ struct TAuthInfo {
 
 struct TGetTablesConfigRequest {
     1: optional TAuthInfo auth_info
+    2: optional string table_name
 }
 
 struct TTableConfigInfo {


### PR DESCRIPTION
## Why I'm doing:

Manual backport of #73210 to branch-4.0. The Mergify auto-backport ([#73657](https://github.com/StarRocks/starrocks/pull/73657)) failed to cherry-pick `LakeInformationSchemaDataSourceTest.java` because branch-4.0 still imports `com.starrocks.sql.ast.UserIdentity` (vs. main's `com.starrocks.catalog.UserIdentity`) and does not yet contain the `testGetLakePartitionsMeta*` tests that were added on main alongside this change.

## What I'm doing:

Cherry-pick `a9b7e6dc6a` onto branch-4.0 and resolve the test-file conflict:

- Keep the target branch's `com.starrocks.sql.ast.UserIdentity` import.
- Add only the imports needed by the new tests (`PatternMatcher`, `SemanticException`).
- Drop the unrelated `testGetLakePartitionsMeta*` tests from the incoming hunk — they reference `TGetPartitionsMeta{Request,Response}` / `TPartitionMetaInfo` which are not present on branch-4.0.

Production-code changes (`schema_tables_config_scanner.cpp`, `InformationSchemaDataSource.java`, `FrontendService.thrift`) auto-merged cleanly. Final diff stats match #73210 exactly: 4 files, +140 / -0.

### Original change summary

Push the `table_name` predicate from BE down to FE so non-matching tables are skipped before per-table work runs. Closes the symmetric gap left after `table_schema` was already pushed down via `TAuthInfo.pattern`.

- **Thrift:** add optional `table_name` field to `TGetTablesConfigRequest`.
- **BE:** `SchemaTablesConfigScanner` forwards `_param->table` into the request.
- **FE:** `InformationSchemaDataSource.generateTablesConfigResponse` builds a `PatternMatcher` before the per-DB loop and short-circuits non-matching tables before any per-table work runs.

## Unit tests

`LakeInformationSchemaDataSourceTest` covers the new predicate path:

- exact match `table_name` filter returns only the matching table
- MySQL LIKE pattern (`order%`) returns matching tables, excludes others
- non-existent table name returns an empty response
- invalid pattern surfaces a `TException` with the expected message

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation
- [x] This is a backport pr
