### PR TITLE
[Enhancement] optimize jdbc catalog's checkAndSetSupportPartitionInformation (backport #72824)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -37,10 +37,13 @@ import java.util.List;
 import static java.lang.Math.max;
 
 public class MysqlSchemaResolver extends JDBCSchemaResolver {
+    private static final String INFORMATION_SCHEMA = "information_schema";
+    private static final String PARTITIONS_TABLE = "partitions";
+    private static final String PARTITIONS_TABLE_UPPERCASE = "PARTITIONS";
 
     @Override
     protected boolean isInternalSchema(String schemaName) {
-        return schemaName.equalsIgnoreCase("information_schema") ||
+        return schemaName.equalsIgnoreCase(INFORMATION_SCHEMA) ||
                 schemaName.equalsIgnoreCase("mysql") ||
                 schemaName.equalsIgnoreCase("performance_schema") ||
                 schemaName.equalsIgnoreCase("sys");
@@ -82,28 +85,26 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
 
     @Override
     public boolean checkAndSetSupportPartitionInformation(Connection connection) {
-        String catalogSchema = "information_schema";
-        String partitionInfoTable = "partitions";
-        // Different types of MySQL protocol databases have different case names for schema and table names,
-        // which need to be converted to lowercase for comparison
-        try (ResultSet catalogSet = connection.getMetaData().getCatalogs()) {
-            while (catalogSet.next()) {
-                String schemaName = catalogSet.getString("TABLE_CAT");
-                if (schemaName.equalsIgnoreCase(catalogSchema)) {
-                    try (ResultSet tableSet = connection.getMetaData().getTables(catalogSchema, null, null, null)) {
-                        while (tableSet.next()) {
-                            String tableName = tableSet.getString("TABLE_NAME");
-                            if (tableName.equalsIgnoreCase(partitionInfoTable)) {
-                                return this.supportPartitionInformation = true;
-                            }
-                        }
-                    }
-                }
-            }
+        try {
+            return this.supportPartitionInformation =
+                    partitionInfoTableExists(connection, PARTITIONS_TABLE_UPPERCASE) ||
+                            partitionInfoTableExists(connection, PARTITIONS_TABLE);
         } catch (SQLException e) {
             throw new StarRocksConnectorException(e.getMessage());
         }
-        return this.supportPartitionInformation = false;
+    }
+
+    private boolean partitionInfoTableExists(Connection connection, String tableNamePattern) throws SQLException {
+        try (ResultSet tableSet = connection.getMetaData().getTables(
+                INFORMATION_SCHEMA, null, tableNamePattern, null)) {
+            while (tableSet != null && tableSet.next()) {
+                String tableName = tableSet.getString("TABLE_NAME");
+                if (tableName != null && tableName.equalsIgnoreCase(PARTITIONS_TABLE)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -26,6 +26,7 @@ import com.starrocks.connector.PartitionUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.utframe.UtFrameUtils;
 import com.zaxxer.hikari.HikariDataSource;
+import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -58,8 +60,6 @@ public class MysqlSchemaResolverTest {
     PreparedStatement preparedStatement;
 
     private Map<String, String> properties;
-    private MockResultSet dbResult;
-    private MockResultSet tableResult;
     private MockResultSet partitionsResult;
     private Map<JDBCTableName, Integer> tableIdCache;
 
@@ -113,21 +113,31 @@ public class MysqlSchemaResolverTest {
 
     @Test
     public void testCheckPartitionWithPartitionsTable() throws SQLException {
+        List<String> tableNamePatterns = Lists.newArrayList();
         new Expectations() {
             {
                 String catalogSchema = "information_schema";
 
-                dbResult = new MockResultSet("catalog");
-                dbResult.addColumn("TABLE_CAT", Arrays.asList(catalogSchema));
-
-                connection.getMetaData().getCatalogs();
-                result = dbResult;
-                minTimes = 0;
-
                 MockResultSet piResult = new MockResultSet("partitions");
                 piResult.addColumn("TABLE_NAME", Arrays.asList("partitions"));
-                connection.getMetaData().getTables(anyString, null, null, null);
-                result = piResult;
+                connection.getMetaData().getTables(catalogSchema, null, anyString, null);
+                result = new Delegate() {
+                    ResultSet getTables(String catalog, String schemaPattern, String tableNamePattern,
+                                        String[] types) {
+                        tableNamePatterns.add(tableNamePattern);
+                        Assertions.assertNotNull(tableNamePattern);
+                        return piResult;
+                    }
+                };
+                minTimes = 0;
+
+                connection.getMetaData().getCatalogs();
+                result = new Delegate() {
+                    ResultSet getCatalogs() {
+                        Assertions.fail("check partition information should not scan catalogs");
+                        return null;
+                    }
+                };
                 minTimes = 0;
             }
         };
@@ -137,6 +147,7 @@ public class MysqlSchemaResolverTest {
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
         }
+        Assertions.assertEquals(Arrays.asList("partitions"), tableNamePatterns);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -147,7 +147,8 @@ public class MysqlSchemaResolverTest {
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
         }
-        Assertions.assertEquals(Arrays.asList("partitions"), tableNamePatterns);
+        Assertions.assertEquals(1, tableNamePatterns.size());
+        Assertions.assertTrue(tableNamePatterns.get(0).equalsIgnoreCase("partitions"));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Backport #72824 to branch-4.0.

## What I'm doing:

Cherry-pick the JDBC catalog partition information check optimization.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

