### PR TITLE
[BugFix] Fix percentile_union silently downgrading digest compression

### DIFF
--- a/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
@@ -18,6 +18,7 @@
 #include "exprs/agg/factory/aggregate_resolver.hpp"
 #include "exprs/agg/group_concat.h"
 #include "exprs/agg/percentile_cont.h"
+#include "exprs/agg/percentile_union.h"
 #include "types/logical_type.h"
 #include "types/percentile_value.h"
 
@@ -72,7 +73,7 @@ void AggregateFuncResolver::register_others() {
             "percentile_approx_weighted", false,
             AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction());
 
-    add_aggregate_mapping<TYPE_PERCENTILE, TYPE_PERCENTILE, PercentileValue>(
+    add_aggregate_mapping<TYPE_PERCENTILE, TYPE_PERCENTILE, PercentileUnionState>(
             "percentile_union", false, AggregateFactory::MakePercentileUnionAggregateFunction());
 
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_DOUBLE, PercentileState<TYPE_DOUBLE>>(

--- a/be/src/exprs/agg/percentile_union.h
+++ b/be/src/exprs/agg/percentile_union.h
@@ -20,14 +20,39 @@
 #include "exprs/agg/aggregate.h"
 #include "exprs/function_context.h"
 #include "gutil/casts.h"
+#include "types/percentile_value.h"
 
 namespace starrocks {
+
+// Wrapper over PercentileValue that defers ctor compression until the first
+// incoming digest is observed. PercentileValue itself is a value-type stored on
+// disk and copied verbatim through merge/spill paths; adding a flag to it would
+// affect serialization layout, so the flag lives only in this aggregate state.
+struct PercentileUnionState {
+    PercentileValue value;
+    bool compression_initialized = false;
+
+    void reinit_with_compression(double c) {
+        value = PercentileValue(c);
+        compression_initialized = true;
+    }
+
+    int64_t mem_usage() const { return value.mem_usage(); }
+};
+
 class PercentileUnionAggregateFunction final
-        : public AggregateFunctionBatchHelper<PercentileValue, PercentileUnionAggregateFunction> {
+        : public AggregateFunctionBatchHelper<PercentileUnionState, PercentileUnionAggregateFunction> {
 public:
     ALWAYS_INLINE void update_state(FunctionContext* ctx, AggDataPtr state, const PercentileValue* value) const {
+        // Lazy init from the first incoming digest. Covers both local-agg
+        // (update -> update_state) and distributed/spill-restore paths
+        // (merge -> update_state), since merge is the only deserialization
+        // entry point in this aggregate.
+        if (UNLIKELY(!this->data(state).compression_initialized)) {
+            this->data(state).reinit_with_compression(value->compression());
+        }
         int64_t prev_memory = this->data(state).mem_usage();
-        this->data(state).merge(value);
+        this->data(state).value.merge(value);
         ctx->add_mem_usage(this->data(state).mem_usage() - prev_memory);
     }
 
@@ -55,7 +80,7 @@ public:
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<PercentileColumn*>(to);
-        auto& percentile_value = const_cast<PercentileValue&>(this->data(state));
+        auto& percentile_value = const_cast<PercentileValue&>(this->data(state).value);
         column->append(std::move(percentile_value));
     }
 
@@ -67,7 +92,7 @@ public:
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(to->is_object());
         auto* column = down_cast<PercentileColumn*>(to);
-        auto& percentile_value = const_cast<PercentileValue&>(this->data(state));
+        auto& percentile_value = const_cast<PercentileValue&>(this->data(state).value);
         column->append(std::move(percentile_value));
     }
 

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -64,6 +64,8 @@ public:
 
     Value quantile(Value q) { return _tdigest.quantile(q); }
 
+    double compression() const { return _tdigest.compression(); }
+
 private:
     enum PercentileDataType { TDIGEST = 0 };
     TDigest _tdigest;

--- a/be/test/exprs/percentile_functions_test.cpp
+++ b/be/test/exprs/percentile_functions_test.cpp
@@ -17,6 +17,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include "exprs/agg/percentile_union.h"
 #include "exprs/function_context.h"
 #include "types/percentile_value.h"
 
@@ -59,6 +60,28 @@ TEST_F(PercentileFunctionsTest, percentileHashTest) {
     ASSERT_EQ(1, percentile->get_object(0)->quantile(1));
     ASSERT_EQ(2, percentile->get_object(1)->quantile(1));
     ASSERT_EQ(3, percentile->get_object(2)->quantile(1));
+}
+
+TEST_F(PercentileFunctionsTest, percentileUnionStateLazyInitFromFirstUpdate) {
+    // Without the lazy-init fix the union state defaults to TDigest(1000) and
+    // silently downgrades digests stored at higher compression. After the fix
+    // the very first incoming digest's compression seeds the state.
+    PercentileUnionAggregateFunction agg;
+    PercentileUnionState state;
+    ASSERT_FALSE(state.compression_initialized);
+
+    PercentileValue incoming(5000.0);
+    incoming.add(1.0f);
+    agg.update_state(ctx, reinterpret_cast<AggDataPtr>(&state), &incoming);
+
+    ASSERT_TRUE(state.compression_initialized);
+    ASSERT_DOUBLE_EQ(5000.0, state.value.compression());
+
+    // Subsequent updates must not re-seed.
+    PercentileValue second(1000.0);
+    second.add(2.0f);
+    agg.update_state(ctx, reinterpret_cast<AggDataPtr>(&state), &second);
+    ASSERT_DOUBLE_EQ(5000.0, state.value.compression());
 }
 
 TEST_F(PercentileFunctionsTest, percentileNullTest) {


### PR DESCRIPTION
## Why I'm doing:

`percentile_union` currently initializes its aggregate state with the default
`PercentileValue`, which uses `TDigest(1000)`.

When the input digest was created with a higher compression, merging it into
that union state silently downgrades the result to the lower compression. This
loses precision independently of materialized-view rewrite logic and affects
any `percentile_union` path that merges higher-compression percentile values.

## What I'm doing:

Make `percentile_union` lazily initialize its aggregate state from the first
incoming percentile digest:

- Add a `PercentileUnionState` wrapper that keeps the lazy-init flag in
  aggregate state without changing the serialized `PercentileValue` layout.
- Reinitialize the union state with the incoming digest compression on the
  first `update_state` / merge path.
- Expose `PercentileValue::compression()` for the state initialization and test.
- Add a BE unit test covering first-update initialization and verifying later
  updates do not re-seed the state.

Related to #73636

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
