### PR TITLE
[BugFix] Handle mixed range-colocate × hash JOIN in optimizer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
@@ -248,6 +248,10 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
 
         requiredChildrenProperties.set(childIndex, newChildInputProperty);
         childrenOutputProperties.set(childIndex, newChildInputProperty);
+        // Publish the enforcer into childrenBestExprList; downstream enforcements
+        // (transToBucketShuffleJoin) read this list directly and need the converted
+        // child whose lowestCostTable contains the new hash output property.
+        childrenBestExprList.set(childIndex, pair.first);
         return pair.first;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -27,6 +27,8 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.CTEProperty;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionCol;
@@ -362,6 +364,23 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
                     leftOnPredicateColumns, rightOnPredicateColumns);
         }
 
+        // Defense in depth: mixed (Range, Hash) reaching the deriver means the
+        // upstream Guarantor's range→hash normalization did not run.  Fail loud
+        // — the deriver cannot install exchange enforcers itself, and silently
+        // returning a derived property risks downstream misclassification of
+        // the join mode.
+        boolean leftIsRange = leftRawSpec instanceof RangeDistributionSpec;
+        boolean rightIsRange = rightRawSpec instanceof RangeDistributionSpec;
+        boolean leftIsHash = leftRawSpec instanceof HashDistributionSpec;
+        boolean rightIsHash = rightRawSpec instanceof HashDistributionSpec;
+        if ((leftIsRange && rightIsHash) || (leftIsHash && rightIsRange)) {
+            throw new StarRocksPlannerException(
+                    "Mixed range-distribution / hash-distribution JOIN reached output-property "
+                            + "derivation; the upstream Guarantor was expected to normalize the "
+                            + "range side to hash. left=" + leftRawSpec + ", right=" + rightRawSpec,
+                    ErrorType.INTERNAL_ERROR);
+        }
+
         DistributionProperty leftChildDistributionProperty = leftChildOutputProperty.getDistributionProperty();
         DistributionProperty rightChildDistributionProperty = rightChildOutputProperty.getDistributionProperty();
         if (leftChildDistributionProperty.isShuffle() && rightChildDistributionProperty.isShuffle()) {
@@ -397,17 +416,22 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
                         leftOnPredicateColumns, rightOnPredicateColumns);
 
             } else {
-                LOG.error("Children output property distribution error.left child property: {}, " +
-                                "right child property: {}, join node: {}",
-                        leftChildDistributionProperty, rightChildDistributionProperty, node);
-                throw new IllegalStateException("Children output property distribution error.");
+                throw childrenDistributionError(node, leftChildDistributionProperty, rightChildDistributionProperty);
             }
         } else {
-            LOG.error("Children output property distribution error.left child property: {}, " +
-                            "right child property: {}, join node: {}",
-                    leftChildDistributionProperty, rightChildDistributionProperty, node);
-            throw new IllegalStateException("Children output property distribution error.");
+            throw childrenDistributionError(node, leftChildDistributionProperty, rightChildDistributionProperty);
         }
+    }
+
+    private static StarRocksPlannerException childrenDistributionError(PhysicalJoinOperator node,
+                                                                       DistributionProperty leftProperty,
+                                                                       DistributionProperty rightProperty) {
+        LOG.error("Children output property distribution error. left={}, right={}, join={}",
+                leftProperty, rightProperty, node);
+        return new StarRocksPlannerException(
+                "Children output property distribution error. left=" + leftProperty
+                        + ", right=" + rightProperty,
+                ErrorType.INTERNAL_ERROR);
     }
 
     private PhysicalPropertySet computeShuffleJoinOutputProperty(JoinOperator joinType,

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateMixedJoinPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateMixedJoinPlanTest.java
@@ -1,0 +1,248 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * F2 follow-up (colocate.md): mixed range-colocate × hash JOIN must not surface
+ * as MySQL "Unknown error" — the optimizer should plan a shuffle/bucket join.
+ *
+ * <p>The load-bearing fix is in {@code ChildOutputPropertyGuarantor.convertRangeToHashShuffle},
+ * which now publishes the range→hash enforcer back into {@code childrenBestExprList}
+ * so downstream bucket/shuffle enforcement can read it.  The deriver throws a
+ * descriptive {@code StarRocksPlannerException} if a mixed pair ever reaches it.
+ */
+public class RangeColocateMixedJoinPlanTest {
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static boolean savedEnableRangeDistributionConfig;
+    private static boolean savedEnableRangeDistributionSessionVar;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        savedEnableRangeDistributionConfig = Config.enable_range_distribution;
+        savedEnableRangeDistributionSessionVar = connectContext.getSessionVariable().isEnableRangeDistribution();
+        Config.enable_range_distribution = true;
+        connectContext.getSessionVariable().setEnableRangeDistribution(true);
+
+        starRocksAssert.withDatabase("f2_mixed_join").useDatabase("f2_mixed_join");
+
+        starRocksAssert.withTable(
+                "create table cd (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'f2_grp:k1');");
+        starRocksAssert.withTable(
+                "create table cd2 (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'f2_grp:k1');");
+        starRocksAssert.withTable(
+                "create table dim (k1 int, x int)\n"
+                        + "distributed by hash(k1) buckets 3\n"
+                        + "properties('replication_num' = '1');");
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        Config.enable_range_distribution = savedEnableRangeDistributionConfig;
+        if (connectContext != null) {
+            connectContext.getSessionVariable().setEnableRangeDistribution(savedEnableRangeDistributionSessionVar);
+        }
+    }
+
+    @BeforeEach
+    public void resetSessionState() {
+        Deencapsulation.setField(connectContext.getSessionVariable(), "disableColocateJoin", false);
+    }
+
+    // ---------- helpers ----------
+
+    private String plan(String sql) throws Exception {
+        ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(connectContext, sql).second;
+        return execPlan.getExplainString(TExplainLevel.NORMAL);
+    }
+
+    private void assertContainsMarkerNotColocate(String sql, String marker) throws Exception {
+        String fragmentPlan = plan(sql);
+        Assertions.assertTrue(fragmentPlan.contains(marker),
+                () -> "expected plan to contain `" + marker + "` but got:\n" + fragmentPlan);
+        Assertions.assertFalse(fragmentPlan.contains("colocate: true"),
+                () -> "mixed range/hash join must not be a colocate join, plan was:\n" + fragmentPlan);
+    }
+
+    /** For join variants where the optimizer may commute the join direction. */
+    private void assertPlansAsHashJoin(String sql) throws Exception {
+        assertContainsMarkerNotColocate(sql, "HASH JOIN");
+    }
+
+    // ---------- T1–T12 ----------
+
+    /** T1: F2 repro. cd (range-colocate) ⨝ dim (hash) on the colocate key. */
+    @Test
+    public void t1_rangeJoinHashOnColocateKey() throws Exception {
+        // Optimizer chooses dim (LOCAL hash) on the left and cd (range→shuffle)
+        // on the right, producing a bucket-shuffle join.
+        assertContainsMarkerNotColocate(
+                "select count(*) from cd join dim on cd.k1 = dim.k1",
+                "INNER JOIN (BUCKET_SHUFFLE)");
+    }
+
+    /** T2: Hash ⨝ Range, explicit ordering matches the bucket-shuffle path. */
+    @Test
+    public void t2_hashJoinRangeBucketShuffle() throws Exception {
+        assertContainsMarkerNotColocate(
+                "select count(*) from dim join cd on dim.k1 = cd.k1",
+                "INNER JOIN (BUCKET_SHUFFLE)");
+    }
+
+    /** T3: Range ⨝ Hash on non-colocate key — must still plan, no colocate. */
+    @Test
+    public void t3_rangeJoinHashOnNonColocateKey() throws Exception {
+        assertContainsMarkerNotColocate(
+                "select count(*) from cd join dim on cd.k2 = dim.k1",
+                "INNER JOIN");
+    }
+
+    /** T4: Range ⨝ Range colocate (regression — must still pick colocate). */
+    @Test
+    public void t4_rangeJoinRangeStillColocate() throws Exception {
+        String fragmentPlan = plan("select count(*) from cd a join cd2 b on a.k1 = b.k1");
+        Assertions.assertTrue(fragmentPlan.contains("colocate: true"),
+                () -> "range×range join on colocate key must remain colocate, plan was:\n" + fragmentPlan);
+    }
+
+    /** T5: LEFT OUTER variant of T1 — optimizer may commute, just assert it plans. */
+    @Test
+    public void t5_rangeLeftOuterHash() throws Exception {
+        assertPlansAsHashJoin(
+                "select count(*) from cd left outer join dim on cd.k1 = dim.k1");
+    }
+
+    /** T6: LEFT SEMI variant. IN-subquery may rewrite to INNER JOIN; markers loose. */
+    @Test
+    public void t6_rangeLeftSemiHash() throws Exception {
+        assertPlansAsHashJoin(
+                "select count(*) from cd where cd.k1 in (select dim.k1 from dim)");
+    }
+
+    /** T7: LEFT ANTI variant. */
+    @Test
+    public void t7_rangeLeftAntiHash() throws Exception {
+        assertPlansAsHashJoin(
+                "select count(*) from cd where cd.k1 not in (select dim.k1 from dim where dim.k1 is not null)");
+    }
+
+    /** T8: RIGHT OUTER variant — optimizer commutes freely. */
+    @Test
+    public void t8_rangeRightOuterHash() throws Exception {
+        assertPlansAsHashJoin(
+                "select count(*) from cd right outer join dim on cd.k1 = dim.k1");
+    }
+
+    /** T9: FULL OUTER variant. */
+    @Test
+    public void t9_rangeFullOuterHash() throws Exception {
+        assertPlansAsHashJoin(
+                "select count(*) from cd full outer join dim on cd.k1 = dim.k1");
+    }
+
+    /** T10: SHUFFLE hint forces shuffle join even when bucket-shuffle is feasible. */
+    @Test
+    public void t10_rangeJoinHashShuffleHint() throws Exception {
+        assertContainsMarkerNotColocate(
+                "select count(*) from cd join [shuffle] dim on cd.k1 = dim.k1",
+                "INNER JOIN (PARTITIONED)");
+    }
+
+    /** T11: disable_colocate_join (session variable) doesn't break the mixed path. */
+    @Test
+    public void t11_disableColocateJoinSessionVar() throws Exception {
+        Deencapsulation.setField(connectContext.getSessionVariable(), "disableColocateJoin", true);
+        try {
+            assertContainsMarkerNotColocate(
+                    "select count(*) from cd join dim on cd.k1 = dim.k1",
+                    "INNER JOIN");
+        } finally {
+            Deencapsulation.setField(connectContext.getSessionVariable(), "disableColocateJoin", false);
+        }
+    }
+
+    /** T12: Hash(LOCAL) × Range with [shuffle] hint — Guarantor enforces shuffle on both sides. */
+    @Test
+    public void t12_hashLocalRangeShuffleHint() throws Exception {
+        assertContainsMarkerNotColocate(
+                "select count(*) from dim join [shuffle] cd on dim.k1 = cd.k1",
+                "INNER JOIN (PARTITIONED)");
+    }
+
+    // ---------- Optimizer-level invariant ----------
+
+    /**
+     * Invariant: for non-colocate, non-broadcast joins, no child output property
+     * may carry a {@code RangeDistributionSpec}.  Broadcast joins and range×range
+     * colocate joins legitimately carry range specs and are excluded.
+     */
+    @Test
+    public void invariantNoRangeSpecOnNonColocateMixedJoinChildren() throws Exception {
+        ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(connectContext,
+                "select count(*) from cd join dim on cd.k1 = dim.k1").second;
+        OptExpression root = execPlan.getPhysicalPlan();
+        Assertions.assertNotNull(root, "physical plan must be non-null");
+
+        int inspectedJoins = checkNoRangeSpecOnJoinChildren(root, 0);
+        Assertions.assertTrue(inspectedJoins >= 1, "expected at least one join in the F2 repro");
+    }
+
+    private static int checkNoRangeSpecOnJoinChildren(OptExpression node, int count) {
+        Operator op = node.getOp();
+        if (op instanceof PhysicalJoinOperator
+                && !"BROADCAST".equalsIgnoreCase(((PhysicalJoinOperator) op).getJoinHint())) {
+            for (int i = 0; i < node.arity(); i++) {
+                OptExpression child = node.inputAt(i);
+                if (child.getOutputProperty() != null) {
+                    DistributionSpec spec = child.getOutputProperty().getDistributionProperty().getSpec();
+                    Assertions.assertFalse(spec instanceof RangeDistributionSpec,
+                            "non-colocate mixed join child " + i + " carries RangeDistributionSpec, spec=" + spec);
+                }
+            }
+            count++;
+        }
+        for (int i = 0; i < node.arity(); i++) {
+            count = checkNoRangeSpecOnJoinChildren(node.inputAt(i), count);
+        }
+        return count;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OutputPropertyDeriverRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OutputPropertyDeriverRangeTest.java
@@ -15,10 +15,12 @@
 package com.starrocks.sql.optimizer;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.sql.optimizer.base.AnyDistributionSpec;
 import com.starrocks.sql.optimizer.base.DistributionCol;
+import com.starrocks.sql.optimizer.base.DistributionProperty;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.EquivalentDescriptor;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
@@ -34,12 +36,15 @@ import mockit.Mocked;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Direct unit tests for the range-aware branches of {@link OutputPropertyDeriver}:
@@ -56,9 +61,9 @@ class OutputPropertyDeriverRangeTest {
 
     private static RangeDistributionSpec buildRangeSkeleton(long tableId, int... colIds) {
         EquivalentDescriptor descriptor = new EquivalentDescriptor(tableId, Collections.emptyList());
-        List<DistributionCol> cols = java.util.Arrays.stream(colIds)
+        List<DistributionCol> cols = Arrays.stream(colIds)
                 .mapToObj(id -> new DistributionCol(id, true))
-                .collect(java.util.stream.Collectors.toList());
+                .collect(Collectors.toList());
         descriptor.initDistributionUnionFind(cols);
         return new RangeDistributionSpec(cols, descriptor);
     }
@@ -101,8 +106,7 @@ class OutputPropertyDeriverRangeTest {
         // Repeat intersection includes every colocate column id → preserve.
         RangeDistributionSpec childSpec = buildRangeSkeleton(100L, 1, 2);
         PhysicalPropertySet childProperty =
-                new PhysicalPropertySet(
-                        com.starrocks.sql.optimizer.base.DistributionProperty.createProperty(childSpec));
+                new PhysicalPropertySet(DistributionProperty.createProperty(childSpec));
 
         ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "a", true);
         ColumnRefOperator col2 = new ColumnRefOperator(2, IntegerType.INT, "b", true);
@@ -111,9 +115,9 @@ class OutputPropertyDeriverRangeTest {
         new Expectations() {
             {
                 node.getRepeatColumnRef();
-                result = java.util.Arrays.asList(
-                        com.google.common.collect.Lists.newArrayList(col1, col2),
-                        com.google.common.collect.Lists.newArrayList(col1, col2, col3));
+                result = Arrays.asList(
+                        Lists.newArrayList(col1, col2),
+                        Lists.newArrayList(col1, col2, col3));
             }
         };
 
@@ -129,17 +133,16 @@ class OutputPropertyDeriverRangeTest {
         // Intersection drops column 2 (only in first subset) → range dropped.
         RangeDistributionSpec childSpec = buildRangeSkeleton(100L, 1, 2);
         PhysicalPropertySet childProperty =
-                new PhysicalPropertySet(
-                        com.starrocks.sql.optimizer.base.DistributionProperty.createProperty(childSpec));
+                new PhysicalPropertySet(DistributionProperty.createProperty(childSpec));
 
         ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "a", true);
         ColumnRefOperator col2 = new ColumnRefOperator(2, IntegerType.INT, "b", true);
         new Expectations() {
             {
                 node.getRepeatColumnRef();
-                result = java.util.Arrays.asList(
-                        com.google.common.collect.Lists.newArrayList(col1, col2),
-                        com.google.common.collect.Lists.newArrayList(col1));
+                result = Arrays.asList(
+                        Lists.newArrayList(col1, col2),
+                        Lists.newArrayList(col1));
             }
         };
 
@@ -155,8 +158,7 @@ class OutputPropertyDeriverRangeTest {
             @Mocked Projection projection) {
         RangeDistributionSpec childSpec = buildRangeSkeleton(100L, 1);
         PhysicalPropertySet childProperty =
-                new PhysicalPropertySet(
-                        com.starrocks.sql.optimizer.base.DistributionProperty.createProperty(childSpec));
+                new PhysicalPropertySet(DistributionProperty.createProperty(childSpec));
 
         // Projection renames column 1 → column 100 (identity ref).
         ColumnRefOperator aliased = new ColumnRefOperator(100, IntegerType.INT, "a_alias", true);
@@ -177,8 +179,7 @@ class OutputPropertyDeriverRangeTest {
         EquivalentDescriptor equivDesc = childSpec.getEquivalentDescriptor();
         DistributionCol colocateCol = childSpec.getColocateColumns().get(0);
         DistributionCol aliasCol = new DistributionCol(100, true);
-        org.junit.jupiter.api.Assertions.assertTrue(
-                equivDesc.isConnected(aliasCol, colocateCol),
+        assertTrue(equivDesc.isConnected(aliasCol, colocateCol),
                 "alias should be connected to the colocate column in the descriptor");
     }
 
@@ -186,8 +187,7 @@ class OutputPropertyDeriverRangeTest {
     void updatePropertyWithProjectionNoOpOnNullProjection() throws Exception {
         RangeDistributionSpec childSpec = buildRangeSkeleton(100L, 1);
         PhysicalPropertySet childProperty =
-                new PhysicalPropertySet(
-                        com.starrocks.sql.optimizer.base.DistributionProperty.createProperty(childSpec));
+                new PhysicalPropertySet(DistributionProperty.createProperty(childSpec));
         OutputPropertyDeriver deriver = newDeriver(Collections.emptyList());
         // null projection — early-return path. Use reflection directly since
         // JMockit's Deencapsulation.invoke rejects null args.

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OutputPropertyDeriverRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OutputPropertyDeriverRangeTest.java
@@ -18,14 +18,21 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.AnyDistributionSpec;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionCol;
 import com.starrocks.sql.optimizer.base.DistributionProperty;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.EquivalentDescriptor;
+import com.starrocks.sql.optimizer.base.GatherDistributionSpec;
+import com.starrocks.sql.optimizer.base.HashDistributionDesc;
+import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
 import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalRepeatOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -44,6 +51,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -206,5 +214,117 @@ class OutputPropertyDeriverRangeTest {
         OutputPropertyDeriver deriver = newDeriver(Collections.emptyList());
         Deencapsulation.invoke(deriver, "updatePropertyWithProjection", projection, childProperty);
         // No assertion needed beyond "did not throw and did not read projection".
+    }
+
+    // ---- F2 throw-path coverage ----
+
+    private static HashDistributionSpec buildHashSpec(HashDistributionDesc.SourceType source, int... colIds) {
+        EquivalentDescriptor descriptor = new EquivalentDescriptor(200L, Collections.emptyList());
+        List<DistributionCol> cols = Arrays.stream(colIds)
+                .mapToObj(id -> new DistributionCol(id, true))
+                .collect(Collectors.toList());
+        return new HashDistributionSpec(new HashDistributionDesc(cols, source), descriptor);
+    }
+
+    private static PhysicalPropertySet propertyOf(DistributionSpec spec) {
+        return new PhysicalPropertySet(DistributionProperty.createProperty(spec));
+    }
+
+    /**
+     * Stubs the join-operator and expression-context methods that
+     * {@code OutputPropertyDeriver.visitPhysicalJoin} touches before it inspects
+     * the child distribution specs.  With these stubs the throw paths under
+     * test (lines 377, 419, 422) are reachable without a full Memo fixture.
+     */
+    private static void stubInnerJoinWithEmptyColumns(PhysicalHashJoinOperator node,
+                                                      ExpressionContext context) {
+        new Expectations() {
+            {
+                node.getJoinType();
+                result = JoinOperator.INNER_JOIN;
+                minTimes = 0;
+                node.getOnPredicate();
+                result = null;
+                minTimes = 0;
+                node.getJoinHint();
+                result = null;
+                minTimes = 0;
+                context.getChildOutputColumns(0);
+                result = new ColumnRefSet();
+                minTimes = 0;
+                context.getChildOutputColumns(1);
+                result = new ColumnRefSet();
+                minTimes = 0;
+            }
+        };
+    }
+
+    private static StarRocksPlannerException invokeVisitPhysicalJoinExpectingThrow(
+            OutputPropertyDeriver deriver, PhysicalHashJoinOperator node, ExpressionContext context) {
+        // visitPhysicalJoin is private; reflect to invoke it.  Wrap the
+        // InvocationTargetException so JUnit's assertThrows sees the real cause.
+        return assertThrows(StarRocksPlannerException.class, () -> {
+            try {
+                Method method = OutputPropertyDeriver.class.getDeclaredMethod(
+                        "visitPhysicalJoin",
+                        com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator.class,
+                        ExpressionContext.class);
+                method.setAccessible(true);
+                method.invoke(deriver, node, context);
+            } catch (java.lang.reflect.InvocationTargetException e) {
+                if (e.getCause() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getCause();
+                }
+                throw new RuntimeException(e.getCause());
+            }
+        });
+    }
+
+    @Test
+    void visitPhysicalJoinThrowsOnMixedRangeHash(
+            @Mocked PhysicalHashJoinOperator node,
+            @Mocked ExpressionContext context) {
+        stubInnerJoinWithEmptyColumns(node, context);
+        OutputPropertyDeriver deriver = newDeriver(List.of(
+                propertyOf(buildRangeSkeleton(100L, 1)),
+                propertyOf(buildHashSpec(HashDistributionDesc.SourceType.SHUFFLE_JOIN, 2))));
+
+        StarRocksPlannerException ex = invokeVisitPhysicalJoinExpectingThrow(deriver, node, context);
+        assertTrue(ex.getMessage().contains("Mixed range-distribution"),
+                "expected the mixed-range-hash diagnostic, got: " + ex.getMessage());
+    }
+
+    @Test
+    void visitPhysicalJoinThrowsOnInnerInvalidHashCombo(
+            @Mocked PhysicalHashJoinOperator node,
+            @Mocked ExpressionContext context) {
+        stubInnerJoinWithEmptyColumns(node, context);
+        // Both are HashDistributionSpec → outer isShuffle && isShuffle is true.
+        // (BUCKET, LOCAL) does not match colocate (L is not local), bucket-join
+        // (R is not bucket), or shuffle-join (L/R neither shuffle nor enforce),
+        // so falls through to the inner-else typed exception.
+        OutputPropertyDeriver deriver = newDeriver(List.of(
+                propertyOf(buildHashSpec(HashDistributionDesc.SourceType.BUCKET, 1)),
+                propertyOf(buildHashSpec(HashDistributionDesc.SourceType.LOCAL, 2))));
+
+        StarRocksPlannerException ex = invokeVisitPhysicalJoinExpectingThrow(deriver, node, context);
+        assertTrue(ex.getMessage().contains("Children output property distribution error"),
+                "expected the children-distribution diagnostic, got: " + ex.getMessage());
+    }
+
+    @Test
+    void visitPhysicalJoinThrowsOnOuterNonShuffle(
+            @Mocked PhysicalHashJoinOperator node,
+            @Mocked ExpressionContext context) {
+        stubInnerJoinWithEmptyColumns(node, context);
+        // Two GatherDistributionSpec children: type=GATHER, so neither is
+        // isShuffle() — falls through to the outer-else typed exception.
+        OutputPropertyDeriver deriver = newDeriver(List.of(
+                propertyOf(new GatherDistributionSpec()),
+                propertyOf(new GatherDistributionSpec())));
+
+        StarRocksPlannerException ex = invokeVisitPhysicalJoinExpectingThrow(deriver, node, context);
+        assertTrue(ex.getMessage().contains("Children output property distribution error"),
+                "expected the children-distribution diagnostic, got: " + ex.getMessage());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

F2 follow-up from the range-colocate stack (`colocate.md` follow-ups). Mixed range-colocate × hash-distributed JOIN previously surfaced to MySQL clients as `ERROR 1064 (HY000): Unknown error`. Repro:

```sql
set enable_range_distribution = true;
create table cd  (k1 int, k2 int) order by(k1, k2)
    properties('replication_num'='1', 'colocate_with'='grp:k1');
create table dim (k1 int, x int) distributed by hash(k1) buckets 3
    properties('replication_num'='1');
select count(*) from cd join dim on cd.k1 = dim.k1;
-- pre-fix: ERROR 1064 (HY000): Unknown error
-- post-fix: succeeds with INNER JOIN (BUCKET_SHUFFLE)
```

Captured exception stack:

```
java.lang.IllegalStateException                  // null message
  at GroupExpression.getCost:211
  at ChildOutputPropertyGuarantor.enforceChildDistribution:340
  at ChildOutputPropertyGuarantor.transToBucketShuffle:331
  at ChildOutputPropertyGuarantor.transToBucketShuffleJoin:300
  at ChildOutputPropertyGuarantor.visitPhysicalJoin:619
```

`null`-message `IllegalStateException` gets re-rendered by `MysqlErrPacket` as the generic `Unknown error`.

## What I'm doing:

**Primary fix** in `ChildOutputPropertyGuarantor.convertRangeToHashShuffle`. The helper updates `requiredChildrenProperties[i]` and `childrenOutputProperties[i]` to the post-enforcer hash spec but did not publish the enforcer `GroupExpression` into `childrenBestExprList[i]`. Downstream `transToBucketShuffleJoin` reads `childrenBestExprList` directly, gets the stale original range scan, then calls `getCost(Hash(SHUFFLE_JOIN))` on it — `lowestCostTable` doesn't contain that property → `Preconditions.checkState` fires with no message.

Publishing the enforcer into the third list alongside the existing two list updates makes the converted child visible to downstream bucket/shuffle enforcement.

**Defense in depth** in `OutputPropertyDeriver.visitPhysicalJoin`:
- A mixed (Range, Hash) pair reaching property derivation now throws a typed `StarRocksPlannerException` with a descriptive message. The deriver cannot install exchange enforcers itself, so silently producing a derived output would risk downstream misclassification — failing loud is the correct behaviour if the upstream Guarantor invariant ever breaks again.
- The two pre-existing terminal `IllegalStateException` throws are upgraded to the same typed exception so any unsupported child distribution combination surfaces as a real planner error instead of `Unknown error`.

**Tests**:
- New `RangeColocateMixedJoinPlanTest` (13 tests) — end-to-end shared-data plan tests covering both join orientations, the F2 repro, non-colocate keys, every supported join type (INNER / LEFT OUTER / LEFT SEMI / LEFT ANTI / RIGHT OUTER / FULL OUTER), shuffle hint, `disable_colocate_join`, plus a regression for range×range colocate. Includes an optimizer-level invariant that walks the post-optimization `OptExpression` and asserts no non-colocate join child carries a `RangeDistributionSpec`.
- `Config.enable_range_distribution` and the session variable are saved in `@BeforeAll` and restored in `@AfterAll` so the test does not leak into subsequent suites.

Plan and code both went through `/codex-review` — plan: APPROVED after 3 rounds; code: APPROVED after 3 rounds.

Fixes the F2 follow-up tracked in the internal range-colocate design doc.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Plan-shape-only optimizer fix: a previously-failing query now produces a working shuffle/bucket join plan. No SQL syntax, session variable, config, or API surface changes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)