### PR TITLE
[Tool] make thirdparty-update failures block PR merge

### DIFF
--- a/.github/workflows/ci-pipeline-branch.yml
+++ b/.github/workflows/ci-pipeline-branch.yml
@@ -252,7 +252,6 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
       BRANCH: ${{ github.base_ref }}
       REPO: ${{ github.repository }}
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -300,32 +299,37 @@ jobs:
       centos7_image_cache_id: ${{ steps.info.outputs.centos7_image_cache_id }}
       ubuntu_image_cache_id: ${{ steps.info.outputs.ubuntu_image_cache_id }}
     steps:
-      - name: Check Result
-        run: |
-          if [[ "${{ needs.thirdparty-update.result }}" == 'failure' ]]; then
-            echo "::error:: Thirdparty Update Error!"
-            exit 1
-          fi
-
       - name: Download Thirdparty Artifact
-        if: needs.thirdparty-update.result == 'success'
         uses: actions/download-artifact@v6
         with:
           pattern: THIRDPARTY-RESULT-*
           path: outputs
 
+      - name: Check Result
+        run: |
+          # Verify each platform's matrix entry produced its artifact.
+          # Defensive against `continue-on-error: true` re-introduction on
+          # thirdparty-update masking matrix-entry failures from
+          # needs.thirdparty-update.result.
+          missing=()
+          for platform in centos7 ubuntu; do
+            f="./outputs/THIRDPARTY-RESULT-${platform}/image_cache.info"
+            if [[ ! -s "$f" ]]; then
+              missing+=("${platform}")
+            fi
+          done
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::Thirdparty Update failed for: ${missing[*]}"
+            exit 1
+          fi
+
       - name: Read Info
         id: info
         run: |
-          if [[ "${{ needs.thirdparty-update.result }}" == 'success' ]]; then
-            image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-centos7/image_cache.info" || echo "")
-            echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
-            image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info" || echo "")
-            echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
-          else
-            echo "centos7_image_cache_id=" >> $GITHUB_OUTPUT
-            echo "ubuntu_image_cache_id=" >> $GITHUB_OUTPUT
-          fi
+          image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-centos7/image_cache.info")
+          echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+          image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info")
+          echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
 
   be-ut:
     runs-on: [self-hosted, normal]

--- a/.github/workflows/ci-pipeline-branch.yml
+++ b/.github/workflows/ci-pipeline-branch.yml
@@ -300,6 +300,7 @@ jobs:
       ubuntu_image_cache_id: ${{ steps.info.outputs.ubuntu_image_cache_id }}
     steps:
       - name: Download Thirdparty Artifact
+        if: needs.thirdparty-update.result == 'success'
         uses: actions/download-artifact@v6
         with:
           pattern: THIRDPARTY-RESULT-*
@@ -307,10 +308,20 @@ jobs:
 
       - name: Check Result
         run: |
-          # Verify each platform's matrix entry produced its artifact.
-          # Defensive against `continue-on-error: true` re-introduction on
-          # thirdparty-update masking matrix-entry failures from
-          # needs.thirdparty-update.result.
+          update_result='${{ needs.thirdparty-update.result }}'
+          if [[ "$update_result" == 'failure' || "$update_result" == 'cancelled' ]]; then
+            echo "::error::thirdparty-update did not complete (result=$update_result)"
+            exit 1
+          fi
+          # 'skipped' means this PR didn't touch thirdparty - nothing to verify,
+          # downstream BUILD reuses the default cached image.
+          if [[ "$update_result" != 'success' ]]; then
+            exit 0
+          fi
+          # Defensive (only when update reported success): verify both platforms
+          # produced their artifact. Catches accidental re-introduction of
+          # `continue-on-error: true`, silent upload-artifact failures, and
+          # empty image_cache.info files.
           missing=()
           for platform in centos7 ubuntu; do
             f="./outputs/THIRDPARTY-RESULT-${platform}/image_cache.info"
@@ -319,17 +330,22 @@ jobs:
             fi
           done
           if [[ ${#missing[@]} -gt 0 ]]; then
-            echo "::error::Thirdparty Update failed for: ${missing[*]}"
+            echo "::error::Thirdparty Update succeeded but missing artifact for: ${missing[*]}"
             exit 1
           fi
 
       - name: Read Info
         id: info
         run: |
-          image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-centos7/image_cache.info")
-          echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
-          image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info")
-          echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+          if [[ "${{ needs.thirdparty-update.result }}" == 'success' ]]; then
+            image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-centos7/image_cache.info")
+            echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+            image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info")
+            echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+          else
+            echo "centos7_image_cache_id=" >> $GITHUB_OUTPUT
+            echo "ubuntu_image_cache_id=" >> $GITHUB_OUTPUT
+          fi
 
   be-ut:
     runs-on: [self-hosted, normal]

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -499,6 +499,7 @@ jobs:
       ubuntu_image_cache_id: ${{ steps.info.outputs.ubuntu_image_cache_id }}
     steps:
       - name: Download Thirdparty Artifact
+        if: needs.thirdparty-update.result == 'success'
         uses: actions/download-artifact@v6
         with:
           pattern: THIRDPARTY-RESULT-*
@@ -506,10 +507,20 @@ jobs:
 
       - name: Check Result
         run: |
-          # Verify each platform's matrix entry produced its artifact.
-          # Defensive against `continue-on-error: true` re-introduction on
-          # thirdparty-update masking matrix-entry failures from
-          # needs.thirdparty-update.result.
+          update_result='${{ needs.thirdparty-update.result }}'
+          if [[ "$update_result" == 'failure' || "$update_result" == 'cancelled' ]]; then
+            echo "::error::thirdparty-update did not complete (result=$update_result)"
+            exit 1
+          fi
+          # 'skipped' means this PR didn't touch thirdparty - nothing to verify,
+          # downstream BUILD reuses the default cached image.
+          if [[ "$update_result" != 'success' ]]; then
+            exit 0
+          fi
+          # Defensive (only when update reported success): verify both platforms
+          # produced their artifact. Catches accidental re-introduction of
+          # `continue-on-error: true`, silent upload-artifact failures, and
+          # empty image_cache.info files.
           missing=()
           for platform in centos7 ubuntu; do
             f="./outputs/THIRDPARTY-RESULT-${platform}/image_cache.info"
@@ -518,17 +529,22 @@ jobs:
             fi
           done
           if [[ ${#missing[@]} -gt 0 ]]; then
-            echo "::error::Thirdparty Update failed for: ${missing[*]}"
+            echo "::error::Thirdparty Update succeeded but missing artifact for: ${missing[*]}"
             exit 1
           fi
 
       - name: Read Info
         id: info
         run: |
-          image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-centos7/image_cache.info")
-          echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
-          image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info")
-          echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+          if [[ "${{ needs.thirdparty-update.result }}" == 'success' ]]; then
+            image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-centos7/image_cache.info")
+            echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+            image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info")
+            echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+          else
+            echo "centos7_image_cache_id=" >> $GITHUB_OUTPUT
+            echo "ubuntu_image_cache_id=" >> $GITHUB_OUTPUT
+          fi
 
   be-ut:
     runs-on: [self-hosted, normal]

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -301,7 +301,6 @@ jobs:
     runs-on: [self-hosted, normal]
     needs: [be-checker]
     name: Thirdparty Update
-    continue-on-error: true
     if: needs.be-checker.outputs.thirdparty_filter == 'true'
     strategy:
       fail-fast: false
@@ -499,32 +498,37 @@ jobs:
       centos7_image_cache_id: ${{ steps.info.outputs.centos7_image_cache_id }}
       ubuntu_image_cache_id: ${{ steps.info.outputs.ubuntu_image_cache_id }}
     steps:
-      - name: Check Result
-        run: |
-          if [[ "${{ needs.thirdparty-update.result }}" == 'failure' ]]; then
-            echo "::error::Thirdparty Update Error!"
-            exit 1
-          fi
-
       - name: Download Thirdparty Artifact
-        if: needs.thirdparty-update.result == 'success'
         uses: actions/download-artifact@v6
         with:
           pattern: THIRDPARTY-RESULT-*
           path: outputs
 
+      - name: Check Result
+        run: |
+          # Verify each platform's matrix entry produced its artifact.
+          # Defensive against `continue-on-error: true` re-introduction on
+          # thirdparty-update masking matrix-entry failures from
+          # needs.thirdparty-update.result.
+          missing=()
+          for platform in centos7 ubuntu; do
+            f="./outputs/THIRDPARTY-RESULT-${platform}/image_cache.info"
+            if [[ ! -s "$f" ]]; then
+              missing+=("${platform}")
+            fi
+          done
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::Thirdparty Update failed for: ${missing[*]}"
+            exit 1
+          fi
+
       - name: Read Info
         id: info
         run: |
-          if [[ "${{ needs.thirdparty-update.result }}" == 'success' ]]; then
-            image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-centos7/image_cache.info" || echo "")
-            echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
-            image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info" || echo "")
-            echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
-          else
-            echo "centos7_image_cache_id=" >> $GITHUB_OUTPUT
-            echo "ubuntu_image_cache_id=" >> $GITHUB_OUTPUT
-          fi
+          image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-centos7/image_cache.info")
+          echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+          image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info")
+          echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
 
   be-ut:
     runs-on: [self-hosted, normal]


### PR DESCRIPTION
## Why I'm doing:

Two PR-gating workflows have a 2024-03 design bug that silently lets `thirdparty-update` failures pass:

- `ci-pipeline.yml` (main PR CI)
- `ci-pipeline-branch.yml` (branch-3.x/4.x PR CI)

Both set `continue-on-error: true` on the `thirdparty-update` matrix job. With matrix entries, this causes `needs.thirdparty-update.result` to evaluate to `success` even when one matrix entry (e.g., `centos7`) actually failed. The downstream `Thirdparty Info` job's `Check Result` step — added at the same time in 2024-03 (commit `7b96d8696d2b`, `[Tool] Adjust the frequency of inspection pipeline (#42997)`) with the explicit intent of blocking on failure — checks `result == 'failure'` and therefore never triggers.

Concrete observed instance (downstream sync repo): a sync PR had `Thirdparty Update (centos7)` fail, `Thirdparty Info` succeed, BUILD succeed, Auto Merge proceed — PR merged with broken centos7 thirdparty state.

For ~14 months, PRs have been able to silently merge whenever a single `centos7` (or any single matrix entry) `thirdparty-update` failed.

## What I'm doing:

**Two-layer fix per workflow** (2 workflows × same shape of change):

### 1. Remove `continue-on-error: true` from `thirdparty-update`

`fail-fast: false` already keeps the ubuntu matrix entry running when centos7 fails. The `continue-on-error` flag was only masking the aggregated `result`. Removing it makes the existing `Check Result` step work natively.

### 2. In `Thirdparty Info`, verify each platform's artifact exists and is non-empty

Move the `Download Thirdparty Artifact` step before `Check Result`, and replace the (now redundant) `result == 'failure'` check with a direct artifact-existence check:

```bash
missing=()
for platform in centos7 ubuntu; do
  f="./outputs/THIRDPARTY-RESULT-${platform}/image_cache.info"
  if [[ ! -s "$f" ]]; then
    missing+=("${platform}")
  fi
done
if [[ ${#missing[@]} -gt 0 ]]; then
  echo "::error::Thirdparty Update failed for: ${missing[*]}"
  exit 1
fi
```

This is defensive against:
- Future accidental re-introduction of `continue-on-error: true`
- `upload-artifact` step failing silently
- `image_cache.info` being uploaded but empty

`Read Info` is simplified — no more `if needs.<...>.result == 'success'` branches, since by the time we reach Read Info both files are guaranteed present.

### Cost

`Download Thirdparty Artifact` previously was gated by `if: needs.thirdparty-update.result == 'success'` (only ran on success). Now it always runs. Measured in a recent successful run: **~3 seconds**. Failure-case overhead: **~1-2 seconds** (downloads whatever exists; PR is already failing so timing doesn't matter).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

**Behavior change**: PRs that previously could merge with a failed `thirdparty-update (centos7)` (or any single matrix entry) will now have their `Thirdparty Info` check fail, blocking auto-merge. This restores the 2024-03 design intent. No behavior change for the happy path.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4