### PR TITLE
[BugFix] Fix FlatJson crash when subwriters without any appends

### DIFF
--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -947,6 +947,14 @@ Status StringColumnWriter::finish() {
         if (!st.ok()) {
             return st;
         }
+    } else {
+        // No append ever ran, so the deferred speculate-and-set-encoding in
+        // append() never ran either and the inner ScalarColumnWriter still has
+        // _encoding_info == nullptr. ScalarColumnWriter::finish() dereferences
+        // _encoding_info unconditionally, so install a default encoding here
+        // before forwarding. DEFAULT_ENCODING resolves to the type's default
+        // inside EncodingInfo::get().
+        RETURN_IF_ERROR(_scalar_column_writer->set_encoding(DEFAULT_ENCODING));
     }
 
     return _scalar_column_writer->finish();
@@ -1103,6 +1111,11 @@ Status DictColumnWriter::finish() {
         if (!st.ok()) {
             return st;
         }
+    } else {
+        // Same deferred-encoding hazard as StringColumnWriter::finish(): with
+        // zero appends the inner ScalarColumnWriter has _encoding_info ==
+        // nullptr, and its finish() would deref it.
+        RETURN_IF_ERROR(_scalar_column_writer->set_encoding(DEFAULT_ENCODING));
     }
 
     return _scalar_column_writer->finish();

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -147,7 +147,10 @@ Status FlatJsonColumnWriter::_flat_column(MutableColumns& json_datas) {
         }
         RETURN_IF_ERROR(_write_flat_column());
         _flat_columns.clear();
-        col->resize_uninitialized(0); // release after write
+    }
+    // fallback when all flat columns written
+    for (auto& col : json_datas) {
+        col->resize_uninitialized(0);
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/failpoint/fail_point.h"
 #include "column/column.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
@@ -48,6 +49,8 @@
 #include "velocypack/vpack.h"
 
 namespace starrocks {
+
+DEFINE_FAIL_POINT(flat_json_write_column_fail);
 
 FlatJsonColumnWriter::FlatJsonColumnWriter(const ColumnWriterOptions& opts, TypeInfoPtr type_info, WritableFile* wfile,
                                            std::unique_ptr<ObjectColumnWriter> json_writer)
@@ -235,6 +238,11 @@ Status FlatJsonColumnWriter::_write_flat_column() {
     DCHECK(!_flat_columns.empty());
     DCHECK_EQ(_flat_columns.size(), _flat_writers.size());
 
+    // Inject failure between _init_flat_writers() and the per-column append loop.
+    // Exercises the FlatJsonColumnWriter::finish() fallback path that still iterates
+    // _flat_writers[i]->finish() even when no sub-writer has received any append().
+    FAIL_POINT_TRIGGER_RETURN_ERROR(flat_json_write_column_fail);
+
     // IMPORTANT: Final integrity check before writing to prevent  inconsistency
     for (const auto& flat_col : _flat_columns) {
         flat_col->check_or_die();
@@ -272,6 +280,26 @@ Status FlatJsonColumnWriter::finish() {
         for (auto& col : _json_datas) {
             RETURN_IF_ERROR(_json_writer->append(*col));
         }
+        // _flat_column() may have run partway: _init_flat_writers() can have
+        // created sub-writers and stamped is_flat=true plus per-sub-column
+        // children into _json_meta before _write_flat_column() failed. The
+        // column data now belongs entirely to _json_writer, so undo the flat
+        // metadata and drop the half-populated sub-writers. The invariant
+        // checked downstream by get_next_rowid()/write_data()/write_*_index()
+        // is _flat_writers.empty() iff !_is_flat, and a stale is_flat=true
+        // would also mislead the reader into looking for flat sub-columns
+        // that do not exist on disk.
+        _flat_writers.clear();
+        _flat_paths.clear();
+        _flat_types.clear();
+        _flat_columns.clear();
+        _subcolumn_dict_valid.clear();
+        _has_remain = false;
+        _remain_filter.reset();
+        _json_meta->clear_children_columns();
+        _json_meta->mutable_json_meta()->set_is_flat(false);
+        _json_meta->mutable_json_meta()->set_has_remain(false);
+        _json_meta->mutable_json_meta()->clear_remain_filter();
     }
     _json_datas.clear(); // release after write
 

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -740,4 +740,25 @@ TEST_F(ColumnReaderWriterTest, test_large_varchar_column_writer) {
     }
 }
 
+// Reproduces SIGSEGV at offset 0x44 in ScalarColumnWriter::finish() when a
+// VARCHAR/CHAR column writer is finalized without any append. String columns
+// set need_speculate_encoding = true, so ScalarColumnWriter::init() skips
+// set_encoding() and _encoding_info stays nullptr. StringColumnWriter::finish()
+// only fixes that up if _buf_column != nullptr (i.e. at least one append
+// happened). With no appends, _encoding_info->encoding() dereferences nullptr
+// and reads _encoding at offset 0x44.
+TEST_F(ColumnReaderWriterTest, test_string_writer_finish_without_append) {
+    const std::string fname = TEST_DIR + "/" + generate_uuid_string() + ".data";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(fname));
+    ColumnMetaPB meta;
+    ColumnWriterOptions writer_opts = make_writer_opts<TYPE_VARCHAR, DEFAULT_ENCODING, 2>(&meta);
+
+    TabletColumn column = create_varchar_key(1, true, 128);
+    ASSIGN_OR_ABORT(auto writer, ColumnWriter::create(writer_opts, &column, wfile.get()));
+    ASSERT_OK(writer->init());
+
+    // No writer->append(...) call here.
+    ASSERT_OK(writer->finish());
+}
+
 } // namespace starrocks

--- a/test/sql/test_semi/R/test_flat_json_write_fail
+++ b/test/sql/test_semi/R/test_flat_json_write_fail
@@ -1,0 +1,45 @@
+-- name: test_flat_json_write_fail @system @sequential
+CREATE TABLE `js1` (
+  `k1` bigint(20) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+admin enable failpoint 'flat_json_write_column_fail';
+-- result:
+-- !result
+[UC] insert into js1 values
+  (1, parse_json('{"k1": "v11", "k2": "v12", "k3": "v13", "k4": "v14"}')),
+  (2, parse_json('{"k1": "v21", "k2": "v22", "k3": "v23", "k4": "v24"}')),
+  (3, parse_json('{"k1": "v31", "k2": "v32", "k3": "v33", "k4": "v34"}')),
+  (4, parse_json('{"k1": "v41", "k2": "v42", "k3": "v43", "k4": "v44"}')),
+  (5, parse_json('{"k1": "v51", "k2": "v52", "k3": "v53", "k4": "v54"}')),
+  (6, parse_json('{"k1": "v61", "k2": "v62", "k3": "v63", "k4": "v64"}')),
+  (7, parse_json('{"k1": "v71", "k2": "v72", "k3": "v73", "k4": "v74"}')),
+  (8, parse_json('{"k1": "v81", "k2": "v82", "k3": "v83", "k4": "v84"}'));
+admin disable failpoint 'flat_json_write_column_fail';
+-- result:
+-- !result
+select count(*) from js1;
+-- result:
+8
+-- !result
+insert into js1 values (9, parse_json('{"k1": "v91", "k2": "v92", "k3": "v93", "k4": "v94"}'));
+-- result:
+-- !result
+select count(*) from js1;
+-- result:
+9
+-- !result
+drop table js1;
+-- result:
+-- !result
+CLEANUP {
+  admin disable failpoint 'flat_json_write_column_fail';
+} END CLEANUP

--- a/test/sql/test_semi/T/test_flat_json_write_fail
+++ b/test/sql/test_semi/T/test_flat_json_write_fail
@@ -1,0 +1,56 @@
+-- name: test_flat_json_write_fail @system @sequential
+
+-- Regression for SIGSEGV @0x44 in starrocks::ScalarColumnWriter::finish() from
+-- FlatJsonColumnWriter::finish() -> _flat_writers[i]->finish().
+--
+-- For VARCHAR sub-columns ColumnWriter::create() sets need_speculate_encoding=true,
+-- so ScalarColumnWriter::init() leaves _encoding_info as nullptr until the first
+-- append() drives the deferred speculate-and-set-encoding. When the flat-json
+-- write path fails after _init_flat_writers() created the sub-writers but before
+-- they receive any append, FlatJsonColumnWriter::finish() falls back to the
+-- non-flat _json_writer and then unconditionally iterates _flat_writers[i]->finish(),
+-- crashing on the un-appended VARCHAR sub-writers.
+--
+-- The failpoint 'flat_json_write_column_fail' simulates that production path
+-- (e.g. a string > olap_string_max_length tripping check_string_lengths()).
+
+CREATE TABLE `js1` (
+  `k1` bigint(20) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+
+admin enable failpoint 'flat_json_write_column_fail';
+
+-- Insert enough rows with consistent JSON keys for the flat-json deriver to
+-- pick at least one VARCHAR path. Without the fix this insert kills BE during
+-- memtable flush; with the fix it returns a normal error and BE stays up.
+[UC] insert into js1 values
+  (1, parse_json('{"k1": "v11", "k2": "v12", "k3": "v13", "k4": "v14"}')),
+  (2, parse_json('{"k1": "v21", "k2": "v22", "k3": "v23", "k4": "v24"}')),
+  (3, parse_json('{"k1": "v31", "k2": "v32", "k3": "v33", "k4": "v34"}')),
+  (4, parse_json('{"k1": "v41", "k2": "v42", "k3": "v43", "k4": "v44"}')),
+  (5, parse_json('{"k1": "v51", "k2": "v52", "k3": "v53", "k4": "v54"}')),
+  (6, parse_json('{"k1": "v61", "k2": "v62", "k3": "v63", "k4": "v64"}')),
+  (7, parse_json('{"k1": "v71", "k2": "v72", "k3": "v73", "k4": "v74"}')),
+  (8, parse_json('{"k1": "v81", "k2": "v82", "k3": "v83", "k4": "v84"}'));
+
+admin disable failpoint 'flat_json_write_column_fail';
+
+-- BE must still be serving queries after the failed flush.
+select count(*) from js1;
+
+-- And subsequent inserts must work normally.
+insert into js1 values (9, parse_json('{"k1": "v91", "k2": "v92", "k3": "v93", "k4": "v94"}'));
+select count(*) from js1;
+
+drop table js1;
+
+CLEANUP {
+  admin disable failpoint 'flat_json_write_column_fail';
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

```
Built on a system without sched_getcpu() support. Performance may be impacted.UNKNOWN ASAN (build UNKNOWN distro ubuntu arch x86_64)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000, plan_node_id:-1
*** Aborted at 1779437749 (unix time) try "date -d @1779437749" if you are using GNU date ***
PC: @         0x27e1fd41 starrocks::EncodingInfo::encoding() const
*** SIGSEGV (@0x44) received by PID 1483892 (TID 0x7f7b48e0a640) LWP(1484188) from PID 68; stack trace: ***
    @         0x318016c7 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f7bd1373ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x31800ec6 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f7bd131c520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @         0x27e1fd41 starrocks::EncodingInfo::encoding() const
    @         0x27e3e1f0 starrocks::ScalarColumnWriter::finish()
    @         0x27e45059 starrocks::StringColumnWriter::finish()
    @         0x27df5291 starrocks::FlatJsonColumnWriter::finish()
    @         0x2811d2da starrocks::SegmentWriter::finalize_columns(unsigned long*)
    @         0x2811c92d starrocks::SegmentWriter::finalize(unsigned long*, unsigned long*, unsigned long*)
    @         0x2969e369 starrocks::HorizontalRowsetWriter::_flush_segment_writer(std::unique_ptr<starrocks::SegmentWriter, std::default_delete<starrocks::SegmentWriter> >*, starrocks::SegmentPB*)
    @         0x29692d09 starrocks::HorizontalRowsetWriter::_flush_chunk(starrocks::Chunk const&, starrocks::SegmentPB*)
    @         0x29692941 starrocks::HorizontalRowsetWriter::flush_chunk(starrocks::Chunk const&, starrocks::SegmentPB*)
    @         0x2886bf87 starrocks::MemTableRowsetWriterSink::flush_chunk(starrocks::Chunk const&, starrocks::SegmentPB*, bool, long*, long)
    @         0x28991a8e starrocks::MemTable::flush(starrocks::SegmentPB*, bool, long*, long)
    @         0x2627cb7c starrocks::FlushToken::_flush_memtable(starrocks::MemTable*, starrocks::SegmentPB*, bool, long*, long)
    @         0x2627f4f6 starrocks::MemtableFlushTask::run()
    @         0x2d088c71 starrocks::ThreadPool::dispatch_thread()
    @         0x2d0a9eca void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2d0a8868 std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2d0a72dc void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x2d0a5938 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x2d0a3bbe void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @         0x2d0a14c1 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool:@
    @         0x2d09cd57 std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
    @         0x1c82f8f4 std::function<void ()>::operator()() const
    @         0x2d06eb39 starrocks::Thread::supervise_thread(void*)
    @         0x1c6ce616 asan_thread_start(void*)
    @     0x7f7bd136eac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f7bd14008d0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1268cf)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
