### PR TITLE
[Enhancement] Use observable thread pool for `statsCacheRefresherExecutor`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -164,6 +164,11 @@ public class ThreadPoolManager {
                 new BlockedPolicy(poolName, 60), poolName, needRegisterMetric);
     }
 
+    public static ThreadPoolExecutor newDaemonFixedThreadPool(int numThread, String poolName, boolean needRegisterMetric) {
+        return newDaemonThreadPool(numThread, numThread, KEEP_ALIVE_TIME, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(), new BlockedPolicy(poolName, 60), poolName, needRegisterMetric);
+    }
+
     public static PriorityThreadPoolExecutor newDaemonFixedPriorityThreadPool(int numThread, int queueSize,
                                                                               String poolName,
                                                                               boolean needRegisterMetric) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -164,9 +164,10 @@ public class ThreadPoolManager {
                 new BlockedPolicy(poolName, 60), poolName, needRegisterMetric);
     }
 
-    public static ThreadPoolExecutor newDaemonFixedThreadPool(int numThread, String poolName, boolean needRegisterMetric) {
+    public static ThreadPoolExecutor newDaemonFixedThreadPoolWithUnboundedQueue(int numThread, String poolName,
+                                                                                boolean needRegisterMetric) {
         return newDaemonThreadPool(numThread, numThread, KEEP_ALIVE_TIME, TimeUnit.SECONDS,
-                new LinkedBlockingQueue<>(), new BlockedPolicy(poolName, 60), poolName, needRegisterMetric);
+                new LinkedBlockingQueue<>(), new LogDiscardPolicy(poolName), poolName, needRegisterMetric);
     }
 
     public static PriorityThreadPoolExecutor newDaemonFixedPriorityThreadPool(int numThread, int queueSize,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -22,11 +22,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.connector.statistics.ConnectorColumnStatsCacheLoader;
 import com.starrocks.connector.statistics.ConnectorHistogramColumnStatsCacheLoader;
 import com.starrocks.connector.statistics.ConnectorTableColumnKey;
@@ -51,7 +51,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -59,8 +58,8 @@ import java.util.stream.Collectors;
 public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(CachedStatisticStorage.class);
 
-    private final Executor statsCacheRefresherExecutor = Executors.newFixedThreadPool(Config.statistic_cache_thread_pool_size,
-            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("stats-cache-refresher-%d").build());
+    private final Executor statsCacheRefresherExecutor =
+            ThreadPoolManager.newDaemonFixedThreadPool(Config.statistic_cache_thread_pool_size, "stats-cache-refresher", true);
 
     AsyncLoadingCache<TableStatsCacheKey, Optional<Long>> tableStatsCache =
             createAsyncLoadingCache(new TableStatsCacheLoader());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -54,12 +54,12 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-
 public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(CachedStatisticStorage.class);
 
     private final Executor statsCacheRefresherExecutor =
-            ThreadPoolManager.newDaemonFixedThreadPool(Config.statistic_cache_thread_pool_size, "stats-cache-refresher", true);
+            ThreadPoolManager.newDaemonFixedThreadPoolWithUnboundedQueue(Config.statistic_cache_thread_pool_size,
+                    "stats-cache-refresher", true);
 
     AsyncLoadingCache<TableStatsCacheKey, Optional<Long>> tableStatsCache =
             createAsyncLoadingCache(new TableStatsCacheLoader());
@@ -347,7 +347,7 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
         }
         try {
             CompletableFuture<Optional<ColumnStatistic>> result =
-                        columnStatistics.get(new ColumnStatsCacheKey(table.getId(), column));
+                    columnStatistics.get(new ColumnStatsCacheKey(table.getId(), column));
             if (Config.enable_sync_statistics_load) {
                 result.get();
             }
@@ -621,7 +621,6 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
         histogramCache.synchronous().invalidateAll(allKeys);
     }
 
-
     @Override
     public void expireConnectorHistogramStatistics(Table table, List<String> columns) {
         if (table == null || columns == null) {
@@ -676,7 +675,7 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
     }
 
     @Override
-    public void refreshMultiColumnStatistics(Long tableId,  boolean isSync) {
+    public void refreshMultiColumnStatistics(Long tableId, boolean isSync) {
         try {
             if (StatisticUtils.statisticTableBlackListCheck(tableId) ||
                     !StatisticUtils.checkStatisticTableStateNormal()) {
@@ -735,12 +734,12 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
                 .expireAfterWrite(Config.statistic_update_interval_sec * 2, TimeUnit.SECONDS)
                 .maximumSize(Config.statistic_cache_columns)
                 .executor(statsCacheRefresherExecutor);
-        
+
         // Only enable refreshAfterWrite if the config is enabled
         if (Config.enable_statistic_cache_refresh_after_write) {
             cacheBuilder.refreshAfterWrite(Config.statistic_update_interval_sec, TimeUnit.SECONDS);
         }
-        
+
         return cacheBuilder.buildAsync(cacheLoader);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Current `statsCacheRefresherExecutor` is not registered via the `ThreadPoolManager`. Therefore we can not observe metrics for this thread pool.

## What I'm doing:

Leverage the `ThreadPoolManager` to instantiate the thread pool. I added another method that allows unbounded queue size to match previous behavior.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
