### PR TITLE
[Enhancement] turn on pipeline_enable_large_column_checker by default (backport #72798)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -915,7 +915,7 @@ CONF_mInt64(pipeline_poller_timeout_guard_ms, "-1");
 // pipeline fragment prepare timeout guard
 CONF_mInt64(pipeline_prepare_timeout_guard_ms, "-1");
 // whether to enable large column detection in the pipeline execution framework.
-CONF_mBool(pipeline_enable_large_column_checker, "false");
+CONF_mBool(pipeline_enable_large_column_checker, "true");
 
 // The number of scan threads pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -446,7 +446,7 @@ This topic introduces the following types of BE configurations:
 - Unit: -
 - Is mutable: Yes
 - Description: Whether to enable large column detection in the pipeline execution framework. When enabled, queries fail with a capacity limit error if an intermediate column reaches the chunk capacity limit in pipeline execution or spill serialization.
-- Introduced in: -
+- Introduced in: v4.0.0
 
 ### pipeline_poller_timeout_guard_ms
 

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -439,6 +439,15 @@ This topic introduces the following types of BE configurations:
 - Description: The number of scan threads assigned to Pipeline Connector per CPU core in the BE node. This configuration is changed to dynamic from v3.1.7 onwards.
 - Introduced in: -
 
+### pipeline_enable_large_column_checker
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to enable large column detection in the pipeline execution framework. When enabled, queries fail with a capacity limit error if an intermediate column reaches the chunk capacity limit in pipeline execution or spill serialization.
+- Introduced in: -
+
 ### pipeline_poller_timeout_guard_ms
 
 - Default: -1

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -427,6 +427,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：BE 节点中每个 CPU 核心分配给 Pipeline Connector 的扫描线程数量。自 v3.1.7 起变为动态参数。
 - 引入版本：-
 
+### pipeline_enable_large_column_checker
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否在 Pipeline 执行框架中启用大列检测。启用后，如果中间列在 Pipeline 执行或 Spill 序列化过程中达到 Chunk 容量限制，查询将报容量超限错误。
+- 引入版本：-
+
 ### pipeline_poller_timeout_guard_ms
 
 - 默认值：-1

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -434,7 +434,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 单位：-
 - 是否动态：是
 - 描述：是否在 Pipeline 执行框架中启用大列检测。启用后，如果中间列在 Pipeline 执行或 Spill 序列化过程中达到 Chunk 容量限制，查询将报容量超限错误。
-- 引入版本：-
+- 引入版本：v4.0.0
 
 ### pipeline_poller_timeout_guard_ms
 


### PR DESCRIPTION
## Why I'm doing:

Backport #72798 to branch-4.0.

## What I'm doing:

Cherry-pick the default change for `pipeline_enable_large_column_checker` and matching docs.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4