### PR TITLE
[Enhancement] percentile_approx: reset digest compression in place on group init

### DIFF
--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -31,11 +31,17 @@ public:
             : percentile(new PercentileValue(compression)), compression_initialized(true) {}
     ~PercentileApproxState() = default;
 
-    // Reinitialize the PercentileValue with a new compression factor
+    // Reinitialize the PercentileValue with a new compression factor.
     // This is used when the state is already constructed (e.g., as part of NullableAggregateFunctionState)
-    // but we need to apply a different compression factor from FunctionContext
+    // but we need to apply a different compression factor from FunctionContext.
+    // Resets the existing digest in place rather than allocating a fresh
+    // PercentileValue: create() already allocated one at the default compression,
+    // and the first update/merge of every group lands here before any value is
+    // added, so reallocating would waste one heap alloc/free per group on the
+    // high-cardinality path. set_compression yields the identical
+    // empty-at-compression state without the churn.
     void reinit_with_compression(double compression) {
-        percentile = std::make_unique<PercentileValue>(compression);
+        percentile->set_compression(compression);
         compression_initialized = true;
     }
 

--- a/be/src/types/percentile_value.h
+++ b/be/src/types/percentile_value.h
@@ -64,6 +64,13 @@ public:
 
     Value quantile(Value q) { return _tdigest.quantile(q); }
 
+    // Reset to an empty digest with a new compression, in place. Produces the
+    // same state as constructing a fresh PercentileValue(compression) but reuses
+    // this object: the inline TDigest's centroid vectors are empty (compression
+    // is applied before any value is added), so move-assigning a freshly
+    // constructed TDigest touches only scalar fields and does no heap work.
+    void set_compression(double compression) { _tdigest = TDigest(compression); }
+
 private:
     enum PercentileDataType { TDIGEST = 0 };
     TDigest _tdigest;


### PR DESCRIPTION
## Why I'm doing:

`PercentileApproxState` allocates its `PercentileValue` at the default compression
in `create()`, then the first `update`/`merge` of every aggregation group calls
`reinit_with_compression()` to apply the real compression. That reinit reallocated
a fresh `PercentileValue` via `make_unique`, so each group paid two heap
allocations (the `create()` one plus the reinit one), the first one immediately
discarded.

## What I'm doing:

Reset the existing (still empty) digest in place instead of reallocating. At reinit
time no value has been added yet, so `set_compression` reassigns only the
`TDigest`'s scalar fields (the centroid vectors are empty); the resulting state is
byte-for-byte identical to a freshly constructed `PercentileValue(compression)`,
just without the per-group alloc/free. Behavior is unchanged -- this only removes
an allocation on the per-group hot path, most visible on high-cardinality
`GROUP BY` where aggregation barely reduces row count and per-group setup dominates.

### Numbers

Microbench (high-cardinality merge: one record per group; `repetitions=10`, CV < 1.4%),
in-place reset vs the old realloc:

- standard merge path (full TDigest blob per row, current `main` behavior): **+12-13%**
- compact intermediate path (#73749): **+3%**

The asymmetry is allocator tcache behavior: the standard path already deserializes a
temporary digest per group, so removing the reinit allocation saves more there.

## What type of PR is this:

- [ ] BugFix
- [x] Enhancement
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr
