### PR TITLE
[Enhancement] Store BackendStatus.lastSuccessReportTabletsTime as epoch ms and tidy TimeUtils

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
@@ -253,9 +253,9 @@ public class LoadsSystemTable {
             // Prefer the new UTC epoch-ms fields when the BE sets them - those are
             // already comparable to LoadJob.finishTimestamp (System.currentTimeMillis).
             // Fall back to parsing the legacy wall-clock string fields only when an
-            // older BE hasn't been upgraded yet; that path keeps the historical
-            // (buggy on non-Asia/Shanghai sessions) semantics rather than introducing
-            // a third interpretation.
+            // older BE hasn't been upgraded yet; parse those in the fixed cluster
+            // storage zone (+08:00) to match how the legacy BE produced them,
+            // regardless of the current session time_zone.
             filter.loadStartTimeFrom = pickTime(
                     request.isSetLoad_start_time_from_ms() ? request.getLoad_start_time_from_ms() : null,
                     request.isSetLoad_start_time_from() ? request.getLoad_start_time_from() : null);
@@ -285,7 +285,7 @@ public class LoadsSystemTable {
             if (legacyStringField == null) {
                 return null;
             }
-            long ts = TimeUtils.timeStringToLong(legacyStringField);
+            long ts = TimeUtils.timeStringToLongInStorageZone(legacyStringField);
             return ts >= 0 ? ts : null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -39,7 +39,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.gson.Gson;
 import com.starrocks.alter.DecommissionType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
@@ -193,7 +192,7 @@ public class BackendsProcDir implements ProcDirInterface {
 
             backendInfo.add(backend.getHeartbeatErrMsg());
             backendInfo.add(backend.getVersion());
-            backendInfo.add(new Gson().toJson(backend.getBackendStatus()));
+            backendInfo.add(backend.getBackendStatus().toShowBackendsJson());
 
             // data total
             long dataTotalB = backend.getDataTotalCapacityB();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -167,6 +167,18 @@ public class TimeUtils {
         return time.atZone(getSystemTimeZone().toZoneId()).toInstant().getEpochSecond();
     }
 
+    // longToTimeString / timeStringToLong come in two public flavors:
+    //
+    //   - longToTimeString(long) / timeStringToLong(String): session-zone,
+    //     for user-facing SHOW / proc / load output and SQL literals.
+    //   - timeStringToLongInStorageZone(String): parses legacy wall-clock
+    //     strings produced by older BE versions in the fixed +08:00 cluster
+    //     zone; kept only for that RPC compatibility path.
+    //
+    // The (long, DateTimeFormatter) overload remains for the rare callers
+    // that need a non-standard pattern, e.g. backup paths that encode the
+    // timestamp into a filename.
+
     public static String longToTimeString(long timeStamp, DateTimeFormatter dateFormat) {
         if (timeStamp <= 0L) {
             return FeConstants.NULL_STRING;
@@ -184,7 +196,9 @@ public class TimeUtils {
      * connected with different {@code time_zone} session variables see their own
      * local wall-clock. Switching this to a fixed zone is what regressed in #66360;
      * keep it session-zoned. Callers that need a fixed zone should build their own
-     * formatter and use {@link #longToTimeString(long, DateTimeFormatter)} instead.
+     * formatter and use {@link #longToTimeString(long, DateTimeFormatter)} instead;
+     * callers that need a round-trip should carry the epoch-ms directly rather than
+     * going through a wall-clock string at all.
      */
     public static String longToTimeString(long timeStamp) {
         // Fast-path sentinel timestamps (unset / negative) before touching the session
@@ -253,14 +267,38 @@ public class TimeUtils {
         return dateTime;
     }
 
-    public static long timeStringToLong(String timeStr) {
+    // Parses a "yyyy-MM-dd HH:mm:ss" wall-clock string, interpreting it in the
+    // given zone; returns -1 on parse failure. Shared by timeStringToLong(String)
+    // and timeStringToLongInStorageZone(String). Not exposed publicly - callers
+    // pick a public entry point based on the wire/storage contract rather than
+    // by passing a zone.
+    private static long parseTimeStringIn(String timeStr, ZoneId zoneId) {
         LocalDateTime dateTime;
         try {
             dateTime = STRING_TO_DATETIME_FORMAT.parse(timeStr).query(LocalDateTime::from);
         } catch (RuntimeException e) {
             return -1;
         }
-        return dateTime.atZone(TIME_ZONE).toInstant().toEpochMilli();
+        return dateTime.atZone(zoneId).toInstant().toEpochMilli();
+    }
+
+    /**
+     * Parses a wall-clock string in the caller's session timezone. Returns {@code -1}
+     * on parse failure. Use for USER-supplied inputs (SQL literals, request
+     * parameters).
+     */
+    public static long timeStringToLong(String timeStr) {
+        return parseTimeStringIn(timeStr, getTimeZone().toZoneId());
+    }
+
+    /**
+     * Parses legacy wall-clock strings sent by older BE versions over RPC (e.g. the
+     * {@code load_*_time} fields in {@code LoadsSystemTable}), where the producer's
+     * zone was the cluster storage zone (fixed +08:00). Returns {@code -1} on parse
+     * failure. Do NOT use for new code; carry epoch-ms directly instead.
+     */
+    public static long timeStringToLongInStorageZone(String timeStr) {
+        return parseTimeStringIn(timeStr, DEFAULT_STORAGE_ZONE);
     }
 
     // Check if the time zone_value is valid

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
@@ -27,7 +27,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.proc.BaseProcResult;
 import com.starrocks.common.util.LeaderDaemon;
-import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.persist.PartitionVersionRecoveryInfo;
@@ -300,10 +299,11 @@ public class MetaRecoveryDaemon extends LeaderDaemon {
 
     protected boolean checkTabletReportCacheUp(long timeMs) {
         for (Backend backend : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends()) {
-            if (TimeUtils.timeStringToLong(backend.getBackendStatus().lastSuccessReportTabletsTime)
-                    < timeMs) {
+            Backend.BackendStatus status = backend.getBackendStatus();
+            if (status.lastSuccessReportTabletsTimeMs < timeMs) {
                 LOG.warn("last tablet report time of backend {}:{} is {}, should wait it to report tablets",
-                        backend.getHost(), backend.getHeartbeatPort(), backend.getBackendStatus().lastSuccessReportTabletsTime);
+                        backend.getHost(), backend.getHeartbeatPort(),
+                        status.getLastSuccessReportTabletsTimeStr());
                 return false;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/BackendAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/BackendAction.java
@@ -114,7 +114,7 @@ public class BackendAction extends WebBaseAction {
             row.add(String.valueOf(backend.getBrpcPort()));
             row.add(backend.getBackendState().toString());
             row.add(TimeUtils.longToTimeString(backend.getLastStartTime()));
-            row.add(String.valueOf(backend.getBackendStatus().lastSuccessReportTabletsTime));
+            row.add(backend.getBackendStatus().getLastSuccessReportTabletsTimeStr());
             row.add(backend.getVersion());
 
             backendRows.add(row);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/BackendNodeInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/BackendNodeInfo.java
@@ -42,7 +42,7 @@ public class BackendNodeInfo extends ComputeNodeInfo {
 
     public BackendNodeInfo(Backend backend) {
         super(backend);
-        this.lastReportTabletsTime = backend.getBackendStatus().lastSuccessReportTabletsTime;
+        this.lastReportTabletsTime = backend.getBackendStatus().getLastSuccessReportTabletsTimeStr();
         this.memUsed = backend.getMemUsedBytes();
         this.memLimit = backend.getMemLimitBytes();
         this.dataUsedCapacity = backend.getDataUsedCapacityB();

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -75,7 +75,6 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.NetUtils;
-import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.datacache.DataCacheMetrics;
@@ -564,7 +563,7 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
         Backend reportBackend = currentSystemInfo.getBackend(backendId);
         if (reportBackend != null) {
             BackendStatus backendStatus = reportBackend.getBackendStatus();
-            backendStatus.lastSuccessReportTabletsTime = TimeUtils.longToTimeString(start);
+            backendStatus.lastSuccessReportTabletsTimeMs = start;
         }
 
         long cost = System.currentTimeMillis() - start;
@@ -1471,8 +1470,8 @@ public class ReportHandler extends LeaderDaemon implements MemoryTrackable {
         long maxLastSuccessReportTabletsTime = -1L;
 
         for (Backend be : backends) {
-            long lastSuccessReportTabletsTime = TimeUtils.timeStringToLong(be.getBackendStatus().lastSuccessReportTabletsTime);
-            maxLastSuccessReportTabletsTime = Math.max(maxLastSuccessReportTabletsTime, lastSuccessReportTabletsTime);
+            maxLastSuccessReportTabletsTime = Math.max(
+                    maxLastSuccessReportTabletsTime, be.getBackendStatus().lastSuccessReportTabletsTimeMs);
         }
 
         Locker locker = new Locker();

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -40,11 +40,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.DiskInfo;
 import com.starrocks.catalog.DiskInfo.DiskState;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.UpdateBackendInfo;
 import com.starrocks.persist.UpdateDiskInfo;
 import com.starrocks.server.GlobalStateMgr;
@@ -516,15 +518,50 @@ public class Backend extends ComputeNode {
     }
 
     /**
-     * Note: This class must be a POJO in order to display in JSON format
-     * Add additional information in the class to show in `show backends`
-     * if just change new added backendStatus, you can do like following
-     * BackendStatus status = Backend.getBackendStatus();
-     * status.newItem = xxx;
+     * Surfaced in the {@code Status} column of {@code SHOW BACKENDS} /
+     * {@code SHOW PROC '/backends'} via {@link #toShowBackendsJson()}. The JSON shape
+     * {@code {"lastSuccessReportTabletsTime":"yyyy-MM-dd HH:mm:ss"}} (or {@code "N/A"}
+     * when no report has happened yet) is part of the user-visible SQL contract.
+     * {@code toShowBackendsJson()} writes that shape explicitly so the storage type
+     * can stay a long without leaking into the SQL output.
+     *
+     * <p>When adding new state, extend {@code toShowBackendsJson()} alongside it -
+     * this class is never persisted (no {@code @SerializedName}) and never
+     * deserialized, so the explicit serializer is the entire contract.
      */
     public static class BackendStatus {
-        // this will be output as json, so not using FeConstants.null_string;
-        public String lastSuccessReportTabletsTime = "N/A";
+        // Epoch-millisecond timestamp of the last successful tablet report from the BE.
+        // Stored as a long so internal consumers (ReportHandler, MetaRecoveryDaemon)
+        // can compare directly without going through a wall-clock string round-trip
+        // whose result depended on the session timezone. 0 means "never reported";
+        // display code renders that as "N/A".
+        public long lastSuccessReportTabletsTimeMs = 0L;
+
+        /**
+         * Display string for {@link #lastSuccessReportTabletsTimeMs}. Renders 0 (the
+         * "never reported" sentinel) as {@code "N/A"} and any positive value as a
+         * "yyyy-MM-dd HH:mm:ss" wall-clock in the caller's session timezone.
+         * Used by the HTTP backends page, the v2 REST node-info response, and
+         * {@link #toShowBackendsJson()}.
+         */
+        public String getLastSuccessReportTabletsTimeStr() {
+            return lastSuccessReportTabletsTimeMs <= 0L
+                    ? "N/A"
+                    : TimeUtils.longToTimeString(lastSuccessReportTabletsTimeMs);
+        }
+
+        /**
+         * Renders this status as the JSON value that appears in the {@code Status}
+         * column of {@code SHOW BACKENDS} / {@code SHOW PROC '/backends'}. The shape
+         * is pinned to what the previous String-backed implementation produced, so
+         * external tooling that parses the documented JSON keeps working after the
+         * storage type was switched to a long.
+         */
+        public String toShowBackendsJson() {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("lastSuccessReportTabletsTime", getLastSuccessReportTabletsTimeStr());
+            return obj.toString();
+        }
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/TimeUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/TimeUtilsTest.java
@@ -301,6 +301,34 @@ public class TimeUtilsTest {
     }
 
     @Test
+    public void testTimeStringToLongHonorsSessionTimeZone() {
+        new MockUp<TimeUtils>() {
+            @Mock
+            public TimeZone getTimeZone() {
+                return TimeZone.getTimeZone(ZoneOffset.UTC);
+            }
+        };
+        // "2015-03-12 02:00:00" interpreted as UTC -> 1426125600000L
+        Assertions.assertEquals(1426125600000L, TimeUtils.timeStringToLong("2015-03-12 02:00:00"));
+    }
+
+    @Test
+    public void testTimeStringToLongInStorageZoneParsesAsShanghai() {
+        // Parses a legacy wall-clock string as fixed +08:00, independent of any
+        // mocked session timezone. This is the only remaining use case after
+        // BackendStatus stopped round-tripping through a wall-clock string.
+        new MockUp<TimeUtils>() {
+            @Mock
+            public TimeZone getTimeZone() {
+                return TimeZone.getTimeZone(ZoneOffset.UTC);
+            }
+        };
+        // "2015-03-12 10:00:00" interpreted as +08:00 -> 1426125600000L
+        Assertions.assertEquals(1426125600000L,
+                TimeUtils.timeStringToLongInStorageZone("2015-03-12 10:00:00"));
+    }
+
+    @Test
     public void testGetCurrentFormatTimeUsesFixedShanghaiTimeZone() {
         // Pin Instant.now() so the assertion is deterministic; do not rely on wall-clock
         // tolerance windows. Setting the JVM default to UTC simultaneously guards

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/MetaRecoveryDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/MetaRecoveryDaemonTest.java
@@ -23,7 +23,6 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.proc.BaseProcResult;
-import com.starrocks.common.util.TimeUtils;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
@@ -93,8 +92,7 @@ public class MetaRecoveryDaemonTest {
         partition.getDefaultPhysicalPartition().setNextVersion(2L);
 
         for (Backend backend : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends()) {
-            backend.getBackendStatus().lastSuccessReportTabletsTime = TimeUtils
-                    .longToTimeString(System.currentTimeMillis());
+            backend.getBackendStatus().lastSuccessReportTabletsTimeMs = System.currentTimeMillis();
         }
 
         // add a committed txn
@@ -180,8 +178,7 @@ public class MetaRecoveryDaemonTest {
         long timeMs = System.currentTimeMillis();
         MetaRecoveryDaemon metaRecoveryDaemon = new MetaRecoveryDaemon();
         for (Backend backend : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends()) {
-            backend.getBackendStatus().lastSuccessReportTabletsTime = TimeUtils
-                    .longToTimeString(timeMs);
+            backend.getBackendStatus().lastSuccessReportTabletsTimeMs = timeMs;
         }
         Assertions.assertFalse(metaRecoveryDaemon.checkTabletReportCacheUp(timeMs + 1000L));
         Assertions.assertTrue(metaRecoveryDaemon.checkTabletReportCacheUp(timeMs - 1000L));

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -30,7 +30,6 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -413,7 +412,7 @@ public class ReportHandlerTest {
         final SystemInfoService currentSystemInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
         Backend reportBackend = currentSystemInfo.getBackend(10001);
         BackendStatus backendStatus = reportBackend.getBackendStatus();
-        backendStatus.lastSuccessReportTabletsTime = TimeUtils.longToTimeString(Long.MAX_VALUE);
+        backendStatus.lastSuccessReportTabletsTimeMs = Long.MAX_VALUE;
 
         ReportHandler.handleMigration(tabletMetaMigrationMap, 10001);
 

--- a/fe/fe-core/src/test/java/com/starrocks/system/BackendTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/BackendTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.system;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -74,5 +76,35 @@ public class BackendTest {
         BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 1, 64);
         Assertions.assertEquals(64, BackendResourceStat.getInstance().getAvgNumCoresOfBe());
         Assertions.assertEquals(16, BackendResourceStat.getInstance().getSinkDefaultDOP(DEFAULT_WAREHOUSE_ID));
+    }
+
+    @Test
+    public void backendStatusJsonPreservesShowBackendsContract() {
+        // SHOW BACKENDS / SHOW PROC '/backends' surfaces BackendStatus as a JSON
+        // string in the "Status" column. The documented shape is
+        //   {"lastSuccessReportTabletsTime":"<formatted>"} or "N/A" sentinel
+        // independent of how the timestamp is stored internally. Assertions are
+        // structural via JsonParser so a future change to Gson's whitespace or
+        // key ordering does not falsely fail this test - what matters is the
+        // key name, value type, and sentinel.
+        Backend.BackendStatus neverReported = new Backend.BackendStatus();
+        JsonObject neverReportedJson =
+                JsonParser.parseString(neverReported.toShowBackendsJson()).getAsJsonObject();
+        Assertions.assertEquals("N/A",
+                neverReportedJson.get("lastSuccessReportTabletsTime").getAsString());
+
+        Backend.BackendStatus reported = new Backend.BackendStatus();
+        // 2015-03-12 10:00:00 +08:00 -> 1426125600000L
+        reported.lastSuccessReportTabletsTimeMs = 1426125600000L;
+        JsonObject reportedJson =
+                JsonParser.parseString(reported.toShowBackendsJson()).getAsJsonObject();
+        Assertions.assertTrue(reportedJson.has("lastSuccessReportTabletsTime"),
+                "JSON key must remain the documented name");
+        // Don't pin the exact wall-clock - it follows the caller's session
+        // timezone via TimeUtils.longToTimeString(long). What matters for the
+        // SQL-surface contract is that the value is a JSON string, not a number.
+        Assertions.assertTrue(
+                reportedJson.get("lastSuccessReportTabletsTime").getAsJsonPrimitive().isString(),
+                "JSON value must be a string, not a number");
     }
 }


### PR DESCRIPTION
The prior round-trip kept the timestamp as a "yyyy-MM-dd HH:mm:ss" string and re-parsed it back to a long inside ReportHandler / MetaRecoveryDaemon. With longToTimeString(long) being session-zoned, the parse side needed a separate fixed-zone helper so the cycle did not depend on the default session time_zone. The wall-clock was a useless intermediate; the field is in-memory only (no @SerializedName) so no persistence-compat concern blocks switching the storage type.

Rename BackendStatus.lastSuccessReportTabletsTime -> lastSuccessReportTabletsTimeMs and store it as a long epoch-ms (0 means "never reported"). Internal callers compare the long directly; display sites route through a single
BackendStatus.getLastSuccessReportTabletsTimeStr() accessor that renders 0 as "N/A".

The SHOW BACKENDS contract is preserved. BackendStatus only escapes the FE into the "Status" column of SHOW BACKENDS / SHOW PROC '/backends' - it is never persisted - so the previous default-Gson serialization is replaced with an explicit
BackendStatus.toShowBackendsJson() that writes the documented shape {"lastSuccessReportTabletsTime":"<formatted>"} directly. BackendsProcDir calls it in place of `new Gson().toJson(...)`.

Tidy up on TimeUtils:

  - longToTimeStringInStorageZone(long) had only this one caller; remove it.
  - timeStringToLongInStorageZone(String) stays for LoadsSystemTable.pickTime, which still parses legacy wall-clock strings produced by older BE versions over RPC; clarify the javadoc to say that is its only remaining use.
  - longToTimeString(long) retains its fast-path for non-positive sentinels and reuses the pre-parsed DATETIME_TO_STRING_FORMAT .withZone(...) to avoid pattern reparse on the SHOW / proc hot path.
  - Collapse the parse-with-zone logic into a private helper; the public parse surface is just timeStringToLong(String) and timeStringToLongInStorageZone(String).

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
