### PR TITLE
fix(be): correctly read cgroupsv2 memory limit

### DIFF
--- a/be/src/common/system/mem_info.cpp
+++ b/be/src/common/system/mem_info.cpp
@@ -163,10 +163,29 @@ void MemInfo::set_memlimit_if_container() {
                 StringParser::string_to_int<int64_t>(limit_in_bytes_str.data(), limit_in_bytes_str.size(), &result);
     } else if (fs.f_type == CGROUP2_SUPER_MAGIC) {
         // cgroup v2
-        // Read from /sys/fs/cgroup/memory/memory.max
+        std::string cgroup_info;
+        std::string cgroup_path = "";
+        if (FileUtil::read_whole_content("/proc/self/cgroup", cgroup_info)) {
+            std::vector<std::string> lines = strings::Split(cgroup_info, "\n", strings::SkipEmpty());
+            for (const auto& line : lines) {
+                std::vector<std::string> fields = strings::Split(line, ":");
+                if (fields.size() == 3 && fields[0] == "0" && fields[1].empty()) {
+                    cgroup_path = fields[2];
+                    break;
+                }
+            }
+        }
+
         std::string memory_max;
-        if (!FileUtil::read_whole_content("/sys/fs/cgroup/memory.max", memory_max) &&
-            !FileUtil::read_whole_content("/sys/fs/cgroup/kubepods/memory.max", memory_max)) {
+        bool read_success = false;
+        if (!cgroup_path.empty()) {
+            read_success = FileUtil::read_whole_content("/sys/fs/cgroup" + cgroup_path + "/memory.max", memory_max);
+        }
+        if (!read_success) {
+            read_success = FileUtil::read_whole_content("/sys/fs/cgroup/memory.max", memory_max);
+        }
+
+        if (!read_success) {
             LOG(WARNING) << "Fail to get mem info from cgroup2fs";
             return;
         }


### PR DESCRIPTION
## Why I'm doing:

BE/CN does not correctly detect cgroupsv2

## What I'm doing:

Fixes #73727

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Not sure of a good way to test this!

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Don't know what backports make sense!