### PR TITLE
[Enhancement] Support LARGE_LIST and FIXED_SIZE_LIST in Arrow-to-JSON converter

### DIFF
--- a/be/src/column/arrow/arrow_to_json_converter.cpp
+++ b/be/src/column/arrow/arrow_to_json_converter.cpp
@@ -49,9 +49,9 @@ static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* outp
 
 // Convert a single row in Array to json
 template <typename ListArrayT>
-static Status convert_single_arrow_list(const ListArrayT* array, int offset, vpack::Builder* builder);
-static Status convert_single_arrow_struct(const StructArray* array, int offset, vpack::Builder* builder);
-static Status convert_single_arrow_map(const MapArray* array, int offset, vpack::Builder* builder);
+static Status convert_single_arrow_list(const ListArrayT* array, int64_t offset, vpack::Builder* builder);
+static Status convert_single_arrow_struct(const StructArray* array, int64_t offset, vpack::Builder* builder);
+static Status convert_single_arrow_map(const MapArray* array, int64_t offset, vpack::Builder* builder);
 
 // Convert the whole array to json array
 static Status convert_arrow_to_json_array(const Array* array, Type::type value_type, vpack::Builder* output);
@@ -59,14 +59,14 @@ static Status convert_arrow_to_json_array(const StringArray* array, vpack::Build
 static Status convert_arrow_to_json_array(const BooleanArray* array, vpack::Builder* builder);
 
 // Convert the element at offset to a json element, which could be both primitive or nested
-static Status convert_arrow_to_json_element(const Array* array, Type::type type_id, int offset, const std::string& name,
-                                            vpack::Builder* output);
+static Status convert_arrow_to_json_element(const Array* array, Type::type type_id, int64_t offset,
+                                            const std::string& name, vpack::Builder* output);
 
 template <class TypeClass, class CType = typename TypeClass::c_type>
 static enable_if_number<TypeClass, Status> convert_arrow_to_json_array(const NumericArray<TypeClass>* array,
                                                                        vpack::Builder* builder) {
     builder->openArray();
-    for (int i = 0; i < array->length(); i++) {
+    for (int64_t i = 0; i < array->length(); i++) {
         CType value = array->Value(i);
         builder->add(vpack::Value(value));
     }
@@ -115,7 +115,7 @@ static bool inline is_physical_signed(Type::type type) {
 template <typename ListArrayT>
 static Status convert_multi_arrow_list(const ListArrayT* array, JsonColumn* output, size_t array_start_idx,
                                        size_t num_elements) {
-    for (int i = array_start_idx; i < array_start_idx + num_elements; i++) {
+    for (size_t i = array_start_idx; i < array_start_idx + num_elements; i++) {
         vpack::Builder builder;
         RETURN_IF_ERROR(convert_single_arrow_list(array, i, &builder));
         JsonValue json(builder.slice());
@@ -126,7 +126,7 @@ static Status convert_multi_arrow_list(const ListArrayT* array, JsonColumn* outp
 
 static Status convert_multi_arrow_struct(const StructArray* array, JsonColumn* output, size_t array_start_idx,
                                          size_t num_elements) {
-    for (int i = array_start_idx; i < array_start_idx + num_elements; i++) {
+    for (size_t i = array_start_idx; i < array_start_idx + num_elements; i++) {
         vpack::Builder builder;
         RETURN_IF_ERROR(convert_single_arrow_struct(array, i, &builder));
         JsonValue json(builder.slice());
@@ -137,7 +137,7 @@ static Status convert_multi_arrow_struct(const StructArray* array, JsonColumn* o
 
 static Status convert_multi_arrow_map(const MapArray* array, JsonColumn* output, size_t array_start_idx,
                                       size_t num_elements) {
-    for (int i = array_start_idx; i < array_start_idx + num_elements; i++) {
+    for (size_t i = array_start_idx; i < array_start_idx + num_elements; i++) {
         vpack::Builder builder;
         RETURN_IF_ERROR(convert_single_arrow_map(array, i, &builder));
         JsonValue json(builder.slice());
@@ -150,25 +150,25 @@ static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* outp
                                             size_t num_elements) {
     auto type_id = array->type_id();
 
-#define M(type)                                                                  \
-    case type: {                                                                 \
-        using TypeClass = TypeIdTraits<type>::Type;                              \
-        using ArrayType = TypeTraits<TypeClass>::ArrayType;                      \
-        auto real_array = down_cast<const ArrayType*>(array);                    \
-        for (int i = array_start_idx; i < array_start_idx + num_elements; i++) { \
-            vpack::Builder builder;                                              \
-            if (is_physical_signed(type)) {                                      \
-                JsonValue json = JsonValue::from_int(real_array->Value(i));      \
-                output->append(std::move(json));                                 \
-            } else if (arrow::is_unsigned_integer(type)) {                       \
-                JsonValue json = JsonValue::from_uint(real_array->Value(i));     \
-                output->append(std::move(json));                                 \
-            } else if (is_floating(type)) {                                      \
-                JsonValue json = JsonValue::from_double(real_array->Value(i));   \
-                output->append(std::move(json));                                 \
-            }                                                                    \
-        }                                                                        \
-        break;                                                                   \
+#define M(type)                                                                     \
+    case type: {                                                                    \
+        using TypeClass = TypeIdTraits<type>::Type;                                 \
+        using ArrayType = TypeTraits<TypeClass>::ArrayType;                         \
+        auto real_array = down_cast<const ArrayType*>(array);                       \
+        for (size_t i = array_start_idx; i < array_start_idx + num_elements; i++) { \
+            vpack::Builder builder;                                                 \
+            if (is_physical_signed(type)) {                                         \
+                JsonValue json = JsonValue::from_int(real_array->Value(i));         \
+                output->append(std::move(json));                                    \
+            } else if (arrow::is_unsigned_integer(type)) {                          \
+                JsonValue json = JsonValue::from_uint(real_array->Value(i));        \
+                output->append(std::move(json));                                    \
+            } else if (is_floating(type)) {                                         \
+                JsonValue json = JsonValue::from_double(real_array->Value(i));      \
+                output->append(std::move(json));                                    \
+            }                                                                       \
+        }                                                                           \
+        break;                                                                      \
     }
 
     switch (type_id) {
@@ -206,12 +206,12 @@ static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* outp
 }
 
 template <typename ListArrayT>
-static Status convert_single_arrow_list(const ListArrayT* array, int offset, vpack::Builder* builder) {
+static Status convert_single_arrow_list(const ListArrayT* array, int64_t offset, vpack::Builder* builder) {
     std::shared_ptr<Array> slice = array->value_slice(offset);
     return convert_arrow_to_json_array(slice.get(), array->value_type()->id(), builder);
 }
 
-static Status convert_single_arrow_struct(const StructArray* array, int offset, vpack::Builder* builder) {
+static Status convert_single_arrow_struct(const StructArray* array, int64_t offset, vpack::Builder* builder) {
     builder->openObject();
     const StructType* struct_type = array->struct_type();
     for (int i = 0; i < array->num_fields(); i++) {
@@ -225,7 +225,7 @@ static Status convert_single_arrow_struct(const StructArray* array, int offset, 
 }
 
 // Support numeric types and string type
-static StatusOr<std::string> convert_array_element_to_string(const Array* array, int offset) {
+static StatusOr<std::string> convert_array_element_to_string(const Array* array, int64_t offset) {
     switch (array->type_id()) {
     case Type::STRING: {
         auto key_array = down_cast<const StringArray*>(array);
@@ -249,7 +249,7 @@ static StatusOr<std::string> convert_array_element_to_string(const Array* array,
     }
 }
 
-static Status convert_single_arrow_map(const MapArray* array, int offset, vpack::Builder* builder) {
+static Status convert_single_arrow_map(const MapArray* array, int64_t offset, vpack::Builder* builder) {
     const auto& item_array = array->items();
 
     builder->openObject();
@@ -262,7 +262,7 @@ static Status convert_single_arrow_map(const MapArray* array, int offset, vpack:
     return Status::OK();
 }
 
-static Status convert_arrow_to_json_element(const Array* array, Type::type type_id, int offset,
+static Status convert_arrow_to_json_element(const Array* array, Type::type type_id, int64_t offset,
                                             const std::string& field_name, vpack::Builder* builder) {
 #define M(type)                                                          \
     case type: {                                                         \
@@ -345,7 +345,7 @@ static Status convert_arrow_to_json_array(const Array* array, Type::type value_t
     case Type::STRUCT: {
         auto real_array = down_cast<const StructArray*>(array);
         builder->openArray();
-        for (int i = 0; i < array->length(); i++) {
+        for (int64_t i = 0; i < array->length(); i++) {
             RETURN_IF_ERROR(convert_single_arrow_struct(real_array, i, builder));
         }
         builder->close();
@@ -354,7 +354,7 @@ static Status convert_arrow_to_json_array(const Array* array, Type::type value_t
     case Type::LIST: {
         const auto* real_array = down_cast<const ListArray*>(array);
         builder->openArray();
-        for (int i = 0; i < array->length(); i++) {
+        for (int64_t i = 0; i < array->length(); i++) {
             RETURN_IF_ERROR(convert_single_arrow_list(real_array, i, builder));
         }
         builder->close();
@@ -363,7 +363,7 @@ static Status convert_arrow_to_json_array(const Array* array, Type::type value_t
     case Type::LARGE_LIST: {
         const auto* real_array = down_cast<const LargeListArray*>(array);
         builder->openArray();
-        for (int i = 0; i < array->length(); i++) {
+        for (int64_t i = 0; i < array->length(); i++) {
             RETURN_IF_ERROR(convert_single_arrow_list(real_array, i, builder));
         }
         builder->close();
@@ -372,7 +372,7 @@ static Status convert_arrow_to_json_array(const Array* array, Type::type value_t
     case Type::FIXED_SIZE_LIST: {
         const auto* real_array = down_cast<const FixedSizeListArray*>(array);
         builder->openArray();
-        for (int i = 0; i < array->length(); i++) {
+        for (int64_t i = 0; i < array->length(); i++) {
             RETURN_IF_ERROR(convert_single_arrow_list(real_array, i, builder));
         }
         builder->close();
@@ -381,7 +381,7 @@ static Status convert_arrow_to_json_array(const Array* array, Type::type value_t
     case Type::MAP: {
         auto real_array = down_cast<const MapArray*>(array);
         builder->openArray();
-        for (int i = 0; i < array->length(); i++) {
+        for (int64_t i = 0; i < array->length(); i++) {
             RETURN_IF_ERROR(convert_single_arrow_map(real_array, i, builder));
         }
         builder->close();
@@ -396,7 +396,7 @@ static Status convert_arrow_to_json_array(const Array* array, Type::type value_t
 
 static Status convert_arrow_to_json_array(const StringArray* array, vpack::Builder* builder) {
     builder->openArray();
-    for (int i = 0; i < array->length(); i++) {
+    for (int64_t i = 0; i < array->length(); i++) {
         auto value = array->Value(i);
         builder->add(vpack::Value(std::string_view{value.data(), value.length()}));
     }
@@ -406,7 +406,7 @@ static Status convert_arrow_to_json_array(const StringArray* array, vpack::Build
 
 static Status convert_arrow_to_json_array(const BooleanArray* array, vpack::Builder* builder) {
     builder->openArray();
-    for (int i = 0; i < array->length(); i++) {
+    for (int64_t i = 0; i < array->length(); i++) {
         auto value = array->Value(i);
         builder->add(vpack::Value(value));
     }

--- a/be/src/column/arrow/arrow_to_json_converter.cpp
+++ b/be/src/column/arrow/arrow_to_json_converter.cpp
@@ -36,7 +36,9 @@ using namespace arrow;
 using ArrowStatus = Status;
 
 // Convert multi-row Array to JsonColumn
-static Status convert_multi_arrow_list(const ListArray* array, JsonColumn* output, size_t array_start_idx,
+// ListArrayT is one of arrow::ListArray / LargeListArray / FixedSizeListArray.
+template <typename ListArrayT>
+static Status convert_multi_arrow_list(const ListArrayT* array, JsonColumn* output, size_t array_start_idx,
                                        size_t num_elements);
 static Status convert_multi_arrow_struct(const StructArray* array, JsonColumn* output, size_t array_start_idx,
                                          size_t num_elements);
@@ -46,7 +48,8 @@ static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* outp
                                             size_t num_elements);
 
 // Convert a single row in Array to json
-static Status convert_single_arrow_list(const ListArray* array, int offset, vpack::Builder* builder);
+template <typename ListArrayT>
+static Status convert_single_arrow_list(const ListArrayT* array, int offset, vpack::Builder* builder);
 static Status convert_single_arrow_struct(const StructArray* array, int offset, vpack::Builder* builder);
 static Status convert_single_arrow_map(const MapArray* array, int offset, vpack::Builder* builder);
 
@@ -109,7 +112,8 @@ static bool inline is_physical_signed(Type::type type) {
     return false;
 }
 
-static Status convert_multi_arrow_list(const ListArray* array, JsonColumn* output, size_t array_start_idx,
+template <typename ListArrayT>
+static Status convert_multi_arrow_list(const ListArrayT* array, JsonColumn* output, size_t array_start_idx,
                                        size_t num_elements) {
     for (int i = array_start_idx; i < array_start_idx + num_elements; i++) {
         vpack::Builder builder;
@@ -201,7 +205,8 @@ static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* outp
     return Status::OK();
 }
 
-static Status convert_single_arrow_list(const ListArray* array, int offset, vpack::Builder* builder) {
+template <typename ListArrayT>
+static Status convert_single_arrow_list(const ListArrayT* array, int offset, vpack::Builder* builder) {
     std::shared_ptr<Array> slice = array->value_slice(offset);
     return convert_arrow_to_json_array(slice.get(), array->value_type()->id(), builder);
 }
@@ -295,6 +300,19 @@ static Status convert_arrow_to_json_element(const Array* array, Type::type type_
         builder->add(field_name, sub_builder.slice());
         break;
     }
+    case Type::LARGE_LIST: {
+        vpack::Builder sub_builder;
+        RETURN_IF_ERROR(convert_single_arrow_list(down_cast<const LargeListArray*>(array), offset, &sub_builder));
+        builder->add(field_name, sub_builder.slice());
+        break;
+    }
+    case Type::FIXED_SIZE_LIST: {
+        vpack::Builder sub_builder;
+        RETURN_IF_ERROR(
+                convert_single_arrow_list(down_cast<const FixedSizeListArray*>(array), offset, &sub_builder));
+        builder->add(field_name, sub_builder.slice());
+        break;
+    }
     case Type::MAP: {
         vpack::Builder sub_builder;
         RETURN_IF_ERROR(convert_single_arrow_map(down_cast<const MapArray*>(array), offset, &sub_builder));
@@ -335,7 +353,25 @@ static Status convert_arrow_to_json_array(const Array* array, Type::type value_t
         break;
     }
     case Type::LIST: {
-        auto real_array = down_cast<const ListArray*>(array);
+        const auto* real_array = down_cast<const ListArray*>(array);
+        builder->openArray();
+        for (int i = 0; i < array->length(); i++) {
+            RETURN_IF_ERROR(convert_single_arrow_list(real_array, i, builder));
+        }
+        builder->close();
+        break;
+    }
+    case Type::LARGE_LIST: {
+        const auto* real_array = down_cast<const LargeListArray*>(array);
+        builder->openArray();
+        for (int i = 0; i < array->length(); i++) {
+            RETURN_IF_ERROR(convert_single_arrow_list(real_array, i, builder));
+        }
+        builder->close();
+        break;
+    }
+    case Type::FIXED_SIZE_LIST: {
+        const auto* real_array = down_cast<const FixedSizeListArray*>(array);
         builder->openArray();
         for (int i = 0; i < array->length(); i++) {
             RETURN_IF_ERROR(convert_single_arrow_list(real_array, i, builder));
@@ -382,11 +418,15 @@ static Status convert_arrow_to_json_array(const BooleanArray* array, vpack::Buil
 // Convert array to a json column
 // Support all arrow types, including primitive types and nested data types
 Status convert_arrow_to_json(const Array* array, JsonColumn* output, size_t array_start_idx, size_t num_elements) {
-    // std::cerr << "convert_arrow_to_json: " << array->type()->ToString() << std::endl;
     auto type = array->type_id();
     switch (type) {
     case Type::LIST:
         return convert_multi_arrow_list(down_cast<const ListArray*>(array), output, array_start_idx, num_elements);
+    case Type::LARGE_LIST:
+        return convert_multi_arrow_list(down_cast<const LargeListArray*>(array), output, array_start_idx, num_elements);
+    case Type::FIXED_SIZE_LIST:
+        return convert_multi_arrow_list(down_cast<const FixedSizeListArray*>(array), output, array_start_idx,
+                                        num_elements);
     case Type::STRUCT:
         return convert_multi_arrow_struct(down_cast<const StructArray*>(array), output, array_start_idx, num_elements);
     case Type::MAP:

--- a/be/src/column/arrow/arrow_to_json_converter.cpp
+++ b/be/src/column/arrow/arrow_to_json_converter.cpp
@@ -156,7 +156,6 @@ static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* outp
         using ArrayType = TypeTraits<TypeClass>::ArrayType;                         \
         auto real_array = down_cast<const ArrayType*>(array);                       \
         for (size_t i = array_start_idx; i < array_start_idx + num_elements; i++) { \
-            vpack::Builder builder;                                                 \
             if (is_physical_signed(type)) {                                         \
                 JsonValue json = JsonValue::from_int(real_array->Value(i));         \
                 output->append(std::move(json));                                    \
@@ -180,7 +179,6 @@ static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* outp
         auto real_array = down_cast<const BooleanArray*>(array);
         auto array_end_idx = std::min(array_start_idx + num_elements, static_cast<size_t>(array->length()));
         for (size_t i = array_start_idx; i < array_end_idx; i++) {
-            vpack::Builder builder;
             JsonValue json = JsonValue::from_bool(real_array->Value(i));
             output->append(std::move(json));
         }
@@ -190,7 +188,6 @@ static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* outp
         auto real_array = down_cast<const StringArray*>(array);
         auto array_end_idx = std::min(array_start_idx + num_elements, static_cast<size_t>(array->length()));
         for (size_t i = array_start_idx; i < array_end_idx; i++) {
-            vpack::Builder builder;
             auto view = real_array->GetView(i);
             ASSIGN_OR_RETURN(auto json, JsonValue::parse_json_or_string({view.data(), view.length()}));
             output->append(std::move(json));

--- a/be/src/column/arrow/arrow_to_json_converter.cpp
+++ b/be/src/column/arrow/arrow_to_json_converter.cpp
@@ -308,8 +308,7 @@ static Status convert_arrow_to_json_element(const Array* array, Type::type type_
     }
     case Type::FIXED_SIZE_LIST: {
         vpack::Builder sub_builder;
-        RETURN_IF_ERROR(
-                convert_single_arrow_list(down_cast<const FixedSizeListArray*>(array), offset, &sub_builder));
+        RETURN_IF_ERROR(convert_single_arrow_list(down_cast<const FixedSizeListArray*>(array), offset, &sub_builder));
         builder->add(field_name, sub_builder.slice());
         break;
     }

--- a/be/test/column/arrow_to_json_converter_test.cpp
+++ b/be/test/column/arrow_to_json_converter_test.cpp
@@ -70,8 +70,7 @@ TEST(ArrowToJsonConverterTest, ListStructAndMapToJsonColumn) {
     }
 
     {
-        std::vector fields = {arrow::field("id", arrow::int32()),
-                                                             arrow::field("score", arrow::int32())};
+        std::vector fields = {arrow::field("id", arrow::int32()), arrow::field("score", arrow::int32())};
         auto type = arrow::struct_(fields);
         auto id_builder = std::make_shared<arrow::Int32Builder>();
         auto score_builder = std::make_shared<arrow::Int32Builder>();

--- a/be/test/column/arrow_to_json_converter_test.cpp
+++ b/be/test/column/arrow_to_json_converter_test.cpp
@@ -16,7 +16,6 @@
 
 #include <arrow/array.h>
 #include <arrow/builder.h>
-#include <arrow/type.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -32,18 +31,18 @@ namespace starrocks {
 
 static std::string compact_json(const JsonColumn& column, size_t idx) {
     std::string value = column.get(idx).get_json()->to_string_uncheck();
-    value.erase(std::remove_if(value.begin(), value.end(), [](unsigned char c) { return std::isspace(c) != 0; }),
+    value.erase(std::ranges::remove_if(value, [](unsigned char c) { return std::isspace(c) != 0; }).begin(),
                 value.end());
     return value;
 }
 
 TEST(ArrowToJsonConverterTest, StringArrayToJsonColumn) {
     arrow::StringBuilder builder;
-    ASSERT_TRUE(builder.Append(R"({"a": 1})").ok());
-    ASSERT_TRUE(builder.Append("plain").ok());
+    ASSERT_OK(builder.Append(R"({"a": 1})"));
+    ASSERT_OK(builder.Append("plain"));
 
     std::shared_ptr<arrow::Array> array;
-    ASSERT_TRUE(builder.Finish(&array).ok());
+    ASSERT_OK(builder.Finish(&array));
 
     auto column = JsonColumn::create();
     ASSERT_OK(convert_arrow_to_json(array.get(), column.get(), 0, array->length()));
@@ -57,12 +56,12 @@ TEST(ArrowToJsonConverterTest, ListStructAndMapToJsonColumn) {
     {
         auto value_builder = std::make_shared<arrow::Int32Builder>();
         arrow::ListBuilder builder(arrow::default_memory_pool(), value_builder);
-        ASSERT_TRUE(builder.Append().ok());
-        ASSERT_TRUE(value_builder->Append(1).ok());
-        ASSERT_TRUE(value_builder->Append(2).ok());
+        ASSERT_OK(builder.Append());
+        ASSERT_OK(value_builder->Append(1));
+        ASSERT_OK(value_builder->Append(2));
 
         std::shared_ptr<arrow::Array> array;
-        ASSERT_TRUE(builder.Finish(&array).ok());
+        ASSERT_OK(builder.Finish(&array));
 
         auto column = JsonColumn::create();
         ASSERT_OK(convert_arrow_to_json(array.get(), column.get(), 0, array->length()));
@@ -71,18 +70,18 @@ TEST(ArrowToJsonConverterTest, ListStructAndMapToJsonColumn) {
     }
 
     {
-        std::vector<std::shared_ptr<arrow::Field>> fields = {arrow::field("id", arrow::int32()),
+        std::vector fields = {arrow::field("id", arrow::int32()),
                                                              arrow::field("score", arrow::int32())};
         auto type = arrow::struct_(fields);
         auto id_builder = std::make_shared<arrow::Int32Builder>();
         auto score_builder = std::make_shared<arrow::Int32Builder>();
         arrow::StructBuilder builder(type, arrow::default_memory_pool(), {id_builder, score_builder});
-        ASSERT_TRUE(builder.Append().ok());
-        ASSERT_TRUE(id_builder->Append(7).ok());
-        ASSERT_TRUE(score_builder->Append(70).ok());
+        ASSERT_OK(builder.Append());
+        ASSERT_OK(id_builder->Append(7));
+        ASSERT_OK(score_builder->Append(70));
 
         std::shared_ptr<arrow::Array> array;
-        ASSERT_TRUE(builder.Finish(&array).ok());
+        ASSERT_OK(builder.Finish(&array));
 
         auto column = JsonColumn::create();
         ASSERT_OK(convert_arrow_to_json(array.get(), column.get(), 0, array->length()));
@@ -94,14 +93,14 @@ TEST(ArrowToJsonConverterTest, ListStructAndMapToJsonColumn) {
         auto key_builder = std::make_shared<arrow::StringBuilder>();
         auto item_builder = std::make_shared<arrow::Int32Builder>();
         arrow::MapBuilder builder(arrow::default_memory_pool(), key_builder, item_builder);
-        ASSERT_TRUE(builder.Append().ok());
-        ASSERT_TRUE(key_builder->Append("a").ok());
-        ASSERT_TRUE(item_builder->Append(1).ok());
-        ASSERT_TRUE(key_builder->Append("b").ok());
-        ASSERT_TRUE(item_builder->Append(2).ok());
+        ASSERT_OK(builder.Append());
+        ASSERT_OK(key_builder->Append("a"));
+        ASSERT_OK(item_builder->Append(1));
+        ASSERT_OK(key_builder->Append("b"));
+        ASSERT_OK(item_builder->Append(2));
 
         std::shared_ptr<arrow::Array> array;
-        ASSERT_TRUE(builder.Finish(&array).ok());
+        ASSERT_OK(builder.Finish(&array));
 
         auto column = JsonColumn::create();
         ASSERT_OK(convert_arrow_to_json(array.get(), column.get(), 0, array->length()));
@@ -110,12 +109,143 @@ TEST(ArrowToJsonConverterTest, ListStructAndMapToJsonColumn) {
     }
 }
 
+TEST(ArrowToJsonConverterTest, LargeListToJsonColumn) {
+    {
+        auto value_builder = std::make_shared<arrow::Int32Builder>();
+        arrow::LargeListBuilder builder(arrow::default_memory_pool(), value_builder);
+        ASSERT_OK(builder.Append());
+        ASSERT_OK(value_builder->Append(1));
+        ASSERT_OK(value_builder->Append(2));
+        ASSERT_OK(value_builder->Append(3));
+        ASSERT_OK(builder.Append());
+        ASSERT_OK(value_builder->Append(4));
+
+        std::shared_ptr<arrow::Array> array;
+        ASSERT_OK(builder.Finish(&array));
+
+        auto column = JsonColumn::create();
+        ASSERT_OK(convert_arrow_to_json(array.get(), column.get(), 0, array->length()));
+        ASSERT_EQ(2, column->size());
+        EXPECT_EQ("[1,2,3]", compact_json(*column, 0));
+        EXPECT_EQ("[4]", compact_json(*column, 1));
+    }
+
+    {
+        auto large_list_value_builder = std::make_shared<arrow::Int32Builder>();
+        auto large_list_builder =
+                std::make_shared<arrow::LargeListBuilder>(arrow::default_memory_pool(), large_list_value_builder);
+        std::vector fields = {arrow::field("ids", arrow::large_list(arrow::int32()))};
+        auto type = arrow::struct_(fields);
+        arrow::StructBuilder builder(type, arrow::default_memory_pool(), {large_list_builder});
+        ASSERT_OK(builder.Append());
+        ASSERT_OK(large_list_builder->Append());
+        ASSERT_OK(large_list_value_builder->Append(10));
+        ASSERT_OK(large_list_value_builder->Append(20));
+
+        std::shared_ptr<arrow::Array> array;
+        ASSERT_OK(builder.Finish(&array));
+
+        auto column = JsonColumn::create();
+        ASSERT_OK(convert_arrow_to_json(array.get(), column.get(), 0, array->length()));
+        ASSERT_EQ(1, column->size());
+        EXPECT_EQ(R"({"ids":[10,20]})", compact_json(*column, 0));
+    }
+
+    {
+        auto inner_value_builder = std::make_shared<arrow::Int32Builder>();
+        auto inner_builder =
+                std::make_shared<arrow::LargeListBuilder>(arrow::default_memory_pool(), inner_value_builder);
+        arrow::ListBuilder outer_builder(arrow::default_memory_pool(), inner_builder);
+        ASSERT_OK(outer_builder.Append());
+        ASSERT_OK(inner_builder->Append());
+        ASSERT_OK(inner_value_builder->Append(1));
+        ASSERT_OK(inner_value_builder->Append(2));
+        ASSERT_OK(inner_builder->Append());
+        ASSERT_OK(inner_value_builder->Append(3));
+
+        std::shared_ptr<arrow::Array> array;
+        ASSERT_OK(outer_builder.Finish(&array));
+
+        auto column = JsonColumn::create();
+        ASSERT_OK(convert_arrow_to_json(array.get(), column.get(), 0, array->length()));
+        ASSERT_EQ(1, column->size());
+        EXPECT_EQ("[[1,2],[3]]", compact_json(*column, 0));
+    }
+}
+
+TEST(ArrowToJsonConverterTest, FixedSizeListToJsonColumn) {
+    {
+        auto value_builder = std::make_shared<arrow::Int32Builder>();
+        arrow::FixedSizeListBuilder builder(arrow::default_memory_pool(), value_builder, 3);
+        ASSERT_OK(builder.Append());
+        ASSERT_OK(value_builder->Append(1));
+        ASSERT_OK(value_builder->Append(2));
+        ASSERT_OK(value_builder->Append(3));
+        ASSERT_OK(builder.Append());
+        ASSERT_OK(value_builder->Append(4));
+        ASSERT_OK(value_builder->Append(5));
+        ASSERT_OK(value_builder->Append(6));
+
+        std::shared_ptr<arrow::Array> array;
+        ASSERT_OK(builder.Finish(&array));
+
+        auto column = JsonColumn::create();
+        ASSERT_OK(convert_arrow_to_json(array.get(), column.get(), 0, array->length()));
+        ASSERT_EQ(2, column->size());
+        EXPECT_EQ("[1,2,3]", compact_json(*column, 0));
+        EXPECT_EQ("[4,5,6]", compact_json(*column, 1));
+    }
+
+    {
+        auto fsl_value_builder = std::make_shared<arrow::Int32Builder>();
+        auto fsl_builder =
+                std::make_shared<arrow::FixedSizeListBuilder>(arrow::default_memory_pool(), fsl_value_builder, 2);
+        std::vector fields = {arrow::field("ids", arrow::fixed_size_list(arrow::int32(), 2))};
+        auto type = arrow::struct_(fields);
+        arrow::StructBuilder builder(type, arrow::default_memory_pool(), {fsl_builder});
+        ASSERT_OK(builder.Append());
+        ASSERT_OK(fsl_builder->Append());
+        ASSERT_OK(fsl_value_builder->Append(10));
+        ASSERT_OK(fsl_value_builder->Append(20));
+
+        std::shared_ptr<arrow::Array> array;
+        ASSERT_OK(builder.Finish(&array));
+
+        auto column = JsonColumn::create();
+        ASSERT_OK(convert_arrow_to_json(array.get(), column.get(), 0, array->length()));
+        ASSERT_EQ(1, column->size());
+        EXPECT_EQ(R"({"ids":[10,20]})", compact_json(*column, 0));
+    }
+
+    {
+        auto inner_value_builder = std::make_shared<arrow::Int32Builder>();
+        auto inner_builder =
+                std::make_shared<arrow::FixedSizeListBuilder>(arrow::default_memory_pool(), inner_value_builder, 2);
+        arrow::ListBuilder outer_builder(arrow::default_memory_pool(), inner_builder);
+        ASSERT_OK(outer_builder.Append());
+        ASSERT_OK(inner_builder->Append());
+        ASSERT_OK(inner_value_builder->Append(1));
+        ASSERT_OK(inner_value_builder->Append(2));
+        ASSERT_OK(inner_builder->Append());
+        ASSERT_OK(inner_value_builder->Append(3));
+        ASSERT_OK(inner_value_builder->Append(4));
+
+        std::shared_ptr<arrow::Array> array;
+        ASSERT_OK(outer_builder.Finish(&array));
+
+        auto column = JsonColumn::create();
+        ASSERT_OK(convert_arrow_to_json(array.get(), column.get(), 0, array->length()));
+        ASSERT_EQ(1, column->size());
+        EXPECT_EQ("[[1,2],[3,4]]", compact_json(*column, 0));
+    }
+}
+
 TEST(ArrowToJsonConverterTest, UnsupportedArrowType) {
     arrow::BinaryBuilder builder;
-    ASSERT_TRUE(builder.Append("bytes").ok());
+    ASSERT_OK(builder.Append("bytes"));
 
     std::shared_ptr<arrow::Array> array;
-    ASSERT_TRUE(builder.Finish(&array).ok());
+    ASSERT_OK(builder.Finish(&array));
 
     auto column = JsonColumn::create();
     auto status = convert_arrow_to_json(array.get(), column.get(), 0, array->length());


### PR DESCRIPTION
## Why I'm doing:

The Arrow-to-JSON converter only handled `arrow::LIST` at the dispatch level, while the BE converter registry (`arrow_to_starrocks_converter.cpp:1179-1181`) already allowed `LIST` / `LARGE_LIST` / `FIXED_SIZE_LIST` to be loaded into a `JSON` target column. As a result, when a Parquet file produced by Arrow (with the `ARROW:schema` metadata) carried a `LARGE_LIST` or `FIXED_SIZE_LIST` column and the user loaded it into a `JSON` column via `FILES()` / Broker Load, the BE returned `Not supported: arrow type ... is not supported`.

This PR closes that gap so the end-to-end load path actually works.

## What I'm doing:

Support LARGE_LIST and FIXED_SIZE_LIST in Arrow-to-JSON converter

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
