### PR TITLE
[BugFix] Parse decimal-valued unit counters in RuntimeProfileParser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfileParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfileParser.java
@@ -51,6 +51,7 @@ public class RuntimeProfileParser {
             Pattern.compile("^- (.*?): (.*?)$");
     private static final Pattern INFO_KEY_STRING_PATTERN =
             Pattern.compile("^- (.*?)$");
+    private static final BigDecimal UNIT_COUNTER_VALUE_LIMIT = BigDecimal.valueOf(1000);
 
     public static RuntimeProfile parseFrom(String content) {
         LOG.debug("Parse runtime profile from content: {}", content);
@@ -233,20 +234,7 @@ public class RuntimeProfileParser {
         if (!matcher.matches()) {
             return null;
         }
-
-        String name = matcher.group(1);
-        String value = matcher.group(2);
-        String preciseValue = matcher.group(6);
-
-        if (StringUtils.isNotBlank(preciseValue)) {
-            return new CounterTuple(name, TUnit.UNIT, Long.parseLong(preciseValue));
-        } else {
-            long lValue = Long.parseLong(value);
-            if (lValue > 1000) {
-                return null;
-            }
-            return new CounterTuple(name, TUnit.UNIT, lValue);
-        }
+        return buildUnitCounter(matcher, TUnit.UNIT);
     }
 
     private static CounterTuple tryParseUnitPerSecCounter(String item) {
@@ -254,20 +242,21 @@ public class RuntimeProfileParser {
         if (!matcher.matches()) {
             return null;
         }
+        return buildUnitCounter(matcher, TUnit.UNIT_PER_SECOND);
+    }
 
+    private static CounterTuple buildUnitCounter(Matcher matcher, TUnit unit) {
         String name = matcher.group(1);
-        String value = matcher.group(2);
         String preciseValue = matcher.group(6);
-
+        // Both regex groups admit decimals; use BigDecimal so Long.parseLong won't throw.
         if (StringUtils.isNotBlank(preciseValue)) {
-            return new CounterTuple(name, TUnit.UNIT_PER_SECOND, Long.parseLong(preciseValue));
-        } else {
-            long lValue = Long.parseLong(value);
-            if (lValue > 1000) {
-                return null;
-            }
-            return new CounterTuple(name, TUnit.UNIT_PER_SECOND, lValue);
+            return new CounterTuple(name, unit, new BigDecimal(preciseValue).longValue());
         }
+        BigDecimal value = new BigDecimal(matcher.group(2));
+        if (value.compareTo(UNIT_COUNTER_VALUE_LIMIT) > 0) {
+            return null;
+        }
+        return new CounterTuple(name, unit, value.longValue());
     }
 
     private static CounterTuple tryParseTimer(String item) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileParserTest.java
@@ -285,4 +285,36 @@ public class RuntimeProfileParserTest {
 
         checkParser(query);
     }
+
+    @Test
+    public void testUnitCounterAcceptsDecimalValue() {
+        String content = String.join("\n",
+                "profile:",
+                "   - smallDecimal: 5.50",
+                "   - largeDecimal: 3074457345618258400.000",
+                "");
+        RuntimeProfile profile = RuntimeProfileParser.parseFrom(content);
+        Assertions.assertNotNull(profile);
+        Counter small = profile.getCounter("smallDecimal");
+        Assertions.assertNotNull(small);
+        Assertions.assertEquals(TUnit.UNIT, small.getType());
+        Assertions.assertEquals(5, small.getValue());
+        // Above-limit values fall back to the InfoString path so the line stays parseable.
+        Assertions.assertNull(profile.getCounter("largeDecimal"));
+        Assertions.assertEquals("3074457345618258400.000", profile.getInfoString("largeDecimal"));
+    }
+
+    @Test
+    public void testUnitPerSecCounterAcceptsDecimalValue() {
+        String content = String.join("\n",
+                "profile:",
+                "   - rate: 7.25 /sec",
+                "");
+        RuntimeProfile profile = RuntimeProfileParser.parseFrom(content);
+        Assertions.assertNotNull(profile);
+        Counter counter = profile.getCounter("rate");
+        Assertions.assertNotNull(counter);
+        Assertions.assertEquals(TUnit.UNIT_PER_SECOND, counter.getType());
+        Assertions.assertEquals(7, counter.getValue());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

`UNIT_COUNTER_PATTERN` and `UNIT_PER_SEC_COUNTER_PATTERN` admit decimal values like `123.5` or `3074457345618258400.000` (the matched group is `(\\d+(\\.\\d+)?(...)?)`), but `tryParseUnitCounter` / `tryParseUnitPerSecCounter` feed the matched string to `Long.parseLong`, which throws `NumberFormatException` on any non-integer input. BE occasionally prints integer-valued unit counters using a floating-point format (`%.3f`), producing a `.000` suffix that triggers the exception every time the profile is parsed.

The visible symptom is a recurring WARN in the FE log:

```
Failed to get query progress, query_id:7d05cc7c-53d4-11f1-b237-06b9aa81793b
java.lang.NumberFormatException: For input string: "3074457345618258400.000"
    at java.lang.Long.parseLong(Long.java:711)
    at com.starrocks.common.util.RuntimeProfileParser.tryParseUnitCounter(RuntimeProfileParser.java:244)
    at com.starrocks.common.util.RuntimeProfileParser.tryParseCounter(RuntimeProfileParser.java:148)
    at com.starrocks.common.util.RuntimeProfileParser.parseFrom(RuntimeProfileParser.java:87)
    at com.starrocks.common.util.QueryProgressUtils.getQueryProgress(QueryProgressUtils.java:72)
    at com.starrocks.common.util.QueryProgressUtils.getProgressPercent(QueryProgressUtils.java:36)
    at com.starrocks.qe.QueryStatisticsInfo.getExecProgress(QueryStatisticsInfo.java:386)
    at com.starrocks.qe.QueryStatisticsInfo.makeListFromMetricsAndMgrs(QueryStatisticsInfo.java:368)
    at com.starrocks.service.FrontendServiceImpl.getQueryStatistics(FrontendServiceImpl.java:2561)
    ...
```

The exception is caught in `QueryProgressUtils.getQueryProgress`, so the query listing itself does not fail — the affected query just shows `"Failed to get query progress, query_id:..."` in its progress column. But the log gets noisy whenever monitoring polls `/current_queries` or `/global_current_queries`.

## What I'm doing:

Switch both `tryParseUnitCounter` and `tryParseUnitPerSecCounter` to `BigDecimal`, matching the convention already used by `tryParseByteCounter` / `tryParseBytePerSecCounter` in the same file. Values above the existing `> 1000` sanity limit return `null`, so the line falls through to the InfoString matcher and stays parseable.

The two functions had nearly-duplicate bodies; collapsed them into a shared `buildUnitCounter(Matcher, TUnit)` helper.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

(Strictly speaking, lines that previously triggered `NumberFormatException` now parse successfully as InfoString rather than aborting the parse, but the exception was already caught upstream so end-user-visible output for healthy profiles is unchanged.)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
  - `RuntimeProfileParserTest.testUnitCounterAcceptsDecimalValue` and `testUnitPerSecCounterAcceptsDecimalValue`
- [ ] This pr needs user documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

## Test plan

- [x] `mvn checkstyle:check -pl fe-core` — 0 violations
- [x] `mvn test -pl fe-core -Dtest=RuntimeProfileParserTest` — 13/13 pass (11 pre-existing + 2 new)