### PR TITLE
[Tool] ci-report: enable BE total coverage merge on CelerData, skip sync/mergify

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -396,7 +396,12 @@ jobs:
 
       - name: Merge BE Total Coverage
         id: merge
-        if: github.repository == 'StarRocks/starrocks' && steps.download-ut-xml.outputs.size != '0' && steps.download-ut-xml.outcome == 'success' && env.SKIP_COV != 'true'
+        if: >
+          steps.download-ut-xml.outputs.size != '0'
+          && steps.download-ut-xml.outcome == 'success'
+          && env.SKIP_COV != 'true'
+          && !contains(github.event.workflow_run.head_branch, '-sync-pr-')
+          && !startsWith(github.event.workflow_run.head_branch, 'mergify/')
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
 
@@ -415,7 +420,12 @@ jobs:
 
       # Incremental Total Coverage
       - name: Publish Incremental Coverage Report - Total
-        if: always() && steps.download-ut-xml.outputs.size != '0' && steps.download-ut-xml.outcome == 'success'
+        if: >
+          always()
+          && steps.download-ut-xml.outputs.size != '0'
+          && steps.download-ut-xml.outcome == 'success'
+          && !contains(github.event.workflow_run.head_branch, '-sync-pr-')
+          && !startsWith(github.event.workflow_run.head_branch, 'mergify/')
         env:
           be_path: ${{ github.workspace }}/be
           merge_outcome: ${{ steps.merge.outcome }}
@@ -424,7 +434,10 @@ jobs:
           rm -rf ./coverchecker && ln -s /var/local/env/coverchecker ./coverchecker && cd coverchecker && git pull
           export JAVA_HOME=/var/local/env/jdk1.8.0_202;
           export PATH=$JAVA_HOME/bin:$PATH;
-          if [[ "${{ github.repository }}" != "StarRocks/starrocks" ]] || [[ "${merge_outcome}" == "failure" ]]; then
+          # Fallback to raw BE UT coverage only when merge actually failed or was skipped.
+          # Previous code keyed on repository name; now both repos run merge by default,
+          # so the only signal is merge_outcome.
+          if [[ "${merge_outcome}" == "failure" || "${merge_outcome}" == "skipped" ]]; then
               total_xml=${be_path}/be_ut_coverage.xml
           fi
           java -jar cover-checker-console/target/cover-checker-console-1.4.0-jar-with-dependencies.jar \


### PR DESCRIPTION
## Why I'm doing:

Triggered by https://github.com/CelerData/celerdata-enterprise/pull/55044 — `Be Cover Checker` status shows up green but the actual ConsoleReporter output is `0/0 100` (0 covered out of 0 required, trivially-pass). Verified across multiple recent CelerData PRs:

| ci-report run | BE-REPORT ConsoleReporter |
|---|---|
| 26218946835 | `0/2 0` |
| 26217799933 | `0/0 100` |
| #55044 (26216964561) | `0/0 100` |

All CelerData PRs currently produce bogus BE Incremental Coverage. Root cause: the `Merge BE Total Coverage` step in `BE-REPORT` is gated by `github.repository == 'StarRocks/starrocks'` — so the merge never runs on the CelerData mirror. Without merge, the downstream `cover-checker-console` falls back to raw `be_ut_coverage.xml` whose paths don't align with the diff → 0 overlap → 0/0.

## What I'm doing:

Drop the starrocks-only guard on the `Merge BE Total Coverage` step. Filter by branch name instead, to skip the two cases where incremental coverage signal is meaningless:

- `*-sync-pr-*` (StarRocks → CelerData repo-sync PRs — coverage already measured on the source PR)
- `mergify/*` (mergify backport PRs — pure cherry-picks, no new code to cover)

`[UT]` / `[Doc]` PRs are already excluded via the existing `SKIP_COV` output from the `INFO` job (based on PR title), so no extra title check is needed.

Apply the same filter to `Publish Incremental Coverage Report - Total` so sync/mergify PRs don't publish a noisy 0/0 status check either.

Inside the publish step, replace the repo-name fallback with a check on `merge_outcome` — now both repos run merge by default, so the only signal for "fallback to raw be_ut_coverage.xml" is whether merge actually failed/was skipped.

**Companion PR:** [StarRocks/ci-tool#4321](https://github.com/StarRocks/ci-tool/pull/4321) extends `gen_be_cov_remote.sh` to route the `celerdata-ci-release` OSS bucket. **Must merge ci-tool first**, otherwise this workflow change has no effect on CelerData (the merge step would still no-op inside ECI because the script exits early for non-starrocks repos).

Fixes none

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: CI workflow change — BE coverage merge step now runs cross-repo (starrocks + celerdata), skipped for sync/mergify branches

Behavior change matrix:

| Scenario | Before | After |
|---|---|---|
| starrocks normal PR | merge runs | unchanged |
| starrocks mergify backport | merge runs (wasteful) | merge skipped (saves runner) |
| **celerdata normal PR** | **0/0 trivial pass** | **real coverage numbers** |
| celerdata sync PR (`*-sync-pr-*`) | publishes 0/0 status | merge + publish both skipped |
| celerdata mergify backport | publishes 0/0 status | skipped |

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
