### PR TITLE
[Enhancement] enable ms precision for information_schema.loads

### DIFF
--- a/be/src/exec/schema_scanner/schema_column_filler.h
+++ b/be/src/exec/schema_scanner/schema_column_filler.h
@@ -36,13 +36,10 @@ void fill_data_column_with_slot(Column* data_column, void* slot) {
         result->append(date_value);
     } else if constexpr (IsTimestamp<ValueType>) {
         auto* date_time_value = (DateTimeValue*)slot;
-        // Microseconds are dropped here. TimestampValue::create has a default
-        // microsecond=0 7th parameter; pass date_time_value->microsecond() to
-        // preserve it. Today's callers all populate DateTimeValue at second
-        // precision, so this is a no-op for them.
         TimestampValue timestamp_value =
                 TimestampValue::create(date_time_value->year(), date_time_value->month(), date_time_value->day(),
-                                       date_time_value->hour(), date_time_value->minute(), date_time_value->second());
+                                       date_time_value->hour(), date_time_value->minute(), date_time_value->second(),
+                                       date_time_value->microsecond());
         result->append(timestamp_value);
     } else {
         result->append(*(ValueType*)slot);

--- a/be/src/exec/schema_scanner/schema_column_filler.h
+++ b/be/src/exec/schema_scanner/schema_column_filler.h
@@ -36,10 +36,9 @@ void fill_data_column_with_slot(Column* data_column, void* slot) {
         result->append(date_value);
     } else if constexpr (IsTimestamp<ValueType>) {
         auto* date_time_value = (DateTimeValue*)slot;
-        TimestampValue timestamp_value =
-                TimestampValue::create(date_time_value->year(), date_time_value->month(), date_time_value->day(),
-                                       date_time_value->hour(), date_time_value->minute(), date_time_value->second(),
-                                       date_time_value->microsecond());
+        TimestampValue timestamp_value = TimestampValue::create(
+                date_time_value->year(), date_time_value->month(), date_time_value->day(), date_time_value->hour(),
+                date_time_value->minute(), date_time_value->second(), date_time_value->microsecond());
         result->append(timestamp_value);
     } else {
         result->append(*(ValueType*)slot);

--- a/be/src/exec/schema_scanner/schema_loads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_loads_scanner.cpp
@@ -64,7 +64,7 @@ bool _extract_literal_datetime_value(Expr* expr, const cctz::time_zone& session_
     // the literal is carried through to FE so the prefilter matches BE's
     // ms-precision materialized column.
     result.epoch_ms = SchemaLoadsScanner::literal_to_epoch_ms(
-                             session_tz, cctz::civil_second(year, month, day, hour, minute, second), is_lower_bound) +
+                              session_tz, cctz::civil_second(year, month, day, hour, minute, second), is_lower_bound) +
                       usec / 1000;
 
     return true;

--- a/be/src/exec/schema_scanner/schema_loads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_loads_scanner.cpp
@@ -60,11 +60,12 @@ bool _extract_literal_datetime_value(Expr* expr, const cctz::time_zone& session_
     result.str_value = ts.to_string(true);
     int year, month, day, hour, minute, second, usec;
     ts.to_timestamp(&year, &month, &day, &hour, &minute, &second, &usec);
-    // Second precision; see literal_to_epoch_ms for the contract and DST
-    // handling. To enable ms support, also propagate `usec` into the result.
-    (void)usec;
+    // See literal_to_epoch_ms for the DST contract; the sub-second part of
+    // the literal is carried through to FE so the prefilter matches BE's
+    // ms-precision materialized column.
     result.epoch_ms = SchemaLoadsScanner::literal_to_epoch_ms(
-            session_tz, cctz::civil_second(year, month, day, hour, minute, second), is_lower_bound);
+                             session_tz, cctz::civil_second(year, month, day, hour, minute, second), is_lower_bound) +
+                      usec / 1000;
 
     return true;
 }
@@ -203,8 +204,8 @@ int64_t SchemaLoadsScanner::literal_to_epoch_ms(const cctz::time_zone& session_t
     // session_tz, so this prefilter must be no-false-negative against the
     // post-filter. Picking min/max(pre, post) widens for both DST cases.
     //
-    // Returns second-aligned ms. To enable ms support, also propagate `usec`
-    // from _extract_literal_datetime_value.
+    // Returns second-aligned ms; the caller adds the sub-second remainder
+    // from the literal.
     const auto lookup = session_tz.lookup(cs);
     const auto tp = is_lower_bound ? std::min(lookup.pre, lookup.post) : std::max(lookup.pre, lookup.post);
     return tp.time_since_epoch().count() * 1000;
@@ -221,10 +222,7 @@ bool SchemaLoadsScanner::_fill_datetime_column_from_ms(Column* column, bool is_s
         return true;
     }
     DateTimeValue t;
-    // Second precision: the column filler at schema_column_filler.h strips
-    // microseconds regardless. To enable ms support, use the (s, us, tz)
-    // overload here AND pass microsecond() through in the column filler.
-    t.from_unixtime(epoch_ms / 1000, _runtime_state->timezone_obj());
+    t.from_unixtime(epoch_ms / 1000, (epoch_ms % 1000) * 1000, _runtime_state->timezone_obj());
     fill_column_with_slot<TYPE_DATETIME>(column, (void*)&t);
     return true;
 }

--- a/be/src/exec/schema_scanner/schema_loads_scanner.h
+++ b/be/src/exec/schema_scanner/schema_loads_scanner.h
@@ -35,9 +35,9 @@ public:
     Status get_next(ChunkPtr* chunk, bool* eos) override;
 
     // Convert a session-zone DATETIME literal (extracted from a predicate) to
-    // the UTC epoch ms FE compares against. Returns a second-aligned value
-    // (information_schema.loads is second-precision today); for DST-ambiguous
-    // civil times the result widens the bound via min/max of
+    // the UTC epoch ms FE compares against. Returns a second-aligned value;
+    // the caller adds the sub-second remainder from the literal. For
+    // DST-ambiguous civil times the result widens the bound via min/max of
     // cctz::civil_lookup.pre/post so the FE prefilter never drops a row that
     // BE's post-filter would have kept. Public so the anonymous-namespace
     // predicate-extraction helper and the unit test can call it.

--- a/be/test/exec/schema_loads_scanner_test.cpp
+++ b/be/test/exec/schema_loads_scanner_test.cpp
@@ -156,12 +156,11 @@ TEST_F(SchemaLoadsScannerTest, ms_field_materializes_in_session_zone) {
     }
 }
 
-// information_schema.loads is a second-precision view (the legacy "YYYY-MM-DD
-// HH:MM:SS" wire format never carried fractional seconds, and the column
-// filler at schema_column_filler.h drops microseconds when building a
-// TimestampValue). Pin that the materialized column truncates to whole
-// seconds regardless of any ms remainder in the wire payload.
-TEST_F(SchemaLoadsScannerTest, ms_field_is_truncated_to_second_precision) {
+// information_schema.loads now carries sub-second precision: the column filler
+// preserves microseconds and the materialization path passes them through via
+// from_unixtime(s, us, tz). Pin that the rendered column retains the ms
+// remainder from the wire payload.
+TEST_F(SchemaLoadsScannerTest, ms_field_preserves_sub_second_remainder) {
     SchemaLoadsScanner scanner;
     init_scanner(scanner, "UTC");
 
@@ -177,9 +176,8 @@ TEST_F(SchemaLoadsScannerTest, ms_field_is_truncated_to_second_precision) {
     EXPECT_OK(scanner.get_next(&chunk, &eos));
 
     auto ts = read_datetime(chunk, CREATE_TIME);
-    // Wall-clock rendered at second precision; microsecond field is zero.
     EXPECT_EQ("2026-05-15 06:45:08", ts.to_string(/*ignore_microsecond=*/true));
-    EXPECT_EQ(std::string::npos, ts.to_string(/*ignore_microsecond=*/false).find("789"))
+    EXPECT_NE(std::string::npos, ts.to_string(/*ignore_microsecond=*/false).find("789"))
             << "rendered: " << ts.to_string(false);
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
@@ -205,16 +205,10 @@ public class LoadsSystemTable {
         if (value == null || value < 0) {
             return true;
         }
-        // Truncate the full-ms job timestamp to second so this prefilter
-        // matches BE's second-precision materialized column. Otherwise a job
-        // at e.g. ...:08.789 with a `<= ...:08` upper bound is dropped here
-        // but kept by BE's post-filter on the rendered column. To enable ms
-        // support, drop the truncation (the wire carries full ms).
-        long secondAlignedValue = (value / 1000) * 1000;
-        if (lowerBound != null && secondAlignedValue < lowerBound) {
+        if (lowerBound != null && value < lowerBound) {
             return false;
         }
-        return upperBound == null || secondAlignedValue <= upperBound;
+        return upperBound == null || value <= upperBound;
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/LoadsSystemTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/LoadsSystemTableTest.java
@@ -422,21 +422,22 @@ public class LoadsSystemTableTest {
     }
 
     /**
-     * Phase-5 second-precision contract: the BE pushdown literal is second-
-     * aligned (see SchemaLoadsScanner::literal_to_epoch_ms) and BE materializes
-     * the column at second precision, so FE must compare its full-ms job
-     * timestamp at second precision too. A job finishing at the literal second
-     * with a non-zero ms remainder must pass an at-anchor `<=` upper bound,
-     * matching what BE's post-filter on the materialized column would do.
+     * Ms-precision contract: the BE pushdown literal carries sub-second from
+     * the predicate (here zero - `2026-05-15 02:45:08` has usec=0), and FE
+     * compares the full-ms job timestamp directly. A job at the same rendered
+     * second but with a non-zero ms remainder is strictly greater than the
+     * second-aligned `<=` upper bound and must be dropped by the FE prefilter,
+     * matching how BE's post-filter on the ms-precision materialized column
+     * would evaluate `08.789 <= '08'`.
      */
     @Test
-    public void testQuery_secondPrecisionContractFiltersJobMsRemainder(
+    public void testQuery_msPrecisionDropsJobsAfterRenderedSecond(
             @Mocked GlobalStateMgr globalStateMgr,
             @Mocked LoadMgr loadMgr,
             @Mocked StreamLoadMgr streamLoadMgr,
             @Mocked LoadJob jobAtBoundary) {
         long anchorMs = epochMillis("2026-05-15 02:45:08", ZoneId.of("America/New_York"));
-        long jobMsWithRemainder = anchorMs + 789; // same rendered second as the bound
+        long jobMsWithRemainder = anchorMs + 789; // strictly later than the second-aligned bound
 
         new Expectations() {
             {
@@ -474,14 +475,13 @@ public class LoadsSystemTableTest {
         };
 
         TGetLoadsParams req = new TGetLoadsParams();
-        req.setLoad_finish_time_to_ms(anchorMs); // second-aligned bound
+        req.setLoad_finish_time_to_ms(anchorMs); // second-aligned upper bound
 
         TGetLoadsResult result = LoadsSystemTable.query(req);
 
-        // Without phase-5 truncation, the raw-ms compare `anchorMs+789 <= anchorMs`
-        // is false and the row is dropped - even though BE's post-filter on the
-        // second-precision materialized column would have kept it.
-        assertEquals(1, labels(result).size());
-        assertTrue(labels(result).contains("jobAtBoundary"));
+        // anchorMs+789 > anchorMs, so the row fails `value <= upper` at the
+        // FE prefilter; BE post-filter on the ms-precision column would also
+        // reject it.
+        assertEquals(0, labels(result).size());
     }
 }


### PR DESCRIPTION
The previous PR (#73365) carried full ms on the FE-BE thrift wire but truncated to second at every consumer for backward compatibility. Now that wire/data layout is stable, flip the four staged consumer sites to ms precision so the predicate semantics match a regular DATETIME column.

User-visible behavior change for information_schema.loads:
- DATETIME columns now display sub-second when present, e.g. '2026-05-15 06:45:08.789'.
- Predicates that compare against a second-precision literal now respect the sub-second part of the column. Existing exact-equality queries like `WHERE load_finish_time = '...:08'` will stop matching jobs with non-zero ms remainders; range filters are unaffected.

LoadsHistorySyncer is unaffected: its `loads_history.load_finish_time` column is plain DATETIME (second precision), so the destination caps at second on INSERT regardless of upstream precision.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
