### PR TITLE
[BugFix] Invalidate merged privilege cache on public role change

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
@@ -1088,6 +1088,14 @@ public class AuthorizationMgr {
      * requires role lock
      */
     protected void invalidateRolesInCacheRoleUnlocked(long roleId) throws PrivilegeException {
+        // The `public` role is implicitly granted to every user and role, so it never
+        // appears in any cached entry's roleIds and the per-role reverse lookup below
+        // would match nothing. A change to it can affect every cached merged collection,
+        // so drop the whole cache instead.
+        if (roleId == PrivilegeBuiltinConstants.PUBLIC_ROLE_ID) {
+            ctxToMergedPrivilegeCollections.invalidateAll();
+            return;
+        }
         Set<Long> badRoles = getAllDescendantsUnlocked(roleId);
         List<UserPrivKey> badKeys = new ArrayList<>();
         for (UserPrivKey pair : ctxToMergedPrivilegeCollections.asMap().keySet()) {

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
@@ -1380,6 +1380,71 @@ public class AuthorizationMgrTest {
         GlobalVariable.setActivateAllRolesOnLogin(true);
     }
 
+    // The `public` role is implicitly held by every user, so a privilege change on it
+    // must invalidate every cached merged-privilege collection. A user whose cache entry
+    // was populated *before* the change would otherwise keep authorizing against a stale
+    // snapshot. These two tests pin that behavior for GRANT and REVOKE respectively.
+    @Test
+    public void testGrantToPublicRoleInvalidatesMergedPrivilegeCache() throws Exception {
+        boolean oldCacheEnabled = Config.authorization_enable_priv_collection_cache;
+        Config.authorization_enable_priv_collection_cache = true;
+        try {
+            setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
+            DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                    "create user user_grant_public", ctx), ctx);
+            UserIdentity user = UserIdentity.createAnalyzedUserIdentWithIp("user_grant_public", "%");
+
+            // Populate the merged-privilege cache for the user before the grant: the user
+            // has no privilege on db.tbl0 yet, so the check is denied and that snapshot is cached.
+            setCurrentUserAndRoles(ctx, user);
+            Assertions.assertThrows(AccessDeniedException.class, () -> Authorizer.checkTableAction(
+                    ctx, DB_NAME, TABLE_NAME_0, PrivilegeType.SELECT));
+
+            // Grant the privilege to the implicit `public` role.
+            setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
+            DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                    "GRANT select on db.tbl0 TO ROLE public", ctx), ctx);
+
+            // The user must now see the privilege; a stale cache entry would still deny it.
+            setCurrentUserAndRoles(ctx, user);
+            Authorizer.checkTableAction(ctx, DB_NAME, TABLE_NAME_0, PrivilegeType.SELECT);
+        } finally {
+            Config.authorization_enable_priv_collection_cache = oldCacheEnabled;
+        }
+    }
+
+    @Test
+    public void testRevokeFromPublicRoleInvalidatesMergedPrivilegeCache() throws Exception {
+        boolean oldCacheEnabled = Config.authorization_enable_priv_collection_cache;
+        Config.authorization_enable_priv_collection_cache = true;
+        try {
+            setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
+            DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                    "create user user_revoke_public", ctx), ctx);
+            UserIdentity user = UserIdentity.createAnalyzedUserIdentWithIp("user_revoke_public", "%");
+
+            DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                    "GRANT select on db.tbl0 TO ROLE public", ctx), ctx);
+
+            // Populate the merged-privilege cache for the user while public still grants the
+            // privilege, so the cached snapshot includes it.
+            setCurrentUserAndRoles(ctx, user);
+            Authorizer.checkTableAction(ctx, DB_NAME, TABLE_NAME_0, PrivilegeType.SELECT);
+
+            // Revoke the privilege from the implicit `public` role.
+            setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
+            DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                    "REVOKE select on db.tbl0 FROM ROLE public", ctx), ctx);
+
+            // The user must no longer see the privilege; a stale cache entry would still allow it.
+            setCurrentUserAndRoles(ctx, user);
+            Assertions.assertThrows(AccessDeniedException.class, () -> Authorizer.checkTableAction(
+                    ctx, DB_NAME, TABLE_NAME_0, PrivilegeType.SELECT));
+        } finally {
+            Config.authorization_enable_priv_collection_cache = oldCacheEnabled;
+        }
+    }
+
     @Test
     public void testBuiltinRoles() throws Exception {
         AuthorizationMgr manager = ctx.getGlobalStateMgr().getAuthorizationMgr();


### PR DESCRIPTION
## Why I'm doing:

The `public` role is implicitly granted to every user, but `AuthorizationMgr.invalidateRolesInCacheRoleUnlocked()` matches cached merged-privilege entries by their explicit `roleIds`, which never contain `public`. A `GRANT`/`REVOKE` on the `public` role therefore invalidated no cache entries: any FE that had already cached a user's merged privileges (`authorization_enable_priv_collection_cache` is `true` by default) kept authorizing against a stale snapshot until the entry expired. Observed symptoms include a database newly granted to `public` not appearing in `SHOW DATABASES` on some FEs, and -- more seriously -- a privilege revoked from `public` still being honored.

## What I'm doing:

Short-circuit the `public` role in `invalidateRolesInCacheRoleUnlocked()`: since `public` is held implicitly by every user, a change to it can affect every cached merged collection, so the whole cache is dropped instead of relying on the per-role reverse lookup. Adds regression tests covering GRANT and REVOKE on the `public` role.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
