### PR TITLE
[Enhancement] Apply group-by min-max to Iceberg dict-encoded keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
@@ -133,6 +133,54 @@ public class ApplyMinMaxStatisticRule implements TreeRewriteRule {
             }
         }
 
+        // Iceberg scans — dict-only branch. After low-cardinality rewrite the varchar
+        // group-by becomes TYPE_INT with codes in [1, dictSize]; the runtime contract is
+        // enforced by GlobalDictNotMatch retry on the BE side. globalDicts is only
+        // populated for parquet scans (gated in DecodeCollector.visitPhysicalIcebergScan),
+        // so non-parquet falls through naturally via the containsKey check below.
+        List<PhysicalScanOperator> icebergScans = Lists.newArrayList();
+        Utils.extractOperator(root, icebergScans,
+                op -> OperatorType.PHYSICAL_ICEBERG_SCAN.equals(op.getOpType()));
+        for (PhysicalScanOperator scan : icebergScans) {
+            PhysicalIcebergScanOperator iceberg = (PhysicalIcebergScanOperator) scan;
+            IcebergTable table = (IcebergTable) iceberg.getTable();
+
+            final Map<Integer, ColumnDict> globalDicts =
+                    iceberg.getGlobalDicts().stream().collect(Collectors.toMap(p -> p.first, p -> p.second));
+
+            if (iceberg.getProjection() != null) {
+                for (var entry : iceberg.getProjection().getColumnRefMap().entrySet()) {
+                    if (groupByRefSets.contains(entry.getKey()) &&
+                            entry.getValue() instanceof DictMappingOperator mappingOperator) {
+                        ColumnRefOperator column = mappingOperator.getDictColumn();
+                        if (!column.getType().isNumericType() && !column.getType().isDate()) {
+                            continue;
+                        }
+                        if (globalDicts.containsKey(column.getId())) {
+                            final ConstantOperator min = ConstantOperator.createVarchar("0");
+                            final ColumnDict columnDict = globalDicts.get(column.getId());
+                            final ConstantOperator max = ConstantOperator.createVarchar("" + columnDict.getDictSize());
+                            infos.put(entry.getKey().getId(), new Pair<>(min, max));
+                        }
+                    }
+                }
+            }
+            for (ColumnRefOperator column : iceberg.getColRefToColumnMetaMap().keySet()) {
+                if (!groupByRefSets.contains(column.getId())) {
+                    continue;
+                }
+                if (!column.getType().isNumericType() && !column.getType().isDate()) {
+                    continue;
+                }
+                if (globalDicts.containsKey(column.getId())) {
+                    final ConstantOperator min = ConstantOperator.createVarchar("0");
+                    final ColumnDict columnDict = globalDicts.get(column.getId());
+                    final ConstantOperator max = ConstantOperator.createVarchar("" + columnDict.getDictSize());
+                    infos.put(column.getId(), new Pair<>(min, max));
+                }
+            }
+        }
+
         for (PhysicalHashAggregateOperator agg : aggLists) {
             List<Pair<ConstantOperator, ConstantOperator>> groupByMinMaxStats = Lists.newArrayList();
             for (ColumnRefOperator groupBy : agg.getGroupBys()) {


### PR DESCRIPTION
## Why I'm doing:

After low-cardinality rewrite, an Iceberg parquet `GROUP BY` on a varchar+global-dict column becomes a `TYPE_INT` `GROUP BY` with codes in `[1, dictSize]`. The OLAP equivalent of the same query goes through `ApplyMinMaxStatisticRule`'s dict branch, gets `(0, dictSize)` as min/max, and the BE Aggregator compressed-key path (#61632) selects `phase1_slice_cx1` instead of the default `phase1_int32` phmap. The Iceberg version stays on `phase1_int32` because the rule only collects `PHYSICAL_OLAP_SCAN` nodes — leaving the same logical query running through structurally different hash-maps depending on table source.

## What I'm doing:

Mirror the OLAP dict branch for `PHYSICAL_ICEBERG_SCAN` nodes in `ApplyMinMaxStatisticRule`:
- pick up Iceberg scans alongside OLAP ones;
- gate on parquet format (same as `DecodeCollector.visitPhysicalIcebergScan`);
- read `scan.getGlobalDicts()` already populated by `DecodeRewriter` and emit `(0, dictSize)` for dict-encoded group-by columns.

Downstream path is unchanged from OLAP: stats flow through `PlanFragmentBuilder` → `TAggregationNode.group_by_min_max` → BE `_try_to_apply_compressed_key_opt` → `slice_cx1` (and `int32_range_uint8` once #73642 lands).

Numeric/date stats via `IMinMaxStatsMgr.icebergInstance()` are out of scope — that requires snapshot-versioning decisions.

Fixes #73741

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4