### PR TITLE
[Doc] Add Japanese to docs/AGENTS.md

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -107,7 +107,7 @@ Place images in `_assets/` and reference:
 
 1. Create doc in appropriate directory
 2. Add to sidebar in `docusaurus/sidebars.js`
-3. Add English, Chinese, and Japanese versions
+3. Add English and Chinese versions; add Japanese version when applicable
 
 ### For Bug Fixes
 
@@ -117,10 +117,10 @@ Place images in `_assets/` and reference:
 
 ### Translation
 
-When updating English docs, update Chinese and Japanese docs too (or vice versa):
-- `docs/en/path/to/file.md`
-- `docs/ja/path/to/file.md`
-- `docs/zh/path/to/file.md`
+When updating English docs, update Chinese docs too (or vice versa). Update Japanese docs when a corresponding `docs/ja/` page exists or when explicitly requested:
+- `docs/en/path/to/file.md` (required)
+- `docs/zh/path/to/file.md` (required)
+- `docs/ja/path/to/file.md` (when applicable)
 
 ## Sidebar Configuration
 
@@ -148,7 +148,7 @@ module.exports = {
 1. Create `docs/en/category/new-page.md`
 2. Add to `sidebars.js`
 3. Create Chinese version `docs/zh/category/new-page.md`
-4. Create Japanese version `docs/ja/category/new-page.md`
+4. Create Japanese version `docs/ja/category/new-page.md` (when applicable)
 
 ### Update Existing Page
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-StarRocks documentation is built using Docusaurus and hosted at https://docs.starrocks.io/. Documentation is available in both English and Chinese.
+StarRocks documentation is built using Docusaurus and hosted at https://docs.starrocks.io/. Documentation is available in English, Chinese, and Japanese.
 
 Read [`handbook/index.md`](../handbook/index.md) first for repo-wide routing, then use the docs domain map in [`handbook/domains/docs-and-translation.md`](../handbook/domains/docs-and-translation.md) for handbook-vs-public-docs boundaries.
 
@@ -24,6 +24,7 @@ docs/
 │   ├── reference/         # Reference docs (SQL, config)
 │   ├── sql-reference/     # SQL reference
 │   └── using_starrocks/   # User guides
+├── ja/                    # Japanese documentation (mirrors en/)
 ├── zh/                    # Chinese documentation (mirrors en/)
 ├── docusaurus/            # Docusaurus build config
 │   ├── docusaurus.config.js
@@ -106,7 +107,7 @@ Place images in `_assets/` and reference:
 
 1. Create doc in appropriate directory
 2. Add to sidebar in `docusaurus/sidebars.js`
-3. Add both English and Chinese versions
+3. Add English, Chinese, and Japanese versions
 
 ### For Bug Fixes
 
@@ -116,8 +117,9 @@ Place images in `_assets/` and reference:
 
 ### Translation
 
-When updating English docs, update Chinese docs too (or vice versa):
+When updating English docs, update Chinese and Japanese docs too (or vice versa):
 - `docs/en/path/to/file.md`
+- `docs/ja/path/to/file.md`
 - `docs/zh/path/to/file.md`
 
 ## Sidebar Configuration
@@ -146,11 +148,12 @@ module.exports = {
 1. Create `docs/en/category/new-page.md`
 2. Add to `sidebars.js`
 3. Create Chinese version `docs/zh/category/new-page.md`
+4. Create Japanese version `docs/ja/category/new-page.md`
 
 ### Update Existing Page
 
 1. Edit the markdown file
-2. Update both language versions if needed
+2. Update all language versions if needed
 3. Verify links still work
 
 ### Add Code Example

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Before contributing, please read this article carefully to quickly understand th
 
 ## Tips
 
-1. Language: Please use at least one language, Chinese or English. The bilingual version is highly preferred.
+1. Language: Please use at least one language, Chinese, English, or Japanese. Adding/Updating all three language files is highly preferred.
 2. Index: When you add a topic, you also need to add an entry for the topic in the `sidebars.json` file of the `docs/docusaurus` folder. **The path to your topic must be a relative path from the `docs` folder.** This `sidebars.json` file will eventually be rendered as the side navigation bar for documentation on our official website. If you are not sure how to edit this file, you can leave this work to the documentation team.
 3. Images: Images must first be put into the **assets** folder. When inserting images into the documentation, please use the relative path, such as `![test image](../../assets/test.png)`.
 4. Links: For internal links (links to documentation on our official website), please use the relative path of the document, such as `[test md](./data_source/catalog/hive_catalog.md)`. For external links,  the format must be `[link text](link URL)`.
@@ -20,7 +20,7 @@ Before contributing, please read this article carefully to quickly understand th
     > - *Because the documentation is written in Markdown, we recommend that you use markdown-lint to check whether the documentation conforms to the Markdown syntax.*
     > - *When adding the topic index, please pay attention to* *its category* *in the `sidebars.json` file. For example, the ***Stream Load*** topic belongs to the **Loading** chapter.*
 
-2. **Submission phase**: Create a pull request to submit the documentation changes to our documentation repository on GitHub, English documentation is in the `docs/en` folder of the [StarRocks repository](https://github.com/StarRocks/starrocks) and Chinese documentation is in the `docs/zh` folder.
+2. **Submission phase**: Create a pull request to submit the documentation changes to our documentation repository on GitHub, English documentation is in the `docs/en` folder of the [StarRocks repository](https://github.com/StarRocks/starrocks), Chinese documentation is in the `docs/zh` folder, and Japanese is in `docs/ja` folder.
 
    > **Note**
    >

--- a/handbook/domains/docs-and-translation.md
+++ b/handbook/domains/docs-and-translation.md
@@ -20,7 +20,7 @@ Map the boundary between internal engineering knowledge in `handbook/` and publi
 
 - Product behavior, deployment, SQL semantics, and config docs belong in `docs/`, not `handbook/`.
 - Repo operations, architecture notes, policies, and execution plans belong in `handbook/`, not `docs/`.
-- User-facing config or metric changes should update both English and Chinese docs when applicable.
+- User-facing config or metric changes should update English, Japanese, and Chinese docs when applicable.
 
 ## Test and Validation
 


### PR DESCRIPTION
Updates the documentation contributor/agent guidance in docs/AGENTS.md to recognize Japanese (docs/ja) as an additional documentation locale alongside English and Chinese.

Changes:

Update the overview text to state docs are available in English, Chinese, and Japanese.
Add docs/ja/ to the documented directory structure.
Update contribution/translation steps to include Japanese alongside English/Chinese.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
