### PR TITLE
[BugFix] Fix NPE in StatisticsCalcUtils when partition is dropped concurrently    

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -321,16 +322,18 @@ public class StatisticsCalcUtils {
             if (olapScanOperator.getSelectedPartitionId() == null) {
                 selectedPartitions = Lists.newArrayList(olapScanOperator.getTable().getPartitions());
             } else {
+                // filter out null partitions that may have been dropped concurrently
                 selectedPartitions = olapScanOperator.getSelectedPartitionId().stream().map(
-                        olapTable::getPartition).collect(Collectors.toList());
+                        olapTable::getPartition).filter(Objects::nonNull).collect(Collectors.toList());
             }
         } else {
             PhysicalOlapScanOperator olapScanOperator = (PhysicalOlapScanOperator) node;
             if (olapScanOperator.getSelectedPartitionId() == null) {
                 selectedPartitions = Lists.newArrayList(olapScanOperator.getTable().getPartitions());
             } else {
+                // filter out null partitions that may have been dropped concurrently
                 selectedPartitions = olapScanOperator.getSelectedPartitionId().stream().map(
-                        olapTable::getPartition).collect(Collectors.toList());
+                        olapTable::getPartition).filter(Objects::nonNull).collect(Collectors.toList());
             }
         }
         return selectedPartitions;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtilsTest.java
@@ -1,0 +1,250 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.statistics;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Test for StatisticsCalcUtils, especially the fix for NPE when partitions are
+ * dropped concurrently during query planning.
+ */
+public class StatisticsCalcUtilsTest {
+    private static ConnectContext connectContext;
+    private static OptimizerContext optimizerContext;
+    private static ColumnRefFactory columnRefFactory;
+    private static StarRocksAssert starRocksAssert;
+    private static boolean originalRunningUnitTest;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        columnRefFactory = new ColumnRefFactory();
+        optimizerContext = OptimizerFactory.mockContext(connectContext, columnRefFactory);
+
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        String dbName = "statistics_calc_utils_test";
+        starRocksAssert.withDatabase(dbName).useDatabase(dbName);
+        // Save the original value so we can restore it after the test class finishes,
+        // to avoid leaking state into other tests.
+        originalRunningUnitTest = FeConstants.runningUnitTest;
+        FeConstants.runningUnitTest = false;
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        // Restore the original value to avoid polluting global state for other tests.
+        FeConstants.runningUnitTest = originalRunningUnitTest;
+    }
+
+    @BeforeEach
+    public void before() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `test_partition_table` (\n" +
+                "  `k1` int(11) NULL COMMENT \"\",\n" +
+                "  `k2` varchar(20) NULL COMMENT \"\",\n" +
+                "  `v1` bigint(20) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "PARTITION BY RANGE (k1)\n" +
+                "(\n" +
+                "PARTITION p1 VALUES LESS THAN (\"10\"),\n" +
+                "PARTITION p2 VALUES LESS THAN (\"20\"),\n" +
+                "PARTITION p3 VALUES LESS THAN (\"30\")\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+    }
+
+    @AfterEach
+    public void after() throws Exception {
+        starRocksAssert.dropTable("test_partition_table");
+    }
+
+    /**
+     * Test that getTableRowCount does not throw NPE when selectedPartitionIds
+     * contains a partition ID that no longer exists in the table (simulating
+     * concurrent partition drop).
+     */
+    @Test
+    public void testGetTableRowCountWithDroppedPartition() throws Exception {
+        OlapTable table = (OlapTable) connectContext.getGlobalStateMgr()
+                .getLocalMetastore().getDb("statistics_calc_utils_test")
+                .getTable("test_partition_table");
+
+        Collection<Partition> partitions = table.getPartitions();
+        // Get real partition IDs and add a non-existent one to simulate concurrent drop
+        List<Long> partitionIds = partitions.stream()
+                .mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+        // Derive an id guaranteed to be absent from the current table, instead of hard-coding
+        // a magic number that could theoretically collide with a real partition id.
+        long nonExistentPartitionId = partitions.stream()
+                .mapToLong(Partition::getId).max().orElse(0L) + 1L;
+        Assertions.assertFalse(partitionIds.contains(nonExistentPartitionId),
+                "derived partition id should not exist in current table");
+        partitionIds.add(nonExistentPartitionId);
+
+        for (Partition partition : partitions) {
+            partition.getDefaultPhysicalPartition().getLatestBaseIndex().setRowCount(1000);
+        }
+
+        List<Column> columns = table.getColumns();
+        Column column = columns.get(0);
+        Map<ColumnRefOperator, Column> refToColumn = Maps.newHashMap();
+        Map<Column, ColumnRefOperator> columnToRef = Maps.newHashMap();
+        ColumnRefOperator ref = new ColumnRefOperator(0, column.getType(), column.getName(), true);
+        refToColumn.put(ref, column);
+        columnToRef.put(column, ref);
+
+        LogicalOlapScanOperator olapScanOperator = new LogicalOlapScanOperator(table,
+                refToColumn, columnToRef,
+                null, -1, null,
+                table.getBaseIndexMetaId(),
+                partitionIds,
+                null,
+                false,
+                Lists.newArrayList(),
+                Lists.newArrayList(),
+                Lists.newArrayList(),
+                false);
+
+        // This should NOT throw NPE even though one partition ID doesn't exist
+        long rowCount = StatisticsCalcUtils.getTableRowCount(table, olapScanOperator, optimizerContext);
+
+        // Row count should only include existing partitions (3 partitions * 1000 rows each)
+        Assertions.assertEquals(3000, rowCount);
+    }
+
+    /**
+     * Test that getTableRowCount works correctly when all partitions exist.
+     */
+    @Test
+    public void testGetTableRowCountWithAllPartitionsExist() throws Exception {
+        OlapTable table = (OlapTable) connectContext.getGlobalStateMgr()
+                .getLocalMetastore().getDb("statistics_calc_utils_test")
+                .getTable("test_partition_table");
+
+        Collection<Partition> partitions = table.getPartitions();
+        List<Long> partitionIds = partitions.stream()
+                .mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+
+        for (Partition partition : partitions) {
+            partition.getDefaultPhysicalPartition().getLatestBaseIndex().setRowCount(500);
+        }
+
+        List<Column> columns = table.getColumns();
+        Column column = columns.get(0);
+        Map<ColumnRefOperator, Column> refToColumn = Maps.newHashMap();
+        Map<Column, ColumnRefOperator> columnToRef = Maps.newHashMap();
+        ColumnRefOperator ref = new ColumnRefOperator(0, column.getType(), column.getName(), true);
+        refToColumn.put(ref, column);
+        columnToRef.put(column, ref);
+
+        LogicalOlapScanOperator olapScanOperator = new LogicalOlapScanOperator(table,
+                refToColumn, columnToRef,
+                null, -1, null,
+                table.getBaseIndexMetaId(),
+                partitionIds,
+                null,
+                false,
+                Lists.newArrayList(),
+                Lists.newArrayList(),
+                Lists.newArrayList(),
+                false);
+
+        long rowCount = StatisticsCalcUtils.getTableRowCount(table, olapScanOperator, optimizerContext);
+
+        // Row count should be 3 partitions * 500 rows each = 1500
+        Assertions.assertEquals(1500, rowCount);
+    }
+
+    /**
+     * Test that getTableRowCount does not throw NPE when ALL selected partitions
+     * have been dropped (edge case).
+     */
+    @Test
+    public void testGetTableRowCountWithAllPartitionsDropped() throws Exception {
+        OlapTable table = (OlapTable) connectContext.getGlobalStateMgr()
+                .getLocalMetastore().getDb("statistics_calc_utils_test")
+                .getTable("test_partition_table");
+
+        // Derive ids guaranteed to be absent from the current table, instead of hard-coding
+        // magic numbers that could theoretically collide with real partition ids.
+        long maxExistingId = table.getPartitions().stream()
+                .mapToLong(Partition::getId).max().orElse(0L);
+        long nonExistentId1 = maxExistingId + 1L;
+        long nonExistentId2 = maxExistingId + 2L;
+        List<Long> existingIds = table.getPartitions().stream()
+                .mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+        Assertions.assertFalse(existingIds.contains(nonExistentId1),
+                "derived partition id should not exist in current table");
+        Assertions.assertFalse(existingIds.contains(nonExistentId2),
+                "derived partition id should not exist in current table");
+        List<Long> partitionIds = Lists.newArrayList(nonExistentId1, nonExistentId2);
+
+        List<Column> columns = table.getColumns();
+        Column column = columns.get(0);
+        Map<ColumnRefOperator, Column> refToColumn = Maps.newHashMap();
+        Map<Column, ColumnRefOperator> columnToRef = Maps.newHashMap();
+        ColumnRefOperator ref = new ColumnRefOperator(0, column.getType(), column.getName(), true);
+        refToColumn.put(ref, column);
+        columnToRef.put(column, ref);
+
+        LogicalOlapScanOperator olapScanOperator = new LogicalOlapScanOperator(table,
+                refToColumn, columnToRef,
+                null, -1, null,
+                table.getBaseIndexMetaId(),
+                partitionIds,
+                null,
+                false,
+                Lists.newArrayList(),
+                Lists.newArrayList(),
+                Lists.newArrayList(),
+                false);
+
+        // Should not throw NPE, should return minimum row count (1)
+        long rowCount = StatisticsCalcUtils.getTableRowCount(table, olapScanOperator, optimizerContext);
+
+        // When all partitions are dropped, selectedPartitions is empty, row count should be 1 (minimum)
+        Assertions.assertEquals(1, rowCount);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Fix a NullPointerException observed in production when running a customer query against a **view** whose base table is being concurrently rewritten by `INSERT OVERWRITE` (every 5 minutes via a scheduled job).

**Stack trace:**
```
java.lang.NullPointerException
  at com.starrocks.sql.optimizer.statistics.CachedStatisticStorage.lambda$getTableStatistics$1(CachedStatisticStorage.java:85)
  at com.starrocks.sql.optimizer.statistics.CachedStatisticStorage.getTableStatistics(CachedStatisticStorage.java:86)
  at com.starrocks.sql.optimizer.statistics.StatisticsCalcUtils.getPartitionRows(StatisticsCalcUtils.java:167)
  at com.starrocks.sql.optimizer.statistics.StatisticsCalcUtils.getTableRowCount(StatisticsCalcUtils.java:222)
  at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.computeOlapScanNode(StatisticsCalculator.java:346)
```

**Root cause:**

The customer SQL queries a view whose definition references a base OlapTable that is rewritten by `INSERT OVERWRITE` every 5 minutes (so its partition set churns frequently).

- `View.getQueryStatement()` only **parses** the cached `inlineViewDef`; it does not run `Analyzer`. The inner `TableRelation`s have no `Table` attached at parse time. The base `OlapTable` is only resolved later in `QueryAnalyzer.visitView` via `resolveTable(...)`, which returns the **live** `OlapTable` instance from `LocalMetastore`.
- `PlannerMetaLocker` and `AnalyzerUtils.copyOlapTable` operate on the top-level statement; the live base table inside the view is not consistently re-locked / re-snapshotted across the optimizer phase.
- As a result, between the moment `selectedPartitionIds` are computed and the moment `StatisticsCalcUtils.getSelectedPartitions` runs, an `INSERT OVERWRITE` can swap out the partition entries on that live `OlapTable`, and `olapTable.getPartition(id)` returns `null` for an id that no longer exists. The null element then flows into `CachedStatisticStorage.getTableStatistics()` where `p.getId()` is invoked on it, triggering NPE.
- Even setting `cbo_use_lock_db = true` does not help, because the lock is taken on the view, not on the base table referenced inside the view.

**Note:** This PR is a **defensive fix at the symptom layer**, not a root-cause fix. The underlying issue (base tables referenced inside a view aren't covered by the same locking / snapshotting guarantees as top-level tables) is broader and will be tracked separately. Filtering `null` here turns a hard query failure into a slightly-stale row-count estimate, which is at least not worse than what's already happening.

## What I'm doing:

Add `filter(Objects::nonNull)` after `.map(olapTable::getPartition)` in `StatisticsCalcUtils.getSelectedPartitions()` to gracefully skip partitions that have been dropped/replaced concurrently, instead of propagating null elements downstream.

Added unit tests covering:
- Partial partitions dropped during planning
- All partitions exist (regression check)
- All partitions dropped (edge case)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
