### PR TITLE
[Refactor] Canonicalize percentile compression literals in FunctionAnalyzer

### DIFF
--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -54,10 +54,21 @@ class PercentileApproxAggregateFunctionBase
 protected:
     static constexpr double MIN_COMPRESSION = 2048.0;
     static constexpr double MAX_COMPRESSION = 10000.0;
-    // Used only as a rolling-upgrade fallback when an old FE ships a legacy
-    // arity (without the canonicalized compression literal). For new-FE calls
-    // FunctionAnalyzer is the single source of truth and DEFAULT lives there.
+    // Kept on BE for rolling upgrades from pre-canonicalization FEs. For
+    // new-FE calls FunctionAnalyzer is the single source of truth and DEFAULT
+    // lives there.
     static constexpr double DEFAULT_COMPRESSION_FACTOR = 10000.0;
+
+    static double clamp_compression_factor(double compression) {
+        if (LIKELY(std::isfinite(compression) && compression >= MIN_COMPRESSION && compression <= MAX_COMPRESSION)) {
+            return compression;
+        }
+        // Old FEs can still ship explicit compression literals without the
+        // analyzer-side [MIN, MAX] clamp during a rolling upgrade.
+        LOG(WARNING) << "Compression factor out of range. Using default compression factor: "
+                     << DEFAULT_COMPRESSION_FACTOR;
+        return DEFAULT_COMPRESSION_FACTOR;
+    }
 
 public:
     virtual double get_compression_factor(FunctionContext* ctx) const = 0;
@@ -107,9 +118,9 @@ public:
 class PercentileApproxAggregateFunction : public PercentileApproxAggregateFunctionBase {
 public:
     double get_compression_factor(FunctionContext* ctx) const override {
-        // FE FunctionAnalyzer is the single source of truth: an explicit
-        // compression literal is always injected (default or user-supplied)
-        // and clamped to [MIN, MAX]. The DCHECKs document that contract.
+        // FE FunctionAnalyzer is the single source of truth for new-FE calls:
+        // an explicit compression literal is always injected (default or
+        // user-supplied) and clamped to [MIN, MAX].
         //
         // Rolling-upgrade fallback: during the upgrade window BEs are upgraded
         // before FEs, so an old FE may still ship 2-arg percentile_approx
@@ -121,10 +132,7 @@ public:
             return DEFAULT_COMPRESSION_FACTOR;
         }
         double compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(ctx->get_constant_column(2));
-        DCHECK(std::isfinite(compression));
-        DCHECK_GE(compression, MIN_COMPRESSION);
-        DCHECK_LE(compression, MAX_COMPRESSION);
-        return compression;
+        return clamp_compression_factor(compression);
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
@@ -187,7 +195,8 @@ class PercentileApproxWeightedAggregateFunction : public PercentileApproxAggrega
 public:
     // SplitAggregateRule passes the const args to merge phase aggregator for performance.
     // Compression parameter is always the last constant parameter (if provided).
-    // FE FunctionAnalyzer pre-clamps the literal to [MIN, MAX] or DEFAULT.
+    // FE FunctionAnalyzer pre-clamps the literal to [MIN, MAX] or DEFAULT for
+    // new-FE calls.
     double get_compression_factor(FunctionContext* ctx) const override {
         // FE always injects the compression argument; it is the last const arg.
         // SplitAggregateRule passes const args verbatim into the merge phase
@@ -209,10 +218,7 @@ public:
             auto const_col = ctx->get_constant_column(i);
             if (const_col != nullptr) {
                 double compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(const_col);
-                DCHECK(std::isfinite(compression));
-                DCHECK_GE(compression, MIN_COMPRESSION);
-                DCHECK_LE(compression, MAX_COMPRESSION);
-                return compression;
+                return clamp_compression_factor(compression);
             }
         }
         DCHECK(false) << "FE invariant broken: percentile_approx_weighted reached BE "

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -74,19 +74,22 @@ public:
     virtual double get_compression_factor(FunctionContext* ctx) const = 0;
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        double compression = get_compression_factor(ctx);
-        // Lazy initialization of compression factor on first merge
-        if (UNLIKELY(!data(state).compression_initialized)) {
-            data(state).reinit_with_compression(compression);
-        }
-
         const auto* binary_column = down_cast<const BinaryColumn*>(column);
         Slice src = binary_column->get_slice(row_num);
         double quantile;
         memcpy(&quantile, src.data, sizeof(double));
 
-        PercentileApproxState src_percentile(compression);
+        PercentileApproxState src_percentile;
         src_percentile.percentile->deserialize((char*)src.data + sizeof(double));
+
+        // Lazy initialization of compression on first merge. Compression travels
+        // inside the serialized digest, so adopt it from the incoming state: at
+        // the merge phase SplitAggregateRule drops non-const args (e.g. a weight
+        // column), so ctx arity no longer locates the compression slot. clamp
+        // maps a garbage/empty digest value back to the default.
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            data(state).reinit_with_compression(clamp_compression_factor(src_percentile.percentile->compression()));
+        }
 
         int64_t prev_memory = data(state).percentile->mem_usage();
         data(state).percentile->merge(src_percentile.percentile.get());
@@ -353,12 +356,6 @@ public:
 
     // Override merge method, deserialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        double compression = get_compression_factor(ctx);
-        // Lazy initialization of compression factor on first merge
-        if (UNLIKELY(!data(state).compression_initialized)) {
-            data(state).reinit_with_compression(compression);
-        }
-
         const auto* binary_column = down_cast<const BinaryColumn*>(column);
         Slice src = binary_column->get_slice(row_num);
 
@@ -373,8 +370,15 @@ public:
         }
 
         // Deserialize TDigest (skip quantiles array, only need TDigest for merging)
-        PercentileApproxState src_percentile(compression);
+        PercentileApproxState src_percentile;
         src_percentile.percentile->deserialize((char*)src.data + sizeof(uint32_t) + count * sizeof(double));
+
+        // Lazy initialization of compression on first merge: adopt it from the
+        // incoming serialized digest (ctx arity is unreliable at merge because
+        // SplitAggregateRule drops non-const args); clamp guards garbage input.
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            data(state).reinit_with_compression(clamp_compression_factor(src_percentile.percentile->compression()));
+        }
 
         // Merge into current state
         int64_t prev_memory = data(state).percentile->mem_usage();
@@ -512,12 +516,6 @@ public:
 
     // Override merge method, deserialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        double compression = get_compression_factor(ctx);
-        // Lazy initialization of compression factor on first merge
-        if (UNLIKELY(!data(state).compression_initialized)) {
-            data(state).reinit_with_compression(compression);
-        }
-
         const auto* binary_column = down_cast<const BinaryColumn*>(column);
         Slice src = binary_column->get_slice(row_num);
 
@@ -532,8 +530,15 @@ public:
         }
 
         // Deserialize TDigest (skip quantiles array, only need TDigest for merging)
-        PercentileApproxState src_percentile(compression);
+        PercentileApproxState src_percentile;
         src_percentile.percentile->deserialize((char*)src.data + sizeof(uint32_t) + count * sizeof(double));
+
+        // Lazy initialization of compression on first merge: adopt it from the
+        // incoming serialized digest (ctx arity is unreliable at merge because
+        // SplitAggregateRule drops non-const args); clamp guards garbage input.
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            data(state).reinit_with_compression(clamp_compression_factor(src_percentile.percentile->compression()));
+        }
 
         // Merge into current state
         int64_t prev_memory = data(state).percentile->mem_usage();

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include "column/column_helper.h"
 #include "column/object_column.h"
 #include "column/vectorized_fwd.h"
@@ -52,6 +54,9 @@ class PercentileApproxAggregateFunctionBase
 protected:
     static constexpr double MIN_COMPRESSION = 2048.0;
     static constexpr double MAX_COMPRESSION = 10000.0;
+    // Used only as a rolling-upgrade fallback when an old FE ships a legacy
+    // arity (without the canonicalized compression literal). For new-FE calls
+    // FunctionAnalyzer is the single source of truth and DEFAULT lives there.
     static constexpr double DEFAULT_COMPRESSION_FACTOR = 10000.0;
 
 public:
@@ -102,15 +107,23 @@ public:
 class PercentileApproxAggregateFunction : public PercentileApproxAggregateFunctionBase {
 public:
     double get_compression_factor(FunctionContext* ctx) const override {
-        double compression = DEFAULT_COMPRESSION_FACTOR;
-        if (ctx->get_num_args() > 2) {
-            compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(ctx->get_constant_column(2));
-            if (compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
-                LOG(WARNING) << "Compression factor out of range. Using default compression factor: "
-                             << DEFAULT_COMPRESSION_FACTOR;
-                compression = DEFAULT_COMPRESSION_FACTOR;
-            }
+        // FE FunctionAnalyzer is the single source of truth: an explicit
+        // compression literal is always injected (default or user-supplied)
+        // and clamped to [MIN, MAX]. The DCHECKs document that contract.
+        //
+        // Rolling-upgrade fallback: during the upgrade window BEs are upgraded
+        // before FEs, so an old FE may still ship 2-arg percentile_approx
+        // calls without the canonicalized compression literal. Treat that as
+        // the default compression so the old wire format keeps working until
+        // the FE side catches up. Remove once we no longer support upgrades
+        // from pre-canonicalization FEs.
+        if (ctx->get_num_args() <= 2) {
+            return DEFAULT_COMPRESSION_FACTOR;
         }
+        double compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(ctx->get_constant_column(2));
+        DCHECK(std::isfinite(compression));
+        DCHECK_GE(compression, MIN_COMPRESSION);
+        DCHECK_LE(compression, MAX_COMPRESSION);
         return compression;
     }
 
@@ -144,6 +157,7 @@ public:
         DCHECK(src[1]->is_constant());
         const auto* const_column = down_cast<const ConstColumn*>(src[1].get());
         double quantile = const_column->get(0).get_double();
+        double compression = get_compression_factor(ctx);
         // result
         BinaryColumn* result = down_cast<BinaryColumn*>(dst.get());
         Bytes& bytes = result->get_bytes();
@@ -153,7 +167,7 @@ public:
         // serialize percentile one by one
         size_t old_size = bytes.size();
         for (size_t i = 0; i < chunk_size; ++i) {
-            PercentileValue percentile;
+            PercentileValue percentile(compression);
             percentile.add(implicit_cast<float>(data_column->immutable_data()[i]));
 
             size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
@@ -171,27 +185,39 @@ public:
 // PercentileApproxWeightedAggregateFunction: percentile_approx_weighted(expr, weight, DOUBLE p[, DOUBLE compression])
 class PercentileApproxWeightedAggregateFunction : public PercentileApproxAggregateFunctionBase {
 public:
-    // SplitAggregateRule pass the const args to merge phase aggregator for performance.
-    // Compression parameter is always the last constant parameter (if provided)
+    // SplitAggregateRule passes the const args to merge phase aggregator for performance.
+    // Compression parameter is always the last constant parameter (if provided).
+    // FE FunctionAnalyzer pre-clamps the literal to [MIN, MAX] or DEFAULT.
     double get_compression_factor(FunctionContext* ctx) const override {
-        double compression = DEFAULT_COMPRESSION_FACTOR;
+        // FE always injects the compression argument; it is the last const arg.
+        // SplitAggregateRule passes const args verbatim into the merge phase
+        // aggregator, so we still scan from the right to find the first const
+        // column (e.g. weight may be a non-const Int64 column).
+        //
+        // Rolling-upgrade fallback: BEs are upgraded before FEs, so an old FE
+        // may ship the legacy 3-arg form `percentile_approx_weighted(expr, w, q)`
+        // without the canonicalized compression literal. In that case the
+        // rightmost const arg is the quantile (e.g. 0.95), which would
+        // misinterpret as compression and break TDigest. Recognize the legacy
+        // arity explicitly and return DEFAULT. Remove once we no longer
+        // support upgrades from pre-canonicalization FEs.
         int num_args = ctx->get_num_args();
-        if (num_args > 3) {
-            for (int i = num_args - 1; i >= 0; i--) {
-                auto const_col = ctx->get_constant_column(i);
-                if (const_col != nullptr) {
-                    // Found the last constant column, this should be compression
-                    compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(const_col);
-                    if (compression < MIN_COMPRESSION || compression > MAX_COMPRESSION) {
-                        LOG(WARNING) << "Compression factor out of range. Using default compression factor: "
-                                     << DEFAULT_COMPRESSION_FACTOR;
-                        compression = DEFAULT_COMPRESSION_FACTOR;
-                    }
-                    break;
-                }
+        if (num_args <= 3) {
+            return DEFAULT_COMPRESSION_FACTOR;
+        }
+        for (int i = num_args - 1; i >= 0; i--) {
+            auto const_col = ctx->get_constant_column(i);
+            if (const_col != nullptr) {
+                double compression = ColumnHelper::get_const_value<TYPE_DOUBLE>(const_col);
+                DCHECK(std::isfinite(compression));
+                DCHECK_GE(compression, MIN_COMPRESSION);
+                DCHECK_LE(compression, MAX_COMPRESSION);
+                return compression;
             }
         }
-        return compression;
+        DCHECK(false) << "FE invariant broken: percentile_approx_weighted reached BE "
+                         "without an explicit compression argument";
+        return DEFAULT_COMPRESSION_FACTOR;
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
@@ -228,6 +254,7 @@ public:
         // argument 2
         DCHECK(src[2]->is_constant());
         double quantile = src[2]->get(0).get_double();
+        double compression = get_compression_factor(ctx);
         // result
         BinaryColumn* result = down_cast<BinaryColumn*>(dst.get());
         Bytes& bytes = result->get_bytes();
@@ -241,7 +268,7 @@ public:
             int64_t weight = src[1]->get(0).get_int64();
             if (LIKELY(weight != 0)) {
                 for (size_t i = 0; i < chunk_size; ++i) {
-                    PercentileValue percentile;
+                    PercentileValue percentile(compression);
                     double value = data_column->immutable_data()[i];
                     percentile.add(implicit_cast<float>(value), weight);
                     size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
@@ -253,8 +280,8 @@ public:
                 }
             } else {
                 // TODO: optimize for empty weight but should not happen frequently
-                PercentileValue empty_percentile;
-                static size_t delta_size = sizeof(double) + empty_percentile.serialize_size();
+                PercentileValue empty_percentile(compression);
+                size_t delta_size = sizeof(double) + empty_percentile.serialize_size();
                 for (size_t i = 0; i < chunk_size; ++i) {
                     size_t new_size = old_size + delta_size;
                     bytes.resize(new_size);
@@ -268,7 +295,7 @@ public:
             const auto* weight_column = down_cast<const Int64Column*>(src[1].get());
             for (size_t i = 0; i < chunk_size; ++i) {
                 int64_t weight = weight_column->immutable_data()[i];
-                PercentileValue percentile;
+                PercentileValue percentile(compression);
                 double value = data_column->immutable_data()[i];
                 if (LIKELY(weight != 0)) {
                     percentile.add(implicit_cast<float>(value), weight);
@@ -398,6 +425,7 @@ public:
         size_t start = offsets[0];
         size_t end = offsets[1];
         uint32_t count = static_cast<uint32_t>(end - start);
+        double compression = get_compression_factor(ctx);
 
         // Extract quantiles
         std::vector<double> quantiles(count);
@@ -418,7 +446,7 @@ public:
         // serialize percentile one by one
         size_t old_size = bytes.size();
         for (size_t i = 0; i < chunk_size; ++i) {
-            PercentileValue percentile;
+            PercentileValue percentile(compression);
             percentile.add(implicit_cast<float>(data_column->immutable_data()[i]));
 
             size_t new_size = old_size + sizeof(uint32_t) + count * sizeof(double) + percentile.serialize_size();
@@ -556,6 +584,7 @@ public:
         size_t start = offsets[0];
         size_t end = offsets[1];
         uint32_t count = static_cast<uint32_t>(end - start);
+        double compression = get_compression_factor(ctx);
 
         // Extract quantiles
         std::vector<double> quantiles(count);
@@ -580,7 +609,7 @@ public:
             int64_t weight = src[1]->get(0).get_int64();
             if (LIKELY(weight != 0)) {
                 for (size_t i = 0; i < chunk_size; ++i) {
-                    PercentileValue percentile;
+                    PercentileValue percentile(compression);
                     double value = data_column->immutable_data()[i];
                     percentile.add(implicit_cast<float>(value), weight);
 
@@ -600,7 +629,7 @@ public:
                 }
             } else {
                 // TODO: optimize for empty weight but should not happen frequently
-                PercentileValue empty_percentile;
+                PercentileValue empty_percentile(compression);
                 size_t delta_size = sizeof(uint32_t) + count * sizeof(double) + empty_percentile.serialize_size();
                 for (size_t i = 0; i < chunk_size; ++i) {
                     size_t new_size = old_size + delta_size;
@@ -621,7 +650,7 @@ public:
             const auto* weight_column = down_cast<const Int64Column*>(src[1].get());
             for (size_t i = 0; i < chunk_size; ++i) {
                 int64_t weight = weight_column->immutable_data()[i];
-                PercentileValue percentile;
+                PercentileValue percentile(compression);
                 double value = data_column->immutable_data()[i];
                 if (LIKELY(weight != 0)) {
                     percentile.add(implicit_cast<float>(value), weight);

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -64,6 +64,11 @@ public:
 
     Value quantile(Value q) { return _tdigest.quantile(q); }
 
+    // Compression the underlying digest was built with. Forwarded so the merge
+    // path can adopt the compression carried inside a deserialized intermediate
+    // blob instead of re-deriving it from the function context.
+    double compression() const { return _tdigest.compression(); }
+
 private:
     enum PercentileDataType { TDIGEST = 0 };
     TDigest _tdigest;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -138,6 +138,7 @@ set(EXEC_FILES
         ./exprs/agg/data_sketch/ds_theta_test.cpp
         ./exprs/agg/json_each_test.cpp
         ./exprs/agg/aggregate_test.cpp
+        ./exprs/agg/percentile_approx_compression_test.cpp
         ./exprs/agg/window_test.cpp
         ./exprs/agg/agg_compressed_key_test.cpp
         ./exprs/agg/agg_state_functions_test.cpp

--- a/be/test/exprs/agg/percentile_approx_compression_test.cpp
+++ b/be/test/exprs/agg/percentile_approx_compression_test.cpp
@@ -1,0 +1,128 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <memory>
+
+// percentile_approx.h forward-declares FunctionContext and ArrayColumn and is not
+// self-contained; pull in their full definitions before it. Order matters, so keep
+// clang-format from hoisting percentile_approx.h to the top as the main header.
+// clang-format off
+#include "column/array_column.h"
+#include "column/column_helper.h"
+#include "exprs/function_context.h"
+#include "exprs/agg/percentile_approx.h"
+// clang-format on
+
+#include "exprs/agg/base_aggregate_test.h" // UTRawType + FunctionContext test helpers
+
+namespace starrocks {
+
+// Exposes the protected compression contract of
+// PercentileApproxAggregateFunctionBase (clamp + the [MIN, MAX]/DEFAULT
+// constants) so it can be asserted directly.
+class PercentileCompressionExposer : public PercentileApproxAggregateFunction {
+public:
+    static double clamp(double c) { return clamp_compression_factor(c); }
+    static double min_c() { return MIN_COMPRESSION; }
+    static double max_c() { return MAX_COMPRESSION; }
+    static double default_c() { return DEFAULT_COMPRESSION_FACTOR; }
+};
+
+static ColumnPtr const_double(double v) {
+    return ColumnHelper::create_const_column<TYPE_DOUBLE>(v, 1);
+}
+
+TEST(PercentileApproxCompressionTest, clampCompressionFactor) {
+    const double lo = PercentileCompressionExposer::min_c();
+    const double hi = PercentileCompressionExposer::max_c();
+    const double def = PercentileCompressionExposer::default_c();
+
+    // In-range values pass through unchanged.
+    EXPECT_DOUBLE_EQ(lo, PercentileCompressionExposer::clamp(lo));
+    EXPECT_DOUBLE_EQ(hi, PercentileCompressionExposer::clamp(hi));
+    EXPECT_DOUBLE_EQ(5000.0, PercentileCompressionExposer::clamp(5000.0));
+
+    // Below MIN, above MAX, non-positive and non-finite all canonicalize to the default.
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(lo - 1));
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(hi + 1));
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(0.0));
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(-5.0));
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(std::nan("")));
+    EXPECT_DOUBLE_EQ(def, PercentileCompressionExposer::clamp(std::numeric_limits<double>::infinity()));
+}
+
+TEST(PercentileApproxCompressionTest, getCompressionFactorApprox) {
+    PercentileApproxAggregateFunction fn;
+    const double def = PercentileCompressionExposer::default_c();
+
+    // 2-arg call (no explicit compression): legacy/rolling-upgrade path -> default.
+    {
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+                {UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}}, UTRawType{.type = TYPE_DOUBLE}));
+        EXPECT_DOUBLE_EQ(def, fn.get_compression_factor(ctx.get()));
+    }
+    // 3-arg call, in-range constant compression -> used as-is.
+    {
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+                {UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}},
+                UTRawType{.type = TYPE_DOUBLE}));
+        ctx->set_constant_columns({nullptr, nullptr, const_double(5000.0)});
+        EXPECT_DOUBLE_EQ(5000.0, fn.get_compression_factor(ctx.get()));
+    }
+    // 3-arg call, out-of-range constant compression -> clamped to default.
+    {
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+                {UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}},
+                UTRawType{.type = TYPE_DOUBLE}));
+        ctx->set_constant_columns({nullptr, nullptr, const_double(1.0)});
+        EXPECT_DOUBLE_EQ(def, fn.get_compression_factor(ctx.get()));
+    }
+}
+
+TEST(PercentileApproxCompressionTest, getCompressionFactorWeighted) {
+    PercentileApproxWeightedAggregateFunction fn;
+    const double def = PercentileCompressionExposer::default_c();
+
+    // Legacy 3-arg form (value, weight, quantile) without compression -> default.
+    {
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+                {UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_BIGINT}, UTRawType{.type = TYPE_DOUBLE}},
+                UTRawType{.type = TYPE_DOUBLE}));
+        EXPECT_DOUBLE_EQ(def, fn.get_compression_factor(ctx.get()));
+    }
+    // 4-arg form: compression is the rightmost constant; a non-const weight (nullptr) is skipped.
+    {
+        std::unique_ptr<FunctionContext> ctx(
+                FunctionContext::create_test_context({UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_BIGINT},
+                                                      UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}},
+                                                     UTRawType{.type = TYPE_DOUBLE}));
+        ctx->set_constant_columns({nullptr, nullptr, const_double(0.5), const_double(5000.0)});
+        EXPECT_DOUBLE_EQ(5000.0, fn.get_compression_factor(ctx.get()));
+    }
+    // 4-arg form, out-of-range compression -> clamped to default.
+    {
+        std::unique_ptr<FunctionContext> ctx(
+                FunctionContext::create_test_context({UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_BIGINT},
+                                                      UTRawType{.type = TYPE_DOUBLE}, UTRawType{.type = TYPE_DOUBLE}},
+                                                     UTRawType{.type = TYPE_DOUBLE}));
+        ctx->set_constant_columns({nullptr, nullptr, const_double(0.5), const_double(20000.0)});
+        EXPECT_DOUBLE_EQ(def, fn.get_compression_factor(ctx.get()));
+    }
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -508,10 +508,17 @@ public class FunctionAnalyzer {
             // Validate second parameter (percentile) is numeric or array type
             validatePercentileParameter(functionCallExpr.getChild(1), "second", 
                     "percentile_approx", functionCallExpr.getPos());
-            // Validate optional third parameter (compression) is numeric type
+            // NULL is allowed past validate-numeric and routed through clamp,
+            // which canonicalizes it to DEFAULT just like out-of-range ints.
             if (children.size() == 3) {
-                validateNumericParameter(functionCallExpr.getChild(2), "third", "compression", 
-                        "percentile_approx", functionCallExpr.getPos());
+                Expr cArg = functionCallExpr.getChild(2);
+                if (!(cArg instanceof NullLiteral)) {
+                    validateNumericParameter(cArg, "third", "compression",
+                            "percentile_approx", functionCallExpr.getPos());
+                }
+                clampCompressionLiteral(functionCallExpr, 2);
+            } else {
+                injectDefaultCompression(functionCallExpr);
             }
         }
 
@@ -532,10 +539,17 @@ public class FunctionAnalyzer {
             // Validate third parameter (percentile) is numeric or array type
             validatePercentileParameter(functionCallExpr.getChild(2), "third", 
                     "percentile_approx_weighted", functionCallExpr.getPos());
-            // Validate optional fourth parameter (compression) is numeric type
+            // NULL is allowed past validate-numeric and routed through clamp,
+            // which canonicalizes it to DEFAULT just like out-of-range ints.
             if (children.size() == 4) {
-                validateNumericParameter(functionCallExpr.getChild(3), "fourth", "compression", 
-                        "percentile_approx_weighted", functionCallExpr.getPos());
+                Expr cArg = functionCallExpr.getChild(3);
+                if (!(cArg instanceof NullLiteral)) {
+                    validateNumericParameter(cArg, "fourth", "compression",
+                            "percentile_approx_weighted", functionCallExpr.getPos());
+                }
+                clampCompressionLiteral(functionCallExpr, 3);
+            } else {
+                injectDefaultCompression(functionCallExpr);
             }
         }
 
@@ -730,8 +744,8 @@ public class FunctionAnalyzer {
      * @param pos The position in the source code for error reporting
      * @throws SemanticException if the parameter is not numeric type
      */
-    private static void validateNumericParameter(Expr paramExpr, String paramPosition, 
-                                                  String paramName, String functionName, 
+    private static void validateNumericParameter(Expr paramExpr, String paramPosition,
+                                                  String paramName, String functionName,
                                                   NodePosition pos) {
         if (!paramExpr.getType().isNumericType()) {
             throw new SemanticException(
@@ -739,6 +753,82 @@ public class FunctionAnalyzer {
                             functionName, paramPosition, paramName, paramExpr.getType().toSql()),
                     pos);
         }
+    }
+
+    /**
+     * Append {@code IntLiteral(DEFAULT)} as the next child and re-bind the
+     * FunctionCallExpr to the compression-aware overload, so that downstream
+     * (planner / BE) always sees an explicit compression argument. The
+     * registered overloads of percentile_approx[_weighted] expose the
+     * compression slot as DOUBLE in their signature (see the note on
+     * {@link #clampCompressionLiteral}); the IntLiteral here matches the
+     * pattern used for user-written integer literals — SR's standard implicit
+     * cast handles the int→double conversion when the value is materialized.
+     */
+    private static void injectDefaultCompression(FunctionCallExpr fn) {
+        Function current = fn.getFn();
+        Preconditions.checkState(current != null,
+                "function must be resolved before injecting compression");
+        Type[] currentArgs = current.getArgs();
+        Type[] expandedArgs = new Type[currentArgs.length + 1];
+        System.arraycopy(currentArgs, 0, expandedArgs, 0, currentArgs.length);
+        expandedArgs[currentArgs.length] = FloatType.DOUBLE;
+        Function expanded = ExprUtils.getBuiltinFunction(
+                current.getFunctionName().getFunction(), expandedArgs,
+                Function.CompareMode.IS_IDENTICAL);
+        Preconditions.checkState(expanded != null,
+                "no compression-aware overload registered for "
+                        + current.getFunctionName().getFunction());
+        IntLiteral defaultC = new IntLiteral(PercentileCompression.DEFAULT);
+        defaultC.setPos(fn.getPos());
+        fn.addChild(defaultC);
+        fn.setFn(expanded);
+    }
+
+    /**
+     * Canonicalize the compression argument of a percentile function. Only an
+     * integer literal (or literal NULL) is accepted; CAST, arithmetic, column
+     * references and other expressions are rejected up front. Values outside
+     * [MIN, MAX] and literal NULL are replaced with the default.
+     *
+     * AST mutation via {@code setChild} follows the established
+     * {@code FunctionAnalyzer} pattern (see {@code date_trunc} normalization).
+     * <p>
+     * The user-facing contract for compression is integer-only, but the
+     * registered BE function signature keeps DOUBLE for the compression slot:
+     * the percentile aggregates are registered via a variadic template on BE
+     * ({@code add_aggregate_mapping_variadic<DOUBLE, DOUBLE, ...>}) which forces
+     * a single trailing-arg type. Switching to BIGINT end-to-end would require
+     * a new fixed-arity BE template plus parallel changes to FunctionSet,
+     * gensrc, and the resolver — out of scope here. SR's standard implicit
+     * cast wraps this IntLiteral in a planner-side {@code CAST(int AS DOUBLE)}
+     * before the value reaches BE, so the wire format is unaffected.
+     */
+    private static void clampCompressionLiteral(FunctionCallExpr fn, int argIdx) {
+        if (fn.getChildren().size() <= argIdx) {
+            return;
+        }
+        Expr arg = fn.getChild(argIdx);
+        long c;
+        boolean isInvalid;
+        if (arg instanceof NullLiteral) {
+            isInvalid = true;
+            c = 0;
+        } else {
+            // extractIntegerValue accepts both literal ints and user variables
+            // bound to integer constants (`set @c = 5000`).
+            Optional<Long> extracted = extractIntegerValue(arg);
+            if (!extracted.isPresent()) {
+                throw new SemanticException(
+                        "compression must be an integer literal", fn.getPos());
+            }
+            c = extracted.get();
+            isInvalid = c < PercentileCompression.MIN || c > PercentileCompression.MAX;
+        }
+        long finalC = isInvalid ? PercentileCompression.DEFAULT : c;
+        IntLiteral clamped = new IntLiteral(finalC);
+        clamped.setPos(arg.getPos());
+        fn.setChild(argIdx, clamped);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -791,9 +791,12 @@ public class FunctionAnalyzer {
 
     /**
      * Canonicalize the compression argument of a percentile function. Only an
-     * integer literal (or literal NULL) is accepted; CAST, arithmetic, column
-     * references and other expressions are rejected up front. Values outside
-     * [MIN, MAX] and literal NULL are replaced with the default.
+     * integer literal, a user variable bound to an integer constant, or literal
+     * NULL is accepted; CAST, arithmetic, and column references (including
+     * CTE-projected ones) are rejected up front so the planner, MV rewrite, and
+     * BE all see one canonical compression literal rather than an expression that
+     * would only fold later. Values outside [MIN, MAX] and literal NULL are
+     * replaced with the default.
      *
      * AST mutation via {@code setChild} follows the established
      * {@code FunctionAnalyzer} pattern (see {@code date_trunc} normalization).

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -767,8 +767,13 @@ public class FunctionAnalyzer {
      */
     private static void injectDefaultCompression(FunctionCallExpr fn) {
         Function current = fn.getFn();
-        Preconditions.checkState(current != null,
-                "function must be resolved before injecting compression");
+        if (current == null) {
+            // The aggregate-combinator path (e.g. percentile_approx_if) re-runs this
+            // validation on a freshly-built, unresolved FunctionCallExpr whose fn is null;
+            // its mutations are discarded. Skip injection — the real call is canonicalized
+            // on its own resolved pass, and BE keeps its legacy default for the 2-arg arity.
+            return;
+        }
         Type[] currentArgs = current.getArgs();
         Type[] expandedArgs = new Type[currentArgs.length + 1];
         System.arraycopy(currentArgs, 0, expandedArgs, 0, currentArgs.length);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -779,8 +779,7 @@ public class FunctionAnalyzer {
         Preconditions.checkState(expanded != null,
                 "no compression-aware overload registered for "
                         + current.getFunctionName().getFunction());
-        IntLiteral defaultC = new IntLiteral(PercentileCompression.DEFAULT);
-        defaultC.setPos(fn.getPos());
+        IntLiteral defaultC = new IntLiteral(PercentileCompression.DEFAULT, fn.getPos());
         fn.addChild(defaultC);
         fn.setFn(expanded);
     }
@@ -826,8 +825,7 @@ public class FunctionAnalyzer {
             isInvalid = c < PercentileCompression.MIN || c > PercentileCompression.MAX;
         }
         long finalC = isInvalid ? PercentileCompression.DEFAULT : c;
-        IntLiteral clamped = new IntLiteral(finalC);
-        clamped.setPos(arg.getPos());
+        IntLiteral clamped = new IntLiteral(finalC, arg.getPos());
         fn.setChild(argIdx, clamped);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PercentileCompression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PercentileCompression.java
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+/**
+ * Single source of truth for the percentile-aggregate compression literal
+ * contract on the FE side. Mirrors the BE constants in
+ * {@code PercentileApproxAggregateFunctionBase} (be/src/exprs/agg/percentile_approx.h).
+ *
+ * <p>Used by {@link FunctionAnalyzer} to canonicalize the literal in the AST.
+ */
+public final class PercentileCompression {
+    /** Lower bound of the accepted compression range. */
+    public static final long MIN = 2048;
+
+    /** Upper bound of the accepted compression range. */
+    public static final long MAX = 10000;
+
+    /**
+     * Default applied when no explicit compression is given, or when a literal
+     * is out of range / NULL / non-finite. Matches BE
+     * {@code DEFAULT_COMPRESSION_FACTOR}.
+     */
+    public static final long DEFAULT = 10000;
+
+    private PercentileCompression() {
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -32,7 +32,7 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         assertPlanContains(sql, "output: any_value(1: v1)");
 
         sql = "select approx_percentile(v1, 0.99) from t0;";
-        assertPlanContains(sql, "output: percentile_approx(CAST(1: v1 AS DOUBLE), 0.99)");
+        assertPlanContains(sql, "output: percentile_approx(CAST(1: v1 AS DOUBLE), 0.99, 10000.0)");
 
         sql = "select stddev(v1) from t0;";
         assertPlanContains(sql, "output: stddev_samp(1: v1)");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -1014,10 +1014,10 @@ public class TrinoQueryTest extends TrinoTestBase {
         analyzeFail(sql);
 
         sql = "select approx_percentile(2.25, 1.79E-10)";
-        assertPlanContains(sql, "percentile_approx(2.25, 1.79E-10)");
+        assertPlanContains(sql, "percentile_approx(2.25, 1.79E-10, 10000.0)");
 
         sql = "select approx_percentile(2.25, 0.4)";
-        assertPlanContains(sql, "percentile_approx(2.25, 0.4)");
+        assertPlanContains(sql, "percentile_approx(2.25, 0.4, 10000.0)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -288,9 +288,26 @@ public class AnalyzeAggregateTest {
         analyzeFail("select percentile_approx(1,'c') from tall group by tb");
         analyzeFail("select percentile_approx(1,1,'c') from tall group by tb");
         analyzeFail("select percentile_approx(1,1,0.5,tc) from tall group by tb");
-        analyzeSuccess("select percentile_approx(1,1,tc) from tall group by tb");
+        // FunctionAnalyzer now canonicalizes compression at analyze phase:
+        // non-constant compression arguments are rejected up front rather than
+        // letting the query reach TypeChecker.
+        analyzeFail("select percentile_approx(1,1,tc) from tall group by tb",
+                "compression must be an integer literal");
         analyzeSuccess("select percentile_approx(1,5) from tall group by tb");
+        // Out-of-range integer literal: silently clamped to DEFAULT_COMPRESSION_FACTOR.
         analyzeSuccess("select percentile_approx(1,0.5,1047) from tall group by tb");
+        // NULL literal: canonicalized to DEFAULT.
+        analyzeSuccess("select percentile_approx(1, 0.5, NULL) from tall group by tb");
+        // Zero and negative integer literals are out-of-range and silently clamped.
+        analyzeSuccess("select percentile_approx(1, 0.5, 0) from tall group by tb");
+        // Non-integer literal compression is rejected.
+        analyzeFail("select percentile_approx(1, 0.5, 5000.0) from tall group by tb",
+                "compression must be an integer literal");
+        // Casts and arithmetic expressions for compression are rejected.
+        analyzeFail("select percentile_approx(1, 0.5, CAST(5000 AS DOUBLE)) from tall group by tb",
+                "compression must be an integer literal");
+        analyzeFail("select percentile_approx(1, 0.5, 2500 + 2500) from tall group by tb",
+                "compression must be an integer literal");
         analyzeSuccess("select percentile_disc(tj,0.5) from tall group by tb");
         analyzeSuccess("select percentile_cont(tj,0.5) from tall group by tb");
         analyzeSuccess("select percentile_cont(tj, cast(0.5 as double)) from tall group by tb");
@@ -349,7 +366,10 @@ public class AnalyzeAggregateTest {
         analyzeFail("select percentile_approx_weighted(1, 2, 0.5, 'c') from tall group by tb",
                 "requires the fourth parameter (compression) to be numeric type");
         analyzeSuccess("select percentile_approx_weighted(1, 2, 0.5, 100) from tall group by tb");
-        analyzeSuccess("select percentile_approx_weighted(1, 2, 0.5, tc) from tall group by tb");
+        // Non-constant compression is now rejected at analyze phase
+        // (FunctionAnalyzer canonicalizes the literal before plan generation).
+        analyzeFail("select percentile_approx_weighted(1, 2, 0.5, tc) from tall group by tb",
+                "compression must be an integer literal");
 
         // Test with different numeric types
         analyzeSuccess("select percentile_approx_weighted(tc, tj, 0.5) from tall group by tb");
@@ -391,7 +411,10 @@ public class AnalyzeAggregateTest {
         analyzeFail("select percentile_approx(1, 0.5, 'c') from tall group by tb",
                 "requires the third parameter (compression) to be numeric type");
         analyzeSuccess("select percentile_approx(1, 0.5, 100) from tall group by tb");
-        analyzeSuccess("select percentile_approx(1, 0.5, tc) from tall group by tb");
+        // Non-constant compression is now rejected at analyze phase
+        // (FunctionAnalyzer canonicalizes the literal before plan generation).
+        analyzeFail("select percentile_approx(1, 0.5, tc) from tall group by tb",
+                "compression must be an integer literal");
 
         // Test with different numeric types
         analyzeSuccess("select percentile_approx(tc, 0.5) from tall group by tb");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2517,12 +2517,12 @@ public class AggregateTest extends PlanTestBase {
         // For compatibility
         String sql = "select percentile_approx(1, cast(0.4 as DOUBLE));";
         String plan = getCostExplain(sql);
-        assertContains(plan, "percentile_approx[(1.0, 0.4); args: DOUBLE,DOUBLE");
+        assertContains(plan, "percentile_approx[(1.0, 0.4, 10000.0); args: DOUBLE,DOUBLE,DOUBLE");
 
         sql = "with cc as (select 1 as a) select percentile_approx(1, cc.a) from cc;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "2:AGGREGATE (update finalize)\n" +
-                "  |  output: percentile_approx(1.0, 1.0)\n" +
+                "  |  output: percentile_approx(1.0, 1.0, 10000.0)\n" +
                 "  |  group by: ");
         Exception exception = Assertions.assertThrows(StarRocksPlannerException.class, () -> {
             String testSql = "with cc as (select 1 as a, v1 from t0) select percentile_approx(1, cc.a, cc.v1) from cc;";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2528,8 +2528,10 @@ public class AggregateTest extends PlanTestBase {
             String testSql = "with cc as (select 1 as a, v1 from t0) select percentile_approx(1, cc.a, cc.v1) from cc;";
             getFragmentPlan(testSql);
         });
-        Assertions.assertTrue(exception.getMessage().contains("Type check failed. want constant arg in " +
-                "percentile_approx (compression), but input is cast(1: v1 as double)"));
+        // FunctionAnalyzer pre-clamps the compression literal at analyze phase
+        // and rejects non-constant inputs up front (SemanticException extends
+        // StarRocksPlannerException so the assertion above still matches).
+        Assertions.assertTrue(exception.getMessage().contains("compression must be an integer literal"));
 
         Throwable exception2 = assertThrows(StarRocksPlannerException.class, () -> {
             getCostExplain("select percentile_approx(1, cast(1.3 as DOUBLE));");
@@ -2595,18 +2597,17 @@ public class AggregateTest extends PlanTestBase {
                 "column 7 to line 1, column 44. Detail message: percentile_approx_weighted requires " +
                 "the third parameter (percentile) to be ARRAY<NUMERIC>, but got: ARRAY<NULL_TYPE>."));
 
-        // Test compression parameter validation
-        Throwable exception6 = assertThrows(StarRocksPlannerException.class, () -> {
-            getCostExplain("select percentile_approx_weighted(v1, v2, 0.5, 0) from t0;");
-        });
-        assertThat(exception6.getMessage(), containsString("Type check failed. " +
-                "compression parameter must be positive in percentile_approx_weighted, but got: 0.0"));
+        // Compression literals outside [MIN_COMPRESSION, MAX_COMPRESSION] are
+        // canonicalized to DEFAULT_COMPRESSION_FACTOR by FunctionAnalyzer; the
+        // query plans successfully and the compression argument is rewritten to
+        // 10000 before reaching the optimizer.
+        sql = "select percentile_approx_weighted(v1, v2, 0.5, 0) from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "percentile_approx_weighted");
 
-        Throwable exception7 = assertThrows(StarRocksPlannerException.class, () -> {
-            getCostExplain("select percentile_approx_weighted(v1, v2, 0.5, -100) from t0;");
-        });
-        assertThat(exception7.getMessage(), containsString("Type check failed. " +
-                "compression parameter must be positive in percentile_approx_weighted, but got: -100.0"));
+        sql = "select percentile_approx_weighted(v1, v2, 0.5, -100) from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "percentile_approx_weighted");
 
         // Test valid array percentile
         sql = "select percentile_approx_weighted(v1, v2, [0.0, 0.5, 1.0]) from t0;";
@@ -2671,18 +2672,17 @@ public class AggregateTest extends PlanTestBase {
                 "column 7 to line 1, column 31. Detail message: " +
                 "percentile_approx requires the second parameter (percentile) to be ARRAY<NUMERIC>, but got: ARRAY<NULL_TYPE>."));
 
-        // Test compression parameter validation
-        Throwable exception6 = assertThrows(StarRocksPlannerException.class, () -> {
-            getCostExplain("select percentile_approx(v1, 0.5, 0) from t0;");
-        });
-        assertThat(exception6.getMessage(), containsString("Type check failed. " +
-                "compression parameter must be positive in percentile_approx, but got: 0.0"));
+        // Compression literals outside [MIN_COMPRESSION, MAX_COMPRESSION] are
+        // canonicalized to DEFAULT_COMPRESSION_FACTOR by FunctionAnalyzer; the
+        // query plans successfully and the compression argument is rewritten to
+        // 10000 before reaching the optimizer.
+        sql = "select percentile_approx(v1, 0.5, 0) from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "percentile_approx");
 
-        Throwable exception7 = assertThrows(StarRocksPlannerException.class, () -> {
-            getCostExplain("select percentile_approx(v1, 0.5, -100) from t0;");
-        });
-        assertThat(exception7.getMessage(), containsString("Type check failed. " +
-                "compression parameter must be positive in percentile_approx, but got: -100.0"));
+        sql = "select percentile_approx(v1, 0.5, -100) from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "percentile_approx");
 
         // Test valid array percentile
         sql = "select percentile_approx(v1, [0.0, 0.5, 1.0]) from t0;";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -447,7 +447,7 @@ public class ConstantExpressionTest extends PlanTestBase {
                     "  |  <slot 3> : clone(2: percentile_approx)\n" +
                     "  |  \n" +
                     "  1:AGGREGATE (update finalize)\n" +
-                    "  |  output: percentile_approx(2.25, 0.0)\n" +
+                    "  |  output: percentile_approx(2.25, 0.0, 10000.0)\n" +
                     "  |  group by: ");
 
             sql = "SELECT COUNT(CASE WHEN 1 THEN 1 END), COUNT(CASE WHEN TRUE THEN 1 END), " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectHintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectHintTest.java
@@ -99,7 +99,7 @@ public class SelectHintTest extends PlanTestBase {
 
         sql = "select /*+ set_user_variable(@a = 1, @b = 10) */ percentile_approx(v1, @a) from t0";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "percentile_approx(CAST(1: v1 AS DOUBLE), 1.0)");
+        assertContains(plan, "percentile_approx(CAST(1: v1 AS DOUBLE), 1.0, 10000.0)");
 
         Exception exception = Assertions.assertThrows(SemanticException.class, () -> {
             String invalidSql = "select /*+ set_user_variable(@a = 1, @b = 1000000) */ APPROX_TOP_K(v1, @a), " +

--- a/test/sql/test_agg_function/R/test_percentile_approx
+++ b/test/sql/test_agg_function/R/test_percentile_approx
@@ -41,6 +41,10 @@ with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 =
 -- !result
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx(c2, v1, v2 + 1) as int) from tt;
 -- result:
+[REGEX]E: \(1064.*compression must be an integer literal.*
+-- !result
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx(c2, v1, @v2) as int) from tt;
+-- result:
 25000
 -- !result
 select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, array<double>[0.25, 0.5, 0.75]) from t1;

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -59,7 +59,7 @@ select cast(percentile_approx_weighted(c2, 1, 0.9) as int) from t1;
 -- !result
 select cast(percentile_approx_weighted(c2, 0, 0.9, 0) as int) from t1;
 -- result:
-E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: 0.0')
+None
 -- !result
 select cast(percentile_approx_weighted(c2, 0, 0.9, 1) as int) from t1;
 -- result:
@@ -67,7 +67,7 @@ None
 -- !result
 select cast(percentile_approx_weighted(c2, 1, 0.9, 0) as int) from t1;
 -- result:
-E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: 0.0')
+44999
 -- !result
 select cast(percentile_approx_weighted(c2, 1, 0.9, 1) as int) from t1;
 -- result:
@@ -489,11 +489,11 @@ select percentile_approx_weighted(k, v, [0.25, 0.5, 0.75, 0.9]) from t2;
 -- !result
 select percentile_approx_weighted(k, v, 0.5, 0) from t2;
 -- result:
-E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: 0.0')
+3.4000000953674316
 -- !result
 select percentile_approx_weighted(k, v, 0.5, -100) from t2;
 -- result:
-E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: -100.0')
+3.4000000953674316
 -- !result
 select percentile_approx_weighted(k, v, 0.5, 1) from t2;
 -- result:

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -243,6 +243,10 @@ with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 =
 -- !result
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx_weighted(c2, c1, v1, v2 + 1) as int) from tt;
 -- result:
+[REGEX]E: \(1064.*compression must be an integer literal.*
+-- !result
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx_weighted(c2, c1, v1, @v2) as int) from tt;
+-- result:
 35355
 -- !result
 set pipeline_dop=1;
@@ -425,6 +429,10 @@ with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 =
 35355
 -- !result
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx_weighted(c2, c1, v1, v2 + 1) as int) from tt;
+-- result:
+[REGEX]E: \(1064.*compression must be an integer literal.*
+-- !result
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx_weighted(c2, c1, v1, @v2) as int) from tt;
 -- result:
 35355
 -- !result

--- a/test/sql/test_agg_function/T/test_percentile_approx
+++ b/test/sql/test_agg_function/T/test_percentile_approx
@@ -18,6 +18,7 @@ select cast(percentile_approx(c2, 0.9, 10000) as int) from t1;
 
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ cast(percentile_approx(c2, v1) as int) from tt;
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx(c2, v1, v2 + 1) as int) from tt;
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx(c2, v1, @v2) as int) from tt;
 
 select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, array<double>[0.25, 0.5, 0.75]) from t1;
 select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, array<double>[0.0, 0.5, 1.0]) from t1;

--- a/test/sql/test_agg_function/T/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/T/test_percentile_approx_weighted
@@ -95,6 +95,7 @@ select cast(percentile_approx_weighted(c13.b, 1, 0.5) as int) from t1;
 
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ cast(percentile_approx_weighted(c2, c1, v1) as int) from tt;
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx_weighted(c2, c1, v1, v2 + 1) as int) from tt;
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx_weighted(c2, c1, v1, @v2) as int) from tt;
 
 set pipeline_dop=1;
 
@@ -156,6 +157,7 @@ select cast(percentile_approx_weighted(c13.b, 1, 0.5) as int) from t1;
 
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ cast(percentile_approx_weighted(c2, c1, v1) as int) from tt;
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx_weighted(c2, c1, v1, v2 + 1) as int) from tt;
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4097) */ cast(percentile_approx_weighted(c2, c1, v1, @v2) as int) from tt;
 CREATE TABLE `t2` (
   `k` int(11) NULL COMMENT "",
   `v` int(11) NULL COMMENT ""


### PR DESCRIPTION
## Why I'm doing:

`percentile_approx` and `percentile_approx_weighted` currently split
compression handling between FE and BE.

FE can pass several compression expression shapes downstream, while BE still
owns part of the validation and fallback behavior at execution time. That makes
the effective compression harder to reason about in planner-side logic and
leaves more than one place responsible for the same compression contract.

This PR moves the compression literal contract to the analyzer so downstream
code (planner, MV rewrite, BE) sees a single canonical compression value.

## What I'm doing:

Move percentile compression canonicalization to `FunctionAnalyzer`:

- Add FE-side compression constants in `PercentileCompression`.
- Canonicalize compression arguments for `percentile_approx` and
  `percentile_approx_weighted` during analysis.
- Inject an explicit default compression when the optional compression argument
  is omitted.
- Accept an integer literal or a user variable bound to an integer constant for
  the compression argument.
- Reject compression shapes that are not a literal at analysis time — column
  references (including CTE-projected user variables), casts, and arithmetic —
  up front, so they never reach BE as a non-canonical value.
- Make BE consume the FE-canonicalized compression value and use it in the
  serialize-format paths that previously constructed a default
  `PercentileValue`.
- Keep a BE fallback for legacy arities during rolling upgrades from older FEs.

For out-of-range integer compression literals, this PR follows the current user
documentation: values outside the accepted compression range are canonicalized
to the default compression. That includes `0`, which previously failed later
with `compression must be positive`.

That behavior choice is not required by the refactor itself. If reviewers prefer
to preserve the existing hard-fail for non-positive values, we can keep that
validation behavior while still leaving compression canonicalization in
`FunctionAnalyzer`.

## Testing

`test_percentile_approx` and `test_percentile_approx_weighted` lock in the
contract: a pre-existing case that passed compression as `v2 + 1` over a
CTE-projected user variable now asserts the `compression must be an integer
literal` analyzing error, and a companion case passes compression as a direct
user variable (`@v2`) and succeeds. `AnalyzeAggregateTest` and `AggregateTest`
cover literal, NULL, out-of-range, cast, and arithmetic compression at the
analyzer/optimizer level.

Related to #73636

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
