### PR TITLE
[Refactor] Move generic Java runtime helpers to RuntimeEnv

### DIFF
--- a/be/src/exec/hdfs_scanner/jni_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/jni_scanner.cpp
@@ -24,14 +24,14 @@
 #include "fmt/core.h"
 #include "fs/credential/cloud_configuration_factory.h"
 #include "runtime/descriptors_ext.h"
+#include "runtime/env/java/java_runtime.h"
 #include "runtime/runtime_state.h"
-#include "udf/java/java_udf.h"
 
 namespace starrocks {
 
 Status JniScanner::_check_jni_exception(JNIEnv* env, const std::string& message) {
     if (jthrowable thr = env->ExceptionOccurred(); thr) {
-        std::string jni_error_message = JVMFunctionHelper::getInstance().dumpExceptionString(thr);
+        std::string jni_error_message = JavaRuntime::getInstance().dump_exception_string(thr);
         env->ExceptionDescribe();
         env->ExceptionClear();
         env->DeleteLocalRef(thr);
@@ -47,7 +47,7 @@ Status JniScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams&
 
 Status JniScanner::do_open(RuntimeState* state) {
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     RETURN_IF_ERROR(update_jni_scanner_params());
     if (env->EnsureLocalCapacity(_jni_scanner_params.size() * 2 + 6) < 0) {
         RETURN_IF_ERROR(_check_jni_exception(env, "Failed to ensure the local capacity."));
@@ -61,7 +61,7 @@ Status JniScanner::do_open(RuntimeState* state) {
 
 void JniScanner::do_close(RuntimeState* runtime_state) noexcept {
     if (_jni_scanner_obj != nullptr) {
-        JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+        JNIEnv* env = JavaRuntime::getInstance().getEnv();
         if (_jni_scanner_close != nullptr) {
             env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_close);
         }
@@ -69,7 +69,7 @@ void JniScanner::do_close(RuntimeState* runtime_state) noexcept {
         _jni_scanner_obj = nullptr;
     }
     if (_jni_scanner_cls != nullptr) {
-        JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+        JNIEnv* env = JavaRuntime::getInstance().getEnv();
         env->DeleteLocalRef(_jni_scanner_cls);
         _jni_scanner_cls = nullptr;
     }
@@ -396,7 +396,7 @@ Status JniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
 }
 
 StatusOr<size_t> JniScanner::fill_empty_chunk(ChunkPtr* chunk) {
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     long chunk_meta;
     RETURN_IF_ERROR(_get_next_chunk(env, &chunk_meta));
     reset_chunk_meta(chunk_meta);

--- a/be/src/exec/jdbc_scanner.cpp
+++ b/be/src/exec/jdbc_scanner.cpp
@@ -29,6 +29,7 @@
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/expr_executor.h"
+#include "runtime/env/java/java_runtime.h"
 #include "runtime/runtime_state.h"
 #include "types/logical_type.h"
 #include "types/type_descriptor.h"
@@ -38,7 +39,7 @@ namespace starrocks {
 
 #define CHECK_JAVA_EXCEPTION(env, error_message)                                        \
     if (jthrowable thr = env->ExceptionOccurred(); thr) {                               \
-        std::string err = JVMFunctionHelper::getInstance().dumpExceptionString(thr);    \
+        std::string err = JavaRuntime::getInstance().dump_exception_string(thr);        \
         env->ExceptionClear();                                                          \
         env->DeleteLocalRef(thr);                                                       \
         return Status::InternalError(fmt::format("{}, error: {}", error_message, err)); \
@@ -83,8 +84,7 @@ Status JDBCScanner::close(RuntimeState* state) {
 
 Status JDBCScanner::_init_jdbc_bridge() {
     // 1. construct JDBCBridge
-    auto& h = JVMFunctionHelper::getInstance();
-    auto* env = h.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     auto jdbc_bridge_cls = env->FindClass(JDBC_BRIDGE_CLASS_NAME);
     DCHECK(jdbc_bridge_cls != nullptr);
@@ -107,7 +107,7 @@ Status JDBCScanner::_init_jdbc_bridge() {
 
 Status JDBCScanner::_init_jdbc_scan_context(RuntimeState* state) {
     // scan
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     jclass scan_context_cls = env->FindClass(JDBC_SCAN_CONTEXT_CLASS_NAME);
     DCHECK(scan_context_cls != nullptr);
@@ -190,7 +190,7 @@ Status JDBCScanner::_init_jdbc_scan_context(RuntimeState* state) {
 }
 
 Status JDBCScanner::_init_jdbc_scanner() {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     jmethodID get_scanner =
             env->GetMethodID(_jdbc_bridge_cls->clazz(), "getScanner",
@@ -242,7 +242,7 @@ StatusOr<LogicalType> JDBCScanner::_precheck_data_type(const std::string& java_c
 }
 
 Status JDBCScanner::_init_column_class_name(RuntimeState* state) {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     jmethodID get_result_column_class_names =
             env->GetMethodID(_jdbc_scanner_cls->clazz(), "getResultColumnClassNames", "()Ljava/util/List;");
@@ -252,7 +252,6 @@ Status JDBCScanner::_init_column_class_name(RuntimeState* state) {
     CHECK_JAVA_EXCEPTION(env, "get JDBC result column class name failed")
     LOCAL_REF_GUARD_ENV(env, column_class_names);
 
-    auto& helper = JVMFunctionHelper::getInstance();
     JavaListStub list_stub(column_class_names);
     ASSIGN_OR_RETURN(int len, list_stub.size());
 
@@ -260,7 +259,7 @@ Status JDBCScanner::_init_column_class_name(RuntimeState* state) {
     for (int i = 0; i < len; i++) {
         ASSIGN_OR_RETURN(jobject jelement, list_stub.get(i));
         LOCAL_REF_GUARD_ENV(env, jelement);
-        std::string class_name = helper.to_string((jstring)(jelement));
+        std::string class_name = JavaRuntime::getInstance().to_string((jstring)(jelement));
         ASSIGN_OR_RETURN(auto ret_type, _precheck_data_type(class_name, _slot_descs[i]));
         _column_class_names.emplace_back(class_name);
         _result_column_types.emplace_back(ret_type);
@@ -292,7 +291,7 @@ Status JDBCScanner::_init_column_class_name(RuntimeState* state) {
 }
 
 Status JDBCScanner::_init_jdbc_util() {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     // init JDBCUtil method
     auto jdbc_util_cls = env->FindClass(JDBC_UTIL_CLASS_NAME);
@@ -310,7 +309,7 @@ Status JDBCScanner::_init_jdbc_util() {
 }
 
 Status JDBCScanner::_has_next(bool* result) {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     jboolean ret = env->CallBooleanMethod(_jdbc_scanner.handle(), _scanner_has_next);
     CHECK_JAVA_EXCEPTION(env, "call JDBCScanner hasNext failed")
     *result = ret;
@@ -318,7 +317,7 @@ Status JDBCScanner::_has_next(bool* result) {
 }
 
 Status JDBCScanner::_get_next_chunk(jobject* chunk, size_t* num_rows) {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     SCOPED_TIMER(_profile.io_timer);
     COUNTER_UPDATE(_profile.io_counter, 1);
     *chunk = env->CallObjectMethod(_jdbc_scanner.handle(), _scanner_get_next_chunk);
@@ -329,7 +328,7 @@ Status JDBCScanner::_get_next_chunk(jobject* chunk, size_t* num_rows) {
 }
 
 Status JDBCScanner::_close_jdbc_scanner() {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     if (_jdbc_scanner.handle() == nullptr) {
         return Status::OK();
     }
@@ -350,7 +349,7 @@ Status JDBCScanner::_fill_chunk(jobject jchunk, size_t num_rows, ChunkPtr* chunk
     // get result from JNI
     {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
         JavaListStub list_stub(jchunk);
         COUNTER_UPDATE(_profile.rows_read_counter, num_rows);
         (*chunk)->reset();

--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -99,7 +99,7 @@ static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_udaf_shared_contex
     // for input boxing, writeResult for output drain); slots without STRUCT are stored
     // as null-handle entries and the existing fast paths run unchanged.
     {
-        JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+        JNIEnv* env = JavaRuntime::getInstance().getEnv();
         // UDAF `update(State, sql_args...)` — SQL args start at parameter index 1. The
         // method itself returns void, so suppress the helper's return-type pass by
         // passing a default-constructed (TYPE_UNKNOWN) sql_return_type — otherwise the
@@ -129,7 +129,7 @@ static Status build_udaf_unique_context(std::shared_ptr<JavaUDAFSharedContext> u
     ASSIGN_OR_RETURN(agg_ctx->handle, agg_ctx->ctx->udaf_class.newInstance());
 
     // Create a per-aggregator AggBatchCallStub with the shared stub class/method cloned as new global refs
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     JVMClass stub_clazz(env->NewGlobalRef(agg_ctx->ctx->update_stub_clazz.clazz()));
     jobject stub_method = env->NewGlobalRef(agg_ctx->ctx->update_stub_method.handle());
     agg_ctx->update_batch_call_stub = std::make_unique<AggBatchCallStub>(

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -118,7 +118,7 @@ public:
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t batch_size,
                                      MutableColumnPtr& dst) const final {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         // 1 convert input as state
         // 1.1 create state list
@@ -162,14 +162,14 @@ public:
 
         int length = env->GetArrayLength(serialize_szs);
         std::vector<int> slice_sz(length);
-        helper.getEnv()->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
+        JavaRuntime::getInstance().getEnv()->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
         int totalLength = std::accumulate(slice_sz.begin(), slice_sz.end(), 0, [](auto l, auto r) { return l + r; });
         // 4 prepare serialize buffer
         udf_ctxs->buffer_data.resize(totalLength);
         udf_ctxs->buffer =
                 std::make_unique<DirectByteBuffer>(udf_ctxs->buffer_data.data(), udf_ctxs->buffer_data.size());
         // chunk size
-        auto buffer_array = helper.create_object_array(udf_ctxs->buffer->handle(), batch_size);
+        auto buffer_array = JavaRuntime::getInstance().create_object_array(udf_ctxs->buffer->handle(), batch_size);
         RETURN_IF_UNLIKELY_NULL(buffer_array, (void)0);
         LOCAL_REF_GUARD_ENV(env, buffer_array);
         jobject state_and_buffer[2] = {rets, buffer_array};
@@ -232,8 +232,8 @@ public:
         DCHECK(udf_ctxs != nullptr);
         std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
-        helper.getEnv()->PushLocalFrame(num_cols * 3 + 1);
-        auto defer = DeferOp([&helper]() { helper.getEnv()->PopLocalFrame(nullptr); });
+        JavaRuntime::getInstance().getEnv()->PushLocalFrame(num_cols * 3 + 1);
+        auto defer = DeferOp([]() { JavaRuntime::getInstance().getEnv()->PopLocalFrame(nullptr); });
 
         {
             auto states_arr = JavaDataTypeConverter::convert_to_states(ctx, states, state_offset, batch_size);
@@ -250,12 +250,13 @@ public:
 
     void update_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
                                   AggDataPtr* states, const Filter& filter) const override {
-        auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
+        auto& helper = JVMFunctionHelper::getInstance();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         DCHECK(udf_ctxs != nullptr);
         std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
-        helper.getEnv()->PushLocalFrame(num_cols * 3 + 1);
+        JavaRuntime::getInstance().getEnv()->PushLocalFrame(num_cols * 3 + 1);
         auto defer = DeferOp([env = env]() { env->PopLocalFrame(nullptr); });
         {
             auto states_arr = JavaDataTypeConverter::convert_to_states_with_filter(ctx, states, state_offset,
@@ -276,7 +277,7 @@ public:
         auto& helper = JVMFunctionHelper::getInstance();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         DCHECK(udf_ctxs != nullptr);
-        auto* env = helper.getEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
         std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
         env->PushLocalFrame(num_cols * 3 + 1);
@@ -299,7 +300,7 @@ public:
     void _merge_batch_process(FunctionContext* ctx, StatesProvider&& states_provider, MergeCaller&& caller,
                               const Column* column, size_t start, size_t size) const {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
         // get state lists
         auto state_array = states_provider();
         RETURN_IF_UNLIKELY_NULL(state_array, (void)0);
@@ -328,7 +329,7 @@ public:
                      AggDataPtr* states) const override {
         // batch merge
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         DCHECK(udf_ctxs != nullptr);
 
@@ -372,12 +373,12 @@ public:
         auto& helper = JVMFunctionHelper::getInstance();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         DCHECK(udf_ctxs != nullptr);
-        auto* env = helper.getEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
         auto provider = [&]() {
             auto state_handle = reinterpret_cast<JavaUDAFState*>(state)->handle;
             auto res = helper.convert_handle_to_jobject(ctx, state_handle);
             LOCAL_REF_GUARD_ENV(env, res);
-            return helper.create_object_array(res, size);
+            return JavaRuntime::getInstance().create_object_array(res, size);
         };
         auto merger = [&](jobject state_array, jobject buffer_array) {
             jobject state_and_buffer[2] = {state_array, buffer_array};
@@ -390,7 +391,7 @@ public:
     void batch_serialize(FunctionContext* ctx, size_t batch_size, const Buffer<AggDataPtr>& agg_states,
                          size_t state_offset, Column* to) const override {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
         auto* udf_ctxs = get_java_udaf_context(ctx);
 
         const size_t origin_chunk_size = to->size();
@@ -420,7 +421,7 @@ public:
 
         int length = env->GetArrayLength(serialize_szs);
         std::vector<int> slice_sz(length);
-        helper.getEnv()->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
+        JavaRuntime::getInstance().getEnv()->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
         int totalLength = std::accumulate(slice_sz.begin(), slice_sz.end(), 0, [](auto l, auto r) { return l + r; });
         // step 3 prepare serialize buffer
         udf_ctxs->buffer_data.resize(totalLength);
@@ -428,7 +429,7 @@ public:
                 std::make_unique<DirectByteBuffer>(udf_ctxs->buffer_data.data(), udf_ctxs->buffer_data.size());
 
         // step 4 call serialize
-        auto buffer_array = helper.create_object_array(udf_ctxs->buffer->handle(), batch_size);
+        auto buffer_array = JavaRuntime::getInstance().create_object_array(udf_ctxs->buffer->handle(), batch_size);
         LOCAL_REF_GUARD_ENV(env, buffer_array);
         jobject state_and_buffer[2] = {state_array, buffer_array};
         helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->serialize->method.handle(),
@@ -446,7 +447,7 @@ public:
     void batch_finalize(FunctionContext* ctx, size_t batch_size, const Buffer<AggDataPtr>& agg_states,
                         size_t state_offset, Column* to) const override {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
         auto* udf_ctxs = get_java_udaf_context(ctx);
 
         const size_t origin_chunk_size = to->size();

--- a/be/src/exprs/agg/java_window_function.cpp
+++ b/be/src/exprs/agg/java_window_function.cpp
@@ -78,7 +78,7 @@ static Status build_window_unique_context(std::shared_ptr<JavaUDAFSharedContext>
     ASSIGN_OR_RETURN(udaf_ctx->handle, udaf_ctx->ctx->udaf_class.newInstance());
 
     // Create a new FunctionStates instance; clone method refs from the shared context.
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     auto& state_clazz = JVMFunctionHelper::getInstance().function_state_clazz();
     ASSIGN_OR_RETURN(auto instance, state_clazz.newInstance());
     udaf_ctx->states = std::make_unique<UDAFStateList>(

--- a/be/src/exprs/agg/java_window_function.h
+++ b/be/src/exprs/agg/java_window_function.h
@@ -52,8 +52,7 @@ public:
         }
 
         std::vector<jobject> args;
-        auto& helper = JVMFunctionHelper::getInstance();
-        JNIEnv* env = helper.getEnv();
+        JNIEnv* env = JavaRuntime::getInstance().getEnv();
         DeferOp defer = DeferOp([&]() {
             // clean up arrays
             for (auto& arg : args) {
@@ -78,12 +77,11 @@ public:
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
-        auto& helper = JVMFunctionHelper::getInstance();
         auto* udaf_ctx = get_java_udaf_context(ctx);
         DCHECK(udaf_ctx != nullptr);
         jvalue val = udaf_ctx->_func->finalize(this->data(state).handle);
         // insert values to column
-        JNIEnv* env = helper.getEnv();
+        JNIEnv* env = JavaRuntime::getInstance().getEnv();
         const auto& return_type = ctx->get_return_type();
         const bool error_if_overflow = ctx->error_if_overflow();
         int sz = end - start;

--- a/be/src/exprs/java_function_call_expr.cpp
+++ b/be/src/exprs/java_function_call_expr.cpp
@@ -50,7 +50,7 @@ struct UDFFunctionCallHelper {
 
     StatusOr<ColumnPtr> call(FunctionContext* ctx, Columns& columns, size_t size) {
         auto& helper = JVMFunctionHelper::getInstance();
-        JNIEnv* env = helper.getEnv();
+        JNIEnv* env = JavaRuntime::getInstance().getEnv();
         int num_cols = ctx->get_num_args();
         std::vector<const Column*> input_cols;
 
@@ -216,8 +216,7 @@ StatusOr<std::shared_ptr<JavaUDFContext>> JavaFunctionCallExpr::_build_udf_func_
     // UdfTypeDesc tree is the single source of type info shared with both the input
     // boxing path (via JNI field accessors) and the unified Java writeResult helper.
     {
-        auto& helper = JVMFunctionHelper::getInstance();
-        JNIEnv* env = helper.getEnv();
+        JNIEnv* env = JavaRuntime::getInstance().getEnv();
         std::vector<TypeDescriptor> sql_arg_types;
         sql_arg_types.reserve(_children.size());
         for (const auto& child : _children) {

--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -121,7 +121,7 @@ Status JavaUDTFState::open() {
     // per-row element type, so pass `unwrap_return_array_layer=true` to drop the array
     // layer off the reflective formal type before pairing it with `_ret_type`.
     {
-        JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+        JNIEnv* env = JavaRuntime::getInstance().getEnv();
         ASSIGN_OR_RETURN(_process_type_descs,
                          build_method_udf_type_descs(env, _process->method.handle(), _arg_type_descs, _ret_type,
                                                      /*state_offset=*/0, /*unwrap_return_array_layer=*/true));
@@ -175,8 +175,7 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
     const Columns& cols = state->get_columns();
     auto* stateUDTF = down_cast<JavaUDTFState*>(state);
 
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     jmethodID methodID = env->GetMethodID(stateUDTF->get_udtf_clazz(), stateUDTF->method_process()->name.c_str(),
                                           stateUDTF->method_process()->signature.c_str());
@@ -227,10 +226,11 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
 
         rets[i] = env->CallObjectMethodA(stateUDTF->handle(), methodID, call_stack.data());
 
-        if (auto jthr = helper.getEnv()->ExceptionOccurred(); jthr != nullptr) {
-            std::string err = fmt::format("execute UDF Function meet Exception:{}", helper.dumpExceptionString(jthr));
+        if (auto jthr = JavaRuntime::getInstance().getEnv()->ExceptionOccurred(); jthr != nullptr) {
+            std::string err = fmt::format("execute UDF Function meet Exception:{}",
+                                          JavaRuntime::getInstance().dump_exception_string(jthr));
             LOG(WARNING) << err;
-            helper.getEnv()->ExceptionClear();
+            JavaRuntime::getInstance().getEnv()->ExceptionClear();
             state->set_status(Status::InternalError(err));
             return std::make_pair(Columns{}, nullptr);
         }
@@ -269,10 +269,11 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
     res.emplace_back(std::move(col));
 
     // TODO: add error msg to Function State
-    if (auto jthr = helper.getEnv()->ExceptionOccurred(); jthr != nullptr) {
-        std::string err = fmt::format("execute UDF Function meet Exception:{}", helper.dumpExceptionString(jthr));
+    if (auto jthr = JavaRuntime::getInstance().getEnv()->ExceptionOccurred(); jthr != nullptr) {
+        std::string err = fmt::format("execute UDF Function meet Exception:{}",
+                                      JavaRuntime::getInstance().dump_exception_string(jthr));
         LOG(WARNING) << err;
-        helper.getEnv()->ExceptionClear();
+        JavaRuntime::getInstance().getEnv()->ExceptionClear();
     }
 
     return std::make_pair(std::move(res), std::move(offsets_col));

--- a/be/src/fs/hdfs/hdfs_fs_cache.cpp
+++ b/be/src/fs/hdfs/hdfs_fs_cache.cpp
@@ -19,7 +19,7 @@
 #include "common/config_hdfs_fwd.h"
 #include "fs/fs_options_helper.h"
 #include "gutil/strings/substitute.h"
-#include "udf/java/java_udf.h"
+#include "runtime/env/java/java_runtime.h"
 #include "util/hdfs_util.h"
 
 namespace starrocks {

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -68,6 +68,7 @@ set(RUNTIME_ENV_FILES
     env/global_env.cpp
     env/global_thread_pools.cpp
     env/java/java_env.cpp
+    env/java/java_runtime.cpp
 )
 
 ADD_BE_LIB(RuntimeEnv

--- a/be/src/runtime/env/java/java_runtime.cpp
+++ b/be/src/runtime/env/java/java_runtime.cpp
@@ -225,6 +225,22 @@ jobjectArray JavaRuntime::create_object_array(jobject* elements, int size) {
     return res;
 }
 
+jobjectArray JavaRuntime::create_object_2d_array(jobject* elements, int size) {
+    auto* env = getEnv();
+    auto res = env->NewObjectArray(size, _object_array_class, nullptr);
+    if (_check_exception("create_object_2d_array: NewObjectArray failed")) {
+        return nullptr;
+    }
+    for (int i = 0; i < size; ++i) {
+        env->SetObjectArrayElement(res, i, elements[i]);
+        if (_check_exception("create_object_2d_array: SetObjectArrayElement failed")) {
+            env->DeleteLocalRef(res);
+            return nullptr;
+        }
+    }
+    return res;
+}
+
 std::string JavaRuntime::to_jni_class_name(const std::string& name) {
     std::string res = name;
     for (auto& c : res) {

--- a/be/src/runtime/env/java/java_runtime.cpp
+++ b/be/src/runtime/env/java/java_runtime.cpp
@@ -1,0 +1,246 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/env/java/java_runtime.h"
+
+#include <bthread/bthread.h>
+
+#include <cstdlib>
+#include <future>
+#include <utility>
+
+#include "base/logging.h"
+#include "common/thread/priority_thread_pool.hpp"
+#include "fmt/core.h"
+#include "runtime/env/global_env.h"
+#include "runtime/env/java/java_env.h"
+
+namespace starrocks {
+namespace {
+
+class ScopedLocalRef {
+public:
+    ScopedLocalRef(JNIEnv* env, jobject ref) : _env(env), _ref(ref) {}
+    ~ScopedLocalRef() {
+        if (_ref != nullptr) {
+            _env->DeleteLocalRef(_ref);
+        }
+    }
+
+    ScopedLocalRef(const ScopedLocalRef&) = delete;
+    ScopedLocalRef& operator=(const ScopedLocalRef&) = delete;
+
+private:
+    JNIEnv* _env;
+    jobject _ref;
+};
+
+Status check_java_runtime_on_current_thread() {
+    if (getJNIEnv() == nullptr) {
+        return Status::RuntimeError("couldn't get JNIEnv, please check your java runtime");
+    }
+    return Status::OK();
+}
+
+Status check_java_runtime_in_pthread() {
+    if (!bthread_self()) {
+        return check_java_runtime_on_current_thread();
+    }
+
+    auto* pool = GlobalEnv::GetInstance()->jvm_call_pool();
+    if (pool == nullptr) {
+        return Status::RuntimeError("jvm_call_pool is not initialized");
+    }
+
+    std::promise<Status> promise;
+    auto future = promise.get_future();
+    if (!pool->offer([&promise]() { promise.set_value(check_java_runtime_on_current_thread()); })) {
+        return Status::RuntimeError("failed to submit JVM runtime detection to jvm_call_pool");
+    }
+    return future.get();
+}
+
+} // namespace
+
+JavaRuntime& JavaRuntime::getInstance() {
+    static JavaRuntime runtime;
+    return runtime;
+}
+
+JavaRuntime::JavaRuntime() {
+    _object_class = _find_global_class("java/lang/Object");
+    _object_array_class = _find_global_class("[Ljava/lang/Object;");
+    _arrays_class = _find_global_class("java/util/Arrays");
+    _exception_util_class = _find_global_class("org/apache/commons/lang3/exception/ExceptionUtils");
+
+    _arrays_to_string =
+            getEnv()->GetStaticMethodID(_arrays_class, "toString", "([Ljava/lang/Object;)Ljava/lang/String;");
+    CHECK(_arrays_to_string != nullptr);
+    _exception_get_stack_trace = getEnv()->GetStaticMethodID(_exception_util_class, "getStackTrace",
+                                                             "(Ljava/lang/Throwable;)Ljava/lang/String;");
+    CHECK(_exception_get_stack_trace != nullptr);
+}
+
+JNIEnv* JavaRuntime::getEnv() {
+    if (_env == nullptr) {
+        _env = getJNIEnv();
+        CHECK(_env != nullptr) << "couldn't get a JNIEnv";
+    }
+    return _env;
+}
+
+jclass JavaRuntime::_find_global_class(const char* name) {
+    JNIEnv* env = getEnv();
+    jclass local_clazz = env->FindClass(name);
+    CHECK(local_clazz != nullptr) << "not found class " << name << " plz check JDK and jni-packages";
+    ScopedLocalRef local_guard(env, local_clazz);
+    auto global_clazz = static_cast<jclass>(env->NewGlobalRef(local_clazz));
+    CHECK(global_clazz != nullptr) << "failed to create global class ref for " << name;
+    return global_clazz;
+}
+
+bool JavaRuntime::_check_exception(const std::string& message) {
+    JNIEnv* env = getEnv();
+    if (jthrowable throwable = env->ExceptionOccurred()) {
+        ScopedLocalRef throwable_guard(env, throwable);
+        std::string details = dump_exception_string(throwable);
+        LOG(WARNING) << message << "," << details;
+        env->ExceptionClear();
+        return true;
+    }
+    return false;
+}
+
+std::string JavaRuntime::array_to_string(jobject object) {
+    JNIEnv* env = getEnv();
+    env->ExceptionClear();
+    jobject jstr = env->CallStaticObjectMethod(_arrays_class, _arrays_to_string, object);
+    ScopedLocalRef jstr_guard(env, jstr);
+    if (_check_exception("Exception happened when call array_to_string")) {
+        return "";
+    }
+    return to_cxx_string(static_cast<jstring>(jstr));
+}
+
+std::string JavaRuntime::to_string(jobject obj) {
+    JNIEnv* env = getEnv();
+    env->ExceptionClear();
+    jobject res = env->CallObjectMethod(obj, get_to_string_method(_object_class));
+    ScopedLocalRef res_guard(env, res);
+    if (_check_exception("Exception happened when call to_string")) {
+        return "";
+    }
+    return to_cxx_string(static_cast<jstring>(res));
+}
+
+std::string JavaRuntime::to_cxx_string(jstring str) {
+    if (str == nullptr) {
+        return "<null>";
+    }
+    JNIEnv* env = getEnv();
+    const char* chars = env->GetStringUTFChars(str, nullptr);
+    if (chars == nullptr) {
+        env->ExceptionClear();
+        return "";
+    }
+    std::string res = chars;
+    env->ReleaseStringUTFChars(str, chars);
+    return res;
+}
+
+std::string JavaRuntime::dump_exception_string(jthrowable throwable) {
+    JNIEnv* env = getEnv();
+    jobject stack_traces = env->CallStaticObjectMethod(_exception_util_class, _exception_get_stack_trace,
+                                                       static_cast<jobject>(throwable));
+    ScopedLocalRef stack_traces_guard(env, stack_traces);
+    // Avoid recursive exception reporting through this helper.
+    env->ExceptionClear();
+    return to_cxx_string(static_cast<jstring>(stack_traces));
+}
+
+jmethodID JavaRuntime::get_to_string_method(jclass clazz) {
+    return getEnv()->GetMethodID(clazz, "toString", "()Ljava/lang/String;");
+}
+
+StatusOr<jstring> JavaRuntime::to_jstring(const std::string& str) {
+    auto* env = getEnv();
+    auto res = env->NewStringUTF(str.c_str());
+    if (res == nullptr) {
+        env->ExceptionClear();
+        return Status::InternalError(fmt::format("NewStringUTF failed for: {}", str));
+    }
+    return res;
+}
+
+jmethodID JavaRuntime::get_method(jclass clazz, const std::string& method, const std::string& sig) {
+    return getEnv()->GetMethodID(clazz, method.c_str(), sig.c_str());
+}
+
+jmethodID JavaRuntime::get_static_method(jclass clazz, const std::string& method, const std::string& sig) {
+    return getEnv()->GetStaticMethodID(clazz, method.c_str(), sig.c_str());
+}
+
+jobjectArray JavaRuntime::create_object_array(int size) {
+    auto* env = getEnv();
+    auto res = env->NewObjectArray(size, _object_class, nullptr);
+    if (_check_exception("create_object_array: NewObjectArray failed")) {
+        return nullptr;
+    }
+    return res;
+}
+
+jobjectArray JavaRuntime::create_object_array(jobject fill, int size) {
+    auto* env = getEnv();
+    auto res = env->NewObjectArray(size, _object_class, fill);
+    if (_check_exception("create_object_array: NewObjectArray failed")) {
+        return nullptr;
+    }
+    return res;
+}
+
+jobjectArray JavaRuntime::create_object_array(jobject* elements, int size) {
+    auto* env = getEnv();
+    auto res = env->NewObjectArray(size, _object_class, nullptr);
+    if (_check_exception("create_object_array: NewObjectArray failed")) {
+        return nullptr;
+    }
+    for (int i = 0; i < size; ++i) {
+        env->SetObjectArrayElement(res, i, elements[i]);
+        if (_check_exception("create_object_array: SetObjectArrayElement failed")) {
+            env->DeleteLocalRef(res);
+            return nullptr;
+        }
+    }
+    return res;
+}
+
+std::string JavaRuntime::to_jni_class_name(const std::string& name) {
+    std::string res = name;
+    for (auto& c : res) {
+        if (c == '.') {
+            c = '/';
+        }
+    }
+    return res;
+}
+
+Status detect_java_runtime() {
+    const char* java_home = std::getenv("JAVA_HOME");
+    if (java_home == nullptr) {
+        return Status::RuntimeError("env 'JAVA_HOME' is not set");
+    }
+    return check_java_runtime_in_pthread();
+}
+
+} // namespace starrocks

--- a/be/src/runtime/env/java/java_runtime.h
+++ b/be/src/runtime/env/java/java_runtime.h
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <jni.h>
+
+#include <string>
+
+#include "common/status.h"
+#include "common/statusor.h"
+
+namespace starrocks {
+
+// Process-wide Java runtime helper for generic JNI operations. JNIEnv is still
+// cached per native thread because JNI explicitly scopes JNIEnv* to one thread.
+class JavaRuntime {
+public:
+    static JavaRuntime& getInstance();
+
+    JavaRuntime(const JavaRuntime&) = delete;
+    JavaRuntime& operator=(const JavaRuntime&) = delete;
+
+    JNIEnv* getEnv();
+
+    std::string array_to_string(jobject object);
+    std::string to_string(jobject obj);
+    std::string to_cxx_string(jstring str);
+    std::string dump_exception_string(jthrowable throwable);
+
+    jmethodID get_to_string_method(jclass clazz);
+    StatusOr<jstring> to_jstring(const std::string& str);
+    jmethodID get_method(jclass clazz, const std::string& method, const std::string& sig);
+    jmethodID get_static_method(jclass clazz, const std::string& method, const std::string& sig);
+
+    jobjectArray create_object_array(int size);
+    jobjectArray create_object_array(jobject fill, int size);
+    jobjectArray create_object_array(jobject* elements, int size);
+
+    jclass object_class() const { return _object_class; }
+    jclass object_array_class() const { return _object_array_class; }
+
+    static std::string to_jni_class_name(const std::string& name);
+
+private:
+    JavaRuntime();
+
+    jclass _find_global_class(const char* name);
+    bool _check_exception(const std::string& message);
+
+private:
+    inline static thread_local JNIEnv* _env = nullptr;
+
+    jclass _object_class = nullptr;
+    jclass _object_array_class = nullptr;
+    jclass _arrays_class = nullptr;
+    jclass _exception_util_class = nullptr;
+
+    jmethodID _arrays_to_string = nullptr;
+    jmethodID _exception_get_stack_trace = nullptr;
+};
+
+Status detect_java_runtime();
+
+} // namespace starrocks

--- a/be/src/runtime/env/java/java_runtime.h
+++ b/be/src/runtime/env/java/java_runtime.h
@@ -47,6 +47,7 @@ public:
     jobjectArray create_object_array(int size);
     jobjectArray create_object_array(jobject fill, int size);
     jobjectArray create_object_array(jobject* elements, int size);
+    jobjectArray create_object_2d_array(jobject* elements, int size);
 
     jclass object_class() const { return _object_class; }
     jclass object_array_class() const { return _object_array_class; }

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -277,8 +277,7 @@ DEFINE_CAST_TO_JVALUE(TYPE_DATETIME, helper.newLocalDateTime(data_value.timestam
 
 void release_jvalue(bool is_box, jvalue val) {
     if (is_box && val.l) {
-        auto& helper = JVMFunctionHelper::getInstance();
-        helper.getEnv()->DeleteLocalRef(val.l);
+        JavaRuntime::getInstance().getEnv()->DeleteLocalRef(val.l);
     }
 }
 
@@ -377,7 +376,7 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
         JavaListStub list_stub(object);
         jobject elem_desc = get_type_desc_child(helper, type_desc_obj, 0);
         DeferOp drop_elem_desc([&]() {
-            if (elem_desc) helper.getEnv()->DeleteLocalRef(elem_desc);
+            if (elem_desc) JavaRuntime::getInstance().getEnv()->DeleteLocalRef(elem_desc);
         });
         for (size_t i = offset; i < offset + size; ++i) {
             ASSIGN_OR_RETURN(auto e, cast_to_jvalue(type_desc.children[0], true, spec_col->elements_column().get(), i,
@@ -404,11 +403,11 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
 
         jobject key_desc = get_type_desc_child(helper, type_desc_obj, 0);
         DeferOp drop_key_desc([&]() {
-            if (key_desc) helper.getEnv()->DeleteLocalRef(key_desc);
+            if (key_desc) JavaRuntime::getInstance().getEnv()->DeleteLocalRef(key_desc);
         });
         jobject val_desc = get_type_desc_child(helper, type_desc_obj, 1);
         DeferOp drop_val_desc([&]() {
-            if (val_desc) helper.getEnv()->DeleteLocalRef(val_desc);
+            if (val_desc) JavaRuntime::getInstance().getEnv()->DeleteLocalRef(val_desc);
         });
         for (size_t i = offset; i < offset + size; ++i) {
             ASSIGN_OR_RETURN(auto key,
@@ -436,7 +435,7 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
         if (record_class == nullptr) {
             return Status::InternalError("STRUCT cast_to_jvalue: missing formal record class on UdfTypeDesc");
         }
-        DeferOp drop_record_class([&]() { helper.getEnv()->DeleteLocalRef(record_class); });
+        DeferOp drop_record_class([&]() { JavaRuntime::getInstance().getEnv()->DeleteLocalRef(record_class); });
 
         if (!col->is_struct()) {
             return Status::InternalError("expected StructColumn for STRUCT slot");
@@ -452,7 +451,7 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
         // bringing up a parallel single-row record-construction path: it takes
         // per-field Object[1] arrays and a null bitmap and returns Object[1] holding
         // the constructed record (or null when row 0 is null).
-        JNIEnv* env = helper.getEnv();
+        JNIEnv* env = JavaRuntime::getInstance().getEnv();
         jclass object_clazz = env->FindClass("java/lang/Object");
         DeferOp drop_object_clazz([&]() { env->DeleteLocalRef(object_clazz); });
         jobjectArray field_arrays = env->NewObjectArray(num_fields, object_clazz, nullptr);
@@ -508,10 +507,9 @@ static Status handle_decimal_overflow(JNIEnv* env, const TypeDescriptor& td, Col
         return Status::OK();
     }
     if (error_if_overflow) {
-        auto& helper = JVMFunctionHelper::getInstance();
         std::string msg;
         if (jthrowable jthr = env->ExceptionOccurred(); jthr != nullptr) {
-            msg = helper.dumpExceptionString(jthr);
+            msg = JavaRuntime::getInstance().dump_exception_string(jthr);
             env->DeleteLocalRef(jthr);
         }
         env->ExceptionClear();
@@ -578,7 +576,7 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         // DECIMAL32/64: ask Java for the unscaled value as a long. If the helper raised
         // an ArithmeticException (precision overflow or value > long range), translate it
         // — `unscaled` and the data column slot must not be touched in that branch.
-        auto* env = helper.getEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
         jlong unscaled = helper.unscaled_long(val.l, type_desc.precision, type_desc.scale);
         if (env->ExceptionCheck()) {
             return handle_decimal_overflow(env, type_desc, col, row_num, error_if_overflow);
@@ -598,7 +596,7 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         // the int128/int256 cell at row_num. Same overflow short-circuit as the narrow path
         // — `bytes` is null when the helper threw, so we must not fall through to
         // GetByteArrayRegion.
-        auto* env = helper.getEnv();
+        auto* env = JavaRuntime::getInstance().getEnv();
         const int byte_width = (type_desc.type == TYPE_DECIMAL128) ? 16 : 32;
         jbyteArray bytes = helper.unscaled_le_bytes(val.l, type_desc.precision, type_desc.scale, byte_width);
         if (env->ExceptionCheck()) {
@@ -682,8 +680,8 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         case TYPE_DECIMAL64:
         case TYPE_DECIMAL128:
         case TYPE_DECIMAL256: {
-            RETURN_IF_ERROR(
-                    append_decimal_string_to_column(type_desc, helper.to_string(val.l), col, error_if_overflow));
+            RETURN_IF_ERROR(append_decimal_string_to_column(type_desc, JavaRuntime::getInstance().to_string(val.l), col,
+                                                            error_if_overflow));
             break;
         }
         case TYPE_ARRAY: {
@@ -696,7 +694,7 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
             auto* array_column = down_cast<ArrayColumn*>(data_column);
             jobject elem_desc = get_type_desc_child(helper, type_desc_obj, 0);
             DeferOp drop_elem_desc([&]() {
-                if (elem_desc) helper.getEnv()->DeleteLocalRef(elem_desc);
+                if (elem_desc) JavaRuntime::getInstance().getEnv()->DeleteLocalRef(elem_desc);
             });
             for (size_t i = 0; i < len; ++i) {
                 ASSIGN_OR_RETURN(auto element, list_stub.get(i));
@@ -726,11 +724,11 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
 
             jobject key_desc = get_type_desc_child(helper, type_desc_obj, 0);
             DeferOp drop_key_desc([&]() {
-                if (key_desc) helper.getEnv()->DeleteLocalRef(key_desc);
+                if (key_desc) JavaRuntime::getInstance().getEnv()->DeleteLocalRef(key_desc);
             });
             jobject val_desc = get_type_desc_child(helper, type_desc_obj, 1);
             DeferOp drop_val_desc([&]() {
-                if (val_desc) helper.getEnv()->DeleteLocalRef(val_desc);
+                if (val_desc) JavaRuntime::getInstance().getEnv()->DeleteLocalRef(val_desc);
             });
             for (size_t i = 0; i < len; ++i) {
                 ASSIGN_OR_RETURN(auto key_element, key_list_stub.get(i));
@@ -769,7 +767,7 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
             // Look up record component accessors via reflection on Class<?>.
             // The record instance's runtime class is the formal record type the FE
             // analyzer bound to this STRUCT slot; getRecordComponents lives on Class.
-            JNIEnv* env = helper.getEnv();
+            JNIEnv* env = JavaRuntime::getInstance().getEnv();
             jclass record_class = env->GetObjectClass(val.l);
             DeferOp drop_record_class([&]() { env->DeleteLocalRef(record_class); });
             jclass class_clazz = env->FindClass("java/lang/Class");
@@ -835,19 +833,19 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
         return Status::OK();
     }
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     switch (type_desc.type) {
-#define INSTANCE_OF_TYPE(NAME, TYPE)                                                            \
-    case NAME: {                                                                                \
-        if (!env->IsInstanceOf(val, helper.TYPE##_class())) {                                   \
-            auto clazz = env->GetObjectClass(val);                                              \
-            LOCAL_REF_GUARD(clazz);                                                             \
-            return Status::InternalError(fmt::format("Type not matched, expect {}, but got {}", \
-                                                     helper.to_string(helper.TYPE##_class()),   \
-                                                     helper.to_string(clazz)));                 \
-        }                                                                                       \
-        break;                                                                                  \
+#define INSTANCE_OF_TYPE(NAME, TYPE)                                                                              \
+    case NAME: {                                                                                                  \
+        if (!env->IsInstanceOf(val, helper.TYPE##_class())) {                                                     \
+            auto clazz = env->GetObjectClass(val);                                                                \
+            LOCAL_REF_GUARD(clazz);                                                                               \
+            return Status::InternalError(fmt::format("Type not matched, expect {}, but got {}",                   \
+                                                     JavaRuntime::getInstance().to_string(helper.TYPE##_class()), \
+                                                     JavaRuntime::getInstance().to_string(clazz)));               \
+        }                                                                                                         \
+        break;                                                                                                    \
     }
         INSTANCE_OF_TYPE(TYPE_BOOLEAN, uint8_t)
         INSTANCE_OF_TYPE(TYPE_TINYINT, int8_t)
@@ -860,8 +858,8 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
         if (!env->IsInstanceOf(val, helper.string_clazz())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
-            return Status::InternalError(
-                    fmt::format("Type not matched, expect string, but got {}", helper.to_string(clazz)));
+            return Status::InternalError(fmt::format("Type not matched, expect string, but got {}",
+                                                     JavaRuntime::getInstance().to_string(clazz)));
         }
         break;
     }
@@ -872,8 +870,8 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
         if (!env->IsInstanceOf(val, helper.big_decimal_class())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
-            return Status::InternalError(
-                    fmt::format("Type not matched, expect java.math.BigDecimal, but got {}", helper.to_string(clazz)));
+            return Status::InternalError(fmt::format("Type not matched, expect java.math.BigDecimal, but got {}",
+                                                     JavaRuntime::getInstance().to_string(clazz)));
         }
         break;
     }
@@ -881,8 +879,8 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
         if (!env->IsInstanceOf(val, helper.local_date_class())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
-            return Status::InternalError(
-                    fmt::format("Type not matched, expect java.time.LocalDate, but got {}", helper.to_string(clazz)));
+            return Status::InternalError(fmt::format("Type not matched, expect java.time.LocalDate, but got {}",
+                                                     JavaRuntime::getInstance().to_string(clazz)));
         }
         break;
     }
@@ -891,7 +889,7 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
             return Status::InternalError(fmt::format("Type not matched, expect java.time.LocalDateTime, but got {}",
-                                                     helper.to_string(clazz)));
+                                                     JavaRuntime::getInstance().to_string(clazz)));
         }
         break;
     }
@@ -899,8 +897,8 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
         if (!env->IsInstanceOf(val, helper.list_meta().list_class->clazz())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
-            return Status::InternalError(
-                    fmt::format("Type not matched, expect List, but got {}", helper.to_string(clazz)));
+            return Status::InternalError(fmt::format("Type not matched, expect List, but got {}",
+                                                     JavaRuntime::getInstance().to_string(clazz)));
         }
         break;
     }
@@ -908,8 +906,8 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
         if (!env->IsInstanceOf(val, helper.map_meta().map_class->clazz())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
-            return Status::InternalError(
-                    fmt::format("Type not matched, expect Map, but got {}", helper.to_string(clazz)));
+            return Status::InternalError(fmt::format("Type not matched, expect Map, but got {}",
+                                                     JavaRuntime::getInstance().to_string(clazz)));
         }
         break;
     }
@@ -929,7 +927,8 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
             return Status::InternalError(fmt::format("Type not matched, expect record {}, but got {}",
-                                                     helper.to_string(record_class), helper.to_string(clazz)));
+                                                     JavaRuntime::getInstance().to_string(record_class),
+                                                     JavaRuntime::getInstance().to_string(clazz)));
         }
         break;
     }
@@ -947,8 +946,7 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
     }
 
 jobject JavaDataTypeConverter::convert_to_states(FunctionContext* ctx, uint8_t** data, size_t offset, int num_rows) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     int inputs[num_rows];
     jintArray arr = env->NewIntArray(num_rows);
     RETURN_NULL_WITH_REPORT_ERROR(arr == nullptr, ctx, "OOM may happened in Java Heap");
@@ -961,8 +959,7 @@ jobject JavaDataTypeConverter::convert_to_states(FunctionContext* ctx, uint8_t**
 
 jobject JavaDataTypeConverter::convert_to_states_with_filter(FunctionContext* ctx, uint8_t** data, size_t offset,
                                                              const uint8_t* filter, int num_rows) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     int inputs[num_rows];
     jintArray arr = env->NewIntArray(num_rows);
     RETURN_NULL_WITH_REPORT_ERROR(arr == nullptr, ctx, "OOM may happened in Java Heap");
@@ -1189,7 +1186,7 @@ static jobject get_type_desc_child(JVMFunctionHelper& helper, jobject type_desc,
     if (type_desc == nullptr) {
         return nullptr;
     }
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     jobjectArray children = (jobjectArray)env->GetObjectField(type_desc, helper.udf_type_desc_children_field());
     if (children == nullptr) {
         return nullptr;
@@ -1202,7 +1199,7 @@ static jclass get_type_desc_record_class(JVMFunctionHelper& helper, jobject type
     if (type_desc == nullptr) {
         return nullptr;
     }
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     return reinterpret_cast<jclass>(env->GetObjectField(type_desc, helper.udf_type_desc_record_class_field()));
 }
 
@@ -1262,7 +1259,7 @@ static StatusOr<jobject> box_column(JVMFunctionHelper& helper, const TypeDescrip
 
 static StatusOr<jobject> build_list_boxed_array(JVMFunctionHelper& helper, const TypeDescriptor& type_desc,
                                                 const Column* column, jobject type_desc_obj, int num_rows) {
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     JniLocalFrame frame(env, BOXING_FRAME_HEADROOM);
     if (!frame.ok()) {
         return Status::InternalError("failed to push JNI local frame for ARRAY boxing");
@@ -1300,7 +1297,7 @@ static StatusOr<jobject> build_list_boxed_array(JVMFunctionHelper& helper, const
 
 static StatusOr<jobject> build_map_boxed_array(JVMFunctionHelper& helper, const TypeDescriptor& type_desc,
                                                const Column* column, jobject type_desc_obj, int num_rows) {
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     JniLocalFrame frame(env, BOXING_FRAME_HEADROOM);
     if (!frame.ok()) {
         return Status::InternalError("failed to push JNI local frame for MAP boxing");
@@ -1343,7 +1340,7 @@ static StatusOr<jobject> build_map_boxed_array(JVMFunctionHelper& helper, const 
 
 static StatusOr<jobject> build_struct_boxed_array(JVMFunctionHelper& helper, const TypeDescriptor& type_desc,
                                                   const Column* column, jobject type_desc_obj, int num_rows) {
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     // Capacity sized for the per-level fixed locals plus one in-flight sub_result;
     // sub_results are explicitly DeleteLocalRef'd inside the per-field loop so the
     // frame footprint stays bounded regardless of field count.
@@ -1596,7 +1593,7 @@ Status JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, const
                                                      int num_rows, std::vector<jobject>* res,
                                                      const std::vector<jobject>* arg_type_descs) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     for (int i = 0; i < num_cols; ++i) {
         jobject arg = nullptr;
         const TypeDescriptor& arg_type = *ctx->get_arg_type(i);
@@ -1605,12 +1602,12 @@ Status JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, const
                                         : nullptr;
         if (columns[i]->only_null() ||
             (columns[i]->is_nullable() && down_cast<const NullableColumn*>(columns[i])->null_count() == num_rows)) {
-            arg = helper.create_array(num_rows);
+            arg = JavaRuntime::getInstance().create_object_array(num_rows);
         } else if (columns[i]->is_constant()) {
             auto* data_column = down_cast<const ConstColumn*>(columns[i])->data_column_raw_ptr();
             data_column->as_mutable_raw_ptr()->resize(1);
             ASSIGN_OR_RETURN(jvalue jval, cast_to_jvalue(arg_type, true, data_column, 0, type_desc_obj));
-            arg = helper.create_object_array(jval.l, num_rows);
+            arg = JavaRuntime::getInstance().create_object_array(jval.l, num_rows);
             env->DeleteLocalRef(jval.l);
         } else {
             ASSIGN_OR_RETURN(arg, box_column(helper, arg_type, columns[i], type_desc_obj, num_rows));

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -429,7 +429,7 @@ void JVMFunctionHelper::batch_update(FunctionContext* ctx, jobject udaf, jobject
     auto* udaf_ctx = get_java_udaf_context(ctx);
     DCHECK(udaf_ctx != nullptr);
     DCHECK(udaf_ctx->states != nullptr);
-    jobjectArray input_arr = JavaRuntime::getInstance().create_object_array(input, cols);
+    jobjectArray input_arr = JavaRuntime::getInstance().create_object_2d_array(input, cols);
     LOCAL_REF_GUARD(input_arr);
     _env->CallStaticVoidMethod(_udf_helper_class, _batch_update, udaf, update, udaf_ctx->states->handle(), states,
                                input_arr);
@@ -438,7 +438,7 @@ void JVMFunctionHelper::batch_update(FunctionContext* ctx, jobject udaf, jobject
 
 void JVMFunctionHelper::batch_update_state(FunctionContext* ctx, jobject udaf, jobject update, jobject* input,
                                            int cols) {
-    jobjectArray input_arr = JavaRuntime::getInstance().create_object_array(input, cols);
+    jobjectArray input_arr = JavaRuntime::getInstance().create_object_2d_array(input, cols);
     LOCAL_REF_GUARD(input_arr);
     _env->CallStaticVoidMethod(_udf_helper_class, _batch_update_state, udaf, update, input_arr);
     CHECK_UDF_CALL_EXCEPTION(_env, ctx);
@@ -449,7 +449,7 @@ void JVMFunctionHelper::batch_update_if_not_null(FunctionContext* ctx, jobject u
     auto* udaf_ctx = get_java_udaf_context(ctx);
     DCHECK(udaf_ctx != nullptr);
     DCHECK(udaf_ctx->states != nullptr);
-    jobjectArray input_arr = JavaRuntime::getInstance().create_object_array(input, cols);
+    jobjectArray input_arr = JavaRuntime::getInstance().create_object_2d_array(input, cols);
     LOCAL_REF_GUARD(input_arr);
     _env->CallStaticVoidMethod(_udf_helper_class, _batch_update_if_not_null, udaf, update, udaf_ctx->states->handle(),
                                states, input_arr);
@@ -462,7 +462,7 @@ StatusOr<jobject> JVMFunctionHelper::batch_call(BatchEvaluateStub* stub, jobject
 
 jobject JVMFunctionHelper::batch_call(FunctionContext* ctx, jobject caller, jobject method, jobject* input, int cols,
                                       int rows) {
-    jobjectArray input_arr = JavaRuntime::getInstance().create_object_array(input, cols);
+    jobjectArray input_arr = JavaRuntime::getInstance().create_object_2d_array(input, cols);
     LOCAL_REF_GUARD(input_arr);
     auto res = _env->CallStaticObjectMethod(_udf_helper_class, _batch_call, caller, method, rows, input_arr);
     CHECK_UDF_CALL_EXCEPTION(_env, ctx);

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -14,7 +14,6 @@
 
 #include "udf/java/java_udf.h"
 
-#include <iterator>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -144,7 +143,7 @@ void clear_java_udaf_states(FunctionContext* ctx) {
         return;
     }
 
-    auto env = JVMFunctionHelper::getInstance().getEnv();
+    auto env = JavaRuntime::getInstance().getEnv();
     udaf_ctx->states->clear(ctx, env);
 }
 
@@ -164,7 +163,7 @@ void destroy_java_udaf_context(FunctionContext* ctx) {
 }
 
 StatusOr<jobject> MapMeta::newLocalInstance(jobject keys, jobject values) const {
-    JNIEnv* env = getJNIEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     auto res = env->NewObject(immutable_map_class->clazz(), immutable_map_constructor, keys, values);
     RETURN_ERROR_IF_JNI_EXCEPTION(env);
     return res;
@@ -172,30 +171,17 @@ StatusOr<jobject> MapMeta::newLocalInstance(jobject keys, jobject values) const 
 
 JVMFunctionHelper& JVMFunctionHelper::getInstance() {
     if (_env == nullptr) {
-        _env = getJNIEnv();
-        CHECK(_env != nullptr) << "couldn't got a JNIEnv";
+        _env = JavaRuntime::getInstance().getEnv();
     }
     static JVMFunctionHelper helper;
     return helper;
 }
 
-std::pair<JNIEnv*, JVMFunctionHelper&> JVMFunctionHelper::getInstanceWithEnv() {
-    auto& instance = getInstance();
-    return {instance.getEnv(), instance};
-}
-
 void JVMFunctionHelper::_init() {
-    _object_class = JNI_FIND_CLASS("java/lang/Object");
-    _object_array_class = JNI_FIND_CLASS("[Ljava/lang/Object;");
     _string_class = JNI_FIND_CLASS("java/lang/String");
-    _jarrays_class = JNI_FIND_CLASS("java/util/Arrays");
-    _exception_util_class = JNI_FIND_CLASS("org/apache/commons/lang3/exception/ExceptionUtils");
     _big_decimal_class = JNI_FIND_CLASS("java/math/BigDecimal");
 
-    CHECK(_object_class);
     CHECK(_string_class);
-    CHECK(_jarrays_class);
-    CHECK(_exception_util_class);
     CHECK(_big_decimal_class);
     _big_decimal_ctor_string = _env->GetMethodID(_big_decimal_class, "<init>", "(Ljava/lang/String;)V");
     CHECK(_big_decimal_ctor_string);
@@ -234,14 +220,14 @@ void JVMFunctionHelper::_init() {
     DCHECK(_string_construct_with_bytes != nullptr);
 
     // init JNI native methods
-    std::string native_method_name = JVMFunctionHelper::to_jni_class_name(CLASS_NATIVE_METHOD_HELPER_NAME);
+    std::string native_method_name = JavaRuntime::to_jni_class_name(CLASS_NATIVE_METHOD_HELPER_NAME);
     jclass native_method_class = JNI_FIND_CLASS(native_method_name.c_str());
     DCHECK(native_method_class != nullptr);
     int res = _env->RegisterNatives(native_method_class, java_native_methods,
                                     sizeof(java_native_methods) / sizeof(java_native_methods[0]));
 
     // init UDF Helper
-    std::string name = JVMFunctionHelper::to_jni_class_name(CLASS_UDF_HELPER_NAME);
+    std::string name = JavaRuntime::to_jni_class_name(CLASS_UDF_HELPER_NAME);
     _udf_helper_class = JNI_FIND_CLASS(name.c_str());
     DCHECK(_udf_helper_class != nullptr);
     DCHECK_EQ(res, 0);
@@ -256,7 +242,7 @@ void JVMFunctionHelper::_init() {
     // input boxing recursion (which reads children / recordClass per STRUCT slot)
     // and for the per-UDF type desc construction in _build_udf_func_desc.
     {
-        std::string td_name = JVMFunctionHelper::to_jni_class_name("com.starrocks.udf.UdfTypeDesc");
+        std::string td_name = JavaRuntime::to_jni_class_name("com.starrocks.udf.UdfTypeDesc");
         _udf_type_desc_class = JNI_FIND_CLASS(td_name.c_str());
         DCHECK(_udf_type_desc_class != nullptr);
         _udf_type_desc_ctor = _env->GetMethodID(_udf_type_desc_class, "<init>",
@@ -338,119 +324,27 @@ void JVMFunctionHelper::_init() {
     _map_meta.immutable_map_constructor =
             _env->GetMethodID(_map_meta.immutable_map_class->clazz(), "<init>", "(Ljava/util/List;Ljava/util/List;)V");
 
-    name = JVMFunctionHelper::to_jni_class_name(UDAFStateList::clazz_name);
+    name = JavaRuntime::to_jni_class_name(UDAFStateList::clazz_name);
     jclass loaded_clazz = JNI_FIND_CLASS(name.c_str());
     _function_states_clazz = new JVMClass(loaded_clazz);
-}
-
-jobjectArray JVMFunctionHelper::_build_object_array(jclass clazz, jobject* arr, int sz) {
-    jobjectArray res_arr = _env->NewObjectArray(sz, _object_array_class, nullptr);
-    RETURN_IF_JNI_EXCEPTION(_env, "_build_object_array: NewObjectArray failed", nullptr);
-    for (int i = 0; i < sz; ++i) {
-        _env->SetObjectArrayElement(res_arr, i, arr[i]);
-    }
-    return res_arr;
 }
 
 JVMClass& JVMFunctionHelper::function_state_clazz() {
     return *_function_states_clazz;
 }
 
-#define CHECK_FUNCTION_EXCEPTION(_env, name)                   \
-    if (auto e = _env->ExceptionOccurred()) {                  \
-        LOCAL_REF_GUARD(e);                                    \
-        _env->ExceptionClear();                                \
-        LOG(WARNING) << "Exception happened when call " #name; \
-        return "";                                             \
-    }
-
-#define RETURN_ERROR_IF_EXCEPTION(env, errmsg)                                   \
-    if (jthrowable jthr = env->ExceptionOccurred()) {                            \
-        LOCAL_REF_GUARD(jthr);                                                   \
-        std::string msg = fmt::format(errmsg, helper.dumpExceptionString(jthr)); \
-        LOG(WARNING) << msg;                                                     \
-        env->ExceptionClear();                                                   \
-        return Status::RuntimeError(msg);                                        \
+#define RETURN_ERROR_IF_EXCEPTION(env, errmsg)                                                         \
+    if (jthrowable jthr = env->ExceptionOccurred()) {                                                  \
+        LOCAL_REF_GUARD(jthr);                                                                         \
+        std::string msg = fmt::format(errmsg, JavaRuntime::getInstance().dump_exception_string(jthr)); \
+        LOG(WARNING) << msg;                                                                           \
+        env->ExceptionClear();                                                                         \
+        return Status::RuntimeError(msg);                                                              \
     }
 
 Status JVMFunctionHelper::_check_exception_status() {
-    auto& helper = *this;
     RETURN_ERROR_IF_EXCEPTION(_env, "exception happened when invoke method: {}");
     return Status::OK();
-}
-
-std::string JVMFunctionHelper::array_to_string(jobject object) {
-    _env->ExceptionClear();
-    std::string value;
-    jmethodID arrayToStringMethod =
-            _env->GetStaticMethodID(_jarrays_class, "toString", "([Ljava/lang/Object;)Ljava/lang/String;");
-    DCHECK(arrayToStringMethod != nullptr);
-    jobject jstr = _env->CallStaticObjectMethod(_jarrays_class, arrayToStringMethod, object);
-    LOCAL_REF_GUARD(jstr);
-    CHECK_FUNCTION_EXCEPTION(_env, "array_to_string")
-    value = to_cxx_string((jstring)jstr);
-    return value;
-}
-
-std::string JVMFunctionHelper::to_string(jobject obj) {
-    _env->ExceptionClear();
-    std::string value;
-    auto method = getToStringMethod(_object_class);
-    auto res = _env->CallObjectMethod(obj, method);
-    LOCAL_REF_GUARD(res);
-    CHECK_FUNCTION_EXCEPTION(_env, "to_string")
-    value = to_cxx_string((jstring)res);
-    return value;
-}
-
-std::string JVMFunctionHelper::to_cxx_string(jstring str) {
-    if (str == nullptr) {
-        return "<null>";
-    }
-    std::string res;
-    const char* charflow = _env->GetStringUTFChars((jstring)str, nullptr);
-    res = charflow;
-    _env->ReleaseStringUTFChars((jstring)str, charflow);
-    return res;
-}
-
-std::string JVMFunctionHelper::dumpExceptionString(jthrowable throwable) {
-    // toString
-    auto get_stack_trace = _env->GetStaticMethodID(_exception_util_class, "getStackTrace",
-                                                   "(Ljava/lang/Throwable;)Ljava/lang/String;");
-    CHECK(get_stack_trace != nullptr) << "Not Found JNI method getStackTrace";
-    jobject stack_traces = _env->CallStaticObjectMethod(_exception_util_class, get_stack_trace, (jobject)throwable);
-    LOCAL_REF_GUARD(stack_traces);
-    // don't call return if xxx, to avoid recursive
-    _env->ExceptionClear();
-    return to_cxx_string((jstring)stack_traces);
-}
-
-jmethodID JVMFunctionHelper::getToStringMethod(jclass clazz) {
-    return _env->GetMethodID(clazz, "toString", "()Ljava/lang/String;");
-}
-
-StatusOr<jstring> JVMFunctionHelper::to_jstring(const std::string& str) {
-    auto res = _env->NewStringUTF(str.c_str());
-    if (UNLIKELY(res == nullptr)) {
-        _env->ExceptionClear();
-        return Status::InternalError(fmt::format("NewStringUTF failed for: {}", str));
-    }
-    return res;
-}
-
-jmethodID JVMFunctionHelper::getMethod(jclass clazz, const std::string& method, const std::string& sig) {
-    return _env->GetMethodID(clazz, method.c_str(), sig.c_str());
-}
-
-jmethodID JVMFunctionHelper::getStaticMethod(jclass clazz, const std::string& method, const std::string& sig) {
-    return _env->GetStaticMethodID(clazz, method.c_str(), sig.c_str());
-}
-
-jobject JVMFunctionHelper::create_array(int sz) {
-    auto res = _env->NewObjectArray(sz, _object_class, nullptr);
-    RETURN_IF_JNI_EXCEPTION(_env, "create_array: NewObjectArray failed", nullptr);
-    return res;
 }
 
 jobject JVMFunctionHelper::create_boxed_array(int type, int num_rows, bool nullable, DirectByteBuffer* buffs, int sz) {
@@ -513,12 +407,6 @@ Status JVMFunctionHelper::write_result(jobject result, int num_rows, jlong colum
     return Status::OK();
 }
 
-jobject JVMFunctionHelper::create_object_array(jobject o, int num_rows) {
-    jobjectArray res_arr = _env->NewObjectArray(num_rows, _object_array_class, o);
-    RETURN_IF_JNI_EXCEPTION(_env, "create_object_array: NewObjectArray failed", nullptr);
-    return res_arr;
-}
-
 jobject JVMFunctionHelper::batch_create_bytebuf(unsigned char* ptr, const uint32_t* offset, int begin, int end) {
     int size = end - begin;
     auto offsets = _env->NewIntArray(size + 1);
@@ -541,7 +429,7 @@ void JVMFunctionHelper::batch_update(FunctionContext* ctx, jobject udaf, jobject
     auto* udaf_ctx = get_java_udaf_context(ctx);
     DCHECK(udaf_ctx != nullptr);
     DCHECK(udaf_ctx->states != nullptr);
-    jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
+    jobjectArray input_arr = JavaRuntime::getInstance().create_object_array(input, cols);
     LOCAL_REF_GUARD(input_arr);
     _env->CallStaticVoidMethod(_udf_helper_class, _batch_update, udaf, update, udaf_ctx->states->handle(), states,
                                input_arr);
@@ -550,7 +438,7 @@ void JVMFunctionHelper::batch_update(FunctionContext* ctx, jobject udaf, jobject
 
 void JVMFunctionHelper::batch_update_state(FunctionContext* ctx, jobject udaf, jobject update, jobject* input,
                                            int cols) {
-    jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
+    jobjectArray input_arr = JavaRuntime::getInstance().create_object_array(input, cols);
     LOCAL_REF_GUARD(input_arr);
     _env->CallStaticVoidMethod(_udf_helper_class, _batch_update_state, udaf, update, input_arr);
     CHECK_UDF_CALL_EXCEPTION(_env, ctx);
@@ -561,7 +449,7 @@ void JVMFunctionHelper::batch_update_if_not_null(FunctionContext* ctx, jobject u
     auto* udaf_ctx = get_java_udaf_context(ctx);
     DCHECK(udaf_ctx != nullptr);
     DCHECK(udaf_ctx->states != nullptr);
-    jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
+    jobjectArray input_arr = JavaRuntime::getInstance().create_object_array(input, cols);
     LOCAL_REF_GUARD(input_arr);
     _env->CallStaticVoidMethod(_udf_helper_class, _batch_update_if_not_null, udaf, update, udaf_ctx->states->handle(),
                                states, input_arr);
@@ -574,7 +462,7 @@ StatusOr<jobject> JVMFunctionHelper::batch_call(BatchEvaluateStub* stub, jobject
 
 jobject JVMFunctionHelper::batch_call(FunctionContext* ctx, jobject caller, jobject method, jobject* input, int cols,
                                       int rows) {
-    jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
+    jobjectArray input_arr = JavaRuntime::getInstance().create_object_array(input, cols);
     LOCAL_REF_GUARD(input_arr);
     auto res = _env->CallStaticObjectMethod(_udf_helper_class, _batch_call, caller, method, rows, input_arr);
     CHECK_UDF_CALL_EXCEPTION(_env, ctx);
@@ -735,18 +623,6 @@ Slice JVMFunctionHelper::sliceVal(jstring jstr, std::string* buffer) {
     return {buffer->data(), buffer->length()};
 }
 
-std::string JVMFunctionHelper::to_jni_class_name(const std::string& name) {
-    std::string jni_class_name;
-    auto inserter = std::inserter(jni_class_name, jni_class_name.end());
-    std::transform(name.begin(), name.end(), inserter, [](auto ele) {
-        if (ele == '.') {
-            return '/';
-        }
-        return ele;
-    });
-    return jni_class_name;
-}
-
 void JVMFunctionHelper::clear(DirectByteBuffer* buffer, FunctionContext* ctx) {
     auto res = _env->CallNonvirtualObjectMethod(buffer->handle(), _direct_buffer_class, _direct_buffer_clear);
     LOCAL_REF_GUARD(res);
@@ -754,8 +630,7 @@ void JVMFunctionHelper::clear(DirectByteBuffer* buffer, FunctionContext* ctx) {
 }
 
 DirectByteBuffer::DirectByteBuffer(void* ptr, int capacity) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     auto lref = env->NewDirectByteBuffer(ptr, capacity);
     LOCAL_REF_GUARD(lref);
     _handle = env->NewGlobalRef(lref);
@@ -766,8 +641,7 @@ DirectByteBuffer::DirectByteBuffer(void* ptr, int capacity) {
 DirectByteBuffer::~DirectByteBuffer() {
     if (_handle != nullptr) {
         auto ret = call_hdfs_scan_function_in_pthread([this]() {
-            auto& helper = JVMFunctionHelper::getInstance();
-            JNIEnv* env = helper.getEnv();
+            JNIEnv* env = JavaRuntime::getInstance().getEnv();
             env->DeleteGlobalRef(_handle);
             _handle = nullptr;
             return Status::OK();
@@ -784,7 +658,7 @@ UDAFStateList::UDAFStateList(JavaGlobalRef&& handle, JavaGlobalRef&& get, JavaGl
           _add_method(std::move(add)),
           _remove_method(std::move(remove)),
           _clear_method(std::move(clear)) {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     _get_method_id = env->FromReflectedMethod(_get_method.handle());
     _batch_get_method_id = env->FromReflectedMethod(_batch_get_method.handle());
     _add_method_id = env->FromReflectedMethod(_add_method.handle());
@@ -829,11 +703,11 @@ constexpr const char* CLASS_LOADER_NAME = "com.starrocks.udf.UDFClassLoader";
 constexpr const char* CLASS_ANALYZER_NAME = "com.starrocks.udf.UDFClassAnalyzer";
 
 Status ClassLoader::init() {
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     if (env == nullptr) {
         return Status::InternalError("Init JNIEnv fail");
     }
-    std::string name = JVMFunctionHelper::to_jni_class_name(CLASS_LOADER_NAME);
+    std::string name = JavaRuntime::to_jni_class_name(CLASS_LOADER_NAME);
     jclass clazz = env->FindClass(name.c_str());
     LOCAL_REF_GUARD(clazz);
 
@@ -878,14 +752,13 @@ Status ClassLoader::init() {
 }
 
 StatusOr<JVMClass> ClassLoader::getClass(const std::string& className) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     CHECK(env != nullptr) << "couldn't got a JNIEnv";
 
     // class Name java.lang.Object -> java/lang/Object
-    std::string jni_class_name = JVMFunctionHelper::to_jni_class_name(className);
+    std::string jni_class_name = JavaRuntime::to_jni_class_name(className);
     // invoke class loader
-    ASSIGN_OR_RETURN(jstring jstr_name, helper.to_jstring(jni_class_name));
+    ASSIGN_OR_RETURN(jstring jstr_name, JavaRuntime::getInstance().to_jstring(jni_class_name));
     LOCAL_REF_GUARD(jstr_name);
 
     auto loaded_clazz = env->CallObjectMethod(_handle.handle(), _get_class, jstr_name);
@@ -902,11 +775,10 @@ StatusOr<JVMClass> ClassLoader::getClass(const std::string& className) {
 
 StatusOr<JVMClass> ClassLoader::genCallStub(const std::string& stubClassName, jclass clazz, jobject method, int type,
                                             int numActualVarArgs) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
-    std::string jni_class_name = JVMFunctionHelper::to_jni_class_name(stubClassName);
-    ASSIGN_OR_RETURN(jstring jstr_name, helper.to_jstring(jni_class_name));
+    std::string jni_class_name = JavaRuntime::to_jni_class_name(stubClassName);
+    ASSIGN_OR_RETURN(jstring jstr_name, JavaRuntime::getInstance().to_jstring(jni_class_name));
     LOCAL_REF_GUARD(jstr_name);
 
     // generate call stub; pass numActualVarArgs for varargs methods
@@ -920,17 +792,16 @@ StatusOr<JVMClass> ClassLoader::genCallStub(const std::string& stubClassName, jc
 }
 
 jmethodID JavaMethodDescriptor::get_method_id() const {
-    return JVMFunctionHelper::getInstance().getEnv()->FromReflectedMethod(method.handle());
+    return JavaRuntime::getInstance().getEnv()->FromReflectedMethod(method.handle());
 }
 
 Status ClassAnalyzer::has_method(jclass clazz, const std::string& method, bool* has) {
     DCHECK(clazz != nullptr);
     DCHECK(has != nullptr);
 
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = getJNIEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
-    std::string anlyzer_clazz_name = JVMFunctionHelper::to_jni_class_name(CLASS_ANALYZER_NAME);
+    std::string anlyzer_clazz_name = JavaRuntime::to_jni_class_name(CLASS_ANALYZER_NAME);
     jclass class_analyzer = env->FindClass(anlyzer_clazz_name.c_str());
     LOCAL_REF_GUARD(class_analyzer);
 
@@ -944,7 +815,7 @@ Status ClassAnalyzer::has_method(jclass clazz, const std::string& method, bool* 
         return Status::InternalError("couldn't found hasMethod method");
     }
 
-    ASSIGN_OR_RETURN(jstring method_name, helper.to_jstring(method.c_str()));
+    ASSIGN_OR_RETURN(jstring method_name, JavaRuntime::getInstance().to_jstring(method.c_str()));
     LOCAL_REF_GUARD(method_name);
 
     *has = env->CallStaticBooleanMethod(class_analyzer, hasMethod, method_name, (jobject)clazz);
@@ -973,9 +844,8 @@ void ClassAnalyzer::strip_jni_generic_types(std::string* sign) {
 Status ClassAnalyzer::get_signature(jclass clazz, const std::string& method, std::string* sign) {
     DCHECK(clazz != nullptr);
     DCHECK(sign != nullptr);
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
-    std::string anlyzer_clazz_name = JVMFunctionHelper::to_jni_class_name(CLASS_ANALYZER_NAME);
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
+    std::string anlyzer_clazz_name = JavaRuntime::to_jni_class_name(CLASS_ANALYZER_NAME);
     jclass class_analyzer = env->FindClass(anlyzer_clazz_name.c_str());
     LOCAL_REF_GUARD(class_analyzer);
 
@@ -988,7 +858,7 @@ Status ClassAnalyzer::get_signature(jclass clazz, const std::string& method, std
         return Status::InternalError("couldn't found getSignature method");
     }
 
-    ASSIGN_OR_RETURN(jstring method_name, helper.to_jstring(method.c_str()));
+    ASSIGN_OR_RETURN(jstring method_name, JavaRuntime::getInstance().to_jstring(method.c_str()));
     LOCAL_REF_GUARD(method_name);
 
     jobject result_sign = env->CallStaticObjectMethod(class_analyzer, getSign, method_name, (jobject)clazz);
@@ -999,7 +869,7 @@ Status ClassAnalyzer::get_signature(jclass clazz, const std::string& method, std
     if (result_sign == nullptr) {
         return Status::InternalError(fmt::format("couldn't found method:{}", method));
     }
-    *sign = helper.to_string(result_sign);
+    *sign = JavaRuntime::getInstance().to_string(result_sign);
     // Strip generic type parameters from signature to produce standard JNI method descriptor.
     // Java's getGenericParameterTypes() may produce signatures with generic info that:
     // 1. JNI GetMethodID cannot match against the erased method descriptor, returning NULL.
@@ -1012,10 +882,9 @@ Status ClassAnalyzer::get_signature(jclass clazz, const std::string& method, std
 }
 
 StatusOr<jobject> ClassAnalyzer::get_method_object(jclass clazz, const std::string& method) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
-    std::string anlyzer_clazz_name = JVMFunctionHelper::to_jni_class_name(CLASS_ANALYZER_NAME);
+    std::string anlyzer_clazz_name = JavaRuntime::to_jni_class_name(CLASS_ANALYZER_NAME);
     jclass class_analyzer = env->FindClass(anlyzer_clazz_name.c_str());
     LOCAL_REF_GUARD(class_analyzer);
     DCHECK(class_analyzer);
@@ -1023,7 +892,7 @@ StatusOr<jobject> ClassAnalyzer::get_method_object(jclass clazz, const std::stri
     jmethodID getMethodObject = env->GetStaticMethodID(
             class_analyzer, "getMethodObject", "(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/reflect/Method;");
     DCHECK(getMethodObject);
-    ASSIGN_OR_RETURN(jstring method_name, helper.to_jstring(method.c_str()));
+    ASSIGN_OR_RETURN(jstring method_name, JavaRuntime::getInstance().to_jstring(method.c_str()));
     LOCAL_REF_GUARD(method_name);
 
     jobject method_object = env->CallStaticObjectMethod(class_analyzer, getMethodObject, method_name, (jobject)clazz);
@@ -1221,7 +1090,7 @@ Status ClassAnalyzer::get_udaf_method_desc(const std::string& sign, std::vector<
 JavaUDFContext::~JavaUDFContext() = default;
 
 int UDAFFunction::create() {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     jmethodID create = _ctx->ctx->create->get_method_id();
     auto obj = env->CallObjectMethod(_udaf_handle, create);
     LOCAL_REF_GUARD(obj);
@@ -1230,7 +1099,8 @@ int UDAFFunction::create() {
 }
 
 void UDAFFunction::destroy(int state) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID destory = _ctx->ctx->destory->get_method_id();
@@ -1242,7 +1112,7 @@ void UDAFFunction::destroy(int state) {
 
 jvalue UDAFFunction::finalize(int state) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID finalize = _ctx->ctx->finalize->get_method_id();
@@ -1260,7 +1130,7 @@ void AggBatchCallStub::batch_update_single(int num_rows, jobject state, jobject*
     for (int i = 0; i < cols; ++i) {
         jni_inputs[3 + i].l = input[i];
     }
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     env->CallStaticVoidMethodA(_stub_clazz.clazz(), env->FromReflectedMethod(_stub_method.handle()), jni_inputs);
     CHECK_UDF_CALL_EXCEPTION(env, _ctx);
 }
@@ -1272,7 +1142,7 @@ StatusOr<jobject> BatchEvaluateStub::batch_evaluate(int num_rows, jobject* input
     for (int i = 0; i < cols; ++i) {
         jni_inputs[2 + i].l = input[i];
     }
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     auto res = env->CallStaticObjectMethodA(_stub_clazz.clazz(), env->FromReflectedMethod(_stub_method.handle()),
                                             jni_inputs);
     RETURN_ERROR_IF_JNI_EXCEPTION(env);
@@ -1280,7 +1150,8 @@ StatusOr<jobject> BatchEvaluateStub::batch_evaluate(int num_rows, jobject* input
 }
 
 Status JavaListStub::add(jobject element) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     const auto& meta = helper.list_meta();
     env->CallVoidMethod(_list, meta.list_add, element);
     RETURN_ERROR_IF_JNI_EXCEPTION(env);
@@ -1288,7 +1159,8 @@ Status JavaListStub::add(jobject element) {
 }
 
 StatusOr<jobject> JavaListStub::get(int index) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     const auto& meta = helper.list_meta();
     auto res = env->CallObjectMethod(_list, meta.list_get, index);
     RETURN_ERROR_IF_JNI_EXCEPTION(env);
@@ -1296,7 +1168,8 @@ StatusOr<jobject> JavaListStub::get(int index) {
 }
 
 StatusOr<size_t> JavaListStub::size() {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     const auto& meta = helper.list_meta();
     auto res = env->CallIntMethod(_list, meta.list_size);
     RETURN_ERROR_IF_JNI_EXCEPTION(env);
@@ -1304,14 +1177,15 @@ StatusOr<size_t> JavaListStub::size() {
 }
 
 void UDAFFunction::update(jvalue* val) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     jmethodID update = _ctx->ctx->update->get_method_id();
     env->CallVoidMethodA(_udaf_handle, update, val);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
 }
 
 void UDAFFunction::merge(int state, jobject buffer) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID merge = _ctx->ctx->merge->get_method_id();
@@ -1320,7 +1194,8 @@ void UDAFFunction::merge(int state, jobject buffer) {
 }
 
 void UDAFFunction::serialize(int state, jobject buffer) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID serialize = _ctx->ctx->serialize->get_method_id();
@@ -1329,7 +1204,8 @@ void UDAFFunction::serialize(int state, jobject buffer) {
 }
 
 int UDAFFunction::serialize_size(int state) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID serialize_size = _ctx->ctx->serialize_size->get_method_id();
@@ -1339,7 +1215,8 @@ int UDAFFunction::serialize_size(int state) {
 }
 
 void UDAFFunction::reset(int state) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID reset = _ctx->ctx->reset->get_method_id();
@@ -1349,7 +1226,8 @@ void UDAFFunction::reset(int state) {
 
 jobject UDAFFunction::window_update_batch(int state, int peer_group_start, int peer_group_end, int frame_start,
                                           int frame_end, int col_sz, jobject* cols) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
 
@@ -1368,20 +1246,6 @@ jobject UDAFFunction::window_update_batch(int state, int peer_group_start, int p
     jobject res = env->CallObjectMethodA(_udaf_handle, window_update, jvalues);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
     return res;
-}
-
-Status detect_java_runtime() {
-    const char* p = std::getenv("JAVA_HOME");
-    if (p == nullptr) {
-        return Status::RuntimeError("env 'JAVA_HOME' is not set");
-    }
-    auto st = call_hdfs_scan_function_in_pthread([]() {
-        if (getJNIEnv() == nullptr) {
-            return Status::RuntimeError("couldn't get JNIEnv, please check your java runtime");
-        }
-        return Status::OK();
-    });
-    return st->get_future().get();
 }
 
 } // namespace starrocks

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -23,6 +23,7 @@
 #include "exprs/function_context.h"
 #include "jni.h"
 #include "runtime/env/java/java_env.h"
+#include "runtime/env/java/java_runtime.h"
 #include "types/logical_type.h"
 #include "udf/java/type_traits.h"
 
@@ -65,23 +66,8 @@ struct MapMeta {
 class JVMFunctionHelper {
 public:
     static JVMFunctionHelper& getInstance();
-    static std::pair<JNIEnv*, JVMFunctionHelper&> getInstanceWithEnv();
     JVMFunctionHelper(const JVMFunctionHelper&) = delete;
-    // get env
-    JNIEnv* getEnv() { return _env; }
-    // Arrays.toString()
-    std::string array_to_string(jobject object);
-    // Object::toString()
     bool equals(jobject obj1, jobject obj2);
-    std::string to_string(jobject obj);
-    std::string to_cxx_string(jstring str);
-    std::string dumpExceptionString(jthrowable throwable);
-    jmethodID getToStringMethod(jclass clazz);
-    StatusOr<jstring> to_jstring(const std::string& str);
-    jmethodID getMethod(jclass clazz, const std::string& method, const std::string& sig);
-    jmethodID getStaticMethod(jclass clazz, const std::string& method, const std::string& sig);
-    // create a object array
-    jobject create_array(int sz);
     // convert column data to Java Object Array
     jobject create_boxed_array(int type, int num_rows, bool nullable, DirectByteBuffer* buffs, int sz);
     // Convert a DECIMAL column to a BigDecimal[] Java array. `type` is the LogicalType
@@ -139,7 +125,6 @@ public:
         return res;
     }
     // create object array with the same elements
-    jobject create_object_array(jobject o, int num_rows);
     jobject batch_create_bytebuf(unsigned char* ptr, const uint32_t* offset, int begin, int end);
 
     // batch update single
@@ -237,22 +222,14 @@ public:
     // as a java.time.LocalDateTime.
     jobject newLocalDateTime(int64_t packed_timestamp);
     int64_t valLocalDateTime(jobject obj);
-    // replace '.' as '/'
-    // eg: java.lang.Integer -> java/lang/Integer
-    static std::string to_jni_class_name(const std::string& name);
-
     // reset Buffer set read/write position to zero
     void clear(DirectByteBuffer* buffer, FunctionContext* ctx);
-
-    jclass object_class() { return _object_class; }
 
     JVMClass& function_state_clazz();
 
 private:
     JVMFunctionHelper() { _init(); };
     void _init();
-    // pack input array to java object array
-    jobjectArray _build_object_array(jclass clazz, jobject* arr, int sz);
 
     Status _check_exception_status();
 
@@ -267,11 +244,7 @@ private:
     DEFINE_JAVA_PRIM_TYPE(float);
     DEFINE_JAVA_PRIM_TYPE(double);
 
-    jclass _object_class;
-    jclass _object_array_class;
     jclass _string_class;
-    jclass _jarrays_class;
-    jclass _exception_util_class;
     jclass _big_decimal_class;
     jclass _local_date_class;
     jclass _local_datetime_class;
@@ -322,12 +295,12 @@ private:
 
 // local object reference guard.
 // The objects inside are automatically call DeleteLocalRef in the life object.
-#define LOCAL_REF_GUARD(lref)                                                \
-    DeferOp VARNAME_LINENUM(guard)([&lref]() {                               \
-        if (lref) {                                                          \
-            JVMFunctionHelper::getInstance().getEnv()->DeleteLocalRef(lref); \
-            lref = nullptr;                                                  \
-        }                                                                    \
+#define LOCAL_REF_GUARD(lref)                                          \
+    DeferOp VARNAME_LINENUM(guard)([&lref]() {                         \
+        if (lref) {                                                    \
+            JavaRuntime::getInstance().getEnv()->DeleteLocalRef(lref); \
+            lref = nullptr;                                            \
+        }                                                              \
     })
 
 #define LOCAL_REF_GUARD_ENV(env, lref)              \
@@ -339,32 +312,32 @@ private:
     })
 
 // check JNI Exception and set error in FunctionContext
-#define CHECK_UDF_CALL_EXCEPTION(env, ctx)                                         \
-    if (auto e = env->ExceptionOccurred()) {                                       \
-        LOCAL_REF_GUARD(e);                                                        \
-        std::string msg = JVMFunctionHelper::getInstance().dumpExceptionString(e); \
-        LOG(WARNING) << "Exception: " << msg;                                      \
-        ctx->set_error(msg.c_str());                                               \
-        env->ExceptionClear();                                                     \
+#define CHECK_UDF_CALL_EXCEPTION(env, ctx)                                     \
+    if (auto e = env->ExceptionOccurred()) {                                   \
+        LOCAL_REF_GUARD(e);                                                    \
+        std::string msg = JavaRuntime::getInstance().dump_exception_string(e); \
+        LOG(WARNING) << "Exception: " << msg;                                  \
+        ctx->set_error(msg.c_str());                                           \
+        env->ExceptionClear();                                                 \
     }
 
-#define RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, prefix)                     \
-    if (auto e = env->ExceptionOccurred()) {                                       \
-        LOCAL_REF_GUARD(e);                                                        \
-        std::string err = JVMFunctionHelper::getInstance().dumpExceptionString(e); \
-        env->ExceptionClear();                                                     \
-        return Status::InternalError(fmt::format("{}, {}", prefix, err));          \
+#define RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, prefix)                 \
+    if (auto e = env->ExceptionOccurred()) {                                   \
+        LOCAL_REF_GUARD(e);                                                    \
+        std::string err = JavaRuntime::getInstance().dump_exception_string(e); \
+        env->ExceptionClear();                                                 \
+        return Status::InternalError(fmt::format("{}, {}", prefix, err));      \
     }
 
 #define RETURN_ERROR_IF_JNI_EXCEPTION(env) RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, "JNI Exception")
 
-#define RETURN_IF_JNI_EXCEPTION(env, errmsg, ret)                                                                   \
-    if (jthrowable jthr = env->ExceptionOccurred()) {                                                               \
-        LOCAL_REF_GUARD(jthr);                                                                                      \
-        std::string msg = fmt::format("{},{}", errmsg, JVMFunctionHelper::getInstance().dumpExceptionString(jthr)); \
-        LOG(WARNING) << msg;                                                                                        \
-        env->ExceptionClear();                                                                                      \
-        return ret;                                                                                                 \
+#define RETURN_IF_JNI_EXCEPTION(env, errmsg, ret)                                                               \
+    if (jthrowable jthr = env->ExceptionOccurred()) {                                                           \
+        LOCAL_REF_GUARD(jthr);                                                                                  \
+        std::string msg = fmt::format("{},{}", errmsg, JavaRuntime::getInstance().dump_exception_string(jthr)); \
+        LOG(WARNING) << msg;                                                                                    \
+        env->ExceptionClear();                                                                                  \
+        return ret;                                                                                             \
     }
 
 // Used for UDAF serialization and deserialization,
@@ -688,8 +661,5 @@ JavaUDAFUniqueContext* get_java_udaf_context(FunctionContext* ctx);
 void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFUniqueContext> udaf_ctx);
 void clear_java_udaf_states(FunctionContext* ctx);
 void destroy_java_udaf_context(FunctionContext* ctx);
-
-// Check whether java runtime can work
-Status detect_java_runtime();
 
 } // namespace starrocks

--- a/be/src/util/jvm_metrics.cpp
+++ b/be/src/util/jvm_metrics.cpp
@@ -20,15 +20,16 @@
 #include "common/status.h"
 #include "common/statusor.h"
 #include "jni.h"
+#include "runtime/env/java/java_runtime.h"
 #include "udf/java/java_udf.h"
 
-#define CHECK_JNI_EXCEPTION(env, message)                                                          \
-    if (jthrowable thr = env->ExceptionOccurred(); thr) {                                          \
-        std::string jni_error_message = JVMFunctionHelper::getInstance().dumpExceptionString(thr); \
-        env->ExceptionDescribe();                                                                  \
-        env->ExceptionClear();                                                                     \
-        env->DeleteLocalRef(thr);                                                                  \
-        return Status::InternalError(fmt::format("{}, error: {}", message, jni_error_message));    \
+#define CHECK_JNI_EXCEPTION(env, message)                                                       \
+    if (jthrowable thr = env->ExceptionOccurred(); thr) {                                       \
+        std::string jni_error_message = JavaRuntime::getInstance().dump_exception_string(thr);  \
+        env->ExceptionDescribe();                                                               \
+        env->ExceptionClear();                                                                  \
+        env->DeleteLocalRef(thr);                                                               \
+        return Status::InternalError(fmt::format("{}, error: {}", message, jni_error_message)); \
     }
 
 namespace starrocks {
@@ -43,12 +44,12 @@ JVMMetrics* JVMMetrics::instance() {
 Status JVMMetrics::init() {
     RETURN_IF_ERROR(detect_java_runtime());
 
-    // check JNIEnv before calling JVMFunctionHelper::getInstance() to avoid crash
+    // check JNIEnv before calling JavaRuntime::getInstance() to avoid crash
     if (getJNIEnv() == nullptr) {
         return Status::InternalError("get JNIEnv failed");
     }
 
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     jclass management_factory_cls = env->FindClass("java/lang/management/ManagementFactory");
     CHECK_JNI_EXCEPTION(env, "find class ManagementFactory failed")
@@ -186,7 +187,7 @@ Status JVMMetrics::update() {
 }
 
 StatusOr<MemoryUsage> JVMMetrics::get_heap_memory_usage() {
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     jobject memory_usage = env->CallObjectMethod(_memory_mxbean_obj.handle(), _get_heap_memory_usage);
     CHECK_JNI_EXCEPTION(env, "get heap memory usage failed")
@@ -202,7 +203,7 @@ StatusOr<MemoryUsage> JVMMetrics::get_heap_memory_usage() {
 }
 
 StatusOr<MemoryUsage> JVMMetrics::get_non_heap_memory_usage() {
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     jobject memory_usage = env->CallObjectMethod(_memory_mxbean_obj.handle(), _get_non_heap_memory_usage);
     CHECK_JNI_EXCEPTION(env, "get non heap memory usage failed")
@@ -218,7 +219,7 @@ StatusOr<MemoryUsage> JVMMetrics::get_non_heap_memory_usage() {
 }
 
 StatusOr<std::vector<MemoryPool>> JVMMetrics::get_memory_pools() {
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     jobject memory_pools = env->CallStaticObjectMethod(_management_factory_cls->clazz(), _get_memory_pool_mxbeans);
     CHECK_JNI_EXCEPTION(env, "get memory pool mxbeans failed")
@@ -236,7 +237,7 @@ StatusOr<std::vector<MemoryPool>> JVMMetrics::get_memory_pools() {
         jstring name = (jstring)env->CallObjectMethod(memory_pool, _get_name);
         CHECK_JNI_EXCEPTION(env, "get memory pool name failed")
         LOCAL_REF_GUARD_ENV(env, name);
-        std::string name_str = JVMFunctionHelper::getInstance().to_cxx_string(name);
+        std::string name_str = JavaRuntime::getInstance().to_cxx_string(name);
 
         jobject usage = env->CallObjectMethod(memory_pool, _get_usage);
         CHECK_JNI_EXCEPTION(env, "get memory pool usage failed")

--- a/be/test/runtime/CMakeLists.txt
+++ b/be/test/runtime/CMakeLists.txt
@@ -83,6 +83,7 @@ set(RUNTIME_ENV_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
     runtime_env_test.cpp
     java_env_test.cpp
+    java_runtime_test.cpp
 )
 
 add_executable(runtime_env_test ${RUNTIME_ENV_TEST_FILES})

--- a/be/test/runtime/java_runtime_test.cpp
+++ b/be/test/runtime/java_runtime_test.cpp
@@ -1,0 +1,131 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/env/java/java_runtime.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <string>
+
+#include "base/testutil/assert.h"
+#include "runtime/env/java/java_env.h"
+
+namespace starrocks {
+namespace {
+
+class JavaRuntimeTest : public testing::Test {
+protected:
+    void SetUp() override {
+        if (std::getenv("JAVA_HOME") == nullptr) {
+            GTEST_SKIP() << "JAVA_HOME is not set";
+        }
+
+        _env = getJNIEnv();
+        if (_env == nullptr) {
+            GTEST_SKIP() << "JVM is unavailable";
+        }
+
+        jclass exception_util = _env->FindClass("org/apache/commons/lang3/exception/ExceptionUtils");
+        if (exception_util == nullptr) {
+            _env->ExceptionClear();
+            GTEST_SKIP() << "commons-lang3 ExceptionUtils is unavailable";
+        }
+        _env->DeleteLocalRef(exception_util);
+    }
+
+    JNIEnv* env() const { return _env; }
+    JavaRuntime& runtime() const { return JavaRuntime::getInstance(); }
+
+private:
+    JNIEnv* _env = nullptr;
+};
+
+} // namespace
+
+TEST(JavaRuntimeStaticTest, ToJniClassName) {
+    ASSERT_EQ("java/lang/String", JavaRuntime::to_jni_class_name("java.lang.String"));
+    ASSERT_EQ("com/starrocks/udf/UDFHelper", JavaRuntime::to_jni_class_name("com.starrocks.udf.UDFHelper"));
+    ASSERT_EQ("java/lang/String", JavaRuntime::to_jni_class_name("java/lang/String"));
+}
+
+TEST_F(JavaRuntimeTest, GetEnvReturnsStableEnvForCurrentThread) {
+    ASSERT_NE(runtime().getEnv(), nullptr);
+    ASSERT_EQ(env(), runtime().getEnv());
+}
+
+TEST_F(JavaRuntimeTest, StringRoundTrip) {
+    ASSIGN_OR_ASSERT_FAIL(jstring jstr, runtime().to_jstring("starrocks-runtime"));
+    ASSERT_NE(jstr, nullptr);
+
+    ASSERT_EQ("starrocks-runtime", runtime().to_cxx_string(jstr));
+    ASSERT_EQ("starrocks-runtime", runtime().to_string(jstr));
+
+    env()->DeleteLocalRef(jstr);
+}
+
+TEST_F(JavaRuntimeTest, CreateObjectArray) {
+    jobjectArray nulls = runtime().create_object_array(2);
+    ASSERT_NE(nulls, nullptr);
+    ASSERT_EQ(2, env()->GetArrayLength(nulls));
+    jobject first_null = env()->GetObjectArrayElement(nulls, 0);
+    ASSERT_EQ(nullptr, first_null);
+    env()->DeleteLocalRef(nulls);
+
+    ASSIGN_OR_ASSERT_FAIL(jstring fill, runtime().to_jstring("fill"));
+    jobjectArray filled = runtime().create_object_array(fill, 2);
+    ASSERT_NE(filled, nullptr);
+    ASSERT_EQ(2, env()->GetArrayLength(filled));
+    jobject first = env()->GetObjectArrayElement(filled, 0);
+    ASSERT_TRUE(env()->IsSameObject(fill, first));
+
+    env()->DeleteLocalRef(first);
+    env()->DeleteLocalRef(filled);
+    env()->DeleteLocalRef(fill);
+}
+
+TEST_F(JavaRuntimeTest, ArrayToString) {
+    ASSIGN_OR_ASSERT_FAIL(jstring alpha, runtime().to_jstring("alpha"));
+    ASSIGN_OR_ASSERT_FAIL(jstring beta, runtime().to_jstring("beta"));
+    jobject elements[] = {alpha, beta};
+    jobjectArray array = runtime().create_object_array(elements, 2);
+    ASSERT_NE(array, nullptr);
+
+    ASSERT_EQ("[alpha, beta]", runtime().array_to_string(array));
+
+    env()->DeleteLocalRef(array);
+    env()->DeleteLocalRef(beta);
+    env()->DeleteLocalRef(alpha);
+}
+
+TEST_F(JavaRuntimeTest, DumpExceptionString) {
+    jclass clazz = env()->FindClass("java/lang/IllegalArgumentException");
+    ASSERT_NE(clazz, nullptr);
+    ASSERT_EQ(0, env()->ThrowNew(clazz, "runtime-boom"));
+
+    jthrowable throwable = env()->ExceptionOccurred();
+    ASSERT_NE(throwable, nullptr);
+    std::string details = runtime().dump_exception_string(throwable);
+    ASSERT_NE(std::string::npos, details.find("runtime-boom"));
+
+    env()->ExceptionClear();
+    env()->DeleteLocalRef(throwable);
+    env()->DeleteLocalRef(clazz);
+}
+
+TEST_F(JavaRuntimeTest, DetectJavaRuntime) {
+    ASSERT_OK(detect_java_runtime());
+}
+
+} // namespace starrocks

--- a/be/test/runtime/java_runtime_test.cpp
+++ b/be/test/runtime/java_runtime_test.cpp
@@ -102,11 +102,41 @@ TEST_F(JavaRuntimeTest, ArrayToString) {
     jobjectArray array = runtime().create_object_array(elements, 2);
     ASSERT_NE(array, nullptr);
 
+    jclass object_array_class = env()->FindClass("[Ljava/lang/Object;");
+    ASSERT_NE(object_array_class, nullptr);
+    jobject array_class = env()->GetObjectClass(array);
+    ASSERT_TRUE(env()->IsSameObject(object_array_class, array_class));
+
     ASSERT_EQ("[alpha, beta]", runtime().array_to_string(array));
 
+    env()->DeleteLocalRef(array_class);
+    env()->DeleteLocalRef(object_array_class);
     env()->DeleteLocalRef(array);
     env()->DeleteLocalRef(beta);
     env()->DeleteLocalRef(alpha);
+}
+
+TEST_F(JavaRuntimeTest, CreateObject2DArray) {
+    jobjectArray row0 = runtime().create_object_array(1);
+    ASSERT_NE(row0, nullptr);
+    jobjectArray row1 = runtime().create_object_array(1);
+    ASSERT_NE(row1, nullptr);
+    jobject elements[] = {row0, row1};
+
+    jobjectArray array = runtime().create_object_2d_array(elements, 2);
+    ASSERT_NE(array, nullptr);
+    ASSERT_EQ(2, env()->GetArrayLength(array));
+
+    jclass object_2d_array_class = env()->FindClass("[[Ljava/lang/Object;");
+    ASSERT_NE(object_2d_array_class, nullptr);
+    jobject array_class = env()->GetObjectClass(array);
+    ASSERT_TRUE(env()->IsSameObject(object_2d_array_class, array_class));
+
+    env()->DeleteLocalRef(array_class);
+    env()->DeleteLocalRef(object_2d_array_class);
+    env()->DeleteLocalRef(array);
+    env()->DeleteLocalRef(row1);
+    env()->DeleteLocalRef(row0);
 }
 
 TEST_F(JavaRuntimeTest, DumpExceptionString) {

--- a/be/test/udf/java/java_data_converter_test.cpp
+++ b/be/test/udf/java/java_data_converter_test.cpp
@@ -100,11 +100,10 @@ TEST_F(DataConverterTest, cast_to_jval) {
         offsets_data.emplace_back(20);
         std::string target;
         auto arr_col = ArrayColumn::create(std::move(nullable), std::move(offsets));
-        auto& instance = JVMFunctionHelper::getInstance();
         for (size_t i = 0; i < 3; ++i) {
             ASSIGN_OR_ASSERT_FAIL(jvalue v, cast_to_jvalue(tdesc, true, arr_col.get(), i));
             jobject obj = v.l;
-            target = target + instance.to_string(obj);
+            target = target + JavaRuntime::getInstance().to_string(obj);
             LOCAL_REF_GUARD(obj);
         }
         ASSERT_EQ(target, "[0, 1][2, 3, 4, 5, 6, 7, 8, 9][10, 11, 12, 13, 14, 15, 16, 17, 18, 19]");
@@ -181,8 +180,7 @@ TEST_F(DataConverterTest, cast_to_jval) {
         ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(tdesc, true, map_column.get(), 0));
         jobject obj = val.l;
         LOCAL_REF_GUARD(obj);
-        auto& instance = JVMFunctionHelper::getInstance();
-        std::string result = instance.to_string(obj);
+        std::string result = JavaRuntime::getInstance().to_string(obj);
         ASSERT_EQ("{0=20, 1=19}", result);
     }
 }
@@ -301,7 +299,6 @@ TEST_F(DataConverterTest, decimal_roundtrip) {
 // BigDecimal values that exceed the target DECIMAL(p,s) range are either rejected (REPORT_ERROR
 // = default) or silently nulled out (OUTPUT_NULL), matching built-in decimal cast semantics.
 TEST_F(DataConverterTest, append_jvalue_decimal_overflow) {
-    auto& helper = JVMFunctionHelper::getInstance();
     TypeDescriptor tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 5, 2); // max 999.99
 
     // Build a BigDecimal with a value that fits in BigDecimal but not in DECIMAL64(5,2).
@@ -369,8 +366,7 @@ TEST_F(DataConverterTest, assign_jvalue_decimal_null) {
 // it from the JVM, leaving the destination cell untouched. With OUTPUT_NULL the
 // row is nulled and Status is OK.
 TEST_F(DataConverterTest, assign_jvalue_decimal_overflow) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
     auto narrow_tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 5, 2); // narrow target
     auto wide_tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 38, 0);
 
@@ -422,7 +418,7 @@ TEST_F(DataConverterTest, assign_jvalue_decimal_overflow) {
 // is exercised.
 TEST_F(DataConverterTest, check_type_matched_decimal) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     // BigDecimal -> DECIMAL is OK (also tests the four LogicalType variants).
     auto src = build_decimal_col<TYPE_DECIMAL64, int64_t>(18, 4, "1234.5678");
@@ -450,8 +446,7 @@ TEST_F(DataConverterTest, check_type_matched_decimal) {
 // convert_to_boxed_array on a DECIMAL column drives `build_decimal_boxed_array`,
 // which is the batched UDF input path for native DECIMAL columns.
 TEST_F(DataConverterTest, convert_to_boxed_array_decimal) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     auto run = [&](LogicalType type, int precision, int scale, const ColumnPtr& col) {
         auto tdesc = TypeDescriptor::create_decimalv3_type(type, precision, scale);
@@ -475,7 +470,7 @@ TEST_F(DataConverterTest, convert_to_boxed_array_decimal) {
     run(TYPE_DECIMAL256, 76, 10,
         build_decimal_col<TYPE_DECIMAL256, int256_t>(76, 10, "1234567890123456789012345678901234567890.1234567890"));
 
-    // all-null shortcut path: every row null hits the create_array branch instead of
+    // all-null shortcut path: every row null hits the JavaRuntime object-array branch instead of
     // the decimal helper. Keep this case to exercise the early-return.
     {
         auto tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 18, 4);
@@ -697,8 +692,7 @@ TEST_F(DataConverterTest, check_type_matched_date_datetime) {
 // using the JNIPrimTypeId<DateValue> / JNIPrimTypeId<TimestampValue> id, which
 // must be registered against createBoxedLocalDate{,Time}Array in _method_map.
 TEST_F(DataConverterTest, convert_to_boxed_array_date_datetime) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     auto run = [&](LogicalType type, const ColumnPtr& col) {
         TypeDescriptor td(type);
@@ -734,8 +728,7 @@ TEST_F(DataConverterTest, convert_to_boxed_array_date_datetime) {
 // build_decimal_boxed_array fast path) because is_decimalv3_field_type(TYPE_ARRAY)
 // is false; the elements then hit the int32/int64/int128/int256 branches.
 TEST_F(DataConverterTest, convert_to_boxed_array_array_of_decimal) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     auto run = [&](LogicalType type, int precision, int scale) {
         TypeDescriptor element = TypeDescriptor::create_decimalv3_type(type, precision, scale);
@@ -768,7 +761,7 @@ TEST_F(DataConverterTest, convert_to_boxed_array_array_of_decimal) {
 // across the type spectrum used by the UDF analyzer.
 TEST_F(DataConverterTest, build_udf_type_desc_scalar_leaves) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     auto check_leaf = [&](const TypeDescriptor& td) {
         ASSIGN_OR_ASSERT_FAIL(jobject desc, build_udf_type_desc(env, td, /*formal_type=*/nullptr));
@@ -801,8 +794,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_scalar_leaves) {
 // JavaArrayConverter for ARRAY<scalar> / scalar slots — STRUCT-bearing routing
 // is gated on the per-slot UdfTypeDesc being non-null.
 TEST_F(DataConverterTest, convert_to_boxed_array_with_null_descs) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     // ARRAY<INT> column with one populated row.
     TypeDescriptor td = TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT));
@@ -824,8 +816,7 @@ TEST_F(DataConverterTest, convert_to_boxed_array_with_null_descs) {
 // broadcast across num_rows via create_object_array. Drive a const INT to
 // cover the non-STRUCT constant branch alongside the STRUCT-aware routing.
 TEST_F(DataConverterTest, convert_to_boxed_array_constant_short_circuit) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     TypeDescriptor td(TYPE_INT);
     auto inner = ColumnHelper::create_column(td, false);
@@ -843,11 +834,10 @@ TEST_F(DataConverterTest, convert_to_boxed_array_constant_short_circuit) {
 
 // only-null column shortcut: convert_to_boxed_array bypasses both the STRUCT
 // path and the per-type Java helper, returning a plain Object[num_rows] of
-// nulls via JVMFunctionHelper::create_array. Exercise the early-return so the
+// nulls via JavaRuntime::create_object_array. Exercise the early-return so the
 // branch is not stranded uncovered.
 TEST_F(DataConverterTest, convert_to_boxed_array_all_null_short_circuit) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     TypeDescriptor td(TYPE_BIGINT);
     auto col = ColumnHelper::create_column(td, true);
@@ -908,7 +898,7 @@ TypeDescriptor make_test_struct_typedesc() {
 // the right shape.
 TEST_F(DataConverterTest, build_udf_type_desc_struct_via_reflected_method) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     jobject formal = reflected_return_generic_type(env, "structReturn", "()Lcom/starrocks/udf/UdfTestStructRecord;");
     ASSERT_NE(formal, nullptr);
@@ -951,7 +941,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_struct_via_reflected_method) {
 // child carries the formal record class.
 TEST_F(DataConverterTest, build_udf_type_desc_array_of_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     jobject formal = reflected_return_generic_type(env, "arrayOfStruct", "()Ljava/util/List;");
     ASSERT_NE(formal, nullptr);
@@ -987,7 +977,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_array_of_struct) {
 // type arguments" recursion.
 TEST_F(DataConverterTest, build_udf_type_desc_map_of_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     jobject formal = reflected_return_generic_type(env, "mapOfStruct", "()Ljava/util/Map;");
     ASSERT_NE(formal, nullptr);
@@ -1027,7 +1017,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_map_of_struct) {
 // keep threading the formal record class through children[0].children[0].
 TEST_F(DataConverterTest, build_udf_type_desc_array_of_array_of_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     jobject formal = reflected_return_generic_type(env, "arrayOfArrayOfStruct", "()Ljava/util/List;");
     ASSERT_NE(formal, nullptr);
@@ -1062,8 +1052,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_array_of_array_of_struct) {
 // in spots where it expects them. Hand a primitive-array formal at a STRUCT
 // slot to make sure type_to_raw_class's negative path returns Status::Internal.
 TEST_F(DataConverterTest, build_udf_type_desc_struct_rejects_non_class_formal) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     // null formal at a STRUCT slot → "formal Java type is null".
     TypeDescriptor td = make_test_struct_typedesc();
@@ -1078,7 +1067,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_struct_rejects_non_class_formal) {
 // JNI bridge.
 TEST_F(DataConverterTest, convert_to_boxed_array_struct_input) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     // Construct UdfTypeDesc for STRUCT<key INT, value VARCHAR> with
     // UdfTestStructRecord as recordClass.
@@ -1154,8 +1143,7 @@ jint read_logical_type(JVMFunctionHelper& helper, JNIEnv* env, jobject desc) {
 // the signature: returns one null-handle entry per SQL arg and a null-handle ret.
 // Skips the JNI walk over Method.getGenericParameterTypes entirely.
 TEST_F(DataConverterTest, build_method_udf_type_descs_no_struct_short_circuit) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     // Any method handle works since we early-return before reading it.
     jobject method = reflected_test_support_method(
@@ -1183,7 +1171,7 @@ TEST_F(DataConverterTest, build_method_udf_type_descs_no_struct_short_circuit) {
 // to avoid walking update.getGenericReturnType() which is `void`).
 TEST_F(DataConverterTest, build_method_udf_type_descs_udaf_state_offset) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     // void udafUpdateWithStruct(State state, UdfTestStructRecord record)
     jobject method = reflected_test_support_method(
@@ -1218,7 +1206,7 @@ TEST_F(DataConverterTest, build_method_udf_type_descs_udaf_state_offset) {
 // desc carries logicalType=ARRAY with an element child carrying the record class.
 TEST_F(DataConverterTest, build_method_udf_type_descs_udaf_finalize_array_of_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     jobject method = reflected_test_support_method(env, "udafFinalizeArrayOfStruct",
                                                    "(Lcom/starrocks/udf/UdfTestSupport$State;)Ljava/util/List;");
@@ -1253,7 +1241,7 @@ TEST_F(DataConverterTest, build_method_udf_type_descs_udaf_finalize_array_of_str
 // the array class (Class<Record[]>).
 TEST_F(DataConverterTest, build_method_udf_type_descs_udtf_unwrap_return_array) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     // UdfTestStructRecord[] udtfProcessReturnsRecordArray(UdfTestStructRecord)
     jobject method = reflected_test_support_method(
@@ -1291,8 +1279,7 @@ TEST_F(DataConverterTest, build_method_udf_type_descs_udtf_unwrap_return_array) 
 // InternalError. Drives the helper with unwrap=false on the same UDTF-shaped
 // method to confirm the path is wired.
 TEST_F(DataConverterTest, build_method_udf_type_descs_struct_return_without_unwrap_fails) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     jobject method = reflected_test_support_method(
             env, "udtfProcessReturnsRecordArray",
@@ -1313,7 +1300,7 @@ TEST_F(DataConverterTest, build_method_udf_type_descs_struct_return_without_unwr
 // non-null record instance whose components match the column row.
 TEST_F(DataConverterTest, cast_to_jvalue_struct_per_row) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     // Build the per-arg UdfTypeDesc from a method shape — same path UDTF uses.
     jobject method = reflected_test_support_method(
@@ -1370,8 +1357,7 @@ TEST_F(DataConverterTest, cast_to_jvalue_struct_requires_type_desc) {
 // round-trips it through append_jvalue and verifies the resulting column's
 // shape and values.
 TEST_F(DataConverterTest, append_jvalue_struct_per_row_roundtrip) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     jobject method = reflected_test_support_method(
             env, "udtfProcessReturnsRecordArray",
@@ -1400,8 +1386,7 @@ TEST_F(DataConverterTest, append_jvalue_struct_per_row_roundtrip) {
 // check_type_matched STRUCT path: UDTF result-row validator. Accepts the
 // declared record class and rejects an unrelated runtime class.
 TEST_F(DataConverterTest, check_type_matched_struct) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JavaRuntime::getInstance().getEnv();
 
     jobject method = reflected_test_support_method(
             env, "udtfProcessReturnsRecordArray",

--- a/be/test/udf/java/java_udf_test.cpp
+++ b/be/test/udf/java/java_udf_test.cpp
@@ -298,7 +298,7 @@ TEST_F(JavaUDFTest, get_result_from_boxed_array_with_function_context) {
 // jfieldIDs the BE input boxer relies on.
 TEST_F(JavaUDFTest, new_udf_type_desc_scalar_leaf) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     ASSIGN_OR_ASSERT_FAIL(jobject desc,
                           helper.new_udf_type_desc(/*logicalType=*/TYPE_INT, /*children=*/nullptr,
@@ -321,7 +321,7 @@ TEST_F(JavaUDFTest, new_udf_type_desc_scalar_leaf) {
 // the cached field IDs.
 TEST_F(JavaUDFTest, new_udf_type_desc_decimal_and_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JavaRuntime::getInstance().getEnv();
 
     // DECIMAL64(18,4)
     {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
