### PR TITLE
[Enhancement] Iceberg parquet: short-circuit SELECT DISTINCT via dict page

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -459,6 +459,9 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     if (hdfs_scan_node.__isset.can_use_count_opt) {
         _use_count_opt = hdfs_scan_node.can_use_count_opt;
     }
+    if (hdfs_scan_node.__isset.dict_page_shortcut_hint) {
+        _dict_page_shortcut_hint = hdfs_scan_node.dict_page_shortcut_hint;
+    }
     if (hdfs_scan_node.__isset.use_partition_column_value_only) {
         _use_partition_column_value_only = hdfs_scan_node.use_partition_column_value_only;
     }
@@ -858,6 +861,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.use_min_max_opt = _use_min_max_opt;
     scanner_params.can_use_any_column = _can_use_any_column;
     scanner_params.use_count_opt = _use_count_opt;
+    scanner_params.dict_page_shortcut_hint = _dict_page_shortcut_hint;
     scanner_params.all_conjunct_ctxs = _all_conjunct_ctxs;
     if (!_disable_column_access_path_hints && !_column_access_paths.empty()) {
         scanner_params.column_access_paths = &_column_access_paths;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -189,6 +189,8 @@ private:
     // that placeholder column from the data file.
     bool _can_use_any_column = false;
     bool _use_count_opt = false;
+    // Hint for parquet dict-page shortcut. Propagated to HdfsScannerParams.
+    bool _dict_page_shortcut_hint = false;
     const HiveTableDescriptor* _hive_table = nullptr;
 
     bool _has_scan_range_indicate_const_column = false;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -202,6 +202,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.use_min_max_opt = _scanner_params.use_min_max_opt;
     ctx.can_use_any_column = _scanner_params.can_use_any_column;
     ctx.use_count_opt = _scanner_params.use_count_opt;
+    ctx.dict_page_shortcut_hint = _scanner_params.dict_page_shortcut_hint;
     ctx.use_file_metacache = _scanner_params.use_file_metacache;
     ctx.use_file_pagecache = _scanner_params.use_file_pagecache;
     ctx.timezone = _runtime_state->timezone();

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -302,6 +302,9 @@ struct HdfsScannerParams {
     bool can_use_any_column = false;
 
     bool use_count_opt = false;
+    // Hint for parquet reader to emit a row-group's dict-page values directly when
+    // per-RG safety gates pass in GroupReader::prepare().
+    bool dict_page_shortcut_hint = false;
     bool orc_use_column_names = false;
     bool parquet_page_index_enable = false;
     bool parquet_bloom_filter_enable = false;
@@ -381,6 +384,8 @@ struct HdfsScannerContext {
     bool can_use_any_column = false;
 
     bool use_count_opt = false;
+    // Propagated from HdfsScannerParams; consumed by parquet GroupReader.
+    bool dict_page_shortcut_hint = false;
     bool is_first_split = false;
     bool can_use_file_record_count = false;
 

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -204,6 +204,20 @@ public:
         return Status::OK();
     }
 
+    // Emit the entire dictionary as raw values into `column`. Output length equals the
+    // dictionary size; the destination column must be the physical primitive column
+    // (after ColumnHelper::get_data_column) — null bookkeeping is the caller's job.
+    Status get_dict_values(Column* column) override {
+        auto* data_column = down_cast<FixedLengthColumn<T>*>(column);
+        size_t cur_size = data_column->size();
+        data_column->resize_uninitialized(cur_size + _dict.size());
+        T* __restrict dst = data_column->get_data().data() + cur_size;
+        if (!_dict.empty()) {
+            std::memcpy(dst, _dict.data(), _dict.size() * sizeof(T));
+        }
+        return Status::OK();
+    }
+
     Status _do_next_batch_with_nulls(size_t count, const NullInfos& null_infos, ColumnContentType content_type,
                                      Column* dst, const FilterData* filter) override {
         DCHECK(dst->is_nullable());

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -276,6 +276,7 @@ Status FileReader::_init_group_readers() {
     _group_reader_param.datacache_options = &_datacache_options;
     _group_reader_param.scan_range_id = fd_scanner_ctx.scan_range_id;
     _group_reader_param.scan_range = fd_scanner_ctx.scan_range;
+    _group_reader_param.dict_page_shortcut_hint = fd_scanner_ctx.dict_page_shortcut_hint;
 
     int64_t row_group_first_row_id = _scanner_ctx->scan_range->first_row_id;
     int64_t row_group_first_row = 0;

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -481,6 +481,19 @@ Status GroupReader::prepare() {
     // select_offset_index (so the underlying typed_value readers already have the correct range).
     RETURN_IF_ERROR(_promote_variant_virtual_columns());
 
+    // Dict-page shortcut decision: must run AFTER _prepare_column_readers (needs
+    // column_all_pages_dict_encoded() and column-chunk statistics) but BEFORE the
+    // coalesced PAGES IO planning below — otherwise the data-page reads we want to
+    // skip have already been scheduled.
+    {
+        bool active = false;
+        RETURN_IF_ERROR(_maybe_apply_dict_shortcut(&active));
+        if (active) {
+            _has_prepared = true;
+            return Status::OK();
+        }
+    }
+
     // if coalesce read enabled, we have to
     // 1. allocate shared buffered input stream and
     // 2. collect io ranges of every row group reader.
@@ -507,6 +520,92 @@ Status GroupReader::prepare() {
     }
 
     _has_prepared = true;
+    return Status::OK();
+}
+
+Status GroupReader::_maybe_apply_dict_shortcut(bool* out_active) {
+    *out_active = false;
+    if (!_param.dict_page_shortcut_hint) {
+        return Status::OK();
+    }
+    // Writer trust: only parquet-mr guarantees the dict page contains only referenced
+    // values (DictionaryValuesWriter.toDictPageAndClose prunes to lastUsedDictionarySize).
+    // Other writers (arrow-cpp / pyarrow / DuckDB / StarRocks BE) may leave unused dict
+    // entries, which would silently over-approximate DISTINCT results.
+    if (_param.file_metadata == nullptr || _param.file_metadata->writer_version().application_ != "parquet-mr") {
+        return Status::OK();
+    }
+    // Single materialised slot only. Multi-column DISTINCT cannot use independent dict
+    // pages without cartesian-product over-approximation.
+    if (_param.read_cols.size() != 1) {
+        return Status::OK();
+    }
+    // Any per-slot conjunct (predicate-pushdown / dict-filter) means rows are filtered
+    // after read; dict-page values would include filtered-out rows.
+    if (!_param.conjunct_ctxs_by_slot.empty()) {
+        return Status::OK();
+    }
+    // Position deletes (iceberg v2 .position-delete.parquet via IcebergDeleteBuilder,
+    // iceberg v3 deletion vectors, paimon deletion files) all land in the same
+    // DeletionBitmap. Only bail if this row group's row range actually contains any
+    // deleted positions — clean RGs of a partially-deleted file still get the shortcut.
+    if (_skip_rows_ctx != nullptr && _skip_rows_ctx->deletion_bitmap != nullptr) {
+        const uint64_t rg_first = static_cast<uint64_t>(_row_group_first_row);
+        const uint64_t rg_end = rg_first + static_cast<uint64_t>(_row_group_metadata->num_rows);
+        if (_skip_rows_ctx->deletion_bitmap->get_range_cardinality(rg_first, rg_end) > 0) {
+            return Status::OK();
+        }
+    }
+    // Page-index narrowed the row group to a sub-range — dict still describes the
+    // full RG and would include values from skipped pages.
+    if (_range.span_size() != static_cast<uint64_t>(_row_group_metadata->num_rows)) {
+        return Status::OK();
+    }
+
+    const auto& column = _param.read_cols[0];
+    SlotId slot_id = column.slot_id();
+    auto it = _column_readers.find(slot_id);
+    if (it == _column_readers.end()) {
+        return Status::OK();
+    }
+    auto* scalar_reader = dynamic_cast<ScalarColumnReader*>(it->second.get());
+    if (scalar_reader == nullptr) {
+        return Status::OK();
+    }
+    if (!scalar_reader->column_all_pages_dict_encoded()) {
+        return Status::OK();
+    }
+
+    // Dict page does not encode nulls (they are tracked via def-levels). To answer
+    // SELECT DISTINCT correctly we need to know whether the column contains NULLs.
+    // Unset null_count statistic means we cannot tell — bail to the normal path
+    // rather than risk emitting (or omitting) a NULL value that doesn't (does)
+    // exist in the data.
+    const auto* chunk_meta = scalar_reader->get_chunk_metadata();
+    if (chunk_meta == nullptr || !chunk_meta->meta_data.__isset.statistics ||
+        !chunk_meta->meta_data.statistics.__isset.null_count) {
+        return Status::OK();
+    }
+    int64_t null_count = chunk_meta->meta_data.statistics.null_count;
+
+    // parquet-mr may omit the dictionary page when every value is NULL even though
+    // encoding_stats still claims dictionary encoding. ColumnChunkReader would then
+    // crash on _try_load_dictionary. Also catch any (rare) chunk without a declared
+    // dictionary_page_offset. The normal read path handles both correctly.
+    if (null_count == _row_group_metadata->num_rows || !chunk_meta->meta_data.__isset.dictionary_page_offset) {
+        return Status::OK();
+    }
+
+    ColumnPtr buf = ColumnHelper::create_column(column.slot_type(), true);
+    RETURN_IF_ERROR(scalar_reader->materialize_dictionary_values(buf));
+    if (null_count > 0) {
+        buf->as_mutable_raw_ptr()->append_default(1);
+    }
+
+    _dict_shortcut_values = std::move(buf);
+    _dict_shortcut_slot_id = slot_id;
+    _dict_shortcut_active = true;
+    *out_active = true;
     return Status::OK();
 }
 
@@ -566,6 +665,25 @@ const tparquet::RowGroup* GroupReader::get_row_group_metadata() const {
 
 Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
     SCOPED_RAW_TIMER(&_param.stats->group_chunk_read_ns);
+
+    // Dict-page shortcut: prepare() pre-materialised the column-chunk dictionary as
+    // the result for this row group. Emit in chunk_size-bounded batches (caller passes
+    // its desired batch in *row_count) so the upstream aggregate's chunk-size invariant
+    // is preserved even for row groups with very large dictionaries.
+    if (_dict_shortcut_active) {
+        const size_t total = _dict_shortcut_values->size();
+        if (_dict_shortcut_offset >= total) {
+            *row_count = 0;
+            return Status::EndOfFile("");
+        }
+        size_t batch = std::min<size_t>(*row_count, total - _dict_shortcut_offset);
+        auto& dst_col = (*chunk)->get_column_by_slot_id(_dict_shortcut_slot_id);
+        dst_col->as_mutable_raw_ptr()->append(*_dict_shortcut_values, _dict_shortcut_offset, batch);
+        _dict_shortcut_offset += batch;
+        *row_count = batch;
+        return (_dict_shortcut_offset >= total) ? Status::EndOfFile("") : Status::OK();
+    }
+
     if (_is_group_filtered) {
         *row_count = 0;
         return Status::EndOfFile("");

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -125,6 +125,11 @@ struct GroupReaderParam {
 
     int32_t scan_range_id = -1;
     const THdfsScanRange* scan_range = nullptr;
+
+    // Hint to short-circuit a row-group by materialising its dict-page values instead
+    // of decoding data pages. Per-RG decision is made in
+    // GroupReader::_maybe_apply_dict_shortcut().
+    bool dict_page_shortcut_hint = false;
 };
 
 class GroupReader {
@@ -361,6 +366,19 @@ private:
     // this value, so avoid failing unrelated scans on malformed session timezone strings.
     cctz::time_zone _timezone_obj = cctz::utc_time_zone();
     bool _timezone_resolved = false;
+
+    // Dict-page shortcut state. Set in prepare() by _maybe_apply_dict_shortcut() when
+    // all per-RG safety gates pass. When active, get_next() emits the prepared values
+    // in chunk_size-bounded batches and returns EOF after the last batch; the normal
+    // read pipeline is bypassed for this row group.
+    bool _dict_shortcut_active = false;
+    size_t _dict_shortcut_offset = 0;
+    SlotId _dict_shortcut_slot_id = -1;
+    ColumnPtr _dict_shortcut_values;
+
+    // Returns OK with *out_active=true when the dict-page shortcut was applied for this
+    // row group; otherwise *out_active=false and the caller continues normal prepare().
+    Status _maybe_apply_dict_shortcut(bool* out_active);
 };
 
 using GroupReaderPtr = std::shared_ptr<GroupReader>;

--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -544,6 +544,52 @@ Status ScalarColumnReader::_read_range_impl(const Range<uint64_t>& range, const 
     }
 }
 
+Status ScalarColumnReader::materialize_dictionary_values(ColumnPtr& dst) {
+    DCHECK(dst != nullptr);
+    DCHECK(_converter != nullptr) << "prepare() must be called before materialize_dictionary_values";
+
+    // For converted types (e.g. parquet INT96 -> TIMESTAMP, raw 16-byte UUID -> string)
+    // decode into the physical intermediate column first, then convert into dst.  This
+    // mirrors _dict_decode but skips the dict-code stream entirely; we only need the
+    // dictionary page itself.
+    if (_converter->need_convert) {
+        if (_tmp_intermediate_column == nullptr) {
+            _tmp_intermediate_column = _converter->create_src_column();
+        }
+        _tmp_intermediate_column->as_mutable_raw_ptr()->reset_column();
+        Column* physical = ColumnHelper::get_data_column(_tmp_intermediate_column->as_mutable_raw_ptr());
+        size_t before = physical->size();
+        RETURN_IF_ERROR(_reader->get_dict_values(physical));
+        // Keep the nullable wrapper's null array in sync with the data array — converters
+        // dereference both with the same length and crash/corrupt otherwise. Dict values
+        // are never null by construction.
+        if (_tmp_intermediate_column->is_nullable()) {
+            auto* nullable = down_cast<NullableColumn*>(_tmp_intermediate_column->as_mutable_raw_ptr());
+            size_t appended = physical->size() - before;
+            nullable->null_column_raw_ptr()->append_default(appended);
+        }
+        {
+            SCOPED_RAW_TIMER(&_opts.stats->column_convert_ns);
+            RETURN_IF_ERROR(_converter->convert(_tmp_intermediate_column.get(), dst->as_mutable_raw_ptr()));
+        }
+        _tmp_intermediate_column->as_mutable_raw_ptr()->reset_column();
+        return Status::OK();
+    }
+
+    // No conversion required — write directly into dst's data column.  Append zero
+    // nulls if dst is nullable; the caller appends an extra NULL row separately if
+    // the column statistics say null_count > 0.
+    Column* data_column = ColumnHelper::get_data_column(dst->as_mutable_raw_ptr());
+    size_t before = data_column->size();
+    RETURN_IF_ERROR(_reader->get_dict_values(data_column));
+    if (dst->is_nullable()) {
+        auto* nullable = down_cast<NullableColumn*>(dst->as_mutable_raw_ptr());
+        size_t appended = data_column->size() - before;
+        nullable->null_column_raw_ptr()->append_default(appended);
+    }
+    return Status::OK();
+}
+
 Status ScalarColumnReader::_dict_decode(ColumnPtr& dst, ColumnPtr& src) {
     Column* dict_values = ColumnHelper::get_data_column(dst->as_mutable_raw_ptr());
     dict_values->reserve(src->size());

--- a/be/src/formats/parquet/scalar_column_reader.h
+++ b/be/src/formats/parquet/scalar_column_reader.h
@@ -205,6 +205,14 @@ public:
     void collect_column_io_range(std::vector<SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                  ColumnIOTypeFlags types, bool active) override;
 
+    // Loads the column-chunk dictionary page and materialises its values into `dst`,
+    // applying the column converter the same way the normal data-page decode path does.
+    // Output length equals the dictionary size.
+    //
+    // Caller must guarantee column_all_pages_dict_encoded() is true; this method does
+    // not re-check.
+    Status materialize_dictionary_values(ColumnPtr& dst);
+
 private:
     template <bool LAZY_DICT_DECODE, bool LAZY_CONVERT>
     Status _read_range_impl(const Range<uint64_t>& range, const Filter* filter, ColumnContentType content_type,

--- a/be/test/formats/parquet/dict_encoding_test.cpp
+++ b/be/test/formats/parquet/dict_encoding_test.cpp
@@ -213,4 +213,40 @@ TEST(DictEncodingReadTest, BinaryPageTest) {
     constexpr LogicalType DICT_TYPE = LogicalType::TYPE_INT;
     dict_encoding_test<DICT_TYPE, TARGET_TYPE>();
 }
+
+TEST(DictEncodingReadTest, GetDictValuesInt) {
+    DictDecoder<int32_t> decoder;
+    FakeDictDecoder<TYPE_INT> inner;
+    ASSERT_OK(decoder.set_dict(/*chunk_size=*/16, /*num_values=*/10, &inner));
+
+    auto col = Int32Column::create();
+    ASSERT_OK(decoder.get_dict_values(col.get()));
+    ASSERT_EQ(col->size(), 10);
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_EQ(col->get(i).get_int32(), i);
+    }
+}
+
+TEST(DictEncodingReadTest, GetDictValuesVarchar) {
+    DictDecoder<Slice> decoder;
+    FakeDictDecoder<TYPE_VARCHAR> inner;
+    ASSERT_OK(decoder.set_dict(/*chunk_size=*/16, /*num_values=*/5, &inner));
+
+    auto col = BinaryColumn::create();
+    ASSERT_OK(decoder.get_dict_values(col.get()));
+    ASSERT_EQ(col->size(), 5);
+    for (int i = 0; i < 5; ++i) {
+        EXPECTED_UNQUOTE(col->debug_item(i), std::to_string(i));
+    }
+}
+
+TEST(DictEncodingReadTest, GetDictValuesEmptyDict) {
+    DictDecoder<int64_t> decoder;
+    FakeDictDecoder<TYPE_BIGINT> inner;
+    ASSERT_OK(decoder.set_dict(/*chunk_size=*/8, /*num_values=*/0, &inner));
+
+    auto col = Int64Column::create();
+    ASSERT_OK(decoder.get_dict_values(col.get()));
+    EXPECT_EQ(col->size(), 0);
+}
 } // namespace starrocks::parquet

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -220,6 +220,9 @@ public class HdfsScanNode extends ScanNode {
         tHdfsScanNode.setCan_use_min_max_opt(option.getCanUseMinMaxOpt());
         tHdfsScanNode.setUse_partition_column_value_only(option.getUsePartitionColumnValueOnly());
         tHdfsScanNode.setCan_use_count_opt(option.getCanUseCountOpt());
+        if (option.getDictPageShortcutHint()) {
+            tHdfsScanNode.setDict_page_shortcut_hint(true);
+        }
     }
 
     public static void setCloudConfigurationToThrift(THdfsScanNode tHdfsScanNode, CloudConfiguration cc) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -337,6 +337,9 @@ public class IcebergScanNode extends ScanNode {
 
         if (detailLevel == TExplainLevel.VERBOSE) {
             HdfsScanNode.appendDataCacheOptionsInExplain(output, prefix, dataCacheOptions);
+            if (getScanOptimizeOption().getDictPageShortcutHint()) {
+                output.append(prefix).append("dict-page shortcut: hint=true\n");
+            }
             // for global dict
             output.append(explainColumnDict(prefix));
             output.append(explainColumnAccessPath(prefix));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -618,6 +618,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_READ_ICEBERG_PUFFIN_NDV = "enable_read_iceberg_puffin_ndv";
 
     public static final String ENABLE_ICEBERG_COLUMN_STATISTICS = "enable_iceberg_column_statistics";
+
+    public static final String ENABLE_ICEBERG_DICT_PAGE_SHORTCUT = "enable_iceberg_dict_page_shortcut";
     public static final String ENABLE_READ_ICEBERG_EQUALITY_DELETE_WITH_PARTITION_EVOLUTION =
             "enable_read_iceberg_equality_delete_with_partition_evolution";
     public static final String ENABLE_DELTA_LAKE_COLUMN_STATISTICS = "enable_delta_lake_column_statistics";
@@ -3208,6 +3210,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_ICEBERG_COLUMN_STATISTICS)
     private boolean enableIcebergColumnStatistics = false;
 
+    // Iceberg parquet only: SELECT DISTINCT col / GROUP BY col may short-circuit by
+    // emitting the column-chunk dictionary page instead of decoding data pages. BE
+    // applies per-RG safety gates (writer=parquet-mr, fully dict-encoded, null_count
+    // set, no delete files). Off by default.
+    @VarAttr(name = ENABLE_ICEBERG_DICT_PAGE_SHORTCUT)
+    private boolean enableIcebergDictPageShortcut = false;
+
     @VarAttr(name = ENABLE_READ_ICEBERG_EQUALITY_DELETE_WITH_PARTITION_EVOLUTION)
     private boolean enableReadIcebergEqDeleteWithPartitionEvolution = false;
 
@@ -4868,6 +4877,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setUseLowCardinalityOptimizeOnLake(boolean useLowCardinalityOptimizeOnLake) {
         this.useLowCardinalityOptimizeOnLake = useLowCardinalityOptimizeOnLake;
+    }
+
+    public boolean isEnableIcebergDictPageShortcut() {
+        return enableIcebergDictPageShortcut;
+    }
+
+    public void setEnableIcebergDictPageShortcut(boolean v) {
+        this.enableIcebergDictPageShortcut = v;
     }
 
     public boolean isEnableRewriteGroupingsetsToUnionAll() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -105,6 +105,7 @@ import com.starrocks.sql.optimizer.rule.transformation.pruner.RboTablePruneRule;
 import com.starrocks.sql.optimizer.rule.transformation.pruner.UniquenessBasedTablePruneRule;
 import com.starrocks.sql.optimizer.rule.tree.AddDecodeNodeForDictStringRule;
 import com.starrocks.sql.optimizer.rule.tree.AddIndexOnlyPredicateRule;
+import com.starrocks.sql.optimizer.rule.tree.ApplyIcebergDictPageShortcutRule;
 import com.starrocks.sql.optimizer.rule.tree.ApplyMinMaxStatisticRule;
 import com.starrocks.sql.optimizer.rule.tree.ApplyTuningGuideRule;
 import com.starrocks.sql.optimizer.rule.tree.CloneDuplicateColRefRule;
@@ -1026,6 +1027,7 @@ public class QueryOptimizer extends Optimizer {
         result = new AddDecodeNodeForDictStringRule().rewrite(result, rootTaskContext);
         result = new LowCardinalityRewriteRule().rewrite(result, rootTaskContext);
         result = new ApplyMinMaxStatisticRule().rewrite(result, rootTaskContext);
+        result = new ApplyIcebergDictPageShortcutRule().rewrite(result, rootTaskContext);
         // Put before ScalarOperatorsReuseRule
         result = new PruneSubfieldsForComplexType().rewrite(result, rootTaskContext);
         result = new InlineCteProjectPruneRule().rewrite(result, rootTaskContext);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ScanOptimizeOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ScanOptimizeOption.java
@@ -19,6 +19,10 @@ public class ScanOptimizeOption {
     private boolean canUseMinMaxOpt;
     private boolean usePartitionColumnValueOnly;
     private boolean canUseCountOpt;
+    // Hint for BE parquet reader: try to emit a row-group's dict-page values as the
+    // result instead of decoding data pages. BE applies per-RG safety gates and may
+    // decline the hint.
+    private boolean dictPageShortcutHint;
 
     public void setCanUseAnyColumn(boolean v) {
         canUseAnyColumn = v;
@@ -52,12 +56,21 @@ public class ScanOptimizeOption {
         return canUseCountOpt;
     }
 
+    public void setDictPageShortcutHint(boolean v) {
+        this.dictPageShortcutHint = v;
+    }
+
+    public boolean getDictPageShortcutHint() {
+        return dictPageShortcutHint;
+    }
+
     public ScanOptimizeOption copy() {
         ScanOptimizeOption opt = new ScanOptimizeOption();
         opt.canUseAnyColumn = this.canUseAnyColumn;
         opt.canUseMinMaxOpt = this.canUseMinMaxOpt;
         opt.usePartitionColumnValueOnly = this.usePartitionColumnValueOnly;
         opt.canUseCountOpt = this.canUseCountOpt;
+        opt.dictPageShortcutHint = this.dictPageShortcutHint;
         return opt;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyIcebergDictPageShortcutRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyIcebergDictPageShortcutRule.java
@@ -1,0 +1,183 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.task.TaskContext;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+
+// Marks PhysicalIcebergScanOperator with dictPageShortcutHint=true when the plan is
+// a pure single-column DISTINCT / GROUP BY over an iceberg-parquet scan with no
+// predicate. The hint asks BE to consider emitting the column's dict-page values
+// directly. BE applies per-RG safety gates before using the shortcut.
+//
+// Must run after low-cardinality / decode rewrites so that the scan operator and
+// group-by column refs are stable.
+public class ApplyIcebergDictPageShortcutRule implements TreeRewriteRule {
+
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        if (!ConnectContext.get().getSessionVariable().isEnableIcebergDictPageShortcut()) {
+            return root;
+        }
+        root.getOp().accept(new Visitor(), root, false);
+        return root;
+    }
+
+    private static class Visitor extends OptExpressionVisitor<Void, Boolean> {
+        @Override
+        public Void visit(OptExpression optExpression, Boolean limitAbove) {
+            // A LIMIT on any ancestor caps the distinct/group-by output. `select distinct c
+            // ... limit 5` lands the limit on the agg's parent project, not the agg itself,
+            // so checking the agg alone misses it. Carry the signal down to tryMark.
+            boolean limitSeen = Boolean.TRUE.equals(limitAbove) || optExpression.getOp().hasLimit();
+            if (optExpression.getOp().getOpType() == OperatorType.PHYSICAL_HASH_AGG) {
+                tryMark(optExpression, limitSeen);
+            }
+            for (OptExpression child : optExpression.getInputs()) {
+                child.getOp().accept(this, child, limitSeen);
+            }
+            return null;
+        }
+
+        private void tryMark(OptExpression aggExpr, boolean limitAbove) {
+            PhysicalHashAggregateOperator agg = (PhysicalHashAggregateOperator) aggExpr.getOp();
+
+            // distinct / pure group-by — no aggregate functions
+            if (agg.getAggregations() != null && !agg.getAggregations().isEmpty()) {
+                return;
+            }
+            // PR1 — single group-by key
+            if (agg.getGroupBys() == null || agg.getGroupBys().size() != 1) {
+                return;
+            }
+            // agg with predicate (HAVING) — bail
+            if (agg.getPredicate() != null) {
+                return;
+            }
+            // A LIMIT on the distinct/group-by — whether carried on the agg itself or, as with
+            // `select distinct c ... limit 5`, on a parent project above it — caps the row set,
+            // but the shortcut emits the whole column-chunk dictionary, so the capped result
+            // would be wrong. limitAbove folds in both the agg's own limit and any ancestor's.
+            if (limitAbove) {
+                return;
+            }
+            ColumnRefOperator groupByCol = agg.getGroupBys().get(0);
+
+            // Walk down only through identity Project operators. Any other unary op
+            // (TopN, Sort, Limit, Filter, etc.) changes the row set the agg sees, so
+            // dict-page values from the scan would be the wrong input.
+            OptExpression cur = aggExpr;
+            while (cur.getInputs().size() == 1
+                    && cur.getInputs().get(0).getOp().getOpType() != OperatorType.PHYSICAL_ICEBERG_SCAN) {
+                OptExpression child = cur.getInputs().get(0);
+                if (child.getOp().getOpType() != OperatorType.PHYSICAL_PROJECT) {
+                    return;
+                }
+                if (!isIdentityProjection(child)) {
+                    return;
+                }
+                // a LIMIT carried on the intermediate project caps the row set too
+                if (child.getOp().hasLimit()) {
+                    return;
+                }
+                cur = child;
+            }
+            if (cur.getInputs().size() != 1) {
+                return;
+            }
+            OptExpression scanExpr = cur.getInputs().get(0);
+            if (scanExpr.getOp().getOpType() != OperatorType.PHYSICAL_ICEBERG_SCAN) {
+                return;
+            }
+            PhysicalIcebergScanOperator scan = (PhysicalIcebergScanOperator) scanExpr.getOp();
+
+            // any per-row predicate on the scan disqualifies us — BE cannot prove
+            // the RG-level filter alone satisfies the predicate for every surviving row.
+            if (scan.getPredicate() != null) {
+                return;
+            }
+            // scan-level LIMIT changes the row set in ways dict-page values cannot
+            // reproduce (we'd emit the full RG dict instead of the first N rows).
+            if (scan.hasLimit()) {
+                return;
+            }
+
+            IcebergTable table = (IcebergTable) scan.getTable();
+            // parquet only
+            String fileFormat = table.getNativeTable().properties()
+                    .getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT);
+            if (!"parquet".equalsIgnoreCase(fileFormat)) {
+                return;
+            }
+
+            Set<String> partitionNames = Set.copyOf(table.getPartitionColumnNames());
+
+            // scan must read exactly one non-partition data slot, and that slot must
+            // equal the group-by column. partition slots are fine (they materialize
+            // outside the parquet file).
+            List<ColumnRefOperator> nonPartitionSlots = Lists.newArrayList();
+            for (ColumnRefOperator col : scan.getColRefToColumnMetaMap().keySet()) {
+                if (!partitionNames.contains(col.getName())) {
+                    nonPartitionSlots.add(col);
+                }
+            }
+            if (nonPartitionSlots.size() != 1) {
+                return;
+            }
+            // pure partition-col DISTINCT — there's a separate manifest-based path
+            // (use_partition_column_value_only); do not steal it.
+            if (partitionNames.contains(groupByCol.getName())) {
+                return;
+            }
+            ColumnRefOperator dataSlot = nonPartitionSlots.get(0);
+            if (dataSlot.getId() != groupByCol.getId()) {
+                return;
+            }
+
+            // projection on scan must not transform the data slot (we feed raw values
+            // to the agg; any transform makes dict-page values invalid).
+            if (scan.getProjection() != null
+                    && scan.getProjection().getColumnRefMap() != null
+                    && !scan.getProjection().getColumnRefMap().isEmpty()
+                    && !isIdentityProjection(scanExpr)) {
+                return;
+            }
+
+            scan.getScanOptimizeOption().setDictPageShortcutHint(true);
+        }
+
+        private static boolean isIdentityProjection(OptExpression expr) {
+            if (expr.getOp().getProjection() == null) {
+                return true;
+            }
+            return expr.getOp().getProjection().getColumnRefMap().entrySet().stream()
+                    .allMatch(e -> e.getKey().equals(e.getValue()));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergDictPageShortcutTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergDictPageShortcutTest.java
@@ -1,0 +1,102 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class IcebergDictPageShortcutTest extends ConnectorPlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        ConnectorPlanTestBase.beforeClass();
+        connectContext.getSessionVariable().setEnableIcebergDictPageShortcut(true);
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        connectContext.getSessionVariable().setEnableIcebergDictPageShortcut(false);
+    }
+
+    @Test
+    public void testSelectDistinctHintApplied() throws Exception {
+        String sql = "select distinct data from iceberg0.unpartitioned_db.t0";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "dict-page shortcut: hint=true");
+    }
+
+    @Test
+    public void testGroupByEquivalentToDistinct() throws Exception {
+        String sql = "select data from iceberg0.unpartitioned_db.t0 group by data";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "dict-page shortcut: hint=true");
+    }
+
+    @Test
+    public void testMultiColDistinctNotHinted() throws Exception {
+        String sql = "select distinct id, data from iceberg0.unpartitioned_db.t0";
+        String plan = getVerboseExplain(sql);
+        Assertions.assertFalse(plan.contains("dict-page shortcut: hint=true"),
+                "multi-col DISTINCT must not get the hint in PR1");
+    }
+
+    @Test
+    public void testWithPredicateNotHinted() throws Exception {
+        String sql = "select distinct data from iceberg0.unpartitioned_db.t0 where id > 0";
+        String plan = getVerboseExplain(sql);
+        Assertions.assertFalse(plan.contains("dict-page shortcut: hint=true"),
+                "per-row predicate must disable the hint");
+    }
+
+    @Test
+    public void testAggregateFunctionNotHinted() throws Exception {
+        String sql = "select data, count(*) from iceberg0.unpartitioned_db.t0 group by data";
+        String plan = getVerboseExplain(sql);
+        Assertions.assertFalse(plan.contains("dict-page shortcut: hint=true"),
+                "agg with aggregate functions must not get the hint");
+    }
+
+    @Test
+    public void testInnerLimitNotHinted() throws Exception {
+        String sql = "select distinct data from "
+                + "(select data from iceberg0.unpartitioned_db.t0 order by data limit 2) s";
+        String plan = getVerboseExplain(sql);
+        Assertions.assertFalse(plan.contains("dict-page shortcut: hint=true"),
+                "inner LIMIT/ORDER BY changes the row set; shortcut would be incorrect");
+    }
+
+    @Test
+    public void testScanLimitNotHinted() throws Exception {
+        String sql = "select distinct data from iceberg0.unpartitioned_db.t0 limit 5";
+        String plan = getVerboseExplain(sql);
+        Assertions.assertFalse(plan.contains("dict-page shortcut: hint=true"),
+                "scan-level LIMIT must disable the hint");
+    }
+
+    @Test
+    public void testFlagOffNoHint() throws Exception {
+        connectContext.getSessionVariable().setEnableIcebergDictPageShortcut(false);
+        try {
+            String sql = "select distinct data from iceberg0.unpartitioned_db.t0";
+            String plan = getVerboseExplain(sql);
+            Assertions.assertFalse(plan.contains("dict-page shortcut: hint=true"),
+                    "session flag off must produce no hint");
+        } finally {
+            connectContext.getSessionVariable().setEnableIcebergDictPageShortcut(true);
+        }
+    }
+}

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1329,6 +1329,10 @@ struct THdfsScanNode {
 
     // database name it scans, used to disambiguate same-named tables across databases
     29: optional string database_name
+
+    // Hint for BE parquet reader: may emit a row-group's dict-page values as the
+    // result instead of decoding data pages. BE applies per-RG safety gates.
+    30: optional bool dict_page_shortcut_hint
 }
 
 struct TProjectNode {


### PR DESCRIPTION
## Why I'm doing:

`SELECT DISTINCT col FROM iceberg_t` and `SELECT col FROM iceberg_t GROUP BY col` over iceberg parquet currently scan every row of the column: decode RLE codes into strings, push them up to HashAggregate, dedup into a HashSet. For low-cardinality columns (`country`, `region`, `status`, `device_type`) the answer is already sitting on disk — the column-chunk dictionary page contains all distinct values of that row group, but we ignore it and recompute row by row.

On typical low-card columns this means scanning megabytes of data pages to recover ~50 dictionary entries that were one IO away.

## What I'm doing:

A new FE rule (`ApplyIcebergDictPageShortcutRule`, sits after `LowCardinalityRewriteRule` / `ApplyMinMaxStatisticRule` in `QueryOptimizer.physicalRuleRewrite`) recognises the pattern

```
HashAggregate(group_by=[col], aggregations=∅)
  ← [Project(identity)?]
    ← PhysicalIcebergScanOperator(data_slots={col}, parquet, no predicate)
```

and sets a hint on the scan via `ScanOptimizeOption.dictPageShortcutHint`. The hint propagates through `THdfsScanNode` to BE. The rule is a thin pattern-match + one setter — it deliberately doesn't reuse `LowCardinalityRewriteRule` (which works with FE-shipped `global_dict`, rewrites scan output type to int dict-codes, and is off by default for lake) or `ApplyMinMaxStatisticRule` (which targets compressed-key min/max statistics on the agg, not a scan hint). The semantics are different enough that mixing them in either existing pass would be more confusing than helpful.

The parquet `GroupReader` decides per row group in `prepare()` — after column readers are set up but before coalesced PAGES IO planning — whether the shortcut is safe. If yes it materialises the dict-page values via a new `ScalarColumnReader::materialize_dictionary_values()` (reuses the existing column converter so all types are supported, not just strings) and `get_next()` emits the prepared values in `chunk_size`-bounded batches.

Per-RG safety gates:

- **Writer trust**: `FileMetaData.writer_version().application_ == "parquet-mr"` (exact match). parquet-mr is the only writer with explicit prune of unreferenced dict entries (`DictionaryValuesWriter.toDictPageAndClose` writes only `lastUsedDictionarySize`). arrow-cpp/pyarrow/DuckDB writers can leave unused dict entries — silent over-approximation risk.
- **Column chunk fully dict-encoded** via existing `column_all_pages_dict_encoded()` (same gate Trino/Iceberg use for dict-aware predicate filtering).
- **No scan predicate** (`scan.getPredicate() == null`). In principle a predicate that partition pruning, RG zone-map and page-index fully resolve at row-group level (RG either entirely included or entirely excluded, no per-row residual) is safe; but `PredicateFilterEvaluator` currently only signals "RG dropped" or "_range narrowed by page-index", not "predicate proved TRUE for the entire RG". Without that signal we can't runtime-distinguish "fully resolved" from "residual remains", so the conservative gate bails on any scan predicate.
- **No per-slot conjuncts at runtime** (`conjunct_ctxs_by_slot` empty on BE). Runtime filters propagated from upstream joins land on the scan's slot map at execution time, after FE planning is done. If one arrives, the normal pipeline filters rows by it; the shortcut would emit dict values that runtime-filtered rows would never have produced, over-approximating the result. The FE gate catches static predicates; this catches RF arrivals.
- **Deletion bitmap empty for this RG's row range** — uses `DeletionBitmap::get_range_cardinality()`, so clean RGs of partially-deleted v2 position-delete / v3 deletion-vector files still qualify.
- **Page-index did not narrow the RG**: `_range.span_size() == num_rows`.
- **`Statistics.null_count` is set** — needed to decide whether NULL belongs in the result; unset → fallback.
- **`dictionary_page_offset` declared** and **`null_count != num_rows`** — parquet-mr may omit the dict page entirely for all-NULL RGs even when encoding stats claim dict encoding.
- **Single non-partition data-slot** in scan; walker accepts only identity Project between agg and scan (non-row-preserving ops like TopN/Sort/Limit disqualify).

Anything else falls back to the standard row pipeline.

**Off by default** behind `enable_iceberg_dict_page_shortcut` (session variable). Without explicit `SET enable_iceberg_dict_page_shortcut=true` no plan or scan behavior changes.

Also adds `DictDecoder<T>::get_dict_values(Column*)` for non-Slice types so the shortcut works for INT/BIGINT/DECIMAL/DATE etc. (the existing override only covered Slice).

Fixes #73746

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Test plan

- FE: `IcebergDictPageShortcutTest` — 8 plan-explain cases (DISTINCT/GROUP-BY get hint; multi-col, predicate, agg fns, inner LIMIT/ORDER, scan LIMIT, flag-off all rejected).
- BE: `dict_encoding_test` — 3 new cases for `DictDecoder<T>::get_dict_values` on int / varchar / empty dict.
- Manual smoke: end-to-end `SET enable_iceberg_dict_page_shortcut=true; SELECT DISTINCT col FROM iceberg_t;` + `EXPLAIN VERBOSE` to verify `dict-page shortcut: hint=true` line, plus runtime profile bytes-read.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
