### PR TITLE
[Enhancement] Wire IcebergColumnMinMaxMgr into ApplyMinMaxStatisticRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.tree;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
@@ -26,7 +27,9 @@ import com.starrocks.sql.optimizer.base.ColumnIdentifier;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
@@ -112,6 +115,54 @@ public class ApplyMinMaxStatisticRule implements TreeRewriteRule {
                     }
                     final ConstantOperator min = ConstantOperator.createVarchar(minMax.get().minValue());
                     final ConstantOperator max = ConstantOperator.createVarchar(minMax.get().maxValue());
+                    infos.put(column.getId(), new Pair<>(min, max));
+                }
+            }
+        }
+
+        // Iceberg scans — dict-only branch. After low-cardinality rewrite the varchar
+        // group-by becomes TYPE_INT with codes in [1, dictSize]; the runtime contract is
+        // enforced by GlobalDictNotMatch retry on the BE side. globalDicts is only
+        // populated for parquet scans (gated in DecodeCollector.visitPhysicalIcebergScan),
+        // so non-parquet falls through naturally via the containsKey check below.
+        List<PhysicalScanOperator> icebergScans = Lists.newArrayList();
+        Utils.extractOperator(root, icebergScans,
+                op -> OperatorType.PHYSICAL_ICEBERG_SCAN.equals(op.getOpType()));
+        for (PhysicalScanOperator scan : icebergScans) {
+            PhysicalIcebergScanOperator iceberg = (PhysicalIcebergScanOperator) scan;
+            IcebergTable table = (IcebergTable) iceberg.getTable();
+
+            final Map<Integer, ColumnDict> globalDicts =
+                    iceberg.getGlobalDicts().stream().collect(Collectors.toMap(p -> p.first, p -> p.second));
+
+            if (iceberg.getProjection() != null) {
+                for (var entry : iceberg.getProjection().getColumnRefMap().entrySet()) {
+                    if (groupByRefSets.contains(entry.getKey()) &&
+                            entry.getValue() instanceof DictMappingOperator mappingOperator) {
+                        ColumnRefOperator column = mappingOperator.getDictColumn();
+                        if (!column.getType().isNumericType() && !column.getType().isDate()) {
+                            continue;
+                        }
+                        if (globalDicts.containsKey(column.getId())) {
+                            final ConstantOperator min = ConstantOperator.createVarchar("0");
+                            final ColumnDict columnDict = globalDicts.get(column.getId());
+                            final ConstantOperator max = ConstantOperator.createVarchar("" + columnDict.getDictSize());
+                            infos.put(entry.getKey().getId(), new Pair<>(min, max));
+                        }
+                    }
+                }
+            }
+            for (ColumnRefOperator column : iceberg.getColRefToColumnMetaMap().keySet()) {
+                if (!groupByRefSets.contains(column.getId())) {
+                    continue;
+                }
+                if (!column.getType().isNumericType() && !column.getType().isDate()) {
+                    continue;
+                }
+                if (globalDicts.containsKey(column.getId())) {
+                    final ConstantOperator min = ConstantOperator.createVarchar("0");
+                    final ColumnDict columnDict = globalDicts.get(column.getId());
+                    final ConstantOperator max = ConstantOperator.createVarchar("" + columnDict.getDictSize());
                     infos.put(column.getId(), new Pair<>(min, max));
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
@@ -67,131 +67,69 @@ public class ApplyMinMaxStatisticRule implements TreeRewriteRule {
 
         Map<Integer, Pair<ConstantOperator, ConstantOperator>> infos = Maps.newHashMap();
 
-        List<PhysicalOlapScanOperator> scanOperators = Utils.extractPhysicalOlapScanOperator(root);
-        for (PhysicalOlapScanOperator scanOperator : scanOperators) {
-            final Map<Integer, ColumnDict> globalDicts =
-                    scanOperator.getGlobalDicts().stream().collect(Collectors.toMap(p -> p.first, p -> p.second));
-            OlapTable table = (OlapTable) scanOperator.getTable();
+        List<PhysicalOlapScanOperator> olapScans = Utils.extractPhysicalOlapScanOperator(root);
+        for (PhysicalOlapScanOperator scan : olapScans) {
+            OlapTable table = (OlapTable) scan.getTable();
             final Long lastUpdateTime = StatisticUtils.getTableLastUpdateTimestamp(table);
             if (null == lastUpdateTime) {
                 continue;
             }
-            if (table.inputHasTempPartition(scanOperator.getSelectedPartitionId())) {
+            if (table.inputHasTempPartition(scan.getSelectedPartitionId())) {
                 continue;
             }
-            if (scanOperator.getProjection() != null) {
-                for (var entry : scanOperator.getProjection().getColumnRefMap().entrySet()) {
-                    if (groupByRefSets.contains(entry.getKey()) &&
-                            entry.getValue() instanceof DictMappingOperator mappingOperator) {
-                        ColumnRefOperator column = mappingOperator.getDictColumn();
-                        if (!column.getType().isNumericType() && !column.getType().isDate()) {
-                            continue;
-                        }
-                        if (globalDicts.containsKey(column.getId())) {
-                            final ConstantOperator min = ConstantOperator.createVarchar("0");
-                            final ColumnDict columnDict = globalDicts.get(column.getId());
-                            final ConstantOperator max = ConstantOperator.createVarchar("" + columnDict.getDictSize());
-                            infos.put(entry.getKey().getId(), new Pair<>(min, max));
-                        }
-                    }
-                }
-            }
-            for (ColumnRefOperator column : scanOperator.getColRefToColumnMetaMap().keySet()) {
-                if (groupByRefSets.contains(column.getId())) {
-                    if (!column.getType().isNumericType() && !column.getType().isDate()) {
-                        continue;
-                    }
-                    if (globalDicts.containsKey(column.getId())) {
-                        final ConstantOperator min = ConstantOperator.createVarchar("0");
-                        final ColumnDict columnDict = globalDicts.get(column.getId());
-                        final ConstantOperator max = ConstantOperator.createVarchar("" + columnDict.getDictSize());
-                        infos.put(column.getId(), new Pair<>(min, max));
-                        continue;
-                    }
-                    Column c = table.getColumn(column.getName());
-                    Optional<IMinMaxStatsMgr.ColumnMinMax> minMax = IMinMaxStatsMgr.internalInstance()
-                            .getStats(new ColumnIdentifier(table.getId(), c.getColumnId()),
-                                    new StatsVersion(-1, lastUpdateTime));
-                    if (minMax.isEmpty()) {
-                        continue;
-                    }
-                    final ConstantOperator min = ConstantOperator.createVarchar(minMax.get().minValue());
-                    final ConstantOperator max = ConstantOperator.createVarchar(minMax.get().maxValue());
-                    infos.put(column.getId(), new Pair<>(min, max));
-                }
-            }
-        }
-
-        // Iceberg scans — dict-only branch. After low-cardinality rewrite the varchar
-        // group-by becomes TYPE_INT with codes in [1, dictSize]; the runtime contract is
-        // enforced by GlobalDictNotMatch retry on the BE side. globalDicts is only
-        // populated for parquet scans (gated in DecodeCollector.visitPhysicalIcebergScan),
-        // so non-parquet falls through naturally via the containsKey check below.
-        List<PhysicalScanOperator> icebergScans = Lists.newArrayList();
-        Utils.extractOperator(root, icebergScans,
-                op -> OperatorType.PHYSICAL_ICEBERG_SCAN.equals(op.getOpType()));
-        for (PhysicalScanOperator scan : icebergScans) {
-            PhysicalIcebergScanOperator iceberg = (PhysicalIcebergScanOperator) scan;
-            IcebergTable table = (IcebergTable) iceberg.getTable();
-
-            final Map<Integer, ColumnDict> globalDicts =
-                    iceberg.getGlobalDicts().stream().collect(Collectors.toMap(p -> p.first, p -> p.second));
-
-            // Snapshot for IcebergColumnMinMaxMgr lookups. Take it from the scan's own
-            // TvrVersionRange — analyzer already pinned it — so the cache key matches the
-            // exact snapshot BE will read. Null/empty/non-single-snapshot ranges (e.g.
-            // TvrTableDelta) skip the numeric/date fallback below.
-            TvrVersionRange tvr = iceberg.getTvrVersionRange();
-            Long snapshotId = (tvr instanceof TvrTableSnapshot snap && !snap.isEmpty())
-                    ? snap.getSnapshotId() : null;
-
-            if (iceberg.getProjection() != null) {
-                for (var entry : iceberg.getProjection().getColumnRefMap().entrySet()) {
-                    if (groupByRefSets.contains(entry.getKey()) &&
-                            entry.getValue() instanceof DictMappingOperator mappingOperator) {
-                        ColumnRefOperator column = mappingOperator.getDictColumn();
-                        if (!column.getType().isNumericType() && !column.getType().isDate()) {
-                            continue;
-                        }
-                        if (globalDicts.containsKey(column.getId())) {
-                            final ConstantOperator min = ConstantOperator.createVarchar("0");
-                            final ColumnDict columnDict = globalDicts.get(column.getId());
-                            final ConstantOperator max = ConstantOperator.createVarchar("" + columnDict.getDictSize());
-                            infos.put(entry.getKey().getId(), new Pair<>(min, max));
-                        }
-                    }
-                }
-            }
-            for (ColumnRefOperator column : iceberg.getColRefToColumnMetaMap().keySet()) {
-                if (!groupByRefSets.contains(column.getId())) {
-                    continue;
-                }
-                if (!column.getType().isNumericType() && !column.getType().isDate()) {
-                    continue;
-                }
-                if (globalDicts.containsKey(column.getId())) {
-                    final ConstantOperator min = ConstantOperator.createVarchar("0");
-                    final ColumnDict columnDict = globalDicts.get(column.getId());
-                    final ConstantOperator max = ConstantOperator.createVarchar("" + columnDict.getDictSize());
-                    infos.put(column.getId(), new Pair<>(min, max));
-                    continue;
-                }
-                if (snapshotId == null) {
+            Map<Integer, ColumnDict> globalDicts = toGlobalDictMap(scan.getGlobalDicts());
+            // Dict-encoded group-by keys (shared with the iceberg branch below).
+            collectDictGroupByMinMax(scan, groupByRefSets, globalDicts, infos);
+            // Fallback to the internal table-level min/max stats manager for the remaining
+            // numeric/date group-by keys that are not dict-encoded.
+            for (ColumnRefOperator column : scan.getColRefToColumnMetaMap().keySet()) {
+                if (!isUncoveredGroupByKey(column, groupByRefSets, infos)) {
                     continue;
                 }
                 Column c = table.getColumn(column.getName());
                 if (c == null) {
                     continue;
                 }
-                Optional<IMinMaxStatsMgr.ColumnMinMax> minMax = IMinMaxStatsMgr.icebergInstance()
-                        .getStats(new ColumnIdentifier(table.getUUID(), c.getColumnId()),
-                                new StatsVersion(-1, snapshotId));
-                if (minMax.isEmpty()) {
+                putStatsMgrMinMax(column, infos, IMinMaxStatsMgr.internalInstance(),
+                        new ColumnIdentifier(table.getId(), c.getColumnId()),
+                        new StatsVersion(-1, lastUpdateTime));
+            }
+        }
+
+        // Iceberg scans. After low-cardinality rewrite the varchar group-by becomes TYPE_INT with
+        // codes in [1, dictSize]; the runtime contract is enforced by GlobalDictNotMatch retry on
+        // the BE side. globalDicts is only populated for parquet scans (gated in
+        // DecodeCollector.visitPhysicalIcebergScan), so non-parquet falls through naturally.
+        List<PhysicalScanOperator> icebergScans = Lists.newArrayList();
+        Utils.extractOperator(root, icebergScans,
+                op -> OperatorType.PHYSICAL_ICEBERG_SCAN.equals(op.getOpType()));
+        for (PhysicalScanOperator scan : icebergScans) {
+            PhysicalIcebergScanOperator iceberg = (PhysicalIcebergScanOperator) scan;
+            IcebergTable table = (IcebergTable) iceberg.getTable();
+            Map<Integer, ColumnDict> globalDicts = toGlobalDictMap(iceberg.getGlobalDicts());
+            // Dict-encoded group-by keys (shared with the OLAP branch above).
+            collectDictGroupByMinMax(iceberg, groupByRefSets, globalDicts, infos);
+            // Fallback to IcebergColumnMinMaxMgr for the remaining numeric/date group-by keys. Take
+            // the snapshot from the scan's own TvrVersionRange — analyzer already pinned it — so the
+            // cache key matches the exact snapshot BE will read. Null/empty/non-single-snapshot
+            // ranges (e.g. TvrTableDelta) skip the fallback.
+            TvrVersionRange tvr = iceberg.getTvrVersionRange();
+            Long snapshotId = (tvr instanceof TvrTableSnapshot snap && !snap.isEmpty())
+                    ? snap.getSnapshotId() : null;
+            if (snapshotId == null) {
+                continue;
+            }
+            for (ColumnRefOperator column : iceberg.getColRefToColumnMetaMap().keySet()) {
+                if (!isUncoveredGroupByKey(column, groupByRefSets, infos)) {
                     continue;
                 }
-                final ConstantOperator min = ConstantOperator.createVarchar(minMax.get().minValue());
-                final ConstantOperator max = ConstantOperator.createVarchar(minMax.get().maxValue());
-                infos.put(column.getId(), new Pair<>(min, max));
+                Column c = table.getColumn(column.getName());
+                if (c == null) {
+                    continue;
+                }
+                putStatsMgrMinMax(column, infos, IMinMaxStatsMgr.icebergInstance(),
+                        new ColumnIdentifier(table.getUUID(), c.getColumnId()),
+                        new StatsVersion(-1, snapshotId));
             }
         }
 
@@ -209,5 +147,62 @@ public class ApplyMinMaxStatisticRule implements TreeRewriteRule {
         }
 
         return root;
+    }
+
+    // Numeric/date columns are the only ones whose dict codes form the contiguous [0, dictSize]
+    // range the aggregator's compressed-key path can use as group-by min/max bounds.
+    private static boolean isNumericOrDate(ColumnRefOperator column) {
+        return column.getType().isNumericType() || column.getType().isDate();
+    }
+
+    private static Map<Integer, ColumnDict> toGlobalDictMap(List<Pair<Integer, ColumnDict>> globalDicts) {
+        return globalDicts.stream().collect(Collectors.toMap(p -> p.first, p -> p.second));
+    }
+
+    // A numeric/date group-by key on this scan that no scan has supplied min/max for yet.
+    private static boolean isUncoveredGroupByKey(ColumnRefOperator column, ColumnRefSet groupByRefSets,
+            Map<Integer, Pair<ConstantOperator, ConstantOperator>> infos) {
+        return groupByRefSets.contains(column.getId()) && isNumericOrDate(column)
+                && !infos.containsKey(column.getId());
+    }
+
+    // Emit (0, dictSize) min/max for every group-by key backed by a global dict on this scan — both
+    // the projection's DictMappingOperator form and bare scan columns. Shared by the OLAP and
+    // iceberg branches so their dict handling stays identical.
+    private static void collectDictGroupByMinMax(PhysicalScanOperator scan, ColumnRefSet groupByRefSets,
+            Map<Integer, ColumnDict> globalDicts, Map<Integer, Pair<ConstantOperator, ConstantOperator>> infos) {
+        if (scan.getProjection() != null) {
+            for (var entry : scan.getProjection().getColumnRefMap().entrySet()) {
+                if (groupByRefSets.contains(entry.getKey())
+                        && entry.getValue() instanceof DictMappingOperator mappingOperator) {
+                    ColumnRefOperator column = mappingOperator.getDictColumn();
+                    if (isNumericOrDate(column) && globalDicts.containsKey(column.getId())) {
+                        infos.put(entry.getKey().getId(), dictMinMax(globalDicts.get(column.getId())));
+                    }
+                }
+            }
+        }
+        for (ColumnRefOperator column : scan.getColRefToColumnMetaMap().keySet()) {
+            if (groupByRefSets.contains(column.getId()) && isNumericOrDate(column)
+                    && globalDicts.containsKey(column.getId())) {
+                infos.put(column.getId(), dictMinMax(globalDicts.get(column.getId())));
+            }
+        }
+    }
+
+    private static Pair<ConstantOperator, ConstantOperator> dictMinMax(ColumnDict dict) {
+        return new Pair<>(ConstantOperator.createVarchar("0"),
+                ConstantOperator.createVarchar("" + dict.getDictSize()));
+    }
+
+    private static void putStatsMgrMinMax(ColumnRefOperator column,
+            Map<Integer, Pair<ConstantOperator, ConstantOperator>> infos, IMinMaxStatsMgr mgr,
+            ColumnIdentifier columnId, StatsVersion version) {
+        Optional<IMinMaxStatsMgr.ColumnMinMax> minMax = mgr.getStats(columnId, version);
+        if (minMax.isEmpty()) {
+            return;
+        }
+        infos.put(column.getId(), new Pair<>(ConstantOperator.createVarchar(minMax.get().minValue()),
+                ConstantOperator.createVarchar(minMax.get().maxValue())));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
@@ -20,6 +20,8 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Pair;
+import com.starrocks.common.tvr.TvrTableSnapshot;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
@@ -135,6 +137,14 @@ public class ApplyMinMaxStatisticRule implements TreeRewriteRule {
             final Map<Integer, ColumnDict> globalDicts =
                     iceberg.getGlobalDicts().stream().collect(Collectors.toMap(p -> p.first, p -> p.second));
 
+            // Snapshot for IcebergColumnMinMaxMgr lookups. Take it from the scan's own
+            // TvrVersionRange — analyzer already pinned it — so the cache key matches the
+            // exact snapshot BE will read. Null/empty/non-single-snapshot ranges (e.g.
+            // TvrTableDelta) skip the numeric/date fallback below.
+            TvrVersionRange tvr = iceberg.getTvrVersionRange();
+            Long snapshotId = (tvr instanceof TvrTableSnapshot snap && !snap.isEmpty())
+                    ? snap.getSnapshotId() : null;
+
             if (iceberg.getProjection() != null) {
                 for (var entry : iceberg.getProjection().getColumnRefMap().entrySet()) {
                     if (groupByRefSets.contains(entry.getKey()) &&
@@ -164,7 +174,24 @@ public class ApplyMinMaxStatisticRule implements TreeRewriteRule {
                     final ColumnDict columnDict = globalDicts.get(column.getId());
                     final ConstantOperator max = ConstantOperator.createVarchar("" + columnDict.getDictSize());
                     infos.put(column.getId(), new Pair<>(min, max));
+                    continue;
                 }
+                if (snapshotId == null) {
+                    continue;
+                }
+                Column c = table.getColumn(column.getName());
+                if (c == null) {
+                    continue;
+                }
+                Optional<IMinMaxStatsMgr.ColumnMinMax> minMax = IMinMaxStatsMgr.icebergInstance()
+                        .getStats(new ColumnIdentifier(table.getUUID(), c.getColumnId()),
+                                new StatsVersion(-1, snapshotId));
+                if (minMax.isEmpty()) {
+                    continue;
+                }
+                final ConstantOperator min = ConstantOperator.createVarchar(minMax.get().minValue());
+                final ConstantOperator max = ConstantOperator.createVarchar(minMax.get().maxValue());
+                infos.put(column.getId(), new Pair<>(min, max));
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IcebergColumnMinMaxMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IcebergColumnMinMaxMgr.java
@@ -47,7 +47,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 public class IcebergColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable {
-    private record CacheKey(ColumnIdentifier id, StatsVersion version) {}
+    // Key by the primitive snapshot version rather than the StatsVersion object: StatsVersion has no
+    // value-based equals/hashCode (and its version field is mutable), so caching by the object would make
+    // every lookup a distinct key and never hit the warmed entry.
+    private record CacheKey(ColumnIdentifier id, long version) {}
 
     private static final Logger LOG = LogManager.getLogger(IcebergColumnMinMaxMgr.class);
 
@@ -72,7 +75,7 @@ public class IcebergColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable 
         }
 
         try {
-            CompletableFuture<Optional<ColumnMinMax>> result = cache.get(new CacheKey(identifier, version));
+            CompletableFuture<Optional<ColumnMinMax>> result = cache.get(new CacheKey(identifier, version.getVersion()));
             if (result.isDone()) {
                 return result.get();
             }
@@ -113,7 +116,7 @@ public class IcebergColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable 
                     String tableName = StatisticUtils.quoting(names.get(0), names.get(1), names.get(2));
 
                     String sql = "select min(" + columnName + ") as min, max(" + columnName + ") as max " +
-                            " from " + tableName + " VERSION AS OF " + key.version.getVersion();
+                            " from " + tableName + " VERSION AS OF " + key.version;
 
                     ConnectContext context = SIMPLE_EXECUTOR.createConnectContext();
                     context.getSessionVariable().setPipelineDop(1);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -640,6 +640,18 @@ public class MockIcebergMetadata implements ConnectorMetadata {
         return TvrTableSnapshot.of(TvrVersion.of(1L));
     }
 
+    // ConnectorMetadata's default returns TvrTableSnapshot.empty(), which leaves the planned scan
+    // pinned to the MIN snapshot (0 partitions, no data) -- low-cardinality dict collection and the
+    // group-by min/max rule both then no-op. Mirror getCurrentTvrSnapshot so the scan sees a real
+    // snapshot, as production's IcebergMetadata.getTableVersionRange does.
+    @Override
+    public TvrVersionRange getTableVersionRange(
+            String dbName, com.starrocks.catalog.Table table,
+            java.util.Optional<com.starrocks.connector.ConnectorTableVersion> startVersion,
+            java.util.Optional<com.starrocks.connector.ConnectorTableVersion> endVersion) {
+        return getCurrentTvrSnapshot(dbName, table);
+    }
+
     public List<TvrTableDeltaTrait> listTableDeltaTraits(String dbName, com.starrocks.catalog.Table table,
                                                          TvrTableSnapshot fromSnapshotExclusive,
                                                          TvrTableSnapshot toSnapshotInclusive) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -32,7 +32,9 @@ import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorTableInfo;
+import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.PartitionInfo;
+import com.starrocks.connector.PointerType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -61,6 +63,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
@@ -642,14 +645,29 @@ public class MockIcebergMetadata implements ConnectorMetadata {
 
     // ConnectorMetadata's default returns TvrTableSnapshot.empty(), which leaves the planned scan
     // pinned to the MIN snapshot (0 partitions, no data) -- low-cardinality dict collection and the
-    // group-by min/max rule both then no-op. Mirror getCurrentTvrSnapshot so the scan sees a real
-    // snapshot, as production's IcebergMetadata.getTableVersionRange does.
+    // group-by min/max rule both then no-op. Mirror production's IcebergMetadata.getTableVersionRange:
+    // no bounds -> current snapshot; any bound -> TvrTableDelta so time-travel/delta tests keep the
+    // correct TVR shape. Only VERSION pointers are resolvable here; TEMPORAL would need a snapshot
+    // history that the mock does not carry.
     @Override
     public TvrVersionRange getTableVersionRange(
             String dbName, com.starrocks.catalog.Table table,
-            java.util.Optional<com.starrocks.connector.ConnectorTableVersion> startVersion,
-            java.util.Optional<com.starrocks.connector.ConnectorTableVersion> endVersion) {
-        return getCurrentTvrSnapshot(dbName, table);
+            Optional<ConnectorTableVersion> startVersion,
+            Optional<ConnectorTableVersion> endVersion) {
+        if (startVersion.isEmpty() && endVersion.isEmpty()) {
+            return getCurrentTvrSnapshot(dbName, table);
+        }
+        Optional<Long> start = startVersion.map(MockIcebergMetadata::snapshotIdFromVersion);
+        Optional<Long> end = endVersion.map(MockIcebergMetadata::snapshotIdFromVersion);
+        return TvrTableDelta.of(start, end);
+    }
+
+    private static long snapshotIdFromVersion(ConnectorTableVersion version) {
+        if (version.getPointerType() != PointerType.VERSION) {
+            throw new UnsupportedOperationException(
+                    "MockIcebergMetadata only resolves VERSION pointers; got " + version.getPointerType());
+        }
+        return version.getConstantOperator().getBigint();
     }
 
     public List<TvrTableDeltaTrait> listTableDeltaTraits(String dbName, com.starrocks.catalog.Table table,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergCompressedKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergCompressedKeyTest.java
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.optimizer.statistics.ColumnDict;
+import com.starrocks.sql.optimizer.statistics.IRelaxDictManager;
+import mockit.Expectations;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+public class IcebergCompressedKeyTest extends ConnectorPlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        ConnectorPlanTestBase.beforeClass();
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeOnLake(true);
+        // The lake low-cardinality dict rewrite only runs for queries (DecodeCollector gates the
+        // iceberg/hive scan visitors on isQuery). buildPlan() in the test harness does not go through
+        // the production setIsQuery(...) path, so QueryState defaults to false and the rewrite is
+        // skipped, leaving the group-by key un-encoded and the min-max rule a no-op.
+        connectContext.getState().setIsQuery(true);
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        FeConstants.USE_MOCK_DICT_MANAGER = false;
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeOnLake(false);
+        connectContext.getState().setIsQuery(false);
+    }
+
+    @Test
+    public void testIcebergDictGroupByEmitsMinMaxRange() throws Exception {
+        IRelaxDictManager dictManager = IRelaxDictManager.getInstance();
+        ColumnDict columnDict = new ColumnDict(
+                ImmutableMap.<ByteBuffer, Integer>builder()
+                        .put(ByteBuffer.wrap("a".getBytes()), 1)
+                        .put(ByteBuffer.wrap("b".getBytes()), 2)
+                        .build(),
+                0, 0);
+
+        new Expectations(dictManager) {
+            {
+                dictManager.hasGlobalDict(anyString, "data");
+                result = true;
+                minTimes = 0;
+
+                dictManager.getGlobalDict(anyString, "data");
+                result = Optional.of(columnDict);
+                minTimes = 0;
+            }
+        };
+
+        String sql = "select count(*) from iceberg0.unpartitioned_db.t0 group by data";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "group by min-max stats:");
+        assertContains(plan, "- 0:2");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergCompressedKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergCompressedKeyTest.java
@@ -16,8 +16,11 @@ package com.starrocks.sql.plan;
 
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.common.FeConstants;
+import com.starrocks.sql.optimizer.base.ColumnIdentifier;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
+import com.starrocks.sql.optimizer.statistics.IMinMaxStatsMgr;
 import com.starrocks.sql.optimizer.statistics.IRelaxDictManager;
+import com.starrocks.sql.optimizer.statistics.StatsVersion;
 import mockit.Expectations;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -77,5 +80,22 @@ public class IcebergCompressedKeyTest extends ConnectorPlanTestBase {
         String plan = getVerboseExplain(sql);
         assertContains(plan, "group by min-max stats:");
         assertContains(plan, "- 0:2");
+    }
+
+    @Test
+    public void testIcebergNumericGroupByFromMinMaxMgr() throws Exception {
+        IMinMaxStatsMgr mgr = IMinMaxStatsMgr.icebergInstance();
+        new Expectations(mgr) {
+            {
+                mgr.getStats((ColumnIdentifier) any, (StatsVersion) any);
+                result = Optional.of(new IMinMaxStatsMgr.ColumnMinMax("0", "100"));
+                minTimes = 0;
+            }
+        };
+
+        String sql = "select count(*) from iceberg0.unpartitioned_db.t0 group by id";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "group by min-max stats:");
+        assertContains(plan, "- 0:100");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergCompressedKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergCompressedKeyTest.java
@@ -15,19 +15,26 @@
 package com.starrocks.sql.plan;
 
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.FeConstants;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.base.ColumnIdentifier;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
 import com.starrocks.sql.optimizer.statistics.IMinMaxStatsMgr;
 import com.starrocks.sql.optimizer.statistics.IRelaxDictManager;
 import com.starrocks.sql.optimizer.statistics.StatsVersion;
 import mockit.Expectations;
+import mockit.Verifications;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IcebergCompressedKeyTest extends ConnectorPlanTestBase {
 
@@ -84,6 +91,13 @@ public class IcebergCompressedKeyTest extends ConnectorPlanTestBase {
 
     @Test
     public void testIcebergNumericGroupByFromMinMaxMgr() throws Exception {
+        IcebergTable table = (IcebergTable) GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "unpartitioned_db", "t0");
+        ColumnIdentifier expectedId = new ColumnIdentifier(table.getUUID(), table.getColumn("id").getColumnId());
+        // MockIcebergMetadata.getCurrentTvrSnapshot pins TvrVersion.of(1L); the rule must forward
+        // exactly that to IcebergColumnMinMaxMgr so the cache key matches what BE will read.
+        long expectedSnapshotId = 1L;
+
         IMinMaxStatsMgr mgr = IMinMaxStatsMgr.icebergInstance();
         new Expectations(mgr) {
             {
@@ -97,5 +111,16 @@ public class IcebergCompressedKeyTest extends ConnectorPlanTestBase {
         String plan = getVerboseExplain(sql);
         assertContains(plan, "group by min-max stats:");
         assertContains(plan, "- 0:100");
+
+        List<ColumnIdentifier> idCaptures = new ArrayList<>();
+        List<StatsVersion> versionCaptures = new ArrayList<>();
+        new Verifications() {
+            {
+                mgr.getStats(withCapture(idCaptures), withCapture(versionCaptures));
+                times = 1;
+            }
+        };
+        assertEquals(expectedId, idCaptures.get(0));
+        assertEquals(expectedSnapshotId, versionCaptures.get(0).getVersion());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

After #73742 the Iceberg branch of `ApplyMinMaxStatisticRule` only sets
compressed-key min/max for group-by columns that have a global dict (i.e.
varchar after low-cardinality rewrite, with the projected key becoming
`[1, dictSize]`). Iceberg `GROUP BY` on a plain numeric/date column gets
nothing, even though the answer is one cache lookup away:
`IcebergColumnMinMaxMgr` already exists (added in #61155) and serves
`(col, snapshot_id) → (min, max)` from cached manifest stats — but no rule
consumes it.

## What I'm doing:

Inside the Iceberg branch of `ApplyMinMaxStatisticRule`, alongside the dict path:
- Resolve snapshot from the scan's own `TvrVersionRange` — analyzer already
  pinned it for this scan, so the cache key matches the snapshot BE will read
  via the per-range manifest stats. Non-`TvrTableSnapshot` cases (e.g.
  `TvrTableDelta`) are skipped.
- For numeric/date group-by columns not covered by the dict path, call
  `IMinMaxStatsMgr.icebergInstance().getStats(new ColumnIdentifier(table.getUUID(),
  columnId), new StatsVersion(-1, snapshotId))` and feed the result into the
  same `groupByMinMaxStats` accumulator the OLAP and dict paths use.

Cache semantics inherited from `IcebergColumnMinMaxMgr`:
- Cold key returns `Optional.empty()` immediately (`AsyncLoadingCache.get(...).isDone()
  == false`) — the current query proceeds without stats, the async loader warms
  the cache for the next call.
- `enable_min_max_optimization` gates both `getStats` itself and the loader's
  internal `SELECT min,max FROM tbl VERSION AS OF <snapshot_id>` (which is
  then short-circuited by `MinMaxOptOnScanRule` → only manifest IO).
- Snapshot is immutable, so the cache key is stable.

**Stacked on #73742.** That PR adds the Iceberg branch in
`ApplyMinMaxStatisticRule` and the dict sub-branch; this PR plugs the
second sub-branch into the same loop.

Fixes #73748

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Test plan:

- FE: `IcebergCompressedKeyTest#testIcebergNumericGroupByFromMinMaxMgr` —
  mocks `IcebergColumnMinMaxMgr.getStats(...)` to return `(0, 100)` for
  `iceberg0.unpartitioned_db.t0 GROUP BY id` (int column, no global dict);
  asserts the resulting plan contains `group by min-max stats:` and `- 0:100`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
